### PR TITLE
[dev] Make minio use serviceAccount with PodSecurityPolicy

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -139,3 +139,8 @@ components:
 # configure GCP registry
 docker-registry:
   enabled: false
+
+minio:
+  serviceAccount:
+    name: ws-daemon
+    create: false


### PR DESCRIPTION
Now that we've enabled PodSecurityPolicies on devstaging again, we need to ensure minio has a PodSecurityPolicy attached. Rather than adding our own, we're just deploying it using the ws-daemon service account, hence reuse the ws-daemon PodSecurityPolicy.