### PR TITLE
[dashboard] Use logo link to redirect to dashboard

### DIFF
--- a/components/dashboard/src/components/menu.tsx
+++ b/components/dashboard/src/components/menu.tsx
@@ -163,7 +163,7 @@ export class MainMenu extends React.Component<MainMenuProps, MainMenuState> {
             <AppBar position='static'>
                 <Toolbar className="content toolbar">
                     <div className="gitpod-logo">
-                        <a href={this.props.branding ? this.props.branding.homepage : 'javascript:void(0)'}>
+                        <a href="/">
                             <img src={getLogoPath(this.props.branding)} aria-hidden="true" className="logo" />
                         </a>
                     </div>


### PR DESCRIPTION
### What does this PR do?

This will change the `href` link on the dashboard logo (see top left) to `/` instead of `www.gitpod.io` or any custom value related to branding the product (see `values.yaml`). This is a common pattern and will allow everyone to go back to the dashboard with one click.

### Things to consider

1. The `branding.homepage` property is also used for other installations that do not have a `root` path context.
1. The `branding.homepage` is also used in [`/components/dashboard/src/components/create/create-workspace.tsx`](https://github.com/gitpod-io/gitpod/blob/79c8ad5191670c1147b8db5eb2ed0064aa806db6/components/dashboard/src/components/create/create-workspace.tsx#L58). Do we need to also update that?
1. Currently, this is using an href which forces a tab reload. Could we use React Router here to avoid refreshing the tab?
1. This ignores the [`branding.homepage`](https://github.com/gitpod-io/gitpod/blob/a07c5278cf1d8b754224f954fd7c3e2b660f420b/chart/values.yaml#L113) in `values.yaml` which can still be used elsewhere and instead replaces `href` with a fixed path (`/`).

Also, feel free to close this or pick it up if this requires more changes.