### PR TITLE
[node-daemon] Prevent CrashLoop when re-deploying the same version

### DIFF
--- a/components/node-daemon/node-daemon.sh
+++ b/components/node-daemon/node-daemon.sh
@@ -6,6 +6,11 @@
 
 # 1. At this point we'll have copied Theia to the node. We must mark the node with the Theia label so that workspaces get scheduled to it.
 for i in $(seq 1 10); do
+    if kubectl get node $EXECUTING_NODE_NAME -o template='{{ range $k, $v := .metadata.labels}}{{ $k }}{{"\n"}}{{ end }}' | grep -q "gitpod.io/theia.'$VERSION'"; then
+        echo "Theia (version $VERSION) is already available - node is marked"
+        break
+    fi
+
     if kubectl patch node $EXECUTING_NODE_NAME --patch '{"metadata":{"labels":{"gitpod.io/theia.'$VERSION'": "available"}}}'; then
         echo "Theia (version $VERSION) became available - we've marked the node"
         break


### PR DESCRIPTION
Prior the node-daemon would crash because it can't mark a node with the Theia availability label if that node already has the label.

Now, the node-daemon checks if the label is already present.