### PR TITLE
[gitpod-protocol] Produce Go version of the JSON RPC API

### DIFF
--- a/components/gitpod-protocol/hack/dump-service-ast.ts
+++ b/components/gitpod-protocol/hack/dump-service-ast.ts
@@ -1,0 +1,6 @@
+import { TypescriptParser } from 'typescript-parser';
+
+(async () => {
+    const parser = new TypescriptParser();
+    return JSON.stringify(await parser.parseFiles(["src/gitpod-service.ts", "src/protocol.ts", "src/workspace-instance.ts"], ".."));
+})().then(console.log).catch(console.error);

--- a/components/gitpod-protocol/hack/generate.go
+++ b/components/gitpod-protocol/hack/generate.go
@@ -1,0 +1,244 @@
+//go:generate sh generate.sh
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+// Method is a method on the Gitpod Server interface
+type Method struct {
+	Name   string `json:"name"`
+	GoName string `json:"-"`
+
+	Params []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+
+		GoName string `json:"-"`
+		GoType string `json:"-"`
+	}
+	GoParams string
+
+	Result        string `json:"result"`
+	GoResultType  string `json:"-"`
+	GoReturnType  string `json:"-"`
+	Void          bool   `json:"-"`
+	PointerReturn bool   `json:"-"`
+}
+
+const tpl = `package rpc
+
+// GitpodServerInterface wraps the Gitpod server
+type GitpodServerInterface interface {
+	{{- range $m := . }}
+	{{ .GoName }}({{ .GoParams }}) {{ .GoReturnType }}
+	{{- end }}
+}
+
+// FunctionName is the name of an RPC function
+type FunctionName string
+
+const (
+	{{- range $m := . }}
+	// Function{{ .GoName }} is the name of the {{ .Name }} function
+	Function{{ .GoName }} FunctionName = "{{ .Name }}"
+	{{- end }}
+)
+
+// GitpodServer makes JSON RPC calls to the Gitpod server
+type GitpodServer struct {
+	C *jsonrpc2.Conn
+}
+
+{{- range $m := . }}
+// {{ .GoName }} calls {{ .Name }} on the server
+func (gp *GitpodServer) {{ .GoName }}({{ .GoParams }}) {{ .GoReturnType }} {
+	var _params []interface{}
+	{{ range $p := .Params }}
+	_params = append(_params, {{ .GoName }})
+	{{- end }}
+	{{ if .Void }}
+	err = gp.C.Call(ctx, "{{ $m.Name }}", _params, nil)
+	if err != nil {
+		return
+	}
+	{{ else }}
+	var result {{ .GoResultType }}
+	err = gp.C.Call(ctx, "{{ $m.Name }}", _params, &result)
+	if err != nil {
+		return
+	}
+	res = {{ if .PointerReturn }}&{{end}}result
+	{{ end }}
+	return
+}
+{{ end }}
+`
+
+func main() {
+	var mths []Method
+	err := json.NewDecoder(os.Stdin).Decode(&mths)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	out, err := os.OpenFile("gitpod-service.go", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer out.Close()
+
+	allUsedTSTypes := make(map[string]string)
+	for i, m := range mths {
+		mths[i].GoName = strings.ToUpper(m.Name[0:1]) + m.Name[1:]
+
+		rt := typescriptTypeToGoType(m.Result)
+		if rt == "void" {
+			mths[i].GoReturnType = "(err error)"
+			mths[i].Void = true
+		} else {
+			mths[i].GoResultType = strings.TrimPrefix(rt, "*")
+			mths[i].GoReturnType = fmt.Sprintf("(res %s, err error)", rt)
+			mths[i].PointerReturn = !strings.HasPrefix(rt, "[]") && rt != "string"
+		}
+		if strings.HasPrefix(rt, "[]") || strings.HasPrefix(rt, "*") {
+			tt := strings.TrimSuffix(trimTypescriptAdornments(m.Result), "[]")
+			gt := strings.TrimPrefix(rt, "[]")
+			gt = strings.TrimPrefix(gt, "*")
+			allUsedTSTypes[tt] = gt
+		}
+
+		var goParams []string
+		goParams = append(goParams, "ctx context.Context")
+		for j, p := range m.Params {
+			gt := typescriptTypeToGoType(p.Type)
+			mths[i].Params[j].GoName = p.Name
+			mths[i].Params[j].GoType = gt
+			goParams = append(goParams, fmt.Sprintf("%s %s", mths[i].Params[j].GoName, mths[i].Params[j].GoType))
+
+			if strings.HasPrefix(gt, "[]") || strings.HasPrefix(gt, "*") {
+				tt := strings.TrimSuffix(trimTypescriptAdornments(p.Type), "[]")
+				gt = strings.TrimPrefix(gt, "[]")
+				gt = strings.TrimPrefix(gt, "*")
+				allUsedTSTypes[tt] = gt
+			}
+		}
+		mths[i].GoParams = strings.Join(goParams, ", ")
+	}
+
+	tmpl, err := template.New("tpl").Parse(tpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = tmpl.Execute(out, mths)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tmpfile, err := ioutil.TempFile("", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpfile.Close()
+	fmt.Println("tmp file: " + tmpfile.Name())
+	// defer os.Remove(tmpfile.Name())
+	for tst, gt := range allUsedTSTypes {
+		if _, bt := baseTypeMap[tst]; bt {
+			continue
+		}
+
+		fmt.Println("generating " + tst)
+
+		cmd := exec.Command("yarn", "typescript-json-schema", "tsconfig.json", "-o", tmpfile.Name(), tst)
+		cmd.Dir = ".."
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		buf := bytes.NewBuffer(nil)
+		cmd = exec.Command("schema-generate", tmpfile.Name())
+		cmd.Stdout = buf
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		lines := strings.Split(buf.String(), "\n")
+		for _, l := range lines {
+			var hasPrefix bool
+			for _, p := range []string{
+				"//",
+				"package main",
+				"type Root string",
+				"import (",
+				"    \"encoding",
+				"    \"bytes",
+				"    \"fmt",
+				")",
+			} {
+				if strings.HasPrefix(l, p) {
+					hasPrefix = true
+					break
+				}
+			}
+			if hasPrefix {
+				continue
+			}
+			if strings.HasPrefix(l, "type Root struct {") {
+				l = fmt.Sprintf("type %s struct {", gt)
+			}
+
+			fmt.Fprintln(out, l)
+		}
+	}
+}
+
+var baseTypeMap = map[string]string{
+	"string":  "string",
+	"boolean": "bool",
+	"number":  "float32",
+	"void":    "void",
+}
+
+func trimTypescriptAdornments(t string) string {
+	res := t
+	if strings.HasPrefix(res, "Promise<") {
+		res = strings.TrimSuffix(strings.TrimPrefix(res, "Promise<"), ">")
+	}
+	if strings.HasPrefix(res, "Partial<") {
+		res = strings.TrimSuffix(strings.TrimPrefix(res, "Partial<"), ">")
+	}
+	res = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(res), "| undefined"))
+	return res
+}
+
+func typescriptTypeToGoType(ts string) (res string) {
+	res = trimTypescriptAdornments(ts)
+
+	nt, ok := baseTypeMap[res]
+	if ok {
+		res = nt
+	} else {
+		res = "*" + res
+	}
+
+	if strings.HasSuffix(res, "[]") {
+		res = "[]" + strings.TrimSuffix(res, "[]")
+	}
+
+	res = strings.ReplaceAll(res, ".", "")
+
+	return
+}

--- a/components/gitpod-protocol/hack/generate.sh
+++ b/components/gitpod-protocol/hack/generate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+go get -u github.com/a-h/generate/...
+node -e "new (require(\"typescript-parser\").TypescriptParser)().parseFiles([\"../src/gitpod-service.ts\", \"../src/protocol.ts\", \"../src/workspace-instance.ts\"], \"../..\").then(a => console.log(JSON.stringify(a)))" | \
+jq '[.[0] | .declarations[2].methods | .[] | {name: .name, params: .parameters, result: .type}]' | \
+go run generate.go

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -14,13 +14,15 @@
         "@types/js-yaml": "^3.10.1",
         "@types/uuid": "^3.4.5",
         "@types/ws": "^5.1.2",
+        "chai": "^4.1.2",
         "chai-subset": "^1.6.0",
+        "mocha": "^5.0.0",
         "mocha-typescript": "^1.1.11",
         "rimraf": "^2.6.2",
-        "chai": "^4.1.2",
-        "mocha": "^5.0.0",
-        "ts-node": "<7.0.0",
-        "typescript": "^3.1.3"
+        "ts-node": "^9.0.0",
+        "typescript": "^3.1.3",
+        "typescript-json-schema": "^0.43.0",
+        "typescript-parser": "^2.6.1"
     },
     "scripts": {
         "prepare": "yarn run clean && yarn run build",
@@ -37,10 +39,10 @@
         "opentracing": "^0.14.4",
         "prom-client": "^10.2.0",
         "reconnecting-websocket": "^4.2.0",
+        "reflect-metadata": "^0.1.10",
         "uuid": "^3.3.3",
         "vscode-uri": "^1.0.1",
         "vscode-ws-jsonrpc": "^0.2.0",
-        "ws": "^5.2.2",
-        "reflect-metadata": "^0.1.10"
+        "ws": "^5.2.2"
     }
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -44,7 +44,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     // Query/retrieve workspaces
     getWorkspaces(options: GitpodServer.GetWorkspacesOptions): Promise<WorkspaceInfo[]>;
-    getWorkspaceOwner(workspaceId: string): Promise<UserInfo | undefined>;
+    getWorkspaceOwner(workspaceId: string): Promise<UserInfo | undefined>;
     getWorkspaceUsers(workspaceId: string): Promise<WorkspaceInstanceUser[]>;
     getFeaturedRepositories(): Promise<WhitelistedRepository[]>;
     getWorkspace(id: string): Promise<WorkspaceInfo>;
@@ -56,13 +56,13 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
      * @return WorkspaceCreationResult
      */
     createWorkspace(options: GitpodServer.CreateWorkspaceOptions): Promise<WorkspaceCreationResult>;
-    startWorkspace(id: string, options: {forceDefaultImage: boolean}): Promise<StartWorkspaceResult>;
+    startWorkspace(id: string, options: GitpodServer.StartWorkspaceOptions): Promise<StartWorkspaceResult>;
     stopWorkspace(id: string): Promise<void>;
     deleteWorkspace(id: string): Promise<void>;
     setWorkspaceDescription(id: string, desc: string): Promise<void>;
-    controlAdmission(id: string, level: "owner" | "everyone"): Promise<void>;
+    controlAdmission(id: string, level: GitpodServer.AdmissionLevel): Promise<void>;
 
-    updateWorkspaceUserPin(id: string, action: "pin" | "unpin" | "toggle"): Promise<void>;
+    updateWorkspaceUserPin(id: string, action: GitpodServer.PinAction): Promise<void>;
     sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;
     watchWorkspaceImageBuildLogs(workspaceId: string): Promise<void>;
     watchHeadlessWorkspaceLogs(workspaceId: string): Promise<void>;
@@ -73,7 +73,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getWorkspaceTimeout(workspaceId: string): Promise<GetWorkspaceTimeoutResult>;
     sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;
 
-    updateWorkspaceUserPin(id: string, action: "pin" | "unpin" | "toggle"): Promise<void>;
+    updateWorkspaceUserPin(id: string, action: GitpodServer.PinAction): Promise<void>;
 
     // Port management
     getOpenPorts(workspaceId: string): Promise<WorkspaceInstancePort[]>;
@@ -95,7 +95,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     // Gitpod token
     getGitpodTokens(): Promise<GitpodToken[]>;
-    generateNewGitpodToken(options: { name?: string, type: GitpodTokenType, scopes?: [] }): Promise<string>;
+    generateNewGitpodToken(options: GitpodServer.GenerateNewGitpodTokenOptions): Promise<string>;
     deleteGitpodToken(tokenHash: string): Promise<void>;
 
     // misc
@@ -183,6 +183,9 @@ export namespace GitpodServer {
         contextUrl: string;
         mode?: CreateWorkspaceMode;
     }
+    export interface StartWorkspaceOptions {
+        forceDefaultImage: boolean;
+    }
     export interface TakeSnapshotOptions {
         workspaceId: string;
         layoutData?: string;
@@ -214,6 +217,13 @@ export namespace GitpodServer {
     }
     export interface DeleteOwnAuthProviderParams {
         readonly id: string
+    }
+    export type AdmissionLevel = "owner" | "everyone";
+    export type PinAction = "pin" | "unpin" | "toggle";
+    export interface GenerateNewGitpodTokenOptions {
+        name?: string
+        type: GitpodTokenType
+        scopes?: string[] 
     }
 }
 

--- a/components/supervisor/cmd/call-server.go
+++ b/components/supervisor/cmd/call-server.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/supervisor/pkg/gitpod"
+	"github.com/spf13/cobra"
+)
+
+var callServerCmd = &cobra.Command{
+	Use:    "call-server <host> <token>",
+	Hidden: true,
+	Args:   cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			ctx   = context.Background()
+			host  = args[0]
+			token = args[1]
+		)
+
+		api, err := gitpod.ConnectToServer(fmt.Sprintf("ws://%s/api/v1", host), gitpod.ConnectToServerOpts{
+			Token: token,
+		})
+		if err != nil {
+			log.Fatal("ConnectToServer", err)
+		}
+		defer api.Close()
+
+		usr, err := api.GetLoggedInUser(ctx)
+		if err != nil {
+			log.Fatal("GetLoggedInUser", err)
+		}
+		json.NewEncoder(os.Stdout).Encode(usr)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(callServerCmd)
+}

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -17,8 +17,10 @@ require (
 	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/soheilhy/cmux v0.1.4
+	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.31.1
 	google.golang.org/grpc/examples v0.0.0-20200902210233-8630cac324bf // indirect

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -202,6 +202,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -335,6 +336,8 @@ github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbd
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37 h1:marA1XQDC7N870zmSFIoHZpIUduK80USeY0Rkuflgp4=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/components/supervisor/pkg/gitpod/gitpod-service.go
+++ b/components/supervisor/pkg/gitpod/gitpod-service.go
@@ -1,0 +1,1867 @@
+package gitpod
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/sourcegraph/jsonrpc2"
+	"golang.org/x/net/websocket"
+	"golang.org/x/xerrors"
+)
+
+// APIInterface wraps the
+type APIInterface interface {
+	GetLoggedInUser(ctx context.Context) (res *User, err error)
+	UpdateLoggedInUser(ctx context.Context, user *User) (res *User, err error)
+	GetAuthProviders(ctx context.Context) (res []*AuthProviderInfo, err error)
+	GetOwnAuthProviders(ctx context.Context) (res []*AuthProviderEntry, err error)
+	UpdateOwnAuthProvider(ctx context.Context, params *UpdateOwnAuthProviderParams) (err error)
+	DeleteOwnAuthProvider(ctx context.Context, params *DeleteOwnAuthProviderParams) (err error)
+	GetBranding(ctx context.Context) (res *Branding, err error)
+	GetConfiguration(ctx context.Context) (res *Configuration, err error)
+	GetToken(ctx context.Context, query *GetTokenSearchOptions) (res *Token, err error)
+	GetPortAuthenticationToken(ctx context.Context, workspaceID string) (res *Token, err error)
+	DeleteAccount(ctx context.Context) (err error)
+	GetClientRegion(ctx context.Context) (res string, err error)
+	HasPermission(ctx context.Context, permission *PermissionName) (res bool, err error)
+	GetWorkspaces(ctx context.Context, options *GetWorkspacesOptions) (res []*WorkspaceInfo, err error)
+	GetWorkspaceOwner(ctx context.Context, workspaceID string) (res *UserInfo, err error)
+	GetWorkspaceUsers(ctx context.Context, workspaceID string) (res []*WorkspaceInstanceUser, err error)
+	GetFeaturedRepositories(ctx context.Context) (res []*WhitelistedRepository, err error)
+	GetWorkspace(ctx context.Context, id string) (res *WorkspaceInfo, err error)
+	IsWorkspaceOwner(ctx context.Context, workspaceID string) (res bool, err error)
+	CreateWorkspace(ctx context.Context, options *CreateWorkspaceOptions) (res *WorkspaceCreationResult, err error)
+	StartWorkspace(ctx context.Context, id string, options *StartWorkspaceOptions) (res *StartWorkspaceResult, err error)
+	StopWorkspace(ctx context.Context, id string) (err error)
+	DeleteWorkspace(ctx context.Context, id string) (err error)
+	SetWorkspaceDescription(ctx context.Context, id string, desc string) (err error)
+	ControlAdmission(ctx context.Context, id string, level *AdmissionLevel) (err error)
+	UpdateWorkspaceUserPin(ctx context.Context, id string, action *PinAction) (err error)
+	SendHeartBeat(ctx context.Context, options *SendHeartBeatOptions) (err error)
+	WatchWorkspaceImageBuildLogs(ctx context.Context, workspaceID string) (err error)
+	WatchHeadlessWorkspaceLogs(ctx context.Context, workspaceID string) (err error)
+	IsPrebuildAvailable(ctx context.Context, pwsid string) (res bool, err error)
+	SetWorkspaceTimeout(ctx context.Context, workspaceID string, duration *WorkspaceTimeoutDuration) (res *SetWorkspaceTimeoutResult, err error)
+	GetWorkspaceTimeout(ctx context.Context, workspaceID string) (res *GetWorkspaceTimeoutResult, err error)
+	GetOpenPorts(ctx context.Context, workspaceID string) (res []*WorkspaceInstancePort, err error)
+	OpenPort(ctx context.Context, workspaceID string, port *WorkspaceInstancePort) (res *WorkspaceInstancePort, err error)
+	ClosePort(ctx context.Context, workspaceID string, port float32) (err error)
+	GetUserMessages(ctx context.Context, options *GetUserMessagesOptions) (res []*UserMessage, err error)
+	UpdateUserMessages(ctx context.Context, options *UpdateUserMessagesOptions) (err error)
+	GetUserStorageResource(ctx context.Context, options *GetUserStorageResourceOptions) (res string, err error)
+	UpdateUserStorageResource(ctx context.Context, options *UpdateUserStorageResourceOptions) (err error)
+	GetEnvVars(ctx context.Context) (res []*UserEnvVarValue, err error)
+	SetEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error)
+	DeleteEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error)
+	GetGitpodTokens(ctx context.Context) (res []*APIToken, err error)
+	GenerateNewGitpodToken(ctx context.Context, options *GenerateNewGitpodTokenOptions) (res string, err error)
+	DeleteGitpodToken(ctx context.Context, tokenHash string) (err error)
+	SendFeedback(ctx context.Context, feedback string) (res string, err error)
+	RegisterGithubApp(ctx context.Context, installationID string) (err error)
+	TakeSnapshot(ctx context.Context, options *TakeSnapshotOptions) (res string, err error)
+	GetSnapshots(ctx context.Context, workspaceID string) (res []*string, err error)
+	StoreLayout(ctx context.Context, workspaceID string, layoutData string) (err error)
+	GetLayout(ctx context.Context, workspaceID string) (res string, err error)
+	PreparePluginUpload(ctx context.Context, params *PreparePluginUploadParams) (res string, err error)
+	ResolvePlugins(ctx context.Context, workspaceID string, params *ResolvePluginsParams) (res *ResolvedPlugins, err error)
+	InstallUserPlugins(ctx context.Context, params *InstallPluginsParams) (res bool, err error)
+	UninstallUserPlugin(ctx context.Context, params *UninstallPluginParams) (res bool, err error)
+}
+
+// FunctionName is the name of an RPC function
+type FunctionName string
+
+const (
+	// FunctionGetLoggedInUser is the name of the getLoggedInUser function
+	FunctionGetLoggedInUser FunctionName = "getLoggedInUser"
+	// FunctionUpdateLoggedInUser is the name of the updateLoggedInUser function
+	FunctionUpdateLoggedInUser FunctionName = "updateLoggedInUser"
+	// FunctionGetAuthProviders is the name of the getAuthProviders function
+	FunctionGetAuthProviders FunctionName = "getAuthProviders"
+	// FunctionGetOwnAuthProviders is the name of the getOwnAuthProviders function
+	FunctionGetOwnAuthProviders FunctionName = "getOwnAuthProviders"
+	// FunctionUpdateOwnAuthProvider is the name of the updateOwnAuthProvider function
+	FunctionUpdateOwnAuthProvider FunctionName = "updateOwnAuthProvider"
+	// FunctionDeleteOwnAuthProvider is the name of the deleteOwnAuthProvider function
+	FunctionDeleteOwnAuthProvider FunctionName = "deleteOwnAuthProvider"
+	// FunctionGetBranding is the name of the getBranding function
+	FunctionGetBranding FunctionName = "getBranding"
+	// FunctionGetConfiguration is the name of the getConfiguration function
+	FunctionGetConfiguration FunctionName = "getConfiguration"
+	// FunctionGetToken is the name of the getToken function
+	FunctionGetToken FunctionName = "getToken"
+	// FunctionGetPortAuthenticationToken is the name of the getPortAuthenticationToken function
+	FunctionGetPortAuthenticationToken FunctionName = "getPortAuthenticationToken"
+	// FunctionDeleteAccount is the name of the deleteAccount function
+	FunctionDeleteAccount FunctionName = "deleteAccount"
+	// FunctionGetClientRegion is the name of the getClientRegion function
+	FunctionGetClientRegion FunctionName = "getClientRegion"
+	// FunctionHasPermission is the name of the hasPermission function
+	FunctionHasPermission FunctionName = "hasPermission"
+	// FunctionGetWorkspaces is the name of the getWorkspaces function
+	FunctionGetWorkspaces FunctionName = "getWorkspaces"
+	// FunctionGetWorkspaceOwner is the name of the getWorkspaceOwner function
+	FunctionGetWorkspaceOwner FunctionName = "getWorkspaceOwner"
+	// FunctionGetWorkspaceUsers is the name of the getWorkspaceUsers function
+	FunctionGetWorkspaceUsers FunctionName = "getWorkspaceUsers"
+	// FunctionGetFeaturedRepositories is the name of the getFeaturedRepositories function
+	FunctionGetFeaturedRepositories FunctionName = "getFeaturedRepositories"
+	// FunctionGetWorkspace is the name of the getWorkspace function
+	FunctionGetWorkspace FunctionName = "getWorkspace"
+	// FunctionIsWorkspaceOwner is the name of the isWorkspaceOwner function
+	FunctionIsWorkspaceOwner FunctionName = "isWorkspaceOwner"
+	// FunctionCreateWorkspace is the name of the createWorkspace function
+	FunctionCreateWorkspace FunctionName = "createWorkspace"
+	// FunctionStartWorkspace is the name of the startWorkspace function
+	FunctionStartWorkspace FunctionName = "startWorkspace"
+	// FunctionStopWorkspace is the name of the stopWorkspace function
+	FunctionStopWorkspace FunctionName = "stopWorkspace"
+	// FunctionDeleteWorkspace is the name of the deleteWorkspace function
+	FunctionDeleteWorkspace FunctionName = "deleteWorkspace"
+	// FunctionSetWorkspaceDescription is the name of the setWorkspaceDescription function
+	FunctionSetWorkspaceDescription FunctionName = "setWorkspaceDescription"
+	// FunctionControlAdmission is the name of the controlAdmission function
+	FunctionControlAdmission FunctionName = "controlAdmission"
+	// FunctionUpdateWorkspaceUserPin is the name of the updateWorkspaceUserPin function
+	FunctionUpdateWorkspaceUserPin FunctionName = "updateWorkspaceUserPin"
+	// FunctionSendHeartBeat is the name of the sendHeartBeat function
+	FunctionSendHeartBeat FunctionName = "sendHeartBeat"
+	// FunctionWatchWorkspaceImageBuildLogs is the name of the watchWorkspaceImageBuildLogs function
+	FunctionWatchWorkspaceImageBuildLogs FunctionName = "watchWorkspaceImageBuildLogs"
+	// FunctionWatchHeadlessWorkspaceLogs is the name of the watchHeadlessWorkspaceLogs function
+	FunctionWatchHeadlessWorkspaceLogs FunctionName = "watchHeadlessWorkspaceLogs"
+	// FunctionIsPrebuildAvailable is the name of the isPrebuildAvailable function
+	FunctionIsPrebuildAvailable FunctionName = "isPrebuildAvailable"
+	// FunctionSetWorkspaceTimeout is the name of the setWorkspaceTimeout function
+	FunctionSetWorkspaceTimeout FunctionName = "setWorkspaceTimeout"
+	// FunctionGetWorkspaceTimeout is the name of the getWorkspaceTimeout function
+	FunctionGetWorkspaceTimeout FunctionName = "getWorkspaceTimeout"
+	// FunctionGetOpenPorts is the name of the getOpenPorts function
+	FunctionGetOpenPorts FunctionName = "getOpenPorts"
+	// FunctionOpenPort is the name of the openPort function
+	FunctionOpenPort FunctionName = "openPort"
+	// FunctionClosePort is the name of the closePort function
+	FunctionClosePort FunctionName = "closePort"
+	// FunctionGetUserMessages is the name of the getUserMessages function
+	FunctionGetUserMessages FunctionName = "getUserMessages"
+	// FunctionUpdateUserMessages is the name of the updateUserMessages function
+	FunctionUpdateUserMessages FunctionName = "updateUserMessages"
+	// FunctionGetUserStorageResource is the name of the getUserStorageResource function
+	FunctionGetUserStorageResource FunctionName = "getUserStorageResource"
+	// FunctionUpdateUserStorageResource is the name of the updateUserStorageResource function
+	FunctionUpdateUserStorageResource FunctionName = "updateUserStorageResource"
+	// FunctionGetEnvVars is the name of the getEnvVars function
+	FunctionGetEnvVars FunctionName = "getEnvVars"
+	// FunctionSetEnvVar is the name of the setEnvVar function
+	FunctionSetEnvVar FunctionName = "setEnvVar"
+	// FunctionDeleteEnvVar is the name of the deleteEnvVar function
+	FunctionDeleteEnvVar FunctionName = "deleteEnvVar"
+	// FunctionGetGitpodTokens is the name of the getGitpodTokens function
+	FunctionGetGitpodTokens FunctionName = "getGitpodTokens"
+	// FunctionGenerateNewGitpodToken is the name of the generateNewGitpodToken function
+	FunctionGenerateNewGitpodToken FunctionName = "generateNewGitpodToken"
+	// FunctionDeleteGitpodToken is the name of the deleteGitpodToken function
+	FunctionDeleteGitpodToken FunctionName = "deleteGitpodToken"
+	// FunctionSendFeedback is the name of the sendFeedback function
+	FunctionSendFeedback FunctionName = "sendFeedback"
+	// FunctionRegisterGithubApp is the name of the registerGithubApp function
+	FunctionRegisterGithubApp FunctionName = "registerGithubApp"
+	// FunctionTakeSnapshot is the name of the takeSnapshot function
+	FunctionTakeSnapshot FunctionName = "takeSnapshot"
+	// FunctionGetSnapshots is the name of the getSnapshots function
+	FunctionGetSnapshots FunctionName = "getSnapshots"
+	// FunctionStoreLayout is the name of the storeLayout function
+	FunctionStoreLayout FunctionName = "storeLayout"
+	// FunctionGetLayout is the name of the getLayout function
+	FunctionGetLayout FunctionName = "getLayout"
+	// FunctionPreparePluginUpload is the name of the preparePluginUpload function
+	FunctionPreparePluginUpload FunctionName = "preparePluginUpload"
+	// FunctionResolvePlugins is the name of the resolvePlugins function
+	FunctionResolvePlugins FunctionName = "resolvePlugins"
+	// FunctionInstallUserPlugins is the name of the installUserPlugins function
+	FunctionInstallUserPlugins FunctionName = "installUserPlugins"
+	// FunctionUninstallUserPlugin is the name of the uninstallUserPlugin function
+	FunctionUninstallUserPlugin FunctionName = "uninstallUserPlugin"
+)
+
+// ConnectToServerOpts configures the server connection
+type ConnectToServerOpts struct {
+	Context context.Context
+	Token   string
+}
+
+// ConnectToServer establishes a new websocket connection to the server
+func ConnectToServer(endpoint string, opts ConnectToServerOpts) (*APIoverJSONRPC, error) {
+	if opts.Context == nil {
+		opts.Context = context.Background()
+	}
+
+	epURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid endpoint URL: %w", err)
+	}
+
+	var protocol string
+	if epURL.Scheme == "wss:" {
+		protocol = "https"
+	} else {
+		protocol = "http"
+	}
+	origin := fmt.Sprintf("%s://%s/", protocol, epURL.Hostname())
+
+	wscfg, err := websocket.NewConfig(endpoint, origin)
+	if err != nil {
+		return nil, err
+	}
+	if opts.Token != "" {
+		wscfg.Header.Set("Authorization", "Bearer "+opts.Token)
+	}
+	wsconn, err := websocket.DialConfig(wscfg)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot dial endpoint %s: %w", endpoint, err)
+	}
+
+	var res APIoverJSONRPC
+	res.W = wsconn
+	res.C = jsonrpc2.NewConn(opts.Context, jsonrpc2.NewBufferedStream(wsconn, simpleCodec{}), jsonrpc2.HandlerWithError(res.handler))
+	return &res, nil
+}
+
+type simpleCodec struct{}
+
+// WriteObject writes a JSON-RPC 2.0 object to the stream.
+func (s simpleCodec) WriteObject(stream io.Writer, obj interface{}) error {
+	return json.NewEncoder(stream).Encode(obj)
+}
+
+// ReadObject reads the next JSON-RPC 2.0 object from the stream
+// and stores it in the value pointed to by v.
+func (s simpleCodec) ReadObject(stream *bufio.Reader, v interface{}) error {
+	return json.NewDecoder(stream).Decode(v)
+}
+
+// APIoverJSONRPC makes JSON RPC calls to the Gitpod server is the APIoverJSONRPC message type
+type APIoverJSONRPC struct {
+	W *websocket.Conn
+	C *jsonrpc2.Conn
+}
+
+// Close closes the connection
+func (gp *APIoverJSONRPC) Close() (err error) {
+	e1 := gp.C.Close()
+	e2 := gp.W.Close()
+	if e1 != nil {
+		return e1
+	}
+	if e2 != nil {
+		return e2
+	}
+	return nil
+}
+
+func (gp *APIoverJSONRPC) handler(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request) (result interface{}, err error) {
+	return
+}
+
+// GetLoggedInUser calls getLoggedInUser on the server
+func (gp *APIoverJSONRPC) GetLoggedInUser(ctx context.Context) (res *User, err error) {
+	var _params []interface{}
+
+	var result User
+	err = gp.C.Call(ctx, "getLoggedInUser", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// UpdateLoggedInUser calls updateLoggedInUser on the server
+func (gp *APIoverJSONRPC) UpdateLoggedInUser(ctx context.Context, user *User) (res *User, err error) {
+	var _params []interface{}
+
+	_params = append(_params, user)
+
+	var result User
+	err = gp.C.Call(ctx, "updateLoggedInUser", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// GetAuthProviders calls getAuthProviders on the server
+func (gp *APIoverJSONRPC) GetAuthProviders(ctx context.Context) (res []*AuthProviderInfo, err error) {
+	var _params []interface{}
+
+	var result []*AuthProviderInfo
+	err = gp.C.Call(ctx, "getAuthProviders", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetOwnAuthProviders calls getOwnAuthProviders on the server
+func (gp *APIoverJSONRPC) GetOwnAuthProviders(ctx context.Context) (res []*AuthProviderEntry, err error) {
+	var _params []interface{}
+
+	var result []*AuthProviderEntry
+	err = gp.C.Call(ctx, "getOwnAuthProviders", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// UpdateOwnAuthProvider calls updateOwnAuthProvider on the server
+func (gp *APIoverJSONRPC) UpdateOwnAuthProvider(ctx context.Context, params *UpdateOwnAuthProviderParams) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, params)
+
+	err = gp.C.Call(ctx, "updateOwnAuthProvider", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteOwnAuthProvider calls deleteOwnAuthProvider on the server
+func (gp *APIoverJSONRPC) DeleteOwnAuthProvider(ctx context.Context, params *DeleteOwnAuthProviderParams) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, params)
+
+	err = gp.C.Call(ctx, "deleteOwnAuthProvider", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetBranding calls getBranding on the server
+func (gp *APIoverJSONRPC) GetBranding(ctx context.Context) (res *Branding, err error) {
+	var _params []interface{}
+
+	var result Branding
+	err = gp.C.Call(ctx, "getBranding", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// GetConfiguration calls getConfiguration on the server
+func (gp *APIoverJSONRPC) GetConfiguration(ctx context.Context) (res *Configuration, err error) {
+	var _params []interface{}
+
+	var result Configuration
+	err = gp.C.Call(ctx, "getConfiguration", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// GetToken calls getToken on the server
+func (gp *APIoverJSONRPC) GetToken(ctx context.Context, query *GetTokenSearchOptions) (res *Token, err error) {
+	var _params []interface{}
+
+	_params = append(_params, query)
+
+	var result Token
+	err = gp.C.Call(ctx, "getToken", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// GetPortAuthenticationToken calls getPortAuthenticationToken on the server
+func (gp *APIoverJSONRPC) GetPortAuthenticationToken(ctx context.Context, workspaceID string) (res *Token, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result Token
+	err = gp.C.Call(ctx, "getPortAuthenticationToken", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// DeleteAccount calls deleteAccount on the server
+func (gp *APIoverJSONRPC) DeleteAccount(ctx context.Context) (err error) {
+	var _params []interface{}
+
+	err = gp.C.Call(ctx, "deleteAccount", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetClientRegion calls getClientRegion on the server
+func (gp *APIoverJSONRPC) GetClientRegion(ctx context.Context) (res string, err error) {
+	var _params []interface{}
+
+	var result string
+	err = gp.C.Call(ctx, "getClientRegion", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// HasPermission calls hasPermission on the server
+func (gp *APIoverJSONRPC) HasPermission(ctx context.Context, permission *PermissionName) (res bool, err error) {
+	var _params []interface{}
+
+	_params = append(_params, permission)
+
+	var result bool
+	err = gp.C.Call(ctx, "hasPermission", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetWorkspaces calls getWorkspaces on the server
+func (gp *APIoverJSONRPC) GetWorkspaces(ctx context.Context, options *GetWorkspacesOptions) (res []*WorkspaceInfo, err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	var result []*WorkspaceInfo
+	err = gp.C.Call(ctx, "getWorkspaces", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetWorkspaceOwner calls getWorkspaceOwner on the server
+func (gp *APIoverJSONRPC) GetWorkspaceOwner(ctx context.Context, workspaceID string) (res *UserInfo, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result UserInfo
+	err = gp.C.Call(ctx, "getWorkspaceOwner", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// GetWorkspaceUsers calls getWorkspaceUsers on the server
+func (gp *APIoverJSONRPC) GetWorkspaceUsers(ctx context.Context, workspaceID string) (res []*WorkspaceInstanceUser, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result []*WorkspaceInstanceUser
+	err = gp.C.Call(ctx, "getWorkspaceUsers", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetFeaturedRepositories calls getFeaturedRepositories on the server
+func (gp *APIoverJSONRPC) GetFeaturedRepositories(ctx context.Context) (res []*WhitelistedRepository, err error) {
+	var _params []interface{}
+
+	var result []*WhitelistedRepository
+	err = gp.C.Call(ctx, "getFeaturedRepositories", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetWorkspace calls getWorkspace on the server
+func (gp *APIoverJSONRPC) GetWorkspace(ctx context.Context, id string) (res *WorkspaceInfo, err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+
+	var result WorkspaceInfo
+	err = gp.C.Call(ctx, "getWorkspace", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// IsWorkspaceOwner calls isWorkspaceOwner on the server
+func (gp *APIoverJSONRPC) IsWorkspaceOwner(ctx context.Context, workspaceID string) (res bool, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result bool
+	err = gp.C.Call(ctx, "isWorkspaceOwner", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// CreateWorkspace calls createWorkspace on the server
+func (gp *APIoverJSONRPC) CreateWorkspace(ctx context.Context, options *CreateWorkspaceOptions) (res *WorkspaceCreationResult, err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	var result WorkspaceCreationResult
+	err = gp.C.Call(ctx, "createWorkspace", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// StartWorkspace calls startWorkspace on the server
+func (gp *APIoverJSONRPC) StartWorkspace(ctx context.Context, id string, options *StartWorkspaceOptions) (res *StartWorkspaceResult, err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+	_params = append(_params, options)
+
+	var result StartWorkspaceResult
+	err = gp.C.Call(ctx, "startWorkspace", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// StopWorkspace calls stopWorkspace on the server
+func (gp *APIoverJSONRPC) StopWorkspace(ctx context.Context, id string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+
+	err = gp.C.Call(ctx, "stopWorkspace", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteWorkspace calls deleteWorkspace on the server
+func (gp *APIoverJSONRPC) DeleteWorkspace(ctx context.Context, id string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+
+	err = gp.C.Call(ctx, "deleteWorkspace", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// SetWorkspaceDescription calls setWorkspaceDescription on the server
+func (gp *APIoverJSONRPC) SetWorkspaceDescription(ctx context.Context, id string, desc string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+	_params = append(_params, desc)
+
+	err = gp.C.Call(ctx, "setWorkspaceDescription", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ControlAdmission calls controlAdmission on the server
+func (gp *APIoverJSONRPC) ControlAdmission(ctx context.Context, id string, level *AdmissionLevel) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+	_params = append(_params, level)
+
+	err = gp.C.Call(ctx, "controlAdmission", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// WatchWorkspaceImageBuildLogs calls watchWorkspaceImageBuildLogs on the server
+func (gp *APIoverJSONRPC) WatchWorkspaceImageBuildLogs(ctx context.Context, workspaceID string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	err = gp.C.Call(ctx, "watchWorkspaceImageBuildLogs", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// WatchHeadlessWorkspaceLogs calls watchHeadlessWorkspaceLogs on the server
+func (gp *APIoverJSONRPC) WatchHeadlessWorkspaceLogs(ctx context.Context, workspaceID string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	err = gp.C.Call(ctx, "watchHeadlessWorkspaceLogs", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// IsPrebuildAvailable calls isPrebuildAvailable on the server
+func (gp *APIoverJSONRPC) IsPrebuildAvailable(ctx context.Context, pwsid string) (res bool, err error) {
+	var _params []interface{}
+
+	_params = append(_params, pwsid)
+
+	var result bool
+	err = gp.C.Call(ctx, "isPrebuildAvailable", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// SetWorkspaceTimeout calls setWorkspaceTimeout on the server
+func (gp *APIoverJSONRPC) SetWorkspaceTimeout(ctx context.Context, workspaceID string, duration *WorkspaceTimeoutDuration) (res *SetWorkspaceTimeoutResult, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+	_params = append(_params, duration)
+
+	var result SetWorkspaceTimeoutResult
+	err = gp.C.Call(ctx, "setWorkspaceTimeout", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// GetWorkspaceTimeout calls getWorkspaceTimeout on the server
+func (gp *APIoverJSONRPC) GetWorkspaceTimeout(ctx context.Context, workspaceID string) (res *GetWorkspaceTimeoutResult, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result GetWorkspaceTimeoutResult
+	err = gp.C.Call(ctx, "getWorkspaceTimeout", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// SendHeartBeat calls sendHeartBeat on the server
+func (gp *APIoverJSONRPC) SendHeartBeat(ctx context.Context, options *SendHeartBeatOptions) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	err = gp.C.Call(ctx, "sendHeartBeat", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateWorkspaceUserPin calls updateWorkspaceUserPin on the server
+func (gp *APIoverJSONRPC) UpdateWorkspaceUserPin(ctx context.Context, id string, action *PinAction) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, id)
+	_params = append(_params, action)
+
+	err = gp.C.Call(ctx, "updateWorkspaceUserPin", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetOpenPorts calls getOpenPorts on the server
+func (gp *APIoverJSONRPC) GetOpenPorts(ctx context.Context, workspaceID string) (res []*WorkspaceInstancePort, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result []*WorkspaceInstancePort
+	err = gp.C.Call(ctx, "getOpenPorts", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// OpenPort calls openPort on the server
+func (gp *APIoverJSONRPC) OpenPort(ctx context.Context, workspaceID string, port *WorkspaceInstancePort) (res *WorkspaceInstancePort, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+	_params = append(_params, port)
+
+	var result WorkspaceInstancePort
+	err = gp.C.Call(ctx, "openPort", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// ClosePort calls closePort on the server
+func (gp *APIoverJSONRPC) ClosePort(ctx context.Context, workspaceID string, port float32) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+	_params = append(_params, port)
+
+	err = gp.C.Call(ctx, "closePort", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetUserMessages calls getUserMessages on the server
+func (gp *APIoverJSONRPC) GetUserMessages(ctx context.Context, options *GetUserMessagesOptions) (res []*UserMessage, err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	var result []*UserMessage
+	err = gp.C.Call(ctx, "getUserMessages", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// UpdateUserMessages calls updateUserMessages on the server
+func (gp *APIoverJSONRPC) UpdateUserMessages(ctx context.Context, options *UpdateUserMessagesOptions) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	err = gp.C.Call(ctx, "updateUserMessages", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetUserStorageResource calls getUserStorageResource on the server
+func (gp *APIoverJSONRPC) GetUserStorageResource(ctx context.Context, options *GetUserStorageResourceOptions) (res string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	var result string
+	err = gp.C.Call(ctx, "getUserStorageResource", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// UpdateUserStorageResource calls updateUserStorageResource on the server
+func (gp *APIoverJSONRPC) UpdateUserStorageResource(ctx context.Context, options *UpdateUserStorageResourceOptions) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	err = gp.C.Call(ctx, "updateUserStorageResource", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetEnvVars calls getEnvVars on the server
+func (gp *APIoverJSONRPC) GetEnvVars(ctx context.Context) (res []*UserEnvVarValue, err error) {
+	var _params []interface{}
+
+	var result []*UserEnvVarValue
+	err = gp.C.Call(ctx, "getEnvVars", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// SetEnvVar calls setEnvVar on the server
+func (gp *APIoverJSONRPC) SetEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, variable)
+
+	err = gp.C.Call(ctx, "setEnvVar", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteEnvVar calls deleteEnvVar on the server
+func (gp *APIoverJSONRPC) DeleteEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, variable)
+
+	err = gp.C.Call(ctx, "deleteEnvVar", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetGitpodTokens calls getGitpodTokens on the server
+func (gp *APIoverJSONRPC) GetGitpodTokens(ctx context.Context) (res []*APIToken, err error) {
+	var _params []interface{}
+
+	var result []*APIToken
+	err = gp.C.Call(ctx, "getGitpodTokens", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GenerateNewGitpodToken calls generateNewGitpodToken on the server
+func (gp *APIoverJSONRPC) GenerateNewGitpodToken(ctx context.Context, options *GenerateNewGitpodTokenOptions) (res string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	var result string
+	err = gp.C.Call(ctx, "generateNewGitpodToken", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// DeleteGitpodToken calls deleteGitpodToken on the server
+func (gp *APIoverJSONRPC) DeleteGitpodToken(ctx context.Context, tokenHash string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, tokenHash)
+
+	err = gp.C.Call(ctx, "deleteGitpodToken", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// SendFeedback calls sendFeedback on the server
+func (gp *APIoverJSONRPC) SendFeedback(ctx context.Context, feedback string) (res string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, feedback)
+
+	var result string
+	err = gp.C.Call(ctx, "sendFeedback", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// RegisterGithubApp calls registerGithubApp on the server
+func (gp *APIoverJSONRPC) RegisterGithubApp(ctx context.Context, installationID string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, installationID)
+
+	err = gp.C.Call(ctx, "registerGithubApp", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// TakeSnapshot calls takeSnapshot on the server
+func (gp *APIoverJSONRPC) TakeSnapshot(ctx context.Context, options *TakeSnapshotOptions) (res string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, options)
+
+	var result string
+	err = gp.C.Call(ctx, "takeSnapshot", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetSnapshots calls getSnapshots on the server
+func (gp *APIoverJSONRPC) GetSnapshots(ctx context.Context, workspaceID string) (res []*string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result []*string
+	err = gp.C.Call(ctx, "getSnapshots", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// StoreLayout calls storeLayout on the server
+func (gp *APIoverJSONRPC) StoreLayout(ctx context.Context, workspaceID string, layoutData string) (err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+	_params = append(_params, layoutData)
+
+	err = gp.C.Call(ctx, "storeLayout", _params, nil)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetLayout calls getLayout on the server
+func (gp *APIoverJSONRPC) GetLayout(ctx context.Context, workspaceID string) (res string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+
+	var result string
+	err = gp.C.Call(ctx, "getLayout", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// PreparePluginUpload calls preparePluginUpload on the server
+func (gp *APIoverJSONRPC) PreparePluginUpload(ctx context.Context, params *PreparePluginUploadParams) (res string, err error) {
+	var _params []interface{}
+
+	_params = append(_params, params)
+
+	var result string
+	err = gp.C.Call(ctx, "preparePluginUpload", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// ResolvePlugins calls resolvePlugins on the server
+func (gp *APIoverJSONRPC) ResolvePlugins(ctx context.Context, workspaceID string, params *ResolvePluginsParams) (res *ResolvedPlugins, err error) {
+	var _params []interface{}
+
+	_params = append(_params, workspaceID)
+	_params = append(_params, params)
+
+	var result ResolvedPlugins
+	err = gp.C.Call(ctx, "resolvePlugins", _params, &result)
+	if err != nil {
+		return
+	}
+	res = &result
+
+	return
+}
+
+// InstallUserPlugins calls installUserPlugins on the server
+func (gp *APIoverJSONRPC) InstallUserPlugins(ctx context.Context, params *InstallPluginsParams) (res bool, err error) {
+	var _params []interface{}
+
+	_params = append(_params, params)
+
+	var result bool
+	err = gp.C.Call(ctx, "installUserPlugins", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// UninstallUserPlugin calls uninstallUserPlugin on the server
+func (gp *APIoverJSONRPC) UninstallUserPlugin(ctx context.Context, params *UninstallPluginParams) (res bool, err error) {
+	var _params []interface{}
+
+	_params = append(_params, params)
+
+	var result bool
+	err = gp.C.Call(ctx, "uninstallUserPlugin", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// PermissionName is the name of a permission
+type PermissionName string
+
+const (
+	// PermissionNameMonitor is the "monitor" permission
+	PermissionNameMonitor PermissionName = "monitor"
+	// PermissionNameEnforcement is the "enforcement" permission
+	PermissionNameEnforcement PermissionName = "enforcement"
+	// PermissionNamePrivilegedWs is the "privileged-ws" permission
+	PermissionNamePrivilegedWs PermissionName = "privileged-ws"
+	// PermissionNameRegistryAccess is the "registry-access" permission
+	PermissionNameRegistryAccess PermissionName = "registry-access"
+	// PermissionNameAdminUsers is the "admin-users" permission
+	PermissionNameAdminUsers PermissionName = "admin-users"
+	// PermissionNameAdminWorkspaces is the "admin-workspaces" permission
+	PermissionNameAdminWorkspaces PermissionName = "admin-workspaces"
+	// PermissionNameAdminAPI is the "admin-api" permission
+	PermissionNameAdminAPI PermissionName = "admin-api"
+)
+
+// AdmissionLevel is the admission level to a workspace
+type AdmissionLevel string
+
+const (
+	// AdmissionLevelOwner is the "owner" admission level
+	AdmissionLevelOwner AdmissionLevel = "owner"
+	// AdmissionLevelEveryone is the "everyone" admission level
+	AdmissionLevelEveryone AdmissionLevel = "everyone"
+)
+
+// PinAction is the pin action
+type PinAction string
+
+const (
+	// PinActionPin is the "pin" action
+	PinActionPin PinAction = "pin"
+	// PinActionUnpin is the "unpin" action
+	PinActionUnpin PinAction = "unpin"
+	// PinActionToggle is the "toggle" action
+	PinActionToggle PinAction = "toggle"
+)
+
+// WorkspaceTimeoutDuration is the durations one have set for the workspace timeout
+type WorkspaceTimeoutDuration string
+
+const (
+	// WorkspaceTimeoutDuration30m sets "30m" as timeout duration
+	WorkspaceTimeoutDuration30m = "30m"
+	// WorkspaceTimeoutDuration60m sets "60m" as timeout duration
+	WorkspaceTimeoutDuration60m = "60m"
+	// WorkspaceTimeoutDuration180m sets "180m" as timeout duration
+	WorkspaceTimeoutDuration180m = "180m"
+)
+
+// UserInfo is the UserInfo message type
+type UserInfo struct {
+	Name string `json:"name,omitempty"`
+}
+
+// GetUserStorageResourceOptions is the GetUserStorageResourceOptions message type
+type GetUserStorageResourceOptions struct {
+	URI string `json:"uri,omitempty"`
+}
+
+// GetWorkspacesOptions is the GetWorkspacesOptions message type
+type GetWorkspacesOptions struct {
+	Limit        float64 `json:"limit,omitempty"`
+	PinnedOnly   bool    `json:"pinnedOnly,omitempty"`
+	SearchString string  `json:"searchString,omitempty"`
+}
+
+// StartWorkspaceResult is the StartWorkspaceResult message type
+type StartWorkspaceResult struct {
+	InstanceID   string `json:"instanceID,omitempty"`
+	WorkspaceURL string `json:"workspaceURL,omitempty"`
+}
+
+// GetUserMessagesOptions is the GetUserMessagesOptions message type
+type GetUserMessagesOptions struct {
+	ReleaseNotes        bool   `json:"releaseNotes,omitempty"`
+	WorkspaceInstanceID string `json:"workspaceInstanceId,omitempty"`
+}
+
+// APIToken is the APIToken message type
+type APIToken struct {
+
+	// Created timestamp
+	Created string `json:"created,omitempty"`
+	Deleted bool   `json:"deleted,omitempty"`
+
+	// Human readable name of the token
+	Name string `json:"name,omitempty"`
+
+	// Scopes (e.g. limition to read-only)
+	Scopes []string `json:"scopes,omitempty"`
+
+	// Hash value (SHA256) of the token (primary key).
+	TokenHash string `json:"tokenHash,omitempty"`
+
+	// // Token kindfloat64 is the float64 message type
+	Type float64 `json:"type,omitempty"`
+
+	// The user the token belongs to.
+	User *User `json:"user,omitempty"`
+}
+
+// InstallPluginsParams is the InstallPluginsParams message type
+type InstallPluginsParams struct {
+	PluginIds []string `json:"pluginIds,omitempty"`
+}
+
+// OAuth2Config is the OAuth2Config message type
+type OAuth2Config struct {
+	AuthorizationParams map[string]string `json:"authorizationParams,omitempty"`
+	AuthorizationURL    string            `json:"authorizationUrl,omitempty"`
+	CallBackURL         string            `json:"callBackUrl,omitempty"`
+	ClientID            string            `json:"clientId,omitempty"`
+	ClientSecret        string            `json:"clientSecret,omitempty"`
+	ConfigURL           string            `json:"configURL,omitempty"`
+	Scope               string            `json:"scope,omitempty"`
+	ScopeSeparator      string            `json:"scopeSeparator,omitempty"`
+	SettingsURL         string            `json:"settingsUrl,omitempty"`
+	TokenURL            string            `json:"tokenUrl,omitempty"`
+}
+
+// AuthProviderEntry is the AuthProviderEntry message type
+type AuthProviderEntry struct {
+	Host    string        `json:"host,omitempty"`
+	ID      string        `json:"id,omitempty"`
+	Oauth   *OAuth2Config `json:"oauth,omitempty"`
+	OwnerID string        `json:"ownerId,omitempty"`
+
+	// Status  string        `json:"status,omitempty"`   string is the    string message type
+	Type string `json:"type,omitempty"`
+}
+
+// Commit is the Commit message type
+type Commit struct {
+	Ref        string      `json:"ref,omitempty"`
+	RefType    string      `json:"refType,omitempty"`
+	Repository *Repository `json:"repository,omitempty"`
+	Revision   string      `json:"revision,omitempty"`
+}
+
+// Fork is the Fork message type
+type Fork struct {
+	Parent *Repository `json:"parent,omitempty"`
+}
+
+// Repository is the Repository message type
+type Repository struct {
+	AvatarURL     string `json:"avatarUrl,omitempty"`
+	CloneURL      string `json:"cloneUrl,omitempty"`
+	DefaultBranch string `json:"defaultBranch,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Fork          *Fork  `json:"fork,omitempty"`
+	Host          string `json:"host,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Owner         string `json:"owner,omitempty"`
+
+	// Optional for backwards compatibility
+	Private bool   `json:"private,omitempty"`
+	WebURL  string `json:"webUrl,omitempty"`
+}
+
+// WorkspaceCreationResult is the WorkspaceCreationResult message type
+type WorkspaceCreationResult struct {
+	CreatedWorkspaceID         string                    `json:"createdWorkspaceId,omitempty"`
+	ExistingWorkspaces         []*WorkspaceInfo          `json:"existingWorkspaces,omitempty"`
+	RunningPrebuildWorkspaceID string                    `json:"runningPrebuildWorkspaceID,omitempty"`
+	RunningWorkspacePrebuild   *RunningWorkspacePrebuild `json:"runningWorkspacePrebuild,omitempty"`
+	WorkspaceURL               string                    `json:"workspaceURL,omitempty"`
+}
+
+// RunningWorkspacePrebuild is the RunningWorkspacePrebuild message type
+type RunningWorkspacePrebuild struct {
+	PrebuildID  string `json:"prebuildID,omitempty"`
+	SameCluster bool   `json:"sameCluster,omitempty"`
+	Starting    string `json:"starting,omitempty"`
+	WorkspaceID string `json:"workspaceID,omitempty"`
+}
+
+// Workspace is the Workspace message type
+type Workspace struct {
+
+	// The resolved/built fixed named of the base image. This field is only set if the workspace
+	// already has its base image built.
+	BaseImageNameResolved string           `json:"baseImageNameResolved,omitempty"`
+	BasedOnPrebuildID     string           `json:"basedOnPrebuildId,omitempty"`
+	BasedOnSnapshotID     string           `json:"basedOnSnapshotId,omitempty"`
+	Config                *WorkspaceConfig `json:"config,omitempty"`
+
+	// Marks the time when the workspace content has been deleted.
+	ContentDeletedTime string            `json:"contentDeletedTime,omitempty"`
+	Context            *WorkspaceContext `json:"context,omitempty"`
+	ContextURL         string            `json:"contextURL,omitempty"`
+	CreationTime       string            `json:"creationTime,omitempty"`
+	Deleted            bool              `json:"deleted,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	ID                 string            `json:"id,omitempty"`
+
+	// The resolved, fix name of the workspace image. We only use this
+	// to access the logs during an image build.
+	ImageNameResolved string `json:"imageNameResolved,omitempty"`
+
+	// The source where to get the workspace base image from. This source is resolved
+	// during workspace creation. Once a base image has been built the information in here
+	// is superseded by baseImageNameResolved.
+	ImageSource interface{} `json:"imageSource,omitempty"`
+	OwnerID     string      `json:"ownerId,omitempty"`
+	Pinned      bool        `json:"pinned,omitempty"`
+	Shareable   bool        `json:"shareable,omitempty"`
+
+	// Mark as deleted (user-facing). The actual deletion of the workspace content is executed
+	// with a (configurable) delay
+	SoftDeleted string `json:"softDeleted,omitempty"`
+
+	// Marks the time when the workspace was marked as softDeleted. The actual deletion of the
+	// workspace content happens after a configurable period
+
+	// SoftDeletedTime string `json:"softDeletedTime,omitempty"`           string is the            string message type
+	Type string `json:"type,omitempty"`
+}
+
+// WorkspaceConfig is the WorkspaceConfig message type
+type WorkspaceConfig struct {
+	CheckoutLocation string `json:"checkoutLocation,omitempty"`
+
+	// Set of automatically infered feature flags. That's not something the user can set, but
+	// that is set by gitpod at workspace creation time.
+	FeatureFlags []string          `json:"_featureFlags,omitempty"`
+	GitConfig    map[string]string `json:"gitConfig,omitempty"`
+	Github       *GithubAppConfig  `json:"github,omitempty"`
+	Ide          string            `json:"ide,omitempty"`
+	Image        interface{}       `json:"image,omitempty"`
+
+	// Where the config object originates from.
+	//
+	// repo - from the repository
+	// definitly-gp - from github.com/gitpod-io/definitely-gp
+	// derived - computed based on analyzing the repository
+	// default - our static catch-all default config
+	Origin            string        `json:"_origin,omitempty"`
+	Ports             []*PortConfig `json:"ports,omitempty"`
+	Privileged        bool          `json:"privileged,omitempty"`
+	Tasks             []*TaskConfig `json:"tasks,omitempty"`
+	Vscode            *VSCodeConfig `json:"vscode,omitempty"`
+	WorkspaceLocation string        `json:"workspaceLocation,omitempty"`
+}
+
+// WorkspaceContext is the WorkspaceContext message type
+type WorkspaceContext struct {
+	ForceCreateNewWorkspace bool   `json:"forceCreateNewWorkspace,omitempty"`
+	NormalizedContextURL    string `json:"normalizedContextURL,omitempty"`
+	Title                   string `json:"title,omitempty"`
+}
+
+// WorkspaceImageSourceDocker is the WorkspaceImageSourceDocker message type
+type WorkspaceImageSourceDocker struct {
+	DockerFileHash   string  `json:"dockerFileHash,omitempty"`
+	DockerFilePath   string  `json:"dockerFilePath,omitempty"`
+	DockerFileSource *Commit `json:"dockerFileSource,omitempty"`
+}
+
+// WorkspaceImageSourceReference is the WorkspaceImageSourceReference message type
+type WorkspaceImageSourceReference struct {
+
+	// The resolved, fix base image reference
+	BaseImageResolved string `json:"baseImageResolved,omitempty"`
+}
+
+// WorkspaceInfo is the WorkspaceInfo message type
+type WorkspaceInfo struct {
+	LatestInstance *WorkspaceInstance `json:"latestInstance,omitempty"`
+	Workspace      *Workspace         `json:"workspace,omitempty"`
+}
+
+// WorkspaceInstance is the WorkspaceInstance message type
+type WorkspaceInstance struct {
+	Configuration  *WorkspaceInstanceConfiguration `json:"configuration,omitempty"`
+	CreationTime   string                          `json:"creationTime,omitempty"`
+	Deleted        bool                            `json:"deleted,omitempty"`
+	DeployedTime   string                          `json:"deployedTime,omitempty"`
+	ID             string                          `json:"id,omitempty"`
+	IdeURL         string                          `json:"ideUrl,omitempty"`
+	Region         string                          `json:"region,omitempty"`
+	StartedTime    string                          `json:"startedTime,omitempty"`
+	Status         *WorkspaceInstanceStatus        `json:"status,omitempty"`
+	StoppedTime    string                          `json:"stoppedTime,omitempty"`
+	WorkspaceID    string                          `json:"workspaceId,omitempty"`
+	WorkspaceImage string                          `json:"workspaceImage,omitempty"`
+}
+
+// WorkspaceInstanceConditions is the WorkspaceInstanceConditions message type
+type WorkspaceInstanceConditions struct {
+	Deployed          bool   `json:"deployed,omitempty"`
+	Failed            string `json:"failed,omitempty"`
+	FirstUserActivity string `json:"firstUserActivity,omitempty"`
+	NeededImageBuild  bool   `json:"neededImageBuild,omitempty"`
+	PullingImages     bool   `json:"pullingImages,omitempty"`
+	ServiceExists     bool   `json:"serviceExists,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+}
+
+// WorkspaceInstanceConfiguration is the WorkspaceInstanceConfiguration message type
+type WorkspaceInstanceConfiguration struct {
+	FeatureFlags []string `json:"featureFlags,omitempty"`
+	TheiaVersion string   `json:"theiaVersion,omitempty"`
+}
+
+// WorkspaceInstanceRepoStatus is the WorkspaceInstanceRepoStatus message type
+type WorkspaceInstanceRepoStatus struct {
+	Branch               string   `json:"branch,omitempty"`
+	LatestCommit         string   `json:"latestCommit,omitempty"`
+	TotalUncommitedFiles float64  `json:"totalUncommitedFiles,omitempty"`
+	TotalUnpushedCommits float64  `json:"totalUnpushedCommits,omitempty"`
+	TotalUntrackedFiles  float64  `json:"totalUntrackedFiles,omitempty"`
+	UncommitedFiles      []string `json:"uncommitedFiles,omitempty"`
+	UnpushedCommits      []string `json:"unpushedCommits,omitempty"`
+	UntrackedFiles       []string `json:"untrackedFiles,omitempty"`
+}
+
+// WorkspaceInstanceStatus is the WorkspaceInstanceStatus message type
+type WorkspaceInstanceStatus struct {
+	Conditions   *WorkspaceInstanceConditions `json:"conditions,omitempty"`
+	ExposedPorts []*WorkspaceInstancePort     `json:"exposedPorts,omitempty"`
+	Message      string                       `json:"message,omitempty"`
+	NodeName     string                       `json:"nodeName,omitempty"`
+	OwnerToken   string                       `json:"ownerToken,omitempty"`
+	Phase        string                       `json:"phase,omitempty"`
+	Repo         *WorkspaceInstanceRepoStatus `json:"repo,omitempty"`
+	Timeout      string                       `json:"timeout,omitempty"`
+}
+
+// StartWorkspaceOptions is the StartWorkspaceOptions message type
+type StartWorkspaceOptions struct {
+	ForceDefaultImage bool `json:"forceDefaultImage,omitempty"`
+}
+
+// GetWorkspaceTimeoutResult is the GetWorkspaceTimeoutResult message type
+type GetWorkspaceTimeoutResult struct {
+	CanChange bool   `json:"canChange,omitempty"`
+	Duration  string `json:"duration,omitempty"`
+}
+
+// WorkspaceInstancePort is the WorkspaceInstancePort message type
+type WorkspaceInstancePort struct {
+	Port       float64 `json:"port,omitempty"`
+	TargetPort float64 `json:"targetPort,omitempty"`
+	URL        string  `json:"url,omitempty"`
+	Visibility string  `json:"visibility,omitempty"`
+}
+
+// GithubAppConfig is the GithubAppConfig message type
+type GithubAppConfig struct {
+	Prebuilds *GithubAppPrebuildConfig `json:"prebuilds,omitempty"`
+}
+
+// GithubAppPrebuildConfig is the GithubAppPrebuildConfig message type
+type GithubAppPrebuildConfig struct {
+	AddBadge              bool        `json:"addBadge,omitempty"`
+	AddCheck              bool        `json:"addCheck,omitempty"`
+	AddComment            bool        `json:"addComment,omitempty"`
+	AddLabel              interface{} `json:"addLabel,omitempty"`
+	Branches              bool        `json:"branches,omitempty"`
+	Master                bool        `json:"master,omitempty"`
+	PullRequests          bool        `json:"pullRequests,omitempty"`
+	PullRequestsFromForks bool        `json:"pullRequestsFromForks,omitempty"`
+}
+
+// ImageConfigFile is the ImageConfigFile message type
+type ImageConfigFile struct {
+	Context string `json:"context,omitempty"`
+	File    string `json:"file,omitempty"`
+}
+
+// PortConfig is the PortConfig message type
+type PortConfig struct {
+	OnOpen     string  `json:"onOpen,omitempty"`
+	Port       float64 `json:"port,omitempty"`
+	Visibility string  `json:"visibility,omitempty"`
+}
+
+// ResolvedPlugins is the ResolvedPlugins message type
+type ResolvedPlugins struct {
+	AdditionalProperties map[string]*ResolvedPlugin `json:"-,omitempty"`
+}
+
+// ResolvePluginsParams is the ResolvePluginsParams message type
+type ResolvePluginsParams struct {
+	Builtins *ResolvedPlugins `json:"builtins,omitempty"`
+	Config   *WorkspaceConfig `json:"config,omitempty"`
+}
+
+// TaskConfig is the TaskConfig message type
+type TaskConfig struct {
+	Before   string            `json:"before,omitempty"`
+	Command  string            `json:"command,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	Init     string            `json:"init,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	OpenIn   string            `json:"openIn,omitempty"`
+	OpenMode string            `json:"openMode,omitempty"`
+	Prebuild string            `json:"prebuild,omitempty"`
+}
+
+// VSCodeConfig is the VSCodeConfig message type
+type VSCodeConfig struct {
+	Extensions []string `json:"extensions,omitempty"`
+}
+
+// MarshalJSON marshals to JSON
+func (strct *ResolvedPlugins) MarshalJSON() ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0))
+	buf.WriteString("{")
+	comma := false
+	// Marshal any additional Properties
+	for k, v := range strct.AdditionalProperties {
+		if comma {
+			buf.WriteString(",")
+		}
+		buf.WriteString(fmt.Sprintf("\"%s\":", k))
+		tmp, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+
+		buf.Write(tmp)
+		comma = true
+	}
+
+	buf.WriteString("}")
+	rv := buf.Bytes()
+	return rv, nil
+}
+
+// UnmarshalJSON marshals from JSON
+func (strct *ResolvedPlugins) UnmarshalJSON(b []byte) error {
+	var jsonMap map[string]json.RawMessage
+	if err := json.Unmarshal(b, &jsonMap); err != nil {
+		return err
+	}
+	// parse all the defined properties
+	for k, v := range jsonMap {
+		switch k {
+		default:
+			// an additional "*ResolvedPlugin" value
+			var additionalValue *ResolvedPlugin
+			if err := json.Unmarshal([]byte(v), &additionalValue); err != nil {
+				return err // invalid additionalProperty
+			}
+			if strct.AdditionalProperties == nil {
+				strct.AdditionalProperties = make(map[string]*ResolvedPlugin, 0)
+			}
+			strct.AdditionalProperties[k] = additionalValue
+		}
+	}
+	return nil
+}
+
+// Configuration is the Configuration message type
+type Configuration struct {
+	DaysBeforeGarbageCollection float64 `json:"daysBeforeGarbageCollection,omitempty"`
+	GarbageCollectionStartDate  float64 `json:"garbageCollectionStartDate,omitempty"`
+}
+
+// WhitelistedRepository is the WhitelistedRepository message type
+type WhitelistedRepository struct {
+	Avatar      string `json:"avatar,omitempty"`
+	Description string `json:"description,omitempty"`
+	Name        string `json:"name,omitempty"`
+	URL         string `json:"url,omitempty"`
+}
+
+// UserEnvVarValue is the UserEnvVarValue message type
+type UserEnvVarValue struct {
+	ID                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	RepositoryPattern string `json:"repositoryPattern,omitempty"`
+	Value             string `json:"value,omitempty"`
+}
+
+// GenerateNewGitpodTokenOptions is the GenerateNewGitpodTokenOptions message type
+type GenerateNewGitpodTokenOptions struct {
+	Name string `json:"name,omitempty"`
+
+	// Scopes []string `json:"scopes,omitempty"`  float64 is the   float64 message type
+	Type float64 `json:"type,omitempty"`
+}
+
+// TakeSnapshotOptions is the TakeSnapshotOptions message type
+type TakeSnapshotOptions struct {
+	LayoutData  string `json:"layoutData,omitempty"`
+	WorkspaceID string `json:"workspaceId,omitempty"`
+}
+
+// PreparePluginUploadParams is the PreparePluginUploadParams message type
+type PreparePluginUploadParams struct {
+	FullPluginName string `json:"fullPluginName,omitempty"`
+}
+
+// PickAuthProviderEntryHostOwnerIDType is the PickAuthProviderEntryHostOwnerIDType message type
+type PickAuthProviderEntryHostOwnerIDType struct {
+	Host string `json:"host,omitempty"`
+
+	// OwnerId string `json:"ownerId,omitempty"`   string is the    string message type
+	Type string `json:"type,omitempty"`
+}
+
+// PickAuthProviderEntryOwnerID is the PickAuthProviderEntryOwnerID message type
+type PickAuthProviderEntryOwnerID struct {
+	ID      string `json:"id,omitempty"`
+	OwnerID string `json:"ownerId,omitempty"`
+}
+
+// PickOAuth2ConfigClientIDClientSecret is the PickOAuth2ConfigClientIDClientSecret message type
+type PickOAuth2ConfigClientIDClientSecret struct {
+	ClientID     string `json:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"`
+}
+
+// UpdateOwnAuthProviderParams is the UpdateOwnAuthProviderParams message type
+type UpdateOwnAuthProviderParams struct {
+	Entry interface{} `json:"entry,omitempty"`
+}
+
+// CreateWorkspaceOptions is the CreateWorkspaceOptions message type
+type CreateWorkspaceOptions struct {
+	ContextURL string `json:"contextUrl,omitempty"`
+	Mode       string `json:"mode,omitempty"`
+}
+
+// Root is the Root message type
+type Root map[string]*ResolvedPlugin
+
+// ResolvedPlugin is the ResolvedPlugin message type
+type ResolvedPlugin struct {
+	FullPluginName string `json:"fullPluginName,omitempty"`
+	Kind           string `json:"kind,omitempty"`
+	URL            string `json:"url,omitempty"`
+}
+
+// UninstallPluginParams is the UninstallPluginParams message type
+type UninstallPluginParams struct {
+	PluginID string `json:"pluginId,omitempty"`
+}
+
+// DeleteOwnAuthProviderParams is the DeleteOwnAuthProviderParams message type
+type DeleteOwnAuthProviderParams struct {
+	ID string `json:"id,omitempty"`
+}
+
+// BrandingLink is the BrandingLink message type
+type BrandingLink struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// BrandingSocialLink is the BrandingSocialLink message type
+type BrandingSocialLink struct {
+	Type string `json:"type,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// Ide is the Ide message type
+type Ide struct {
+	HelpMenu         []*BrandingLink `json:"helpMenu,omitempty"`
+	Logo             string          `json:"logo,omitempty"`
+	ShowReleaseNotes bool            `json:"showReleaseNotes,omitempty"`
+}
+
+// Links is the Links message type
+type Links struct {
+	Footer []*BrandingLink       `json:"footer,omitempty"`
+	Header []*BrandingLink       `json:"header,omitempty"`
+	Legal  []*BrandingLink       `json:"legal,omitempty"`
+	Social []*BrandingSocialLink `json:"social,omitempty"`
+}
+
+// Branding is the Branding message type
+type Branding struct {
+	Favicon  string `json:"favicon,omitempty"`
+	Homepage string `json:"homepage,omitempty"`
+	Ide      *Ide   `json:"ide,omitempty"`
+	Links    *Links `json:"links,omitempty"`
+
+	// Either including domain OR absolute path (interpreted relative to host URL)
+	Logo                          string `json:"logo,omitempty"`
+	Name                          string `json:"name,omitempty"`
+	RedirectURLAfterLogout        string `json:"redirectUrlAfterLogout,omitempty"`
+	RedirectURLIfNotAuthenticated string `json:"redirectUrlIfNotAuthenticated,omitempty"`
+	ShowProductivityTips          bool   `json:"showProductivityTips,omitempty"`
+	StartupLogo                   string `json:"startupLogo,omitempty"`
+}
+
+// WorkspaceInstanceUser is the WorkspaceInstanceUser message type
+type WorkspaceInstanceUser struct {
+	AvatarURL  string `json:"avatarUrl,omitempty"`
+	InstanceID string `json:"instanceId,omitempty"`
+	LastSeen   string `json:"lastSeen,omitempty"`
+	Name       string `json:"name,omitempty"`
+	UserID     string `json:"userId,omitempty"`
+}
+
+// SendHeartBeatOptions is the SendHeartBeatOptions message type
+type SendHeartBeatOptions struct {
+	InstanceID    string  `json:"instanceId,omitempty"`
+	RoundTripTime float64 `json:"roundTripTime,omitempty"`
+	WasClosed     bool    `json:"wasClosed,omitempty"`
+}
+
+// UpdateUserStorageResourceOptions is the UpdateUserStorageResourceOptions message type
+type UpdateUserStorageResourceOptions struct {
+	Content string `json:"content,omitempty"`
+	URI     string `json:"uri,omitempty"`
+}
+
+// AdditionalUserData is the AdditionalUserData message type
+type AdditionalUserData struct {
+	EmailNotificationSettings *EmailNotificationSettings `json:"emailNotificationSettings,omitempty"`
+	Platforms                 []*UserPlatform            `json:"platforms,omitempty"`
+}
+
+// EmailNotificationSettings is the EmailNotificationSettings message type
+type EmailNotificationSettings struct {
+	DisallowTransactionalEmails bool `json:"disallowTransactionalEmails,omitempty"`
+}
+
+// Identity is the Identity message type
+type Identity struct {
+	AuthID         string `json:"authId,omitempty"`
+	AuthName       string `json:"authName,omitempty"`
+	AuthProviderID string `json:"authProviderId,omitempty"`
+
+	// This is a flag that triggers the HARD DELETION of this entity
+	Deleted      bool     `json:"deleted,omitempty"`
+	PrimaryEmail string   `json:"primaryEmail,omitempty"`
+	Readonly     bool     `json:"readonly,omitempty"`
+	Tokens       []*Token `json:"tokens,omitempty"`
+}
+
+// User is the User message type
+type User struct {
+	AdditionalData               *AdditionalUserData `json:"additionalData,omitempty"`
+	AllowsMarketingCommunication bool                `json:"allowsMarketingCommunication,omitempty"`
+	AvatarURL                    string              `json:"avatarUrl,omitempty"`
+
+	// Whether the user has been blocked to use our service, because of TOS violation for example.
+	// Optional for backwards compatibility.
+	Blocked bool `json:"blocked,omitempty"`
+
+	// The timestamp when the user entry was created
+	CreationDate string `json:"creationDate,omitempty"`
+
+	// A map of random settings that alter the behaviour of Gitpod on a per-user basis
+	FeatureFlags *UserFeatureSettings `json:"featureFlags,omitempty"`
+
+	// Optional for backwards compatibility
+	FullName string `json:"fullName,omitempty"`
+
+	// The user id
+	ID         string      `json:"id,omitempty"`
+	Identities []*Identity `json:"identities,omitempty"`
+
+	// Whether the user is logical deleted. This flag is respected by all queries in UserDB
+	MarkedDeleted bool   `json:"markedDeleted,omitempty"`
+	Name          string `json:"name,omitempty"`
+
+	// whether this user can run workspaces in privileged mode
+	Privileged bool `json:"privileged,omitempty"`
+
+	// The permissions and/or roles the user has
+	RolesOrPermissions []string `json:"rolesOrPermissions,omitempty"`
+}
+
+// Token is the Token message type
+type Token struct {
+	ExpiryDate   string   `json:"expiryDate,omitempty"`
+	IDToken      string   `json:"idToken,omitempty"`
+	RefreshToken string   `json:"refreshToken,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	UpdateDate   string   `json:"updateDate,omitempty"`
+	Username     string   `json:"username,omitempty"`
+	Value        string   `json:"value,omitempty"`
+}
+
+// UserFeatureSettings is the UserFeatureSettings message type
+type UserFeatureSettings struct {
+
+	// Permanent feature flags are added to each and every workspace instance
+	// this user starts.
+	PermanentWSFeatureFlags []string `json:"permanentWSFeatureFlags,omitempty"`
+
+	// This field is used as marker to grant users a free trial for using private repositories,
+	// independent of any subscription or Chargebee.
+	//   - it is set when the user uses their first private repo
+	//   - whether the trial is expired or not is juged by the UserService
+	PrivateRepoTrialStartDate string `json:"privateRepoTrialStartDate,omitempty"`
+}
+
+// UserPlatform is the UserPlatform message type
+type UserPlatform struct {
+	Browser string `json:"browser,omitempty"`
+
+	// Since when does the user have the browser extension installe don this device.
+	BrowserExtensionInstalledSince string `json:"browserExtensionInstalledSince,omitempty"`
+
+	// Since when does the user not have the browser extension installed anymore (but previously had).
+	BrowserExtensionUninstalledSince string `json:"browserExtensionUninstalledSince,omitempty"`
+	FirstUsed                        string `json:"firstUsed,omitempty"`
+	LastUsed                         string `json:"lastUsed,omitempty"`
+	Os                               string `json:"os,omitempty"`
+	UID                              string `json:"uid,omitempty"`
+	UserAgent                        string `json:"userAgent,omitempty"`
+}
+
+// Requirements is the Requirements message type
+type Requirements struct {
+	Default     []string `json:"default,omitempty"`
+	PrivateRepo []string `json:"privateRepo,omitempty"`
+	PublicRepo  []string `json:"publicRepo,omitempty"`
+}
+
+// AuthProviderInfo is the AuthProviderInfo message type
+type AuthProviderInfo struct {
+	AuthProviderID      string        `json:"authProviderId,omitempty"`
+	AuthProviderType    string        `json:"authProviderType,omitempty"`
+	Description         string        `json:"description,omitempty"`
+	DisallowLogin       bool          `json:"disallowLogin,omitempty"`
+	HiddenOnDashboard   bool          `json:"hiddenOnDashboard,omitempty"`
+	Host                string        `json:"host,omitempty"`
+	Icon                string        `json:"icon,omitempty"`
+	IsReadonly          bool          `json:"isReadonly,omitempty"`
+	LoginContextMatcher string        `json:"loginContextMatcher,omitempty"`
+	OwnerID             string        `json:"ownerId,omitempty"`
+	Requirements        *Requirements `json:"requirements,omitempty"`
+	Scopes              []string      `json:"scopes,omitempty"`
+	SettingsURL         string        `json:"settingsUrl,omitempty"`
+	Verified            bool          `json:"verified,omitempty"`
+}
+
+// GetTokenSearchOptions is the GetTokenSearchOptions message type
+type GetTokenSearchOptions struct {
+	Host string `json:"host,omitempty"`
+}
+
+// SetWorkspaceTimeoutResult is the SetWorkspaceTimeoutResult message type
+type SetWorkspaceTimeoutResult struct {
+	ResetTimeoutOnWorkspaces []string `json:"resetTimeoutOnWorkspaces,omitempty"`
+}
+
+// UserMessage is the UserMessage message type
+type UserMessage struct {
+	Content string `json:"content,omitempty"`
+
+	// date from where on this message should be shown
+	From  string `json:"from,omitempty"`
+	ID    string `json:"id,omitempty"`
+	Title string `json:"title,omitempty"`
+	URL   string `json:"url,omitempty"`
+}
+
+// UpdateUserMessagesOptions is the UpdateUserMessagesOptions message type
+type UpdateUserMessagesOptions struct {
+	MessageIds []string `json:"messageIds,omitempty"`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3454,28 +3454,12 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@16.4.2", "@types/react@16.7.0", "@types/react@^16.8.0":
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.2.tgz#f1a9cf1ee85221530def2ac26aee20f910a9dac8"
   integrity sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==
   dependencies:
     csstype "^2.2.0"
-
-"@types/react@16.7.0":
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.0.tgz#d33202339d6fb672c2ad0930c835ecf8ae0ac521"
-  integrity sha512-bHwfht6kILzUj1Hs5vmr9vpokDmcNXPbR55tKE/ZEylb3WtSt9hAuO68rsm73/sre2/MwLijfo8sD4ANe+HDUg==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^16.8.0":
-  version "16.9.49"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
-  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
 
 "@types/request-promise@^4.1.41":
   version "4.1.42"
@@ -7535,11 +7519,6 @@ csstype@^2.0.0, csstype@^2.2.0, csstype@^2.5.2:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
 
-csstype@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
-  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -9908,7 +9887,7 @@ glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.6, glob@^7.0.6, glob@^7.1.6:
+glob@7.1.6, glob@^7.0.6, glob@^7.1.6, glob@~7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -12318,6 +12297,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.10:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -13310,7 +13294,7 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.0.0, nan@^2.10.0, nan@^2.13.2, nan@^2.14.0, nan@^2.9.2:
+nan@2.14.1, nan@^2.0.0, nan@^2.10.0, nan@^2.13.2, nan@^2.14.0, nan@^2.9.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
@@ -13896,7 +13880,7 @@ onigasm@^2.2.0:
     lru-cache "^5.1.1"
     tslint "^5.20.1"
 
-oniguruma@^7.0.0:
+oniguruma@7.2.1, oniguruma@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
   integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
@@ -15351,17 +15335,7 @@ react-autosize-textarea@^7.0.0:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
-react-dom@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.12.0"
-
-react-dom@^16.4.1, react-dom@^16.8.0:
+react-dom@16.12.0, react-dom@16.7.0, react-dom@^16.4.1, react-dom@^16.8.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
@@ -15454,17 +15428,7 @@ react-virtualized@^9.20.0:
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
 
-react@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
-  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.12.0"
-
-react@^16.4.1, react@^16.8.0:
+react@16.12.0, react@16.7.0, react@^16.4.1, react@^16.8.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
@@ -16338,14 +16302,6 @@ sb-scandir@^2.0.0:
     p-map "^1.2.0"
     sb-promisify "^2.0.1"
 
-scheduler@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
-  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 scheduler@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
@@ -16768,6 +16724,14 @@ source-map-support@^0.5.12:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -17810,6 +17774,17 @@ ts-node@^8:
     source-map-support "^0.5.6"
     yn "3.1.1"
 
+ts-node@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-protoc-gen@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/ts-protoc-gen/-/ts-protoc-gen-0.13.0.tgz#2763ae4e4a1a7d7001d53d2f3043357c691701ea"
@@ -17980,6 +17955,32 @@ typescript-formatter@^7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
+typescript-json-schema@^0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.43.0.tgz#8bd9c832f1f15f006ff933907ce192222fdfd92f"
+  integrity sha512-4c9IMlIlHYJiQtzL1gh2nIPJEjBgJjDUs50gsnnc+GFyDSK1oFM3uQIBSVosiuA/4t6LSAXDS9vTdqbQC6EcgA==
+  dependencies:
+    "@types/json-schema" "^7.0.5"
+    glob "~7.1.6"
+    json-stable-stringify "^1.0.1"
+    typescript "~4.0.2"
+    yargs "^15.4.1"
+
+typescript-parser@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript-parser/-/typescript-parser-2.6.1.tgz#b5f86e3f9d35ad46a346a32068cab61bbd96f803"
+  integrity sha512-p4ZC10pu67KO8+WJALsJWhbAq4pRBIcP+ls8Bhl+V8KvzYQDwxw/P5hJhn3rBdLnfS5aGLflfh7WiZpN6yi+5g==
+  dependencies:
+    lodash "^4.17.10"
+    lodash-es "^4.17.10"
+    tslib "^1.9.3"
+    typescript "^3.0.3"
+
+typescript@^3.0.3, typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
 typescript@^3.1.3, typescript@^3.2.2:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
@@ -17990,10 +17991,10 @@ typescript@^3.9.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@~4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"
@@ -18492,25 +18493,12 @@ vscode-debugprotocol@^1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.32.0.tgz#cca9eccb3f73ded5e525e01621a72ca2bb577dc3"
 
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
 vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
-
-vscode-languageserver-protocol@^3.15.0-next.8:
+vscode-languageserver-protocol@3.14.1, vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.0-next.8:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
@@ -18522,11 +18510,6 @@ vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
-
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
 vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next:
   version "3.15.1"
@@ -19307,7 +19290,7 @@ yargs@^14.2, yargs@^14.2.0:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.3.1:
+yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
This PR produces a Go version of the JSON RPC over Websockets API offered by the server.

The way we go about that is super hacky and involves manual effort. Typescript is a rather complex language, which makes it hard to produce types and infer protocol definitions from it. Hence, we automate as much as makes sense, and manually clean up afterwards. The steps are as follows:
1. Use typescript-parser to produce an AST as JSON from `GitpodServer`
2. Consume that AST in a script and produce the Go interface, client implementation and handy constants
3. In the same script, produce JSON schema for all used types using `typescript-json-schema` and convert that schema to Go using `schema-generate`

This leaves us with a rough bit of Go code which I manually cleaned up (fixed syntax errors, completed union types/enums, made go vet compatible). The result of this process for now lives in `supervisor/pkg/gitpod` because for now no one else consumes this API. That may well change when we push more towards `gitpod-cli`.

### How to test
I've left a test call command in supervisor for this purpose:
```
TKN=$(curl -s localhost:22999/_supervisor/v1/token/cw-supervisor-talk-to-server.staging.gitpod-dev.com/function:getWorkspace | jq -r '.token')
/theia/supervisor call-server cw-supervisor-talk-to-server.staging.gitpod-dev.com $TKN
```