### PR TITLE
Fix guard access for Gitpod token

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -167,8 +167,11 @@ export class TypeORMUserDBImpl implements UserDB {
     }
 
     public async findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]> {
-        const repo = await this.getGitpodTokenRepo();
-        return repo.find({ where: { user: { id: userId } } });
+        const repo = await this.getGitpodTokenRepo()
+        const qBuilder = repo.createQueryBuilder('gitpodToken')
+            .leftJoinAndSelect("gitpodToken.user", "user");
+        qBuilder.where('user.id = :userId', { userId });
+        return qBuilder.getMany();
     }
 
     public async storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void> {


### PR DESCRIPTION
Not sure why "GitpodToken" uses an ORM relationship. I don't generally think we should use them at all as they are hard to understand and cause trouble such as in this case. I didn't want to change the shape of protocol so late in the game, so I opted for just fixing the issue.

Fixes gitpod-io/gitpod#2047