### PR TITLE
Add config of DinD MTU flag to helm charts

### DIFF
--- a/chart/templates/image-builder-deployment.yaml
+++ b/chart/templates/image-builder-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
-        args: [ "dockerd", "--userns-remap=default", "-H tcp://127.0.0.1:2375" ]
+        args: [ "dockerd", "--userns-remap=default", "-H tcp://127.0.0.1:2375" {{- if $comp.dindMtu -}}, "--mtu={{ $comp.dindMtu}}"{{- end -}} ]
         volumeMounts:
         - mountPath: /var/lib/docker
           name: dind-storage

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -174,7 +174,8 @@ components:
     registryCerts:
     - name: builtin
       secret: builtin-registry-certs
-    dindImage: docker:18.06-dind
+    dindImage: docker:19.03-dind
+    dindMtu: ""
     dindResources:
       requests:
         cpu: 100m

--- a/install/docker/gitpod-image/values.yaml
+++ b/install/docker/gitpod-image/values.yaml
@@ -18,7 +18,7 @@ components:
         dnsConfig: null
         dnsPolicy: ClusterFirst
   imageBuilder:
-    dindImage: docker:19.03-dind
+    dindMtu: 1450
 
 docker-registry:
   persistence:


### PR DESCRIPTION
This change allows to set the MTU of the Docker in Docker image. Setting it to 1450 prevents “failed to connect to all addresses” errors in the docker-compose setting.

See gitpod-io/gitpod#2004