### PR TITLE
[registry-facade] Support daemonSet deployment to ease network load

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -205,6 +205,7 @@ async function deployToDev(version, previewWithHttps, workspaceFeatureFlags) {
     flags+=` --set devBranch=${destname}`;
     flags+=` --set components.wsDaemon.servicePort=${wsdaemonPort}`;
     flags+=` --set components.wsDaemon.registryProxyPort=${registryProxyPort}`;
+    flags+=` --set components.registryFacade.ports.registry.servicePort=${registryNodePort}`;
     flags+=` --set ingressMode=${context.Annotations.ingressMode || "hosts"}`;
     workspaceFeatureFlags.forEach((f, i) => {
         flags+=` --set components.server.defaultFeatureFlags[${i}]='${f}'`
@@ -255,7 +256,8 @@ async function deployToDev(version, previewWithHttps, workspaceFeatureFlags) {
 
 async function issueAndInstallCertficate(namespace, domain) {
     // Always use 'terraform apply' to make sure the certificate is present and up-to-date
-    await exec(`cd .werft/certs \
+    await exec(`set -x \
+        && cd .werft/certs \
         && terraform init \
         && export GOOGLE_APPLICATION_CREDENTIALS="${GCLOUD_SERVICE_ACCOUNT_PATH}" \
         && terraform apply -auto-approve \

--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -38,6 +38,9 @@ components:
     - name: "dev"
       address: "ws-manager-dev:8080"
 
+  registryFacade:
+    daemonSet: true
+
   workspace:
     # configure GCP registry
     pullSecret:

--- a/chart/templates/registry-facade-deployment.yaml
+++ b/chart/templates/registry-facade-deployment.yaml
@@ -5,7 +5,11 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 apiVersion: apps/v1
+{{- if $comp.daemonSet }}
+kind: DaemonSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: registry-facade
   labels:
@@ -20,12 +24,14 @@ spec:
       component: registry-facade
       kind: pod
       stage: {{ .Values.installation.stage }}
+{{- if not $comp.daemonSet }}
   replicas: {{ $comp.replicas | default 1 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
+{{- end }}
   template:
     metadata:
       name: registry-facade
@@ -35,7 +41,11 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
     spec:
+{{- if $comp.daemonSet }}
+{{ include "gitpod.workspaceAffinity" $this | indent 6 }}
+{{- else }}
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
+{{- end }}
       serviceAccountName: registry-facade
       containers:
       - name: registry-facade
@@ -46,6 +56,9 @@ spec:
         ports:
         - name: registry
           containerPort: {{ $comp.ports.registry.containerPort }}
+{{- if $comp.daemonSet }}
+          hostPort: {{ $comp.ports.registry.servicePort }}
+{{- end }}
         securityContext:
           privileged: false
           runAsUser: 1000

--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -71,10 +71,17 @@ daemon:
     nodeHostsFile: "/mnt/hosts"
     serviceProxy:
       enabled: true
+{{- if .Values.components.registryFacade }}
+      fixedHosts:
+        registryFacade:
+          - alias: {{ (printf "reg.%s" (.Values.components.registryFacade.hostname | default .Values.hostname)) | quote }}
+            addr: 127.0.0.1
+{{- else }}
       mapping:
         - selector: "component=registry-facade,feature=registry"
           alias: {{ (printf "reg.%s" (.Values.components.registryFacade.hostname | default .Values.hostname)) | quote }}
           proxyPort: {{ $comp.registryProxyPort }}
+{{- end }}
   disk:
     path: "/mnt/wsdaemon-workingarea"
     minBytesAvail: 21474836480

--- a/chart/templates/ws-manager-configmap.yaml
+++ b/chart/templates/ws-manager-configmap.yaml
@@ -92,7 +92,7 @@ data:
             },
             {{ if $comp.eventTraceLogLocation }}"eventTraceLog": "{{ $comp.eventTraceLogLocation }}",{{- end }}
             "reconnectionInterval": "30s",
-            "registryFacadeHost": {{ (printf "reg.%s:%v" (.Values.components.registryFacade.hostname | default .Values.hostname) .Values.components.wsDaemon.registryProxyPort) | quote }}
+            "registryFacadeHost": {{ (printf "reg.%s:%v" (.Values.components.registryFacade.hostname | default .Values.hostname) (ternary .Values.components.registryFacade.ports.registry.servicePort .Values.components.wsDaemon.registryProxyPort .Values.components.registryFacade.daemonSet)) | quote }}
             {{- if and (not $wsproxy.disabled) (eq .Values.ingressMode "noDomain") -}}
             , "ingressPortAllocator": {
                 "ingressRange": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -193,6 +193,7 @@ components:
     dependsOn:
     - "registry-facade-configmap.yaml"
     certificatesSecret: {}
+    daemonSet: false
     resources:
       cpu: 100m
       memory: 32Mi

--- a/components/ws-daemon/pkg/hosts/config.go
+++ b/components/ws-daemon/pkg/hosts/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Enabled       bool              `json:"enabled"`
 	NodeHostsFile string            `json:"nodeHostsFile"`
 	FromNodeIPs   map[string]string `json:"fromPodNodeIP"`
+	FixedHosts    map[string][]Host `json:"fixedHosts"`
 	ServiceProxy  struct {
 		Enabled     bool `json:"enabled,omitempty"`
 		PortMapping []struct {
@@ -59,6 +60,12 @@ func FromConfig(cfg Config, clientset kubernetes.Interface, kubernetesNamespace 
 			Namespace: kubernetesNamespace,
 			Selector:  src,
 			Alias:     alias,
+		})
+	}
+	for alias, entry := range cfg.FixedHosts {
+		provider = append(provider, FixedIPSource{
+			Alias: alias,
+			Hosts: entry,
 		})
 	}
 	hg, err := NewDirectController(kubernetesNamespace, cfg.NodeHostsFile, provider...)

--- a/components/ws-daemon/pkg/hosts/hosts.go
+++ b/components/ws-daemon/pkg/hosts/hosts.go
@@ -20,8 +20,8 @@ import (
 
 // Host maps an IP address to a hostname
 type Host struct {
-	Addr string
-	Name string
+	Addr string `json:"addr"`
+	Name string `json:"name"`
 }
 
 // HostSource provides a hostname and its corresponding IP address

--- a/components/ws-daemon/pkg/hosts/kubernetes.go
+++ b/components/ws-daemon/pkg/hosts/kubernetes.go
@@ -170,6 +170,34 @@ func (s *ServiceClusterIPSource) Source() <-chan []Host {
 	return s.src
 }
 
+// FixedIPSource is a Host source that's fixed at configuration time
+type FixedIPSource struct {
+	Alias string
+	Hosts []Host
+}
+
+// Name returns the ID of this source
+func (fi FixedIPSource) Name() string {
+	return fi.Alias
+}
+
+// Start starts the source
+func (fi FixedIPSource) Start() error {
+	return nil
+}
+
+// Source provides hosts on the channel
+func (fi FixedIPSource) Source() <-chan []Host {
+	res := make(chan []Host)
+	go func() {
+		res <- fi.Hosts
+	}()
+	return res
+}
+
+// Stop stops this source from providing hosts
+func (fi FixedIPSource) Stop() {}
+
 // PodHostIPSource provides hosts based on Kubernetes pods
 type PodHostIPSource struct {
 	ID        string


### PR DESCRIPTION
This PR introduces a new deployment mode for registry-facade whereby registry-facade is deployed as daemonset on every one. ws-daemon makes static entries to `/etc/hosts` pointing to 127.0.0.1. Deploying registry-facade as DaemonSet can be enabled via the `values.yaml`, something we do now for dev-staging, and will also do in IO staging.

The idea is that maybe regfac pulls are slower because of the burden they place on the Kubernetes network, and due to ws-daemon having to proxy all its traffic. With this setup, there is no proxying and not much k8s networking required.

### How to test
- start a workspace. If the workspace starts and `mount | grep theia` comes back empty, everything works as intended.

### But the build failed?!?
What failed is the certificate business towards the end. Not quite sure why, but it seems it's related to the branch name. For now I've fixed it manually, i.e. the branch is built and deployed properly.