### PR TITLE
[supervisor/frontend] only reveal ide for regular workspaces

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -36,7 +36,7 @@
     "@types/ua-parser-js": "^0.7.33",
     "@types/uuid": "^3.1.0",
     "babel-loader": "^8.0.6",
-    "css-loader": "^4.2.2",
+    "css-loader": "^0.28.11",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^4.4.1",
     "request": "^2.88.2",

--- a/components/dashboard/src/components/start-workspace.tsx
+++ b/components/dashboard/src/components/start-workspace.tsx
@@ -234,7 +234,7 @@ export class StartWorkspace extends React.Component<StartWorkspaceProps, StartWo
                 if (this.workspace) {
                     const ctxUrl = this.workspace.contextURL.replace('prebuild/', '');
                     this.redirectTo(new GitpodHostUrl(window.location.toString()).withContext(ctxUrl).toString());
-                } else if (!this.runsInIFrame()) {
+                } else {
                     this.redirectToDashboard();
                 }
             }

--- a/components/supervisor/frontend/src/heart-beat.ts
+++ b/components/supervisor/frontend/src/heart-beat.ts
@@ -4,9 +4,6 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { fetchWorkspaceInfo } from "./supervisor-service-client";
-import { WorkspaceInfoResponse } from "@gitpod/supervisor-api-grpc/lib/info_pb";
-
 let lastActivity = 0;
 const updateLastActivitiy = () => {
     lastActivity = new Date().getTime();
@@ -17,8 +14,8 @@ export const track = (w: Window) => {
 }
 
 let intervalHandle: NodeJS.Timer | undefined;
-export function schedule({ instanceId }: WorkspaceInfoResponse.AsObject): void {
-    if (intervalHandle === undefined) {
+export function schedule(instanceId: string): void {
+    if (intervalHandle !== undefined) {
         return;
     }
     const sendHeartBeat = async (wasClosed?: true) => {

--- a/components/supervisor/frontend/src/ide-frame.ts
+++ b/components/supervisor/frontend/src/ide-frame.ts
@@ -4,18 +4,18 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { ideReady, contentReady } from "./supervisor-service-client";
+import { SupervisorServiceClient } from "./supervisor-service-client";
 
 const ideURL = new URL(window.location.href);
 ideURL.searchParams.append('gitpod-ide-index', 'true');
 
-export function load(): Promise<HTMLIFrameElement> {
+export function load(supervisorServiceClient: SupervisorServiceClient): Promise<HTMLIFrameElement> {
     return new Promise(resolve => {
         const ideFrame = document.createElement('iframe');
         ideFrame.src = ideURL.href;
         ideFrame.className = 'gitpod-frame ide';
         ideFrame.style.visibility = 'hidden';
-        Promise.all([ideReady, contentReady]).then(() => {
+        Promise.all([supervisorServiceClient.ideReady, supervisorServiceClient.contentReady]).then(() => {
             console.info('IDE backend and content are ready, attaching IDE frontend...');
             document.body.appendChild(ideFrame);
             ideFrame.contentWindow?.addEventListener('DOMContentLoaded', () => {

--- a/components/supervisor/frontend/src/loading-frame.ts
+++ b/components/supervisor/frontend/src/loading-frame.ts
@@ -11,10 +11,7 @@ import { ConsoleLogger } from 'vscode-ws-jsonrpc';
 
 const serverOrigin = new URL(startUrl).origin;
 window.addEventListener('message', event => {
-    if (event.origin === serverOrigin) {
-        return;
-    }
-    if (event.isTrusted && event.data.type == 'relocate' && event.data.url) {
+    if (event.origin === serverOrigin && event.data.type == 'relocate' && event.data.url) {
         window.location.href = event.data.url;
     }
 }, false)

--- a/components/supervisor/frontend/src/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/supervisor-service-client.ts
@@ -6,24 +6,29 @@
 
 import { WorkspaceInfoResponse } from "@gitpod/supervisor-api-grpc/lib/info_pb";
 
-const checkReady: (kind: 'content' | 'ide' | 'supervisor') => Promise<void> = kind =>
-    fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/status/' + kind + '/wait/true', { credentials: 'include' }).then(response => {
-        if (response.ok) {
-            return;
-        }
-        console.debug(`failed to check whether ${kind} is ready, trying again...`, response.status, response.statusText);
-        return checkReady(kind);
-    }, e => {
-        console.debug(`failed to check whether ${kind} is ready, trying again...`, e);
-        return checkReady(kind);
-    });
-export const supervisorReady = checkReady('supervisor');
-export const ideReady = supervisorReady.then(() => checkReady('ide'));
-export const contentReady = supervisorReady.then(() => checkReady('content'));
+export class SupervisorServiceClient {
+    readonly supervisorReady = this.checkReady('supervisor');
+    readonly ideReady = this.supervisorReady.then(() => this.checkReady('ide'))
+    readonly contentReady = this.supervisorReady.then(() => this.checkReady('content'));
 
-export const fetchWorkspaceInfo = (async () => {
-    await supervisorReady;
-    const response = await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/info/workspace', { credentials: 'include' });
-    const result = await response.json();
-    return result as WorkspaceInfoResponse.AsObject;
-});
+    async fetchWorkspaceInfo(): Promise<WorkspaceInfoResponse.AsObject> {
+        await this.supervisorReady;
+        const response = await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/info/workspace', { credentials: 'include' });
+        const result = await response.json();
+        return result as WorkspaceInfoResponse.AsObject;
+    }
+
+    private async checkReady(kind: 'content' | 'ide' | 'supervisor'): Promise<void> {
+        await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/status/' + kind + '/wait/true', { credentials: 'include' }).then(response => {
+            if (response.ok) {
+                return;
+            }
+            console.debug(`failed to check whether ${kind} is ready, trying again...`, response.status, response.statusText);
+            return this.checkReady(kind);
+        }, e => {
+            console.debug(`failed to check whether ${kind} is ready, trying again...`, e);
+            return this.checkReady(kind);
+        });
+    }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6240,11 +6240,6 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
-  integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
-
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -7405,24 +7400,6 @@ css-loader@^0.28.1, css-loader@^0.28.11:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-loader@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.2.2.tgz#b668b3488d566dc22ebcf9425c5f254a05808c89"
-  integrity sha512-omVGsTkZPVwVRpckeUnLshPp12KsmMSLqYxs12+RzM9jRR5Y+Idn/tBffjXRvOE+qW7if24cuceFJqYR5FmGBg==
-  dependencies:
-    camelcase "^6.0.0"
-    cssesc "^3.0.0"
-    icss-utils "^4.1.1"
-    loader-utils "^2.0.0"
-    postcss "^7.0.32"
-    postcss-modules-extract-imports "^2.0.0"
-    postcss-modules-local-by-default "^3.0.3"
-    postcss-modules-scope "^2.2.0"
-    postcss-modules-values "^3.0.0"
-    postcss-value-parser "^4.1.0"
-    schema-utils "^2.7.0"
-    semver "^7.3.2"
-
 css-loader@~0.26.1:
   version "0.26.4"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.26.4.tgz#b61e9e30db94303e6ffc892f10ecd09ad025a1fd"
@@ -7470,11 +7447,6 @@ css-what@2.1:
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
-
-cssesc@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
-  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 "cssnano@>=2.6.1 <4", cssnano@^3.10.0:
   version "3.10.0"
@@ -10808,13 +10780,6 @@ icss-utils@^2.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-2.1.0.tgz#83f0a0ec378bf3246178b6c2ad9136f135b1c962"
   dependencies:
     postcss "^6.0.1"
-
-icss-utils@^4.0.0, icss-utils@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
-  integrity sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==
-  dependencies:
-    postcss "^7.0.14"
 
 idb@^4.0.5:
   version "4.0.5"
@@ -14706,29 +14671,12 @@ postcss-modules-extract-imports@^1.2.0:
   dependencies:
     postcss "^6.0.1"
 
-postcss-modules-extract-imports@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz#818719a1ae1da325f9832446b01136eeb493cd7e"
-  integrity sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==
-  dependencies:
-    postcss "^7.0.5"
-
 postcss-modules-local-by-default@^1.0.1, postcss-modules-local-by-default@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
   dependencies:
     css-selector-tokenizer "^0.7.0"
     postcss "^6.0.1"
-
-postcss-modules-local-by-default@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0"
-  integrity sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==
-  dependencies:
-    icss-utils "^4.1.1"
-    postcss "^7.0.32"
-    postcss-selector-parser "^6.0.2"
-    postcss-value-parser "^4.1.0"
 
 postcss-modules-scope@^1.0.0, postcss-modules-scope@^1.1.0:
   version "1.1.0"
@@ -14737,28 +14685,12 @@ postcss-modules-scope@^1.0.0, postcss-modules-scope@^1.1.0:
     css-selector-tokenizer "^0.7.0"
     postcss "^6.0.1"
 
-postcss-modules-scope@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz#385cae013cc7743f5a7d7602d1073a89eaae62ee"
-  integrity sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==
-  dependencies:
-    postcss "^7.0.6"
-    postcss-selector-parser "^6.0.0"
-
 postcss-modules-values@^1.1.0, postcss-modules-values@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
   dependencies:
     icss-replace-symbols "^1.1.0"
     postcss "^6.0.1"
-
-postcss-modules-values@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz#5b5000d6ebae29b4255301b4a3a54574423e7f10"
-  integrity sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==
-  dependencies:
-    icss-utils "^4.0.0"
-    postcss "^7.0.6"
 
 postcss-normalize-charset@^1.1.0:
   version "1.1.1"
@@ -14811,15 +14743,6 @@ postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
-  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
-  dependencies:
-    cssesc "^3.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-
 postcss-svgo@^2.1.1:
   version "2.1.6"
   resolved "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz#b6df18aa613b666e133f08adb5219c2684ac108d"
@@ -14840,11 +14763,6 @@ postcss-unique-selectors@^2.0.2:
 postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
-
-postcss-value-parser@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
-  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
 postcss-zindex@^2.0.1:
   version "2.2.0"
@@ -14870,15 +14788,6 @@ postcss@^6.0.1:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
-
-postcss@^7.0.14, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.32"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
-  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 postcss@^7.0.27:
   version "7.0.31"


### PR DESCRIPTION
#### What it does

- fixes css bundling int the dashboard as a follow-up of https://github.com/gitpod-io/gitpod/commit/95e75d59e38505d24245556aec8fa92f7fb186d9
- fixes the heart beat scheduling in the supervisor
- prevents loading the ide frame in the supervisor if the workspace is headless

#### How to test

- Start a regular workspace and check that IDE is revealed: http://ak-reveal-ide-only-for-regulas-ws.staging.gitpod-dev.com/#https://github.com/akosyakov/theia-training/tree/solution-1
- Start a prebuild workspace and check that IDE is not revealed, but the prebuild output is logged: http://ak-reveal-ide-only-for-regulas-ws.staging.gitpod-dev.com/#prebuild/https://github.com/akosyakov/theia-training/tree/solution-1