### PR TITLE
blobserve redirect improvements

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -135,4 +135,15 @@ export class GitpodHostUrl {
 
         return undefined;
     }
+
+    get blobServe(): boolean {
+        const hostSegments = this.url.host.split(".");
+        if (hostSegments[0] === 'blobserve') {
+            return true;
+        }
+
+        const pathSegments = this.url.pathname.split("/")
+        return pathSegments[0] === "blobserve";
+    }
+
 }

--- a/components/supervisor/frontend/package.json
+++ b/components/supervisor/frontend/package.json
@@ -12,6 +12,7 @@
     "@babel/plugin-transform-classes": "^7.10.0",
     "@babel/plugin-transform-runtime": "^7.10.0",
     "@babel/preset-env": "^7.10.0",
+    "@types/sharedworker": "^0.0.29",
     "babel-loader": "^8.0.6",
     "concurrently": "^5.3.0",
     "copy-webpack-plugin": "^6.2.0",

--- a/components/supervisor/frontend/src/ide/ide-worker.ts
+++ b/components/supervisor/frontend/src/ide/ide-worker.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+
+/**
+ * Installs the proxy (shared) worker serving from the same origin to fetch content from the blobserve origin.
+ */
+export function install(): void {
+    if (window.Worker) {
+        const Worker = window.Worker;
+        window.Worker = <any>function (stringUrl: string | URL, options?: WorkerOptions) {
+            if (!new GitpodHostUrl(stringUrl).blobServe) {
+                return new Worker(stringUrl, options);
+            }
+            return new Worker(proxyUrl(stringUrl), options);
+        };
+    }
+    if (window.SharedWorker) {
+        const SharedWorker = window.SharedWorker;
+        window.SharedWorker = <any>function (stringUrl: string, options?: string | SharedWorkerOptions) {
+            if (!new GitpodHostUrl(stringUrl).blobServe) {
+                return new SharedWorker(stringUrl, options);
+            }
+            return new SharedWorker(proxyUrl(stringUrl), options);
+        };
+    }
+}
+
+function proxyUrl(stringUrl: string | URL): string {
+    // TODO(ak) importScripts is not going to work for module workers: https://web.dev/module-workers/
+    const js = `importScripts('${stringUrl}');`;
+    return `data:text/javascript;charset=utf-8,${encodeURIComponent(js)}`
+}

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 require('../src/shared/index.css');
+// TODO get rid of inversify deps
 require("reflect-metadata");
 
 import { createGitpodService } from "@gitpod/gitpod-protocol";
@@ -12,6 +13,7 @@ import { DisposableCollection } from '@gitpod/gitpod-protocol/lib/util/disposabl
 import * as GitpodServiceClient from "./ide/gitpod-service-client";
 import * as heartBeat from "./ide/heart-beat";
 import * as IDEFrontendService from "./ide/ide-frontend-service-impl";
+import * as IDEWorker from "./ide/ide-worker";
 import * as IDEWebSocket from "./ide/ide-web-socket";
 import { SupervisorServiceClient } from "./ide/supervisor-service-client";
 import * as LoadingFrame from "./shared/loading-frame";
@@ -20,6 +22,7 @@ import { serverUrl, startUrl } from "./shared/urls";
 window.gitpod = {
     service: createGitpodService(serverUrl.toString())
 };
+IDEWorker.install();
 IDEWebSocket.install();
 const ideService = IDEFrontendService.create();
 const pendingGitpodServiceClient = GitpodServiceClient.create();

--- a/components/ws-daemon/seccomp-profile-installer/go.mod
+++ b/components/ws-daemon/seccomp-profile-installer/go.mod
@@ -4,11 +4,12 @@ go 1.15
 
 require (
 	github.com/Microsoft/hcsshim v0.8.10 // indirect
-	github.com/containerd/containerd v1.4.1 // indirect
+	github.com/containerd/containerd v1.4.1
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect
 	github.com/containerd/ttrpc v1.0.2 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -215,7 +215,13 @@ func TheiaRootHandler(r *mux.Router, config *RouteHandlerConfig, infoProvider Wo
 	client := http.Client{Timeout: 30 * time.Second}
 	r.NewRoute().HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		mode := req.Header.Get("Sec-Fetch-Mode")
-		if mode == "navigate" || mode == "nested-navigate" || mode == "same-origin" || mode == "websocket" {
+		dest := req.Header.Get("Sec-Fetch-Dest")
+		if mode == "navigate" || mode == "nested-navigate" || mode == "websocket" {
+			theiaProxyPass.ServeHTTP(w, req)
+			return
+		}
+
+		if mode == "same-origin" && !(dest == "worker" || dest == "sharedworker") {
 			theiaProxyPass.ServeHTTP(w, req)
 			return
 		}

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -214,6 +214,11 @@ func TheiaRootHandler(r *mux.Router, config *RouteHandlerConfig, infoProvider Wo
 
 	client := http.Client{Timeout: 30 * time.Second}
 	r.NewRoute().HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.RawQuery != "" || req.URL.RawFragment != "" {
+			theiaProxyPass.ServeHTTP(w, req)
+			return
+		}
+
 		coords := getWorkspaceCoords(req)
 		info := infoProvider.WorkspaceInfo(coords.ID)
 		if info == nil {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,12 +3466,28 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.4.2", "@types/react@16.7.0", "@types/react@^16.8.0":
+"@types/react@*":
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.2.tgz#f1a9cf1ee85221530def2ac26aee20f910a9dac8"
   integrity sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==
   dependencies:
     csstype "^2.2.0"
+
+"@types/react@16.7.0":
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.0.tgz#d33202339d6fb672c2ad0930c835ecf8ae0ac521"
+  integrity sha512-bHwfht6kILzUj1Hs5vmr9vpokDmcNXPbR55tKE/ZEylb3WtSt9hAuO68rsm73/sre2/MwLijfo8sD4ANe+HDUg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.8.0":
+  version "16.9.55"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.55.tgz#47078587f5bfe028a23b6b46c7b94ac0d436acff"
+  integrity sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/request-promise@^4.1.41":
   version "4.1.42"
@@ -3558,6 +3574,11 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/sharedworker@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/sharedworker/-/sharedworker-0.0.29.tgz#69ce70764a0380f4c27ae036f6f9c4e2c75dbdac"
+  integrity sha512-vdlrZJKGrAedfcMt4Tn8gIa3tJxRhrTtwfEu9jmVtaCZHgbensRMEbpkZ+dY/6WpE12a8K00KaQnJV0lH9ZmdA==
 
 "@types/showdown@^1.7.1":
   version "1.9.3"
@@ -7547,6 +7568,11 @@ csso@~2.3.1:
 csstype@^2.0.0, csstype@^2.2.0, csstype@^2.5.2:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
+
+csstype@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"
+  integrity sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -13390,7 +13416,7 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@2.14.1, nan@^2.0.0, nan@^2.10.0, nan@^2.13.2, nan@^2.14.0, nan@^2.9.2:
+nan@^2.0.0, nan@^2.10.0, nan@^2.13.2, nan@^2.14.0, nan@^2.9.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
@@ -13976,7 +14002,7 @@ onigasm@^2.2.0:
     lru-cache "^5.1.1"
     tslint "^5.20.1"
 
-oniguruma@7.2.1, oniguruma@^7.0.0:
+oniguruma@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
   integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
@@ -15397,7 +15423,17 @@ react-autosize-textarea@^7.0.0:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
-react-dom@16.12.0, react-dom@16.7.0, react-dom@^16.4.1, react-dom@^16.8.0:
+react-dom@16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
+  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.12.0"
+
+react-dom@^16.4.1, react-dom@^16.8.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
@@ -15490,7 +15526,17 @@ react-virtualized@^9.20.0:
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
 
-react@16.12.0, react@16.7.0, react@^16.4.1, react@^16.8.0:
+react@16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
+  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.12.0"
+
+react@^16.4.1, react@^16.8.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
@@ -16370,6 +16416,14 @@ sb-scandir@^2.0.0:
   dependencies:
     p-map "^1.2.0"
     sb-promisify "^2.0.1"
+
+scheduler@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
+  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.18.0:
   version "0.18.0"
@@ -18596,12 +18650,25 @@ vscode-debugprotocol@^1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.32.0.tgz#cca9eccb3f73ded5e525e01621a72ca2bb577dc3"
 
+vscode-jsonrpc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
+  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+
 vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
-vscode-languageserver-protocol@3.14.1, vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.0-next.8:
+vscode-languageserver-protocol@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
+  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+  dependencies:
+    vscode-jsonrpc "^4.0.0"
+    vscode-languageserver-types "3.14.0"
+
+vscode-languageserver-protocol@^3.15.0-next.8:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
@@ -18613,6 +18680,11 @@ vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
+
+vscode-languageserver-types@3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
+  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
 vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next:
   version "3.15.1"


### PR DESCRIPTION
- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https

#### What it does

- fix #2093: URIs with query cannot be static and should not be redirected to the blobserve, it breaks loading of icons for Gitpod Code from 3rd party extensions
- fix #2061: install proxying (Shared)Worker which serve from the workspace origin but fetch the worker content from the blobserve
- utilize [fetch metadata](https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header) to prevent redirect to blobserve for user navigation and same-origin requests (if not workers, see point above)

#### How to test

- Theia: 
- Code: