### PR TITLE
deprecate ide property

### DIFF
--- a/components/dashboard/public/schemas/gitpod-schema.json
+++ b/components/dashboard/public/schemas/gitpod-schema.json
@@ -5,12 +5,20 @@
     "type": "object",
     "properties": {
         "ide": {
-            "type": "string",
-            "enum": [
+          "oneOf":[
+            {
+              "type":"string"
+            },
+            {
+              "enum": [
                 "theia",
                 "code"
-            ],
-            "default": "theia"
+              ]
+            }
+          ],
+          "default": "theia",
+          "description": "Controls what ide should be used for a workspace.",
+          "deprecationMessage": "The 'ide' property is an experimental feature and enabled only for some users."
         },
         "ports": {
             "type": "array",

--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -5,12 +5,20 @@
     "type": "object",
     "properties": {
         "ide": {
-            "type": "string",
-            "enum": [
+          "oneOf":[
+            {
+              "type":"string"
+            },
+            {
+              "enum": [
                 "theia",
                 "code"
-            ],
-            "default": "theia"
+              ]
+            }
+          ],
+          "default": "theia",
+          "description": "Controls what ide should be used for a workspace.",
+          "deprecationMessage": "The 'ide' property is an experimental feature and enabled only for some users."
         },
         "ports": {
             "type": "array",


### PR DESCRIPTION
to indicate an experimental feature

#### How to test
- Open gitpod.yml
- Check that there is no content assist for the ide property
- if ide property is provided then there should be a deprecation notice
- ide property should allows ide, theia and random string