### PR TITLE
[gitlab] Don't double-encode path when getting the last commit of a Dockerfile

### DIFF
--- a/components/server/src/gitlab/file-provider.ts
+++ b/components/server/src/gitlab/file-provider.ts
@@ -26,8 +26,7 @@ export class GitlabFileProvider implements FileProvider {
 
     public async getLastChangeRevision(repository: Repository, revisionOrBranch: string, user: User, path: string): Promise<string> {
         const result = await this.gitlabApi.run<GitLab.Commit[]>(user, async g => {
-            const encodedPath = encodeURIComponent(path);
-            return g.Commits.all(`${repository.owner}/${repository.name}`, { path: encodedPath, ref_name: revisionOrBranch });
+            return g.Commits.all(`${repository.owner}/${repository.name}`, { path, ref_name: revisionOrBranch });
         });
 
         if (GitLab.ApiError.is(result)) {


### PR DESCRIPTION
Explanation: We've recently bumped the library that fetches GitLab commits. It seems that it now handles the encoding of paths, so we should no longer do it ourselves (because this currently leads to double-encoding).

Should fix https://github.com/gitpod-io/gitpod/issues/1995