### PR TITLE
[supervisor] fix #2092: handle gracefully ide restart

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 02021b3f4267917afb774747dcca21601fce52cb
+ENV GP_CODE_COMMIT 8a139e627387c9abd52d1161288fe019903e3270
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-task-contribution.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-task-contribution.ts
@@ -4,19 +4,18 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { injectable, inject, postConstruct } from 'inversify';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
-import { GitpodTerminalWidget } from './gitpod-terminal-widget';
-import { GitpodTaskState, GitpodTaskServer, GitpodTask } from '../common/gitpod-task-protocol';
+import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 import { IBaseTerminalServer } from '@theia/terminal/lib/common/base-terminal-protocol';
-import { Emitter } from '@theia/core';
+import { inject, injectable, postConstruct } from 'inversify';
+import { GitpodTask, GitpodTaskServer, GitpodTaskState } from '../common/gitpod-task-protocol';
+import { GitpodTerminalWidget } from './gitpod-terminal-widget';
 
 interface GitpodTaskTerminalWidget extends GitpodTerminalWidget {
     readonly kind: 'gitpod-task'
-    /** undefined if not running */
-    remoteTerminal?: string
+    applyTask(updated: GitpodTask): Promise<void>
 }
 namespace GitpodTaskTerminalWidget {
     const idPrefix = 'gitpod-task-terminal'
@@ -40,16 +39,20 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
     @inject(GitpodTaskServer)
     private readonly server: GitpodTaskServer;
 
-    private readonly onDidChangeEmitter = new Emitter<GitpodTask[]>();
-    private readonly onDidChange = this.onDidChangeEmitter.event;
-
     private readonly taskTerminals = new Map<string, GitpodTaskTerminalWidget>();
+
+    private readonly pendingInitialTasks = new Deferred<GitpodTask[]>();
+    private readonly pendingInitializeLayout = new Deferred<void>();
+    private updateQueue = this.pendingInitializeLayout.promise;
 
     @postConstruct()
     protected init(): void {
         // register client before connection is opened
         this.server.setClient({
-            onDidChange: ({ updated }) => this.onDidChangeEmitter.fire(updated)
+            onDidChange: ({ updated }) => {
+                this.pendingInitialTasks.resolve(updated);
+                this.queue(() => this.updateTerminals(updated));
+            }
         });
         this.terminals.onDidCreateTerminal(terminal => {
             if (GitpodTaskTerminalWidget.is(terminal)) {
@@ -57,19 +60,60 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
                 terminal.onDidDispose(() =>
                     this.taskTerminals.delete(terminal.id)
                 );
+                const attachTerminal = terminal['attachTerminal'].bind(terminal);
+                terminal['attachTerminal'] = id => attachTerminal(id).then(terminalId => {
+                    if (IBaseTerminalServer.validateId(terminalId)) {
+                        return terminalId
+                    }
+                    return terminal['createTerminal']()
+                })
+                let starting = false;
+                const start = terminal['start'].bind(terminal);
+                terminal['start'] = async id => {
+                    starting = true;
+                    try {
+                        return start(id)
+                    } finally {
+                        starting = false;
+                    }
+                }
+
+                let task: GitpodTask | undefined;
+                const update = async () => {
+                    if (task?.state === GitpodTaskState.CLOSED) {
+                        terminal.dispose();
+                        return;
+                    }
+                    const remoteTerminal = task?.terminal;
+                    if (task?.state !== GitpodTaskState.RUNNING || !remoteTerminal || starting) {
+                        return;
+                    }
+                    const terminalId = terminal.terminalId;
+                    if (IBaseTerminalServer.validateId(terminalId)) {
+                        await this.server.attach({ terminalId, remoteTerminal });
+                    } else {
+                        await terminal.start();
+                    }
+                }
+                terminal.applyTask = updated => {
+                    task = updated
+                    return update()
+                }
                 terminal.onTerminalDidClose(() => {
-                    if (terminal.remoteTerminal) {
-                        fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/terminal/close/' + terminal.remoteTerminal, {
+                    if (task && task.terminal && task.state !== GitpodTaskState.CLOSED) {
+                        fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/terminal/close/' + task.terminal, {
                             credentials: "include"
                         })
                     }
                 });
+                terminal.onDidOpen(update)
+                terminal.onDidOpenFailure(update);
             }
         });
     }
 
     async onDidInitializeLayout(): Promise<void> {
-        const tasks = await this.server.getTasks();
+        const tasks = await this.pendingInitialTasks.promise;
         let ref: TerminalWidget | undefined;
         for (const task of tasks) {
             if (task.state == GitpodTaskState.CLOSED) {
@@ -79,30 +123,24 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
                 const id = GitpodTaskTerminalWidget.toTerminalId(task.id);
                 let terminal = this.taskTerminals.get(id);
                 if (!terminal) {
-                    terminal = await this.terminals.newTerminal({
+                    terminal = (await this.terminals.newTerminal({
                         id,
                         kind: 'gitpod-task',
                         title: task.presentation!.name,
                         useServerTitle: false
-                    }) as GitpodTaskTerminalWidget;
-                    await terminal.start();
+                    })) as GitpodTaskTerminalWidget;
                     this.terminals.activateTerminal(terminal, {
                         ref,
                         area: task.presentation.openIn || 'bottom',
                         mode: task.presentation.openMode || 'tab-after'
                     });
-                } else if (!IBaseTerminalServer.validateId(terminal.terminalId)) {
-                    await terminal.start();
                 }
-                if (terminal) {
-                    ref = terminal;
-                }
+                ref = terminal;
             } catch (e) {
                 console.error('Failed to start Gitpod task terminal:', e);
             }
         }
-        this.updateTerminals(tasks);
-        this.onDidChange(tasks => this.updateTerminals(tasks));
+        this.pendingInitializeLayout.resolve();
 
         // if there is no terminal at all, lets start one
         if (!this.terminals.all.length) {
@@ -112,7 +150,7 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
         }
     }
 
-    protected async updateTerminals(tasks: GitpodTask[]): Promise<void> {
+    private async updateTerminals(tasks: GitpodTask[]): Promise<void> {
         for (const task of tasks) {
             try {
                 const id = GitpodTaskTerminalWidget.toTerminalId(task.id);
@@ -120,24 +158,15 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
                 if (!terminal) {
                     continue;
                 }
-                if (task.state === GitpodTaskState.CLOSED) {
-                    delete terminal.remoteTerminal;
-                    terminal.dispose();
-                    continue;
-                }
-                if (task.state !== GitpodTaskState.RUNNING) {
-                    continue;
-                }
-                terminal.remoteTerminal = task.terminal;
-                if (task.terminal) {
-                    await this.server.attach({
-                        terminalId: terminal.terminalId,
-                        remoteTerminal: task.terminal
-                    });
-                }
+                await terminal.applyTask(task);
             } catch (e) {
                 console.error('Failed to update Gitpod task terminal:', e);
             }
         }
     }
+
+    private queue(update: () => Promise<void>): Promise<void> {
+        return this.updateQueue = this.updateQueue.then(update, update);
+    }
+
 }

--- a/components/theia/packages/gitpod-extension/src/common/gitpod-port-server.ts
+++ b/components/theia/packages/gitpod-extension/src/common/gitpod-port-server.ts
@@ -11,7 +11,6 @@ export const gitpodPortServicePath = '/services/gitpodPorts';
 
 export const GitpodPortServer = Symbol('GitpodPortServer');
 export interface GitpodPortServer extends JsonRpcServer<GitpodPortClient> {
-    getPorts(): Promise<PortsStatus.AsObject[]>;
     exposePort(params: ExposeGitpodPortParams): Promise<void>;
 }
 
@@ -20,6 +19,7 @@ export interface GitpodPortClient {
 }
 
 export interface DidChangeGitpodPortsEvent {
+    initial?: boolean
     added?: PortsStatus.AsObject[]
     updated?: PortsStatus.AsObject[]
     removed?: number[]

--- a/components/theia/packages/gitpod-extension/src/common/gitpod-task-protocol.ts
+++ b/components/theia/packages/gitpod-extension/src/common/gitpod-task-protocol.ts
@@ -28,7 +28,6 @@ export const gitpodTaskServicePath = "/services/gitpodTasks";
 
 export const GitpodTaskServer = Symbol('GitpodTaskServer');
 export interface GitpodTaskServer extends JsonRpcServer<GitpodTaskClient> {
-    getTasks(): Promise<GitpodTask[]>;
     attach(params: AttachTaskTerminalParams): Promise<void>
 }
 export interface GitpodTaskClient {

--- a/components/theia/packages/gitpod-extension/src/node/gitpod-backend-module.ts
+++ b/components/theia/packages/gitpod-extension/src/node/gitpod-backend-module.ts
@@ -60,7 +60,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         new JsonRpcConnectionHandler<GitpodPortClient>(gitpodPortServicePath, client => {
             const server = context.container.get<GitpodPortServerImpl>(GitpodPortServer);
             server.setClient(client);
-            client.onDidCloseConnection(() => server.disposeClient(client));
             return server;
         })
     ).inSingletonScope();
@@ -69,7 +68,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         new JsonRpcConnectionHandler<GitpodTaskClient>(gitpodTaskServicePath, client => {
             const server = context.container.get<GitpodTaskServerImpl>(GitpodTaskServer);
             server.setClient(client);
-            client.onDidCloseConnection(() => server.disposeClient(client));
             return server;
         })
     ).inSingletonScope();


### PR DESCRIPTION
- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https

#### What it does

- fix #2092: handle gracefully IDE restart, before stopping an IDE crashed the supervisor
- ports and tasks Theia services are adjusted to handle IDE restart as well

#### How to test

- kill the IDE process, check that it gets restarted and frontend reconnected
- check that tasks terminals are reconnected and usable
- check that ports are functional
  - on reconnect to a restarted server there should not be double notifications, i.e. if you closed the preview, it should not pop up again
- check both Theia (https://akosyakov-supervisor-panics-if-2092.staging.gitpod-dev.com/#https://github.com/akosyakov/theia-training/tree/solution-1) and Code (https://akosyakov-supervisor-panics-if-2092.staging.gitpod-dev.com/#https://github.com/akosyakov/go-gin-app)