### PR TITLE
Adjust the access control page for mobile.

### DIFF
--- a/components/dashboard/public/styles.css
+++ b/components/dashboard/public/styles.css
@@ -793,3 +793,26 @@ footer .logo-icon {
 .upgrade-hours .button {
     margin-left: 1em;
 }
+
+/* ----------------------------------------- */
+/* ----- Access Control ----- */
+/* ----------------------------------------- */
+
+@media(max-width: 620px) {
+    .access-control__card {
+        padding: 20px 10px !important;
+    }
+}
+
+
+.access-control__card-container {
+    width: 31%;
+    min-width: 300px;
+    margin-bottom: 30px !important;
+}
+
+@media(max-width: 340px) {
+    .access-control__card-container {
+        min-width: 280px;
+    }
+}

--- a/components/dashboard/src/components/access-control/access-control.tsx
+++ b/components/dashboard/src/components/access-control/access-control.tsx
@@ -255,7 +255,7 @@ export class AccessControl extends React.Component<AccessControlProps, AccessCon
                 const oldProviderScopes = oldScopes.get(authProvider.host);
                 const newProviderScopes = newScopes.get(authProvider.host);
                 if (oldProviderScopes && newProviderScopes) {
-                    renderedTokens.push(<Grid item style={{ width: '31%' }}>
+                    renderedTokens.push(<Grid item className="access-control__card-container">
                         {this.renderProviderTokens(authProvider, oldProviderScopes, newProviderScopes)}
                     </Grid>);
                 }
@@ -264,6 +264,7 @@ export class AccessControl extends React.Component<AccessControlProps, AccessCon
         return (<Grid
             container
             alignItems="stretch"
+            wrap="wrap"
             justify="space-evenly">
             {renderedTokens}
         </Grid>);
@@ -327,7 +328,9 @@ export class AccessControl extends React.Component<AccessControlProps, AccessCon
                 minHeight: '100%',
                 display: 'flex',
                 flexDirection: 'column'
-            }}>
+            }}
+                className="access-control__card"
+            >
             <Grid item>
                 <Typography variant="h5" component="h3">
                     {icon && (<img src={icon} className={'provider-icon'} />)}


### PR DESCRIPTION
Fixes gitpod-io/gitpod#1855

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/94138810-192ffb80-fe82-11ea-9385-8672180d3fd4.png)
