### PR TITLE
[supervisor/frontend] expose gitpod server on ide frame

### DIFF
--- a/components/gitpod-protocol/src/typings/globals.ts
+++ b/components/gitpod-protocol/src/typings/globals.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+interface Window {
+    gitpod: {
+        service: import('../gitpod-service').GitpodService
+    }
+}

--- a/components/supervisor/frontend/src/globals.d.ts
+++ b/components/supervisor/frontend/src/globals.d.ts
@@ -4,6 +4,8 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+/// <reference types='@gitpod/gitpod-protocol/lib/typings/globals'/>
+
 /**
 * API specified by https://wicg.github.io/keyboard-map/
 */

--- a/components/theia/packages/gitpod-extension/src/browser/utils.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/utils.ts
@@ -4,17 +4,13 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { createGitpodService } from "@gitpod/gitpod-protocol";
+/// <reference types='@gitpod/gitpod-protocol/lib/typings/globals'/>
+
 import { GitpodService } from "@gitpod/gitpod-protocol";
-import { GitpodHostUrl, workspaceIDRegex } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { workspaceIDRegex } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
 export function getGitpodService(): GitpodService {
-    if (!(window as any)['_gitpodService']) {
-        const serverUrl = new GitpodHostUrl(window.location.href).withoutWorkspacePrefix().toString();
-        const service = createGitpodService(serverUrl);
-        (window as any)['_gitpodService'] = service;
-    }
-    return (window as any)['_gitpodService'];
+    return window.gitpod.service;
 }
 
 export function getWorkspaceID() {


### PR DESCRIPTION
- [ ] /werft ws-feature-flags=registry_facade
- [x] /werft https

Expose the gitpod server API on the ide frame to avoid an additional ws connection.

#### How to test

- start a workspace
- check that Theia is loaded
- check that there is no an additional opened ws connection from Theia to the server