### PR TITLE
various staging fixes for theia/supervisor

### DIFF
--- a/components/gitpod-protocol/src/ide-service.ts
+++ b/components/gitpod-protocol/src/ide-service.ts
@@ -4,9 +4,11 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-interface Window {
-    gitpod: {
-        service: import('../gitpod-service').GitpodService
-        ideService?: import('../ide-service').IDEService
-    }
+import { Event } from "./util/event";
+
+export type IDEState = 'init' | 'ready';
+
+export interface IDEService {
+    readonly state: IDEState;
+    readonly onDidChange: Event<void>;
 }

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -98,6 +98,13 @@ export class GitpodHostUrl {
         return this.with(url => ({ pathname: '/graphql/' }));
     }
 
+    asStart(): GitpodHostUrl {
+        return this.with({
+            pathname: '/start/',
+            hash: '#' + this.workspaceId
+        });
+    }
+
     asWorkspaceAuth(instanceID: string, redirect?: boolean): GitpodHostUrl {
         return this.with(url => ({ pathname: `/api/auth/workspace-cookie/${instanceID}`, search: redirect ? "redirect" : "" }));
     }
@@ -114,7 +121,7 @@ export class GitpodHostUrl {
         return result;
     }
 
-    get workspaceId(): string | undefined {
+    get workspaceId(): string | undefined {
         const hostSegs = window.location.host.split(".");
         if (hostSegs.length > 1 && hostSegs[0].match(workspaceIDRegex)) {
             // URL has a workspace prefix

--- a/components/supervisor/frontend/src/ide-frame.ts
+++ b/components/supervisor/frontend/src/ide-frame.ts
@@ -4,32 +4,76 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { IDEService } from "@gitpod/gitpod-protocol/lib/ide-service";
+import { Emitter } from "@gitpod/gitpod-protocol/lib/util/event";
 import { SupervisorServiceClient } from "./supervisor-service-client";
 
 const ideURL = new URL(window.location.href);
 ideURL.searchParams.append('gitpod-ide-index', 'true');
 
-export function load(supervisorServiceClient: SupervisorServiceClient): Promise<HTMLIFrameElement> {
+interface IDECapabilities {
+    /**
+     * Controls whether IDE frame can provide IDE service.
+     */
+    readonly service?: boolean
+}
+
+export function load(supervisorServiceClient: SupervisorServiceClient): Promise<{
+    frame: HTMLIFrameElement
+    service: IDEService
+}> {
     return new Promise(resolve => {
-        const ideFrame = document.createElement('iframe');
-        ideFrame.src = ideURL.href;
-        ideFrame.className = 'gitpod-frame ide';
-        ideFrame.style.visibility = 'hidden';
+        const frame = document.createElement('iframe');
+        frame.src = ideURL.href;
+        frame.className = 'gitpod-frame ide';
+        frame.style.visibility = 'hidden';
+
+        let capabilities: IDECapabilities = { service: false };
+        const onDidChangeEmitter = new Emitter<void>();
+        let _delegate: IDEService | undefined;
+        const service: IDEService = {
+            get state() {
+                if (capabilities.service) {
+                    return _delegate?.state || 'init';
+                }
+                return 'ready';
+            },
+            onDidChange: onDidChangeEmitter.event
+        }
+        frame.onload = () => {
+            const capabilitiesElementAttribute = frame.contentDocument?.getElementById('gitpod-ide-capabilities')?.getAttribute('data-settings');
+            capabilities = capabilitiesElementAttribute && JSON.parse(capabilitiesElementAttribute) || capabilities;
+            resolve({ frame, service });
+        }
+        Object.defineProperty(window.gitpod, 'ideService', {
+            get() {
+                return _delegate;
+            },
+            set(delegate: IDEService) {
+                if (_delegate) {
+                    console.error(new Error('ideService is already set'));
+                    return;
+                }
+                _delegate = delegate;
+                onDidChangeEmitter.fire();
+                delegate.onDidChange(() => onDidChangeEmitter.fire());
+            }
+        });
+
         Promise.all([supervisorServiceClient.ideReady, supervisorServiceClient.contentReady]).then(() => {
             console.info('IDE backend and content are ready, attaching IDE frontend...');
-            document.body.appendChild(ideFrame);
-            ideFrame.contentWindow?.addEventListener('DOMContentLoaded', () => {
-                ideFrame.contentWindow?.history.replaceState(null, '', window.location.href);
-                if (ideFrame.contentWindow) {
-                    ideFrame.contentWindow.gitpod = window.gitpod;
+            document.body.appendChild(frame);
+            frame.contentWindow?.addEventListener('DOMContentLoaded', () => {
+                frame.contentWindow?.history.replaceState(null, '', window.location.href);
+                if (frame.contentWindow) {
+                    frame.contentWindow.gitpod = window.gitpod;
                 }
-                if (navigator.keyboard?.getLayoutMap && ideFrame.contentWindow?.navigator.keyboard?.getLayoutMap) {
-                    ideFrame.contentWindow.navigator.keyboard.getLayoutMap = navigator.keyboard.getLayoutMap.bind(navigator.keyboard);
+                if (navigator.keyboard?.getLayoutMap && frame.contentWindow?.navigator.keyboard?.getLayoutMap) {
+                    frame.contentWindow.navigator.keyboard.getLayoutMap = navigator.keyboard.getLayoutMap.bind(navigator.keyboard);
                 }
-                if (navigator.keyboard?.addEventListener && ideFrame.contentWindow?.navigator.keyboard?.addEventListener) {
-                    ideFrame.contentWindow.navigator.keyboard.addEventListener = navigator.keyboard.addEventListener.bind(navigator.keyboard);
+                if (navigator.keyboard?.addEventListener && frame.contentWindow?.navigator.keyboard?.addEventListener) {
+                    frame.contentWindow.navigator.keyboard.addEventListener = navigator.keyboard.addEventListener.bind(navigator.keyboard);
                 }
-                resolve(ideFrame);
             }, { once: true });
         });
     });

--- a/components/supervisor/frontend/src/ide-frame.ts
+++ b/components/supervisor/frontend/src/ide-frame.ts
@@ -19,6 +19,7 @@ export function load(supervisorServiceClient: SupervisorServiceClient): Promise<
             console.info('IDE backend and content are ready, attaching IDE frontend...');
             document.body.appendChild(ideFrame);
             ideFrame.contentWindow?.addEventListener('DOMContentLoaded', () => {
+                ideFrame.contentWindow?.history.replaceState(null, '', window.location.href);
                 if (ideFrame.contentWindow) {
                     ideFrame.contentWindow.gitpod = window.gitpod;
                 }

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -35,7 +35,7 @@ import { JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy
     }
 
     const supervisorServiceClient = new SupervisorServiceClient();
-    const ideFrame = await IdeFrame.load(supervisorServiceClient);
+    const ide = await IdeFrame.load(supervisorServiceClient);
 
     //#region current-frame
     let currentFrame: HTMLIFrameElement = loading.frame;
@@ -43,8 +43,8 @@ import { JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy
     const nextFrame = () => {
         const instance = gitpodServiceClient.info.latestInstance;
         if (instance) {
-            if (instance.status.phase === 'running' && ideFrame.parentElement) {
-                return ideFrame;
+            if (instance.status.phase === 'running' && ide.service.state === 'ready') {
+                return ide.frame;
             }
             if (instance.status.phase === 'stopped') {
                 stopped = true;
@@ -74,11 +74,12 @@ import { JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy
 
     updateCurrentFrame();
     gitpodServiceClient.onDidChangeInfo(() => updateCurrentFrame());
+    ide.service.onDidChange(() => updateCurrentFrame());
     //#endregion
 
     //#region heart-beat
     heartBeat.track(window);
-    heartBeat.track(ideFrame.contentWindow!);
+    heartBeat.track(ide.frame.contentWindow!);
     const updateHeartBeat = () => {
         if (gitpodServiceClient.info.latestInstance?.status.phase === 'running') {
             heartBeat.schedule(gitpodServiceClient.info.latestInstance.id);

--- a/components/supervisor/frontend/src/urls.ts
+++ b/components/supervisor/frontend/src/urls.ts
@@ -10,7 +10,4 @@ export const workspaceUrl = new GitpodHostUrl(window.location.href);
 
 export const serverUrl = workspaceUrl.withoutWorkspacePrefix();
 
-export const startUrl = serverUrl.with({
-    pathname: '/start/',
-    hash: '#' + workspaceUrl.workspaceId
-}).toString();
+export const startUrl = serverUrl.asStart().toString();

--- a/components/theia/app/BUILD.yaml
+++ b/components/theia/app/BUILD.yaml
@@ -3,6 +3,7 @@ packages:
     type: yarn
     srcs:
       - package.json
+      - preload.html
       - "webpack.config.js"
       - "startup.sh"
       - "**/*.ico"

--- a/components/theia/app/package.json
+++ b/components/theia/app/package.json
@@ -71,6 +71,11 @@
           "go.useLanguageServer": true
         }
       }
+    },
+    "generator": {
+        "config": {
+            "preloadTemplate": "preload.html"
+        }
     }
   },
   "resolutions": {

--- a/components/theia/app/preload.html
+++ b/components/theia/app/preload.html
@@ -1,0 +1,8 @@
+<script>
+	const gitpodIDECapabilitiesElement = document.createElement("meta");
+    gitpodIDECapabilitiesElement.setAttribute("id", "gitpod-ide-capabilities");
+    gitpodIDECapabilitiesElement.setAttribute("data-settings", JSON.stringify({
+        service: true
+    }));
+    document.head.appendChild(gitpodIDECapabilitiesElement);
+</script>

--- a/components/theia/packages/gitpod-extension/src/node/supervisor-serverd-ports-service.ts
+++ b/components/theia/packages/gitpod-extension/src/node/supervisor-serverd-ports-service.ts
@@ -87,10 +87,6 @@ export class SupervisorServedPortsServiceImpl implements ServedPortsServiceServe
         if (idx > -1) {
             this.clients.splice(idx, 1);
         }
-
-        if (this.clients.length == 0) {
-            this.dispose();
-        }
     }
     
     dispose(): void {


### PR DESCRIPTION
#### What it does 

- make sure that IDE frame has the same `window.location.href` as the top window for backward compatibility and proper opening of new windows by the IDE
- make supervisor ready checks more reliable by checking the actual response content
- making sure that port notifications are delivered even if all client windows were closed, before it was stopped and new notifications did not arrive after opening another window
- allow an IDE window to notify the supervisor window about state changes, i.e. whether it is ready to be revealed
  - first an IDE should indicate that it is capable to provide such service by adding the following in index.html: `<meta id="gitpod-ide-capabilities" data-settings="{&quot;service&quot;:true}">`
  - next it should implement [IDEService](https://github.com/gitpod-io/gitpod/blob/357d7345027471c861f433d5401cc2de10591d3f/components/gitpod-protocol/src/ide-service.ts) and assign it with `window.gitpod.ideService = myService;`

#### How to test

- start a workspace and check that Theia is revealed, check as well that default Theia loading screen does not pop up (https://github.com/gitpod-io/gitpod/issues/1945)
- open another workspace from Theia, it should open a new window without `gitpod-ide-index` in the query param
- close all windows, then open a new window and check that port notifications are still delivered, i.e. run Node.js http server on a new port:
```js
const http = require('http');

const requestListener = function (req, res) {
  res.writeHead(200);
  res.end('Hello, World!');
}

const server = http.createServer(requestListener);
server.listen(0);
```