### PR TITLE
[ws-daemon] Add workaround for containerd ErrNotFound issue

### DIFF
--- a/chart/templates/ws-daemon-clusterrole.yaml
+++ b/chart/templates/ws-daemon-clusterrole.yaml
@@ -37,3 +37,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete

--- a/components/ws-daemon/pkg/container/container.go
+++ b/components/ws-daemon/pkg/container/container.go
@@ -21,6 +21,10 @@ type Runtime interface {
 	// Implementors have to respect context cancelation.
 	WaitForContainerStop(ctx context.Context, workspaceInstanceID string) error
 
+	// ContainerExists finds out if a container with the given ID exists. The existence of the container says nothing about the
+	// container's state, which may be running, stopped, deleted, unkown or something else.
+	ContainerExists(ctx context.Context, id ID) (exists bool, err error)
+
 	// ContainerUpperdir finds the workspace container's overlayfs upperdir. The location returned here has to be accessible from
 	// the calling process (i.e. if the calling process runs in a container itself, the returned location has to be accessible from
 	// within that container).

--- a/components/ws-daemon/pkg/container/containerd.go
+++ b/components/ws-daemon/pkg/container/containerd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/typeurl"
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -398,6 +399,19 @@ func (s *Containerd) WaitForContainerStop(ctx context.Context, workspaceInstance
 		err = ctx.Err()
 		return
 	}
+}
+
+// ContainerExists finds out if a container with the given ID exists.
+func (s *Containerd) ContainerExists(ctx context.Context, id ID) (exists bool, err error) {
+	_, err = s.Client.ContainerService().Get(ctx, string(id))
+	if err == errdefs.ErrNotFound {
+		return false, nil
+	}
+	if err == nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // ContainerUpperdir finds the workspace container's overlayfs upperdir.

--- a/components/ws-daemon/pkg/daemon/containerd4214.go
+++ b/components/ws-daemon/pkg/daemon/containerd4214.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/dispatch"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// propagationGracePeriod is the time we allow on top of a container's deletionGracePeriod
+	// to make sure the changes propagate on the data plane.
+	propagationGracePeriod = 10 * time.Second
+
+	maxDeletionAttempts     = 10
+	deletionAttemptInterval = 2 * time.Second
+)
+
+// Containerd4214Workaround words around https://github.com/containerd/containerd/pull/4214
+//
+// containerd/runc had an issue where if runc deleted a container and containerd would not know about it
+// the Kubernetes CRI would fail to stop the pod. This bug was fixed in containerd 1.4.0 and backported
+// to containerd 1.3.7.
+//
+// Some clusters might run an older version of containerd, for which we build this workaround.
+type Containerd4214Workaround struct {
+	mu      sync.Mutex
+	handled map[string]struct{}
+}
+
+// WorkspaceAdded does nothing but implemented the dispatch.Listener interface
+func (c *Containerd4214Workaround) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspace) error {
+	return nil
+}
+
+// WorkspaceUpdated gets called when a workspace pod is updated. For containers being deleted, we'll check
+// if they're still running after their terminationGracePeriod and if Kubernetes still knows about them.
+func (c *Containerd4214Workaround) WorkspaceUpdated(ctx context.Context, ws *dispatch.Workspace) error {
+	if ws.Pod.DeletionTimestamp == nil {
+		return nil
+	}
+
+	c.mu.Lock()
+	if c.handled == nil {
+		c.handled = make(map[string]struct{})
+	}
+	if _, exists := c.handled[ws.InstanceID]; exists {
+		c.mu.Unlock()
+		return nil
+	}
+	c.handled[ws.InstanceID] = struct{}{}
+	c.mu.Unlock()
+
+	var gracePeriod int64
+	if ws.Pod.DeletionGracePeriodSeconds != nil {
+		gracePeriod = *ws.Pod.DeletionGracePeriodSeconds
+	} else {
+		gracePeriod = 30
+	}
+	ttl := time.Duration(gracePeriod)*time.Second + propagationGracePeriod
+
+	dsp := dispatch.GetFromContext(ctx)
+	go func() {
+		time.Sleep(ttl)
+		err := c.ensurePodGetsDeleted(dsp.Runtime, dsp.Kubernetes, ws)
+		if err != nil {
+			log.WithError(err).Error("cannot ensure workspace pod gets deleted")
+		}
+	}()
+
+	return nil
+}
+
+// ensurePodGetsDeleted will check if the container still exists on this node, i.e. still runs.
+// If it doesn't, it'll force delete it from Kubernetes. We'll retry several times, with an exponential
+// back-off.
+func (c *Containerd4214Workaround) ensurePodGetsDeleted(rt container.Runtime, clientSet kubernetes.Interface, ws *dispatch.Workspace) (err error) {
+	var (
+		log         = log.WithFields(ws.OWI())
+		podName     = ws.Pod.Name
+		namespace   = ws.Pod.Namespace
+		containerID = ws.ContainerID
+	)
+
+	delay := deletionAttemptInterval
+	for attempt := 0; attempt < maxDeletionAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(delay)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		var exists bool
+		exists, err = rt.ContainerExists(ctx, containerID)
+		cancel()
+		if err != nil {
+			log.WithField("attempt", attempt).WithError(err).Warn("Containerd4214Workaround cannot check if container still exists")
+			continue
+		}
+		if exists {
+			continue
+		}
+
+		err = clientSet.CoreV1().Pods(namespace).Delete(podName, v1.NewDeleteOptions(0))
+		if err, ok := err.(*k8serr.StatusError); ok && err.ErrStatus.Code == http.StatusNotFound {
+			return nil
+		}
+		if err != nil {
+			log.WithField("attempt", attempt).WithError(err).WithField("contaienrID", containerID).Warn("cannot force-delete orphaned workspace pod")
+			continue
+		}
+
+		log.WithField("attempt", attempt).Info("force-deleted workspace pod after its container was gone")
+		return nil
+	}
+	return err
+}

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -50,6 +50,7 @@ func NewDaemon(config Config, prom prometheus.Registerer) (*Daemon, error) {
 	}
 	dsptch, err := dispatch.NewDispatch(containerRuntime, clientset, config.Runtime.KubernetesNamespace, nodename,
 		resources.NewDispatchListener(&config.Resources, prom),
+		&Containerd4214Workaround{},
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds a workaround to ws-daemon which force-deletes Kubernetes pods if their containers are gone, and they've exceeded their deletion grace period.

This fix is necessary when we run in environments with a too old containerd version that don't contain https://github.com/containerd/containerd/pull/4214. 

### How to test
1. start three workspaces
2. delete them all using `kubectl delete pod -l component=workspace`
3. none of those workspaces should require force-delete, check with
  ```
  kubectl get pods -l component=ws-daemon -o json | jq -r '.items[] | .metadata.name' | while read f; do kubectl logs $f; done | grep force-delete
  ```
4. enable user-ns: `leeway run components/ws-daemon:enabled-userns-ff`
5. start three new workspaces
6. delete them all using `kubectl delete pod -l component=workspace`
7. some workspaces (maybe all) may have required force-delete, check with the same command as above