### PR TITLE
[server] Provide token-based API access

### DIFF
--- a/chart/config/proxy/lib.locations.conf
+++ b/chart/config/proxy/lib.locations.conf
@@ -148,8 +148,15 @@ location /internal-wsdl {
 #####   API / auth -> server
 ### mapping $request_uri -> $request_uri_api_dropped: vhost.map-api-request-uri.conf
 
-# Websocket connection
+# Websocket connections
 location = /api/gitpod {
+    include lib.proxy.conf;
+    include lib.cors-headers.conf;
+    include lib.ws-sse.conf;
+
+    proxy_pass http://ws-apiserver$request_uri_api_dropped;
+}
+location = /api/v1 {
     include lib.proxy.conf;
     include lib.cors-headers.conf;
     include lib.ws-sse.conf;

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -148,7 +148,7 @@ export class TypeORMUserDBImpl implements UserDB {
         return result.sort(order);
     }
 
-    public async findUserByGitpodToken(tokenHash: string, tokenType?: GitpodTokenType): Promise<User | undefined> {
+    public async findUserByGitpodToken(tokenHash: string, tokenType?: GitpodTokenType): Promise<{user: User, token: GitpodToken} | undefined> {
         const repo = await this.getGitpodTokenRepo();
         const qBuilder = repo.createQueryBuilder('gitpodToken')
             .leftJoinAndSelect("gitpodToken.user", "user");
@@ -159,7 +159,11 @@ export class TypeORMUserDBImpl implements UserDB {
         }
         qBuilder.andWhere("gitpodToken.deleted <> TRUE AND user.markedDeleted <> TRUE AND user.blocked <> TRUE");
         const token = await qBuilder.getOne();
-        return token && token.user;
+        if (!token) {
+            return;
+        }
+
+        return {user: token.user, token};
     }
 
     public async findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]> {

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -110,7 +110,7 @@ export interface UserDB {
     findAllUsers(offset: number, limit: number, orderBy: keyof User, orderDir: "ASC" | "DESC", searchTerm?: string, minCreationDate?: Date, maxCreationDate?: Date, excludeBuiltinUsers?: boolean): Promise<{total: number, rows: User[]}>;
     findUserByName(name: string): Promise<User | undefined>;
 
-    findUserByGitpodToken(tokenHash: string, tokenType?: GitpodTokenType): Promise<MaybeUser>;
+    findUserByGitpodToken(tokenHash: string, tokenType?: GitpodTokenType): Promise<{user: User, token: GitpodToken} | undefined>;
     findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]>;
     storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void>;
     deleteGitpodToken(tokenHash: string): Promise<void>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -250,7 +250,8 @@ export interface GitpodToken {
 }
 
 export enum GitpodTokenType {
-    API_AUTH_TOKEN = 0
+    API_AUTH_TOKEN = 0,
+    MACHINE_AUTH_TOKEN = 1
 }
 
 export interface OneTimeSecret {

--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -60,4 +60,4 @@ scripts:
       telepresence --swap-deployment server \
                    --method vpn-tcp \
                    --run yarn start-ee-inspect | \
-        leeway run gitpod-core/components:dejson-log-output
+        leeway run components:dejson-log-output

--- a/components/server/ee/src/graphql/graphql-controller.ts
+++ b/components/server/ee/src/graphql/graphql-controller.ts
@@ -35,7 +35,10 @@ export class GraphQLController {
             const ctx = request as any as Context;
             ctx.authToken = this.bearerToken(request.headers);
             if (!ctx.user && !!ctx.authToken) {
-                ctx.user = await this.userDb.findUserByGitpodToken(ctx.authToken, GitpodTokenType.API_AUTH_TOKEN);
+                const ut = await this.userDb.findUserByGitpodToken(ctx.authToken, GitpodTokenType.API_AUTH_TOKEN);
+                if (!!ut) {
+                    ctx.user = ut.user;
+                }
             }
             return {
                 schema,

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -20,7 +20,7 @@ import { AuthProviderService } from './auth-provider-service';
 export class Authenticator {
 
     protected passportInitialize: express.Handler;
-    protected passportsession: express.Handler;
+    protected passportSession: express.Handler;
 
     @inject(Env) protected env: Env;
     @inject(UserDB) protected userDb: UserDB;
@@ -32,7 +32,7 @@ export class Authenticator {
     protected setup() {
         // Setup passport
         this.passportInitialize = passport.initialize();
-        this.passportsession = passport.session();
+        this.passportSession = passport.session();
         passport.serializeUser((user: User, done) => {
             if (user) {
                 done(null, user.id);
@@ -57,7 +57,7 @@ export class Authenticator {
     get initHandlers(): express.Handler[] {
         return [
             this.passportInitialize,    // adds `passport.user` to session
-            this.passportsession        // deserializes session user into  `req.user`
+            this.passportSession        // deserializes session user into  `req.user`
         ];
     }
 

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -1,0 +1,57 @@
+import * as websocket from 'ws';
+import * as express from 'express';
+import * as crypto from 'crypto';
+import { Headers } from 'request';
+import { WsRequestHandler, WsNextFunction } from '../express/ws-handler';
+import { GitpodTokenType } from '@gitpod/gitpod-protocol';
+import { injectable, inject } from 'inversify';
+import { UserDB } from '@gitpod/gitpod-db/lib/user-db';
+import { WithResourceAccessGuard, TokenResourceGuard } from './resource-access';
+import { WithFunctionAccessGuard, ExplicitFunctionAccessGuard } from './function-access';
+
+export function getBearerToken(headers: Headers): string | undefined {
+    const authorizationHeader = headers["authorization"];
+    if (!authorizationHeader || !(typeof authorizationHeader === "string")) {
+        return;
+    }
+    if (!authorizationHeader.startsWith("Bearer ")) {
+        return;
+    }
+
+    const token = authorizationHeader.substring("Bearer ".length);
+    const hash = crypto.createHash('sha256').update(token, 'utf8').digest("hex");
+    return hash;
+}
+
+@injectable()
+export class BearerAuth {
+    @inject(UserDB) protected readonly userDB: UserDB;
+
+    public get websocketHandler(): WsRequestHandler {
+        return async (ws: websocket, req: express.Request, next: WsNextFunction): Promise<void> => {
+            const token = getBearerToken(req.headers)
+            if (!token) {
+                throw new Error("not authenticated");
+            }
+
+            const userAndToken = await this.userDB.findUserByGitpodToken(token, GitpodTokenType.API_AUTH_TOKEN);
+            if (!userAndToken) {
+                throw new Error("invalid Bearer token");
+            }
+
+            const resourceGuard = new TokenResourceGuard(userAndToken.user.id, userAndToken.token.scopes);
+            (req as WithResourceAccessGuard).resourceGuard = resourceGuard;
+
+            const functionScopes = userAndToken.token.scopes
+                .filter(s => s.startsWith("function:"))
+                .map(s => s.substring("function:".length));
+            // We always install a function access guard. If the token has no scopes, it's not allowed to do anything.
+            (req as WithFunctionAccessGuard).functionGuard = new ExplicitFunctionAccessGuard(functionScopes);
+
+            req.user = userAndToken.user;
+
+            return next();
+        }
+    }
+
+}

--- a/components/server/src/auth/function-access.ts
+++ b/components/server/src/auth/function-access.ts
@@ -1,0 +1,24 @@
+import { injectable } from "inversify";
+
+export interface FunctionAccessGuard {
+    canAccess(name: string): boolean;
+}
+
+export interface WithFunctionAccessGuard {
+    functionGuard?: FunctionAccessGuard;
+}
+
+@injectable()
+export class AllAccessFunctionGuard {
+    canAccess(name: string): boolean {
+        return true;
+    }
+}
+
+export class ExplicitFunctionAccessGuard {
+    constructor(protected readonly allowedCalls: string[]) {}
+
+    canAccess(name: string): boolean {
+        return this.allowedCalls.some(c => c === name);
+    }
+}

--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -1,0 +1,101 @@
+import { suite, test } from "mocha-typescript";
+import * as chai from 'chai';
+const expect = chai.expect;
+import { TokenResourceGuard, ScopedResourceGuard, GuardedResource } from "./resource-access";
+
+@suite class TestResourceAccess {
+
+    @test public async areScopesSubsetOf() {
+        const tests: {
+            name: string
+            upper: string[]
+            lower: string[]
+            isSubset: boolean
+        }[] = [
+            {name: "empty scopes", upper: [], lower: [], isSubset: true},
+            {name: "empty upper, function lower", upper: [], lower: ["function:foo"], isSubset: false},
+            {name: "empty upper, resource lower", upper: [], lower: ["resource:workspace::foobar::get"], isSubset: false},
+            {name: "resource default upper, resource lower", upper: ["resource:default"], lower: ["resource:workspace::foobar::get"], isSubset: false},
+            {name: "resource upper, empty lower", upper: ["resource:workspace::foobar::get"], lower: [], isSubset: true},
+            {name: "resource upper, one op less lower", upper: ["resource:workspace::foobar::get,create"], lower: ["resource:workspace::foobar::get"], isSubset: true},
+            {name: "resource upper, different resource lower", upper: ["resource:workspace::foobar::get,create"], lower: ["resource:workspace::blabla::get"], isSubset: false},
+            {name: "function upper, empty lower", upper: ["function:foo"], lower: [], isSubset: true},
+            {name: "function upper, function lower", upper: ["function:foo"], lower: ["function:foo"], isSubset: true},
+            {name: "function upper, one function lower", upper: ["function:foo", "function:bar"], lower: ["function:foo"], isSubset: true},
+        ];
+
+        tests.forEach(t => {
+            const res = TokenResourceGuard.areScopesSubsetOf(t.upper, t.lower);
+            expect(res).to.be.eq(t.isSubset, `"${t.name}" expected areScopesSubsetOf(upper, lower) === ${t.isSubset}, but was ${res}`);
+        });
+    }
+
+    @test public async scopedResourceGuardIsAllowedUnder() {
+        const tests: {
+            name: string
+            parent: ScopedResourceGuard.ResourceScope
+            child: ScopedResourceGuard.ResourceScope
+            isAllowed: boolean
+        }[] = [
+            {name: "different kind", isAllowed: false, parent: {kind: "workspace", subjectID: "foo", operations: ["get"]}, child: {kind: "workspaceInstance", subjectID: "foo", operations: ["get"]}},
+            {name: "different subject", isAllowed: false, parent: {kind: "workspace", subjectID: "foo", operations: ["get"]}, child: {kind: "workspace", subjectID: "somethingElse", operations: ["get"]}},
+            {name: "new op", isAllowed: false, parent: {kind: "workspace", subjectID: "foo", operations: ["get"]}, child: {kind: "workspace", subjectID: "foo", operations: ["get", "create"]}},
+            {name: "fewer ops", isAllowed: true, parent: {kind: "workspace", subjectID: "foo", operations: ["get", "create"]}, child: {kind: "workspace", subjectID: "foo", operations: ["get"]}},
+            {name: "exact match", isAllowed: true, parent: {kind: "workspace", subjectID: "foo", operations: ["get"]}, child: {kind: "workspace", subjectID: "foo", operations: ["get"]}},
+            {name: "no ops", isAllowed: true, parent: {kind: "workspace", subjectID: "foo", operations: []}, child: {kind: "workspace", subjectID: "foo", operations: []}},
+        ];
+
+        tests.forEach(t => {
+            const res = ScopedResourceGuard.isAllowedUnder(t.parent, t.child);
+            expect(res).to.be.eq(t.isAllowed, `"${t.name}" expected isAllowedUnder(parent, child) === ${t.isAllowed}, but was ${res}`);
+        });
+    }
+
+    @test public async tokenResourceGuardCanAccess() {
+        const workspaceResource: GuardedResource = {kind: "workspace", subject: {id:"wsid", ownerId: "foo"} as any};
+        const tests: {
+            name: string
+            guard: TokenResourceGuard
+            expectation: boolean
+        }[] = [
+            {
+                name: "no scopes", 
+                guard: new TokenResourceGuard(workspaceResource.subject.ownerId, []), 
+                expectation: false,
+            },
+            {
+                name: "default scope positive", 
+                guard: new TokenResourceGuard(workspaceResource.subject.ownerId, [TokenResourceGuard.DefaultResourceScope]), 
+                expectation: true,
+            },
+            {
+                name: "default scope negative", 
+                guard: new TokenResourceGuard("someoneElse", [TokenResourceGuard.DefaultResourceScope]), 
+                expectation: false,
+            },
+            {
+                name: "explicit scope", 
+                guard: new TokenResourceGuard(workspaceResource.subject.ownerId, [
+                    "resource:"+ScopedResourceGuard.marshalResourceScope(workspaceResource, ["get"]),
+                ]), 
+                expectation: true,
+            },
+            {
+                name: "default and explicit scope", 
+                guard: new TokenResourceGuard(workspaceResource.subject.ownerId, [
+                    "resource:default",
+                    "resource:"+ScopedResourceGuard.marshalResourceScope(workspaceResource, ["create"]),
+                ]), 
+                expectation: true,
+            },
+        ]
+
+        await Promise.all(tests.map(async t => {
+            const res = await t.guard.canAccess(workspaceResource, "get")
+            expect(res).to.be.eq(t.expectation, `"${t.name}" expected canAccess(...) === ${t.expectation}, but was ${res}`);
+        }))
+    }
+
+}
+
+module.exports = new TestResourceAccess();

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -1,0 +1,108 @@
+import { Workspace, WorkspaceInstance, User, Snapshot, GitpodToken, Token } from "@gitpod/gitpod-protocol";
+import { injectable } from "inversify";
+
+export type GuardedResource =
+    GuardedWorkspace |
+    GuardedWorkspaceInstance |
+    GuardedUser |
+    GuardedSnapshot |
+    GuardedGitpodToken |
+    GuardedToken |
+    GuardedUserStorage
+;
+
+export interface GuardedWorkspace {
+    kind: "workspace";
+    subject: Workspace;
+}
+
+export interface GuardedWorkspaceInstance {
+    kind: "workspaceInstance";
+    subject: WorkspaceInstance | undefined;
+    workspaceOwnerID: string;
+}
+
+export interface GuardedUser {
+    kind: "user";
+    subject: User;
+}
+
+export interface GuardedSnapshot {
+    kind: "snapshot";
+    subject: Snapshot | undefined;
+    workspaceOwnerID: string;
+}
+
+export interface GuardedUserStorage {
+    kind: "userStorage";
+    userID: string;
+    uri: string;
+}
+
+export interface GuardedGitpodToken {
+    kind: "gitpodToken";
+    subject: GitpodToken;
+}
+
+export interface GuardedToken {
+    kind: "token";
+    subject: Token;
+    tokenOwnerID: string;
+}
+
+export type ResourceAccessOp =
+    "create" |
+    "update" |
+    "get"    |
+    "delete"
+;
+
+export const ResourceAccessGuard = Symbol("ResourceAccessGuard");
+
+export interface ResourceAccessGuard {
+    canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean>;
+}
+
+/**
+ * CompositeResourceAccessGuard grants access to resources if at least one of its children does.
+ */
+export class CompositeResourceAccessGuard implements ResourceAccessGuard {
+    
+    constructor(protected readonly children: ResourceAccessGuard[]) {}
+
+    async canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean> {
+        // if a single guard permitts access, we're good to go
+        return (await Promise.all(this.children.map(c => c.canAccess(resource, operation)))).some(x => x);
+    }
+
+}
+
+/**
+ * OwnerResourceGuard grants access to resources if the user asking for access is the owner of that
+ * resource.
+ */
+@injectable()
+export class OwnerResourceGuard implements ResourceAccessGuard {
+
+    constructor(readonly userId: string) {}
+
+    async canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean> {
+        switch (resource.kind) {
+            case "gitpodToken":
+                return resource.subject.user.id === this.userId;
+            case "snapshot":
+                return resource.workspaceOwnerID === this.userId;
+            case "token":
+                return resource.tokenOwnerID === this.userId;
+            case "user":
+                return resource.subject.id === this.userId;
+            case "userStorage":
+                return resource.userID === this.userId;
+            case "workspace":
+                return resource.subject.ownerId === this.userId;
+            case "workspaceInstance":
+                return resource.workspaceOwnerID === this.userId;
+        }
+    }
+
+}

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -65,6 +65,7 @@ import { HostContextProviderImpl } from './auth/host-context-provider-impl';
 import { AuthProviderParams } from './auth/auth-provider';
 import { AuthErrorHandler } from './auth/auth-error-handler';
 import { MonitoringEndpointsApp } from './monitoring-endpoints';
+import { ResourceAccessGuard, OwnerResourceGuard } from './auth/resource-access';
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Env).toSelf().inSingletonScope();
@@ -108,6 +109,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(WebsocketConnectionManager).toDynamicValue(ctx =>
         new WebsocketConnectionManager<GitpodClient, GitpodServer>(() => ctx.container.get<GitpodServerImpl<GitpodClient, GitpodServer>>(GitpodServerImpl))
     ).inSingletonScope();
+    bind(ResourceAccessGuard).to(OwnerResourceGuard).inSingletonScope();
 
     bind(ImageBuilderClientConfig).toDynamicValue(() => {
         return { address: "image-builder:8080" }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -65,7 +65,7 @@ import { HostContextProviderImpl } from './auth/host-context-provider-impl';
 import { AuthProviderParams } from './auth/auth-provider';
 import { AuthErrorHandler } from './auth/auth-error-handler';
 import { MonitoringEndpointsApp } from './monitoring-endpoints';
-import { ResourceAccessGuard, OwnerResourceGuard } from './auth/resource-access';
+import { BearerAuth } from './auth/bearer-authenticator';
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Env).toSelf().inSingletonScope();
@@ -109,7 +109,6 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(WebsocketConnectionManager).toDynamicValue(ctx =>
         new WebsocketConnectionManager<GitpodClient, GitpodServer>(() => ctx.container.get<GitpodServerImpl<GitpodClient, GitpodServer>>(GitpodServerImpl))
     ).inSingletonScope();
-    bind(ResourceAccessGuard).to(OwnerResourceGuard).inSingletonScope();
 
     bind(ImageBuilderClientConfig).toDynamicValue(() => {
         return { address: "image-builder:8080" }
@@ -191,4 +190,5 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(AuthProviderEntryDB).to(AuthProviderEntryDBImpl).inSingletonScope();
     bind(AuthProviderService).toSelf().inSingletonScope();
+    bind(BearerAuth).toSelf().inSingletonScope();
 });

--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -136,5 +136,3 @@ export function getRequestingClientInfo(req: express.Request) {
     const fingerprint = crypto.createHash('sha256').update(`${ip}–${ua}`).digest('hex');
     return { ua, fingerprint };
 }
-
-

--- a/components/server/src/express/ws-handler.ts
+++ b/components/server/src/express/ws-handler.ts
@@ -55,7 +55,10 @@ export class WsExpressHandler {
         const stack = WsLayer.createStack(...handlers);
         const dispatch = (ws: websocket, request: express.Request) => {
             handler(ws, request);
-            stack.dispatch(ws, request);
+            stack.dispatch(ws, request).catch(err => {
+                log.error("websocket stack error", err);
+                ws.terminate();
+            });
         }
 
         this.httpServer.on('upgrade', (request: http.IncomingMessage, socket: net.Socket, head: Buffer) => {

--- a/components/server/src/express/ws-layer.ts
+++ b/components/server/src/express/ws-layer.ts
@@ -12,7 +12,7 @@ import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 export interface WsLayer {
     handleError: WsErrorHandler;
     handleRequest: WsRequestHandler;
-    dispatch: (ws: websocket, req: express.Request) => MaybePromise;
+    dispatch: (ws: websocket, req: express.Request) => Promise<void>;
     next: (ws: websocket, req: express.Request, err?: any) => MaybePromise;
 }
 
@@ -58,7 +58,7 @@ export class WsLayerImpl implements WsLayer {
         }
     }
 
-    async dispatch(ws: websocket, req: express.Request) {
+    async dispatch(ws: websocket, req: express.Request): Promise<void> {
         try {
             return this.next(ws, req);
         } catch (err) {

--- a/components/server/src/user/enforcement-endpoint.ts
+++ b/components/server/src/user/enforcement-endpoint.ts
@@ -29,7 +29,6 @@ export class EnforcementController {
     @inject(UserDeletionService) protected readonly userDeletionService: UserDeletionService;
     @inject(AuthorizationService) protected readonly authService: AuthorizationService;
     @inject(GitpodServerImpl) protected readonly _gitpodServer: GitpodServerImpl<GitpodClient, GitpodServer>;
-    // @inject(ResourceAccessGuard) protected readonly resourceAccessGuard: ResourceAccessGuard;
 
     get apiRouter(): express.Router {
         const router = express.Router();

--- a/components/server/src/websocket-connection-manager.ts
+++ b/components/server/src/websocket-connection-manager.ts
@@ -11,6 +11,7 @@ import { ConnectionHandler } from "@gitpod/gitpod-protocol/lib/messaging/handler
 import { MessageConnection } from "vscode-jsonrpc";
 import { EventEmitter } from "events";
 import * as express from "express";
+import { OwnerResourceGuard, ResourceAccessGuard } from "./auth/resource-access";
 
 export type GitpodServiceFactory<C extends GitpodClient, S extends GitpodServer> = () => GitpodServerImpl<C, S>;
 
@@ -41,7 +42,16 @@ export class WebsocketConnectionManager<C extends GitpodClient, S extends Gitpod
 
         const gitpodServer = this.serverFactory();
         const clientRegion = (expressReq as any).headers["x-glb-client-region"];
-        gitpodServer.initialize(client, clientRegion, expressReq.user as User);
+        const user = expressReq.user as User;
+        
+        let resourceGuard: ResourceAccessGuard;
+        if (!!user) {
+            resourceGuard = new OwnerResourceGuard(user.id);
+        } else {
+            resourceGuard = {canAccess: async () => false };
+        }
+
+        gitpodServer.initialize(client, clientRegion, user, resourceGuard);
         client.onDidCloseConnection(() => {
             gitpodServer.dispose();
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -139,7 +139,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
 
     protected async guardAccess(resource: GuardedResource, op: ResourceAccessOp) {
         if (!(await this.resourceAccessGuard.canAccess(resource, op))) {
-            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, "operation not permitted");
+            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, `operation not permitted: missing ${op} permission on ${resource.kind}`);
         }
     }
 


### PR DESCRIPTION
This PR introduces token-based access to Gitpod's JSON-RPC over Websocket API.
We will use this kind of access for moving functionality to supervisor and integrating IDE's other than Theia.

## Token-based Authentication
We already have API tokens in Gitpod: the `GitpodToken` previously introduced for the GraphQL admin API. This PR re-uses those tokens and introduces a new token type: [`MACHINE_API_TOKEN == 1`](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/gitpod-protocol/src/protocol.ts#L254). These tokens can be used to authenticate against Gitpod when connecting to the new websocket API endpoint `/api/v1`. Sending an `Authorization: Bearer <token>` header will provide access to the API.

Tokens are always associated with a user and by default have the same rights as the user has - on the functions the token is scoped for (see below). To create a new token use the `generateNewGitpodToken` function. For now there's a bit of a chicken and egg problem: one needs to use the classic session-based authentication to create an API token in the first place. If we ever find that to be a problem (e.g. in combination with new IDE's/supervisor token integration), we could consider producing a token per workspace and making that available as OTS, or allowing the owner token to create specifically scoped tokens.

We are introducing the new `/api/v1` API endpoint has different requirements from the old `/api/gitpod` one:
- no sessions: because the machine API access is token authenticated we do not need or want sessions. The latter would just cost resources for no benefit.
- hard authentication: if there's no token, or the token is invalid we want to end the websocket connection early. This is unlike the `/api/gitpod` endpoint where some operations can happen without user session (e.g. `getBranding`).
- API versioning: at the moment the API exposed on `/api/v1` isn't meant for public consumption, but sooner than later we'll have such a public API. It's a good idea to implement the versioning pattern now. Having a special endpoint for the dashboard (`/api/gitpod`) also gives us more control over which API version we want to use in the dashboard.

## Scoping
Tokens are constrained along two dimensions: functions and resources. Functions refer to the [functions of the Gitpod JSON-RPC API](https://github.com/gitpod-io/gitpod/blob/cw/resource-guard/components/gitpod-protocol/src/gitpod-service.ts), and resources to [various resources](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/auth/resource-access.ts#L7-L15) within Gitpod. Function scoping is enforced on the [RPC interface](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/websocket-connection-manager.ts#L131-L134), resource scoping is enforced throughout the [server implementation](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/workspace/gitpod-server-impl.ts#L140-L144).

### Function Scopes
All tokens must explicitly list the functions they can use, as part of their scopes. E.g. a token with `[]` as scopes cannot access a single function of the API. Function scopes are written as `function:<functionName>`, e.g. `function:getWorkspace`. A token's scopes are defined when the token is created. Note: you can not exceed the scope of your own authentication when creating new tokens, e.g. if your current authentication/token only has `function:generateNewGitpodToken` and `function:getWorkspace`, you cannot create a new token with `function:startWorkspace`.

### Resource Scopes
All tokens must explicitly list the resources they can use, as part of their scopes. E.g. a token with `[]` as scopes cannot access a single resource. Other than the scheme described below, there's a special `resource:default` scope which grants the same access to resources that the token's owner has. Mixing the default scope with other explicit resource scopes behaves just like mixing other resource scopes: they are additive in what they allow.

Resource scopes consist of three elements:
- kind: determines the type of resource we're talking about. The list of kinds is defined in [`resource-access.ts`](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/auth/resource-access.ts#L7-L54), and includes `workspace`, `workspaceInstance`, `gitpodToken`, and `snapshot`.
- subjectID: is the ID of the resource that we want to provide access to. What that ID actually is depends on the kind of resource and is [defined here](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/auth/resource-access.ts#L184-L201). For example, for a workspace it's the ID of that workspace, same goes for workspace instances, users and snapshots.
- operations: denote the type of access to a resource and is one of [`create`, `update`, `get`, `delete`](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/auth/resource-access.ts#L56-L61).

We encode resource scopes like this: `resource:<kind>::<subjectID>::<op1>,<op2>`. There's a [marshal and unmarshal](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/auth/resource-access.ts#L162-L182) function available.

## Other access-limiting concepts in Gitpod
The resource and function guards are not the first - or only - means of controlling access in Gitpod. Below is a comparison to the existing methods:
- Roles and Permissions: are per-user (not per token) based permissions that enable/disable entire functional branches of Gitpod. E.g. the `admin` permission grants access to the Admin dashboard. These permissions are orthogonal to function/resource scoping, in that they limit access beyond that function scoping does. E.g. if a token has the `function:adminListWorkspaces` scope, the function call will only succeed if the token's user has the `ADMIN_WORKSPACES` permission.
- Owner checks: Gitpod has historically done a set of owner checks, e.g. when sharing the workspace we ensured that only the owner can do so. This strategy remains the [default strategy](https://github.com/gitpod-io/gitpod/blob/308cb5c3c4651ca7d85902ed72baffcf85a6f764/components/server/src/auth/resource-access.ts#L93-L116). The previous owner checks however have been superseded by the resource guard calls. This way we don't keep the old checks around and can actually support tokens.
- `checkUser/checkUserBlocked`: it's actually the `GitpodServerImpl` that checks if a user is present and if it isn't blocked. This part of the authentication process remains as it is. Using a token for authentication provides the token's owner to the server, hence all operations happen in the name of token owner, as does `checkUser` and `checkUserBlocked`. Thus, if a token owner gets blocked, so do all of their tokens.

# How to test?
1. Get yourself some token: the easiest way for now to do that is to manually add one in the database: 
  ```SQL
  insert into d_b_gitpod_token (tokenHash, type, userId, scopes, created) VALUES ("<your-hash>", 1, "<your-gitpod-user-id>", "resource:default,function:getWorkspace,function:generateNewGitpodToken", "foo");
  ```
  To get the token hash, run
  ```bash
  node<<EOF
  const crypto = require('crypto');
  const hash = (token) => crypto.createHash('sha256').update(token, 'utf8').digest("hex");
  console.log(hash("foobar"))
  EOF
  ```
  where `foobar` is your token.
2. connect to the API endpoint, e.g. using [websocat](https://github.com/vi/websocat/releases). Notice the bearer header. Replace foobar with whatever your token is:
```bash
./websocat  ws://cw-resource-guard.staging.gitpod-dev.com/api/v1 -H "Origin:http://cw-resource-guard.staging.gitpod-dev.com" -H "Authorization:Bearer foobar" --jsonrpc -v
```
3. Once websocat is running you can send JSON RPC messages like:
```
generateNewGitpodToken {"type":1, "scopes": ["resource:default", "function:getWorkspace"]}
getWorkspace "some-workspace-id"
startWorkspace
```

# Caveats
- this PR does nothing for token expiry and invalidation. Tokens, once created, live until they're manually deleted. We should introduce a time and resource-based expiry mechanism.

## Thanks
to @AlexTugarev for the super helpful discussions, listening to my Node/TS rants and help wading through the JSON RPC stack.