### PR TITLE
[dev] Bump dev-image build to pull latest werft client

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cercscheduler.3
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
 workspaceLocation: gitpod/gitpod-ws.theia-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-improve-core-previews.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev-environment:cw-dev.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full-vnc:latest
 
-ENV TRIGGER_REBUILD 1
+ENV TRIGGER_REBUILD 2
 
 USER root
 
@@ -54,7 +54,9 @@ RUN cd /usr/bin && curl -L https://github.com/TypeFox/leeway/releases/download/v
 RUN cd /usr/bin && curl -L https://github.com/32leaves/dazzle/releases/download/v0.0.3/dazzle_0.0.3_Linux_x86_64.tar.gz | tar xz
 
 # werft CLI
-RUN cd /usr/bin && curl -L https://github.com/csweichel/werft/releases/download/v0.0.4/werft-client-linux-amd64.tar.gz | tar xz && mv werft-client-linux-amd64 werft
+ENV WERFT_K8S_NAMESPACE=werft
+ENV WERFT_DIAL_MODE=kubernetes
+RUN cd /usr/bin && curl -L https://github.com/csweichel/werft/releases/download/v0.0.5rc/werft-client-linux-amd64.tar.gz | tar xz && mv werft-client-linux-amd64 werft
 
 # yq - jq for YAML files
 RUN cd /usr/bin && curl -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 > yq && chmod +x yq


### PR DESCRIPTION
Pulls the latest werft release which supports the werft CLI without manual `kubectl port-forward`.

/werft no-preview