### PR TITLE
[ws-proxy] Fix private ports in ws-proxy

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -289,6 +289,7 @@ func TheiaWebviewHandler(r *mux.Router, config *RouteHandlerConfig) {
 
 // installWorkspacePortRoutes configures routing for exposed ports
 func installWorkspacePortRoutes(r *mux.Router, config *RouteHandlerConfig) {
+	r.Use(config.WorkspaceAuthHandler)
 	// filter all session cookies
 	r.Use(sensitiveCookieHandler(config.Config.GitpodInstallation.HostName))
 	r.Use(handlers.CompressHandler)

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -128,7 +128,8 @@ func TestRoutes(t *testing.T) {
 				method: "GET",
 				url:    "/some/path/on/an/exposed/port",
 				headers: map[string]string{
-					"Cookie": "_gitpod_io_=s%3Af2da2196-4afe-46e7-97b6-00eadfb4e373.KuHVEHhTuNln8RiegerwgSsAYF0LqwV5wI18tVeUNUw; ",
+					"Cookie":        "_gitpod_io_=s%3Af2da2196-4afe-46e7-97b6-00eadfb4e373.KuHVEHhTuNln8RiegerwgSsAYF0LqwV5wI18tVeUNUw; ",
+					"Authenticated": "yes",
 				},
 			},
 			targets: []proxyTarget{
@@ -183,8 +184,9 @@ func TestRoutes(t *testing.T) {
 			description: "Exposed port: Websocket support does not hinder regular requests",
 			router:      portRouter,
 			req: testRequest{
-				method: "GET",
-				url:    "/some/path",
+				method:  "GET",
+				url:     "/some/path",
+				headers: map[string]string{"Authenticated": "yes"},
 			},
 			targets: []proxyTarget{
 				{

--- a/components/ws-proxy/pkg/proxy/workspaceinfo.go
+++ b/components/ws-proxy/pkg/proxy/workspaceinfo.go
@@ -270,7 +270,16 @@ func (p *RemoteWorkspaceInfoProvider) WorkspaceCoords(publicPort string) *Worksp
 func getPortStr(urlStr string) string {
 	portURL, err := url.Parse(urlStr)
 	if err != nil {
+		log.WithField("url", urlStr).WithError(err).Error("error parsing URL while getting URL port")
 		return ""
+	}
+	if portURL.Port() == "" {
+		switch scheme := portURL.Scheme; scheme {
+		case "http":
+			return "80"
+		case "https":
+			return "443"
+		}
 	}
 	return portURL.Port()
 }


### PR DESCRIPTION
This PR fixes the auth of private ports. Without this, private ports can be accessed through the new `ws-proxy` even when the user is not logged in.

## How to test

Open a private port and a public port (you can use [this repo](http://clu-ws-proxy-port-auth.staging.gitpod-dev.com/#https://github.com/corneliusludmann/gitpod-playground/tree/test-port-visibility) → port 8080 is private, port 8081 is public). Make sure both ports are accessible and only the public port is accessible in an incognito browser window.