### PR TITLE
[user-storage] add limit for content length

### DIFF
--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-user-storage-contribution.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-user-storage-contribution.ts
@@ -17,6 +17,8 @@ export class GitpodUserStorageContribution extends UserStorageContribution {
     protected readonly provider: GitpodUserStorageProvider;
 
     protected async createProvider(service: FileService): Promise<FileSystemProvider> {
+        const delegate = await super.createProvider(service);
+        this.provider.setDelegate(delegate);
         return this.provider;
     }
 


### PR DESCRIPTION
To avoid flooding of the database, we need to limit the size of user storage resources uploaded to the server. 

In case we reach a defined threshold we fall back to Theia's default file-based storage. 