### PR TITLE
[server] Fix permissions in takeSnapshot

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -242,7 +242,7 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
             }
 
             await this.guardAccess({kind: "workspaceInstance", subject: instance, workspaceOwnerID: workspace.ownerId}, "get");
-            await this.guardAccess({kind: "snapshot", subject: undefined, workspaceOwnerID: workspaceId}, "create");
+            await this.guardAccess({kind: "snapshot", subject: undefined, workspaceOwnerID: workspace.ownerId}, "create");
 
             const client = await this.workspaceManagerClientProvider.get(instance.region);
             const request = new TakeSnapshotRequest();
@@ -257,7 +257,6 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
                 originalWorkspaceId: workspaceId,
                 layoutData
             });
-            this.workspaceDb.trace({ span }).store(workspace);
 
             return id;
         } catch (e) {


### PR DESCRIPTION
This PR fixes permissions for snapshots. Prior to this change, when attempting to create a snapshot, you'd see `Cannot take snapshot: Error: operation not permitted: missing create permission on snapshot`

## How to test
1. take a snapshot as workspace owner
2. take a snapshot on a shared workspace (here you should still see the error)