### PR TITLE
Fixing name of registry auth secret for external registries

### DIFF
--- a/install/helm/utils/create-gcp-resources.go
+++ b/install/helm/utils/create-gcp-resources.go
@@ -464,7 +464,7 @@ gitpod:
       registry:
         # name must not end with a "/"
         name: gcr.io/`+projectID+`
-        secretName: image-builder-registry-secret
+        secretName: external-registry-auth
         path: secrets/registry-auth.json
 
     workspace:

--- a/install/helm/values/registry.yaml
+++ b/install/helm/values/registry.yaml
@@ -8,7 +8,7 @@ gitpod:
       registry:
         # name must not end with a "/"
         name: your.registry.com/gitpod
-        secretName: image-builder-registry-secret
+        secretName: external-registry-auth
         path: secrets/registry-auth.json
 
     # server:
@@ -17,7 +17,7 @@ gitpod:
 
     workspace:
       pullSecret:
-        secretName: image-builder-registry-secret
+        secretName: external-registry-auth
 
   docker-registry:
     enabled: false


### PR DESCRIPTION
This change makes it more clear what the purpose of the secret is for.
Since it is used by both the image-builder and workspace components it
does not make sense to call it an image-builder secret. Also the designation
of "auth" makes it more clear this is not a generic secret like the other ones
and also matches how the `builtin-registry-auth` is named.

Signed-off-by: john.gallucci <john.gallucci@baesystems.com>