### PR TITLE
Harmonize server api

### DIFF
--- a/components/dashboard/ee/src/admin.tsx
+++ b/components/dashboard/ee/src/admin.tsx
@@ -27,7 +27,7 @@ export interface AdminIndexProps {
 export const AdminIndex: React.SFC<AdminIndexProps | undefined> = (_props: AdminIndexProps) => {
     const props = _props || {};
     const service = createGitpodService();
-    service.server.getLoggedInUser().catch(e => {
+    service.server.getLoggedInUser({}).catch(e => {
         console.error(e);
         window.location.href = new GitpodHostUrl(window.location.toString()).asDashboard().toString();
     });

--- a/components/dashboard/ee/src/components/admin/user-view.tsx
+++ b/components/dashboard/ee/src/components/admin/user-view.tsx
@@ -57,9 +57,9 @@ export class UserView extends React.Component<UserViewProps, UserViewState> {
 
     async componentDidMount() {
         try {
-            const loggedInUser = await this.props.service.server.getLoggedInUser();
+            const loggedInUser = await this.props.service.server.getLoggedInUser({});
             const [ user ] = await Promise.all([
-                this.props.service.server.adminGetUser(this.props.userID)
+                this.props.service.server.adminGetUser({id: this.props.userID})
             ]);
             this.setState({user, ourself: loggedInUser.id === this.props.userID});
         } catch (err) {

--- a/components/dashboard/ee/src/components/admin/workspace-view.tsx
+++ b/components/dashboard/ee/src/components/admin/workspace-view.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import { GitpodService, WorkspaceAndInstance } from '@gitpod/gitpod-protocol';
+import { GitpodService, AdminServer } from '@gitpod/gitpod-protocol';
 import Typography from '@material-ui/core/Typography';
 import Table from '@material-ui/core/Table';
 import TableRow from '@material-ui/core/TableRow';
@@ -23,13 +23,13 @@ export interface WorkspaceViewProps {
 }
 
 interface WorkspaceViewState {
-    workspace?: WorkspaceAndInstance;
+    workspace?: AdminServer.WorkspaceAndInstance;
 }
 
 interface DetailRowSpec {
     name: string;
-    actions?: (u: WorkspaceAndInstance) => JSX.Element;
-    render?: (u: WorkspaceAndInstance) => any;
+    actions?: (u: AdminServer.WorkspaceAndInstance) => JSX.Element;
+    render?: (u: AdminServer.WorkspaceAndInstance) => any;
 }
 
 export class WorkspaceView extends React.Component<WorkspaceViewProps, WorkspaceViewState> {
@@ -41,7 +41,7 @@ export class WorkspaceView extends React.Component<WorkspaceViewProps, Workspace
 
     async componentDidMount() {
         try {
-            const workspace = await this.props.service.server.adminGetWorkspace(this.props.workspaceID);
+            const workspace = await this.props.service.server.adminGetWorkspace({workspaceId: this.props.workspaceID});
             this.setState({workspace});
         } catch (err) {
             var rerr: ResponseError<any> = err;
@@ -57,7 +57,7 @@ export class WorkspaceView extends React.Component<WorkspaceViewProps, Workspace
 
     render() {
         const workspace = this.state.workspace;
-        const fields: { [P in keyof Partial<WorkspaceAndInstance>]: DetailRowSpec } = {
+        const fields: { [P in keyof Partial<AdminServer.WorkspaceAndInstance>]: DetailRowSpec } = {
             workspaceId: { 
                 name: "ID" 
             },

--- a/components/dashboard/ee/src/components/admin/workspaces-view.tsx
+++ b/components/dashboard/ee/src/components/admin/workspaces-view.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import { GitpodService, WorkspaceAndInstance } from '@gitpod/gitpod-protocol';
+import { GitpodService, AdminServer } from '@gitpod/gitpod-protocol';
 import { DataTable, SearchSpec, ColSpec } from './datatable';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import Link from '@material-ui/core/Link';
@@ -19,7 +19,7 @@ export interface WorkspacesViewProps {
 }
 
 export const WorkspacesView: React.SFC<WorkspacesViewProps> = props => {
-    const update = async (q: SearchSpec<WorkspaceAndInstance>) => {
+    const update = async (q: SearchSpec<AdminServer.WorkspaceAndInstance>) => {
         try {
             return props.service.server.adminGetWorkspaces({
                 limit: q.rowsPerPage,
@@ -40,7 +40,7 @@ export const WorkspacesView: React.SFC<WorkspacesViewProps> = props => {
             throw err;
         }
     }
-    const columns: ColSpec<WorkspaceAndInstance>[] = [
+    const columns: ColSpec<AdminServer.WorkspaceAndInstance>[] = [
         {
             header: "ID",
             property: "workspaceId",
@@ -73,7 +73,7 @@ export const WorkspacesView: React.SFC<WorkspacesViewProps> = props => {
         })
     }
 
-    return <DataTable<WorkspaceAndInstance> 
+    return <DataTable<AdminServer.WorkspaceAndInstance> 
         columns={columns} 
         defaultOrderCol="instanceCreationTime" 
         defaultOrderDir="desc"

--- a/components/dashboard/ee/src/components/license/index.tsx
+++ b/components/dashboard/ee/src/components/license/index.tsx
@@ -59,7 +59,7 @@ export class License extends React.Component<LicenseProps, LicenseState> {
         })();
     }
     protected async updateLicense() {
-        const { isAdmin, licenseInfo } = await this.props.service.server.getLicenseInfo();
+        const { isAdmin, licenseInfo } = await this.props.service.server.getLicenseInfo({});
         this.setState({
             isAdmin,
             licenseInfo
@@ -171,7 +171,7 @@ export class License extends React.Component<LicenseProps, LicenseState> {
         if (!newKey) {
             return;
         }
-        await this.props.service.server.adminSetLicense(newKey);
+        await this.props.service.server.adminSetLicense({key: newKey});
         this.setState({ newKey: undefined });
         await this.updateLicense();
     };

--- a/components/dashboard/ee/src/license.tsx
+++ b/components/dashboard/ee/src/license.tsx
@@ -13,5 +13,5 @@ import { License, LicenseProps } from "./components/license";
 export { License, LicenseProps };
 
 const service = createGitpodService();
-const user = service.server.getLoggedInUser();
+const user = service.server.getLoggedInUser({});
 renderEntrypoint(License, { service, user });

--- a/components/dashboard/src/browser-extension-detection.ts
+++ b/components/dashboard/src/browser-extension-detection.ts
@@ -14,13 +14,13 @@ export namespace browserExtension {
     const cookieName = 'user-platform';
 
     export async function getUserPlatform(service: GitpodService): Promise<UserPlatform | undefined> {
-        const user = await service.server.getLoggedInUser();
+        const user = await service.server.getLoggedInUser({});
         const uid = Cookies.get(cookieName);
         return user.additionalData && user.additionalData.platforms && user.additionalData.platforms.find(p => p.uid === uid);
     }
 
     export async function updatePlatformInformation(service: GitpodService): Promise<void> {
-        const user = await service.server.getLoggedInUser();
+        const user = await service.server.getLoggedInUser({});
         const now = new Date().toISOString();
         let uid: string | undefined = Cookies.get(cookieName);
         const parser = new UAParser();
@@ -80,7 +80,7 @@ export namespace browserExtension {
         }
 
         // update user data
-        service.server.updateLoggedInUser({ additionalData: user.additionalData });
+        service.server.updateLoggedInUser({ user: { additionalData: user.additionalData } });
         Cookies.set(cookieName, uid!, { expires: 365 });
     }
 

--- a/components/dashboard/src/components/access-control/access-control.tsx
+++ b/components/dashboard/src/components/access-control/access-control.tsx
@@ -44,7 +44,7 @@ interface AccessControlProps {
 
 export class AccessControl extends React.Component<AccessControlProps, AccessControlState> {
 
-    protected authProvidersPromise = this.props.service.server.getAuthProviders();
+    protected authProvidersPromise = this.props.service.server.getAuthProviders({});
 
     constructor(props: AccessControlProps) {
         super(props);
@@ -59,7 +59,7 @@ export class AccessControl extends React.Component<AccessControlProps, AccessCon
 
     protected async onLoad(): Promise<void> {
         try {
-            const [authProviders, user] = await Promise.all([this.authProvidersPromise, this.props.service.server.getLoggedInUser()]);
+            const [authProviders, user] = await Promise.all([this.authProvidersPromise, this.props.service.server.getLoggedInUser({})]);
             const oldScopes = await this.getOldScopes(authProviders);
             const newScopes = this.addNewScopesFromQuery(authProviders, this.clone(oldScopes));
             const notification = this.getNotificationsFromQuery(authProviders);

--- a/components/dashboard/src/components/api-tokens.tsx
+++ b/components/dashboard/src/components/api-tokens.tsx
@@ -60,7 +60,9 @@ export class ApiTokenView extends React.Component<ApiTokenViewProps, ApiTokenVie
     }
 
     protected async hasApiPermission() {
-        return this.props.service.server.hasPermission(Permission.ADMIN_API);
+        return this.props.service.server.hasPermission({
+            permission: Permission.ADMIN_API,
+        });
     }
 
     render() {
@@ -184,7 +186,7 @@ export class ApiTokenView extends React.Component<ApiTokenViewProps, ApiTokenVie
 
     protected async deleteToken(tokenHash: string) {
         try {
-            await this.props.service.server.deleteGitpodToken(tokenHash);
+            await this.props.service.server.deleteGitpodToken({tokenHash});
             await this.updateTokens();
         } catch (e) {
             this.setState({error: e.toString(), showDialog: "error"});
@@ -208,7 +210,7 @@ export class ApiTokenView extends React.Component<ApiTokenViewProps, ApiTokenVie
     }
 
     protected async updateTokens() {
-        const tokens = ((await this.props.service.server.getGitpodTokens())||[]).filter(token => token.type === GitpodTokenType.API_AUTH_TOKEN);
+        const tokens = ((await this.props.service.server.getGitpodTokens({}))||[]).filter(token => token.type === GitpodTokenType.API_AUTH_TOKEN);
         this.setState({ tokens });
     }
 }

--- a/components/dashboard/src/components/auth-providers.tsx
+++ b/components/dashboard/src/components/auth-providers.tsx
@@ -80,7 +80,7 @@ export class AuthProviders extends React.Component<AuthProvidersProps, AuthProvi
         if (!this.noUserMode && !this.props.user) {
             return;
         }
-        const ownAuthProviders = await this.props.service.server.getOwnAuthProviders();
+        const ownAuthProviders = await this.props.service.server.getOwnAuthProviders({});
         this.setState({ ownAuthProviders });
     }
 

--- a/components/dashboard/src/components/create/create-workspace.tsx
+++ b/components/dashboard/src/components/create/create-workspace.tsx
@@ -115,7 +115,7 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
 
     protected pollWorkspacePrebuild(pwsid: string) {
         this.timeout = setInterval(async () => {
-            const isAvailable = await this.props.service.server.isPrebuildAvailable(pwsid);
+            const isAvailable = await this.props.service.server.isPrebuildAvailable({ pwsid });
             if (!isAvailable) {
                 return;
             }

--- a/components/dashboard/src/components/create/index.tsx
+++ b/components/dashboard/src/components/create/index.tsx
@@ -37,7 +37,7 @@ export async function start(Component: React.ComponentType<CreateWorkspaceProps>
     }
     async function showWelcome(_contextUrl?: string) {
         const moveOn = new Deferred<void>();
-        service.server.getLoggedInUser().then(user => {
+        service.server.getLoggedInUser({}).then(user => {
             // when logged in proceed, just in case the cookie was deleted manually
             if (user) {
                 moveOn.resolve();
@@ -57,7 +57,7 @@ export async function start(Component: React.ComponentType<CreateWorkspaceProps>
             return redirectNotAuthenticated(service);
         }
         try {
-            await service.server.getLoggedInUser();
+            await service.server.getLoggedInUser({});
             // if logged in without context -> go to workspaces
             window.location.href = getWorkspacesUrl();
             return;

--- a/components/dashboard/src/components/delete-account-view.tsx
+++ b/components/dashboard/src/components/delete-account-view.tsx
@@ -112,14 +112,14 @@ export class DeleteAccountView extends React.Component<DeleteAccountViewProps, D
     }
 
     protected async getUsername() {
-        const user = await this.props.service.server.getLoggedInUser();
+        const user = await this.props.service.server.getLoggedInUser({});
         this.setState({ username: user.name });
     }
 
     protected async deleteAccount() {
         this.setState({ status: "in-progress" });
         try {
-            await this.props.service.server.deleteAccount();
+            await this.props.service.server.deleteAccount({});
 
             this.setState({ status: "done" });
         } catch (err) {

--- a/components/dashboard/src/components/github/install-github-app.tsx
+++ b/components/dashboard/src/components/github/install-github-app.tsx
@@ -54,7 +54,7 @@ export class InstallGithubApp extends React.Component<{}, InstallGithubAppState>
 
     async componentWillMount() {
         try {
-            await this.service.server.getLoggedInUser();
+            await this.service.server.getLoggedInUser({});
             this.setState({ isLoggedIn: true });
         } catch (e) {
             if (e instanceof ResponseError) {
@@ -163,7 +163,7 @@ export class InstallGithubApp extends React.Component<{}, InstallGithubAppState>
 
     protected async registerApp(installationId: string) {
         try {
-            await this.service.server.registerGithubApp(installationId);
+            await this.service.server.registerGithubApp({installationId});
 
             const thisUrl = new GitpodHostUrl(new URL(window.location.toString()));
             const returnTo = encodeURIComponent(thisUrl.with({ search: `installation_id=${installationId}&done=true` }).toString());

--- a/components/dashboard/src/components/license-check.tsx
+++ b/components/dashboard/src/components/license-check.tsx
@@ -25,7 +25,7 @@ export class LicenseCheck extends React.Component<LicenseCheckProps, LicenseChec
     }
 
     public async componentWillMount() {
-        this.setState({ result: await this.props.service.validateLicense() });
+        this.setState({ result: await this.props.service.validateLicense({}) });
     }
 
     public render() {

--- a/components/dashboard/src/components/page-frame.tsx
+++ b/components/dashboard/src/components/page-frame.tsx
@@ -47,10 +47,10 @@ export class ApplicationFrame extends React.Component<ApplicationProps, Applicat
             return;
         }
         const server = this.props.service.server;
-        const userPromise = this.props.userPromise || server.getLoggedInUser();
+        const userPromise = this.props.userPromise || server.getLoggedInUser({});
         const [user, authProviders] = await Promise.all([
             userPromise.catch(log.error),
-            server.getAuthProviders().catch(log.error),
+            server.getAuthProviders({}).catch(log.error),
         ]);
         this.setState({
             user: user || undefined,

--- a/components/dashboard/src/components/repositories.tsx
+++ b/components/dashboard/src/components/repositories.tsx
@@ -37,9 +37,9 @@ export class FeaturedRepositories extends React.Component<FeaturedRepositoryProp
 		this.disposables.dispose();
 	}
 
-	private async updateRepositoryList(options?: GitpodServer.GetWorkspacesOptions) {
+	private async updateRepositoryList(options?: GitpodServer.GetWorkspacesParams) {
 		try {
-			const repositories = await this.props.service.server.getFeaturedRepositories();
+			const repositories = await this.props.service.server.getFeaturedRepositories({});
 			this.setState({ repositories });
 		} catch (err) {
 			log.error(err);

--- a/components/dashboard/src/components/running-prebuild-view.tsx
+++ b/components/dashboard/src/components/running-prebuild-view.tsx
@@ -57,7 +57,7 @@ export class RunningPrebuildView extends React.Component<RunningPrebuildViewProp
     }
 
     componentWillMount() {
-        this.props.service.server.watchHeadlessWorkspaceLogs(this.props.prebuildingWorkspaceId);
+        this.props.service.server.watchHeadlessWorkspaceLogs({workspaceId: this.props.prebuildingWorkspaceId});
     }
 
     public render() {

--- a/components/dashboard/src/components/running-workspace-selector.tsx
+++ b/components/dashboard/src/components/running-workspace-selector.tsx
@@ -87,12 +87,18 @@ export class RunningWorkspaceSelector extends React.Component<RunningWorkspaceSe
     }
 
     protected async onToggleShareable(ws: Workspace) {
-        await this.props.service.server.controlAdmission(ws.id, ws.shareable ? "owner" : "everyone");
+        await this.props.service.server.controlAdmission({
+            workspaceId: ws.id,
+            level: ws.shareable ? "owner" : "everyone",
+        });
         await this.props.requestUpdate();
     }
 
     protected async onTogglePinned(ws: Workspace) {
-        await this.props.service.server.updateWorkspaceUserPin(ws.id, "toggle")
+        await this.props.service.server.updateWorkspaceUserPin({
+            action: "toggle",
+            workspaceId: ws.id,
+        })
         await this.props.requestUpdate();
     }
 

--- a/components/dashboard/src/components/show-not-found-error.tsx
+++ b/components/dashboard/src/components/show-not-found-error.tsx
@@ -32,7 +32,7 @@ export default class ShowNotFoundError extends React.Component<ShowNotFoundError
 
     protected async onLoad(): Promise<void> {
         try {
-            const authProviders = await this.props.service.server.getAuthProviders();
+            const authProviders = await this.props.service.server.getAuthProviders({});
             this.setState({ authProviders });
         } catch (err) {
             this.setState({});

--- a/components/dashboard/src/components/user-env-vars.tsx
+++ b/components/dashboard/src/components/user-env-vars.tsx
@@ -53,19 +53,19 @@ export class UserEnvVars extends React.Component<UserEnvVarsProps, UserEnvVarsSt
     }
 
     protected async update() {
-        const envVars = await this.props.service.server.getEnvVars();
+        const envVars = await this.props.service.server.getEnvVars({});
         this.setState({
             envVars: envVars.sort((a, b) => a.name.localeCompare(b.name))
         });
     }
 
     protected deleteEnvVar = async (envVar: UserEnvVarValue) => {
-        await this.props.service.server.deleteEnvVar(envVar);
+        await this.props.service.server.deleteEnvVar({variable: envVar});
         this.update();
     };
 
     protected updateEnvVar = async (oldEnv: UserEnvVarValue, newEnv: UserEnvVarValue) => {
-        await this.props.service.server.setEnvVar(newEnv);
+        await this.props.service.server.setEnvVar({variable: newEnv});
         this.update();
     };
 
@@ -82,9 +82,11 @@ export class UserEnvVars extends React.Component<UserEnvVarsProps, UserEnvVarsSt
         }
 
         await this.props.service.server.setEnvVar({
-            name,
-            value: 'my value',
-            repositoryPattern: `*/*`
+            variable: {
+                name,
+                value: 'my value',
+                repositoryPattern: `*/*`
+            }
         });
         this.update();
     };

--- a/components/dashboard/src/components/user-settings.tsx
+++ b/components/dashboard/src/components/user-settings.tsx
@@ -57,12 +57,12 @@ export class UserSettings extends React.Component<UserSettingsProps, UserSetting
         settings.disallowTransactionalEmails = !allowsTransactionalMail;
         const additionalData = { ...this.state.additionalData };
         additionalData.emailNotificationSettings!.disallowTransactionalEmails = !allowsTransactionalMail;
-        const user = await this.props.service.server.updateLoggedInUser({ additionalData });
+        const user = await this.props.service.server.updateLoggedInUser({ user: { additionalData } });
         this.update(user);
     }
 
     private async updateAllowsMarketingCommunication(allowsMarketingCommunication: boolean): Promise<void> {
-        const user = await this.props.service.server.updateLoggedInUser({ allowsMarketingCommunication });
+        const user = await this.props.service.server.updateLoggedInUser({ user: { allowsMarketingCommunication } });
         this.update(user);
     }
 

--- a/components/dashboard/src/components/with-branding.tsx
+++ b/components/dashboard/src/components/with-branding.tsx
@@ -41,7 +41,7 @@ export class WithBranding extends React.Component<WithBrandingProps, WithBrandin
     static async getBranding(service?: GitpodService, forceRefresh?: boolean): Promise<Branding | undefined> {
         let b = WithBranding.getCachedBranding();
         if ((!b || forceRefresh) && !!service) {
-            b = await service.server.getBranding();
+            b = await service.server.getBranding({});
             setCacheItem('branding_v1', JSON.stringify(b));
 
             updateBrowserTab();

--- a/components/dashboard/src/components/workspace-entry.tsx
+++ b/components/dashboard/src/components/workspace-entry.tsx
@@ -72,7 +72,10 @@ class EditableDescription extends React.Component<EditableDescriptionProps, Edit
     protected readonly handleEnter = () => this.doHandleEnter();
     protected doHandleEnter() {
         if (!this.isEmpty()) {
-            this.props.service.server.setWorkspaceDescription(this.props.workspace.id, this.newDescription);
+            this.props.service.server.setWorkspaceDescription({
+                desc: this.newDescription,
+                workspaceId: this.props.workspace.id,
+            });
             this.setState({
                 editDescription: !this.state.editDescription,
                 description: this.newDescription
@@ -188,13 +191,13 @@ export default class WorkspaceEntry extends React.Component<WorkspaceEntryProps,
     }
 
     handleStop = () => {
-        this.props.service.server.stopWorkspace(this.props.workspace.id);
+        this.props.service.server.stopWorkspace({workspaceId: this.props.workspace.id});
     }
 
     deleteWorkspace = async () => {
         try {
             if (!this.state || this.state.hasSnaphots === undefined) {
-                const snapshots = await this.props.service.server.getSnapshots(this.props.workspace.id);
+                const snapshots = await this.props.service.server.getSnapshots({workspaceId: this.props.workspace.id});
                 this.setState({ hasSnaphots: snapshots.length > 0 });
             }
 
@@ -207,7 +210,7 @@ export default class WorkspaceEntry extends React.Component<WorkspaceEntryProps,
 
     doDeleteWorkspace = async () => {
         try {
-            await this.props.service.server.deleteWorkspace(this.props.workspace.id);
+            await this.props.service.server.deleteWorkspace({workspaceId: this.props.workspace.id});
             this.props.handleWorkspaceDeleted(this.props.workspace);
         } catch (err) {
             console.log(err);
@@ -245,7 +248,7 @@ export default class WorkspaceEntry extends React.Component<WorkspaceEntryProps,
         } else if (status === 'running') {
             buttons.push((
                 <Button key='stop' className='button' variant='outlined' color='primary' 
-                    onClick={() => this.props.service.server.stopWorkspace(this.props.workspace.id)} 
+                    onClick={() => this.props.service.server.stopWorkspace({workspaceId: this.props.workspace.id})} 
                     title={stopTooltip}>
                     Stop
                 </Button>

--- a/components/dashboard/src/components/workspaces.tsx
+++ b/components/dashboard/src/components/workspaces.tsx
@@ -61,7 +61,7 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
             // local storage not supported: ignore
         }
 
-		this.props.service.server.getFeaturedRepositories()
+		this.props.service.server.getFeaturedRepositories({})
 			.then(repos => this.setState({ featuredRepositories: repos }))
 			.catch( /* We did not get our repos. UX is slightly degraded as the featured repos are not shown. */ );
 	}
@@ -70,7 +70,7 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 		this.disposables.dispose();
 	}
 
-	private async updateWorkspaces(options?: GitpodServer.GetWorkspacesOptions) {
+	private async updateWorkspaces(options?: GitpodServer.GetWorkspacesParams) {
 		try {
 			const workspaces = await this.props.service.server.getWorkspaces({
 				limit: this.getLimit(),
@@ -158,7 +158,10 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 	}
 
 	private handleTogglePinned = async (ws: Workspace) => {
-        await this.props.service.server.updateWorkspaceUserPin(ws.id, "toggle")
+        await this.props.service.server.updateWorkspaceUserPin({
+            action: "toggle",
+            workspaceId: ws.id,
+        })
         this.updateWorkspaces();
 	};
 
@@ -168,7 +171,10 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 
 	private handleToggleShareable = async (ws: Workspace) => {
         try {
-            await this.props.service.server.controlAdmission(ws.id, ws.shareable ? "owner" : "everyone");
+            await this.props.service.server.controlAdmission({
+                workspaceId: ws.id,
+                level: ws.shareable ? "owner" : "everyone",
+            });
         } catch (e) {
             this.setState(() => {throw e});
         }

--- a/components/dashboard/src/configuration.tsx
+++ b/components/dashboard/src/configuration.tsx
@@ -11,6 +11,6 @@ import { globalCache } from "./util";
 export async function getGitpodConfiguration(): Promise<Configuration> {
     return globalCache('config', () => {
         const service = createGitpodService();
-        return service.server.getConfiguration();
+        return service.server.getConfiguration({});
     });
 }

--- a/components/dashboard/src/first-steps.tsx
+++ b/components/dashboard/src/first-steps.tsx
@@ -18,7 +18,7 @@ import { AuthProviders } from './components/auth-providers';
 import { GitpodService } from '@gitpod/gitpod-protocol';
 
 const service = createGitpodService();
-const userPromise = service.server.getLoggedInUser();
+const userPromise = service.server.getLoggedInUser({});
 
 // redirect asap, if already logged in
 userPromise.then(() => {

--- a/components/dashboard/src/login.tsx
+++ b/components/dashboard/src/login.tsx
@@ -12,8 +12,8 @@ import { renderEntrypoint } from "./entrypoint";
 import { Login } from './components/login/login';
 
 const service = createGitpodService();
-const user = service.server.getLoggedInUser();
-const authProviders = service.server.getAuthProviders().then(list => list.filter(p => !p.disallowLogin));
+const user = service.server.getLoggedInUser({});
+const authProviders = service.server.getAuthProviders({}).then(list => list.filter(p => !p.disallowLogin));
 
 export class LoginIndex extends React.Component {
     render() {

--- a/components/dashboard/src/settings.tsx
+++ b/components/dashboard/src/settings.tsx
@@ -11,5 +11,5 @@ import { renderEntrypoint } from './entrypoint';
 import { Settings } from "./components/settings";
 
 const service = createGitpodService();
-const user = service.server.getLoggedInUser();
+const user = service.server.getLoggedInUser({});
 renderEntrypoint(Settings, { service, user });

--- a/components/dashboard/src/terms-of-service.tsx
+++ b/components/dashboard/src/terms-of-service.tsx
@@ -11,7 +11,7 @@ import { TermsOfService } from "./components/tos/terms-of-service";
 import { renderEntrypoint } from "./entrypoint";
 
 const service = createGitpodService();
-const user = service.server.getLoggedInUser();
+const user = service.server.getLoggedInUser({});
 
 export class TosIndex extends React.Component {
     render() {

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -7,7 +7,7 @@
 import { injectable, inject } from "inversify";
 import { Repository, EntityManager, DeepPartial, UpdateQueryBuilder } from "typeorm";
 import { AbstractWorkspaceDB, MaybeWorkspace, MaybeWorkspaceInstance, WorkspaceDB, FindWorkspacesOptions, PrebuiltUpdatableAndWorkspace, WorkspaceInstanceSessionWithWorkspace, PrebuildWithWorkspace, WorkspaceAndOwner, WorkspacePortsAuthData, WorkspaceOwnerAndSoftDeleted } from "../workspace-db";
-import { Workspace, WorkspaceInstance, WorkspaceInfo, WorkspaceInstanceUser, WhitelistedRepository, Snapshot, LayoutData, PrebuiltWorkspace, RunningWorkspaceInfo, PrebuiltWorkspaceUpdatable, WorkspaceAndInstance, WorkspaceType } from "@gitpod/gitpod-protocol";
+import { Workspace, WorkspaceInstance, WorkspaceInfo, WorkspaceInstanceUser, WhitelistedRepository, Snapshot, LayoutData, PrebuiltWorkspace, RunningWorkspaceInfo, PrebuiltWorkspaceUpdatable, WorkspaceType, AdminServer } from "@gitpod/gitpod-protocol";
 import { TypeORM } from "./typeorm";
 import { DBWorkspace } from "./entity/db-workspace";
 import { DBWorkspaceInstance } from "./entity/db-workspace-instance";
@@ -695,7 +695,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl extends AbstractWorkspaceDB
 
 
 
-    public async findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof WorkspaceAndInstance, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string): Promise<{ total: number, rows: WorkspaceAndInstance[] }> {
+    public async findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof AdminServer.WorkspaceAndInstance, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string): Promise<{ total: number, rows: AdminServer.WorkspaceAndInstance[] }> {
         let joinConditions = [];
         let joinConditionParams: any = {};
         if (!!ownerId) {
@@ -750,13 +750,13 @@ export abstract class AbstractTypeORMWorkspaceDBImpl extends AbstractWorkspaceDB
             delete res["creationTime"];
             delete res["instance"];
 
-            return <WorkspaceAndInstance>(res);
+            return <AdminServer.WorkspaceAndInstance>(res);
         });
 
         return { rows, total };
     }
 
-    async findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined> {
+    async findWorkspaceAndInstance(id: string): Promise<AdminServer.WorkspaceAndInstance | undefined> {
         const workspaceRepo = await this.getWorkspaceRepo();
         const workspace = await workspaceRepo.findOneById(id);
         if (!workspace) {
@@ -780,7 +780,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl extends AbstractWorkspaceDB
         delete res["id"];
         delete res["creationTime"];
 
-        return <WorkspaceAndInstance>(res);
+        return <AdminServer.WorkspaceAndInstance>(res);
     }
 
 }

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -7,7 +7,7 @@
 import { DeepPartial } from 'typeorm';
 import { injectable } from 'inversify';
 
-import { Workspace, WorkspaceInfo, WorkspaceInstance, WorkspaceInstanceUser, WhitelistedRepository, Snapshot, LayoutData, PrebuiltWorkspace, PrebuiltWorkspaceUpdatable, RunningWorkspaceInfo, WorkspaceAndInstance, WorkspaceType } from '@gitpod/gitpod-protocol';
+import { Workspace, WorkspaceInfo, WorkspaceInstance, WorkspaceInstanceUser, WhitelistedRepository, Snapshot, LayoutData, PrebuiltWorkspace, PrebuiltWorkspaceUpdatable, RunningWorkspaceInfo, WorkspaceType, AdminServer } from '@gitpod/gitpod-protocol';
 
 export type MaybeWorkspace = Workspace | undefined;
 export type MaybeWorkspaceInstance = WorkspaceInstance | undefined;
@@ -80,8 +80,8 @@ export interface WorkspaceDB {
     findWorkspacesForContentDeletion(minSoftDeletedTimeInDays: number, limit: number): Promise<WorkspaceOwnerAndSoftDeleted[]>;
     findPrebuiltWorkspacesForGC(daysUnused: number, limit: number): Promise<WorkspaceAndOwner[]>;
     findAllWorkspaces(offset: number, limit: number, orderBy: keyof Workspace, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string, minCreationTime?: Date, maxCreationDateTime?: Date, type?: WorkspaceType): Promise<{ total: number, rows: Workspace[] }>;
-    findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof WorkspaceAndInstance, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string): Promise<{ total: number, rows: WorkspaceAndInstance[] }>;
-    findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
+    findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof AdminServer.WorkspaceAndInstance, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string): Promise<{ total: number, rows: AdminServer.WorkspaceAndInstance[] }>;
+    findWorkspaceAndInstance(id: string): Promise<AdminServer.WorkspaceAndInstance | undefined>;
 
     findAllWorkspaceInstances(offset: number, limit: number, orderBy: keyof WorkspaceInstance, orderDir: "ASC" | "DESC", ownerId?: string, minCreationTime?: Date, maxCreationTime?: Date, onlyRunning?: boolean, type?: WorkspaceType): Promise<{ total: number, rows: WorkspaceInstance[] }>;
 
@@ -135,8 +135,8 @@ export abstract class AbstractWorkspaceDB implements WorkspaceDB {
     abstract findWorkspacesForGarbageCollection(minAgeInDays: number, limit: number): Promise<WorkspaceAndOwner[]>;
     abstract findWorkspacesForContentDeletion(minSoftDeletedTimeInDays: number, limit: number): Promise<WorkspaceOwnerAndSoftDeleted[]>;
     abstract findPrebuiltWorkspacesForGC(daysUnused: number, limit: number): Promise<WorkspaceAndOwner[]>
-    abstract findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof WorkspaceAndInstance, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string): Promise<{ total: number, rows: WorkspaceAndInstance[] }>;
-    abstract findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
+    abstract findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof AdminServer.WorkspaceAndInstance, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string): Promise<{ total: number, rows: AdminServer.WorkspaceAndInstance[] }>;
+    abstract findWorkspaceAndInstance(id: string): Promise<AdminServer.WorkspaceAndInstance | undefined>;
     abstract findAllWorkspaces(offset: number, limit: number, orderBy: keyof Workspace, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string, minCreationTime?: Date, maxCreationDateTime?: Date, type?: WorkspaceType): Promise<{ total: number, rows: Workspace[] }>;
     abstract findAllWorkspaceInstances(offset: number, limit: number, orderBy: keyof WorkspaceInstance, orderDir: "ASC" | "DESC", ownerId?: string, minCreationTime?: Date, maxCreationTime?: Date, onlyRunning?: boolean, type?: WorkspaceType): Promise<{ total: number, rows: WorkspaceInstance[] }>;
 

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -10,61 +10,81 @@ import { WorkspaceInstance, WorkspaceInstancePhase } from "./workspace-instance"
 import { RoleOrPermission } from "./permission";
 
 export interface AdminServer {
-    adminGetUsers(req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>>;
-    adminGetUser(id: string): Promise<User>;
-    adminBlockUser(req: AdminBlockUserRequest): Promise<User>;
-    adminModifyRoleOrPermission(req: AdminModifyRoleOrPermissionRequest): Promise<User>;
-    adminModifyPermanentWorkspaceFeatureFlag(req: AdminModifyPermanentWorkspaceFeatureFlagRequest): Promise<User>;
+    adminGetUsers(params: AdminServer.AdminGetUsersParams): Promise<AdminServer.AdminGetListResult<User>>;
+    adminGetUser(params: AdminServer.AdminGetUserParams): Promise<User>;
+    adminBlockUser(params: AdminServer.AdminBlockUserParams): Promise<User>;
+    adminModifyRoleOrPermission(params: AdminServer.AdminModifyRoleOrPermissionParams): Promise<User>;
+    adminModifyPermanentWorkspaceFeatureFlag(params: AdminServer.AdminModifyPermanentWorkspaceFeatureFlagParams): Promise<User>;
 
-    adminGetWorkspaces(req: AdminGetWorkspacesRequest): Promise<AdminGetListResult<WorkspaceAndInstance>>;
-    adminGetWorkspace(id: string): Promise<WorkspaceAndInstance>;
-    adminForceStopWorkspace(id: string): Promise<void>;
+    adminGetWorkspaces(params: AdminServer.AdminGetWorkspacesParams): Promise<AdminServer.AdminGetListResult<AdminServer.WorkspaceAndInstance>>;
+    adminGetWorkspace(params: AdminServer.AdminGetWorkspaceParams): Promise<AdminServer.WorkspaceAndInstance>;
+    adminForceStopWorkspace(params: AdminServer.adminForceStopWorkspaceParams): Promise<void>;
 
-    adminSetLicense(key: string): Promise<void>;
+    adminSetLicense(params: AdminServer.AdminSetLicenseParams): Promise<void>;
 }
 
-export interface AdminGetListRequest<T> {
-    offset: number
-    limit: number
-    orderBy: keyof T
-    orderDir: "asc" | "desc"
-    searchTerm?: string;
-}
+export namespace AdminServer {
+    export type AdminGetUsersParams = AdminGetListParams<User>
 
-export interface AdminGetListResult<T> {
-    total: number
-    rows: T[]
-}
+    export interface AdminGetUserParams {
+        readonly id: string;
+    }
 
-export interface AdminBlockUserRequest {
-    id: string
-    blocked: boolean
-}
+    export interface AdminGetListParams<T> {
+        offset: number
+        limit: number
+        orderBy: keyof T
+        orderDir: "asc" | "desc"
+        searchTerm?: string;
+    }
 
-export interface AdminModifyRoleOrPermissionRequest {
-    id: string;
-    rpp: {
-        r: RoleOrPermission
-        add: boolean
-    }[]
-}
+    export interface AdminGetListResult<T> {
+        total: number
+        rows: T[]
+    }
 
-export interface AdminModifyPermanentWorkspaceFeatureFlagRequest {
-    id: string;
-    changes: {
-        featureFlag: NamedWorkspaceFeatureFlag
-        add: boolean
-    }[]
-}
+    export interface AdminBlockUserParams {
+        id: string
+        blocked: boolean
+    }
 
-export interface WorkspaceAndInstance extends Without<Workspace, "id"|"creationTime">, Without<WorkspaceInstance, "id"|"creationTime"> {
-    workspaceId: string;
-    workspaceCreationTime: string;
-    instanceId: string;
-    instanceCreationTime: string;
-    phase: WorkspaceInstancePhase;
-}
+    export interface AdminModifyRoleOrPermissionParams {
+        id: string;
+        rpp: {
+            r: RoleOrPermission
+            add: boolean
+        }[]
+    }
 
-export interface AdminGetWorkspacesRequest extends AdminGetListRequest<WorkspaceAndInstance> {
-    ownerId?: string
+    export interface AdminModifyPermanentWorkspaceFeatureFlagParams {
+        id: string;
+        changes: {
+            featureFlag: NamedWorkspaceFeatureFlag
+            add: boolean
+        }[]
+    }
+
+    export interface WorkspaceAndInstance extends Without<Workspace, "id"|"creationTime">, Without<WorkspaceInstance, "id"|"creationTime"> {
+        workspaceId: string;
+        workspaceCreationTime: string;
+        instanceId: string;
+        instanceCreationTime: string;
+        phase: WorkspaceInstancePhase;
+    }
+
+    export interface AdminGetWorkspacesParams extends AdminGetListParams<WorkspaceAndInstance> {
+        ownerId?: string
+    }
+
+    export interface AdminGetWorkspaceParams {
+        workspaceId: string;
+    }
+
+    export interface adminForceStopWorkspaceParams {
+        workspaceId: string;
+    }
+
+    export interface AdminSetLicenseParams {
+        key: string;
+    }
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -7,7 +7,7 @@
 import { User, WorkspaceInfo, WorkspaceCreationResult, UserMessage, WorkspaceInstanceUser,
     WhitelistedRepository, WorkspaceImageBuild, AuthProviderInfo, Branding, CreateWorkspaceMode,
     Token, UserEnvVarValue, ResolvePluginsParams, PreparePluginUploadParams,
-    ResolvedPlugins, Configuration, InstallPluginsParams, UninstallPluginParams, UserInfo, GitpodTokenType, GitpodToken, AuthProviderEntry } from './protocol';
+    ResolvedPlugins, Configuration, InstallPluginsParams, UninstallPluginParams, UserInfo, GitpodTokenType, GitpodToken, AuthProviderEntry, WorkspaceConfig } from './protocol';
 import { JsonRpcProxy, JsonRpcServer } from './messaging/proxy-factory';
 import { injectable, inject } from 'inversify';
 import { Disposable } from 'vscode-jsonrpc';
@@ -26,7 +26,116 @@ export interface GitpodClient {
 }
 
 export const GitpodServer = Symbol('GitpodServer');
+
 export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, LicenseService {
+    // User related API
+    getLoggedInUser(params: GitpodServer.GetLoggedInUserParams): Promise<User>;
+    updateLoggedInUser(params: GitpodServer.UpdateLoggedInUserParams): Promise<User>;
+    getAuthProviders(params: GitpodServer.GetAuthProvidersParams): Promise<AuthProviderInfo[]>;
+    getOwnAuthProviders(params: GitpodServer.GetOwnAuthProvidersParams): Promise<AuthProviderEntry[]>;
+    updateOwnAuthProvider(params: GitpodServer.UpdateOwnAuthProviderParams): Promise<void>;
+    deleteOwnAuthProvider(params: GitpodServer.DeleteOwnAuthProviderParams): Promise<void>;
+    getBranding(params: GitpodServer.GetBrandingParams): Promise<Branding>;
+    getConfiguration(params: GitpodServer.GetConfigurationParams): Promise<Configuration>;
+    getToken(params: GitpodServer.GetTokenParams): Promise<Token | undefined>;
+    getPortAuthenticationToken(params: GitpodServer.GetPortAuthenticationTokenParams): Promise<Token>;
+    deleteAccount(params: GitpodServer.DeleteAccountParams): Promise<void>;
+    getClientRegion(params: GitpodServer.GetClientRegionParams): Promise<string | undefined>;
+    hasPermission(params: GitpodServer.HasPermissionParams): Promise<boolean>;
+
+    // Query/retrieve workspaces
+    getWorkspaces(params: GitpodServer.GetWorkspacesParams): Promise<WorkspaceInfo[]>;
+    getWorkspaceOwner(params: GitpodServer.GetWorkspaceOwnerParams): Promise<UserInfo | undefined>;
+    getWorkspaceUsers(params: GitpodServer.GetWorkspaceUsersParams): Promise<WorkspaceInstanceUser[]>;
+    getFeaturedRepositories(params: GitpodServer.GetFeaturedRepositoriesParams): Promise<WhitelistedRepository[]>;
+    getWorkspace(params: GitpodServer.GetWorkspaceParams): Promise<WorkspaceInfo>;
+    isWorkspaceOwner(params: GitpodServer.IsWorkspaceOwnerParams): Promise<boolean>;
+
+    /**
+     * Creates and starts a workspace for the given context URL.
+     * @param options GitpodServer.CreateWorkspaceOptions
+     * @return WorkspaceCreationResult
+     */
+    createWorkspace(params: GitpodServer.CreateWorkspaceParams): Promise<WorkspaceCreationResult>;
+    startWorkspace(params: GitpodServer.StartWorkspaceParams): Promise<StartWorkspaceResult>;
+    stopWorkspace(params: GitpodServer.StopWorkspaceParams): Promise<void>;
+    deleteWorkspace(params: GitpodServer.DeleteWorkspaceParams): Promise<void>;
+    setWorkspaceDescription(params: GitpodServer.SetWorkspaceDescriptionParams): Promise<void>;
+    controlAdmission(params: GitpodServer.ControlAdmissionParams): Promise<void>;
+
+    updateWorkspaceUserPin(params: GitpodServer.UpdateWorkspaceUserPinParams): Promise<void>;
+    sendHeartBeat(params: GitpodServer.SendHeartBeatParams): Promise<void>;
+    watchWorkspaceImageBuildLogs(params: GitpodServer.WatchWorkspaceImageBuildLogsParams): Promise<void>;
+    watchHeadlessWorkspaceLogs(params: GitpodServer.WatchHeadlessWorkspaceLogsParams): Promise<void>;
+    isPrebuildAvailable(params: GitpodServer.IsPrebuildAvailableParams): Promise<boolean>;
+
+    // Workspace timeout
+    setWorkspaceTimeout(params: GitpodServer.SetWorkspaceTimeoutParams): Promise<SetWorkspaceTimeoutResult>;
+    getWorkspaceTimeout(params: GitpodServer.GetWorkspaceTimeoutParams): Promise<GetWorkspaceTimeoutResult>;
+    sendHeartBeat(params: GitpodServer.SendHeartBeatParams): Promise<void>;
+
+    updateWorkspaceUserPin(params: GitpodServer.UpdateWorkspaceUserPinParams): Promise<void>;
+
+    // Port management
+    getOpenPorts(params: GitpodServer.GetOpenPortsParams): Promise<WorkspaceInstancePort[]>;
+    openPort(params: GitpodServer.OpenPortParams): Promise<WorkspaceInstancePort | undefined>;
+    closePort(params: GitpodServer.ClosePortParams): Promise<void>;
+
+    // User messages
+    getUserMessages(params: GitpodServer.GetUserMessagesParams): Promise<UserMessage[]>;
+    updateUserMessages(params: GitpodServer.UpdateUserMessagesParams): Promise<void>;
+
+    // User storage
+    getUserStorageResource(params: GitpodServer.GetUserStorageResourceParams): Promise<string>;
+    updateUserStorageResource(params: GitpodServer.UpdateUserStorageResourceParams): Promise<void>;
+
+    // user env vars
+    getEnvVars(params: GitpodServer.GetEnvVarsParams): Promise<UserEnvVarValue[]>;
+    setEnvVar(params: GitpodServer.SetEnvVarParams): Promise<void>;
+    deleteEnvVar(params: GitpodServer.DeleteEnvVarParams): Promise<void>;
+
+    // Gitpod token
+    getGitpodTokens(params: GitpodServer.GetGitpodTokensParams): Promise<GitpodToken[]>;
+    generateNewGitpodToken(params: GitpodServer.GenerateNewGitpodTokenParams): Promise<string>;
+    deleteGitpodToken(params: GitpodServer.DeleteGitpodTokenParams): Promise<void>;
+
+    // misc
+    sendFeedback(params: GitpodServer.SendFeedbackParams): Promise<string | undefined>;
+    registerGithubApp(params: GitpodServer.RegisterGithubAppParams): Promise<void>;
+
+    /**
+     * Stores a new snapshot for the given workspace and bucketId
+     * @return the snapshot id
+     */
+    takeSnapshot(params: GitpodServer.TakeSnapshotParams): Promise<string>;
+
+    /**
+     * Returns the list of snapshots that exist for a workspace.
+     */
+    getSnapshots(params: GitpodServer.GetSnapshotsParams): Promise<string[]>;
+
+    /**
+     * stores/updates layout information for the given workspace
+     */
+    storeLayout(params: GitpodServer.StoreLayoutParams): Promise<void>;
+
+    /**
+     * retrieves layout information for the given workspace
+     */
+    getLayout(params: GitpodServer.GetLayoutParams): Promise<string | undefined>;
+
+    /**
+     * @param params
+     * @returns promise resolves to an URL to be used for the upload
+     */
+    preparePluginUpload(params: GitpodServer.PreparePluginUploadParams): Promise<string>
+    resolvePlugins(params: GitpodServer.ResolvePluginsParams): Promise<ResolvedPlugins>;
+    installUserPlugins(params: GitpodServer.InstallUserPluginsParams): Promise<boolean>;
+    uninstallUserPlugin(params: GitpodServer.UninstallUserPluginParams): Promise<boolean>;
+}
+
+
+export interface GitpodServerV0 extends JsonRpcServer<GitpodClient>, AdminServer, LicenseService {
     // User related API
     getLoggedInUser(): Promise<User>;
     updateLoggedInUser(user: Partial<User>): Promise<User>;
@@ -36,14 +145,14 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     deleteOwnAuthProvider(params: GitpodServer.DeleteOwnAuthProviderParams): Promise<void>;
     getBranding(): Promise<Branding>;
     getConfiguration(): Promise<Configuration>;
-    getToken(query: GitpodServer.GetTokenSearchOptions): Promise<Token | undefined>;
+    getToken(query: GitpodServerV0.GetTokenSearchOptions): Promise<Token | undefined>;
     getPortAuthenticationToken(workspaceId: string): Promise<Token>;
     deleteAccount(): Promise<void>;
     getClientRegion(): Promise<string | undefined>;
     hasPermission(permission: PermissionName): Promise<boolean>;
 
     // Query/retrieve workspaces
-    getWorkspaces(options: GitpodServer.GetWorkspacesOptions): Promise<WorkspaceInfo[]>;
+    getWorkspaces(options: GitpodServerV0.GetWorkspacesOptions): Promise<WorkspaceInfo[]>;
     getWorkspaceOwner(workspaceId: string): Promise<UserInfo | undefined>;
     getWorkspaceUsers(workspaceId: string): Promise<WorkspaceInstanceUser[]>;
     getFeaturedRepositories(): Promise<WhitelistedRepository[]>;
@@ -55,7 +164,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
      * @param options GitpodServer.CreateWorkspaceOptions
      * @return WorkspaceCreationResult
      */
-    createWorkspace(options: GitpodServer.CreateWorkspaceOptions): Promise<WorkspaceCreationResult>;
+    createWorkspace(options: GitpodServerV0.CreateWorkspaceOptions): Promise<WorkspaceCreationResult>;
     startWorkspace(id: string, options: {forceDefaultImage: boolean}): Promise<StartWorkspaceResult>;
     stopWorkspace(id: string): Promise<void>;
     deleteWorkspace(id: string): Promise<void>;
@@ -63,7 +172,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     controlAdmission(id: string, level: "owner" | "everyone"): Promise<void>;
 
     updateWorkspaceUserPin(id: string, action: "pin" | "unpin" | "toggle"): Promise<void>;
-    sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;
+    sendHeartBeat(options: GitpodServerV0.SendHeartBeatOptions): Promise<void>;
     watchWorkspaceImageBuildLogs(workspaceId: string): Promise<void>;
     watchHeadlessWorkspaceLogs(workspaceId: string): Promise<void>;
     isPrebuildAvailable(pwsid: string): Promise<boolean>;
@@ -71,7 +180,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     // Workspace timeout
     setWorkspaceTimeout(workspaceId: string, duration: WorkspaceTimeoutDuration): Promise<SetWorkspaceTimeoutResult>;
     getWorkspaceTimeout(workspaceId: string): Promise<GetWorkspaceTimeoutResult>;
-    sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;
+    sendHeartBeat(options: GitpodServerV0.SendHeartBeatOptions): Promise<void>;
 
     updateWorkspaceUserPin(id: string, action: "pin" | "unpin" | "toggle"): Promise<void>;
 
@@ -81,12 +190,12 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     closePort(workspaceId: string, port: number): Promise<void>;
 
     // User messages
-    getUserMessages(options: GitpodServer.GetUserMessagesOptions): Promise<UserMessage[]>;
-    updateUserMessages(options: GitpodServer.UpdateUserMessagesOptions): Promise<void>;
+    getUserMessages(options: GitpodServerV0.GetUserMessagesOptions): Promise<UserMessage[]>;
+    updateUserMessages(options: GitpodServerV0.UpdateUserMessagesOptions): Promise<void>;
 
     // User storage
-    getUserStorageResource(options: GitpodServer.GetUserStorageResourceOptions): Promise<string>;
-    updateUserStorageResource(options: GitpodServer.UpdateUserStorageResourceOptions): Promise<void>;
+    getUserStorageResource(options: GitpodServerV0.GetUserStorageResourceOptions): Promise<string>;
+    updateUserStorageResource(options: GitpodServerV0.UpdateUserStorageResourceOptions): Promise<void>;
 
     // user env vars
     getEnvVars(): Promise<UserEnvVarValue[]>;
@@ -106,7 +215,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
      * Stores a new snapshot for the given workspace and bucketId
      * @return the snapshot id
      */
-    takeSnapshot(options: GitpodServer.TakeSnapshotOptions): Promise<string>;
+    takeSnapshot(options: GitpodServerV0.TakeSnapshotOptions): Promise<string>;
 
     /**
      * Returns the list of snapshots that exist for a workspace.
@@ -171,6 +280,239 @@ export interface StartWorkspaceResult {
 }
 
 export namespace GitpodServer {
+    export interface GetLoggedInUserParams {}
+
+    export interface UpdateLoggedInUserParams {
+        readonly user: Partial<User>;
+    }
+
+    export interface GetAuthProvidersParams {}
+
+    export interface GetOwnAuthProvidersParams {}
+
+    export interface UpdateOwnAuthProviderParams {
+        readonly entry: AuthProviderEntry.UpdateEntry | AuthProviderEntry.NewEntry;
+    }
+
+    export interface DeleteOwnAuthProviderParams {
+        readonly id: string;
+    }
+
+    export interface GetBrandingParams {}
+
+    export interface GetConfigurationParams {}
+
+    export interface GetTokenParams {
+        readonly host: string;
+    }
+
+    export interface GetPortAuthenticationTokenParams {
+        readonly workspaceId: string;
+    }
+
+    export interface DeleteAccountParams {}
+
+    export interface GetClientRegionParams {}
+
+    export interface HasPermissionParams {
+        readonly permission: PermissionName;
+    }
+
+    export interface GetWorkspacesParams {
+        readonly limit?: number;
+        readonly searchString?: string;
+        readonly pinnedOnly?: boolean;
+    }
+
+    export interface GetWorkspaceOwnerParams {
+        readonly workspaceId: string;
+    }
+
+    export interface GetWorkspaceUsersParams {
+        readonly workspaceId: string;
+    }
+
+    export interface GetFeaturedRepositoriesParams {}
+
+    export interface GetWorkspaceParams {
+        readonly workspaceId: string;
+    }
+
+    export interface IsWorkspaceOwnerParams {
+        readonly workspaceId: string;
+    }
+
+    export interface CreateWorkspaceParams {
+        readonly contextUrl: string;
+        readonly mode?: CreateWorkspaceMode;
+    }
+
+    export interface StartWorkspaceParams {
+        readonly workspaceId: string;
+        readonly forceDefaultImage: boolean
+    }
+
+    export interface StopWorkspaceParams {
+        readonly workspaceId: string;
+    }
+
+    export interface DeleteWorkspaceParams {
+        readonly workspaceId: string;
+    }
+
+    export interface SetWorkspaceDescriptionParams {
+        readonly workspaceId: string;
+        readonly desc: string;
+    }
+
+    export interface ControlAdmissionParams {
+        readonly workspaceId: string;
+        readonly level: "owner" | "everyone";
+    }
+
+    export interface UpdateWorkspaceUserPinParams {
+        readonly workspaceId: string;
+        readonly action: "pin" | "unpin" | "toggle";
+    }
+
+    export interface SendHeartBeatParams {
+        readonly instanceId: string;
+        readonly wasClosed?: boolean;
+        readonly roundTripTime?: number;
+    }
+
+    export interface WatchWorkspaceImageBuildLogsParams {
+        readonly workspaceId: string;
+    }
+
+    export interface WatchHeadlessWorkspaceLogsParams {
+        readonly workspaceId: string;
+    }
+
+    export interface IsPrebuildAvailableParams {
+        readonly pwsid: string;
+    }
+
+    export interface SetWorkspaceTimeoutParams {
+        readonly workspaceId: string;
+        readonly duration: WorkspaceTimeoutDuration;
+    }
+
+    export interface GetWorkspaceTimeoutParams {
+        readonly workspaceId: string;
+    }
+
+    export interface SendHeartBeatParams {
+        readonly instanceId: string;
+        readonly wasClosed?: boolean;
+        readonly roundTripTime?: number;
+    }
+
+    export interface UpdateWorkspaceUserPinParams {
+        readonly workspaceId: string;
+        readonly action: "pin" | "unpin" | "toggle";
+    }
+
+    export interface GetOpenPortsParams {
+        readonly workspaceId: string;
+    }
+
+    export interface OpenPortParams {
+        readonly workspaceId: string;
+        readonly port: WorkspaceInstancePort;
+    }
+
+    export interface ClosePortParams {
+        readonly workspaceId: string;
+        readonly port: number;
+    }
+
+    export interface GetUserMessagesParams {
+        readonly releaseNotes?: boolean;
+        readonly workspaceInstanceId: string;
+    }
+
+    export interface UpdateUserMessagesParams {
+        readonly messageIds: string[];
+    }
+
+    export interface GetUserStorageResourceParams {
+        readonly uri: string;
+    }
+
+    export interface UpdateUserStorageResourceParams {
+        readonly uri: string;
+        readonly content: string;
+    }
+
+    export interface GetEnvVarsParams {}
+
+    export interface SetEnvVarParams {
+        readonly variable: UserEnvVarValue;
+    }
+
+    export interface DeleteEnvVarParams {
+        readonly variable: UserEnvVarValue;
+    }
+
+    export interface GetGitpodTokensParams {}
+
+    export interface GenerateNewGitpodTokenParams {
+        readonly name?: string;
+        readonly type: GitpodTokenType;
+        readonly scopes?: string[];
+    }
+
+    export interface DeleteGitpodTokenParams {
+        readonly tokenHash: string;
+    }
+
+    export interface SendFeedbackParams {
+        readonly feedback: string;
+    }
+
+    export interface RegisterGithubAppParams {
+        readonly installationId: string;
+    }
+
+    export interface TakeSnapshotParams {
+        readonly workspaceId: string;
+        readonly layoutData?: string;
+    }
+
+    export interface GetSnapshotsParams {
+        readonly workspaceId: string;
+    }
+
+    export interface StoreLayoutParams {
+        readonly workspaceId: string;
+        readonly layoutData: string;
+    }
+
+    export interface GetLayoutParams {
+        readonly workspaceId: string;
+    }
+
+    export interface PreparePluginUploadParams {
+        readonly fullPluginName: string;
+    }
+
+    export interface ResolvePluginsParams {
+        readonly workspaceId: string;
+        readonly config?: WorkspaceConfig;
+        readonly builtins?: ResolvedPlugins;
+    }
+
+    export interface InstallUserPluginsParams {
+        readonly pluginIds: string[];
+    }
+
+    export interface UninstallUserPluginParams {
+        readonly pluginId: string;
+    }
+}
+
+export namespace GitpodServerV0 {
     export interface GetWorkspacesOptions {
         limit?: number;
         searchString?: string;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -6,8 +6,8 @@
 
 import { User, WorkspaceInfo, WorkspaceCreationResult, UserMessage, WorkspaceInstanceUser,
     WhitelistedRepository, WorkspaceImageBuild, AuthProviderInfo, Branding, CreateWorkspaceMode,
-    Token, UserEnvVarValue, ResolvePluginsParams, PreparePluginUploadParams,
-    ResolvedPlugins, Configuration, InstallPluginsParams, UninstallPluginParams, UserInfo, GitpodTokenType, GitpodToken, AuthProviderEntry, WorkspaceConfig } from './protocol';
+    Token, UserEnvVarValue, ResolvedPlugins, Configuration, UserInfo, GitpodTokenType, GitpodToken,
+    AuthProviderEntry, WorkspaceConfig } from './protocol';
 import { JsonRpcProxy, JsonRpcServer } from './messaging/proxy-factory';
 import { injectable, inject } from 'inversify';
 import { Disposable } from 'vscode-jsonrpc';
@@ -132,114 +132,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     resolvePlugins(params: GitpodServer.ResolvePluginsParams): Promise<ResolvedPlugins>;
     installUserPlugins(params: GitpodServer.InstallUserPluginsParams): Promise<boolean>;
     uninstallUserPlugin(params: GitpodServer.UninstallUserPluginParams): Promise<boolean>;
-}
-
-
-export interface GitpodServerV0 extends JsonRpcServer<GitpodClient>, AdminServer, LicenseService {
-    // User related API
-    getLoggedInUser(): Promise<User>;
-    updateLoggedInUser(user: Partial<User>): Promise<User>;
-    getAuthProviders(): Promise<AuthProviderInfo[]>;
-    getOwnAuthProviders(): Promise<AuthProviderEntry[]>;
-    updateOwnAuthProvider(params: GitpodServer.UpdateOwnAuthProviderParams): Promise<void>;
-    deleteOwnAuthProvider(params: GitpodServer.DeleteOwnAuthProviderParams): Promise<void>;
-    getBranding(): Promise<Branding>;
-    getConfiguration(): Promise<Configuration>;
-    getToken(query: GitpodServerV0.GetTokenSearchOptions): Promise<Token | undefined>;
-    getPortAuthenticationToken(workspaceId: string): Promise<Token>;
-    deleteAccount(): Promise<void>;
-    getClientRegion(): Promise<string | undefined>;
-    hasPermission(permission: PermissionName): Promise<boolean>;
-
-    // Query/retrieve workspaces
-    getWorkspaces(options: GitpodServerV0.GetWorkspacesOptions): Promise<WorkspaceInfo[]>;
-    getWorkspaceOwner(workspaceId: string): Promise<UserInfo | undefined>;
-    getWorkspaceUsers(workspaceId: string): Promise<WorkspaceInstanceUser[]>;
-    getFeaturedRepositories(): Promise<WhitelistedRepository[]>;
-    getWorkspace(id: string): Promise<WorkspaceInfo>;
-    isWorkspaceOwner(workspaceId: string): Promise<boolean>;
-
-    /**
-     * Creates and starts a workspace for the given context URL.
-     * @param options GitpodServer.CreateWorkspaceOptions
-     * @return WorkspaceCreationResult
-     */
-    createWorkspace(options: GitpodServerV0.CreateWorkspaceOptions): Promise<WorkspaceCreationResult>;
-    startWorkspace(id: string, options: {forceDefaultImage: boolean}): Promise<StartWorkspaceResult>;
-    stopWorkspace(id: string): Promise<void>;
-    deleteWorkspace(id: string): Promise<void>;
-    setWorkspaceDescription(id: string, desc: string): Promise<void>;
-    controlAdmission(id: string, level: "owner" | "everyone"): Promise<void>;
-
-    updateWorkspaceUserPin(id: string, action: "pin" | "unpin" | "toggle"): Promise<void>;
-    sendHeartBeat(options: GitpodServerV0.SendHeartBeatOptions): Promise<void>;
-    watchWorkspaceImageBuildLogs(workspaceId: string): Promise<void>;
-    watchHeadlessWorkspaceLogs(workspaceId: string): Promise<void>;
-    isPrebuildAvailable(pwsid: string): Promise<boolean>;
-    
-    // Workspace timeout
-    setWorkspaceTimeout(workspaceId: string, duration: WorkspaceTimeoutDuration): Promise<SetWorkspaceTimeoutResult>;
-    getWorkspaceTimeout(workspaceId: string): Promise<GetWorkspaceTimeoutResult>;
-    sendHeartBeat(options: GitpodServerV0.SendHeartBeatOptions): Promise<void>;
-
-    updateWorkspaceUserPin(id: string, action: "pin" | "unpin" | "toggle"): Promise<void>;
-
-    // Port management
-    getOpenPorts(workspaceId: string): Promise<WorkspaceInstancePort[]>;
-    openPort(workspaceId: string, port: WorkspaceInstancePort): Promise<WorkspaceInstancePort | undefined>;
-    closePort(workspaceId: string, port: number): Promise<void>;
-
-    // User messages
-    getUserMessages(options: GitpodServerV0.GetUserMessagesOptions): Promise<UserMessage[]>;
-    updateUserMessages(options: GitpodServerV0.UpdateUserMessagesOptions): Promise<void>;
-
-    // User storage
-    getUserStorageResource(options: GitpodServerV0.GetUserStorageResourceOptions): Promise<string>;
-    updateUserStorageResource(options: GitpodServerV0.UpdateUserStorageResourceOptions): Promise<void>;
-
-    // user env vars
-    getEnvVars(): Promise<UserEnvVarValue[]>;
-    setEnvVar(variable: UserEnvVarValue): Promise<void>;
-    deleteEnvVar(variable: UserEnvVarValue): Promise<void>;
-
-    // Gitpod token
-    getGitpodTokens(): Promise<GitpodToken[]>;
-    generateNewGitpodToken(options: { name?: string, type: GitpodTokenType, scopes?: [] }): Promise<string>;
-    deleteGitpodToken(tokenHash: string): Promise<void>;
-
-    // misc
-    sendFeedback(feedback: string): Promise<string | undefined>;
-    registerGithubApp(installationId: string): Promise<void>;
-
-    /**
-     * Stores a new snapshot for the given workspace and bucketId
-     * @return the snapshot id
-     */
-    takeSnapshot(options: GitpodServerV0.TakeSnapshotOptions): Promise<string>;
-
-    /**
-     * Returns the list of snapshots that exist for a workspace.
-     */
-    getSnapshots(workspaceID: string): Promise<string[]>;
-
-    /**
-     * stores/updates layout information for the given workspace
-     */
-    storeLayout(workspaceId: string, layoutData: string): Promise<void>;
-
-    /**
-     * retrieves layout information for the given workspace
-     */
-    getLayout(workspaceId: string): Promise<string | undefined>;
-
-    /**
-     * @param params
-     * @returns promise resolves to an URL to be used for the upload
-     */
-    preparePluginUpload(params: PreparePluginUploadParams): Promise<string>
-    resolvePlugins(workspaceId: string, params: ResolvePluginsParams): Promise<ResolvedPlugins>;
-    installUserPlugins(params: InstallPluginsParams): Promise<boolean>;
-    uninstallUserPlugin(params: UninstallPluginParams): Promise<boolean>;
 }
 
 export const WorkspaceTimeoutValues = ["30m", "60m", "180m"] as const;
@@ -509,53 +401,6 @@ export namespace GitpodServer {
 
     export interface UninstallUserPluginParams {
         readonly pluginId: string;
-    }
-}
-
-export namespace GitpodServerV0 {
-    export interface GetWorkspacesOptions {
-        limit?: number;
-        searchString?: string;
-        pinnedOnly?: boolean;
-    }
-    export interface GetAccountStatementOptions {
-        date?: string;
-    }
-    export interface CreateWorkspaceOptions {
-        contextUrl: string;
-        mode?: CreateWorkspaceMode;
-    }
-    export interface TakeSnapshotOptions {
-        workspaceId: string;
-        layoutData?: string;
-    }
-    export interface GetUserMessagesOptions {
-        readonly releaseNotes?: boolean;
-        readonly workspaceInstanceId: string;
-    }
-    export interface UpdateUserMessagesOptions {
-        readonly messageIds: string[];
-    }
-    export interface GetUserStorageResourceOptions {
-        readonly uri: string;
-    }
-    export interface UpdateUserStorageResourceOptions {
-        readonly uri: string;
-        readonly content: string;
-    }
-    export interface GetTokenSearchOptions {
-        readonly host: string;
-    }
-    export interface SendHeartBeatOptions {
-        readonly instanceId: string;
-        readonly wasClosed?: boolean;
-        readonly roundTripTime?: number;
-    }
-    export interface UpdateOwnAuthProviderParams {
-        readonly entry: AuthProviderEntry.UpdateEntry | AuthProviderEntry.NewEntry
-    }
-    export interface DeleteOwnAuthProviderParams {
-        readonly id: string
     }
 }
 

--- a/components/gitpod-protocol/src/license-protocol.ts
+++ b/components/gitpod-protocol/src/license-protocol.ts
@@ -32,7 +32,15 @@ export enum LicenseFeature {
 }
 
 export interface LicenseService {
-    validateLicense(): Promise<LicenseValidationResult>;
-    getLicenseInfo(): Promise<GetLicenseInfoResult>;
-    licenseIncludesFeature(feature: LicenseFeature): Promise<boolean>
+    validateLicense(params: LicenseService.ValidateLicenseParams): Promise<LicenseValidationResult>;
+    getLicenseInfo(params: LicenseService.GetLicenseInfoParams): Promise<GetLicenseInfoResult>;
+    licenseIncludesFeature(params: LicenseService.LicenseIncludesFeatureParams): Promise<boolean>
+}
+
+export namespace LicenseService {
+    export interface ValidateLicenseParams {}
+    export interface GetLicenseInfoParams {}
+    export interface LicenseIncludesFeatureParams {
+        readonly feature: LicenseFeature;
+    }
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -468,23 +468,6 @@ export namespace Workspace {
     }
 }
 
-export interface PreparePluginUploadParams {
-    fullPluginName: string;
-}
-
-export interface ResolvePluginsParams {
-    config?: WorkspaceConfig
-    builtins?: ResolvedPlugins
-}
-
-export interface InstallPluginsParams {
-    pluginIds: string[]
-}
-
-export interface UninstallPluginParams {
-    pluginId: string;
-}
-
 export type ResolvedPluginKind = 'user' | 'workspace' | 'builtin';
 
 export interface ResolvedPlugins {

--- a/components/server/src/theia-plugin/theia-plugin-service.ts
+++ b/components/server/src/theia-plugin/theia-plugin-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { ResolvePluginsParams, ResolvedPlugins, TheiaPlugin, PreparePluginUploadParams, InstallPluginsParams, UninstallPluginParams, ResolvedPluginKind } from '@gitpod/gitpod-protocol';
+import { ResolvedPlugins, TheiaPlugin, ResolvedPluginKind, GitpodServer } from '@gitpod/gitpod-protocol';
 import { TheiaPluginDB } from "@gitpod/gitpod-db/lib/theia-plugin-db";
 import { Env } from '../env';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
@@ -113,7 +113,7 @@ export class TheiaPluginService {
      *
      * @returns a public facing URL for the upload which contains the ID of a newly created DB entry for the plugin
      */
-    async preparePluginUpload(params: PreparePluginUploadParams, userId: string): Promise<string> {
+    async preparePluginUpload(params: GitpodServer.PreparePluginUploadParams, userId: string): Promise<string> {
         const { fullPluginName } = params;
         const pathFn = (pluginEntryId: string) => this.toObjectPath(pluginEntryId, userId, fullPluginName);
         const pluginEntry = await this.pluginDB.newPlugin(userId, fullPluginName, this.bucketName, pathFn);
@@ -145,7 +145,7 @@ export class TheiaPluginService {
             }).toString();
     }
 
-    async resolvePlugins(userId: string, { config, builtins }: ResolvePluginsParams): Promise<ResolvedPlugins> {
+    async resolvePlugins(userId: string, { config, builtins }: Pick<GitpodServer.ResolvePluginsParams, "builtins"|"config">): Promise<ResolvedPlugins> {
         const resolved: ResolvedPlugins = {};
         const addedPlugins = new Set<string>();
         const resolvePlugin = async (extension: string, kind: ResolvedPluginKind) => {
@@ -194,7 +194,7 @@ export class TheiaPluginService {
         return this.getPublicPluginURL(pluginEntry.id)
     }
 
-    async installUserPlugins(userId: string, params: InstallPluginsParams): Promise<boolean> {
+    async installUserPlugins(userId: string, params: GitpodServer.InstallUserPluginsParams): Promise<boolean> {
         if (!params.pluginIds.length) {
             return false;
         }
@@ -210,7 +210,7 @@ export class TheiaPluginService {
         });
     }
 
-    async uninstallUserPlugin(userId: string, params: UninstallPluginParams): Promise<boolean> {
+    async uninstallUserPlugin(userId: string, params: GitpodServer.UninstallUserPluginParams): Promise<boolean> {
         return await this.updateUserPlugins(userId, pluginIds =>
             pluginIds.delete(params.pluginId)
         );

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -14,7 +14,7 @@ const workspaceUrl = new GitpodHostUrl(window.location.href);
 const { workspaceId } = workspaceUrl;
 if (workspaceId) {
     const gitpodService = createGitpodService(workspaceUrl.withoutWorkspacePrefix().toString());
-    gitpodService.server.getWorkspace(workspaceId).then(info => {
+    gitpodService.server.getWorkspace({workspaceId}).then(info => {
         document.title = info.workspace.description;
     });
 } else {

--- a/components/theia/packages/gitpod-extension/src/browser/activity/gitpod-not-running-dialog.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/activity/gitpod-not-running-dialog.ts
@@ -192,7 +192,7 @@ export class GitpodNotRunningOverlay extends BaseWidget {
                 }
             }
             connectionStatus.onStatusChange(async () => {
-                const wsInfo = await service.server.getWorkspace(info.workspaceId);
+                const wsInfo = await service.server.getWorkspace({workspaceId: info.workspaceId});
                 if (wsInfo.latestInstance) {
                     onInstanceUpdate(wsInfo.latestInstance);
                 }
@@ -200,7 +200,7 @@ export class GitpodNotRunningOverlay extends BaseWidget {
             const doc = window.document;
             doc.addEventListener('visibilitychange', async () => {
                 if (doc.visibilityState === 'visible') {
-                    const wsInfo = await service.server.getWorkspace(info.workspaceId);
+                    const wsInfo = await service.server.getWorkspace({workspaceId: info.workspaceId});
                     if (wsInfo.latestInstance) {
                         onInstanceUpdate(wsInfo.latestInstance);
                     }
@@ -234,7 +234,7 @@ export class GitpodNotRunningOverlay extends BaseWidget {
     }
 
     private async getContextUrl(info: GitpodInfo, service: GitpodService): Promise<string> {
-        const workspace = await service.server.getWorkspace(info.workspaceId);
+        const workspace = await service.server.getWorkspace({workspaceId: info.workspaceId});
         return workspace.workspace.contextURL;
     }
 }

--- a/components/theia/packages/gitpod-extension/src/browser/cli-service-client.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/cli-service-client.ts
@@ -42,7 +42,7 @@ export class CliServiceClientImpl implements CliServiceClient {
     protected async init() {
         this.gitpodInfo = await this.infoProvider.getInfo();
         const service = await this.serviceProvider.getService();
-        this.isWorkspaceOwner.resolve(await service.server.isWorkspaceOwner(this.gitpodInfo.workspaceId));
+        this.isWorkspaceOwner.resolve(await service.server.isWorkspaceOwner({workspaceId: this.gitpodInfo.workspaceId}));
     }
 
     protected async checkWorkspaceOwner() {
@@ -92,7 +92,7 @@ export class CliServiceClientImpl implements CliServiceClient {
         const service = await this.serviceProvider.getService();
 
         const matchedVariables = await this.matchWithApplicableVars(params.variables, service.server);
-        await Promise.all(matchedVariables.map(v => service.server.setEnvVar(v)));
+        await Promise.all(matchedVariables.map(v => service.server.setEnvVar({variable: v})));
 
         return {};
     }
@@ -103,7 +103,7 @@ export class CliServiceClientImpl implements CliServiceClient {
         const vars = params.variables.map(v => { return { name: v, value: "" } });
         const matchedVariables = await this.matchWithApplicableVars(vars, service.server);
         const candidates = matchedVariables.filter(v => !!v.id);
-        await Promise.all(candidates.map(v => service.server.deleteEnvVar(v)));
+        await Promise.all(candidates.map(v => service.server.deleteEnvVar({variable: v})));
 
         return {
             deleted: candidates.map(v => v.name),
@@ -143,7 +143,7 @@ export class CliServiceClientImpl implements CliServiceClient {
     }
 
     protected async getApplicableEnvvars(service: GitpodServer): Promise<UserEnvVarValue[]> {
-        const ws = await service.getWorkspace(this.gitpodInfo.workspaceId);
+        const ws = await service.getWorkspace({workspaceId: this.gitpodInfo.workspaceId});
 
         const context = ws.workspace.context;
         if (!("repository" in context)) {
@@ -154,13 +154,13 @@ export class CliServiceClientImpl implements CliServiceClient {
         const owner = repository.owner;
         const repo = repository.name;
 
-        const vars = await service.getEnvVars();
+        const vars = await service.getEnvVars({});
         return UserEnvVar.filter(vars, owner, repo);
 
     }
 
     protected async getRepo(service: GitpodServer): Promise<{ owner: string, repo: string } | undefined> {
-        const ws = await service.getWorkspace(this.gitpodInfo.workspaceId);
+        const ws = await service.getWorkspace({workspaceId: this.gitpodInfo.workspaceId});
 
         const context = ws.workspace.context;
         if (!CommitContext.is(context)) {
@@ -175,7 +175,7 @@ export class CliServiceClientImpl implements CliServiceClient {
     async getPortURL(params: GetPortURLRequest): Promise<GetPortURLResponse> {
         const service = await this.serviceProvider.getService();
         
-        const ws = await service.server.getWorkspace(this.gitpodInfo.workspaceId);
+        const ws = await service.server.getWorkspace({workspaceId: this.gitpodInfo.workspaceId});
         if (!ws.latestInstance) {
             throw new Error("workspace has no instance");
         }

--- a/components/theia/packages/gitpod-extension/src/browser/extensions/extensions-installer.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/extensions/extensions-installer.ts
@@ -10,7 +10,7 @@ import { MessageService } from '@theia/core/lib/common/message-service';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { CancellationTokenSource, CancellationToken } from '@theia/core/lib/common/cancellation';
 import { ErrorCodes } from '@gitpod/gitpod-protocol/lib/messaging/error';
-import { InstallPluginsParams, ResolvedPluginKind } from '@gitpod/gitpod-protocol';
+import { ResolvedPluginKind, GitpodServer } from '@gitpod/gitpod-protocol';
 import { GitpodPluginService, DeployedPlugin } from '../../common/gitpod-plugin-service';
 import { OpenVSXExtensionProvider } from '../../common/openvsx-extension-provider';
 import { GitpodServiceProvider } from '../gitpod-service-provider';
@@ -98,7 +98,7 @@ export class ExtensionsInstaller {
         }
     }
 
-    protected async installPlugins(params: InstallPluginsParams, pluginKind: ResolvedPluginKind, token: CancellationToken): Promise<void> {
+    protected async installPlugins(params: GitpodServer.InstallUserPluginsParams, pluginKind: ResolvedPluginKind, token: CancellationToken): Promise<void> {
         if (pluginKind === 'user') {
             const { server } = await this.serviceProvider.getService();
             if (token.isCancellationRequested) {

--- a/components/theia/packages/gitpod-extension/src/browser/extensions/extensions-source.tsx
+++ b/components/theia/packages/gitpod-extension/src/browser/extensions/extensions-source.tsx
@@ -86,11 +86,11 @@ export class ExtensionNodes {
             this.serviceProvider.getService()
         ]);
         const [workspaceOwner, isWorkspaceOwner] = await Promise.all([
-            server.getWorkspaceOwner(gitpodInfo.workspaceId),
-            server.isWorkspaceOwner(gitpodInfo.workspaceId)
+            server.getWorkspaceOwner({workspaceId: gitpodInfo.workspaceId}),
+            server.isWorkspaceOwner({workspaceId: gitpodInfo.workspaceId})
         ])
         this._workspaceOwner = workspaceOwner;
-        this.isWorkspaceOwner = isWorkspaceOwner;
+        this.isWorkspaceOwner = isWorkspaceOwner || false;
         this.update();
         this.pluginSupport.onDidChangePlugins(() => this.update());
     }

--- a/components/theia/packages/gitpod-extension/src/browser/extensions/gitpod-plugin-server.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/extensions/gitpod-plugin-server.ts
@@ -32,7 +32,7 @@ export class GitpodPluginServer implements PluginServer {
         if (!this.workspaceStorageURI) {
             const info = await this.info.getInfo();
             const service = await this.serviceProvider.getService();
-            const ws = await service.server.getWorkspace(info.workspaceId);
+            const ws = await service.server.getWorkspace({workspaceId: info.workspaceId});
             if (CommitContext.is(ws.workspace.context)) {
                 this.workspaceStorageURI = 'workspace-storage:/' + encodeURIComponent(ws.workspace.context.repository.cloneUrl) +'/';
             }

--- a/components/theia/packages/gitpod-extension/src/browser/extensions/gitpod-plugin-support.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/extensions/gitpod-plugin-support.ts
@@ -8,7 +8,7 @@ import { injectable, inject } from "inversify";
 import { HostedPluginSupport } from "@theia/plugin-ext/lib/hosted/browser/hosted-plugin";
 import { PluginMetadata } from "@theia/plugin-ext";
 import { GitpodPluginClient, DidDeployPluginsResult } from "../../common/gitpod-plugin-service";
-import { ResolvedPlugins, ResolvePluginsParams } from "@gitpod/gitpod-protocol";
+import { ResolvedPlugins, GitpodServer } from "@gitpod/gitpod-protocol";
 import { GitpodServiceProvider } from "../gitpod-service-provider";
 import { MessageService } from "@theia/core/lib/common/message-service";
 import { Progress } from "@theia/core/lib/common/message-service-protocol";
@@ -33,10 +33,14 @@ export class GitpodPluginSupport extends HostedPluginSupport implements GitpodPl
     @inject(MessageService)
     protected readonly messageService: MessageService;
 
-    async resolve(params: ResolvePluginsParams): Promise<ResolvedPlugins> {
+    async resolve(params: GitpodServer.ResolvePluginsParams): Promise<ResolvedPlugins> {
         const info = await this.infoProvider.getInfo();
         const { server } = await this.serviceProvider.getService();
-        return await server.resolvePlugins(info.workspaceId, params);
+        return await server.resolvePlugins({
+            workspaceId: info.workspaceId,
+            builtins: params.builtins,
+            config: params.config,
+        });
     }
 
     protected deployProgress: Promise<Progress> | undefined;

--- a/components/theia/packages/gitpod-extension/src/browser/git-host-watcher.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/git-host-watcher.ts
@@ -60,7 +60,7 @@ export class GitHostWatcher implements FrontendApplicationContribution {
             return this.authProviders;
         }
         const service = await this.serviceProvider.getService();
-        this.authProviders = await service.server.getAuthProviders();
+        this.authProviders = await service.server.getAuthProviders({});
         return this.authProviders;
     }
 

--- a/components/theia/packages/gitpod-extension/src/browser/githoster/git-state.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/githoster/git-state.ts
@@ -191,7 +191,7 @@ export abstract class GitState {
             }
         }
         const info = await this.infoService.getInfo();
-        const ws = await this.serviceProvider.getService().server.getWorkspace(info.workspaceId);
+        const ws = await this.serviceProvider.getService().server.getWorkspace({workspaceId: info.workspaceId});
         if (IssueContext.is(ws.workspace.context)) {
             return {
                 label: `${ws.workspace.context.repository.owner}/${ws.workspace.context.repository.name}#${ws.workspace.context.nr}`,

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-account-info.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-account-info.ts
@@ -69,7 +69,7 @@ export class GitpodAccountInfoDialog extends AbstractDialog<void> {
 
     async open() {
         const service = await this.gitpodServiceProvider.getService();
-        this.user.textContent = '' + (await service.server.getLoggedInUser()).name;
+        this.user.textContent = '' + (await service.server.getLoggedInUser({})).name;
         super.open();
     }
 }

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-branding.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-branding.ts
@@ -19,7 +19,7 @@ export class GitpodBranding {
     @postConstruct()
     protected async init() {
         const service = await this.serviceProvider.getService();
-        this.brandingPromise.resolve(await service.server.getBranding());
+        this.brandingPromise.resolve(await service.server.getBranding({}));
     }
 
     get branding(): Promise<Branding> {

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-git-token-provider.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-git-token-provider.ts
@@ -45,7 +45,7 @@ export class GitpodGitTokenProvider {
     @postConstruct()
     protected async init() {
         const { server } = this.serviceProvider.getService();
-        const [gitpodInfo, authProviders] = await Promise.all([this.infoProvider.getInfo(), server.getAuthProviders()]);
+        const [gitpodInfo, authProviders] = await Promise.all([this.infoProvider.getInfo(), server.getAuthProviders({})]);
         this.gitpodInfo = gitpodInfo;
         this.authProviders = authProviders;
     }

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-open-context.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-open-context.ts
@@ -40,7 +40,7 @@ export class GitpodOpenContext implements FrontendApplicationContribution, Initi
     async onStart(app: FrontendApplication) {
         const info = await this.GitpodInfoService.getInfo();
         const service = await this.gitpodServiceProvider.getService();
-        this.workspace = (await service.server.getWorkspace(info.workspaceId)).workspace;
+        this.workspace = (await service.server.getWorkspace({workspaceId: info.workspaceId})).workspace;
         await this.refresh();
     }
 

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-share-widget.tsx
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-share-widget.tsx
@@ -31,7 +31,7 @@ export class GitpodShareWidget extends ReactWidget {
     protected async onAfterAttach() {
         const info = await this.infoProvider.getInfo();
         const service = await this.serviceProvider.getService();
-        this.isWorkspaceOwner = await service.server.isWorkspaceOwner(info.workspaceId);
+        this.isWorkspaceOwner = await service.server.isWorkspaceOwner({workspaceId: info.workspaceId});
         this.update();
 
         this.startWorkspaceUserPolling(info.workspaceId);
@@ -44,8 +44,8 @@ export class GitpodShareWidget extends ReactWidget {
         if (this.isWorkspaceOwner) {
             this.workspaceUserPoll = setInterval(async () => {
                 const gitpodService = await this.serviceProvider.getService();
-                const user = await gitpodService.server.getLoggedInUser();
-                this.workspaceUsers = (await gitpodService.server.getWorkspaceUsers(workspaceId)).filter(u => u.userId != user.id);
+                const user = await gitpodService.server.getLoggedInUser({});
+                this.workspaceUsers = (await gitpodService.server.getWorkspaceUsers({workspaceId})).filter(u => u.userId != user.id);
                 this.update();
             }, 10000);
         }
@@ -151,15 +151,15 @@ export class GitpodShareDialog extends AbstractDialog<boolean> {
     protected async setWorkspaceShareable(shareable: boolean): Promise<void> {
         const info = await this.infoProvider.getInfo();
         const gitpodService = this.serviceProvider.getService();
-        await gitpodService.server.controlAdmission(info.workspaceId, shareable ? "everyone" : "owner");
+        await gitpodService.server.controlAdmission({workspaceId: info.workspaceId, level: shareable ? "everyone" : "owner"});
         const layout = this.layoutRestorer.captureLayout();
-        gitpodService.server.storeLayout(info.workspaceId, layout);
+        gitpodService.server.storeLayout({workspaceId: info.workspaceId, layoutData: layout});
     }
 
     protected async isWorkspaceShared(): Promise<boolean> {
         const info = await this.infoProvider.getInfo();
         const gitpodService = this.serviceProvider.getService();
-        const workspace = await gitpodService.server.getWorkspace(info.workspaceId);
+        const workspace = await gitpodService.server.getWorkspace({ workspaceId: info.workspaceId });
         return workspace.workspace.shareable || false;
     }
 

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-shell-layout-restorer.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-shell-layout-restorer.ts
@@ -41,7 +41,7 @@ export class GitpodLayoutRestorer extends ShellLayoutRestorer {
         super(widgetManager, logger, storageService);
         const service = this.serviceProvider.getService()
         const workspaceId = getWorkspaceID();
-        service.server.getLayout(workspaceId).then(layout => {
+        service.server.getLayout({workspaceId}).then(layout => {
             // update placeholders with new workspace id
             const replaced = layout && replaceAll(layout, workspaceIdPlaceHolder, workspaceId);
             this.layoutData.resolve(replaced);

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-snapshot-support.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-snapshot-support.ts
@@ -72,7 +72,7 @@ export class SnapshotTakenDialog extends AbstractDialog<boolean> {
     }
 
     public async open() {
-        const canCreateSnapshot = await this.service.server.licenseIncludesFeature(LicenseFeature.CreateSnapshot);
+        const canCreateSnapshot = await this.service.server.licenseIncludesFeature({feature: LicenseFeature.CreateSnapshot});
         if (!canCreateSnapshot) {
             this.showNoLicenseContent();
         }

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-ui-contribution.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-ui-contribution.ts
@@ -86,11 +86,11 @@ export class GitpodUiContribution implements FrontendApplicationContribution, Co
         const workspaceId = getWorkspaceID();
         try {
             const service = this.serviceProvider.getService();
-            const user = await service.server.getLoggedInUser();
-            service.server.isWorkspaceOwner(workspaceId).then((isOwner) => {
+            const user = await service.server.getLoggedInUser({});
+            service.server.isWorkspaceOwner({workspaceId}).then((isOwner) => {
                 this.isWorkspaceOwner.resolve(isOwner);
             });
-            service.server.getWorkspaceTimeout(workspaceId).then(resp => {
+            service.server.getWorkspaceTimeout({workspaceId}).then(resp => {
                 this.canChangeTimeout.resolve(resp.canChange);
             });
 
@@ -106,7 +106,7 @@ export class GitpodUiContribution implements FrontendApplicationContribution, Co
                     this.onInstanceUpdate(i);
                 }
             });
-            service.server.getWorkspace(workspaceId).then(ws => {
+            service.server.getWorkspace({workspaceId}).then(ws => {
                 if (!ws.latestInstance) {
                     return;
                 }
@@ -245,8 +245,8 @@ export class GitpodUiContribution implements FrontendApplicationContribution, Co
         const service = await this.serviceProvider.getService();
         const info = await this.infoProvider.getInfo();
 
-        if (await service.server.isWorkspaceOwner(info.workspaceId)) {
-            service.server.stopWorkspace(info.workspaceId);
+        if (await service.server.isWorkspaceOwner({workspaceId: info.workspaceId})) {
+            service.server.stopWorkspace({workspaceId: info.workspaceId});
         } else {
             this.showNoPermissionMessage();
         }
@@ -327,9 +327,9 @@ export class GitpodUiContribution implements FrontendApplicationContribution, Co
         const service = await this.serviceProvider.getService();
         const info = await this.infoProvider.getInfo();
 
-        if (await service.server.isWorkspaceOwner(info.workspaceId)) {
+        if (await service.server.isWorkspaceOwner({workspaceId: info.workspaceId})) {
             try {
-                const result = await service.server.setWorkspaceTimeout(info.workspaceId, "180m");
+                const result = await service.server.setWorkspaceTimeout({ workspaceId: info.workspaceId, duration: "180m" });
                 if (!!result.resetTimeoutOnWorkspaces && result.resetTimeoutOnWorkspaces.length > 0) {
                     this.messageService.warn(`Workspace timeout has been extended to three hours. This reset the workspace timeout for other workspaces.`);
                 } else {

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-ws-connection-provider.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-ws-connection-provider.ts
@@ -85,7 +85,7 @@ export class GitpodWebSocketConnectionProvider extends WebSocketConnectionProvid
         s.registerClient({ onInstanceUpdate })
         const doc = window.document;
         const update = async () => {
-            const wsInfo = await s.server.getWorkspace(workspaceId);
+            const wsInfo = await s.server.getWorkspace({workspaceId});
             onInstanceUpdate(wsInfo.latestInstance);
         }
         doc.addEventListener('visibilitychange', async () => {

--- a/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-port-view-widget.tsx
+++ b/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-port-view-widget.tsx
@@ -56,7 +56,7 @@ export class GitpodPortViewWidget extends ReactWidget {
     @postConstruct()
     protected async initialize() {
         this.workspaceId = getWorkspaceID();
-        this.isWorkspaceOwner = await (this.serviceProvider.getService()).server.isWorkspaceOwner(this.workspaceId);
+        this.isWorkspaceOwner = await (this.serviceProvider.getService()).server.isWorkspaceOwner({ workspaceId: this.workspaceId });
         this.update();
     }
 

--- a/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-ports-auth-manager.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-ports-auth-manager.ts
@@ -46,7 +46,7 @@ export class GitpodPortsAuthManger {
         //  - the cookie (which carries the token) expires 5mins after the token itself
         const updateCookie = async () => {
             const service = await this.serviceProvider.getService();
-            const token = await service.server.getPortAuthenticationToken(workspaceId);
+            const token = await service.server.getPortAuthenticationToken({workspaceId});
 
             let expires: Date | undefined = undefined;
             if (token.expiryDate) {

--- a/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-ports-service.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-ports-service.ts
@@ -117,7 +117,7 @@ export class GitpodPortsService {
                 // if the response arrives before the event add `didOpen` ports
                 this.updateServedPorts({ ports: servedPorts, didOpen: receivedServedPortsEvent ? [] : servedPorts, didClose: [] });
             }),
-            this.service.server.getOpenPorts(this.workspaceId).then(openPorts => {
+            this.service.server.getOpenPorts({workspaceId: this.workspaceId}).then(openPorts => {
                 if (!receivedInstanceUpdate) {
                     this.updateInstancePortConfig(openPorts);
                 }
@@ -179,7 +179,7 @@ export class GitpodPortsService {
 
     protected workspaceConfigPorts: PortConfig[] = [];
     protected async loadWorkspaceConfigPorts(workspaceId: string) {
-        const workspaceInfo = await this.service.server.getWorkspace(workspaceId);
+        const workspaceInfo = await this.service.server.getWorkspace({workspaceId});
         const config = workspaceInfo.workspace.config;
         this.workspaceConfigPorts = config.ports ? config.ports : [];
     }
@@ -286,7 +286,7 @@ export class GitpodPortsService {
                 }
             });
         });
-        await this.service.server.openPort(this.workspaceId, cfg);
+        await this.service.server.openPort({workspaceId: this.workspaceId, port: cfg});
 
         await portOpenedInK8s;
     }

--- a/components/theia/packages/gitpod-extension/src/browser/waitfor-content-contribution.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/waitfor-content-contribution.ts
@@ -46,7 +46,7 @@ export class WaitForContentContribution implements FrontendApplicationContributi
         let iv: number | undefined;
         const resolveIfRunning = async () => {
             try {
-                const wsinfo = await this.serviceProvider.getService().server.getWorkspace(info.workspaceId);
+                const wsinfo = await this.serviceProvider.getService().server.getWorkspace({workspaceId: info.workspaceId});
                 if (!wsinfo.latestInstance) {
                     console.warn("getWorkspace did not return a workspace instance");
                     return;

--- a/components/theia/packages/gitpod-extension/src/common/gitpod-plugin-service.ts
+++ b/components/theia/packages/gitpod-extension/src/common/gitpod-plugin-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
-import { ResolvedPlugins, ResolvedPluginKind, ResolvePluginsParams, InstallPluginsParams, UninstallPluginParams } from "@gitpod/gitpod-protocol";
+import { ResolvedPlugins, ResolvedPluginKind, GitpodServer } from "@gitpod/gitpod-protocol";
 import { PluginModel } from '@theia/plugin-ext/lib/common/plugin-protocol';
 
 export const gitpodPluginPath = '/services/gitpodPlugin';
@@ -19,9 +19,9 @@ export interface GitpodPluginService {
 
     find(params: FindExtensionsParams, token: CancellationToken): Promise<FindExtensionsResult>;
 
-    install(params: InstallPluginsParams, token: CancellationToken): Promise<void>;
+    install(params: GitpodServer.InstallUserPluginsParams, token: CancellationToken): Promise<void>;
 
-    uninstall(params: UninstallPluginParams, token: CancellationToken): Promise<void>;
+    uninstall(params: GitpodServer.UninstallUserPluginParams, token: CancellationToken): Promise<void>;
 
     upload(params: UploadExtensionParams): Promise<string>;
 
@@ -42,7 +42,7 @@ export interface GitpodPluginClientEventEmitter {
 }
 
 export interface GitpodPluginClient extends GitpodPluginClientEventEmitter {
-    resolve(params: ResolvePluginsParams): Promise<ResolvedPlugins>;
+    resolve(params: Pick<GitpodServer.ResolvePluginsParams, "builtins"|"config">): Promise<ResolvedPlugins>;
 }
 
 export interface FindExtensionsParams {

--- a/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-deployer.ts
+++ b/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-deployer.ts
@@ -27,7 +27,7 @@ import { GitpodPluginDeployerHandler } from "./gitpod-plugin-deployer-handler";
 import { GitpodPluginModel } from './gitpod-plugin-model';
 import { GitpodPluginResolver } from './gitpod-plugin-resolver';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
-import { WorkspaceConfig, ResolvedPlugins, ResolvedPlugin, InstallPluginsParams, UninstallPluginParams } from '@gitpod/gitpod-protocol';
+import { WorkspaceConfig, ResolvedPlugins, ResolvedPlugin, GitpodServer } from '@gitpod/gitpod-protocol';
 import filenamify = require('filenamify');
 import { ApplicationPackage } from '@theia/application-package/lib/application-package';
 import { PluginIndexEntry } from '@gitpod/gitpod-protocol/lib/theia-plugins';
@@ -257,10 +257,10 @@ export class GitpodPluginDeployer implements GitpodPluginService {
 
     protected async resolvePlugins(): Promise<ResolvedPlugins | undefined> {
         try {
-            const value: GitpodPluginClient = this.clients.values().next().value;
-            if (value) {
+            const client: GitpodPluginClient = this.clients.values().next().value;
+            if (client) {
                 const config = await this.parse();
-                const resolved = await value.resolve({ config, builtins: this.getBuiltins() });
+                const resolved = await client.resolve({ config, builtins: this.getBuiltins() });
                 return resolved;
             }
         } catch (e) {
@@ -428,7 +428,7 @@ export class GitpodPluginDeployer implements GitpodPluginService {
         }
     }
 
-    async install({ pluginIds }: InstallPluginsParams, token: CancellationToken): Promise<void> {
+    async install({ pluginIds }: GitpodServer.InstallUserPluginsParams, token: CancellationToken): Promise<void> {
         await this.updateGitpodFile(async (gitpodFilePath) => {
             let content = '';
             try {
@@ -444,7 +444,7 @@ export class GitpodPluginDeployer implements GitpodPluginService {
         }, token);
     }
 
-    async uninstall({ pluginId }: UninstallPluginParams, token: CancellationToken): Promise<void> {
+    async uninstall({ pluginId }: GitpodServer.UninstallUserPluginParams, token: CancellationToken): Promise<void> {
         return this.updateGitpodFile(async (gitpodFilePath) => {
             let content = '';
             try {


### PR DESCRIPTION
This PR harmonises the Gitpod API so that all calls use a "params structure".

At the moment most API calls accept multiple parameters/arguments, instead of a single parameter struct. While this makes the API definition a tad easier to read, it comes with a host of downsides.:
- it’s inconsistent. Some calls take param structs, other’s don’t
- the JSON RPC proxy can’t handle optional arguments, something that one has to know and which breaks really weirdly.
- it prevents handling cross-cutting concerns on the RPC layer, e.g. API scoping, enforcing resource access permissions. This is because in JSON RPC parameters have no names, but just positions. When there’s just one parameter that is a struct, parameters do have names. Using param structs on JSON RPC interfaces is also how other big hitters, e.g. LSP do it. Also, now is the time to clean up our act before we make this API truly public. We want our API to be consistent, and need to implement proper scoping/resource access restrictions.