### PR TITLE
Fix failed prebuids

### DIFF
--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -64,7 +64,7 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 
 		rc[si.Snapshot] = *info
 	}
-	if si := initializer.GetPrebuild(); si != nil && si.Prebuild != nil {
+	if si := initializer.GetPrebuild(); si != nil && si.Prebuild != nil && si.Prebuild.Snapshot != "" {
 		bkt, obj, err := storage.ParseSnapshotName(si.Prebuild.Snapshot)
 		if err != nil {
 			return nil, err

--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -74,11 +74,14 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
                     prebuild.state = "timeout";
                     prebuild.error = status.conditions!.timeout;
                     headlessUpdateType = HeadlessWorkspaceEventType.AbortedTimedOut;
+                } else if (!!status.conditions!.failed) {
+                    prebuild.state = "aborted";
+                    prebuild.error = status.conditions!.failed;
+                    headlessUpdateType = HeadlessWorkspaceEventType.FinishedButFailed;
                 } else {
                     prebuild.state = "available";
-                    prebuild.error = status.conditions!.failed;
                     prebuild.snapshot = status.conditions!.snapshot;
-                    headlessUpdateType = !!status.conditions!.failed ? HeadlessWorkspaceEventType.FinishedButFailed : HeadlessWorkspaceEventType.FinishedSuccessfully;
+                    headlessUpdateType = HeadlessWorkspaceEventType.FinishedSuccessfully;
                 }
                 await this.workspaceDB.trace({span}).storePrebuiltWorkspace(prebuild);
 


### PR DESCRIPTION
This PR improves the handling of failed prebuilds.

If a prebuild workspace fails (i.e. has a failed condition), ws-manager-bridge now does the right thing and doesn't mark the prebuild as available.
If a prebuild has no snapshot, e.g. because it failed prior and ws-manager-bridge did not do the right thing, we now ignore that empty snapshot rather than fail catastrophically.

### How to test
1. ws-manager-bridge failure handling: start a prebuild, once running added a `gitpod/explicitFail` annotation to the prebuild workspace pod, watch the prebuild fail, look in the database to see that the prebuild was marked as aborted.
2. ws-daemon empty snapshot handling: run a prebuild to completetion. Once done, set the snapshot field in the database to an empty string. Start a workspace from that snapshot.
