### PR TITLE
[helm] made the upload of the credentialsfiles in  optional

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -200,8 +200,8 @@ spec:
           value: {{ .Values.components.wsDaemon.remoteStorage.gcloud.projectId }}
         - name: GCLOUD_REGION
           value: {{ .Values.components.wsDaemon.remoteStorage.gcloud.region }}
-        - name: GCLOUD_CREDENTIALS_FILE
 {{- if .Values.components.wsDaemon.remoteStorage.gcloud.credentialsFile }}
+        - name: GCLOUD_CREDENTIALS_FILE
           value: {{ base .Values.components.wsDaemon.remoteStorage.gcloud.credentialsFile }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The `credentialsFile` in `server-deployment` is optional to allow an upload directly to Kubernetes.