### PR TITLE
[server] Support deploy-time configuration of workspace feature flags

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           privileged: false
           runAsUser: 31001
         volumeMounts:
-{{- if .Values.components.server.storage }}
+{{- if $comp.storage }}
         - name: storage-key
           mountPath: "/storageKeySecret"
           readOnly: true
@@ -78,8 +78,8 @@ spec:
           mountPath: "/github-app-cert"
           readOnly: true
 {{- end }}
-{{- if .Values.components.server.serverContainer.volumeMounts }}
-{{ toYaml .Values.components.server.serverContainer.volumeMounts | indent 8 }}
+{{- if $comp.serverContainer.volumeMounts }}
+{{ toYaml $comp.serverContainer.volumeMounts | indent 8 }}
 {{- end }}
 {{ include "gitpod.container.defaultEnv" $this | indent 8 }}
 {{ include "gitpod.container.dbEnv" $this | indent 8 }}
@@ -129,13 +129,13 @@ spec:
         - name: MAKE_NEW_USERS_ADMIN
           value: {{ $comp.makeNewUsersAdmin | quote }}
     {{- end }}
-    {{- if .Values.components.server.portAccessForUsersOnly }}
+    {{- if $comp.portAccessForUsersOnly }}
         - name: PORT_ACCESS_FOR_USERS_ONLY
           value: "true"
     {{- end }}
-    {{- if .Values.components.server.sessionMaxAgeMs }}
+    {{- if $comp.sessionMaxAgeMs }}
         - name: SESSION_MAX_AGE_MS
-          value: {{ .Values.components.server.sessionMaxAgeMs | quote }}
+          value: {{ $comp.sessionMaxAgeMs | quote }}
     {{- end }}
         - name: SESSION_SECRET
           value: {{ $comp.sessionSecret | quote }}
@@ -157,9 +157,9 @@ spec:
         - name: LOCAL_THEIA
           value: "true"
     {{- end }}
-    {{- if .Values.components.server.theiaPluginsBucketName }}
+    {{- if $comp.theiaPluginsBucketName }}
         - name: THEIA_PLUGINS_BUCKET_NAME_OVERRIDE
-          value: {{ .Values.components.server.theiaPluginsBucketName }}
+          value: {{ $comp.theiaPluginsBucketName }}
     {{- end }}
     {{- if .Values.devBranch }}
         - name: DEV_BRANCH
@@ -171,6 +171,8 @@ spec:
           value: {{ index (include "ws-manager-list" $this | fromYaml) "manager" | default dict | toJson | b64enc | quote }}
         - name: GITPOD_BASEIMG_REGISTRY_WHITELIST
           value: {{ $comp.defaultBaseImageRegistryWhitelist | toJson | quote }}
+        - name: GITPOD_DEFAULT_FEATURE_FLAGS
+          value: {{ $comp.defaultFeatureFlags | toJson | quote }}
         - name: AUTH_PROVIDERS_CONFIG
           valueFrom:
             configMapKeyRef:
@@ -187,7 +189,7 @@ spec:
             secretKeyRef:
               name: server-proxy-apikey
               key: apikey
-{{- if (or .Values.components.wsSync.remoteStorage.gcloud .Values.components.server.storage) }}
+{{- if (or .Values.components.wsSync.remoteStorage.gcloud $comp.storage) }}
         - name: GCLOUD_PROJECT_ID
           value: {{ .Values.components.wsSync.remoteStorage.gcloud.projectId }}
         - name: GCLOUD_REGION
@@ -197,22 +199,22 @@ spec:
 {{- end }}
         - name: GITPOD_GARBAGE_COLLECTION_DISABLED
           value: {{ $comp.garbageCollection.disabled | default "false" | quote }}
-{{- if .Values.components.server.serverContainer.env }}
-{{ toYaml .Values.components.server.serverContainer.env | indent 8 }}
+{{- if $comp.serverContainer.env }}
+{{ toYaml $comp.serverContainer.env | indent 8 }}
 {{- end }}
       volumes:
-{{- if .Values.components.server.storage.secretName }}
+{{- if $comp.storage.secretName }}
       - name: storage-key
         secret:
-          secretName: {{ .Values.components.server.storage.secretName }}
+          secretName: {{ $comp.storage.secretName }}
 {{- end }}
 {{- if $comp.github.app }}
       - name: github-app-cert-secret
         secret:
           secretName: {{ $comp.github.app.appCert }}
 {{- end }}
-{{- if .Values.components.server.volumes }}
-{{ toYaml .Values.components.server.volumes | indent 6 }}
+{{- if $comp.volumes }}
+{{ toYaml $comp.volumes | indent 6 }}
 {{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -224,6 +224,7 @@ components:
     storage: {}
     wsman: []
     defaultBaseImageRegistryWhitelist: []
+    defaultFeatureFlags: []
     ports:
       http:
         expose: true

--- a/components/server/src/env.ts
+++ b/components/server/src/env.ts
@@ -11,7 +11,7 @@ import { AbstractComponentEnv, getEnvVar } from '@gitpod/gitpod-protocol/lib/env
 import { AuthProviderParams, parseAuthProviderParamsFromEnv } from './auth/auth-provider';
 
 import * as fs from "fs";
-import { Branding } from '@gitpod/gitpod-protocol';
+import { Branding, NamedWorkspaceFeatureFlag, WorkspaceFeatureFlags } from '@gitpod/gitpod-protocol';
 
 import { BrandingParser } from './branding-parser';
 
@@ -136,6 +136,20 @@ export class Env extends AbstractComponentEnv {
 
         return JSON.parse(wljson);
     })()
+
+    readonly defaultFeatureFlags: NamedWorkspaceFeatureFlag[] = (() => {
+        const json = process.env.GITPOD_DEFAULT_FEATURE_FLAGS;
+        if (!json) {
+            return [];
+        }
+
+        let r = JSON.parse(json);
+        if (!Array.isArray(r)) {
+            return [];
+        }
+        r = r.filter(e => e in WorkspaceFeatureFlags);
+        return r;
+    })();
 
     /** defaults to: false */
     readonly portAccessForUsersOnly: boolean = this.parsePortAccessForUsersOnly();

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -219,6 +219,7 @@ export class WorkspaceStarter {
         if (workspace.config.privileged) {
             featureFlags.push("privileged");
         }
+        featureFlags = featureFlags.concat(this.env.defaultFeatureFlags);
         if (user.featureFlags && user.featureFlags.permanentWSFeatureFlags) {
             featureFlags = featureFlags.concat(featureFlags, user.featureFlags.permanentWSFeatureFlags);
         }


### PR DESCRIPTION
This change makes feature flags configurable at deploy-time for the whole installation.
It introduces a new env var on server `GITPOD_DEFAULT_FEATURE_FLAGS` which contains a JSON formatted list of named feature flags, and exposes that list in helm at `components.server.defaultFeatureFlags`. For convenience's sake this env var can be set as build config named `ws-feature-flags`.

To test this PR: untick the two settings below and re-run the werft job. Now workspaces should start without using the registry facade (`mount | grep theia`).

- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https