### PR TITLE
[chart] Fix templated configMap name for 'ws-proxy-config'

### DIFF
--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -131,7 +131,7 @@ spec:
 {{ include "gitpod.container.defaultEnv" (dict "root" . "gp" $.Values "comp" $wsProxy "noVersion" true) | indent 8 }}
         volumeMounts:
 {{- if (and $wsProxy (not $wsProxy.disabled) $wsProxy.portRange) }}
-        - name: {{ template "gitpod.comp.configMap" $this }}
+        - name: {{ template "gitpod.comp.configMap" $thisWsProxy }}
           mountPath: "/config"
           readOnly: true
 {{- end }}


### PR DESCRIPTION
Should fix https://github.com/gitpod-io/gitpod/pull/1957#pullrequestreview-511503083

⚠️ I wasn't able to test this PR, because this failed:

```
$ cd chart && helm template .
helm.go:71: cannot construct google default token source: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

@wulfthimm or @csweichel: please test this PR, or provide a hint how I can test it myself.