### PR TITLE
blobserve redirect improvements

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -135,4 +135,15 @@ export class GitpodHostUrl {
 
         return undefined;
     }
+
+    get blobServe(): boolean {
+        const hostSegments = this.url.host.split(".");
+        if (hostSegments[0] === 'blobserve') {
+            return true;
+        }
+
+        const pathSegments = this.url.pathname.split("/")
+        return pathSegments[0] === "blobserve";
+    }
+
 }

--- a/components/supervisor/frontend/package.json
+++ b/components/supervisor/frontend/package.json
@@ -12,6 +12,7 @@
     "@babel/plugin-transform-classes": "^7.10.0",
     "@babel/plugin-transform-runtime": "^7.10.0",
     "@babel/preset-env": "^7.10.0",
+    "@types/sharedworker": "^0.0.29",
     "babel-loader": "^8.0.6",
     "concurrently": "^5.3.0",
     "copy-webpack-plugin": "^6.2.0",

--- a/components/supervisor/frontend/public/worker-proxy.js
+++ b/components/supervisor/frontend/public/worker-proxy.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+// @ts-check
+
+/**
+ * The proxy (shared) worker serving from the workspace origin to fetch content from the blobserve origin.
+ */
+
+// TODO(ak) importScripts is not going to work for module workers: https://web.dev/module-workers/
+(function () {
+    var originalImportScripts = self.importScripts;
+    // hash contains the original worker URL to be used as a base URI to resolve script URLs
+    var baseURI = decodeURI(location.hash.substr(1));
+    self.importScripts = function (scriptUrl) {
+        return originalImportScripts(new URL(scriptUrl, baseURI).toString());
+    }
+    originalImportScripts(baseURI);
+})();

--- a/components/supervisor/frontend/src/ide/ide-worker.ts
+++ b/components/supervisor/frontend/src/ide/ide-worker.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+/**
+ * Installs the proxy (shared) worker serving from the same origin to fetch content from the blobserve origin.
+ */
+export function install(): void {
+    if (window.Worker) {
+        const Worker = window.Worker;
+        window.Worker = <any>function (scriptUrl: string | URL, options?: WorkerOptions) {
+            return new Worker(proxyUrl(scriptUrl), options);
+        };
+    }
+    if (window.SharedWorker) {
+        const SharedWorker = window.SharedWorker;
+        window.SharedWorker = <any>function (scriptUrl: string, options?: string | SharedWorkerOptions) {
+            return new SharedWorker(proxyUrl(scriptUrl), options);
+        };
+    }
+}
+
+function proxyUrl(scriptUrl: string | URL): string {
+    scriptUrl = typeof scriptUrl === 'string' ? new URL(scriptUrl, document.baseURI) : scriptUrl;
+    if (scriptUrl.origin !== location.origin || (scriptUrl.protocol !== 'http:' && scriptUrl.protocol !== 'https:')) {
+        return scriptUrl.toString();
+    }
+    return new URL('_supervisor/frontend/worker-proxy.js#' + encodeURI(scriptUrl.toString()), document.baseURI).toString();
+};

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 require('../src/shared/index.css');
+// TODO get rid of inversify deps
 require("reflect-metadata");
 
 import { createGitpodService } from "@gitpod/gitpod-protocol";
@@ -12,6 +13,7 @@ import { DisposableCollection } from '@gitpod/gitpod-protocol/lib/util/disposabl
 import * as GitpodServiceClient from "./ide/gitpod-service-client";
 import * as heartBeat from "./ide/heart-beat";
 import * as IDEFrontendService from "./ide/ide-frontend-service-impl";
+import * as IDEWorker from "./ide/ide-worker";
 import * as IDEWebSocket from "./ide/ide-web-socket";
 import { SupervisorServiceClient } from "./ide/supervisor-service-client";
 import * as LoadingFrame from "./shared/loading-frame";
@@ -20,6 +22,7 @@ import { serverUrl, startUrl } from "./shared/urls";
 window.gitpod = {
     service: createGitpodService(serverUrl.toString())
 };
+IDEWorker.install();
 IDEWebSocket.install();
 const ideService = IDEFrontendService.create();
 const pendingGitpodServiceClient = GitpodServiceClient.create();

--- a/components/ws-daemon/seccomp-profile-installer/go.mod
+++ b/components/ws-daemon/seccomp-profile-installer/go.mod
@@ -4,11 +4,12 @@ go 1.15
 
 require (
 	github.com/Microsoft/hcsshim v0.8.10 // indirect
-	github.com/containerd/containerd v1.4.1 // indirect
+	github.com/containerd/containerd v1.4.1
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect
 	github.com/containerd/ttrpc v1.0.2 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -168,7 +168,8 @@ func redirectToBlobserve(w http.ResponseWriter, req *http.Request, config *Route
 			req.URL.Path,
 		)
 	}
-	http.Redirect(w, req, redirectURL, 303)
+	// permament redirect to tell the browser to cache redirect request and don't ask the server again
+	http.Redirect(w, req, redirectURL, 308)
 }
 
 // SupervisorIDEHostHandler serves supervisor's IDE host

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -214,6 +214,11 @@ func TheiaRootHandler(r *mux.Router, config *RouteHandlerConfig, infoProvider Wo
 
 	client := http.Client{Timeout: 30 * time.Second}
 	r.NewRoute().HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.RawQuery != "" || req.URL.RawFragment != "" {
+			theiaProxyPass.ServeHTTP(w, req)
+			return
+		}
+
 		coords := getWorkspaceCoords(req)
 		info := infoProvider.WorkspaceInfo(coords.ID)
 		if info == nil {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3559,6 +3559,11 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/sharedworker@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/sharedworker/-/sharedworker-0.0.29.tgz#69ce70764a0380f4c27ae036f6f9c4e2c75dbdac"
+  integrity sha512-vdlrZJKGrAedfcMt4Tn8gIa3tJxRhrTtwfEu9jmVtaCZHgbensRMEbpkZ+dY/6WpE12a8K00KaQnJV0lH9ZmdA==
+
 "@types/showdown@^1.7.1":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@types/showdown/-/showdown-1.9.3.tgz#eaa881b03a32d3720184731754d3025fc450b970"


### PR DESCRIPTION
- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https

#### What it does

- fix #2093: URIs with query cannot be static and should not be redirected to the blobserve, it breaks loading of icons for Gitpod Code from 3rd party extensions
- fix #2061: install proxying (Shared)Worker which serve from the workspace origin but fetch the worker content from the blobserve
- utilize [fetch metadata](https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header) to prevent redirect to blobserve for user navigation and same-origin requests (if not workers, see point above)
- use permament redirect for the same workspace to avoid extra requests on page reload or workspace restart

#### How to test

- Start Theia workspace: https://ak-enh-blobserve-redirect.staging.gitpod-dev.com/#https://github.com/gitpod-io/go-gin-app
- Open devtools.
- Amend the last commin in the scm view and open the changed file. Check that the diff is properly highlighted.
- In the network tab of devtools check that workerMain is properly loaded.
- In the source tab of devtools check that editorWorkerService worker is running.
- Reload the page, check everything again.
- Stop this workspace, start another one (new), everything again and at the end check that workerMain was served from the browser cache.
- Enabel devops role for your user: `update d_b_user set rolesOrPermissions = '["admin","devops"]' where name = 'akosyakov';`
- Start Code workspace: https://ak-enh-blobserve-redirect.staging.gitpod-dev.com/#https://github.com/akosyakov/go-gin-app
- Check that file icons are loaded, i.e. in the explorer you see real icons, not placeholders.
- Run check similar to Theia workspace from above.
- In addition check an extension host worker (thread which handles web extensions) is running.
- Test everything in Chrome, FF and Safari.