### PR TITLE
[preview envs] Make https opt-in

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -206,6 +206,11 @@ async function deployToDev(version, previewWithHttps) {
     } else {
         werft.log(`versions file not found at '${pathToVersions}', not using it.`);
     }
+    if (!certificatePromise) {
+        // it's not possible to set certificatesSecret={} so we set secretName to empty string
+        flags+=` --set certificatesSecret.secretName=""`;
+    }
+    
     try {
         shell.cd("chart");
         werft.log('helm', 'installing Gitpod');

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -19,7 +19,7 @@ function parseVersion(context) {
         return explicitVersion;
     }
     let version = context.Name;
-    const PREFIX_TO_STRIP = "gitpod-core-build-";
+    const PREFIX_TO_STRIP = "gitpod-build-";
     if (version.substr(0, PREFIX_TO_STRIP.length) === PREFIX_TO_STRIP) {
         version = version.substr(PREFIX_TO_STRIP.length);
     }

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -101,7 +101,7 @@ async function deployToDev(version) {
     const destname = version.split(".")[0];
     const namespace = `staging-${destname}`;
     const domain = `${destname}.staging.gitpod-dev.com`;
-    const url = `http://${domain}`;
+    const url = `https://${domain}`;
     const wssyncPort = `1${Math.floor(Math.random()*1000)}`;
     const wsmanNodePort = `2${Math.floor(Math.random()*1000)}`;
     const registryNodePort = `${30000 + Math.floor(Math.random()*1000)}`;
@@ -147,9 +147,9 @@ async function deployToDev(version) {
         werft.fail('authProviders', err);
     }
 
-    // // TODO [geropl] Now that the certs reside in a separate namespaces, start the actual certificate issuing _before_ the namespace cleanup
-    // werft.log('certificate', "organizing a certificate for the preview environment...");
-    // const certificatePromise = issueAndInstallCertficate(namespace, domain);
+    // TODO [geropl] Now that the certs reside in a separate namespaces, start the actual certificate issuing _before_ the namespace cleanup
+    werft.log('certificate', "organizing a certificate for the preview environment...");
+    const certificatePromise = issueAndInstallCertficate(namespace, domain);
 
     werft.log("predeploy cleanup", "removing old unnamespaced objects - this might take a while");
     try {
@@ -222,14 +222,14 @@ async function deployToDev(version) {
         exec(`werft log result -d "dev installation" -c github url ${url}/workspaces/`);
     }
 
-    // // Delay success until certificate is actually present
-    // werft.log('certificate', "awaiting promised certificate")
-    // try {
-    //     await certificatePromise;
-    //     werft.done('certificate');
-    // } catch (err) {
-    //     werft.fail('certificate', err);
-    // }
+    // Delay success until certificate is actually present
+    werft.log('certificate', "awaiting promised certificate")
+    try {
+        await certificatePromise;
+        werft.done('certificate');
+    } catch (err) {
+        werft.fail('certificate', err);
+    }
 }
 
 async function issueAndInstallCertficate(namespace, domain) {
@@ -253,7 +253,7 @@ async function issueAndInstallCertficate(namespace, domain) {
             break;
         }
 
-        sleep(3000);
+        sleep(5000);
     }
 
     werft.log('certificate', `copying certificate from "certs/${namespace}" to "${namespace}/proxy-config-certificates"`);

--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -6,11 +6,11 @@ installation:
   shortname: "dev"
 hostname: staging.gitpod-dev.com
 imagePrefix: eu.gcr.io/gitpod-core-dev/build/
-certificatesSecret: {}
-  # secretName: proxy-config-certificates
-  # fullChainName: tls.crt
-  # chainName: tls.crt
-  # keyName: tls.key
+certificatesSecret:
+  secretName: proxy-config-certificates
+  fullChainName: tls.crt
+  chainName: tls.crt
+  keyName: tls.key
 version: not-set
 affinity:
   nodeAffinity:


### PR DESCRIPTION
 - makes HTTPS + certs opt-in: The mechanism works, it just seems to be not very tolerant in case we hit either:
   - the general letsencrypt [rate limit (50 / week)](https://tools.letsdebug.net/cert-search?m=domain&q=gitpod-dev.com&d=168)
   - or we have too many [faulty validation requests](https://letsencrypt.org/docs/rate-limits/#failed-validations)
   Having it opt-in gives us better opportunity to reduce volume and do debugging
 - minor: after the repo-move the prefix stripping did not work anymore, rendering all preview envs with "gitpod-build-"