### PR TITLE
Install Gitpod Server API token in all workspaces

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1600693766152-ExpandScopes.ts
+++ b/components/gitpod-db/src/typeorm/migration/1600693766152-ExpandScopes.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ExpandScopes1600693766152 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("ALTER TABLE d_b_gitpod_token MODIFY COLUMN scopes text");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -185,6 +185,16 @@ export class TypeORMUserDBImpl implements UserDB {
             `, [tokenHash]);
     }
 
+    public async deleteGitpodTokensNamedLike(userId: string, namePattern: string): Promise<void> {
+        const repo = await this.getGitpodTokenRepo();
+        await repo.query(`
+            UPDATE d_b_gitpod_token AS gt
+            SET gt.deleted = TRUE
+            WHERE userId = ?
+              AND name LIKE ?
+        `, [userId, namePattern]);
+    }
+
     public async findIdentitiesByName(identity: Identity): Promise<Identity[]> {
         const userRepo = await this.getIdentitiesRepo();
         const qBuilder = userRepo.createQueryBuilder('identity')

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -114,6 +114,7 @@ export interface UserDB {
     findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]>;
     storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void>;
     deleteGitpodToken(tokenHash: string): Promise<void>;
+    deleteGitpodTokensNamedLike(userId: string, namePattern: string): Promise<void>;
 }
 export type PartialUserUpdate = Partial<Without<User, "identities">> & Pick<User, "id">
 

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 import * as websocket from 'ws';
 import * as express from 'express';
 import * as crypto from 'crypto';

--- a/components/server/src/auth/function-access.ts
+++ b/components/server/src/auth/function-access.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 import { injectable } from "inversify";
 
 export interface FunctionAccessGuard {

--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 import { suite, test } from "mocha-typescript";
 import * as chai from 'chai';
 const expect = chai.expect;

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 import { Workspace, WorkspaceInstance, User, Snapshot, GitpodToken, Token } from "@gitpod/gitpod-protocol";
 
 declare var resourceInstance: GuardedResource;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -923,7 +923,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
 
         try {
             const instance = await this.workspaceDb.trace({ span }).findRunningInstance(workspaceId);
-            const workspace = await this.workspaceDb.trace({ span }).findByInstanceId(workspaceId);
+            const workspace = await this.workspaceDb.trace({ span }).findById(workspaceId);
             if (!instance || !workspace) {
                 throw new ResponseError(ErrorCodes.NOT_FOUND, `Workspace ${workspaceId} has no running instance`);
             }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -596,18 +596,15 @@ export class WorkspaceStarter {
             "function:openPort",
             "function:closePort",
             "function:getLayout",
+            "function:generateNewGitpodToken",
+            "function:takeSnapshot",
+            "function:storeLayout",
 
-            ScopedResourceGuard.marshalResourceScope({kind: "workspace", subject: workspace}, ["get", "update"]),
-            ScopedResourceGuard.marshalResourceScope({kind: "workspaceInstance", subject: instance, workspaceOwnerID: workspace.ownerId}, ["get", "update", "delete"]),
-            "resource:default",
-            // TODO(cw): the resource scoping doesn't work for us. E.g. we cannot express that we want to allow the creation of snapshots.
-            //         Hence, we're falling back to resource:default. That scope is way to permissive for some functions though.
-            //         We should fix this resource scoping issue (e.g. something like resource:snapshot::*::create) and then we can
-            //         allow the functions below.
-            
-            // "function:generateNewGitpodToken",
-            // "function:takeSnapshot",
-            // "function:storeLayout",
+            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "workspace", subjectID: workspace.id, operations: ["get", "update"]}),
+            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "workspaceInstance", subjectID: instance.id, operations: ["get", "update", "delete"]}),
+            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "snapshot", subjectID: "*", operations: ["create", "get"]}),
+            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "gitpodToken", subjectID: "*", operations: ["create"]}),
+            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "userStorage", subjectID: "*", operations: ["create", "get", "update"]}),
         ]
     }
 

--- a/components/supervisor-api/generate.sh
+++ b/components/supervisor-api/generate.sh
@@ -5,7 +5,7 @@ PROTOC_INCLUDE="-I. -I $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_
 GO111MODULE=on  go get github.com/golang/protobuf/protoc-gen-go@v1.3.5 
 GO111MODULE=off go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 protoc $PROTOC_INCLUDE --go_out=plugins=grpc:go *.proto
-protoc $PROTOC_INCLUDE --grpc-gateway_out=logtostderr=true,paths=source_relative:go *.proto
+protoc $PROTOC_INCLUDE --grpc-gateway_out=allow_colon_final_segments=true,logtostderr=true,paths=source_relative:go *.proto
 
 # GO111MODULE=on go get github.com/golang/mock/mockgen@latest
 # cd go

--- a/components/supervisor-api/go/status.pb.gw.go
+++ b/components/supervisor-api/go/status.pb.gw.go
@@ -679,21 +679,21 @@ func RegisterStatusServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 }
 
 var (
-	pattern_StatusService_SupervisorStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "supervisor"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_SupervisorStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "supervisor"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_IDEStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "ide"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_IDEStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "ide"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_IDEStatus_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "status", "ide", "wait", "true"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_IDEStatus_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "status", "ide", "wait", "true"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_ContentStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "content"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_ContentStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "content"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_ContentStatus_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "status", "content", "wait", "true"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_ContentStatus_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "status", "content", "wait", "true"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_BackupStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "backup"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_BackupStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "backup"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_PortsStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "ports"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_PortsStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "status", "ports"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_StatusService_PortsStatus_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "status", "ports", "observe", "true"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_StatusService_PortsStatus_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "status", "ports", "observe", "true"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (

--- a/components/supervisor-api/go/terminal.pb.gw.go
+++ b/components/supervisor-api/go/terminal.pb.gw.go
@@ -326,11 +326,11 @@ func RegisterTerminalServiceHandlerClient(ctx context.Context, mux *runtime.Serv
 }
 
 var (
-	pattern_TerminalService_List_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "terminal", "list"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TerminalService_List_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "terminal", "list"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_TerminalService_Listen_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "terminal", "listen", "alias"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TerminalService_Listen_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "terminal", "listen", "alias"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_TerminalService_Write_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "terminal", "write", "alias"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TerminalService_Write_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "terminal", "write", "alias"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (

--- a/components/supervisor-api/go/token.pb.gw.go
+++ b/components/supervisor-api/go/token.pb.gw.go
@@ -590,11 +590,11 @@ func RegisterTokenServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 var (
 	pattern_TokenService_GetToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "token", "host", "scope"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_TokenService_SetToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "token", "host"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TokenService_SetToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "token", "host"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_TokenService_ClearToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "token", "value"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TokenService_ClearToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "token", "value"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_TokenService_ClearToken_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "token", "clear", "all", "true"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TokenService_ClearToken_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 4, 1, 5, 3}, []string{"v1", "token", "clear", "all", "true"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (

--- a/components/supervisor-api/go/token.pb.gw.go
+++ b/components/supervisor-api/go/token.pb.gw.go
@@ -588,7 +588,7 @@ func RegisterTokenServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 }
 
 var (
-	pattern_TokenService_GetToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "token", "host", "scope"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TokenService_GetToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "token", "host", "scope"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_TokenService_SetToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "token", "host"}, "", runtime.AssumeColonVerbOpt(true)))
 


### PR DESCRIPTION
This PR introduces a "default server API token" to all workspaces, which is made available using supervisor's token service.
The default token is
- primarily limited to [workspace-related functionality](https://github.com/gitpod-io/gitpod/compare/cw/ots-gitpod-token?expand=1#diff-14cd7385ea3df3dacee2bb06eee12ff7R585-R607)
- [injected as one-time secret](https://github.com/gitpod-io/gitpod/compare/cw/ots-gitpod-token?expand=1#diff-14cd7385ea3df3dacee2bb06eee12ff7R517) and not passed around in clear text
- [deleted when the instance is stopped](https://github.com/gitpod-io/gitpod/compare/cw/ots-gitpod-token?expand=1#diff-d362d2b309dd67cac13a1650417c2b93R267-R279)
- stored in the DB, [including all the scopes](https://github.com/gitpod-io/gitpod/compare/cw/ots-gitpod-token?expand=1#diff-14cd7385ea3df3dacee2bb06eee12ff7R508). This might not be neccesary and in the future we might want to move to something less heavy on the database
- [not expiring](https://github.com/gitpod-io/gitpod/compare/cw/ots-gitpod-token?expand=1#diff-6209035cbcb1a7f37466089617efc301R229) over the lifetime of the workspace instance.

We'll use this token to provide heartbeats from supervisor's frontend, to auto-expose ports from within supervisor, and provide more functionality with the `gp` CLI.

### How to test
- start a workspace and :
  ```bash
  # get a token for some operation, e.g. getWorkspace
  TKN=$(curl -s localhost:22999/_supervisor/v1/token/cw-ots-gitpod-token.staging.gitpod-dev.com/function:getWorkspace | jq -r '.token')
  echo $TKN

  # download websocat
  curl -OL https://github.com/vi/websocat/releases/download/v1.6.0/websocat_amd64-linux
  chmod +x websocat_amd64-linux

  # make a call using the token
  echo getWorkspace \"$GITPOD_WORKSPACE_ID\" | ./websocat_amd64-linux ws://cw-ots-gitpod-token.staging.gitpod-dev.com/api/v1 --jsonrpc -H "Origin: http://cw-ots-gitpod-token.staging.gitpod-dev.com/" -H "Authorization:  Bearer $TKN"
  ```
- stop the workspace
- check that the gitpod token has been deleted
  ```bash
  kubectl port-forward deployment/mysql 3306 &
  echo 'SELECT tokenHash, type, deleted FROM d_b_gitpod_token' | mysql -u root -ptest -h 127.0.0.1 gitpod
  ```