### PR TITLE
[ws-daemon] Make IWS available before content is initialized

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -817,8 +817,8 @@ func workspaceLifecycleHooks(cfg Config, kubernetesNamespace string, workspaceEx
 	}
 
 	return map[session.WorkspaceState][]session.WorkspaceLivecycleHook{
-		session.WorkspaceInitializing: {setupWorkspace},
-		session.WorkspaceReady:        {setupWorkspace, startLiveBackup, iws.ServeWorkspace(uidmapper)},
+		session.WorkspaceInitializing: {setupWorkspace, iws.ServeWorkspace(uidmapper)},
+		session.WorkspaceReady:        {setupWorkspace, startLiveBackup},
 		session.WorkspaceDisposing:    {iws.StopServingWorkspace},
 	}
 }

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -124,6 +124,12 @@ type InWorkspaceServiceServer struct {
 
 // Start creates the syscall socket the IWS server listens on, and starts the gRPC server on it
 func (wbs *InWorkspaceServiceServer) Start() error {
+	// It's possible that the kubelet hasn't create the ServiceLocDaemon directory yet.
+	err := os.MkdirAll(wbs.Session.ServiceLocDaemon, 0755)
+	if err != nil && !os.IsExist(err) {
+		return xerrors.Errorf("cannot create ServiceLocDaemon: %w", err)
+	}
+
 	socketFN := filepath.Join(wbs.Session.ServiceLocDaemon, "daemon.sock")
 	if _, err := os.Stat(socketFN); err == nil {
 		// a former ws-daemon instance left their sockets laying around.


### PR DESCRIPTION
This PR makes ws-daemon's InWorkspaceService initialisation independent of content initialisation.
Before, it was tied to "workspace ready" which is reached after the content has been initialised.
This should fix the issue we've seed in staging.

Fixes gitpod-io/gitpod#2188

### How to test (that "root in workspaces" still works)
1. log in to create your user: http://csweichel-last-backup-failed-cannot-2188.staging.gitpod-dev.com/workspaces
2. run `leeway run components/ws-daemon:enabled-userns-ff` to enable user namespaces (easier once #2171 is merged)
3. start a workspace

Note: we cannot really test if this fixes the issue on staging without deploying this change on staging.