### PR TITLE
[dev] Delete workspaces before deleting the deployment

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -115,6 +115,17 @@ async function deployToDev(version, previewWithHttps, workspaceFeatureFlags) {
     const registryNodePort = `${30000 + Math.floor(Math.random()*1000)}`;
 
     try {
+        const objs = shell
+            .exec(`kubectl get pod -l component=workspace --namespace ${namespace} --no-headers -o=custom-columns=:metadata.name`)
+            .split("\n")
+            .map(o => o.trim())
+            .filter(o => o.length > 0);
+
+        objs.forEach(o => {
+            werft.log("prep", `deleting workspace ${o}`);
+            exec(`kubectl delete pod --namespace ${namespace} ${o}`, {slice: 'prep'});
+        });
+
         recreateNamespace(namespace, {slice: 'prep'});
         [
             "kubectl config current-context",


### PR DESCRIPTION
so that user-namespaced and FWB workspaces still find a running ws-daemon prior to shutdown.

We should consider giving ws-daemon a pod priority similar to [`system-node-critical`](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/). This exact priority class can [only be used in the `kube-system` namespace](https://github.com/kubernetes/kubernetes/blob/f780ac028b444ed15d03de755c12fcf84c783286/plugin/pkg/admission/priority/admission.go#L145).

### How to test
1. start a workspace and trigger a re-deployment. The workspace should be explicitly deleted first, [like here](https://werft.gitpod-dev.com/job/gitpod-build-cw-delete-workspaces-first.4/logs#deploy:prep).
2. delete the workspace and trigger a re-deployment. The job should run just fine, [like here](https://werft.gitpod-dev.com/job/gitpod-build-cw-delete-workspaces-first.5).