### PR TITLE
[ws-manager] Control workspace container command

### DIFF
--- a/components/image-builder/workspace-image-layer/gitpod-layer/alpine/Dockerfile
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/alpine/Dockerfile
@@ -32,8 +32,3 @@ RUN \
     cat /var/gitpod/.bashrc-prepend > "$BASH_RC"                            && \
     cat ~/.bashrc-org >> "$BASH_RC"                                         && \
     cat /var/gitpod/.bashrc-append >> "$BASH_RC"
-
-# This is necessary to override potential entrypoints in the base image which otherwise would have control over the startup process
-# In most cases the workspace start just fails
-ENTRYPOINT ["/theia/supervisor"]
-CMD ["run"]

--- a/components/image-builder/workspace-image-layer/gitpod-layer/amazon/Dockerfile
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/amazon/Dockerfile
@@ -36,9 +36,3 @@ RUN \
 	cat /var/gitpod/.bashrc-prepend > "$BASH_RC"                            && \
 	cat ~/.bashrc-org >> "$BASH_RC"                                         && \
 	cat /var/gitpod/.bashrc-append >> "$BASH_RC"
-
-# This is necessary to override potential entrypoints in the base image which otherwise would have control over the startup process
-# In most cases the workspace start just fails
-# FIXME(Kreyren): This is a duplicate code that should be present in all distros
-ENTRYPOINT ["/theia/supervisor"]
-CMD ["run"]

--- a/components/image-builder/workspace-image-layer/gitpod-layer/debian/Dockerfile
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/debian/Dockerfile
@@ -32,8 +32,3 @@ RUN \
     cat /var/gitpod/.bashrc-prepend > "$BASH_RC"                            && \
     cat ~/.bashrc-org >> "$BASH_RC"                                         && \
     cat /var/gitpod/.bashrc-append >> "$BASH_RC"
-
-# This is necessary to override potential entrypoints in the base image which otherwise would have control over the startup process
-# In most cases the workspace start just fails
-ENTRYPOINT ["/theia/supervisor"]
-CMD ["run"]

--- a/components/supervisor/supervisor-config.json
+++ b/components/supervisor/supervisor-config.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "/ide/startup.sh",
   "theiaPort": 23000,
-  "healthEndpoint": ":22999",
+  "apiEndpointPort": 22999,
   "frontendLocation": "/.supervisor/frontend/"
 }

--- a/components/theia/app/leeway.Dockerfile
+++ b/components/theia/app/leeway.Dockerfile
@@ -45,11 +45,14 @@ RUN cp /theia/node/bin/node /theia/node/bin/gitpod-node && rm /theia/node/bin/no
 FROM scratch
 COPY --from=builder_alpine /theia/ /theia/
 
+# standard supervisor entrypoint used when supervisor isn't coming from this image
+WORKDIR /ide/
+COPY --from=builder_alpine /theia/node_modules/@gitpod/gitpod-ide/startup.sh /ide/
+
 ENV GITPOD_BUILT_IN_PLUGINS /theia/node_modules/@gitpod/gitpod-ide/plugins/
 COPY components-theia-app--builtin-plugins/plugins/ ${GITPOD_BUILT_IN_PLUGINS}
 
+# supervisor is still needed here to work without registry-facade
+# TODO(cw): remove once registry-facade is standard
 COPY components-supervisor--app/supervisor /theia/supervisor
 COPY supervisor-config.json /theia/
-
-WORKDIR "/theia"
-ENTRYPOINT ["/theia/supervisor"]

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -378,7 +378,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 				pod.Spec.Containers[i].Lifecycle = &corev1.Lifecycle{
 					PreStop: &corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: []string{"/theia/supervisor", "container", "backup"},
+							Command: []string{"/.supervisor/supervisor", "container", "backup"},
 						},
 					},
 				}
@@ -391,6 +391,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			for i, c := range pod.Spec.Containers {
 				if c.Name == "workspace" {
 					pod.Spec.Containers[i].Image = image
+					pod.Spec.Containers[i].Command = []string{"/.supervisor/supervisor", "run"}
 				}
 			}
 
@@ -509,7 +510,8 @@ func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) 
 			SuccessThreshold: 1,
 			TimeoutSeconds:   1,
 		},
-		Env: env,
+		Env:     env,
+		Command: []string{"/theia/supervisor", "run"},
 	}, nil
 }
 

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -51,6 +51,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -36,6 +36,10 @@
                 {
                     "name": "workspace",
                     "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000
@@ -129,7 +133,7 @@
                         "preStop": {
                             "exec": {
                                 "command": [
-                                    "/theia/supervisor",
+                                    "/.supervisor/supervisor",
                                     "container",
                                     "backup"
                                 ]

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_privileged.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_privileged.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
@@ -43,6 +43,10 @@
                 {
                     "name": "workspace",
                     "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -50,6 +50,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -51,6 +51,10 @@
                 {
                     "name": "workspace",
                     "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
                     "ports": [
                         {
                             "containerPort": 23000


### PR DESCRIPTION
Until now we've relied on the gitpod layer to determine the entry point of a workspace.
With supervisor becoming mandatory for all workspaces, this PR enforces that behaviour by making ws-manager control the workspace container's entrypoint/command.

It also makes Theia compatible with the new layout supervisor expects.

/werft ws-feature-flags=registry_facade
/werft https