### PR TITLE
[Dashboard] Better Stopped Screen

### DIFF
--- a/components/dashboard/public/styles.css
+++ b/components/dashboard/public/styles.css
@@ -477,17 +477,19 @@ footer .logo-icon {
     right: 0;
     margin: auto;
     text-align: center;
-    z-index: 999;
-    user-select: none;
+    z-index: 1001;
 }
 
 .start .message.stopped-reason {
-    top: 43vh;
+    top: 39vh;
 }
 
-.start .message.start-action {
-    top: 50vh;
-    z-index: 1001;
+.start .message .start-action {
+    margin: 20px 0;
+}
+
+.start .message .start-action .button {
+    margin: 0 20px;
 }
 
 .start .error.message {

--- a/components/dashboard/src/bootanimation.ts
+++ b/components/dashboard/src/bootanimation.ts
@@ -269,7 +269,7 @@ export class Bootanimation {
         var rotateX = Math.sin(now) * 0.1 + 0.75 + this.mousePosition[1];
         var rotateY = Math.cos(now) * 0.1 - 0.75 + this.mousePosition[0];
 
-        if (this.inErrorMode) {
+        if (this.isStopped) {
             xoffset = yoffset = 0;
             rotateX = 0.75;
             rotateY = -0.75;
@@ -323,7 +323,7 @@ export class Bootanimation {
             glow);
         this.gl.uniform3fv(
             this.programInfo.uniformLocations.baseColor,
-            this.inErrorMode ? [0.83, 0.153, 0.243] : [0, 0.53, 0.75]);
+            this.inErrorMode ? [0.83, 0.153, 0.243] : (this.isStopped ? [0.53, 0.53, 0.53] :[0, 0.53, 0.75]));
 
         this.gl.drawElements(this.gl.TRIANGLES, 90, this.gl.UNSIGNED_SHORT, 0);
     }


### PR DESCRIPTION
This PR improves the stopping and stopped screen, providing more and better to understand information.

### How to test

- start a workspace. open the dashboard in another browser, stop the workspace. See how the stopping screen is shown and eventually the stopped screen.
- do the same but this time with pending changes. see how the changes are shown.

Fixes gitpod-io/gitpod#2084