### PR TITLE
[supervisor-frontend] delegating keyboard APIs to the ide host window context

### DIFF
--- a/components/supervisor/frontend/src/globals.d.ts
+++ b/components/supervisor/frontend/src/globals.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+/**
+* API specified by https://wicg.github.io/keyboard-map/
+*/
+interface Navigator {
+    keyboard?: Keyboard;
+}
+interface Keyboard {
+    getLayoutMap?(): Promise<Map<string, string>>;
+    addEventListener?(type: 'layoutchange', listener: EventListenerOrEventListenerObject): void;
+}

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -52,12 +52,20 @@ const loadingFrame = document.createElement('iframe');
 loadingFrame.src = startURL;
 loadingFrame.className = 'gitpod-frame loading';
 
-const onDOMContentLoaded = new Promise(resolve => window.addEventListener('DOMContentLoaded', resolve));
+const onDOMContentLoaded = new Promise(resolve => window.addEventListener('DOMContentLoaded', resolve, { once: true }));
 
 Promise.all([onDOMContentLoaded, checkReady('ide'), checkReady('content')]).then(() => {
-    console.info('IDE backend and content are ready, revealing IDE frontend...');
+    console.info('IDE backend and content are ready, attaching IDE frontend...');
     ideFrame.onload = () => loadingFrame.remove();
     document.body.appendChild(ideFrame);
+    ideFrame.contentWindow?.addEventListener('DOMContentLoaded', () => {
+        if (navigator.keyboard?.getLayoutMap && ideFrame.contentWindow?.navigator.keyboard?.getLayoutMap) {
+            ideFrame.contentWindow.navigator.keyboard.getLayoutMap = navigator.keyboard.getLayoutMap.bind(navigator.keyboard);
+        }
+        if (navigator.keyboard?.addEventListener && ideFrame.contentWindow?.navigator.keyboard?.addEventListener) {
+            ideFrame.contentWindow.navigator.keyboard.addEventListener = navigator.keyboard.addEventListener.bind(navigator.keyboard);
+        }
+    }, { once: true });
 });
 
 onDOMContentLoaded.then(() => {


### PR DESCRIPTION
- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https

#### How to test

- Check that one can still open Theia:
https://ak-keyboard-api.staging.gitpod-dev.com#https://github.com/gitpod-io/go-gin-app
- Check that Code is opened if .gitpod.yml contains `ide: code`:
https://ak-keyboard-api.staging.gitpod-dev.com#https://github.com/akosyakov/go-gin-app

You should see that both IDEs detected keyboard layouts properly:
- use the quick command palette to change keyboard layout and see what is detected by default
<img width="737" alt="Screenshot 2020-09-18 at 15 03 21" src="https://user-images.githubusercontent.com/3082655/93600625-39fadb80-f9c0-11ea-9b05-94cd1b0a886a.png">
- in Code there should be a status bar item:
<img width="361" alt="Screenshot 2020-09-18 at 15 03 02" src="https://user-images.githubusercontent.com/3082655/93600653-42ebad00-f9c0-11ea-95aa-967fd610984c.png">
- there should not be any warnings/errors in browser logs like `getLayoutMap` cannot be called from the nested window context