### PR TITLE
[supervisor] Tones down the logging in the supervisor CLI

### DIFF
--- a/components/common-go/log/log.go
+++ b/components/common-go/log/log.go
@@ -6,6 +6,8 @@ package log
 
 import (
 	"fmt"
+
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -55,11 +57,13 @@ func Init(service, version string, json, verbose bool) {
 				},
 			},
 		})
-		Log.Info("enabled JSON logging")
+	} else {
+		log.SetFormatter(&logrus.TextFormatter{})
 	}
 	if verbose {
 		log.SetLevel(log.DebugLevel)
-		Log.Info("enabled verbose logging")
+	} else {
+		log.SetLevel(log.InfoLevel)
 	}
 }
 

--- a/components/supervisor/cmd/rings.go
+++ b/components/supervisor/cmd/rings.go
@@ -41,6 +41,7 @@ var ring0Cmd = &cobra.Command{
 	Short:  "starts the supervisor ring0",
 	Hidden: true,
 	Run: func(_ *cobra.Command, args []string) {
+		log.Init(ServiceName, Version, true, true)
 		log := log.WithField("ring", 0)
 
 		var failed bool
@@ -152,6 +153,7 @@ var ring1Cmd = &cobra.Command{
 	Short:  "starts the supervisor ring1",
 	Hidden: true,
 	Run: func(_cmd *cobra.Command, args []string) {
+		log.Init(ServiceName, Version, true, true)
 		log := log.WithField("ring", 1)
 		defer log.Info("done")
 
@@ -327,6 +329,7 @@ var ring2Cmd = &cobra.Command{
 	Short:  "starts the supervisor ring2",
 	Hidden: true,
 	Run: func(_cmd *cobra.Command, args []string) {
+		log.Init(ServiceName, Version, true, true)
 		log := log.WithField("ring", 2)
 		defer log.Info("done")
 

--- a/components/supervisor/cmd/root.go
+++ b/components/supervisor/cmd/root.go
@@ -28,7 +28,7 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	log.Init(ServiceName, Version, true, true)
+	log.Init(ServiceName, Version, false, true)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
 	"github.com/spf13/cobra"
 )
@@ -18,6 +19,8 @@ var runCmd = &cobra.Command{
 	Short: "starts the supervisor",
 
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Init(ServiceName, Version, true, true)
+
 		var opts []supervisor.RunOption
 		if runCmdOpts.InNamespace {
 			opts = append(opts,


### PR DESCRIPTION
Removes unnecessary "enabled verbose logging" and "enabled JSON logging" messages.

### How to test
1. Start a workspace and observe how supervisor still logs in JSON
2. Use supervisor CLI, e.g. `/theia/supervisor terminal list`. Notice that the "enabled ..." messages are gone