### PR TITLE
[ws-manager] Control entrypoint

### DIFF
--- a/chart/templates/node-daemon-daemonset.yaml
+++ b/chart/templates/node-daemon-daemonset.yaml
@@ -72,7 +72,7 @@ spec:
         - --copy-to
         - /mnt/theia-storage/theia/theia-{{ .Values.version }}
         - -d
-        - /theia
+        - /ide
         securityContext:
           privileged: true
         resources:

--- a/chart/templates/registry-facade-configmap.yaml
+++ b/chart/templates/registry-facade-configmap.yaml
@@ -52,7 +52,7 @@ data:
             "repos": {
                 "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.theiaImage) }}": {
                     "prePull": ["{{- template "gitpod.comp.version" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.theiaImage) -}}"],
-                    "workdir": "/theia/node_modules/@gitpod/gitpod-ide/lib"
+                    "workdir": "/ide/node_modules/@gitpod/gitpod-ide/lib"
                 },
                 "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}": {
                     "prePull": ["{{- template "gitpod.comp.version" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) -}}"],

--- a/components/image-builder/workspace-image-layer/gitpod-layer/alpine/Dockerfile
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/alpine/Dockerfile
@@ -32,8 +32,3 @@ RUN \
     cat /var/gitpod/.bashrc-prepend > "$BASH_RC"                            && \
     cat ~/.bashrc-org >> "$BASH_RC"                                         && \
     cat /var/gitpod/.bashrc-append >> "$BASH_RC"
-
-# This is necessary to override potential entrypoints in the base image which otherwise would have control over the startup process
-# In most cases the workspace start just fails
-ENTRYPOINT ["/theia/supervisor"]
-CMD ["run"]

--- a/components/image-builder/workspace-image-layer/gitpod-layer/amazon/Dockerfile
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/amazon/Dockerfile
@@ -36,9 +36,3 @@ RUN \
 	cat /var/gitpod/.bashrc-prepend > "$BASH_RC"                            && \
 	cat ~/.bashrc-org >> "$BASH_RC"                                         && \
 	cat /var/gitpod/.bashrc-append >> "$BASH_RC"
-
-# This is necessary to override potential entrypoints in the base image which otherwise would have control over the startup process
-# In most cases the workspace start just fails
-# FIXME(Kreyren): This is a duplicate code that should be present in all distros
-ENTRYPOINT ["/theia/supervisor"]
-CMD ["run"]

--- a/components/image-builder/workspace-image-layer/gitpod-layer/debian/Dockerfile
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/debian/Dockerfile
@@ -32,8 +32,3 @@ RUN \
     cat /var/gitpod/.bashrc-prepend > "$BASH_RC"                            && \
     cat ~/.bashrc-org >> "$BASH_RC"                                         && \
     cat /var/gitpod/.bashrc-append >> "$BASH_RC"
-
-# This is necessary to override potential entrypoints in the base image which otherwise would have control over the startup process
-# In most cases the workspace start just fails
-ENTRYPOINT ["/theia/supervisor"]
-CMD ["run"]

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -5,6 +5,7 @@ packages:
       - "**/*.go"
       - "go.mod"
       - "go.sum"
+      - "supervisor-config.json"
     deps:
       - components/common-go:lib
       - components/content-service-api/go:lib

--- a/components/theia/app/leeway.Dockerfile
+++ b/components/theia/app/leeway.Dockerfile
@@ -6,50 +6,50 @@
 ################ Alpine ####################
 # copy nodejs from the official alpine-based image because of https://github.com/TypeFox/gitpod/issues/2579
 FROM node:12.18.3-alpine AS node_installer
-RUN mkdir -p /theia/node/bin \
-             /theia/node/include/node/ \
-             /theia/node/lib/node_modules/npm/ \
-             /theia/node/lib/ && \
-    cp -a  /usr/local/bin/node              /theia/node/bin/ && \
-    cp -a  /usr/local/bin/npm               /theia/node/bin/ && \
-    cp -a  /usr/local/bin/npx               /theia/node/bin/ && \
-    cp -ar /usr/local/include/node/         /theia/node/include/ && \
-    cp -ar /usr/local/lib/node_modules/npm/ /theia/node/lib/node_modules/
+RUN mkdir -p /ide/node/bin \
+             /ide/node/include/node/ \
+             /ide/node/lib/node_modules/npm/ \
+             /ide/node/lib/ && \
+    cp -a  /usr/local/bin/node              /ide/node/bin/ && \
+    cp -a  /usr/local/bin/npm               /ide/node/bin/ && \
+    cp -a  /usr/local/bin/npx               /ide/node/bin/ && \
+    cp -ar /usr/local/include/node/         /ide/node/include/ && \
+    cp -ar /usr/local/lib/node_modules/npm/ /ide/node/lib/node_modules/
 
 FROM alpine:3.9 AS builder_alpine
 
 RUN apk add --no-cache bash gcc g++ make pkgconfig python libc6-compat libexecinfo-dev git patchelf findutils
 
 # install node
-COPY --from=node_installer /theia/node/ /theia/node/
-ENV PATH=$PATH:/theia/node/bin/
+COPY --from=node_installer /ide/node/ /ide/node/
+ENV PATH=$PATH:/ide/node/bin/
 
-# install yarn by download+unpack to ensure it does NOT put anything into /theia/node/
+# install yarn by download+unpack to ensure it does NOT put anything into /ide/node/
 RUN wget https://github.com/yarnpkg/yarn/releases/download/v1.15.2/yarn-v1.15.2.tar.gz
 RUN tar zvxf yarn-v1.15.2.tar.gz
 ENV PATH=$PATH:/yarn-v1.15.2/bin/
 
 COPY components-theia-app--installer /theia-installer
-WORKDIR /theia
+WORKDIR /ide/
 RUN /theia-installer/install.sh
 
 # copy native dependencies of node
 COPY package-libs.sh /usr/bin/
-RUN package-libs.sh /theia/node/bin/node
+RUN package-libs.sh /ide/node/bin/node
 
 # copy native dependencies of node modules
-RUN find /theia/node_modules/ -iname *.node -exec package-libs.sh {} \;
+RUN find /ide/node_modules/ -iname *.node -exec package-libs.sh {} \;
 
-RUN cp /theia/node/bin/node /theia/node/bin/gitpod-node && rm /theia/node/bin/node
+RUN cp /ide/node/bin/node /ide/node/bin/gitpod-node && rm /ide/node/bin/node
+RUN cp /ide/node_modules/@gitpod/gitpod-ide/startup.sh /ide/startup.sh
 
 FROM scratch
-COPY --from=builder_alpine /theia/ /theia/
+COPY --from=builder_alpine /ide/ /ide/
 
-ENV GITPOD_BUILT_IN_PLUGINS /theia/node_modules/@gitpod/gitpod-ide/plugins/
+ENV GITPOD_BUILT_IN_PLUGINS /ide/node_modules/@gitpod/gitpod-ide/plugins/
 COPY components-theia-app--builtin-plugins/plugins/ ${GITPOD_BUILT_IN_PLUGINS}
 
-COPY components-supervisor--app/supervisor /theia/supervisor
-COPY supervisor-config.json /theia/
+WORKDIR "/.supervisor"
+COPY components-supervisor--app/supervisor components-supervisor--app/supervisor-config.json /.supervisor/
 
-WORKDIR "/theia"
-ENTRYPOINT ["/theia/supervisor"]
+WORKDIR "/ide"

--- a/components/theia/app/package-libs.sh
+++ b/components/theia/app/package-libs.sh
@@ -17,7 +17,7 @@
 # This allows to have self-contained and thereby portable linux executables.
 
 BINARY=$1
-DST=/theia/node/lib/
+DST=/ide/node/lib/
 
 echo "$BINARY: Starting rewiring libs to $DST"
 

--- a/components/theia/app/startup.sh
+++ b/components/theia/app/startup.sh
@@ -30,5 +30,5 @@ export USER=gitpod
 [ -s /home/gitpod/.sdkman/bin/sdkman-init.sh ] && [ -z "$SDKMAN_VERSION" ] && source "/home/gitpod/.sdkman/bin/sdkman-init.sh"
 [ -s ~/.nvm/nvm-lazy.sh ] && source ~/.nvm/nvm-lazy.sh
 
-cd /theia/node_modules/@gitpod/gitpod-ide
-exec /theia/node/bin/gitpod-node ./src-gen/backend/main.js $*
+cd /ide/node_modules/@gitpod/gitpod-ide
+exec /ide/node/bin/gitpod-node ./src-gen/backend/main.js $*

--- a/components/theia/static-server/leeway.Dockerfile
+++ b/components/theia/static-server/leeway.Dockerfile
@@ -7,5 +7,5 @@ ARG BASE
 FROM ${BASE}
 
 COPY components-theia-static-server--app/static-server /server
-WORKDIR /theia/node_modules/@gitpod/gitpod-ide/lib
+WORKDIR /ide/node_modules/@gitpod/gitpod-ide/lib
 ENTRYPOINT [ "/server" ]

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -509,7 +509,8 @@ func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) 
 			SuccessThreshold: 1,
 			TimeoutSeconds:   1,
 		},
-		Env: env,
+		Env:     env,
+		Command: []string{"/.supervisor/supervisor", "run"},
 	}, nil
 }
 

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -378,7 +378,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 				pod.Spec.Containers[i].Lifecycle = &corev1.Lifecycle{
 					PreStop: &corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: []string{"/theia/supervisor", "container", "backup"},
+							Command: []string{"/.supervisor/supervisor", "container", "backup"},
 						},
 					},
 				}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -51,6 +51,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -36,6 +36,10 @@
                 {
                     "name": "workspace",
                     "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -133,7 +133,7 @@
                         "preStop": {
                             "exec": {
                                 "command": [
-                                    "/theia/supervisor",
+                                    "/.supervisor/supervisor",
                                     "container",
                                     "backup"
                                 ]

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_privileged.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_privileged.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
@@ -43,6 +43,10 @@
                 {
                     "name": "workspace",
                     "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -51,6 +51,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000


### PR DESCRIPTION
Until now we've relied on the gitpod layer to determine the entry point of a workspace.
With supervisor becoming mandatory for all workspaces, this PR enforces that behaviour by making ws-manager control the workspace container's entrypoint/command.

It also makes Theia compatible with the new layout supervisor expects.