### PR TITLE
[ws-sync] Add shiftfs module loader for user-namespaced workspaces

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -126,6 +126,9 @@ components:
     volumeMounts:
     - mountPath: /mnt/sync-tmp
       name: gcloud-tmp
+    userNamespaces:
+      shiftfsModuleLoader:
+        enabled: true
 
   # Enable ws-proxy in dev
   wsProxy:

--- a/chart/templates/cluster-privileged-unconfined-podsecuritypolicy.yaml
+++ b/chart/templates/cluster-privileged-unconfined-podsecuritypolicy.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'unconfined'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'unconfined'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default,unconfined'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:
   privileged: true

--- a/chart/templates/ws-sync-daemonset.yaml
+++ b/chart/templates/ws-sync-daemonset.yaml
@@ -32,6 +32,9 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: '9500'
         checksum/tlskey: {{ include (print $.Template.BasePath "/ws-sync-tlssecret.yaml") $ | sha256sum }}
+        {{- if $comp.userNamespaces.shiftfsModuleLoader.enabled }}
+        seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
+        {{- end }}
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       # see https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/ for more
@@ -77,8 +80,25 @@ spec:
           path: /proc/mounts
           type: File
       {{- end }}
+      {{- if $comp.userNamespaces.shiftfsModuleLoader.enabled }}
+      - name: node-linux-src
+        hostPath: 
+          path: /usr/src
+          type: Directory
+      {{- end }}
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
+{{- end }}
+{{- if $comp.userNamespaces.shiftfsModuleLoader.enabled }}
+      initContainers:
+      - name: shiftfs-module-loader
+        volumeMounts:
+        - mountPath: /usr/src
+          name: node-linux-src
+          readOnly: true
+        image: {{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" $comp.userNamespaces.shiftfsModuleLoader) }}
+        securityContext:
+          privileged: true
 {{- end }}
       containers:
       - name: ws-sync

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -378,6 +378,10 @@ components:
       runtime: containerd
       containerd:
         socket: /run/containerd/containerd.sock
+    userNamespaces:
+      shiftfsModuleLoader:
+        enabled: false
+        imageName: "shiftfs-module-loader"
     remoteStorage:
       kind: minio
       minio:

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -24,6 +24,7 @@ packages:
       - components/ws-manager:docker
       - components/ws-proxy:docker
       - components/ws-sync:docker
+      - components/ws-sync/shiftfs-module-loader:docker
       - components/gitpod-protocol:publish
       - components/supervisor-api/typescript-grpc:publish
   - name: all-apps

--- a/components/ws-sync/shiftfs-module-loader/.gitignore
+++ b/components/ws-sync/shiftfs-module-loader/.gitignore
@@ -1,0 +1,1 @@
+shiftfs.c

--- a/components/ws-sync/shiftfs-module-loader/BUILD.yaml
+++ b/components/ws-sync/shiftfs-module-loader/BUILD.yaml
@@ -1,0 +1,13 @@
+packages:
+  - name: docker
+    type: docker
+    argdeps:
+      - imageRepoBase
+    srcs:
+      - entrypoint.sh
+      - dkms.conf
+      - Makefile
+    config:
+      dockerfile: leeway.Dockerfile
+      image:
+        - ${imageRepoBase}/shiftfs-module-loader:${version}

--- a/components/ws-sync/shiftfs-module-loader/Makefile
+++ b/components/ws-sync/shiftfs-module-loader/Makefile
@@ -1,0 +1,33 @@
+# source: https://github.com/toby63/shiftfs-dkms/blob/master/Makefile
+
+modname := shiftfs
+obj-m := $(modname).o
+
+KVERSION := $(shell uname -r)
+KDIR := /lib/modules/$(KVERSION)/build
+PWD := "$$(pwd)"
+
+ifdef DEBUG
+CFLAGS_$(obj-m) := -DDEBUG
+endif
+
+EXTRA_CFLAGS := -DSHIFTFS_MAGIC=0x6a656a62
+
+default:
+	$(MAKE) -C $(KDIR) M=$(PWD) EXTRA_CFLAGS="${EXTRA_CFLAGS}" modules
+
+clean:
+	$(MAKE) O=$(PWD) -C $(KDIR) M=$(PWD) clean
+
+load:
+	-rmmod $(modname)
+	insmod $(modname).ko
+
+install:	
+	install -m 0755 -o root -g root $(modname).ko /lib/modules/$(KVERSION)/fs/
+	depmod -a
+
+uninstall:
+	rm /lib/modules/$(KVERSION)/fs/$(modname).ko
+	depmod -a
+

--- a/components/ws-sync/shiftfs-module-loader/README.md
+++ b/components/ws-sync/shiftfs-module-loader/README.md
@@ -1,0 +1,6 @@
+This folder contains a fairly restricted, experimental shiftfs DKMS loader that can be run from within
+a Kubernetes cluster.
+
+It heavily draws inspiration from:
+  https://github.com/falcosecurity/falco
+  https://github.com/toby63/shiftfs-dkms

--- a/components/ws-sync/shiftfs-module-loader/dkms.conf
+++ b/components/ws-sync/shiftfs-module-loader/dkms.conf
@@ -1,0 +1,4 @@
+PACKAGE_NAME="shiftfs"
+PACKAGE_VERSION="1.2"
+BUILT_MODULE_NAME[0]="shiftfs"
+DEST_MODULE_LOCATION[0]="/kernel/fs/"

--- a/components/ws-sync/shiftfs-module-loader/entrypoint.sh
+++ b/components/ws-sync/shiftfs-module-loader/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DRIVER_NAME=shiftfs
+DRIVER_VERSION=1.2
+ARCH=$(uname -m)
+KERNEL_RELEASE=$(uname -r)
+KERNEL_VERSION=$(uname -v | sed 's/#\([[:digit:]]\+\).*/\1/')
+
+if lsmod | grep $DRIVER_NAME; then
+    echo "shiftfs is already loaded - nothing to do here"
+    exit 0
+fi
+
+set -ex
+mkdir -p /lib/modules/${KERNEL_RELEASE}
+ln -s /usr/src/linux-headers-${KERNEL_RELEASE} /lib/modules/${KERNEL_RELEASE}/build
+dkms install -m ${DRIVER_NAME} -v ${DRIVER_VERSION} -k $KERNEL_RELEASE --kernelsourcedir /usr/src/linux-headers-${KERNEL_RELEASE}
+insmod /var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko

--- a/components/ws-sync/shiftfs-module-loader/leeway.Dockerfile
+++ b/components/ws-sync/shiftfs-module-loader/leeway.Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y git gcc make dkms curl
+
+# expects the host's /lib/modules to be mounted with a /lib/modules/<host-kernel-version>/build directory containing
+# the kernel header files.
+
+WORKDIR /build
+COPY entrypoint.sh ./
+RUN mkdir -p /usr/src/shiftfs-1.2 && curl -o /usr/src/shiftfs-1.2/shiftfs.c -L https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/plain/fs/shiftfs.c
+COPY dkms.conf Makefile /usr/src/shiftfs-1.2/
+
+CMD [ "./entrypoint.sh" ]


### PR DESCRIPTION
This PR adds an init container to ws-sync which compiles and loads `shiftfs` using DKMS.
This is in preparation for user namespaced workspaces.

By default this loader is disabled in the `values.yaml`.

## How to test
1. ssh into one of the ubuntu pool machines and run `rmmod shiftfs`
2. restart ws-sync: `kubectl delete pod -l component=ws-sync`
3. observe how the init container loads the module: `kubectl logs -c shiftfs-module-loader ws-sync-...`