### PR TITLE
User-Facing Experimental Features

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -123,6 +123,8 @@ spec:
           value: "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.theiaImage) }}"
         - name: CODE_IMAGE_REPO
           value: "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) }}"
+        - name: EXPERIMENTAL_FEATURE_FLAGS
+          value: {{ .Values.previewFeatureFlags | toJson | quote }}
         - name: WORKSPACE_DEFAULT_IMAGE
           value: "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.defaultImage) }}"
         - name: IDE_IMAGE_ALIASES

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,6 +123,7 @@ branding:
         url: https://www.gitpod.io/terms/
 workspaceScheduler: workspace-scheduler
 serverProxyApiKey: "fF7+aCPvF9Pa0AEjmoZ+yWVh6PqBjM5VEA0wyQs3FH4="
+previewFeatureFlags: ["registry_facade", "user_namespace"]
 
 components:
   nodeDaemon:

--- a/components/dashboard/public/styles.css
+++ b/components/dashboard/public/styles.css
@@ -65,7 +65,11 @@ h3 {
   font-size: 1.5rem;
   font-weight: 500;
 }
-h4, h5, h6 {
+h4 {
+  font-size: 1rem;
+  font-weight: 500;
+}
+h5, h6 {
   font-size: 30px;
   font-weight: 200;
 }

--- a/components/dashboard/src/components/feature-settings.tsx
+++ b/components/dashboard/src/components/feature-settings.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as protocol from '@gitpod/gitpod-protocol';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Grid from '@material-ui/core/Grid';
+import Checkbox from '@material-ui/core/Checkbox';
+import * as React from 'react';
+import debounce = require('lodash.debounce');
+import { IDESettings } from './ide-settings';
+
+export class FeatureSettingsProps {
+    service: protocol.GitpodService;
+    user: protocol.User;
+}
+
+export class FeatureSettingsState {
+    experimentalFeatures: boolean
+    additionalData: protocol.AdditionalUserData
+}
+
+export class FeatureSettings extends React.Component<FeatureSettingsProps, FeatureSettingsState> {
+
+    constructor(props: FeatureSettingsProps) {
+        super(props);
+    }
+
+    private setStateFromUser(user: protocol.User) {
+        this.setState(prevState => {
+            const additionalData = user.additionalData || {};
+            return { ...prevState, 
+                additionalData,
+                experimentalFeatures: additionalData.experimentalFeatures || false,
+            };
+        });
+    }
+
+    componentWillMount() {
+        this.setStateFromUser((this.props.user));
+    }
+
+    componentDidUpdate(prevProps: FeatureSettingsProps) {
+        if (this.props.user !== prevProps.user) {
+            this.setStateFromUser((this.props.user));
+        }
+    }
+
+    render() {
+        return <Grid xs={12}>
+            <div><small>Enabling experimental features gives you access to Gitpod's latest functionality and features. Some of those you'll notice immediately, others operate behind the scenes. <i>Here be dragons.</i></small></div>
+            <FormControlLabel control={<Checkbox checked={this.state.experimentalFeatures} onChange={() => this.updateFeatureFlags(!this.state.experimentalFeatures)} />} label={"Enable experimental features"} />
+            { this.state.experimentalFeatures && <div>
+                <h4>Default IDE</h4>
+                <div><small>By default Gitpod uses Eclipse Theia as IDE. However, other IDEs may become available in the future. Choose below to try a different IDE.</small></div>
+                <IDESettings service={this.props.service} user={this.props.user} />
+            </div> }
+        </Grid>
+    }
+
+    protected updateFeatureFlags = debounce(async (enable: boolean) => {
+        try {
+            const additionalData = (this.state.additionalData || {});
+            additionalData.experimentalFeatures = enable;
+            const user = await this.props.service.server.updateLoggedInUser({ additionalData });
+            this.setStateFromUser(user);
+        } catch (e) {
+            console.error('Failed to update IDE settings:', e);
+        }
+    }, 150);
+    
+}

--- a/components/dashboard/src/components/feature-settings.tsx
+++ b/components/dashboard/src/components/feature-settings.tsx
@@ -18,7 +18,7 @@ export class FeatureSettingsProps {
 }
 
 export class FeatureSettingsState {
-    experimentalFeatures: boolean
+    featurePreview: boolean
     additionalData: protocol.AdditionalUserData
 }
 
@@ -33,7 +33,7 @@ export class FeatureSettings extends React.Component<FeatureSettingsProps, Featu
             const additionalData = user.additionalData || {};
             return { ...prevState, 
                 additionalData,
-                experimentalFeatures: additionalData.experimentalFeatures || false,
+                featurePreview: additionalData.featurePreview || false,
             };
         });
     }
@@ -50,9 +50,12 @@ export class FeatureSettings extends React.Component<FeatureSettingsProps, Featu
 
     render() {
         return <Grid xs={12}>
-            <div><small>Enabling experimental features gives you access to Gitpod's latest functionality and features. Some of those you'll notice immediately, others operate behind the scenes. <i>Here be dragons.</i></small></div>
-            <FormControlLabel control={<Checkbox checked={this.state.experimentalFeatures} onChange={() => this.updateFeatureFlags(!this.state.experimentalFeatures)} />} label={"Enable experimental features"} />
-            { this.state.experimentalFeatures && <div>
+            <div><small>This option enables a Beta preview of some of the latest functionalities and features that are being actively developed. Some of them are user-facing features while others
+                take place in the backstage, see <a href="https://www.gitpod.io/docs/feature-preview/" target="_blank">relevant documentation</a>. If you have suggestions on how we can improve a
+                feature, please provide feedback by <a href="https://github.com/gitpod-io/gitpod/issues/new/choose" target="_blank">opening an issue</a>.
+            </small></div>
+            <FormControlLabel control={<Checkbox checked={this.state.featurePreview} onChange={() => this.updateFeatureFlags(!this.state.featurePreview)} />} label={"Enable Feature Preview"} />
+            { this.state.featurePreview && <div>
                 <h4>Default IDE</h4>
                 <div><small>By default Gitpod uses Eclipse Theia as IDE. However, other IDEs may become available in the future. Choose below to try a different IDE.</small></div>
                 <IDESettings service={this.props.service} user={this.props.user} />
@@ -63,7 +66,7 @@ export class FeatureSettings extends React.Component<FeatureSettingsProps, Featu
     protected updateFeatureFlags = debounce(async (enable: boolean) => {
         try {
             const additionalData = (this.state.additionalData || {});
-            additionalData.experimentalFeatures = enable;
+            additionalData.featurePreview = enable;
             const user = await this.props.service.server.updateLoggedInUser({ additionalData });
             this.setStateFromUser(user);
         } catch (e) {

--- a/components/dashboard/src/components/ide-settings.tsx
+++ b/components/dashboard/src/components/ide-settings.tsx
@@ -69,7 +69,7 @@ export class IDESettings extends React.Component<IDESettingsProps, IDESettingsSt
         return <React.Fragment>
             {this.renderRadio('Theia', 'theia')}
             {this.renderRadio('Code', 'code')}
-            {this.renderRadio('IDE Image:', 'image')}
+            { this.props.user.rolesOrPermissions?.includes("ide-settings") && this.renderRadio('Image', 'image') }
         </React.Fragment>
     }
 
@@ -97,12 +97,9 @@ export class IDESettings extends React.Component<IDESettingsProps, IDESettingsSt
 
     protected updateIDESettings = debounce(async ({ value, image }: IDESettingsState) => {
         try {
-            ;
             const settings = this.state.additionalData?.ideSettings || {};
             if (value === 'theia') {
                 delete settings.defaultIde;
-            } else if (value === 'image') {
-                settings.defaultIde = image;
             } else {
                 settings.defaultIde = value;
             }

--- a/components/dashboard/src/components/settings/index.tsx
+++ b/components/dashboard/src/components/settings/index.tsx
@@ -13,12 +13,12 @@ import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url'
 import { ResponseError } from 'vscode-jsonrpc';
 
 import { UserSettings } from '../user-settings';
-import { IDESettings } from '../ide-settings';
 import { DeleteAccountView } from '../delete-account-view';
 import Paper from '@material-ui/core/Paper';
 import { ApiTokenView } from '../api-tokens';
 import { AuthProviders } from '../auth-providers';
 import { User, GitpodService } from '@gitpod/gitpod-protocol';
+import { FeatureSettings } from '../feature-settings';
 
 interface SettingsProps {
     service: GitpodService;
@@ -69,15 +69,17 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
                 <Paper style={{ padding: 20 }}>
                     <h3>Email Settings</h3>
                     <UserSettings service={this.props.service} user={this.state.user} />
-                    {this.state.user && this.state.hasIDESettingsPermission && <React.Fragment>
-                        <h3 style={{ marginTop: 50 }}>IDE Settings</h3>
-                        <IDESettings service={this.props.service} user={this.state.user} />
-                    </React.Fragment>}
+                    
                     <h3 style={{ marginTop: 50 }}>Environment Variables</h3>
                     <UserEnvVars service={this.props.service} user={this.state.user} />
                     <ApiTokenView service={this.props.service} />
+                    
                     <h3 style={{ marginTop: 50 }}>Git Provider Integrations</h3>
                     <AuthProviders service={this.props.service} user={this.state.user} mode="user-settings" />
+
+                    <h3 style={{ marginTop: 50 }}>Feature Preview</h3>
+                    { this.state.user && <FeatureSettings service={this.props.service} user={this.state.user} /> }
+
                     <DeleteAccountView service={this.props.service} />
                 </Paper>
             </ApplicationFrame>

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -195,7 +195,8 @@ namespace TestData {
             conditions: {},
         },
         configuration: {
-            theiaVersion: "unknown"
+            theiaVersion: "unknown",
+            ideImage: "unknown"
         },
         deleted: false
     };

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -54,7 +54,8 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             conditions: {},
         },
         configuration: {
-            theiaVersion: "unknown"
+            theiaVersion: "unknown",
+            ideImage: "unknown"
         },
         deleted: false
     };
@@ -73,7 +74,8 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             conditions: {},
         },
         configuration: {
-            theiaVersion: "unknown"
+            theiaVersion: "unknown",
+            ideImage: "unknown"
         },
         deleted: false
     };

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -87,6 +87,7 @@ export namespace User {
 export interface AdditionalUserData {
     platforms?: UserPlatform[];
     emailNotificationSettings?: EmailNotificationSettings;
+    experimentalFeatures?: boolean;
     ideSettings?: IDESettings;
 }
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -87,7 +87,7 @@ export namespace User {
 export interface AdditionalUserData {
     platforms?: UserPlatform[];
     emailNotificationSettings?: EmailNotificationSettings;
-    experimentalFeatures?: boolean;
+    featurePreview?: boolean;
     ideSettings?: IDESettings;
 }
 
@@ -518,8 +518,7 @@ export interface WorkspaceConfig {
     gitConfig?: { [config: string]: string };
     github?: GithubAppConfig;
     vscode?: VSCodeConfig;
-    ide?: 'theia' | 'code' | string;
-
+    
     /**
      * Where the config object originates from.
      * 

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -186,8 +186,12 @@ export interface WorkspaceInstanceRepoStatus {
 // WorkspaceInstanceConfiguration contains all per-instance configuration
 export interface WorkspaceInstanceConfiguration {
     // theiaVersion is the version of Theia this workspace instance uses
-    theiaVersion: string;
+    // @deprected: replaced with the ideImage field
+    theiaVersion?: string;
 
     // feature flags are the lowercase feature-flag names as passed to ws-manager
     featureFlags?: NamedWorkspaceFeatureFlag[];
+
+    // ideImage is the ref of the IDE image this instance uses.
+    ideImage: string;
 }

--- a/components/server/src/env.ts
+++ b/components/server/src/env.ts
@@ -45,6 +45,11 @@ export class Env extends AbstractComponentEnv {
         return res;
     })()
 
+    readonly previewFeatureFlags: NamedWorkspaceFeatureFlag[] = (() => {
+        const v = process.env.EXPERIMENTAL_FEATURE_FLAGS;
+        return !!v ? JSON.parse(v) : [];
+    })();
+
     readonly gitpodRegion: string = process.env.GITPOD_REGION || 'unknown';
 
     readonly sessionMaxAgeMs: number = Number.parseInt(process.env.SESSION_MAX_AGE_MS || '259200000' /* 3 days */, 10);

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -139,20 +139,6 @@ export class ConfigProvider {
                 config._featureFlags = workspacePersistedFlags.filter(f => (user.featureFlags!.permanentWSFeatureFlags || []).includes(f));
             }
 
-            if (this.authService.hasPermission(user, 'ide-settings')) {
-                if (!config.ide) {
-                    config.ide = user.additionalData?.ideSettings?.defaultIde;
-                }
-                if (config.ide) {
-                    const mapped = this.env.ideImageAliases[config.ide];
-                    if (!!mapped) {
-                        config.ide = mapped;
-                    }
-                }
-            } else {
-                delete config.ide;
-            }
-
             return config;
         } catch (e) {
             TraceContext.logError({ span }, e);
@@ -168,7 +154,6 @@ export class ConfigProvider {
                 port: 3000
             }],
             tasks: [],
-            ide: this.env.ideDefaultImage,
             image: this.env.workspaceDefaultImage
         };
     }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -232,8 +232,13 @@ export class WorkspaceStarter {
      */
     protected async newInstance(workspace: Workspace, user: User): Promise<WorkspaceInstance> {
         const theiaVersion = this.env.theiaVersion;
+        const ideImage = this.env.ideDefaultImage;
+        
+        // TODO(cw): once we allow changing the IDE in the workspace config (i.e. .gitpod.yml), we must
+        //           give that value precedence over the default choice.
         const configuration: WorkspaceInstanceConfiguration = {
-            theiaVersion
+            theiaVersion,
+            ideImage,
         };
 
         let featureFlags: NamedWorkspaceFeatureFlag[] = workspace.config._featureFlags || [];
@@ -248,6 +253,25 @@ export class WorkspaceStarter {
         if (!this.authService.hasPermission(user, "privileged-ws")) {
             featureFlags = featureFlags.filter(f => f != "privileged");
         }
+
+        // if the user has feature preview enabled, we need to add the respective feature flags.
+        // Beware: all feature flags we add here are not workspace-persistent feature flags, e.g. no full-workspace backup.
+        if (!!user.additionalData?.featurePreview) {
+            featureFlags = featureFlags.concat(this.env.previewFeatureFlags.filter(f => !featureFlags.includes(f)));
+
+            const ideChoice = user.additionalData?.ideSettings?.defaultIde;
+            if (!!ideChoice) {
+                const mappedImage = this.env.ideImageAliases[ideChoice];
+                if (!!mappedImage) {
+                    configuration.ideImage = mappedImage;
+                } else if (this.authService.hasPermission(user, "ide-settings")) {
+                    // if the IDE choice isn't one of the preconfiured choices, we assume its the image name.
+                    // For now, this feature requires special permissions.
+                    configuration.ideImage = ideChoice;
+                }
+            }
+        }
+
         if (!!featureFlags) {
             // only set feature flags if there actually are any. Otherwise we waste the
             // few bytes of JSON in the database for no good reason.
@@ -565,9 +589,17 @@ export class WorkspaceStarter {
         const userTimeoutPromise = this.userService.getDefaultWorkspaceTimeout(user);
 
         const featureFlags = instance.configuration!.featureFlags || [];
-        let ideImage = workspace.config.ide;
-        if (!ideImage || featureFlags.every(f => f !== 'registry_facade')) {
+
+        let ideImage: string;
+        if (!featureFlags.includes('registry_facade')) {
+            // We don't have registry facade enabled. Theia is the only IDE we support in this mode.
+            // We assemble the image name here instead of resorting to env.ideDefaultImage, because
+            // the latter might not be Theia after all.
             ideImage = `${this.env.theiaImageRepo}:${instance.configuration!.theiaVersion}`
+        } else if (!!instance.configuration?.ideImage) {
+            ideImage = instance.configuration?.ideImage;
+        } else {
+            ideImage = this.env.ideDefaultImage;
         }
 
         const spec = new StartWorkspaceSpec();


### PR DESCRIPTION
This PR lets users enable "experimental features" within Gitpod.

@gtsiolis proposed that we should have a single "experimental features" flag as compared to surfacing the individual feature flags. This makes perfect sense, as some of those flags interact with each other (you cannot use GP Code without `registry_facade`), and others make no sense to the user directly (e.g. `registry_facade`). Instead, we let the user express the intent that they'd like to use the latest and greatest.

What the latest and greatest is, is something we can then decide. At the moment it's tied to a Gitpod installation, i.e. we can change what "experimental features" are by redeploying.

### How does it work?
When user's enable experimental features, we set a flag in the user's `additionalConfig`. Upon workspace **instance** creation we check if the user has this flag set, and if so, set additional feature flags on the workspace and apply the IDE image of choice.
The concrete feature flags we set when experimental features are enabled are configured on the server in `EXPERIMENTAL_FEATURE_FLAGS`.

Tying this decision to the workspace instance provides the following trade off:
- :+1: we can at any point remove experimental feature flags if we see that they break the user's experience, or worse, impact the overall system negatively.
- :+1: enabling experimental features makes those available also for existing workspaces. Until we make workspace-permanent feature flags (e.g. `full_workspace_backup`) experimental features, this defers the need for marking which workspace supports those new features and which one doesn't. Instead, if the user ticks the "experimental features" box, the system behaves coherently different.

When we have workspace-permanent feature flags (e.g. `full_workspace_backup`) from which there is "no way back", i.e. once a workspace was started (not just created) with that flag, it cannot be started without it anymore, then we need to introduce some more machinery for providing feedback.

This PR also moves the IDE configuration away from the workspace configuration again, meaning you cannot set the IDE in your `.gitpod.yml` "anymore". For now users can choose between Theia and Code, a rather personal preference. Only when we enable custom IDE images, does it make sense to set this on a project level. I'd argue we should not do this before registry facade has graduated to regular production, and isn't a feature flag anymore.

### UX
The UX is far from refined. There's some basic explanation what the experimental features do, but not much. Also, there's no feedback afterwards, i.e. user's can't tell what impact that choice had. We'll probably need some iteration on that.

### How to test?
1. Head over to https://cw-gitpod-enable-feature.staging.gitpod-dev.com/settings/ and enable "experimental features"
2. Start a workspace. `sudo` should work.
3. Change the IDE to `Code` and start a new workspace. It should come up with GP Code instead of Theia.