### PR TITLE
[Gitpod k3s] Add process group killing to tini in k3s Docker containers

### DIFF
--- a/install/docker/examples/gitpod-gitlab/gitlab/Dockerfile
+++ b/install/docker/examples/gitpod-gitlab/gitlab/Dockerfile
@@ -10,4 +10,4 @@ COPY gitlab-helm-installer.yaml /var/lib/rancher/k3s/server/manifests/
 
 COPY entrypoint.sh /entrypoint
 
-ENTRYPOINT [ "/tini", "--", "/entrypoint" ]
+ENTRYPOINT [ "/tini", "-g", "--", "/entrypoint" ]

--- a/install/docker/gitpod-image/Dockerfile
+++ b/install/docker/gitpod-image/Dockerfile
@@ -17,4 +17,4 @@ COPY chart--helm/gitpod /chart
 
 COPY entrypoint.sh /entrypoint
 
-ENTRYPOINT [ "/tini", "--", "/entrypoint" ]
+ENTRYPOINT [ "/tini", "-g", "--", "/entrypoint" ]


### PR DESCRIPTION
Without this, docker stop does not work well because sub processes are not killed.

see https://github.com/krallin/tini#process-group-killing

/werft no-preview