### PR TITLE
fix #2036: gp url should await when IDE is up

### DIFF
--- a/components/theia/packages/gitpod-extension/src/browser/utils.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/utils.ts
@@ -7,23 +7,13 @@
 /// <reference types='@gitpod/gitpod-protocol/lib/typings/globals'/>
 
 import { GitpodService } from "@gitpod/gitpod-protocol";
-import { workspaceIDRegex } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
 export function getGitpodService(): GitpodService {
     return window.gitpod.service;
 }
 
+const workspaceID = new GitpodHostUrl(window.location.href).workspaceId || "unknown-workspace-id";
 export function getWorkspaceID() {
-    const hostSegs = window.location.host.split(".");
-    if (hostSegs.length > 1 && hostSegs[0].match(workspaceIDRegex)) {
-        // URL has a workspace prefix
-        return hostSegs[0];
-    }
-
-    const pathSegs = window.location.pathname.split("/")
-    if (pathSegs.length > 3 && pathSegs[1] === "workspace") {
-        return pathSegs[2];
-    }
-
-    return "unknown-workspace-id";
+    return workspaceID;
 }


### PR DESCRIPTION
#### What it does

Since the supervisor took over tasks, now tasks can be executed before Theia is running. For now we postpone calls till Theia is ready. Later we want to get rid of calls to Theia altogether: https://github.com/gitpod-io/gitpod/issues/2042

#### How to test

- Start http://akosyakov-supervisor-export-in-2036.staging.gitpod-dev.com/#https://github.com/ant-design/ant-design
- `echo $DEV_URL` in the task terminal should not print empty result