### PR TITLE
blobserve http caching across workspaces

### DIFF
--- a/chart/config/proxy/vhost.server.conf
+++ b/chart/config/proxy/vhost.server.conf
@@ -148,3 +148,23 @@ server {
     include lib.workspace-port-locations.conf;
     include lib.region-headers.conf;
 }
+
+server {
+    listen {{ $listen }};
+    # Matches:
+    #  - \.ws(-[a-z0-9]+)?              workspace base domain
+    server_name "~^blobserve\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$";
+
+{{- if $useHttps }}
+    {{- if eq .Values.ingressMode "pathAndHost" }}
+    listen 80;
+    {{- end }}
+
+    include lib.ssl.conf;
+    include lib.https_redirect.conf;
+{{- end }}
+
+    include lib.cors-server.conf;
+    include lib.region-headers.conf;
+    include lib.log-headers.conf;
+}

--- a/components/ws-proxy/pkg/proxy/proxy.go
+++ b/components/ws-proxy/pkg/proxy/proxy.go
@@ -68,9 +68,10 @@ func (p *WorkspaceProxy) Server() (*http.Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	theiaRouter, portRouter := p.WorkspaceRouter(r, p.WorkspaceInfoProvider)
+	theiaRouter, portRouter, blobserveRouter := p.WorkspaceRouter(r, p.WorkspaceInfoProvider)
 	installTheiaRoutes(theiaRouter, handlerConfig, p.WorkspaceInfoProvider)
 	installWorkspacePortRoutes(portRouter, handlerConfig)
+	installBlobserveRoutes(blobserveRouter, handlerConfig)
 
 	return &http.Server{Addr: p.Address, Handler: r}, nil
 }


### PR DESCRIPTION
#### What it does

- fix #1984: implement long-lived caching with versioned URLs for blobserve resources across workspaces

It works by redirecting request to blobserve to URL which includes image and version, i.e. to `blobserve.ws-dev.gitpod.io/image:tag/main.js`. Such URLs are served with max-age equals 1 year that clients don't need to ask the server about them.

#### How to test

- Create a new workspace and see how much does it take initially to load supervisor and IDE static resources. In my case it was 3.6Mb transffered in 2.08s:
<img width="1904" alt="Screenshot 2020-10-13 at 15 24 41" src="https://user-images.githubusercontent.com/3082655/95866731-91465e80-0d68-11eb-9b4a-ee594290fd40.png">
- Now start another workspace and compare results. In my case it was 9.8kb transffered in 1.07s:
<img width="1904" alt="Screenshot 2020-10-13 at 15 25 15" src="https://user-images.githubusercontent.com/3082655/95866915-cd79bf00-0d68-11eb-8582-2f542ca0e7a3.png">

Unfortunately we still need many requests for redirects that's why time drops only 2x for the good connection, for the bad connection the difference is drastic. We can get rid of hitting the server for redirects later with usage of service workers: https://github.com/gitpod-io/gitpod/issues/1982#issuecomment-707669272
