### PR TITLE
[installer] Don't run as root

### DIFF
--- a/install/installer/entrypoint.sh
+++ b/install/installer/entrypoint.sh
@@ -4,6 +4,6 @@
 # See License-AGPL.txt in the project root for license information.
 
 
-source /google-cloud-sdk/path.bash.inc
+source $HOME/google-cloud-sdk/path.bash.inc
 
 gp-install $*

--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -26,25 +26,31 @@ RUN echo "chart_location = \"../helm/gitpod\"" >> installer.auto.tfvars && \
     rm installer.auto.tfvars
 
 FROM alpine
+RUN addgroup -g 1000 installer && \
+    adduser -D -G installer -u 1000 installer && \
+    mkdir /dist /workspace && \
+    chown -R installer:installer /dist /workspace
+
 ENV GITPOD_INSTALLER_IN_DOCKER="true"
 ENV KUBECONFIG="/workspace/kubectl"
-RUN apk add --no-cache aws-cli curl git bash ncurses && \
-    echo 'export PS1="[\t] \w\\$ "' >> ~/.bashrc
+RUN apk add --no-cache aws-cli python3 curl git bash ncurses
 
 RUN curl -o terraform.zip -L https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip && \
     unzip terraform.zip && \
     rm terraform.zip && \
     mv terraform /usr/bin
 
-RUN apk add --no-cache python3 && \
-    curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-305.0.0-linux-x86_64.tar.gz | tar xz && \
-    /google-cloud-sdk/install.sh && \
-    echo source /google-cloud-sdk/completion.bash.inc >> ~/.bashrc && \
-    echo source /google-cloud-sdk/path.bash.inc >> ~/.bashrc
-
 RUN curl -L https://get.helm.sh/helm-v2.16.10-linux-amd64.tar.gz | tar xz && \
     mv linux-amd64/helm /usr/bin && \
     rm -r linux-amd64
+
+USER installer
+WORKDIR /home/installer
+RUN curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-305.0.0-linux-x86_64.tar.gz | tar xz && \
+    ./google-cloud-sdk/install.sh && \
+    echo source $PWD/google-cloud-sdk/completion.bash.inc >> ~/.bashrc && \
+    echo source $PWD/google-cloud-sdk/path.bash.inc >> ~/.bashrc && \
+    echo 'export PS1="[\t] \w\\$ "' >> ~/.bashrc
 
 WORKDIR /dist
 COPY entrypoint.sh layout.yaml ./


### PR DESCRIPTION
Moves the installer from root to UID 1000 because
- it's good practice to not run as root if not needed,
- that will hopefully work better when run directly on Linux machines.