### PR TITLE
Fixes minio configuration to use localized endpoint

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -151,7 +151,7 @@ spec:
         - name: MINIO_END_POINT
           value: minio.{{ .Release.Namespace }}.svc.cluster.local
         - name: MINIO_PORT
-          value: "9000"
+          value: {{ .Values.minio.port | default "9000" }}
         - name: MINIO_ACCESS_KEY
           value: {{ .Values.minio.accessKey }}
         - name: MINIO_SECRET_KEY

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -151,7 +151,7 @@ spec:
         - name: MINIO_END_POINT
           value: minio.{{ .Release.Namespace }}.svc.cluster.local
         - name: MINIO_PORT
-          value: {{ .Values.minio.port | default "9000" }}
+          value: {{ .Values.minio.port | default 9000 | quote }}
         - name: MINIO_ACCESS_KEY
           value: {{ .Values.minio.accessKey }}
         - name: MINIO_SECRET_KEY

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -408,7 +408,8 @@ components:
     remoteStorage:
       kind: minio
       minio:
-        endpoint: minio:9000
+        endpoint: minio
+        port: 9000
         accessKey: EXAMPLEvalue
         secretKey: Someone.Should/ReallyChangeThisKey!!
         tmpdir: /tmp

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -409,7 +409,7 @@ components:
       kind: minio
       minio:
         endpoint: minio
-        port: "9000"
+        port: 9000
         accessKey: EXAMPLEvalue
         secretKey: Someone.Should/ReallyChangeThisKey!!
         tmpdir: /tmp

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -409,7 +409,7 @@ components:
       kind: minio
       minio:
         endpoint: minio
-        port: 9000
+        port: "9000"
         accessKey: EXAMPLEvalue
         secretKey: Someone.Should/ReallyChangeThisKey!!
         tmpdir: /tmp


### PR DESCRIPTION
Fixes #1936 

Fixes Minio configuration to use endpoint values from `values.yaml`.