### PR TITLE
[dev] Fix supervisor API swagger build

### DIFF
--- a/components/supervisor-api/typescript-rest/build.sh
+++ b/components/supervisor-api/typescript-rest/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GO111MODULES=off go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+GO111MODULES=off go get -v github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2
 THIRD_PARTY_INCLUDES=${PROTOLOC:-$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway}
 if [ ! -d $THIRD_PARTY_INCLUDES/third_party/googleapis ]; then
     tmpdir=$(mktemp -d)
@@ -11,7 +11,7 @@ fi
 mkdir -p lib
 export PROTO_INCLUDE="-I$THIRD_PARTY_INCLUDES/third_party/googleapis -I /usr/lib/protoc/include"
 
-protoc $PROTO_INCLUDE --swagger_out=logtostderr=true:. -I${PROTOLOC:-..} ${PROTOLOC:-..}/*.proto && \
+protoc $PROTO_INCLUDE --openapiv2_out=logtostderr=true:. -I${PROTOLOC:-..} ${PROTOLOC:-..}/*.proto && \
 mv *.swagger.json lib && \
 for f in $(ls lib/*.swagger.json); do 
     yarn dtsgen -o ${f%.swagger.json}.dt.ts $f


### PR DESCRIPTION
Fixes the supervisor API swagger build.

### How to test
1. Open a workspace
2. Make sure the `yarn build` worked.