### PR TITLE
[ws-daemon] Tone down resource controller logs

### DIFF
--- a/components/ws-daemon/pkg/dispatch/dispatch.go
+++ b/components/ws-daemon/pkg/dispatch/dispatch.go
@@ -241,7 +241,6 @@ func (d *Dispatch) handlePodUpdate(oldPod, newPod *corev1.Pod) {
 	if !state.SeenContainer {
 		return
 	}
-	log.WithFields(wsk8s.GetOWIFromObject(&oldPod.ObjectMeta)).Info("received received pod update for a workspace")
 
 	state.Workspace.Pod = newPod
 

--- a/components/ws-daemon/pkg/resources/dispatch.go
+++ b/components/ws-daemon/pkg/resources/dispatch.go
@@ -134,6 +134,5 @@ func (d *DispatchListener) WorkspaceUpdated(ctx context.Context, ws *dispatch.Wo
 	}
 
 	gov.SetFixedCPULimit(scaledLimit)
-	gov.log.WithField("limit", scaledLimit).Info("set fixed CPU limit for workspace")
 	return nil
 }

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -10,8 +10,6 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4
-	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
 	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -67,8 +67,6 @@ github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YAR
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -82,8 +80,6 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c h1:N7A4JCA2G+j5fuFxCsJqjFU/sZe0mj8H0sSoSwbaikw=
-github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c/go.mod h1:Nn5wlyECw3iJrzi0AhIWg+AJUb4PlRQVW4/3XHH1LZA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=


### PR DESCRIPTION
This PR makes the resource controller less noisy in the logs.

Prior, the resource controller would complain if the cgroup did not exist. Usually that's because the container hasn't started yet, or has stopped already - either way, that's no reason to spam the logs.

### How to test
1. start a workspace
2. stop a workspace
3. notice how ws-daemon no longer produces logs like
  ![image](https://user-images.githubusercontent.com/3210701/98781111-24b99080-23f6-11eb-978a-3db07226a34e.png)
  but more like this
  ![image](https://user-images.githubusercontent.com/3210701/98781267-5b8fa680-23f6-11eb-81e5-57be47cd27d8.png)
