### PR TITLE
Unescape pre-flight response when uploading plugin

### DIFF
--- a/components/server/src/theia-plugin/theia-plugin-controller.ts
+++ b/components/server/src/theia-plugin/theia-plugin-controller.ts
@@ -54,7 +54,7 @@ export class TheiaPluginController {
 
             try {
                 const url = await this.pluginService.preflight(id, type);
-                res.send(encodeURI(url));
+                res.send(url);
             } catch (err) {
                 log.warn("Upload failed (Step: preflight)", err, { req });
 


### PR DESCRIPTION
Fixes issue where the response URI for uploading plugins is unescaped which generates a "400 Bad Request" error when uploading to Minio.

Closes #2067