### PR TITLE
[workspace] Fix ws-manager component path

### DIFF
--- a/gitpod-ws.theia-workspace
+++ b/gitpod-ws.theia-workspace
@@ -4,7 +4,7 @@
       { "path": "components/common-go" },
       { "path": "components/content-service" },
       { "path": "components/ee/cerc" },
-      { "path": "components/ee/ws-manager" },
+      { "path": "components/ws-manager" },
       { "path": "components/ee/ws-scheduler" },
       { "path": "components/gitpod-cli" },
       { "path": "components/image-builder" },


### PR DESCRIPTION
This fixes the workspace loading error related to `ws-manager`.