### PR TITLE
Upate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Gitpod](https://gitpod.io) provides an online IDE with a complete terminal for any GitHub project.
 It comes with tight GitHub-integration to keep you in the flow.
 
-Simply prefix any GitHub URL with `https://gitpod.io#`.
+Simply prefix any GitHub URL with `gitpod.io/#`.
 
 This repository is used for bug tracking and feature requests. Feedback is welcome! :heart:
 


### PR DESCRIPTION
We're now using a more standard Gitpod URL prefix (see #307).