### PR TITLE
fixes for task terminals

### DIFF
--- a/components/dashboard/src/components/create/create-workspace.tsx
+++ b/components/dashboard/src/components/create/create-workspace.tsx
@@ -123,7 +123,7 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
             if (token.isCancellationRequested) {
                 return;
             }
-            available = await this.props.service.server.isPrebuildAvailable(prebuildID);
+            available = await this.props.service.server.isPrebuildDone(prebuildID);
         }
         if (available) {
             this.doCreateWorkspaceWithMode(CreateWorkspaceMode.UsePrebuild);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -76,7 +76,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     sendHeartBeat(options: GitpodServer.SendHeartBeatOptions): Promise<void>;
     watchWorkspaceImageBuildLogs(workspaceId: string): Promise<void>;
     watchHeadlessWorkspaceLogs(workspaceId: string): Promise<void>;
-    isPrebuildAvailable(pwsid: string): Promise<boolean>;
+    isPrebuildDone(pwsid: string): Promise<boolean>;
 
     // Workspace timeout
     setWorkspaceTimeout(workspaceId: string, duration: WorkspaceTimeoutDuration): Promise<SetWorkspaceTimeoutResult>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -604,6 +604,10 @@ export interface PrebuiltWorkspace {
 }
 
 export namespace PrebuiltWorkspace {
+    export function isDone(pws: PrebuiltWorkspace) {
+        return pws.state === "available" || pws.state === "timeout" || pws.state === 'aborted';
+    }
+
     export function isAvailable(pws: PrebuiltWorkspace) {
         return pws.state === "available" && !!pws.snapshot;
     }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -146,11 +146,11 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
     }
 
 
-    public async isPrebuildAvailable(pwsid: string): Promise<boolean> {
+    public async isPrebuildDone(pwsid: string): Promise<boolean> {
         // Allowed in the free version, because it is read only.
         // this.requireEELicense(Feature.FeaturePrebuild);
 
-        const span = opentracing.globalTracer().startSpan("isPrebuildAvailable");
+        const span = opentracing.globalTracer().startSpan("isPrebuildDone");
         span.setTag("pwsid", pwsid);
         const ctx: TraceContext = { span };
         try {
@@ -160,7 +160,7 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
                 return true;
             }
 
-            return PrebuiltWorkspace.isAvailable(pws);
+            return PrebuiltWorkspace.isDone(pws);
         } catch (e) {
             TraceContext.logError({ span }, e);
             throw e;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -695,7 +695,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         }
     }
 
-    public async isPrebuildAvailable(pwsid: string): Promise<boolean> {
+    public async isPrebuildDone(pwsid: string): Promise<boolean> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, "Prebuilds are implemented in Gitpod's enterprise edition")
     }
 

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.33.1

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -464,6 +464,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/components/supervisor/pkg/gitpod/gitpod-service.go
+++ b/components/supervisor/pkg/gitpod/gitpod-service.go
@@ -51,7 +51,7 @@ type APIInterface interface {
 	SendHeartBeat(ctx context.Context, options *SendHeartBeatOptions) (err error)
 	WatchWorkspaceImageBuildLogs(ctx context.Context, workspaceID string) (err error)
 	WatchHeadlessWorkspaceLogs(ctx context.Context, workspaceID string) (err error)
-	IsPrebuildAvailable(ctx context.Context, pwsid string) (res bool, err error)
+	IsPrebuildDone(ctx context.Context, pwsid string) (res bool, err error)
 	SetWorkspaceTimeout(ctx context.Context, workspaceID string, duration *WorkspaceTimeoutDuration) (res *SetWorkspaceTimeoutResult, err error)
 	GetWorkspaceTimeout(ctx context.Context, workspaceID string) (res *GetWorkspaceTimeoutResult, err error)
 	GetOpenPorts(ctx context.Context, workspaceID string) (res []*WorkspaceInstancePort, err error)
@@ -143,8 +143,8 @@ const (
 	FunctionWatchWorkspaceImageBuildLogs FunctionName = "watchWorkspaceImageBuildLogs"
 	// FunctionWatchHeadlessWorkspaceLogs is the name of the watchHeadlessWorkspaceLogs function
 	FunctionWatchHeadlessWorkspaceLogs FunctionName = "watchHeadlessWorkspaceLogs"
-	// FunctionIsPrebuildAvailable is the name of the isPrebuildAvailable function
-	FunctionIsPrebuildAvailable FunctionName = "isPrebuildAvailable"
+	// FunctionIsPrebuildDone is the name of the isPrebuildDone function
+	FunctionIsPrebuildDone FunctionName = "isPrebuildDone"
 	// FunctionSetWorkspaceTimeout is the name of the setWorkspaceTimeout function
 	FunctionSetWorkspaceTimeout FunctionName = "setWorkspaceTimeout"
 	// FunctionGetWorkspaceTimeout is the name of the getWorkspaceTimeout function
@@ -708,14 +708,14 @@ func (gp *APIoverJSONRPC) WatchHeadlessWorkspaceLogs(ctx context.Context, worksp
 	return
 }
 
-// IsPrebuildAvailable calls isPrebuildAvailable on the server
-func (gp *APIoverJSONRPC) IsPrebuildAvailable(ctx context.Context, pwsid string) (res bool, err error) {
+// IsPrebuildDone calls isPrebuildDone on the server
+func (gp *APIoverJSONRPC) IsPrebuildDone(ctx context.Context, pwsid string) (res bool, err error) {
 	var _params []interface{}
 
 	_params = append(_params, pwsid)
 
 	var result bool
-	err = gp.C.Call(ctx, "isPrebuildAvailable", _params, &result)
+	err = gp.C.Call(ctx, "isPrebuildDone", _params, &result)
 	if err != nil {
 		return
 	}

--- a/components/supervisor/pkg/gitpod/mock.go
+++ b/components/supervisor/pkg/gitpod/mock.go
@@ -461,19 +461,19 @@ func (mr *MockAPIInterfaceMockRecorder) WatchHeadlessWorkspaceLogs(ctx, workspac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchHeadlessWorkspaceLogs", reflect.TypeOf((*MockAPIInterface)(nil).WatchHeadlessWorkspaceLogs), ctx, workspaceID)
 }
 
-// IsPrebuildAvailable mocks base method
-func (m *MockAPIInterface) IsPrebuildAvailable(ctx context.Context, pwsid string) (bool, error) {
+// IsPrebuildDone mocks base method
+func (m *MockAPIInterface) IsPrebuildDone(ctx context.Context, pwsid string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPrebuildAvailable", ctx, pwsid)
+	ret := m.ctrl.Call(m, "IsPrebuildDone", ctx, pwsid)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsPrebuildAvailable indicates an expected call of IsPrebuildAvailable
-func (mr *MockAPIInterfaceMockRecorder) IsPrebuildAvailable(ctx, pwsid interface{}) *gomock.Call {
+// IsPrebuildDone indicates an expected call of IsPrebuildDone
+func (mr *MockAPIInterfaceMockRecorder) IsPrebuildDone(ctx, pwsid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrebuildAvailable", reflect.TypeOf((*MockAPIInterface)(nil).IsPrebuildAvailable), ctx, pwsid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrebuildDone", reflect.TypeOf((*MockAPIInterface)(nil).IsPrebuildDone), ctx, pwsid)
 }
 
 // SetWorkspaceTimeout mocks base method

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -185,10 +185,10 @@ type WorkspaceConfig struct {
 	GitpodHost string `env:"GITPOD_HOST"`
 
 	// GitpodTasks is the task configuration of the workspace
-	GitpodTasks *string `env:"GITPOD_TASKS"`
+	GitpodTasks string `env:"GITPOD_TASKS"`
 
 	// GitpodHeadless controls whether the workspace is running headless
-	GitpodHeadless *string `env:"GITPOD_HEADLESS"`
+	GitpodHeadless string `env:"GITPOD_HEADLESS"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service
@@ -288,12 +288,17 @@ func (c WorkspaceConfig) GitpodAPIEndpoint() (endpoint, host string, err error) 
 	return
 }
 
+// getGitpodTasks returns true if the workspace is headless
+func (c WorkspaceConfig) isHeadless() bool {
+	return c.GitpodHeadless == "true"
+}
+
 // getGitpodTasks parses gitpod tasks
 func (c WorkspaceConfig) getGitpodTasks() (tasks *[]TaskConfig, err error) {
-	if c.GitpodTasks == nil {
+	if c.GitpodTasks == "" {
 		return
 	}
-	err = json.Unmarshal([]byte(*c.GitpodTasks), &tasks)
+	err = json.Unmarshal([]byte(c.GitpodTasks), &tasks)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse tasks: %w", err)
 	}

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -144,6 +144,7 @@ func Run(options ...RunOption) {
 	taskManager := newTasksManager(cfg, termMuxSrv, cstate)
 
 	termMuxSrv.DefaultWorkdir = cfg.RepoRoot
+	termMuxSrv.Env = buildIDEEnv(cfg)
 
 	apiServices := []RegisterableService{
 		&statusService{

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -141,7 +141,7 @@ func Run(options ...RunOption) {
 		termMux    = terminal.NewMux()
 		termMuxSrv = terminal.NewMuxTerminalService(termMux)
 	)
-	taskManager := newTasksManager(cfg, termMuxSrv, cstate)
+	taskManager := newTasksManager(cfg, termMuxSrv, cstate, &loggingHeadlessTaskProgressReporter{})
 
 	termMuxSrv.DefaultWorkdir = cfg.RepoRoot
 	termMuxSrv.Env = buildIDEEnv(cfg)

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -214,7 +214,13 @@ func (tm *tasksManager) Run(ctx context.Context, wg *sync.WaitGroup) {
 		if t.config.Env != nil {
 			openRequest.Env = *t.config.Env
 		}
-		resp, err := tm.terminalService.Open(ctx, openRequest)
+		var ReadTimeout time.Duration
+		if !runContext.headless {
+			ReadTimeout = 5 * time.Second
+		}
+		resp, err := tm.terminalService.OpenWithOptions(ctx, openRequest, terminal.TermOptions{
+			ReadTimeout: ReadTimeout,
+		})
 		if err != nil {
 			taskLog.WithError(err).Error("cannot open new task terminal")
 			tm.setTaskState(t, api.TaskState_closed)

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -248,7 +248,7 @@ func (tm *tasksManager) Run(ctx context.Context, wg *sync.WaitGroup) {
 		if runContext.headless {
 			tm.watch(t, terminal)
 		}
-		terminal.PTY.Write([]byte(t.command + "\r\n"))
+		terminal.PTY.Write([]byte(t.command + "\n"))
 	}
 
 	if runContext.headless {
@@ -260,7 +260,7 @@ func (task *task) getCommand(context *runContext) string {
 	commands := task.getCommands(context)
 	command := composeCommand(composeCommandOptions{
 		commands: commands,
-		format:   "{\r\n%s\r\n}",
+		format:   "{\n%s\n}",
 		sep:      " && ",
 	})
 
@@ -354,13 +354,13 @@ func (tm *tasksManager) watch(task *task, terminal *terminal.Term) {
 					if elapsedInMinutes != "1" {
 						duration += "s"
 					}
-					duration += " of watching your code build.\r\n"
+					duration += " of watching your code build.\n"
 				}
 				data := string(buf[:n])
 				fileWriter.Write(buf[:n])
 				workspaceLog.WithField("type", "workspaceTaskOutput").WithField("data", data).Info()
 
-				endMessage := "\r\n🍌 This task ran as part of a workspace prebuild.\r\n" + duration + "\r\n"
+				endMessage := "\n🍌 This task ran as part of a workspace prebuild.\n" + duration + "\n"
 				fileWriter.WriteString(endMessage)
 				fileWriter.Flush()
 				success = true

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -431,15 +431,22 @@ type loggingHeadlessTaskProgressReporter struct {
 }
 
 func (r *loggingHeadlessTaskProgressReporter) write(data string, task *task, terminal *terminal.Term) {
-	log.WithField("component", "workspace").WithField("pid", terminal.Command.Process.Pid).WithField("type", "workspaceTaskOutput").WithField("data", data).Info()
+	log.WithField("component", "workspace").WithField("pid", terminal.Command.Process.Pid).
+		WithField("taskLogMsg", taskLogMessage{Type: "workspaceTaskOutput", Data: data}).Info()
 }
 
 func (r *loggingHeadlessTaskProgressReporter) done(success bool) {
 	workspaceLog := log.WithField("component", "workspace")
-	workspaceLog.WithField("type", "workspaceTaskOutput").WithField("data", "🚛 uploading prebuilt workspace").Info()
+	workspaceLog.WithField("taskLogMsg", taskLogMessage{Type: "workspaceTaskOutput", Data: "🚛 uploading prebuilt workspace"}).Info()
 	if !success {
-		workspaceLog.WithField("type", "workspaceTaskFailed").WithField("error", "one of the tasks failed with non-zero exit code").Info()
+		workspaceLog.WithField("error", "one of the tasks failed with non-zero exit code").
+			WithField("taskLogMsg", taskLogMessage{Type: "workspaceTaskFailed"}).Info()
 		return
 	}
-	workspaceLog.WithField("type", "workspaceTaskDone").Info()
+	workspaceLog.WithField("taskLogMsg", taskLogMessage{Type: "workspaceTaskDone"}).Info()
+}
+
+type taskLogMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data"`
 }

--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package supervisor
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/supervisor/pkg/terminal"
+	"github.com/google/go-cmp/cmp"
+)
+
+var skipCommand = "echo \"skip\""
+var failCommand = "exit 1"
+
+func TestTaskManager(t *testing.T) {
+
+	tests := []struct {
+		Desc        string
+		Headless    bool
+		Source      api.WorkspaceInitSource
+		GitpodTasks *[]TaskConfig
+
+		ExpectedReporter testHeadlessTaskProgressReporter
+	}{
+		{
+			Desc:     "headless prebuild should finish without tasks",
+			Headless: true,
+			Source:   api.WorkspaceInitFromOther,
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: true,
+			},
+		},
+		{
+			Desc:        "headless prebuild should finish without init tasks",
+			Headless:    true,
+			Source:      api.WorkspaceInitFromOther,
+			GitpodTasks: &[]TaskConfig{{Command: &skipCommand}},
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: true,
+			},
+		},
+		{
+			Desc:        "headless prebuild should finish with successful init tasks",
+			Headless:    true,
+			Source:      api.WorkspaceInitFromOther,
+			GitpodTasks: &[]TaskConfig{{Init: &skipCommand}, {Init: &skipCommand}},
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: true,
+			},
+		},
+		{
+			Desc:        "headless prebuild should finish with failed init tasks",
+			Headless:    true,
+			Source:      api.WorkspaceInitFromOther,
+			GitpodTasks: &[]TaskConfig{{Init: &failCommand}, {Init: &failCommand}},
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: false,
+			},
+		},
+		{
+			Desc:        "headless prebuild should finish with at least one failed init tasks (first)",
+			Headless:    true,
+			Source:      api.WorkspaceInitFromOther,
+			GitpodTasks: &[]TaskConfig{{Init: &failCommand}, {Init: &skipCommand}},
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: false,
+			},
+		},
+		{
+			Desc:        "headless prebuild should finish with at least one failed init tasks (second)",
+			Headless:    true,
+			Source:      api.WorkspaceInitFromOther,
+			GitpodTasks: &[]TaskConfig{{Init: &skipCommand}, {Init: &failCommand}},
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: false,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Desc, func(t *testing.T) {
+			storeLocation, err := ioutil.TempDir("", "tasktest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(storeLocation)
+
+			gitpodTasks := ""
+			if test.GitpodTasks != nil {
+				result, err := json.Marshal(test.GitpodTasks)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gitpodTasks = string(result)
+			}
+
+			var (
+				terminalService = terminal.NewMuxTerminalService(terminal.NewMux())
+				contentState    = NewInMemoryContentState("")
+				reporter        = testHeadlessTaskProgressReporter{}
+				taskManager     = newTasksManager(&Config{
+					WorkspaceConfig: WorkspaceConfig{
+						GitpodTasks:    gitpodTasks,
+						GitpodHeadless: strconv.FormatBool(test.Headless),
+					},
+				}, terminalService, contentState, &reporter)
+			)
+			taskManager.storeLocation = storeLocation
+			contentState.MarkContentReady(test.Source)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go taskManager.Run(context.Background(), &wg)
+			wg.Wait()
+			if diff := cmp.Diff(test.ExpectedReporter, reporter); diff != "" {
+				t.Errorf("unexpected output (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}
+
+type testHeadlessTaskProgressReporter struct {
+	Done    bool
+	Success bool
+}
+
+func (r *testHeadlessTaskProgressReporter) write(data string, task *task, terminal *terminal.Term) {
+}
+
+func (r *testHeadlessTaskProgressReporter) done(success bool) {
+	r.Done = true
+	r.Success = success
+}

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -21,10 +21,15 @@ import (
 
 // NewMuxTerminalService creates a new terminal service
 func NewMuxTerminalService(m *Mux) *MuxTerminalService {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/bash"
+	}
 	return &MuxTerminalService{
 		Mux:            m,
 		DefaultWorkdir: "/workspace",
-		LoginShell:     []string{"/bin/bash", "-i", "-l"},
+		DefaultShell:   shell,
+		Env:            os.Environ(),
 	}
 }
 
@@ -33,7 +38,8 @@ type MuxTerminalService struct {
 	Mux *Mux
 
 	DefaultWorkdir string
-	LoginShell     []string
+	DefaultShell   string
+	Env            []string
 
 	tokens map[*Term]string
 }
@@ -50,9 +56,9 @@ func (srv *MuxTerminalService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint 
 
 // Open opens a new terminal running the login shell
 func (srv *MuxTerminalService) Open(ctx context.Context, req *api.OpenTerminalRequest) (*api.OpenTerminalResponse, error) {
-	cmd := exec.Command(srv.LoginShell[0], srv.LoginShell[1:]...)
+	cmd := exec.Command(srv.DefaultShell)
 	cmd.Dir = srv.DefaultWorkdir
-	cmd.Env = append(os.Environ(), "TERM=xterm-color")
+	cmd.Env = append(srv.Env, "TERM=xterm-color")
 	for key, value := range req.Env {
 		cmd.Env = append(cmd.Env, key+"="+value)
 	}

--- a/components/ws-manager/pkg/manager/headless.go
+++ b/components/ws-manager/pkg/manager/headless.go
@@ -103,7 +103,7 @@ func (hl *HeadlessListener) handleLogLine(pod *corev1.Pod, line string) (continu
 		if originalMsg.Component != "workspace" {
 			return true
 		}
-		taskMsg = originalMsg.taskLogMessage
+		taskMsg = originalMsg.Message
 	}
 	if taskMsg.Type == "workspaceTaskOutput" {
 		hl.OnHeadlessLog(pod, taskMsg.Data)
@@ -126,8 +126,8 @@ type taskLogMessage struct {
 }
 
 type workspaceLogMessage struct {
-	taskLogMessage
-	Component string `json:"component"`
+	Message   taskLogMessage `json:"taskLogMsg"`
+	Component string         `json:"component"`
 }
 
 //region backward compatibility

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -611,15 +611,6 @@ func (m *Monitor) actOnHeadlessDone(pod *corev1.Pod, failed bool) (err error) {
 		}
 	}
 
-	// if the workspace task failed, that means the headless workspace failed
-	if failed {
-		err := handleFailure("task failed")
-		if err != nil {
-			tracing.LogError(span, err)
-			log.WithError(err).Warn("cannot stop failed headless workspace")
-		}
-	}
-
 	// healthy prebuilds don't fail the workspace, thus we have to stop them ourselves
 	err = m.manager.stopWorkspace(ctx, id, stopWorkspaceNormallyGracePeriod)
 	if err != nil {


### PR DESCRIPTION
#### What it does

- fix #2086:
  - align shell with current IDE expectations
  - remove unnecessary line delimiters in task commands
- fix #2208: ensure task status order
- always run task terminals for regular workspaces to avoid closing terminals on workspace restart
- redirect from the prebuild to a workspace on the start page only when the prebuild is stopped to avoid opening a workspace without the prebuild
- don't hang the create page if the prebuild is done but not available
- resolved the read/write deadlock for task terminals
- fix #2265: ensure that headless tasks done is reported always

#### How to test

- Start a regular workspace and check task output: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod
- Restart this workspace and check that terminals are not gone.
- Start a prebuild workspace and check task output: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/gitpod
  - regular to test create page: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod
- Check that both terminals history is proper after prebuilt is done.
- Run a prebuild on the repo without init tasks: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#prebuild/https://github.com/jankeromnes/hugo-gitpod
  - regular to test create page: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#https://github.com/jankeromnes/hugo-gitpod
- Run a prebuild on the repo with failing init task: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#prebuild/https://github.com/akosyakov/test-maven-repo/tree/failed_prebuild
  - regular to test create page: http://akosyakov-verbose-output-from-gitpod-2086.staging.gitpod-dev.com/#https://github.com/akosyakov/test-maven-repo/tree/failed_prebuild