### PR TITLE
[ws-daemon] Isolate content initialiser better

### DIFF
--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -30,6 +30,8 @@ daemon:
       attempts: 3
     fullWorkspaceBackup:
       workdir: "/mnt/node0/gitpod-{{ .Release.Namespace }}"
+    initializer:
+      command: "/app/content-initializer"
   uidmapper:
     procLocation: "/proc"
     rootUIDRange:

--- a/components/content-service/pkg/layer/provider.go
+++ b/components/content-service/pkg/layer/provider.go
@@ -69,7 +69,7 @@ func (s *Provider) downloadContentManifest(ctx context.Context, bkt, obj string)
 		}
 	}()
 
-	info, err = s.Storage.Download(ctx, bkt, obj)
+	info, err = s.Storage.SignDownload(ctx, bkt, obj)
 	if err != nil {
 		return
 	}
@@ -151,7 +151,7 @@ func (s *Provider) GetContentLayer(ctx context.Context, owner, workspaceID strin
 
 	// check if legacy workspace backup is present
 	var layer *Layer
-	info, err := s.Storage.Download(ctx, bucket, fmt.Sprintf(fmtLegacyBackupName, workspaceID))
+	info, err := s.Storage.SignDownload(ctx, bucket, fmt.Sprintf(fmtLegacyBackupName, workspaceID))
 	if err != nil && !xerrors.Is(err, storage.ErrNotFound) {
 		return nil, nil, err
 	}
@@ -315,7 +315,7 @@ func (s *Provider) layerFromContentManifest(ctx context.Context, mf *csapi.Works
 	// we have a valid full workspace backup
 	l = make([]Layer, len(mf.Layers))
 	for i, mfl := range mf.Layers {
-		info, err := s.Storage.Download(ctx, mfl.Bucket, mfl.Object)
+		info, err := s.Storage.SignDownload(ctx, mfl.Bucket, mfl.Object)
 		if err != nil {
 			return nil, err
 		}

--- a/components/content-service/pkg/layer/provider_test.go
+++ b/components/content-service/pkg/layer/provider_test.go
@@ -211,7 +211,7 @@ func (*testStorage) Bucket(userID string) string {
 	return "bucket-" + userID
 }
 
-func (s *testStorage) Download(ctx context.Context, bucket, obj string) (info *storage.DownloadInfo, err error) {
+func (s *testStorage) SignDownload(ctx context.Context, bucket, obj string) (info *storage.DownloadInfo, err error) {
 	info, ok := s.Objs[obj]
 	if !ok || info == nil {
 		return nil, storage.ErrNotFound

--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -259,14 +259,25 @@ func (rs *DirectGCPStorage) Download(ctx context.Context, destination string, na
 
 // DownloadSnapshot downloads a snapshot. The snapshot name is expected to be one produced by Qualify
 func (rs *DirectGCPStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
-	segments := strings.Split(name, "@")
-	if len(segments) != 2 {
-		return false, xerrors.Errorf("%s is not a valid GCloud remote storage FQN", name)
+	bkt, obj, err := ParseSnapshotName(name)
+	if err != nil {
+		return false, err
 	}
 
-	obj := segments[0]
-	bkt := segments[1]
 	return rs.download(ctx, destination, bkt, obj)
+}
+
+// ParseSnapshotName parses the name of a snapshot into bucket and object
+func ParseSnapshotName(name string) (bkt, obj string, err error) {
+	segments := strings.Split(name, "@")
+	if len(segments) != 2 {
+		err = xerrors.Errorf("%s is not a valid GCloud remote storage FQN", name)
+		return
+	}
+
+	obj = segments[0]
+	bkt = segments[1]
+	return
 }
 
 // Qualify fully qualifies a snapshot name so that it can be downloaded using DownloadSnapshot
@@ -632,6 +643,11 @@ func (rs *DirectGCPStorage) Bucket(ownerID string) string {
 	return gcpBucketName(rs.Stage, ownerID)
 }
 
+// BackupObject returns a backup's object name that a direct downloader would download
+func (rs *DirectGCPStorage) BackupObject(name string) string {
+	return rs.objectName(name)
+}
+
 func gcpBucketName(stage Stage, ownerID string) string {
 	return fmt.Sprintf("gitpod-%s-user-%s", stage, ownerID)
 }
@@ -720,8 +736,8 @@ func (p *PresignedGCPStorage) Bucket(owner string) string {
 	return gcpBucketName(p.stage, owner)
 }
 
-// Download provides presigned URLs to access remote storage objects
-func (p *PresignedGCPStorage) Download(ctx context.Context, bucket, object string) (*DownloadInfo, error) {
+// SignDownload provides presigned URLs to access remote storage objects
+func (p *PresignedGCPStorage) SignDownload(ctx context.Context, bucket, object string) (*DownloadInfo, error) {
 	client, err := newGCPClient(ctx, p.config)
 	if err != nil {
 		return nil, err

--- a/components/content-service/pkg/storage/noop.go
+++ b/components/content-service/pkg/storage/noop.go
@@ -48,11 +48,21 @@ func (rs *DirectNoopStorage) Bucket(string) string {
 	return ""
 }
 
+// BackupObject returns a backup's object name that a direct downloader would download
+func (rs *DirectNoopStorage) BackupObject(name string) string {
+	return ""
+}
+
+// SnapshotObject returns a snapshot's object name that a direct downloer would download
+func (rs *DirectNoopStorage) SnapshotObject(name string) string {
+	return ""
+}
+
 // PresignedNoopStorage does nothing
 type PresignedNoopStorage struct{}
 
-// Download returns ErrNotFound
-func (*PresignedNoopStorage) Download(ctx context.Context, bucket, obj string) (info *DownloadInfo, err error) {
+// SignDownload returns ErrNotFound
+func (*PresignedNoopStorage) SignDownload(ctx context.Context, bucket, obj string) (info *DownloadInfo, err error) {
 	return nil, ErrNotFound
 }
 

--- a/components/content-service/pkg/storage/storage.go
+++ b/components/content-service/pkg/storage/storage.go
@@ -31,18 +31,24 @@ var (
 	ErrNotFound = fmt.Errorf("not found")
 )
 
-// Namer provides names for storage objects
-type Namer interface {
+// BucketNamer provides names for storage buckets
+type BucketNamer interface {
 	// Bucket provides the bucket name for a particular user
 	Bucket(userID string) string
 }
 
+// ObjectNamer provides names for storage objects
+type ObjectNamer interface {
+	// BackupObject returns a backup's object name that a direct downloader would download
+	BackupObject(name string) string
+}
+
 // PresignedAccess provides presigned URLs to access remote storage objects
 type PresignedAccess interface {
-	Namer
+	BucketNamer
 
-	// Download describes an object for download - if the object is not found, ErrNotFound is returned
-	Download(ctx context.Context, bucket, obj string) (info *DownloadInfo, err error)
+	// SignDownload describes an object for download - if the object is not found, ErrNotFound is returned
+	SignDownload(ctx context.Context, bucket, obj string) (info *DownloadInfo, err error)
 }
 
 // ObjectMeta describtes the metadata of a remote object
@@ -71,7 +77,8 @@ type DirectDownloader interface {
 
 // DirectAccess represents a remote location where we can store data
 type DirectAccess interface {
-	Namer
+	BucketNamer
+	ObjectNamer
 	DirectDownloader
 
 	// Init initializes the remote storage - call this before calling anything else on the interface

--- a/components/ws-daemon/BUILD.yaml
+++ b/components/ws-daemon/BUILD.yaml
@@ -15,10 +15,30 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+  - name: content-initializer
+    type: go
+    srcs:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+    deps:
+      - components/common-go:lib
+      - components/content-service-api/go:lib
+      - components/content-service:lib
+      - components/ws-daemon-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=linux
+    prep:
+      - ["mv", "cmd/content-initializer/main.go", "."]
+    config:
+      packaging: app
+      dontTest: true
   - name: docker
     type: docker
     deps:
       - :app
+      - :content-initializer
     argdeps:
       - imageRepoBase
     config:

--- a/components/ws-daemon/cmd/content-initializer.go
+++ b/components/ws-daemon/cmd/content-initializer.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
+	"github.com/spf13/cobra"
+)
+
+// contentInitializerCmd creates a workspace snapshot
+var contentInitializerCmd = &cobra.Command{
+	Use:   "content-initializer",
+	Short: "fork'ed by ws-daemon to initialize content",
+	Args:  cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return content.RunInitializerChild()
+	},
+}
+
+func init() {
+	clientCmd.AddCommand(contentInitializerCmd)
+}

--- a/components/ws-daemon/cmd/content-initializer/main.go
+++ b/components/ws-daemon/cmd/content-initializer/main.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"os"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
+)
+
+func main() {
+	log.Init("content-initializer", "", true, true)
+	tracing.Init("content-initializer")
+
+	err := content.RunInitializerChild()
+	if err != nil {
+		log.WithError(err).Error("content init failed")
+		os.Exit(42)
+	}
+}

--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/components/ws-daemon/go.sum
+++ b/components/ws-daemon/go.sum
@@ -147,7 +147,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
-github.com/fatih/gomodifytags v1.9.0/go.mod h1:TbUyEjH1Zo0GkJd2Q52oVYqYcJ0eGNqG8bsiOb75P9c=
 github.com/fatih/gomodifytags v1.12.0/go.mod h1:TbUyEjH1Zo0GkJd2Q52oVYqYcJ0eGNqG8bsiOb75P9c=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:latest
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
-RUN apk add --no-cache git bash openssh-client lz4 e2fsprogs coreutils tar
+RUN apk add --no-cache git bash openssh-client lz4 e2fsprogs coreutils tar runc strace
 
 # Add gitpod user for operations (e.g. checkout because of the post-checkout hook!)
 RUN addgroup -g 33333 gitpod \
@@ -13,6 +13,7 @@ RUN addgroup -g 33333 gitpod \
     && echo "gitpod:gitpod" | chpasswd
 
 COPY components-ws-daemon--app/ws-daemon /app/ws-daemond
+COPY components-ws-daemon--content-initializer/ws-daemon /app/content-initializer
 
 USER root
 ENTRYPOINT [ "/app/ws-daemond" ]

--- a/components/ws-daemon/pkg/content/config.go
+++ b/components/ws-daemon/pkg/content/config.go
@@ -51,4 +51,13 @@ type Config struct {
 		// WorkDir is a directory located on the same disk as the upperdir of containers
 		WorkDir string `json:"workdir"`
 	} `json:"fullWorkspaceBackup,omitempty"`
+
+	// Initializer configures the isolated content initializer runtime
+	Initializer struct {
+		// Command is the path to content-initializer executable
+		Command string `json:"command"`
+
+		// Args are additional arguments to pass to the CI runtime
+		Args []string `json:"args"`
+	} `json:"initializer"`
 }

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -1,0 +1,346 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package content
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	wsinit "github.com/gitpod-io/gitpod/content-service/pkg/initializer"
+	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opentracing/opentracing-go"
+
+	"golang.org/x/xerrors"
+)
+
+// RunInitializerOpts configure RunInitializer
+type RunInitializerOpts struct {
+	// Command is the path to the initializer executable we'll run
+	Command string
+	// Args is a set of additional arguments to pass to the initializer executable
+	Args []string
+
+	UID uint32
+	GID uint32
+
+	OWI map[string]interface{}
+}
+
+func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps storage.PresignedAccess, workspaceOwner string, initializer *csapi.WorkspaceInitializer) (rc map[string]storage.DownloadInfo, err error) {
+	rc = make(map[string]storage.DownloadInfo)
+
+	backup, err := ps.SignDownload(ctx, rs.Bucket(workspaceOwner), rs.BackupObject(storage.DefaultBackup))
+	if err == storage.ErrNotFound {
+		// no backup found - that's fine
+	} else if err != nil {
+		return nil, err
+	} else {
+		rc[storage.DefaultBackup] = *backup
+	}
+
+	if si := initializer.GetSnapshot(); si != nil {
+		bkt, obj, err := storage.ParseSnapshotName(si.Snapshot)
+		if err != nil {
+			return nil, err
+		}
+		info, err := ps.SignDownload(ctx, bkt, obj)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot find snapshot: %w", err)
+		}
+
+		rc[storage.DefaultBackup] = *info
+	}
+	if si := initializer.GetPrebuild(); si != nil && si.Prebuild != nil {
+		bkt, obj, err := storage.ParseSnapshotName(si.Prebuild.Snapshot)
+		if err != nil {
+			return nil, err
+		}
+		info, err := ps.SignDownload(ctx, bkt, obj)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot find prebuild: %w", err)
+		}
+
+		rc[storage.DefaultBackup] = *info
+	}
+
+	return rc, nil
+}
+
+// RunInitializer runs a content initializer in a user, PID and mount namespace to isolate it from ws-daemon
+func RunInitializer(ctx context.Context, destination string, initializer *csapi.WorkspaceInitializer, remoteContent map[string]storage.DownloadInfo, opts RunInitializerOpts) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "RunInitializer")
+	defer tracing.FinishSpan(span, &err)
+
+	span.LogKV("remoteContent", remoteContent)
+
+	// it's possible the destination folder doesn't exist yet, because the kubelet hasn't created it yet.
+	// If we fail to create the folder, it either already exists, or we'll fail when we try and mount it.
+	err = os.MkdirAll(destination, 0755)
+	if err != nil && !os.IsExist(err) {
+		return xerrors.Errorf("cannot mkdir destination: %w", err)
+	}
+
+	init, err := proto.Marshal(initializer)
+	if err != nil {
+		return err
+	}
+
+	if opts.GID == 0 {
+		opts.GID = wsinit.GitpodGID
+	}
+	if opts.UID == 0 {
+		opts.UID = wsinit.GitpodUID
+	}
+
+	tmpdir, err := ioutil.TempDir("", "content-init")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	err = os.MkdirAll(filepath.Join(tmpdir, "rootfs"), 0755)
+	if err != nil {
+		return err
+	}
+
+	msg := msgInitContent{
+		Destination:   "/dst",
+		Initializer:   init,
+		RemoteContent: remoteContent,
+		TraceInfo:     tracing.GetTraceID(span),
+		GID:           int(opts.GID),
+		UID:           int(opts.UID),
+		OWI:           opts.OWI,
+	}
+	fc, err := json.MarshalIndent(msg, "", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "rootfs", "content.json"), fc, 0644)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("runc", "spec")
+	cmd.Dir = tmpdir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return xerrors.Errorf("cannot create runc spec: %s: %w", string(out), err)
+	}
+
+	cfgFN := filepath.Join(tmpdir, "config.json")
+	var spec specs.Spec
+	fc, err = ioutil.ReadFile(cfgFN)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(fc, &spec)
+	if err != nil {
+		return err
+	}
+
+	// we assemble the root filesystem from the ws-daemon container
+	for _, d := range []string{"app", "bin", "dev", "etc", "lib", "opt", "sbin", "sys", "usr", "var"} {
+		spec.Mounts = append(spec.Mounts, specs.Mount{
+			Destination: "/" + d,
+			Source:      "/" + d,
+			Type:        "bind",
+			Options:     []string{"rbind", "rprivate"},
+		})
+	}
+	spec.Mounts = append(spec.Mounts, specs.Mount{
+		Destination: "/dst",
+		Source:      destination,
+		Type:        "bind",
+		Options:     []string{"bind", "rprivate"},
+	})
+
+	spec.Hostname = "content-init"
+	spec.Process.Terminal = false
+	spec.Process.NoNewPrivileges = true
+	spec.Process.User.UID = opts.UID
+	spec.Process.User.GID = opts.GID
+	spec.Process.Args = []string{"/app/content-initializer"}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "JAEGER_") {
+			spec.Process.Env = append(spec.Process.Env, e)
+		}
+	}
+
+	// TODO(cw): make the initializer work without chown
+	spec.Process.Capabilities.Ambient = append(spec.Process.Capabilities.Ambient, "CAP_CHOWN")
+	spec.Process.Capabilities.Bounding = append(spec.Process.Capabilities.Bounding, "CAP_CHOWN")
+	spec.Process.Capabilities.Effective = append(spec.Process.Capabilities.Effective, "CAP_CHOWN")
+	spec.Process.Capabilities.Inheritable = append(spec.Process.Capabilities.Inheritable, "CAP_CHOWN")
+	spec.Process.Capabilities.Permitted = append(spec.Process.Capabilities.Permitted, "CAP_CHOWN")
+	// TODO(cw): setup proper networking in a netns, rather than relying on ws-daemons network
+	n := 0
+	for _, x := range spec.Linux.Namespaces {
+		if x.Type == specs.NetworkNamespace {
+			continue
+		}
+
+		spec.Linux.Namespaces[n] = x
+		n++
+	}
+	spec.Linux.Namespaces = spec.Linux.Namespaces[:n]
+
+	fc, err = json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(cfgFN, fc, 0644)
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.Command("runc", "--root", "state", "--debug", "--log-format", "json", "run", "gogogo")
+	cmd.Dir = tmpdir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunInitializerChild is the function that's exepcted to run when we call `/proc/self/exe content-initializer`
+func RunInitializerChild() (err error) {
+	fc, err := ioutil.ReadFile("/content.json")
+	if err != nil {
+		return err
+	}
+
+	var initmsg msgInitContent
+	json.Unmarshal(fc, &initmsg)
+	if err != nil {
+		return err
+	}
+
+	span := opentracing.StartSpan("RunInitializerChild", opentracing.FollowsFrom(tracing.FromTraceID(initmsg.TraceInfo)))
+	defer tracing.FinishSpan(span, &err)
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
+
+	var req csapi.WorkspaceInitializer
+	err = proto.Unmarshal(initmsg.Initializer, &req)
+	if err != nil {
+		return err
+	}
+
+	rs := &remoteContentStorage{RemoteContent: initmsg.RemoteContent}
+
+	initializer, err := wsinit.NewFromRequest(ctx, "/dst", rs, &req)
+	if err != nil {
+		return err
+	}
+
+	initSource, err := wsinit.InitializeWorkspace(ctx, "/dst", rs,
+		wsinit.WithInitializer(initializer),
+		wsinit.WithCleanSlate,
+		wsinit.WithChown(initmsg.UID, initmsg.GID),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Place the ready file to make Theia "open its gates"
+	err = wsinit.PlaceWorkspaceReadyFile(ctx, "/dst", initSource, initmsg.UID, initmsg.GID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type remoteContentStorage struct {
+	RemoteContent map[string]storage.DownloadInfo
+}
+
+// Init does nothing
+func (rs *remoteContentStorage) Init(ctx context.Context, owner, workspace string) error {
+	return nil
+}
+
+// EnsureExists does nothing
+func (rs *remoteContentStorage) EnsureExists(ctx context.Context) error {
+	return nil
+}
+
+// Download always returns false and does nothing
+func (rs *remoteContentStorage) Download(ctx context.Context, destination string, name string) (exists bool, err error) {
+	info, exists := rs.RemoteContent[name]
+	if !exists {
+		return false, nil
+	}
+
+	resp, err := http.Get(info.URL)
+	if err != nil {
+		return true, err
+	}
+	defer resp.Body.Close()
+
+	err = archive.Untar(resp.Body, destination, &archive.TarOptions{})
+	if err != nil {
+		return true, err
+	}
+
+	return true, nil
+}
+
+// DownloadSnapshot always returns false and does nothing
+func (rs *remoteContentStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
+	return rs.Download(ctx, destination, name)
+}
+
+// Qualify just returns the name
+func (rs *remoteContentStorage) Qualify(name string) string {
+	return name
+}
+
+// Upload does nothing
+func (rs *remoteContentStorage) Upload(ctx context.Context, source string, name string, opts ...storage.UploadOption) (string, string, error) {
+	return "", "", fmt.Errorf("not implemented")
+}
+
+// Bucket returns an empty string
+func (rs *remoteContentStorage) Bucket(string) string {
+	return ""
+}
+
+// BackupObject returns a backup's object name that a direct downloader would download
+func (rs *remoteContentStorage) BackupObject(name string) string {
+	return ""
+}
+
+// SnapshotObject returns a snapshot's object name that a direct downloer would download
+func (rs *remoteContentStorage) SnapshotObject(name string) string {
+	return ""
+}
+
+type msgInitContent struct {
+	Destination   string
+	RemoteContent map[string]storage.DownloadInfo
+	Initializer   []byte
+	UID, GID      int
+
+	TraceInfo string
+	OWI       map[string]interface{}
+}


### PR DESCRIPTION
This PR introduces another defence-in-depth layer to the classic workspace content init path: it wraps all init operations (including Git) in a "container".

`ws-daemon` is fairly privileged, and we want to isolate it as much as possible from user-specific workload and files, e.g. in case of Git remote execution CVEs. In this PR we delegate the actual content initialisation to a `content-initializer` binary which gets started using `runc`. The userland for this process comes from rbind-mounts to the ws-daemon rootfs.

To make backup works we pre-sign snapshots, prebuilds and backups, inject them into the content-initialiser and offer them using a new `storage.DirectAccess` implementation.

### How to test

#### Basic Restart
1. Start a workspace from an example repo
2. Make changes in that workspace
3. Stop the workspace
4. Start the workspace again, make sure your changes are still present

#### Prebuilds
1. Start a prebuild for a repo
2. Start a workspace from that prebuild

#### User Namespaces
1. Enable user namespaces for your user: `leeway run components/ws-daemon:enabled-userns-ff`
2. Start a new workspace and ensure it starts
3. Start an old workspace from one of the previous tests. It should start without problems and file permissions in `/workspace` should be as expected.