### PR TITLE
[chart] Template most configMap names in order to allow overrides

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -292,6 +292,11 @@ registry.{{ .Values.hostname }}
 {{ template "gitpod.comp.imageRepo" . }}:{{- template "gitpod.comp.version" . -}}
 {{- end -}}
 
+{{- define "gitpod.comp.configMap" -}}
+{{- $comp := .comp -}}
+{{ $comp.configMapName | default (printf "%s-config" $comp.name) }}
+{{- end -}}
+
 {{- define "gitpod.pull-secret" -}}
 {{- $ := .root -}}
 {{- if (and .secret .secret.secretName .secret.path (not (eq ($.Files.Get .secret.path) ""))) -}}

--- a/chart/templates/image-builder-deployment.yaml
+++ b/chart/templates/image-builder-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       volumes:
       - name: configuration
         configMap:
-          name: image-builder-config
+          name: {{ template "gitpod.comp.configMap" $this }}
       - name: dind-storage
         {{- if $comp.hostDindData }}
         hostPath:

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -131,7 +131,7 @@ spec:
 {{ include "gitpod.container.defaultEnv" (dict "root" . "gp" $.Values "comp" $wsProxy "noVersion" true) | indent 8 }}
         volumeMounts:
 {{- if (and $wsProxy (not $wsProxy.disabled) $wsProxy.portRange) }}
-        - name: ws-proxy-config
+        - name: {{ template "gitpod.comp.configMap" $this }}
           mountPath: "/config"
           readOnly: true
 {{- end }}

--- a/chart/templates/registry-facade-deployment.yaml
+++ b/chart/templates/registry-facade-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         emptyDir: {}
       - name: config
         configMap:
-          name: registry-facade-config
+          name: {{ template "gitpod.comp.configMap" $this }}
       {{- if .Values.components.workspace.pullSecret.secretName }}
       - name: pull-secret
         secret:

--- a/chart/templates/ws-manager-bridge-deployment.yaml
+++ b/chart/templates/ws-manager-bridge-deployment.yaml
@@ -67,6 +67,6 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: ws-manager-bridge-config
+          name: {{ template "gitpod.comp.configMap" $this }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/templates/ws-manager-deployment.yaml
+++ b/chart/templates/ws-manager-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: ws-manager-config
+          name: {{ template "gitpod.comp.configMap" $this }}
       - name: tls-certs
         secret:
           secretName: ws-sync-tls

--- a/chart/templates/ws-manager-node-daemonset.yaml
+++ b/chart/templates/ws-manager-node-daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           secretName: ws-manager-node-tls
       - name: config
         configMap:
-          name: ws-manager-node-config
+          name: {{ template "gitpod.comp.configMap" $this }}
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: ws-proxy-config
+          name: {{ template "gitpod.comp.configMap" $this }}
 {{- if $.Values.certificatesSecret.secretName }}
       - name: config-certificates
         secret:

--- a/chart/templates/ws-scheduler-deployment.yaml
+++ b/chart/templates/ws-scheduler-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: ws-scheduler-config
+          name: {{ template "gitpod.comp.configMap" $this }}
       containers:
       - name: scheduler
         args: ["run", "-v", "--config", "/config/config.json"]

--- a/chart/templates/ws-sync-daemonset.yaml
+++ b/chart/templates/ws-sync-daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           secretName: ws-sync-tls
       - name: config
         configMap:
-          name: ws-sync-config
+          name: {{ template "gitpod.comp.configMap" $this }}
       {{- if $comp.fullWorkspaceBackup.enabled }}
       - name: containerd-socket
         hostPath:


### PR DESCRIPTION
In our charts, configMap names typically follow the format `<component>-config`.

This change makes these names a template, and allows for potential overrides (you can set the component's `configMapName` to a custom value in order to point to a different configMap).