### PR TITLE
[content-service] Fix remote content use

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1592203031938-Baseline.ts
+++ b/components/gitpod-db/src/typeorm/migration/1592203031938-Baseline.ts
@@ -60,10 +60,9 @@ export class Baseline1592203031938 implements MigrationInterface {
                     { url: 'https://github.com/gitpod-io/django-locallibrary-tutorial', description: '**Python** - Tutorial "Local Library" website written in Django', priority: 10 },
                     { url: 'https://github.com/gitpod-io/gs-spring-boot.git', description: '**Java** - Building an Application with Spring Boot', priority: 9 },
                     { url: 'https://github.com/gitpod-io/symfony-demo.git', description: '**PHP** - Symfony Demo Application', priority: 5 },
-                    { url: 'https://github.com/theia-ide/theia.git', description: "**Typescript** - Deep dive into Gitpod's open-source IDE, Theia.", priority: 4 }
+                    { url: 'https://github.com/theia-ide/theia.git', description: '**Typescript** - Deep dive into Gitpod\\\'s open-source IDE, Theia.', priority: 4 }
                 ]
-                const values = entries.map(e => `('${e.url}', '${e.description}', ${e.priority})`).join(",");
-                await queryRunner.query(`INSERT IGNORE INTO d_b_repository_white_list (url, description, priority) VALUES ${values}`);
+                await Promise.all(entries.map(e => queryRunner.query(`INSERT IGNORE INTO d_b_repository_white_list (url, description, priority) VALUES (?, ?, ?)`, [e.url, e.description, e.priority])));
             }
         }
 

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -62,7 +62,7 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 			return nil, xerrors.Errorf("cannot find snapshot: %w", err)
 		}
 
-		rc[storage.DefaultBackup] = *info
+		rc[si.Snapshot] = *info
 	}
 	if si := initializer.GetPrebuild(); si != nil && si.Prebuild != nil {
 		bkt, obj, err := storage.ParseSnapshotName(si.Prebuild.Snapshot)
@@ -74,7 +74,7 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 			return nil, xerrors.Errorf("cannot find prebuild: %w", err)
 		}
 
-		rc[storage.DefaultBackup] = *info
+		rc[si.Prebuild.Snapshot] = *info
 	}
 
 	return rc, nil


### PR DESCRIPTION
Fixes snapshots and prebuilds by correctly setting the remote content map:
![image](https://user-images.githubusercontent.com/3210701/99496783-31e5fa80-2975-11eb-9ca1-5c37f764df41.png)

Now prebuilds work as expected:
![image](https://user-images.githubusercontent.com/3210701/99496544-cf8cfa00-2974-11eb-872e-e4e4a56e3854.png)

Also fixes the db migration that broke in #2145 

### How to test
1. start a prebuild
2. use the prebuild