### PR TITLE
[installer] updated Terraform to v0.13.5

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:wth-update-terraform-0.13.5.8
 workspaceLocation: gitpod/gitpod-ws.theia-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:wth-update-terraform-0.13.5.8
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:wth-update-terraform-0.13.5.8
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -171,7 +171,7 @@ RUN sudo curl -o aws-iam-authenticator "https://amazon-eks.s3-us-west-2.amazonaw
     && sudo cp ./aws-iam-authenticator $HOME/.aws-iam/aws-iam-authenticator
 
 # Install Terraform
-ARG RELEASE_URL="https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip"
+ARG RELEASE_URL="https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip"
 RUN mkdir -p ~/.terraform \
     && cd ~/.terraform \
     && wget ${RELEASE_URL} \

--- a/install/aws-terraform/kubernetes.tf
+++ b/install/aws-terraform/kubernetes.tf
@@ -5,8 +5,7 @@
 
 # Derived from https://learn.hashicorp.com/terraform/kubernetes/provision-eks-cluster
 module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.44.0"
+  source = "terraform-aws-modules/vpc/aws"
 
   name                 = "gitpod"
   cidr                 = "10.0.0.0/16"

--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -35,7 +35,7 @@ ENV GITPOD_INSTALLER_IN_DOCKER="true"
 ENV KUBECONFIG="/workspace/kubectl"
 RUN apk add --no-cache aws-cli python3 curl git bash ncurses
 
-RUN curl -o terraform.zip -L https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_linux_amd64.zip && \
+RUN curl -o terraform.zip -L https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip && \
     unzip terraform.zip && \
     rm terraform.zip && \
     mv terraform /usr/bin


### PR DESCRIPTION
The installer has been build with Terraform v0.13.0 which is not supported by the aws installer scripts. The version in now `0.13.5` which is also included in the installer.