### PR TITLE
[ws-daemon] Use `tar` to unarchive backup instead of archive pkg

### DIFF
--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1


### PR DESCRIPTION
Fixes #2160

### How to test
1. Start a workspace on gitpod: http://cw-fix-2160.staging.gitpod-dev.com/#github.com/gitpod-io/gitpod
2. Stop the workspace
3. Start it again