### PR TITLE
Update the GKE cluster versions on terraform file

### DIFF
--- a/install/gcp-full-terraform/modules/kubernetes/main.tf
+++ b/install/gcp-full-terraform/modules/kubernetes/main.tf
@@ -81,7 +81,7 @@ resource "google_container_cluster" "gitpod" {
   subnetwork = var.subnets[0]
 
 
-  min_master_version = "1.15.12-gke.9"
+  min_master_version = "1.16.15-gke.4300"
 
 }
 

--- a/install/gcp-terraform/modules/kubernetes/main.tf
+++ b/install/gcp-terraform/modules/kubernetes/main.tf
@@ -66,7 +66,7 @@ resource "google_container_cluster" "gitpod" {
   }
 
   network            = var.network
-  min_master_version = "1.15.12-gke.9"
+  min_master_version = "1.16.15-gke.4300"
 }
 
 resource "google_container_node_pool" "gitpod_cluster" {


### PR DESCRIPTION
Hello, Gitpod team🙂

This PR update the obsoleted GKE cluster versions to `1.16.15-gke.4300`. I use the current stable version on [Google Cloud documentation](https://cloud.google.com/kubernetes-engine/docs/release-notes) and can successfully install Gitpod on GCP using this version.

Related issue: #1990
Related question on the forum: https://community.gitpod.io/t/error-for-one-liner-installs-on-gcp-and-aws/1992