### PR TITLE
Fix user env variables for GitLab repos in subgroups

### DIFF
--- a/components/dashboard/src/components/user-env-vars.tsx
+++ b/components/dashboard/src/components/user-env-vars.tsx
@@ -206,7 +206,7 @@ class UserEnvVarComponent extends React.Component<UserEnvVarComponentProps, User
             return 'Must not be empty.';
         }
         const split = pattern.split('/');
-        if (split.length !== 2) {
+        if (split.length < 2) {
             return "Please use the form 'organization/repo'.";
         }
         for (const name of split) {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -149,13 +149,12 @@ export interface UserEnvVar extends UserEnvVarValue {
 export namespace UserEnvVar {
 
     export function normalizeRepoPattern(pattern: string) {
-        const [owner, repo] = pattern.split('/');
-        return `${owner.toLocaleLowerCase()}/${repo.toLocaleLowerCase()}`;
+        return pattern.toLocaleLowerCase();
     }
 
     export function filter<T extends UserEnvVarValue>(vars: T[], owner: string, repo: string): T[] {
         let result = vars.filter(e => {
-            const [ownerPattern, repoPattern] = e.repositoryPattern.split('/');
+            const [ownerPattern, repoPattern] = splitRepositoryPattern(e.repositoryPattern);
             if (ownerPattern !== '*' && ownerPattern !== '#' && (!!owner && ownerPattern !== owner.toLocaleLowerCase())) {
                 return false;
             }
@@ -195,7 +194,7 @@ export namespace UserEnvVar {
                 //      */*         = 3
                 //      #/#         = 4 (used for env vars passed through the URL)
                 // the lower the score, the higher the precedence.
-                const [ownerPattern, repoPattern] = e.repositoryPattern.split('/');
+                const [ownerPattern, repoPattern] = splitRepositoryPattern(e.repositoryPattern);
                 let score = 0;
                 if (repoPattern == "*") {
                     score += 1;
@@ -216,6 +215,13 @@ export namespace UserEnvVar {
         }
 
         return result;
+    }
+
+    function splitRepositoryPattern(repositoryPattern: string): string[] {
+        const patterns = repositoryPattern.split('/');
+        const repoPattern = patterns.pop() || "";
+        const ownerPattern = patterns.join('/');
+        return [ownerPattern, repoPattern];
     }
 }
 


### PR DESCRIPTION
This allows projects like 'foo/bar/baz' where 'foo/bar' is the owner and 'baz' the user.

Assuming this repo: https://gitlab.com/gp-test-group/gp-test-subgroup/gp-test-project-in-subgroup
```
owner: gp-test-group/gp-test-subgroup
repo:  gp-test-project-in-subgroup
```

These repo patterns work:
```
*/*
gp-test-group/gp-test-subgroup/gp-test-project-in-subgroup
gp-test-group/gp-test-subgroup/*
*/gp-test-project-in-subgroup
```

These do _not_ work (for the given project):
```
gp-test-group/*
gp-test-group/*/gp-test-project-in-subgroup
*/gp-test-subgroup/gp-test-project-in-subgroup
```

### How to test

- Set environment variables on http://corneliusludmann-environment-variables-1358.staging.gitpod-dev.com/settings/, e.g. for the repo patterns listed above
- Open the repo and make sure that the env vars are there.
- Run `gp env FOO=bar` and check that the env var is listed on the settings page.


### Corresponding issue
Issue: https://github.com/gitpod-io/gitpod/issues/1358