### PR TITLE
[helm] Remove starting strip marker of template expression after license comment

### DIFF
--- a/chart/templates/cerc-service-account.yaml
+++ b/chart/templates/cerc-service-account.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 TypeFox GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{- if not .Values.components.cerc.disabled -}}
+{{ if not .Values.components.cerc.disabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/templates/cerc-unprivileged-rolebinding.yaml
+++ b/chart/templates/cerc-unprivileged-rolebinding.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 TypeFox GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{- if not .Values.components.cerc.disabled -}}
+{{ if not .Values.components.cerc.disabled -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:


### PR DESCRIPTION
Having these strip markers leads to a comment like `... project root for license information.kind:RoleBindung` or `... project root for license information.apiVersion: v1` (the first YAML line is added to the comment).
