### PR TITLE
[ide] use pseudo terminals for tasks

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 8a139e627387c9abd52d1161288fe019903e3270
+ENV GP_CODE_COMMIT 053541afb9f5d8338041c5ed182ef9e6e12e589e
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-task-contribution.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-task-contribution.ts
@@ -4,23 +4,20 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { Deferred } from '@theia/core/lib/common/promise-util';
+import { FrontendApplicationContribution, Widget, WidgetManager } from '@theia/core/lib/browser';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
-import { IBaseTerminalServer } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { inject, injectable, postConstruct } from 'inversify';
-import { GitpodTask, GitpodTaskServer, GitpodTaskState } from '../common/gitpod-task-protocol';
+import { GitpodTaskServer, GitpodTaskState } from '../common/gitpod-task-protocol';
 import { GitpodTerminalWidget } from './gitpod-terminal-widget';
 
 interface GitpodTaskTerminalWidget extends GitpodTerminalWidget {
     readonly kind: 'gitpod-task'
-    applyTask(updated: GitpodTask): Promise<void>
 }
 namespace GitpodTaskTerminalWidget {
     const idPrefix = 'gitpod-task-terminal'
-    export function is(terminal: TerminalWidget): terminal is GitpodTaskTerminalWidget {
-        return terminal.kind === 'gitpod-task';
+    export function is(terminal: Widget): terminal is GitpodTaskTerminalWidget {
+        return terminal instanceof GitpodTerminalWidget && terminal.kind === 'gitpod-task';
     }
     export function toTerminalId(id: string): string {
         return idPrefix + ':' + id;
@@ -36,84 +33,40 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
     @inject(TerminalFrontendContribution)
     private readonly terminals: TerminalFrontendContribution;
 
+    @inject(WidgetManager)
+    private readonly widgetManager: WidgetManager;
+
     @inject(GitpodTaskServer)
     private readonly server: GitpodTaskServer;
 
-    private readonly taskTerminals = new Map<string, GitpodTaskTerminalWidget>();
-
-    private readonly pendingInitialTasks = new Deferred<GitpodTask[]>();
-    private readonly pendingInitializeLayout = new Deferred<void>();
-    private updateQueue = this.pendingInitializeLayout.promise;
-
     @postConstruct()
     protected init(): void {
-        // register client before connection is opened
-        this.server.setClient({
-            onDidChange: ({ updated }) => {
-                this.pendingInitialTasks.resolve(updated);
-                this.queue(() => this.updateTerminals(updated));
-            }
-        });
-        this.terminals.onDidCreateTerminal(terminal => {
+        this.widgetManager.onWillCreateWidget(event => {
+            const terminal = event.widget;
             if (GitpodTaskTerminalWidget.is(terminal)) {
-                this.taskTerminals.set(terminal.id, terminal);
-                terminal.onDidDispose(() =>
-                    this.taskTerminals.delete(terminal.id)
-                );
-                const attachTerminal = terminal['attachTerminal'].bind(terminal);
-                terminal['attachTerminal'] = id => attachTerminal(id).then(terminalId => {
-                    if (IBaseTerminalServer.validateId(terminalId)) {
-                        return terminalId
-                    }
-                    return terminal['createTerminal']()
-                })
-                let starting = false;
-                const start = terminal['start'].bind(terminal);
-                terminal['start'] = async id => {
-                    starting = true;
-                    try {
-                        return start(id)
-                    } finally {
-                        starting = false;
-                    }
+                terminal['createTerminal'] = () => {
+                    const taskId = GitpodTaskTerminalWidget.getTaskId(terminal);
+                    return this.server.attach(taskId);
                 }
-
-                let task: GitpodTask | undefined;
-                const update = async () => {
-                    if (task?.state === GitpodTaskState.CLOSED) {
-                        terminal.dispose();
-                        return;
-                    }
-                    const remoteTerminal = task?.terminal;
-                    if (task?.state !== GitpodTaskState.RUNNING || !remoteTerminal || starting) {
-                        return;
-                    }
-                    const terminalId = terminal.terminalId;
-                    if (IBaseTerminalServer.validateId(terminalId)) {
-                        await this.server.attach({ terminalId, remoteTerminal });
-                    } else {
-                        await terminal.start();
-                    }
+                terminal['attachTerminal'] = () => {
+                    const taskId = GitpodTaskTerminalWidget.getTaskId(terminal);
+                    return this.server.attach(taskId);
                 }
-                terminal.applyTask = updated => {
-                    task = updated
-                    return update()
-                }
-                terminal.onTerminalDidClose(() => {
-                    if (task && task.terminal && task.state !== GitpodTaskState.CLOSED) {
-                        fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/terminal/close/' + task.terminal, {
-                            credentials: "include"
-                        })
-                    }
-                });
-                terminal.onDidOpen(update)
-                terminal.onDidOpenFailure(update);
+                terminal.onDidOpenFailure(() => terminal.dispose());
             }
         });
     }
 
     async onDidInitializeLayout(): Promise<void> {
-        const tasks = await this.pendingInitialTasks.promise;
+        const tasks = await this.server.getTasks()
+
+        const taskTerminals = new Map<string, GitpodTaskTerminalWidget>();
+        for (const terminal of this.terminals.all) {
+            if (GitpodTaskTerminalWidget.is(terminal)) {
+                taskTerminals.set(terminal.id, terminal);
+            }
+        }
+
         let ref: TerminalWidget | undefined;
         for (const task of tasks) {
             if (task.state == GitpodTaskState.CLOSED) {
@@ -121,14 +74,16 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
             }
             try {
                 const id = GitpodTaskTerminalWidget.toTerminalId(task.id);
-                let terminal = this.taskTerminals.get(id);
+                let terminal = taskTerminals.get(id);
                 if (!terminal) {
                     terminal = (await this.terminals.newTerminal({
                         id,
                         kind: 'gitpod-task',
                         title: task.presentation!.name,
-                        useServerTitle: false
+                        useServerTitle: false,
+                        destroyTermOnClose: true,
                     })) as GitpodTaskTerminalWidget;
+                    terminal.start();
                     this.terminals.activateTerminal(terminal, {
                         ref,
                         area: task.presentation.openIn || 'bottom',
@@ -140,7 +95,6 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
                 console.error('Failed to start Gitpod task terminal:', e);
             }
         }
-        this.pendingInitializeLayout.resolve();
 
         // if there is no terminal at all, lets start one
         if (!this.terminals.all.length) {
@@ -148,25 +102,6 @@ export class GitpodTaskContribution implements FrontendApplicationContribution {
             terminal.start();
             this.terminals.open(terminal);
         }
-    }
-
-    private async updateTerminals(tasks: GitpodTask[]): Promise<void> {
-        for (const task of tasks) {
-            try {
-                const id = GitpodTaskTerminalWidget.toTerminalId(task.id);
-                const terminal = this.taskTerminals.get(id);
-                if (!terminal) {
-                    continue;
-                }
-                await terminal.applyTask(task);
-            } catch (e) {
-                console.error('Failed to update Gitpod task terminal:', e);
-            }
-        }
-    }
-
-    private queue(update: () => Promise<void>): Promise<void> {
-        return this.updateQueue = this.updateQueue.then(update, update);
     }
 
 }

--- a/components/theia/packages/gitpod-extension/src/common/gitpod-task-protocol.ts
+++ b/components/theia/packages/gitpod-extension/src/common/gitpod-task-protocol.ts
@@ -28,17 +28,7 @@ export const gitpodTaskServicePath = "/services/gitpodTasks";
 
 export const GitpodTaskServer = Symbol('GitpodTaskServer');
 export interface GitpodTaskServer extends JsonRpcServer<GitpodTaskClient> {
-    attach(params: AttachTaskTerminalParams): Promise<void>
+    getTasks(): Promise<GitpodTask[]>
+    attach(taskId: string): Promise<number>
 }
-export interface GitpodTaskClient {
-    onDidChange(event: DidChangeGitpodTasksEvent): void
-}
-
-export interface DidChangeGitpodTasksEvent {
-    updated: GitpodTask[]
-}
-
-export interface AttachTaskTerminalParams {
-    terminalId: number
-    remoteTerminal: string
-}
+export interface GitpodTaskClient { }

--- a/components/theia/packages/gitpod-extension/src/node/gitpod-backend-module.ts
+++ b/components/theia/packages/gitpod-extension/src/node/gitpod-backend-module.ts
@@ -43,6 +43,7 @@ import { SupervisorClientProvider } from "./supervisor-client-provider";
 import { GitpodTaskServer, GitpodTaskClient, gitpodTaskServicePath } from "../common/gitpod-task-protocol";
 import { GitpodTaskServerImpl } from "./gitpod-task-server-impl";
 import { GitpodPortServer, GitpodPortClient, gitpodPortServicePath } from "../common/gitpod-port-server";
+import { GitpodTaskTerminalProcess, GitpodTaskTerminalProcessFactory, GitpodTaskTerminalProcessOptions } from "./gitpod-task-terminal-process";
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(ShellProcess).to(GitpodShellProcess).inTransientScope();
@@ -63,6 +64,15 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
             return server;
         })
     ).inSingletonScope();
+
+    bind(GitpodTaskTerminalProcessFactory).toFactory(context =>
+        (options: GitpodTaskTerminalProcessOptions) => {
+            const child = context.container.createChild();
+            child.bind(GitpodTaskTerminalProcessOptions).toConstantValue(options);
+            child.bind(GitpodTaskTerminalProcess).toSelf().inSingletonScope();
+            return child.get(GitpodTaskTerminalProcess);
+        }
+    );
     bind(GitpodTaskServer).to(GitpodTaskServerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(context =>
         new JsonRpcConnectionHandler<GitpodTaskClient>(gitpodTaskServicePath, client => {

--- a/components/theia/packages/gitpod-extension/src/node/gitpod-task-server-impl.ts
+++ b/components/theia/packages/gitpod-extension/src/node/gitpod-task-server-impl.ts
@@ -5,48 +5,41 @@
  */
 
 import { TasksStatusRequest, TasksStatusResponse } from '@gitpod/supervisor-api-grpc/lib/status_pb';
-import { JsonRpcProxy } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ApplicationShell } from '@theia/core/lib/browser';
+import { JsonRpcProxy } from '@theia/core/lib/common/messaging/proxy-factory';
 import { Deferred } from '@theia/core/lib/common/promise-util';
-import { ProcessManager, TerminalProcess } from '@theia/process/lib/node';
-import * as fs from 'fs';
+import { ProcessManager } from '@theia/process/lib/node';
 import { inject, injectable, postConstruct } from 'inversify';
-import * as path from 'path';
-import * as util from 'util';
-import { AttachTaskTerminalParams, GitpodTask, GitpodTaskClient, GitpodTaskServer } from '../common/gitpod-task-protocol';
+import { GitpodTask, GitpodTaskClient, GitpodTaskServer, GitpodTaskState } from '../common/gitpod-task-protocol';
 import { SupervisorClientProvider } from './supervisor-client-provider';
-import psTree = require('ps-tree');
+import { GitpodTaskTerminalProcess, GitpodTaskTerminalProcessFactory } from './gitpod-task-terminal-process';
+import { ShellTerminalServer } from '@theia/terminal/lib/node/shell-terminal-server';
+import { IShellTerminalServer } from '@theia/terminal/lib/common/shell-terminal-protocol';
 
 @injectable()
 export class GitpodTaskServerImpl implements GitpodTaskServer {
 
-    protected run = true;
-    protected stopUpdates: (() => void) | undefined;
+    private run = true;
+    private stopUpdates: (() => void) | undefined;
 
     private readonly clients = new Set<GitpodTaskClient>();
 
     private readonly tasks = new Map<string, GitpodTask>();
     private readonly deferredReady = new Deferred<void>();
-    private readonly supervisorBin = (async () => {
-        let supervisor = '/.supervisor/supervisor';
-        try {
-            await util.promisify(fs.stat)(supervisor);
-        } catch (e) {
-            supervisor = '/theia/supervisor';
-            try {
-                await util.promisify(fs.stat)(supervisor);
-            } catch {
-                throw e;
-            }
-        }
-        return supervisor;
-    })();
-
-    @inject(ProcessManager)
-    protected readonly processManager: ProcessManager;
 
     @inject(SupervisorClientProvider)
     private readonly supervisorClientProvider: SupervisorClientProvider;
+
+    @inject(ProcessManager)
+    private readonly processManager: ProcessManager;
+
+    @inject(GitpodTaskTerminalProcessFactory)
+    private readonly processFactory: GitpodTaskTerminalProcessFactory;
+
+    @inject(IShellTerminalServer)
+    private readonly shellTerminalServer: ShellTerminalServer;
+
+    private readonly processes = new Map<string, GitpodTaskTerminalProcess>();
 
     @postConstruct()
     async start(): Promise<void> {
@@ -62,7 +55,6 @@ export class GitpodTaskServerImpl implements GitpodTaskServer {
                     evts.on("close", resolve);
                     evts.on("error", reject);
                     evts.on("data", (response: TasksStatusResponse) => {
-                        const updated: GitpodTask[] = [];
                         for (const task of response.getTasksList()) {
                             const openIn = task.getPresentation()!.getOpenIn();
                             const openMode = task.getPresentation()!.getOpenMode();
@@ -78,11 +70,8 @@ export class GitpodTaskServerImpl implements GitpodTaskServer {
                                 }
                             }
                             this.tasks.set(task.getId(), update);
-                            updated.push(update);
                         }
-                        for (const client of this.clients) {
-                            client.onDidChange({ updated });
-                        }
+                        this.updateProcesses();
                         this.deferredReady.resolve();
                     });
                 });
@@ -93,35 +82,47 @@ export class GitpodTaskServerImpl implements GitpodTaskServer {
         }
     }
 
-    async attach({ terminalId, remoteTerminal }: AttachTaskTerminalParams): Promise<void> {
-        const terminalProcess = this.processManager.get(terminalId);
-        if (!(terminalProcess instanceof TerminalProcess)) {
-            return;
+    protected updateProcesses(): void {
+        for (const [id, task] of this.tasks) {
+            let process = this.processes.get(id);
+            if (task.state === GitpodTaskState.CLOSED) {
+                if (process) {
+                    process.kill();
+                }
+                continue;
+            }
+            if (!process) {
+                const newProcess = this.processFactory({ id });
+                this.shellTerminalServer['postCreate'](newProcess);
+                this.processes.set(id, newProcess);
+                const listener = this.processManager.onDelete(processId => {
+                    if (newProcess.id === processId) {
+                        this.processes.delete(id);
+                        listener.dispose();
+                    }
+                })
+                process = newProcess;
+            }
+            if (task.state === GitpodTaskState.RUNNING && task.terminal) {
+                process.listen(task.terminal);
+            }
         }
-        const [supervisorBin, children] = await Promise.all([
-            this.supervisorBin,
-            util.promisify(psTree)(terminalProcess.pid)
-        ]);
-        const supervisorCommand = path.basename(supervisorBin);
-        if (children.some(child => child.COMMAND === supervisorCommand)) {
-            return;
-        }
-        terminalProcess.write(`${supervisorBin} terminal attach -ir ${remoteTerminal}\r\n`);
+    }
+
+    async getTasks(): Promise<GitpodTask[]> {
+        await this.deferredReady.promise;
+        return [...this.tasks.values()];
+    }
+
+    async attach(taskId: string): Promise<number> {
+        await this.deferredReady.promise;
+        const process = this.processes.get(taskId)
+        return process ? process.id : -1;
     }
 
     setClient(client: JsonRpcProxy<GitpodTaskClient>): void {
-        let closed = false;
-        this.deferredReady.promise.then(() => {
-            if (closed) {
-                return;
-            }
-            this.clients.add(client);
-            client.onDidChange({
-                updated: [...this.tasks.values()]
-            })
-        });
+        this.clients.add(client);
         client.onDidCloseConnection(() => {
-            closed = true;
             this.clients.delete(client);
         });
     }

--- a/components/theia/packages/gitpod-extension/src/node/gitpod-task-terminal-process.ts
+++ b/components/theia/packages/gitpod-extension/src/node/gitpod-task-terminal-process.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { ITerminalServiceClient } from '@gitpod/supervisor-api-grpc/lib/terminal_grpc_pb';
+import { CloseTerminalRequest, ListenTerminalRequest, ListenTerminalResponse, SetTerminalSizeRequest, WriteTerminalRequest } from '@gitpod/supervisor-api-grpc/lib/terminal_pb';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { MultiRingBuffer, ProcessErrorEvent, ProcessManager } from '@theia/process/lib/node';
+import { TerminalProcess } from '@theia/process/lib/node/terminal-process';
+import { inject, injectable, named } from 'inversify';
+import { SupervisorClientProvider } from './supervisor-client-provider';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { timeout } from '@theia/core/lib/common/promise-util';
+
+@injectable()
+export class GitpodTaskTerminalProcessOptions {
+    id: string
+}
+
+export const GitpodTaskTerminalProcessFactory = Symbol('GitpodTaskTerminalProcessFactory');
+export interface GitpodTaskTerminalProcessFactory {
+    (options: GitpodTaskTerminalProcessOptions): GitpodTaskTerminalProcess
+}
+
+@injectable()
+export class GitpodTaskTerminalProcess extends TerminalProcess {
+
+    private alias?: string;
+
+    private readonly client: ITerminalServiceClient;
+
+    constructor(
+        @inject(GitpodTaskTerminalProcessOptions) options: GitpodTaskTerminalProcessOptions,
+        @inject(ProcessManager) processManager: ProcessManager,
+        @inject(MultiRingBuffer) ringBuffer: MultiRingBuffer,
+        @inject(ILogger) @named('terminal') logger: ILogger,
+        @inject(SupervisorClientProvider) clientProvider: SupervisorClientProvider
+    ) {
+        super({
+            command: options.id,
+            isPseudo: true
+        }, processManager, ringBuffer, logger);
+        this.client = clientProvider.getTerminalClient();
+    }
+
+    async listen(alias: string): Promise<void> {
+        if (this.alias) {
+            return;
+        }
+        this.alias = alias;
+        this.emitOnStarted();
+        while (this.alias) {
+            await new Promise(resolve => {
+                try {
+                    const request = new ListenTerminalRequest();
+                    request.setAlias(alias);
+                    const stream = this.client.listen(request);
+                    stream.on('close', resolve);
+                    stream.on('end', () => {
+                        this.alias = undefined;
+                        this.emitOnExit();
+                        process.nextTick(() => {
+                            this.emitOnClose();
+                        });
+                        resolve();
+                    });
+                    stream.on('error', (e: ProcessErrorEvent) => {
+                        this.alias = undefined;
+                        this.emitOnError(e);
+                        resolve();
+                    });
+                    stream.on('data', (response: ListenTerminalResponse) => {
+                        let str = '';
+                        for (const buffer of [response.getStdout(), response.getStderr()]) {
+                            if (typeof buffer === 'string') {
+                                str += buffer;
+                            } else {
+                                str += BinaryBuffer.wrap(buffer).toString()
+                            }
+                        }
+                        if (str !== '') {
+                            this.ringBuffer.enq(str);
+                        }
+                    });
+                } catch (e) {
+                    resolve();
+                }
+            });
+            await timeout(2000);
+        }
+    }
+
+    kill(): void {
+        if (!this.alias) {
+            return;
+        }
+        const request = new CloseTerminalRequest();
+        request.setAlias(this.alias);
+        this.client.close(request, e => {
+            if (e) {
+                console.error(`[${this.alias}] failed to kill the gitpod task terminal:`, e);
+            }
+        });
+    }
+
+    resize(cols: number, rows: number): void {
+        if (!this.alias) {
+            return;
+        }
+        const request = new SetTerminalSizeRequest();
+        request.setAlias(this.alias);
+        request.setCols(cols);
+        request.setRows(rows);
+        request.setForce(true);
+        this.client.setSize(request, e => {
+            if (e) {
+                console.error(`[${this.alias}] failed to resize the gitpod task terminal:`, e);
+            }
+        });
+    }
+
+    write(data: string): void {
+        if (!this.alias) {
+            return;
+        }
+        const request = new WriteTerminalRequest();
+        request.setAlias(this.alias);
+        request.setStdin(BinaryBuffer.fromString(data).buffer);
+        this.client.write(request, e => {
+            if (e) {
+                console.error(`[${this.alias}] failed to write to the gitpod task terminal:`, e);
+            }
+        });
+    }
+
+}

--- a/components/theia/packages/gitpod-extension/src/node/supervisor-client-provider.ts
+++ b/components/theia/packages/gitpod-extension/src/node/supervisor-client-provider.ts
@@ -7,12 +7,14 @@
 import { injectable } from "inversify";
 import { IStatusServiceClient, StatusServiceClient } from "@gitpod/supervisor-api-grpc/lib/status_grpc_pb";
 import { IControlServiceClient, ControlServiceClient } from "@gitpod/supervisor-api-grpc/lib/control_grpc_pb";
+import { ITerminalServiceClient, TerminalServiceClient } from "@gitpod/supervisor-api-grpc/lib/terminal_grpc_pb";
 import * as grpc from "@grpc/grpc-js";
 
 @injectable()
 export class SupervisorClientProvider {
     protected statusClient: IStatusServiceClient | undefined;
     protected controlClient: IControlServiceClient | undefined;
+    private terminalClient: TerminalServiceClient | undefined;
 
     public async getStatusClient(): Promise<IStatusServiceClient> {
         if (!this.statusClient) {
@@ -28,6 +30,13 @@ export class SupervisorClientProvider {
         }
 
         return this.controlClient;
+    }
+
+    getTerminalClient(): ITerminalServiceClient {
+        if (!this.terminalClient) {
+            this.terminalClient = new TerminalServiceClient(process.env.SUPERVISOR_ADDR || "localhost:22999", grpc.credentials.createInsecure());
+        }
+        return this.terminalClient;
     }
 
 }


### PR DESCRIPTION
- [x] /werft ws-feature-flags=registry_facade
- [x] /werft https

#### What it does

- fix #2159: This PR refactors how Theia attaches to task terminals.
- closes #2116: I could not reproduce it against this PR.

The previous approach was to create a usual Theia terminal (process) and use `supervisor attach` to connect them to a task terminal. It required synchronisations of starting Theia terminals and attaching them to task terminals which is not trivial tasks as well as confusing from user perspective.

This PR introduces a new kind of Theia terminal process which don't use own pty but delegate to the terminal supervisor process. For each task only one such process is created on the backend and all clients always connecting to them.

Code is changed as well to use pseudo terminals: https://github.com/gitpod-io/vscode/commit/053541afb9f5d8338041c5ed182ef9e6e12e589e

#### How to test

##### Working with terminals

- Start a workspace with tasks and open several windows for it.
- Type in one window and check that changes are reflected in another window.
- Resize the terminal and check that content is nicely realigned.
- Close the terminal in one window and check that it gets closed in another window. Use `/theia/supervisor terminal list` to check that underlying terminal is gone.

##### Preserving layout

- Start a workspace with several tasks, open new terminals and relayout: http://akosyakov-race-conditions-while-2159.staging.gitpod-dev.com/#https://github.com/akosyakov/theia-training/tree/solution-1
- Reload the page and check that layout is preserved.
- Restart this workspace and check that layout is still preserved.

##### Reconnecting

- Kill an IDE from one of terminals. Check that terminals are reconnected eventually and tasks are still running.
- Emulate the network disconnection (don't use chrome, it cannot throttle websockets). Check that terminals are reconnected eventually and tasks are still running.

##### Code

- Enable devops role for your user: `update d_b_user set rolesOrPermissions = '["admin","devops"]';`
- Check that everything works in Code as well: http://akosyakov-race-conditions-while-2159.staging.gitpod-dev.com/#https://github.com/akosyakov/go-gin-app