### PR TITLE
Fix minio port reference preserving endpoint

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -153,7 +153,7 @@ spec:
         - name: MINIO_END_POINT
           value: minio.{{ .Release.Namespace }}.svc.cluster.local
         - name: MINIO_PORT
-          value: "9000"
+          value: {{ (split ":" .Values.minio.endpoint)._1 | default 9000 | quote }}
         - name: MINIO_ACCESS_KEY
           value: {{ .Values.minio.accessKey }}
         - name: MINIO_SECRET_KEY

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -151,9 +151,9 @@ spec:
         - name: GITPOD_STORAGE_CLIENT
           value: minio
         - name: MINIO_END_POINT
-          value: minio.{{ .Release.Namespace }}.svc.cluster.local
+          value: {{ (split ":" (.Values.minio.endpoint | toString))._0 | default "minio.{{ .Release.Namespace }}.svc.cluster.local" | quote }}
         - name: MINIO_PORT
-          value: {{ (split ":" .Values.minio.endpoint)._1 | default 9000 | quote }}
+          value: {{ (split ":" (.Values.minio.endpoint | toString))._1 | default 9000 | quote }}
         - name: MINIO_ACCESS_KEY
           value: {{ .Values.minio.accessKey }}
         - name: MINIO_SECRET_KEY

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -387,7 +387,7 @@ components:
     remoteStorage:
       kind: minio
       minio:
-        endpoint: minio:9000
+        endpoint: :9000
         accessKey: EXAMPLEvalue
         secretKey: Someone.Should/ReallyChangeThisKey!!
         tmpdir: /tmp


### PR DESCRIPTION
This PR fixes minio port reference in `server-deployment.yaml` preserving the `endpoint` in `values.yaml`

Fixes #1936 