### PR TITLE
fixes #2039: don't log `this task ran ...` in prebuilds

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -357,8 +357,6 @@ func (tm *tasksManager) watch(task *task, terminal *terminal.Term) {
 
 				endMessage := "\r\n🍌 This task ran as part of a workspace prebuild.\r\n" + duration + "\r\n"
 				fileWriter.WriteString(endMessage)
-				workspaceLog.WithField("type", "workspaceTaskOutput").WithField("data", endMessage).Info()
-
 				fileWriter.Flush()
 				success = true
 				break


### PR DESCRIPTION
#### What it does

It only logs such message to the file that it is visible from the workspace.

#### How to test

- Login: http://akosyakov-supervisor-i-see-the-2039.staging.gitpod-dev.com/
- Start a prebuild make sure that you don't see such message at the end: http://akosyakov-supervisor-i-see-the-2039.staging.gitpod-dev.com/#prebuild/https://github.com/nisarhassan12/svgr
- Check that you see this message in the actual workspace.