### PR TITLE
[GitHub] Add stale.yml for GitHub stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,67 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  # Issues that we cannot process since the information from the reporter is not sufficient:
+  - reporter-feedback-needed
+  # Issues that were probably solved by a comment and which will not be processed further as long as the reporter does not get in touch again:
+  - solved
+  # Issues that are not Gitpod issues in the strict sense and that are not pursued further:
+  - not-a-gitpod-issue
+  # Issues that should be discussed at community.gitpod.io instead:
+  - ask-the-community
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
This PR adds configuration for the stale bot (https://github.com/probot/stale) to this repository. After merging, the bot needs to be installed here: https://github.com/marketplace/stale

With this PR I propose the following configuration:

- Only issues with the following labels will be processed by this bot _(feel free to propose any kind of changes to this labels list)_:
  - **reporter-feedback-needed**: Issues that we cannot process since the information from the reporter is not sufficient.
  - **solved**: Issues that were probably solved by a comment and which will not be processed further as long as the reporter does not get in touch again.
  - **not-a-gitpod-issue**: Issues that are not Gitpod issues in the strict sense and that are not pursued further.
  - **ask-the-community**: Issues that should be discussed at community.gitpod.io instead.
- Issues become stale with one of the labels above and inactivity of 30 days. After 7 more days these will be closed.
- Issues with the label `pinned` will never be considered stale.