### PR TITLE
[build] Only build installer when with-installer is set or master builds

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -22,9 +22,6 @@ packages:
       - components/ws-manager:docker
       - components/ws-proxy:docker
       - components/ws-sync:docker
-      - install/installer:docker
-      - install/docker/gitpod-image:docker
-      - install/docker/examples/gitpod-gitlab/gitlab:docker
   - name: all-apps
     type: generic
     deps:

--- a/install/BUILD.yaml
+++ b/install/BUILD.yaml
@@ -1,0 +1,9 @@
+packages:
+  - name: all
+    type: generic
+    argdeps:
+      - version
+    deps:
+      - install/installer:docker
+      - install/docker/gitpod-image:docker
+      - install/docker/examples/gitpod-gitlab/gitlab:docker


### PR DESCRIPTION
because the installer build just adds a minute or two to each build, when it's solely needed.

- [ ] /werft with-installer