### PR TITLE
[supervisor] reconnect if the server ws is closed

### DIFF
--- a/components/supervisor/pkg/gitpod/reconnecting-ws.go
+++ b/components/supervisor/pkg/gitpod/reconnecting-ws.go
@@ -64,7 +64,7 @@ func (rc *ReconnectingWebsocket) WriteObject(v interface{}) error {
 		if err == nil {
 			return nil
 		}
-		if !websocket.IsCloseError(err) {
+		if !websocket.IsUnexpectedCloseError(err) {
 			return err
 		}
 		select {
@@ -90,7 +90,7 @@ func (rc *ReconnectingWebsocket) ReadObject(v interface{}) error {
 		if err == nil {
 			return nil
 		}
-		if !websocket.IsCloseError(err) {
+		if !websocket.IsUnexpectedCloseError(err) {
 			return err
 		}
 		select {


### PR DESCRIPTION
#### What it does

- fix #2158: `websocket.IsCloseError` returns true only for provided codes, one should use `websocket. IsUnexpectedCloseError` for any code

#### How to test

- start a workspace and check that toggling port visibility gets reflected in the UI
- kill the server pod and try to toggle visibility again, it should start working again at some point
- inspect workspace pod logs for how reconnection to the server went