### PR TITLE
[ws-daemon] Disable dynamic CPU limiting by default

### DIFF
--- a/.werft/values.variant.cpuLimits.yaml
+++ b/.werft/values.variant.cpuLimits.yaml
@@ -1,0 +1,14 @@
+workspaceSizing:
+  dynamic:
+    cpu: 
+      buckets:
+        # three minutes of 5 CPUs: 5 [numCPU] * 100 [jiffies/sec] * (3 * 60) [seconds] = 90000
+        - budget: 90000
+          limit: 500
+        # five minutes  of 4 CPUs: 4 [numCPU] * 100 [jiffies/sec] * (5 * 60) [seconds] = 120000
+        - budget: 120000
+          limit: 400
+        # remainder of 2 CPUs where a user has to stay below sustained use of 1.8 CPUs for 5 minutes:
+        #                       1.8 [numCPU] * 100 [jiffies/sec] * (5 * 60) [seconds] = 54000
+        - budget: 54000
+          limit: 200

--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -42,32 +42,15 @@ daemon:
         size: 70000
   resources:
     cgroupBasePath: "/mnt/node-cgroups"
-    # We don't split our actual budget equally amongst participants. Instead we assume we have a maximum
-    # number of over-consumers. We hand out CPU in buckets:
-    #   three minutes of 5 CPUs: 5 [numCPU] * 100 [jiffies/sec] * (3 * 60) [seconds] = 90000
-    #   five minutes  of 4 CPUs: 4 [numCPU] * 100 [jiffies/sec] * (5 * 60) [seconds] = 120000
-    #   remainder of 2 CPUs where a user has to stay below sustained use of 1.8 CPUs for 5 minutes:
-    #                          1.8 [numCPU] * 100 [jiffies/sec] * (5 * 60) [seconds] = 54000
-    # 
-    # Compared to the actual budget, this is severe overbooking:
-    # budget is (numCPU * overbookingFactor * jiffies/sec * controlPeriod[sec]) / numWS = [jiffies / workspace]
-    #           (16     * 1                 * 100         * (15 * 60))          / 25    = 57600
-    #
-    # We express everything in jiffies/sec where 1 jiffie is 1% of a CPU core.
     cpuBuckets: 
-      - budget: 90000
-        limit: 500
-      - budget: 120000
-        limit: 400
-      - budget: 54000
-        limit: 200
+{{ .Values.workspaceSizing.dynamic.cpu.buckets | toYaml | indent 6 }}
     processPriorities:
       supervisor: 0
       theia: 5
       shell: 6
       default: 10
-    controlPeriod: "15m"
-    samplingPeriod: "10s"
+    controlPeriod: {{ .Values.workspaceSizing.dynamic.cpu.controlPeriod | quote }}
+    samplingPeriod: {{ .Values.workspaceSizing.dynamic.cpu.samplingPeriod | quote }}
   hosts:
     enabled: true
     nodeHostsFile: "/mnt/hosts"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,6 +48,27 @@ workspaceSizing:  # for n1-standard-16 (16 vCPUs, 60 GB memory)
   limits:
     cpu: "5"
     memory: "12Gi"
+  dynamic:
+    # Gitpod supports dynamic CPU limiting. We express those limits in "buckets of CPU time" (jiffies where 1 jiffie is 1% of a vCPU).
+    # Each bucket has a limit (i.e. max CPU rate in jiffies/sec, 100 jiffies/sec = 1 vCPU).
+    #
+    # For example:
+    #   # three minutes of 5 CPUs: 5 [numCPU] * 100 [jiffies/sec] * (3 * 60) [seconds] = 90000
+    #   - budget: 90000
+    #     limit: 500
+    #   # five minutes  of 4 CPUs: 4 [numCPU] * 100 [jiffies/sec] * (5 * 60) [seconds] = 120000
+    #   - budget: 120000
+    #     limit: 400
+    #   # remainder of 2 CPUs where a user has to stay below sustained use of 1.8 CPUs for 5 minutes:
+    #   #                       1.8 [numCPU] * 100 [jiffies/sec] * (5 * 60) [seconds] = 54000
+    #   - budget: 54000
+    #     limit: 200
+    #
+    # if there are no buckets configured, the dynamic CPU limiting is disabled.
+    cpu: 
+      buckets: []
+      samplingPeriod: "10s"
+      controlPeriod: "15m"
 db:
   host: db
   port: 3306

--- a/components/ws-daemon/pkg/resources/controller.go
+++ b/components/ws-daemon/pkg/resources/controller.go
@@ -127,7 +127,6 @@ func NewController(containerID, instanceID string, cgroupPath string, opts ...Co
 		InstanceID:     instanceID,
 		SamplingPeriod: 10 * time.Second,
 		ControlPeriod:  15 * time.Minute,
-		cpuLimiter:     FixedLimiter(7000),
 		Prometheus:     prometheus.DefaultRegisterer,
 	}
 	for _, o := range opts {
@@ -196,6 +195,10 @@ func (gov *Controller) Start(ctx context.Context) {
 const userHZ = 100
 
 func (gov *Controller) controlCPU() {
+	if gov.cpuLimiter == nil {
+		return
+	}
+
 	sample, err := gov.cfsController.GetUsage()
 	if xerrors.Is(err, os.ErrNotExist) {
 		// the cgroup doesn't exist (yet or anymore). That's ok.


### PR DESCRIPTION
This PR makes the CPU bucketing of ws-daemon configurable, and disables it by default.
It adds a new config section in the `values.yaml`:
```YAML
workspaceSizing:
  dynamic:
    cpu: 
      buckets: []
        controlPeriod: "15m"
        samplingPeriod: "10s"
```

Using this section one can configure the CPU buckets, thereby enabling the dynamic CPU limiting. By default no buckets are configured, hence no dynamic limiting takes place.

To enable CPU limiting on a dev-staging branch, one can use
```
/werft dynamic-cpu-limits
```

Fixes gitpod-io/gitpod#2163
