### PR TITLE
Generalize instructions to sign-in to GCP

### DIFF
--- a/scripts/setup-google-adc.sh
+++ b/scripts/setup-google-adc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # #### Instructions to fill the GCP_ADC_FILE env var
-#  1. `gcloud auth login <your-typefox-email>` and authenticate
+#  1. `gcloud auth login <gcp-email>` and authenticate
 #  2. `gcloud auth application-default login` and authenticate
 #  3. `cat ~/.config/gcloud/application_default_credentials.json` and copy the output
 #  4. Go to https://gitpod.io/environment-variables/ and create:


### PR DESCRIPTION
I thought it might be better to write `gcp-email` as it is more broad, which makes it more clear to someone who works outside of Typefox. 