### PR TITLE
[ws-proxy] Properly handle supervisor proxy-pass errors

### DIFF
--- a/components/supervisor/frontend/src/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/supervisor-service-client.ts
@@ -18,16 +18,24 @@ export class SupervisorServiceClient {
         return result as WorkspaceInfoResponse.AsObject;
     }
 
-    private async checkReady(kind: 'content' | 'ide' | 'supervisor'): Promise<void> {
-        await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/status/' + kind + '/wait/true', { credentials: 'include' }).then(response => {
+    private async checkReady(kind: 'content' | 'ide' | 'supervisor', delay?: boolean): Promise<void> {
+        if (delay) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+
+        let wait = "/wait/true";
+        if (kind == "supervisor") {
+            wait = "";
+        }
+        return fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/status/' + kind + wait, { credentials: 'include' }).then(response => {
             if (response.ok) {
                 return;
             }
             console.debug(`failed to check whether ${kind} is ready, trying again...`, response.status, response.statusText);
-            return this.checkReady(kind);
+            return this.checkReady(kind, true);
         }, e => {
             console.debug(`failed to check whether ${kind} is ready, trying again...`, e);
-            return this.checkReady(kind);
+            return this.checkReady(kind, true);
         });
     }
 


### PR DESCRIPTION
This PR re-introduces the default error behaviour of [SingleHostReverseProxy](https://golang.org/pkg/net/http/httputil/), where "the default is to log the provided error and return a 502 Status Bad Gateway response."

Prior to this change requests to the supervisor endpoint would seemingly succeed (i.e. return 200 OK) although supervisor was still unavailable. Now, ws-proxy will return 502 in those cases.