### PR TITLE
blobserver caching fixes

### DIFF
--- a/components/theia/app/scripts/postgenerate.js
+++ b/components/theia/app/scripts/postgenerate.js
@@ -6,13 +6,24 @@
 
 // @ts-check
 
-const os = require('os');
 const fs = require('fs');
 const path = require('path');
 
 const filePath = path.resolve(__dirname, '../lib/index.html');
-fs.writeFileSync(filePath, fs.readFileSync(filePath, { encoding: 'utf-8' }).replace('<script', [
-    '<meta id="gitpod-ide-capabilities" data-settings="' + JSON.stringify({ service: true }).replace(/"/g, '&quot;') + '">',
-    '<script type="text/javascript"  src="/_supervisor/frontend/main.js"  charset="utf-8"></script>',
-    '<script'
-].join(os.EOL + '  ')), { encoding: 'utf-8' });
+fs.writeFileSync(filePath, `<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="apple-mobile-web-app-capable" content="yes">
+    <meta id="gitpod-ide-capabilities" data-settings="{&quot;service&quot;:true}">
+</head>
+
+<body>
+	<script type="text/javascript" src="/_supervisor/frontend/main.js" charset="utf-8"></script>
+	<div class="theia-preload"></div>
+	<script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
+</body>
+
+</html>`, { encoding: 'utf-8' });

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -198,3 +198,13 @@ func createDefaultTransport(config *TransportConfig) *http.Transport {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 }
+
+// tell the browser to cache for 1 year and don't ask the server during this period
+func withLongTermCaching() proxyPassOpt {
+	return func(cfg *proxyPassConfig) {
+		cfg.ResponseHandler = func(resp *http.Response, req *http.Request) error {
+			resp.Header.Set("Cache-Control", "public, max-age=31536000")
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
#### What it does

- only use permanent redirects for IDE image, the supervisor image can change between workspace restarts
- enable long term caching for the blobserve IDE resources fetched within the same workspace, i.e. there is no need to fetch index.html again
- always proxy pass to the blob server before redirecting to ensure that images are downloaded
- fixes the blob server to redonwload the image if it was removed in the meantime
- retry to proxy pass to the blob server on the timeout error till the request is dropped by a user instead of exposing the error to a user
- make sure that the request is proxied pass to the workspace if the blobserve responses with client/server error codes
- fetch the supervisor, ide and loading screen in parallel

#### How to test

- start a workspace, open the devtools and reload
- check that the supervisor, ide and loading screen are fetched in parallel (you can try with slow 3G settings to make it more visible)
- check that most of static requests are pulled from the cache
- exec into the registry facade, wipe out the blobserve directory and reload the page
- check that images were downloaded in the blobserve again
- check that the page eventually is loaded, it can hang a bit waiting for the download
- check that IDE static requests are still pulled from the cache