### PR TITLE
[supervisor] Support debugging with a separate debug loop

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -65,6 +65,8 @@ components:
             env:
             - name: THEIA_RATELIMIT_LOG
               value: "50"
+            - name: GITPOD_SUPERVISOR_DEBUG
+              value: "true"
       prebuild:
         spec:
           containers:

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -30,3 +30,38 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/supervisor:${version}
+scripts:
+  - name: debug
+    description: replaces a workspace's supervisor with a freshly built, debuggable one
+    script: |-
+      [ -z "$TARGET_WORKSPACE" ] && {
+        echo "usage: TARGET_WORKSPACE=<your-workspace-id> leeway run components/supervisor:debug"
+        echo ""
+        echo "Possible target workspaces:"
+        kubectl get pod -o json -l component=workspace | jq -r '.items[].metadata.name'
+        exit -1
+      }
+
+      set -eox pipefail
+      CGO_ENABLED=0 go build .
+      kubectl cp supervisor $TARGET_WORKSPACE:/tmp/new-supervisor
+      rm supervisor
+      kubectl exec -it $TARGET_WORKSPACE sh <<EOF
+      cd /tmp
+      echo "#!/bin/sh" > /tmp/supervisor.debug
+      echo "chmod +x /tmp/new-supervisor" >> /tmp/supervisor.debug
+      echo "exec \$GOPATH/bin/dlv exec --listen=0.0.0.0:32991 --headless --api-version=2 /tmp/new-supervisor -- run --without-debug --without-teardown-canary" >> /tmp/supervisor.debug
+      chmod +x supervisor.debug
+      cp /theia/supervisor-config.json /tmp
+      cp /.supervisor/supervisor-config.json /tmp
+      echo "installing dlv in the workspace"
+      go get github.com/go-delve/delve/cmd/dlv
+      echo "killing supervisor in the workspace"
+      kill \$(cat /tmp/supervisor.pid)
+      EOF
+
+      trap "exit" INT TERM ERR
+      trap "kill 0" EXIT
+
+      kubectl port-forward $TARGET_WORKSPACE 32991 &
+      kubectl logs -f $TARGET_WORKSPACE

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -11,6 +11,7 @@ import (
 
 var runCmdOpts struct {
 	NoTeardownCanary bool
+	NoDebug          bool
 }
 
 var runCmd = &cobra.Command{
@@ -22,6 +23,9 @@ var runCmd = &cobra.Command{
 		if runCmdOpts.NoTeardownCanary {
 			opts = append(opts, supervisor.WithoutTeardownCanary())
 		}
+		if runCmdOpts.NoDebug {
+			opts = append(opts, supervisor.WithoutDebug())
+		}
 
 		supervisor.Run(opts...)
 	},
@@ -31,4 +35,5 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().BoolVar(&runCmdOpts.NoTeardownCanary, "without-teardown-canary", false, "disables the teardown canary")
+	runCmd.Flags().BoolVar(&runCmdOpts.NoDebug, "without-debug", false, "disables the supervisor debug functionality")
 }

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -185,10 +185,15 @@ type WorkspaceConfig struct {
 	GitpodHost string `env:"GITPOD_HOST"`
 
 	// GitpodTasks is the task configuration of the workspace
-	GitpodTasks *string `env:"GITPOD_TASKS"`
+	GitpodTasks string `env:"GITPOD_TASKS"`
 
 	// GitpodHeadless controls whether the workspace is running headless
-	GitpodHeadless *string `env:"GITPOD_HEADLESS"`
+	GitpodHeadless string `env:"GITPOD_HEADLESS"`
+
+	// GitpodSupervisorDebug controls the use of supervisor's debug mode. If this is set to
+	// "true", supervisor will start - and monitor - itself, which allows for restarting
+	// supervisor in a running workspace.
+	GitpodSupervisorDebug string `env:"GITPOD_SUPERVISOR_DEBUG"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service
@@ -290,10 +295,10 @@ func (c WorkspaceConfig) GitpodAPIEndpoint() (endpoint, host string, err error) 
 
 // getGitpodTasks parses gitpod tasks
 func (c WorkspaceConfig) getGitpodTasks() (tasks *[]TaskConfig, err error) {
-	if c.GitpodTasks == nil {
+	if c.GitpodTasks == "" {
 		return
 	}
-	err = json.Unmarshal([]byte(*c.GitpodTasks), &tasks)
+	err = json.Unmarshal([]byte(c.GitpodTasks), &tasks)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse tasks: %w", err)
 	}

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -152,7 +152,7 @@ func (tm *tasksManager) init(ctx context.Context) *runContext {
 	}
 
 	contentSource, _ := tm.contentState.ContentSource()
-	headless := tm.config.GitpodHeadless != nil && *tm.config.GitpodHeadless == "true"
+	headless := tm.config.GitpodHeadless == "true"
 	runContext := &runContext{
 		contentSource: contentSource,
 		headless:      headless,


### PR DESCRIPTION
This PR provides preliminary debugging support for supervisor in core dev-staging.
It does that by wrapping supervisor in a "debug loop" much like we do for the IDE itself.

To enable this behaviour, make sure the workspace has an env var `GITPOD_SUPERVISOR_DEBUG == "true"`. We set that env var as part of the workspace template. If there's a file `/tmp/supervisor.debug`, supervisor will start that one instead of executing itself. The PID of the child process running in the debug loop is written to `/tmp/supervisor.pid`. This way we can terminate the "child supervisor" and make it restart.

In addition to supervisor's newfound debugging support, there's a script that helps with debugging. It builds and uploads supervisor to the workspace, installs delve and uses the debug loop mechanism to replace the previous supervisor.
```
cd components/supervisor
leeway run .:debug
```

![image](https://user-images.githubusercontent.com/3210701/97164102-ec714b80-1781-11eb-86db-1088b801ad80.png)
