### PR TITLE
[blobserve] Resolve blob layer only once

### DIFF
--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000
+	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
@@ -22,6 +23,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.32.0
 	gotest.tools/v3 v3.0.3 // indirect

--- a/components/registry-facade/pkg/blobserve/blobserve.go
+++ b/components/registry-facade/pkg/blobserve/blobserve.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -18,7 +17,6 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry"
 	"github.com/gorilla/mux"
-	"golang.org/x/xerrors"
 )
 
 // Server offers image blobs for download
@@ -26,9 +24,7 @@ type Server struct {
 	Config   Config
 	Resolver registry.ResolverProvider
 
-	blobspace *blobspace
-	refcache  map[string]string
-	mu        sync.RWMutex
+	refstore *refstore
 }
 
 // Config configures a server.
@@ -50,16 +46,15 @@ type Config struct {
 
 // NewServer creates a new blob server
 func NewServer(cfg Config, resolver registry.ResolverProvider) (*Server, error) {
-	bs, err := newBlobSpace(cfg.BlobSpace.Location, cfg.BlobSpace.MaxSize, 10*time.Minute)
+	refstore, err := newRefStore(cfg, resolver)
 	if err != nil {
 		return nil, err
 	}
 
 	s := &Server{
-		Config:    cfg,
-		Resolver:  resolver,
-		blobspace: bs,
-		refcache:  make(map[string]string),
+		Config:   cfg,
+		Resolver: resolver,
+		refstore: refstore,
 	}
 	for repo, repoCfg := range cfg.Repos {
 		for _, ver := range repoCfg.PrePull {
@@ -118,7 +113,7 @@ func (reg *Server) serve(w http.ResponseWriter, req *http.Request) {
 
 	// The blobFor operation's context must be independent of this request. Even if we do not
 	// serve this request in time, we might want to serve another from the same ref in the future.
-	blob, err := reg.blobFor(context.Background(), ref, req.Header.Get("X-BlobServe-ReadOnly") == "true")
+	blob, err := reg.refstore.BlobFor(context.Background(), ref, req.Header.Get("X-BlobServe-ReadOnly") == "true")
 	if err == errdefs.ErrNotFound {
 		http.Error(w, fmt.Sprintf("image %s not found: %q", ref, err), http.StatusNotFound)
 		return
@@ -176,95 +171,8 @@ func isNoWebsocketRequest(req *http.Request, match *mux.RouteMatch) bool {
 
 // Prepare downloads a blob and prepares it for use independently of any request
 func (reg *Server) Prepare(ctx context.Context, ref string) (err error) {
-	_, err = reg.blobFor(ctx, ref, false)
+	_, err = reg.refstore.BlobFor(ctx, ref, false)
 	return
-}
-
-func (reg *Server) blobFor(ctx context.Context, ref string, readOnly bool) (fs http.FileSystem, err error) {
-	reg.mu.RLock()
-	dgst := reg.refcache[ref]
-	reg.mu.RUnlock()
-
-	state := blobUnknown
-	if dgst != "" {
-		fs, state = reg.blobspace.Get(dgst)
-	}
-
-	if state == blobUnknown {
-		if readOnly {
-			return nil, errdefs.ErrNotFound
-		}
-		return reg.downloadBlobFor(ctx, ref)
-	}
-
-	if state != blobReady {
-		return nil, xerrors.Errorf("unready blob for %s", dgst)
-	}
-
-	return fs, nil
-}
-
-func (reg *Server) downloadBlobFor(ctx context.Context, ref string) (fs http.FileSystem, err error) {
-	// TODO(cw): If multiple requests are made while the download happens we'll start multiple downloads (one per request).
-	//           Instead we should properly sync/manage/timeout state here.
-
-	resolver := reg.Resolver()
-	_, desc, err := resolver.Resolve(ctx, ref)
-	if err != nil {
-		return nil, err
-	}
-	fetcher, err := resolver.Fetcher(ctx, ref)
-	if err != nil {
-		return nil, err
-	}
-
-	manifest, _, err := registry.DownloadManifest(ctx, fetcher, desc)
-	if err != nil {
-		return nil, err
-	}
-
-	layerCount := len(manifest.Layers)
-	if layerCount <= 0 {
-		log.WithField("ref", ref).Error("image has no layers - cannot serve its blob")
-		return nil, errdefs.ErrNotFound
-	}
-	if layerCount > 1 {
-		log.WithField("ref", ref).Warn("image has more than one layers - serving from first layer only")
-	}
-	blobLayer := manifest.Layers[0]
-	dgst := blobLayer.Digest.Hex()
-
-	for {
-		fs, state := reg.blobspace.Get(dgst)
-		switch state {
-		case blobUnknown:
-			in, err := fetcher.Fetch(ctx, blobLayer)
-			defer in.Close()
-			if err != nil {
-				return nil, err
-			}
-
-			log.WithField("digest", dgst).WithField("ref", ref).Info("downloading blob to serve over HTTP")
-			err = reg.blobspace.AddFromTarGzip(ctx, dgst, in)
-			if err != nil {
-				return nil, xerrors.Errorf("cannot download blob: %w", err)
-			}
-
-		case blobUnready:
-			if ctx.Err() != nil {
-				return nil, err
-			}
-
-			// TODO: replace busy waiting on the blob becoming available with something mutex/channel based
-			time.Sleep(500 * time.Millisecond)
-
-		case blobReady:
-			reg.mu.Lock()
-			reg.refcache[ref] = dgst
-			reg.mu.Unlock()
-			return fs, nil
-		}
-	}
 }
 
 type prefixingFilesystem struct {

--- a/components/registry-facade/pkg/blobserve/refstore.go
+++ b/components/registry-facade/pkg/blobserve/refstore.go
@@ -1,0 +1,260 @@
+package blobserve
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/remotes"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/xerrors"
+)
+
+const (
+	// parallelBlobDownloads is the number of service worker a refstore uses to
+	// serve download requests.
+	parallelBlobDownloads = 10
+)
+
+type refstore struct {
+	Resolver registry.ResolverProvider
+
+	mu        sync.RWMutex
+	refcache  map[string]*refstate
+	requests  chan downloadRequest
+	blobspace blobspace
+
+	close chan struct{}
+	once  *sync.Once
+}
+
+func newRefStore(cfg Config, resolver registry.ResolverProvider) (*refstore, error) {
+	bs, err := newBlobSpace(cfg.BlobSpace.Location, cfg.BlobSpace.MaxSize, 10*time.Minute)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &refstore{
+		Resolver:  resolver,
+		blobspace: bs,
+		refcache:  make(map[string]*refstate),
+		requests:  make(chan downloadRequest),
+		once:      &sync.Once{},
+		close:     make(chan struct{}),
+	}
+	for i := 0; i < parallelBlobDownloads; i++ {
+		go res.serveRequests()
+	}
+	return res, nil
+}
+
+type refstate struct {
+	Digest string
+
+	ch chan struct{}
+}
+
+func (r *refstate) Done() bool {
+	select {
+	case <-r.ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *refstate) Wait(ctx context.Context) (err error) {
+	select {
+	case <-r.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *refstate) MarkDone() {
+	close(r.ch)
+}
+
+func (store *refstore) BlobFor(ctx context.Context, ref string, readOnly bool) (fs http.FileSystem, err error) {
+	store.mu.RLock()
+	rs, exists := store.refcache[ref]
+	store.mu.RUnlock()
+
+	if exists {
+		err = rs.Wait(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !exists && readOnly {
+		return nil, errdefs.ErrNotFound
+	}
+
+	blobState := blobUnknown
+	if exists {
+		// refcache thinks this blob should exist. It might have been GC'ed in the meantime,
+		// hence blobState can validly be blobUnknown.
+		fs, blobState = store.blobspace.Get(rs.Digest)
+	}
+	if blobState == blobUnknown {
+		// if refcache thinks the blob should exist, but it doesn't, we force a redownload.
+		err = store.downloadBlobFor(ctx, ref, exists)
+		if err != nil {
+			return nil, err
+		}
+		store.mu.RLock()
+		rs, exists = store.refcache[ref]
+		store.mu.RUnlock()
+
+		// Even though we triggered a download, that doesn't mean
+		// it was our download request that actually is at work here.
+		// We have to wait for the download to actually finish.
+		err = rs.Wait(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		// now that we've (re-)attempted to download the blob, it must exist.
+		// if it doesn't something went wrong while trying to download this thing.
+		fs, blobState = store.blobspace.Get(rs.Digest)
+		if blobState != blobReady {
+			return nil, errdefs.ErrNotFound
+		}
+	}
+
+	return fs, nil
+}
+
+func (store *refstore) Close() {
+	store.once.Do(func() {
+		close(store.requests)
+		close(store.close)
+	})
+}
+
+type downloadRequest struct {
+	Context context.Context
+	Ref     string
+	Force   bool
+	Resp    chan<- error
+}
+
+func (store *refstore) downloadBlobFor(ctx context.Context, ref string, force bool) (err error) {
+	resp := make(chan error, 1)
+	store.requests <- downloadRequest{
+		Context: ctx,
+		Ref:     ref,
+		Resp:    resp,
+		Force:   force,
+	}
+
+	select {
+	case r := <-resp:
+		return r
+	case <-store.close:
+		return xerrors.Errorf("store closed")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (store *refstore) serveRequests() {
+	for req := range store.requests {
+		req.Resp <- store.handleRequest(req.Context, req.Ref, req.Force)
+	}
+}
+
+func (store *refstore) handleRequest(ctx context.Context, ref string, force bool) (err error) {
+	store.mu.Lock()
+	rs, exists := store.refcache[ref]
+	if exists && !force {
+		// someone has handled this request already
+		store.mu.Unlock()
+		return nil
+	}
+	rs = &refstate{ch: make(chan struct{})}
+	store.refcache[ref] = rs
+	store.mu.Unlock()
+
+	defer func() {
+		if err != nil {
+			store.mu.Lock()
+			delete(store.refcache, ref)
+			store.mu.Unlock()
+		}
+		rs.MarkDone()
+	}()
+
+	resolver := store.Resolver()
+
+	layer, err := resolveRef(ctx, ref, resolver)
+	if err != nil {
+		return err
+	}
+	digest := layer.Digest.Hex()
+	rs.Digest = digest
+
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	for {
+		_, state := store.blobspace.Get(digest)
+		switch state {
+		case blobUnknown:
+			in, err := fetcher.Fetch(ctx, *layer)
+			if err != nil {
+				return err
+			}
+
+			err = store.blobspace.AddFromTarGzip(ctx, digest, in)
+			in.Close()
+			if err != nil {
+				return xerrors.Errorf("cannot download blob: %w", err)
+			}
+
+		case blobUnready:
+			if ctx.Err() != nil {
+				return err
+			}
+
+			// TODO(cw): replace busy waiting on the blob becoming available with something mutex/channel based
+			time.Sleep(500 * time.Millisecond)
+
+		case blobReady:
+			return nil
+		}
+	}
+}
+
+func resolveRef(ctx context.Context, ref string, resolver remotes.Resolver) (*ociv1.Descriptor, error) {
+	_, desc, err := resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	manifest, _, err := registry.DownloadManifest(ctx, fetcher, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	layerCount := len(manifest.Layers)
+	if layerCount <= 0 {
+		log.WithField("ref", ref).Error("image has no layers - cannot serve its blob")
+		return nil, errdefs.ErrNotFound
+	}
+	if layerCount > 1 {
+		log.WithField("ref", ref).Warn("image has more than one layers - serving from first layer only")
+	}
+	blobLayer := manifest.Layers[0]
+	return &blobLayer, nil
+}

--- a/components/registry-facade/pkg/blobserve/refstore_test.go
+++ b/components/registry-facade/pkg/blobserve/refstore_test.go
@@ -1,0 +1,487 @@
+package blobserve
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/containerd/containerd/remotes"
+	"github.com/google/go-cmp/cmp"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestBlobFor(t *testing.T) {
+	const (
+		refDescriptor = "test"
+		hashManifest  = "5de870aced7e6c182a10e032e94de15893c95edd80d9cc20348b0f1627826d93"
+		hashLayer     = "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"
+	)
+	var (
+		provideDescriptor = func() ([]byte, error) {
+			return json.Marshal(ociv1.Descriptor{
+				MediaType: ociv1.MediaTypeImageManifest,
+				Digest:    "sha256:" + hashManifest,
+				Size:      10,
+			})
+		}
+		descriptorLayer = ociv1.Descriptor{
+			MediaType: ociv1.MediaTypeImageLayerGzip,
+			Digest:    "sha256:4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714",
+			Size:      10,
+		}
+		provideManifest = func() ([]byte, error) {
+			return json.Marshal(ociv1.Manifest{
+				Layers: []ociv1.Descriptor{
+					descriptorLayer,
+				},
+			})
+		}
+		provideLayer = func() ([]byte, error) {
+			out := bytes.NewBuffer(nil)
+			gz := gzip.NewWriter(out)
+			tr := tar.NewWriter(gz)
+			tr.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: "foo.txt", Size: 0})
+			tr.Close()
+			gz.Close()
+			return out.Bytes(), nil
+		}
+	)
+	type Expectation struct {
+		Error    string
+		Refcache map[string]string
+		Content  map[string]blobstate
+	}
+
+	tests := []struct {
+		Desc             string
+		FetchableContent map[string]provider
+		ExtraAction      func(t *testing.T, s *refstore) error
+		Expectation      Expectation
+	}{
+		{
+			Desc: "cached fetch",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+				hashLayer:     provideLayer,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) (err error) {
+				_, err = s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+
+				// fetching again with an empty fake fetcher should work just fine - everything is cached now
+				s.Resolver = func() remotes.Resolver { return &fakeFetcher{} }
+				_, err = s.BlobFor(context.Background(), "test", false)
+				return err
+			},
+			Expectation: Expectation{
+				Content: map[string]blobstate{hashLayer: blobReady},
+				Refcache: map[string]string{
+					refDescriptor: hashLayer,
+				},
+			},
+		},
+		{
+			Desc:             "ref not found",
+			FetchableContent: map[string]provider{},
+			Expectation: Expectation{
+				Error: "not found",
+			},
+		},
+		{
+			Desc: "manifest not found",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+			},
+			Expectation: Expectation{
+				Error: "cannot download manifest: " + hashManifest + " not found",
+			},
+		},
+		{
+			Desc: "layer not found",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+			},
+			Expectation: Expectation{
+				Error: hashLayer + " not found",
+			},
+		},
+		{
+			Desc: "no layers",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest: func() ([]byte, error) {
+					return json.Marshal(ociv1.Manifest{})
+				},
+			},
+			Expectation: Expectation{
+				Error: "not found",
+			},
+		},
+		{
+			Desc: "two layers",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest: func() ([]byte, error) {
+					return json.Marshal(ociv1.Manifest{
+						Layers: []ociv1.Descriptor{
+							descriptorLayer,
+							{
+								MediaType: ociv1.MediaTypeImageLayerGzip,
+								Digest:    "sha256:ff20094863725f7f1a6b06b281d009143c1510f1985ff87bc0229816ac3e853c",
+								Size:      10,
+							},
+						},
+					})
+				},
+				hashLayer: provideLayer,
+			},
+			Expectation: Expectation{
+				Content: map[string]blobstate{hashLayer: blobReady},
+				Refcache: map[string]string{
+					refDescriptor: hashLayer,
+				},
+			},
+		},
+		{
+			Desc: "layer on second attempt",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) (err error) {
+				_, err = s.BlobFor(context.Background(), refDescriptor, false)
+				if err == nil {
+					return fmt.Errorf("found layer although we shouldn't have")
+				}
+				s.Resolver = func() remotes.Resolver {
+					return &fakeFetcher{
+						Content: map[string]provider{
+							refDescriptor: provideDescriptor,
+							hashManifest:  provideManifest,
+							hashLayer:     provideLayer,
+						},
+					}
+				}
+				_, err = s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				Refcache: map[string]string{
+					refDescriptor: hashLayer,
+				},
+				Content: map[string]blobstate{
+					hashLayer: blobReady,
+				},
+			},
+		},
+		{
+			Desc: "1000 parallel downloads",
+			ExtraAction: func(t *testing.T, s *refstore) error {
+				var (
+					mu   sync.Mutex
+					once bool
+					run  = make(chan struct{})
+				)
+				s.Resolver = func() remotes.Resolver {
+					mu.Lock()
+					defer mu.Unlock()
+
+					if once {
+						return &fakeFetcher{}
+					}
+					once = true
+
+					return &fakeFetcher{
+						Content: map[string]provider{
+							refDescriptor: provideDescriptor,
+							hashManifest:  provideManifest,
+							hashLayer:     provideLayer,
+						},
+					}
+				}
+
+				eg, ctx := errgroup.WithContext(context.Background())
+				for i := 0; i < 1000; i++ {
+					i := i
+					eg.Go(func() error {
+						if i == 100 {
+							close(run)
+						}
+						_, err := s.BlobFor(ctx, refDescriptor, false)
+						if err != nil {
+							return fmt.Errorf("client %03d: %w", i, err)
+						}
+						return nil
+					})
+				}
+				err := eg.Wait()
+				return err
+			},
+			Expectation: Expectation{
+				Refcache: map[string]string{"test": "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"},
+				Content:  map[string]blobstate{"4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714": blobReady},
+			},
+		},
+		{
+			Desc: "readonly pre-existing",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+				hashLayer:     provideLayer,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) error {
+				_, err := s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+				_, err = s.BlobFor(context.Background(), refDescriptor, true)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				Refcache: map[string]string{"test": "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"},
+				Content:  map[string]blobstate{"4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714": blobReady},
+			},
+		},
+		{
+			Desc: "readonly non-existent",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+				hashLayer:     provideLayer,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) error {
+				_, err := s.BlobFor(context.Background(), refDescriptor, true)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				Error: "not found",
+			},
+		},
+		{
+			Desc: "blobspace looses blobs",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+				hashLayer:     provideLayer,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) error {
+				_, err := s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+
+				delete(s.blobspace.(*inMemoryBlobspace).Content, hashLayer)
+
+				_, err = s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				Content: map[string]blobstate{hashLayer: blobReady},
+				Refcache: map[string]string{
+					refDescriptor: hashLayer,
+				},
+			},
+		},
+		{
+			Desc: "blobspace looses blobs (readonly)",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+				hashLayer:     provideLayer,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) error {
+				_, err := s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+
+				delete(s.blobspace.(*inMemoryBlobspace).Content, hashLayer)
+
+				_, err = s.BlobFor(context.Background(), refDescriptor, true)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				Content: map[string]blobstate{hashLayer: blobReady},
+				Refcache: map[string]string{
+					refDescriptor: hashLayer,
+				},
+			},
+		},
+		{
+			Desc: "first layer download fails",
+			FetchableContent: map[string]provider{
+				refDescriptor: provideDescriptor,
+				hashManifest:  provideManifest,
+				hashLayer:     provideLayer,
+			},
+			ExtraAction: func(t *testing.T, s *refstore) error {
+				bs := s.blobspace.(*inMemoryBlobspace)
+				oadd := bs.Adder
+
+				bs.Adder = func(ctx context.Context, name string, in io.Reader) (err error) {
+					return fmt.Errorf("failed to download")
+				}
+				_, err := s.BlobFor(context.Background(), refDescriptor, false)
+				if err == nil {
+					return fmt.Errorf("first download didn't fail")
+				}
+
+				bs.Adder = oadd
+				_, err = s.BlobFor(context.Background(), refDescriptor, false)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				Content: map[string]blobstate{hashLayer: blobReady},
+				Refcache: map[string]string{
+					refDescriptor: hashLayer,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Desc, func(t *testing.T) {
+			ff := &fakeFetcher{Content: test.FetchableContent}
+
+			content := make(map[string]blobstate)
+			bs := &inMemoryBlobspace{
+				Content: content,
+				Adder: func(ctx context.Context, name string, in io.Reader) (err error) {
+					content[name] = blobReady
+					return nil
+				},
+			}
+
+			var res Expectation
+
+			s := &refstore{
+				Resolver:  func() remotes.Resolver { return ff },
+				blobspace: bs,
+				refcache:  make(map[string]*refstate),
+				close:     make(chan struct{}),
+				once:      &sync.Once{},
+				requests:  make(chan downloadRequest),
+			}
+			for i := 0; i < parallelBlobDownloads; i++ {
+				go s.serveRequests()
+			}
+			defer s.Close()
+
+			var err error
+			if test.ExtraAction == nil {
+				_, err = s.BlobFor(context.Background(), refDescriptor, false)
+			} else {
+				err = test.ExtraAction(t, s)
+			}
+			if err != nil {
+				res.Error = err.Error()
+			}
+
+			if len(content) > 0 {
+				res.Content = content
+			}
+			if len(s.refcache) > 0 {
+				res.Refcache = make(map[string]string)
+				for k, v := range s.refcache {
+					res.Refcache[k] = v.Digest
+				}
+			}
+
+			if diff := cmp.Diff(test.Expectation, res); diff != "" {
+				t.Errorf("unexpected state (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}
+
+type inMemoryBlobspace struct {
+	Content map[string]blobstate
+	Adder   func(ctx context.Context, name string, in io.Reader) (err error)
+}
+
+func (s *inMemoryBlobspace) Get(name string) (fs http.FileSystem, state blobstate) {
+	return nil, s.Content[name]
+}
+
+func (s *inMemoryBlobspace) AddFromTarGzip(ctx context.Context, name string, in io.Reader) (err error) {
+	return s.Adder(ctx, name, in)
+}
+
+type provider func() ([]byte, error)
+
+type fakeFetcher struct {
+	Content map[string]provider
+}
+
+func (f *fakeFetcher) Resolve(ctx context.Context, ref string) (name string, desc ociv1.Descriptor, err error) {
+	name = ref
+	fc, ok := f.Content[ref]
+	if !ok {
+		err = fmt.Errorf("not found")
+		return
+	}
+	c, err := fc()
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(c, &desc)
+	return
+}
+
+// Pusher returns a new pusher for the provided reference
+func (f *fakeFetcher) Pusher(ctx context.Context, ref string) (remotes.Pusher, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Fetcher returns a new fetcher for the provided reference.
+// All content fetched from the returned fetcher will be
+// from the namespace referred to by ref.
+func (f *fakeFetcher) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
+	return f, nil
+}
+
+func (f *fakeFetcher) Fetch(ctx context.Context, desc ociv1.Descriptor) (io.ReadCloser, error) {
+	fc, ok := f.Content[desc.Digest.Encoded()]
+	if !ok {
+		return nil, fmt.Errorf("%s not found", desc.Digest.Encoded())
+	}
+	c, err := fc()
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.NopCloser(bytes.NewReader(c)), nil
+}


### PR DESCRIPTION
This PR makes blobserve more resilient towards concurrent access.
When multiple requests are made for the same reference, this change ensures that we're only resolving/downloading it once.

Also, this PR increases the test coverage.

### ToDo
- [x] add tests for concurrent access patterns
- [x] add test for failing ref resolution
- [x] add test for failing blob download