### PR TITLE
prevent multi confirmation dialogs on beforeunload event

### DIFF
--- a/components/dashboard/src/components/start-workspace.tsx
+++ b/components/dashboard/src/components/start-workspace.tsx
@@ -359,12 +359,13 @@ export class StartWorkspace extends React.Component<StartWorkspaceProps, StartWo
                     </React.Fragment>;
                 }
             }
-            if (this.state.workspaceInstance.status.phase === 'stopped') {
+            if (this.state.workspaceInstance.status.phase === 'stopped' && this.props.workspaceId) {
+                const startUrl = new GitpodHostUrl(window.location.toString()).asStart(this.props.workspaceId).toString();
                 message = <React.Fragment>
                     {message}
-                    <div className='message start-action'><Button className='button' variant='outlined' color='secondary' onClick={() =>
-                        this.startWorkspace(this.props.workspaceId, true, false)
-                    }>Start Workspace</Button></div>
+                    <div className='message start-action'><Button className='button' variant='outlined' color='secondary' onClick={() => {
+                        this.redirectTo(startUrl)
+                    }}>Start Workspace</Button></div>
                 </React.Fragment>;
             }
         }

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -98,10 +98,10 @@ export class GitpodHostUrl {
         return this.with(url => ({ pathname: '/graphql/' }));
     }
 
-    asStart(): GitpodHostUrl {
+    asStart(workspaceId = this.workspaceId): GitpodHostUrl {
         return this.with({
             pathname: '/start/',
-            hash: '#' + this.workspaceId
+            hash: '#' + workspaceId
         });
     }
 

--- a/components/supervisor/frontend/src/heart-beat.ts
+++ b/components/supervisor/frontend/src/heart-beat.ts
@@ -26,7 +26,9 @@ export function schedule(instanceId: string): void {
         }
     }
     sendHeartBeat();
-    window.addEventListener('beforeunload', () => sendHeartBeat(true), { once: true });
+    window.addEventListener('beforeunload', () => {
+        sendHeartBeat(true);
+    }, { once: true });
 
     let activityInterval = 10000;
     intervalHandle = setInterval(() => {

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -79,6 +79,7 @@ import { JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy
 
     //#region heart-beat
     heartBeat.track(window);
+    heartBeat.track(loading.frame.contentWindow!);
     heartBeat.track(ide.frame.contentWindow!);
     const updateHeartBeat = () => {
         if (gitpodServiceClient.info.latestInstance?.status.phase === 'running') {

--- a/components/supervisor/frontend/src/loading-frame.ts
+++ b/components/supervisor/frontend/src/loading-frame.ts
@@ -10,11 +10,13 @@ import { MessageConnection, createMessageConnection } from 'vscode-jsonrpc/lib/m
 import { ConsoleLogger } from 'vscode-ws-jsonrpc';
 
 const serverOrigin = new URL(startUrl).origin;
-window.addEventListener('message', event => {
+const relocateListener = (event: MessageEvent) => {
     if (event.origin === serverOrigin && event.data.type == 'relocate' && event.data.url) {
+        window.removeEventListener('message', relocateListener);
         window.location.href = event.data.url;
     }
-}, false)
+};
+window.addEventListener('message', relocateListener, false);
 
 export function load(): Promise<{
     frame: HTMLIFrameElement,


### PR DESCRIPTION
#### What it does

- accept only one relocate message from the loading frame in the supervisor frontend
- redirects to the start page instead of trying to restart from the same loading screen

#### How to test

- create a new workspace
- do dirty changes and don't save them
- stop the workspace
- click `Start Workspace` button when the workspace is stopped
- you should get only one confirmation dialog (unfortunately it is expected since we need it to preserver the layout state and so on)