### PR TITLE
[ide] Workspace sharing is a EE feature

### DIFF
--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-share-widget.tsx
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-share-widget.tsx
@@ -11,7 +11,6 @@ import { GitpodServiceProvider } from "./gitpod-service-provider";
 import { GitpodInfoService } from "../common/gitpod-info";
 import { WorkspaceInstanceUser } from "@gitpod/gitpod-protocol";
 import { GitpodLayoutRestorer } from "./gitpod-shell-layout-restorer";
-import { ResponseError } from 'vscode-jsonrpc';
 import { ErrorCodes } from '@gitpod/gitpod-protocol/lib/messaging/error';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 
@@ -108,7 +107,7 @@ export class GitpodShareDialog extends AbstractDialog<boolean> {
             this.shareWorkspace = true;
             this.updateUI();
         } catch (e) {
-            if (e instanceof ResponseError && (e.code == ErrorCodes.EE_FEATURE || e.code == ErrorCodes.EE_LICENSE_REQUIRED)) {
+            if ('code' in e && (e.code == ErrorCodes.EE_FEATURE || e.code == ErrorCodes.EE_LICENSE_REQUIRED)) {
                 this.showNoLicenseContent();
             }
         }


### PR DESCRIPTION
This PR re-enables a proper message to be shown if no EE license is present.

<img width="595" alt="Screen Shot 2020-10-01 at 14 39 01" src="https://user-images.githubusercontent.com/914497/94810117-e2af2f00-03f3-11eb-835b-4ec53ad2cdf7.png">
