### PR TITLE
[server] fix workspace lookup regressions

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -580,7 +580,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
                 throw new ResponseError(ErrorCodes.NOT_FOUND, "workspace does not exist");
             }
 
-            const ws = await this.workspaceDb.trace({ span }).findByInstanceId(instanceId);
+            const ws = await this.workspaceDb.trace({ span }).findById(wsi.workspaceId);
             if (!ws) {
                 throw new ResponseError(ErrorCodes.NOT_FOUND, "workspace does not exist");
             }
@@ -923,7 +923,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
 
         try {
             const instance = await this.workspaceDb.trace({ span }).findRunningInstance(workspaceId);
-            const workspace = await this.workspaceDb.trace({ span }).findByInstanceId(workspaceId);
+            const workspace = await this.workspaceDb.trace({ span }).findById(workspaceId);
             if (!instance || !workspace) {
                 throw new ResponseError(ErrorCodes.NOT_FOUND, `Workspace ${workspaceId} has no running instance`);
             }


### PR DESCRIPTION
Start a workspace and check that there are not failed requests to the server in logs, i.e. that a workspace is no running.