### PR TITLE
integrate supervisor into code

### DIFF
--- a/components/gitpod-protocol/src/ide-frontend-service.ts
+++ b/components/gitpod-protocol/src/ide-frontend-service.ts
@@ -7,13 +7,13 @@
 import { Event } from "./util/event";
 import { Disposable } from "./util/disposable";
 
-export type IDEState = 'init' | 'ready' | 'terminated';
+export type IDEFrontendState = 'init' | 'ready' | 'terminated';
 
-export interface IDEService {
-    readonly state: IDEState;
+export interface IDEFrontendService {
+    readonly state: IDEFrontendState;
     readonly onDidChange: Event<void>;
     /**
-     * Starts the ide application.
+     * Starts the ide frontend application.
      * Returns the disposable object which is triggered when the ide application should be stopped.
      *
      * On stop the application should store the unsaved changes.

--- a/components/gitpod-protocol/src/ide-service.ts
+++ b/components/gitpod-protocol/src/ide-service.ts
@@ -5,10 +5,20 @@
  */
 
 import { Event } from "./util/event";
+import { Disposable } from "./util/disposable";
 
-export type IDEState = 'init' | 'ready';
+export type IDEState = 'init' | 'ready' | 'terminated';
 
 export interface IDEService {
     readonly state: IDEState;
     readonly onDidChange: Event<void>;
+    /**
+     * Starts the ide application.
+     * Returns the disposable object which is triggered when the ide application should be stopped.
+     *
+     * On stop the application should store the unsaved changes.
+     * It won't receive any `beforeunload` events from window anymore to prevent
+     * confirmation dialogs for stopped workspaces.
+     */
+    start(): Disposable;
 }

--- a/components/gitpod-protocol/src/typings/globals.ts
+++ b/components/gitpod-protocol/src/typings/globals.ts
@@ -7,6 +7,6 @@
 interface Window {
     gitpod: {
         service: import('../gitpod-service').GitpodService
-        ideService?: import('../ide-service').IDEService
+        ideService?: import('../ide-frontend-service').IDEFrontendService
     }
 }

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT f8db5f48de4c0169bef40eb6cf79a9125369f6e9
+ENV GP_CODE_COMMIT 074132acc5f9cf4aa27bbde1e57500e083414769
 RUN git clone https://github.com/gitpod-io/vscode.git --branch gp-code --single-branch gp-code
 WORKDIR /gp-code
 RUN git reset --hard $GP_CODE_COMMIT

--- a/components/supervisor/frontend/src/ide/ide-frontend-service-impl.ts
+++ b/components/supervisor/frontend/src/ide/ide-frontend-service-impl.ts
@@ -4,18 +4,18 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { IDEService, IDEState } from "@gitpod/gitpod-protocol/lib/ide-service";
+import { IDEFrontendService, IDEFrontendState } from "@gitpod/gitpod-protocol/lib/ide-frontend-service";
 import { Disposable, DisposableCollection } from "@gitpod/gitpod-protocol/lib/util/disposable";
 import { Emitter } from "@gitpod/gitpod-protocol/lib/util/event";
 
-interface IDECapabilities {
+interface IDEFrontendCapabilities {
     /**
-     * Controls whether IDE frame can provide IDE service.
+     * Controls whether IDE window can provide the IDE frontend service.
      */
     readonly service?: boolean
 }
 
-let state: IDEState = 'init';
+let state: IDEFrontendState = 'init';
 window.addEventListener('beforeunload', e => {
     if (state === 'terminated') {
         // workspace is stopping or stopped avoid to prompt a user with confirmation dialogs
@@ -23,13 +23,13 @@ window.addEventListener('beforeunload', e => {
     }
 }, { capture: true });
 
-export function create(): IDEService {
-    let capabilities: IDECapabilities = { service: false };
+export function create(): IDEFrontendService {
+    let capabilities: IDEFrontendCapabilities = { service: false };
     const onDidChangeEmitter = new Emitter<void>();
-    let _delegate: IDEService | undefined;
+    let _delegate: IDEFrontendService | undefined;
     const toStop = new DisposableCollection();
     toStop.push(onDidChangeEmitter);
-    const service: IDEService = {
+    const service: IDEFrontendService = {
         get state() {
             if (state === 'terminated') {
                 return 'terminated';
@@ -61,7 +61,7 @@ export function create(): IDEService {
         get() {
             return _delegate;
         },
-        set(delegate: IDEService) {
+        set(delegate: IDEFrontendService) {
             if (_delegate) {
                 console.error(new Error('ideService is already set'));
                 return;

--- a/components/supervisor/frontend/src/ide/ide-service-impl.ts
+++ b/components/supervisor/frontend/src/ide/ide-service-impl.ts
@@ -4,7 +4,8 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { IDEService } from "@gitpod/gitpod-protocol/lib/ide-service";
+import { IDEService, IDEState } from "@gitpod/gitpod-protocol/lib/ide-service";
+import { Disposable, DisposableCollection } from "@gitpod/gitpod-protocol/lib/util/disposable";
 import { Emitter } from "@gitpod/gitpod-protocol/lib/util/event";
 
 interface IDECapabilities {
@@ -14,18 +15,45 @@ interface IDECapabilities {
     readonly service?: boolean
 }
 
+let state: IDEState = 'init';
+window.addEventListener('beforeunload', e => {
+    if (state === 'terminated') {
+        // workspace is stopping or stopped avoid to prompt a user with confirmation dialogs
+        e.stopImmediatePropagation();
+    }
+}, { capture: true });
+
 export function create(): IDEService {
     let capabilities: IDECapabilities = { service: false };
     const onDidChangeEmitter = new Emitter<void>();
     let _delegate: IDEService | undefined;
+    const toStop = new DisposableCollection();
+    toStop.push(onDidChangeEmitter);
     const service: IDEService = {
         get state() {
+            if (state === 'terminated') {
+                return 'terminated';
+            }
             if (capabilities.service) {
                 return _delegate?.state || 'init';
             }
-            return 'ready';
+            return state;
         },
-        onDidChange: onDidChangeEmitter.event
+        onDidChange: onDidChangeEmitter.event,
+        start: () => {
+            if (state === 'terminated') {
+                throw new Error('IDE has been stopped');
+            }
+            state = 'ready';
+            toStop.push(Disposable.create(() => {
+                state = 'terminated';
+                onDidChangeEmitter.fire();
+            }))
+            if (_delegate) {
+                toStop.push(_delegate.start());
+            }
+            return toStop;
+        }
     }
     const capabilitiesElementAttribute = document.getElementById('gitpod-ide-capabilities')?.getAttribute('data-settings');
     capabilities = capabilitiesElementAttribute && JSON.parse(capabilitiesElementAttribute) || capabilities;
@@ -39,6 +67,9 @@ export function create(): IDEService {
                 return;
             }
             _delegate = delegate;
+            if (state === 'ready') {
+                toStop.push(delegate.start());
+            }
             onDidChangeEmitter.fire();
             delegate.onDidChange(() => onDidChangeEmitter.fire());
         }

--- a/components/supervisor/frontend/src/ide/ide-web-socket.ts
+++ b/components/supervisor/frontend/src/ide/ide-web-socket.ts
@@ -5,6 +5,7 @@
  */
 
 import ReconnectingWebSocket from 'reconnecting-websocket';
+import { Disposable } from '@gitpod/gitpod-protocol/lib/util/disposable';
 
 let connected = false;
 const workspaceSockets = new Set<IDEWebSocket>();
@@ -39,14 +40,15 @@ export function install(): void {
     window.WebSocket = IDEWebSocket as any;
 }
 
-export function connectWorkspace(): void {
+export function connectWorkspace(): Disposable {
     if (connected) {
-        return;
+        return Disposable.NULL;
     }
     connected = true;
     for (const socket of workspaceSockets) {
         socket.reconnect();
     }
+    return Disposable.create(() => disconnectWorkspace());
 }
 
 export function disconnectWorkspace(): void {

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -11,7 +11,7 @@ import { createGitpodService } from "@gitpod/gitpod-protocol";
 import { DisposableCollection } from '@gitpod/gitpod-protocol/lib/util/disposable';
 import * as GitpodServiceClient from "./ide/gitpod-service-client";
 import * as heartBeat from "./ide/heart-beat";
-import * as IDEService from "./ide/ide-service-impl";
+import * as IDEFrontendService from "./ide/ide-frontend-service-impl";
 import * as IDEWebSocket from "./ide/ide-web-socket";
 import { SupervisorServiceClient } from "./ide/supervisor-service-client";
 import * as LoadingFrame from "./shared/loading-frame";
@@ -21,7 +21,7 @@ window.gitpod = {
     service: createGitpodService(serverUrl.toString())
 };
 IDEWebSocket.install();
-const ideService = IDEService.create();
+const ideService = IDEFrontendService.create();
 const pendingGitpodServiceClient = GitpodServiceClient.create();
 (async () => {
     const gitpodServiceClient = await pendingGitpodServiceClient;
@@ -62,7 +62,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     //#region current-frame
-    let currentFrame: HTMLElement = loading.frame;
+    let current: HTMLElement = loading.frame;
     let stopped = false;
     const nextFrame = () => {
         const instance = gitpodServiceClient.info.latestInstance;
@@ -87,13 +87,21 @@ window.addEventListener('DOMContentLoaded', async () => {
         return loading.frame;
     }
     const updateCurrentFrame = () => {
-        const newCurrentFrame = nextFrame();
-        if (currentFrame === newCurrentFrame) {
+        const newCurrent = nextFrame();
+        if (current === newCurrent) {
             return;
         }
-        currentFrame.style.visibility = 'hidden';
-        newCurrentFrame.style.visibility = 'visible';
-        currentFrame = newCurrentFrame;
+        current.style.visibility = 'hidden';
+        newCurrent.style.visibility = 'visible';
+        if (current === document.body) {
+            while (document.body.firstChild && document.body.firstChild !== newCurrent) {
+                document.body.removeChild(document.body.firstChild);
+            }
+            while (document.body.lastChild && document.body.lastChild !== newCurrent) {
+                document.body.removeChild(document.body.lastChild);
+            }
+        }
+        current = newCurrent;
     }
 
     updateCurrentFrame();

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-frontend-module.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-frontend-module.ts
@@ -6,10 +6,10 @@
 
 import '../../src/browser/extensions/style/extensions.css'
 
-import { ContainerModule, inject, injectable } from "inversify";
+import { ContainerModule, injectable } from "inversify";
 import { GitHubTokenProvider, InitialGitHubDataProvider, GetGitHubTokenParams } from "./github";
 import { GitpodCreditAlerContribution } from './gitpod-credit-alert-contribution';
-import { FrontendApplicationContribution, WebSocketConnectionProvider, WidgetFactory, bindViewContribution, ShellLayoutRestorer, CommonFrontendContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, WebSocketConnectionProvider, WidgetFactory, bindViewContribution, ShellLayoutRestorer, CommonFrontendContribution, FrontendApplication } from '@theia/core/lib/browser';
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { GitpodLocalStorageService } from './gitpod-local-storage-service';
 import { GitpodOpenContext, GitpodWorkspaceService } from './gitpod-open-context';
@@ -62,36 +62,50 @@ import { ConnectionStatusOptions } from '@theia/core/lib/browser/connection-stat
 import { extensionsModule } from './extensions/extensions-module';
 import { GitpodUserStorageContribution } from './gitpod-user-storage-contribution';
 import { GitpodUserStorageProvider } from './gitpod-user-storage-provider';
-import { IDEService, IDEState } from '@gitpod/gitpod-protocol/lib/ide-service';
-import { Emitter } from '@gitpod/gitpod-protocol/lib/util/event';
-import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { Emitter } from '@theia/core/lib/common/event';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 
 @injectable()
-class IDEServiceContribution implements FrontendApplicationContribution, IDEService {
+class GitpodFrontendApplication extends FrontendApplication {
 
-    get state(): IDEState {
-        return this.stateService.state === 'ready' ? 'ready' : 'init';
+    async start(): Promise<void> {
+        const pendingStart = new Deferred<void>();
+        const stateService = this.stateService;
+        const onDidChangeEmitter = new Emitter<void>();
+        const toStop = new DisposableCollection(
+            onDidChangeEmitter,
+            Disposable.create(() => {
+                // save state on workspace stop
+                this.layoutRestorer.storeLayout(this);
+                this.stopContributions();
+            })
+        );
+        window.gitpod.ideService = {
+            get state() {
+                if (toStop.disposed) {
+                    return 'terminated';
+                }
+                // closing_window because of https://github.com/eclipse-theia/theia/issues/8618
+                if (stateService.state === 'ready' || stateService.state === 'closing_window') {
+                    return 'ready';
+                }
+                return 'init';
+            },
+            onDidChange: onDidChangeEmitter.event,
+            start: () => {
+                super.start().then(pendingStart.resolve, pendingStart.reject);
+                return toStop;
+            }
+        };
+        stateService.onStateChanged(() => onDidChangeEmitter.fire());
+        return pendingStart.promise;
     }
 
-    private readonly onDidChangeEmitter = new Emitter<void>();
-    readonly onDidChange = this.onDidChangeEmitter.event;
-
-    @inject(FrontendApplicationStateService)
-    private readonly stateService: FrontendApplicationStateService;
-
-    initialize(): void {
-        window.gitpod.ideService = this;
-        if (this.stateService.state !== 'ready') {
-            this.stateService.reachedState('ready').then(() =>
-                this.onDidChangeEmitter.fire()
-            );
-        }
-    }
 }
-//#endregion
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(FrontendApplicationContribution).to(IDEServiceContribution).inSingletonScope();
+    rebind(FrontendApplication).to(GitpodFrontendApplication).inSingletonScope();
 
     rebind(CommonFrontendContribution).to(GitpodCommonFrontendContribution).inSingletonScope();
 

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -139,9 +139,6 @@ func TheiaRootHandler(infoProvider WorkspaceInfoProvider) RouteHandler {
 			reslv = staticTheiaResolver
 		}
 		resolver := func(config *Config, req *http.Request) (*url.URL, error) {
-			if req.URL.Path == "/" {
-				req.URL.Path = "/index.html"
-			}
 			return reslv(config, req)
 		}
 


### PR DESCRIPTION
- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https

#### What it does

- it is a follow-up of https://github.com/gitpod-io/gitpod/pull/1963 bumping up code to commit which integrates the supervisor
  - registration: https://github.com/gitpod-io/vscode/blob/b7d1abfe52328f9787543518c0d1698a798d9b28/src/vs/code/browser/workbench/workbench.html#L5-L7
  - implementation of IDEService:  https://github.com/gitpod-io/vscode/blob/b7d1abfe52328f9787543518c0d1698a798d9b28/src/vs/code/browser/workbench/workbench.ts#L252-L272
- fix #1959 by asking the IDE service to stop which triggers preserving state and preventing dispatching `beforeunload` event when the workspace is stopped to avoid confirmation dialogs

#### How to test

- login
- test Theia:
  - start a regular workspace http://ak-fix-code.staging.gitpod-dev.com/#https://github.com/gitpod-io/go-gin-app
    - change the layout, do dirty changes, try to reload the page, you should still see the confirmation dialog, cancel it and then stop the workspace
    - start the workspace from the loading screen, the layout should be preserved, but you should not see the confirmation dialog about dirty changes
  - start a prebuild workspace http://ak-fix-code.staging.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/go-gin-app
    - ide code should be loaded, but the application should not be started, i.e. browser logs should be clean, no contributions or plugins loading
- test Code:
  - grant `devops` role to your user, i.e. run a query like: `update d_b_user set rolesOrPermissions = '["admin","devops"]' where name = 'akosyakov';`
  - start workspace http://ak-fix-code.staging.gitpod-dev.com/#https://github.com/akosyakov/go-gin-app
  - check that Code is loaded
  - click on Gitpod in remote status bar item (left most) and select stop workspace, check that loading screen is shown
  - restart the workspace from the loading screen and check that Code is loaded again
  