### PR TITLE
Allow setting port visibility in .gitpod.yml

### DIFF
--- a/components/dashboard/public/schemas/gitpod-schema.json
+++ b/components/dashboard/public/schemas/gitpod-schema.json
@@ -36,6 +36,14 @@
                         ],
                         "description": "What to do when a service on this port was detected. 'notify' (default) will show a notification asking the user what to do. 'open-browser' will open a new browser tab. 'open-preview' will open in the preview on the right of the IDE. 'ignore' will do nothing."
                     },
+                    "visibility": {
+                        "type": "string",
+                        "enum": [
+                            "private",
+                            "public"
+                        ],
+                        "description": "Whether the port visibility should be private or public. 'public' (default) will allow everyone with the port URL to access the port. 'private' will only allow users with workspace access to access the port."
+                    },
                     "name": {
                         "type": "string",
                         "deprecationMessage": "The 'name' property is deprecated.",

--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -36,6 +36,14 @@
                         ],
                         "description": "What to do when a service on this port was detected. 'notify' (default) will show a notification asking the user what to do. 'open-browser' will open a new browser tab. 'open-preview' will open in the preview on the right of the IDE. 'ignore' will do nothing."
                     },
+                    "visibility": {
+                        "type": "string",
+                        "enum": [
+                            "private",
+                            "public"
+                        ],
+                        "description": "Whether the port visibility should be private or public. 'public' (default) will allow everyone with the port URL to access the port. 'private' will only allow users with workspace access to access the port."
+                    },
                     "name": {
                         "type": "string",
                         "deprecationMessage": "The 'name' property is deprecated.",

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -542,7 +542,7 @@ export class WorkspaceStarter {
 
             spec.setPort(p.port);
             spec.setTarget(target);
-            spec.setVisibility(PortVisibility.PORT_VISIBILITY_PUBLIC);
+            spec.setVisibility(p.visibility == 'private' ? PortVisibility.PORT_VISIBILITY_PRIVATE : PortVisibility.PORT_VISIBILITY_PUBLIC);
             return spec;
         }).filter(spec => !!spec) as PortSpec[];
 

--- a/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-port-view-widget.tsx
+++ b/components/theia/packages/gitpod-extension/src/browser/ports/gitpod-port-view-widget.tsx
@@ -169,7 +169,7 @@ class GitpodPortViewComponent extends React.Component<GitpodPortViewProps, Gitpo
                 actions.push(<button className="theia-button" data-port={port.port} onClick={this.onOpenBrowser}>Open Browser</button>);
 
                 // TODO: extract serving process name (e.g. use netstat instead of /proc/net/tcp) and show here, i.e. don't override the label
-                label = 'open';
+                label = `open ${port.visibility === 'public' ? '(public)' : '(private)'}`;
             } else if (port.served == 'locally') {
                 label = 'served on localhost only, thus cannot be exposed';
             } else {


### PR DESCRIPTION
Allows to specify a port visibility in `.gitpod.yml` like this:
```
ports:
  - port: 8080
    onOpen: open-browser
    visibility: private
  - port: 8081
    onOpen: open-browser
    visibility: public
```

# How to test
- Open this repo: http://corneliusludmann-allow-port-visibility-1867.staging.gitpod-dev.com/#https://github.com/corneliusludmann/gitpod-playground/tree/test-port-visibility
- This repo has the following config:
```
ports:
  - port: 8080
    onOpen: open-browser
    visibility: private
  - port: 8081
    onOpen: open-browser
    visibility: public

tasks:
  - command: curl lama.sh | sh
  - command: sleep 2; curl lama.sh | sh -s -- --port 8081
```

- After workspace start you'll see these ports:
![image](https://user-images.githubusercontent.com/24960040/94135381-ae6fc780-fe63-11ea-94ae-7bfd7f28339d.png)


## Open Problems
- Schema validation does not work:
![image](https://user-images.githubusercontent.com/24960040/94135597-f989da80-fe63-11ea-8fe4-41957ebb8256.png)
Anyone an idea why?

- Could not test if the port is really private. It seems that the dev staging environment does not support private ports (the proxy does not block private ports). However, that's a general problem with private ports, not with this PR.

Fixes gitpod-io/gitpod#1867