### PR TITLE
fix(gcp-terraform): typo in helm variables set

### DIFF
--- a/install/gcp-terraform/modules/helm/main.tf
+++ b/install/gcp-terraform/modules/helm/main.tf
@@ -61,7 +61,7 @@ resource "helm_release" "gitpod" {
   }
 
   set {
-    name = "components.proxy.certbot.enaled"
+    name = "components.proxy.certbot.enabled"
     value = var.certbotEnabled
   }
 


### PR DESCRIPTION
Introduced with #1733 