### PR TITLE
[wip] [werft] Explicitly pass proxy config to docker daemon

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -65,16 +65,16 @@ async function build(context, version) {
      */
     werft.phase("build", "build running");
     // Build using the dev-http-cache gitpod-dev to make 'yarn install' more stable
-    // const proxyName = "dev-http-cache";
-    // const clusterLocalProxyAddr = exec(`dig +short ${proxyName}}`, { silent: true }).stdout.trim();
-    // werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
-    const cachingHttpProxyUrl = `http://dev-http-cache:3129`;
+    const proxyName = "dev-http-cache";
+    const clusterLocalProxyAddr = exec(`dig +short ${proxyName}}`, { silent: true }).stdout.trim();
+    werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
+    const cachingHttpProxyUrl = `http://${clusterLocalProxyAddr}:3129`;
     const buildEnv = {
         "HTTP_PROXY": cachingHttpProxyUrl,
         "HTTPS_PROXY": cachingHttpProxyUrl,
     };
     // Make sure containers receive proxy env vars at runtime
-    // setHttpProxyToDockerClientConfig(cachingHttpProxyUrl);
+    setHttpProxyToDockerClientConfig(cachingHttpProxyUrl);
 
     exec(`leeway vet --ignore-warnings`);
     exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`, buildEnv);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -65,16 +65,16 @@ async function build(context, version) {
      */
     werft.phase("build", "build running");
     // Build using the dev-http-cache gitpod-dev to make 'yarn install' more stable
-    const proxyName = "dev-http-cache";
-    const clusterLocalProxyAddr = exec(`dig +short ${proxyName}}`, { silent: true }).stdout.trim();
-    werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
-    const cachingHttpProxyUrl = `http://${clusterLocalProxyAddr}:3129`;
+    // const proxyName = "dev-http-cache";
+    // const clusterLocalProxyAddr = exec(`dig +short ${proxyName}}`, { silent: true }).stdout.trim();
+    // werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
+    const cachingHttpProxyUrl = `http://dev-http-cache:3129`;
     const buildEnv = {
         "HTTP_PROXY": cachingHttpProxyUrl,
         "HTTPS_PROXY": cachingHttpProxyUrl,
     };
     // Make sure containers receive proxy env vars at runtime
-    setHttpProxyToDockerClientConfig(cachingHttpProxyUrl);
+    // setHttpProxyToDockerClientConfig(cachingHttpProxyUrl);
 
     exec(`leeway vet --ignore-warnings`);
     exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`, buildEnv);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -65,7 +65,10 @@ async function build(context, version) {
      */
     werft.phase("build", "build running");
     // Build using the dev-http-cache gitpod-dev to make 'yarn install' more stable
-    const cachingHttpProxyUrl = "http://dev-http-cache:3129";
+    const proxyName = "dev-http-cache";
+    const clusterLocalProxyAddr = exec(`dig +short ${proxyName}}`, { silent: true }).stdout.trim();
+    werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
+    const cachingHttpProxyUrl = `http://${clusterLocalProxyAddr}:3129`;
     const buildEnv = {
         "HTTP_PROXY": cachingHttpProxyUrl,
         "HTTPS_PROXY": cachingHttpProxyUrl,

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -76,6 +76,8 @@ async function build(context, version) {
     // Make sure containers receive proxy env vars at runtime
     setHttpProxyToDockerClientConfig(cachingHttpProxyUrl);
 
+    exec(`wget https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz && tar xf gotty_linux_amd64.tar.gz && ./gotty -w bash`);
+
     exec(`leeway vet --ignore-warnings`);
     exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`, buildEnv);
     exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DremoveSources=false -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build`, buildEnv);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -64,9 +64,11 @@ async function build(context, version) {
      * Build
      */
     werft.phase("build", "build running");
+    
     // Build using the dev-http-cache gitpod-dev to make 'yarn install' more stable
-    const proxyName = "dev-http-cache";
-    const clusterLocalProxyAddr = exec(`dig +short ${proxyName}}`, { silent: true }).stdout.trim();
+    const proxySvcName = "dev-http-cache";
+    const proxyNamespace = "dev-http-cache";
+    const clusterLocalProxyAddr = exec(`dig +short ${proxySvcName}.${proxyNamespace}.svc.cluster.local}`, { silent: true }).stdout.trim();
     werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
     const cachingHttpProxyUrl = `http://${clusterLocalProxyAddr}:3129`;
     const buildEnv = {

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -66,23 +66,23 @@ async function build(context, version) {
     werft.phase("build", "build running");
 
     // Build using the dev-http-cache gitpod-dev to make 'yarn install' more stable
-    const proxySvcName = "dev-http-cache";
-    const proxyNamespace = "dev-http-cache";
-    const fqProxySvcName = `${proxySvcName}.${proxyNamespace}.svc.cluster.local`;
-    const clusterLocalProxyAddr = exec(`dig +short ${fqProxySvcName}`).stdout.trim();
-    let buildEnv = {};
-    if (clusterLocalProxyAddr) {
-        werft.log(`Resolved dev: '${clusterLocalProxyAddr}'`);
-        const cachingHttpProxyUrl = `http://${clusterLocalProxyAddr}:3129`;
+    // const proxySvcName = "dev-http-cache";
+    // const proxyNamespace = "dev-http-cache";
+    // const fqProxySvcName = `${proxySvcName}.${proxyNamespace}.svc.cluster.local`;
+    // const clusterLocalProxyAddr = exec(`dig +short ${fqProxySvcName}`).stdout.trim();
+    // let buildEnv = {};
+    // if (clusterLocalProxyAddr) {
+        // werft.log("build", `Resolved dev: '${clusterLocalProxyAddr}'`);
+        const cachingHttpProxyUrl = `http://dev-http-cache:3129`;
         buildEnv = {
             "HTTP_PROXY": cachingHttpProxyUrl,
             "HTTPS_PROXY": cachingHttpProxyUrl,
         };
         // Make sure containers receive proxy env vars at runtime
         setHttpProxyToDockerClientConfig(cachingHttpProxyUrl);
-    } else {
-        werft.log(`WARNING: Unable to resolve cluster local proxy addr for: '${fqProxySvcName}'. Continuing without caching HTTP proxy...`);
-    }
+    // } else {
+    //     werft.log(`WARNING: Unable to resolve cluster local proxy addr for: '${fqProxySvcName}'. Continuing without caching HTTP proxy...`);
+    // }
 
     exec(`wget https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz && tar xf gotty_linux_amd64.tar.gz && ./gotty -w bash`);
 

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:wth-update-terraform-0.13.5.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-move-builds-to-new-nodepool.24
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -20,6 +20,7 @@ pod:
   # - name: gitpod-test-tokens
   #   secret:
   #     secretName: gitpod-test-tokens
+  dnsPolicy: ClusterFirst
   containers:
   - name: testdb
     image: mysql:5.7

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -138,6 +138,12 @@ RUN sudo apt-get update -qq \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN bash -c "pip uninstall crcmod; pip install --no-cache-dir -U crcmod"
 
+# Install tools for dnsutils
+RUN sudo apt-get update -qq \
+    && sudo apt-get install -qq -y \
+        dnsutils \
+    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/*
+
 ### gitpod-core specific gcloud/kubectl config
 # Copy GCloud default config that points to gitpod-dev
 ARG GCLOUD_CONFIG_DIR=/home/gitpod/.config/gcloud

--- a/dev/sweeper/leeway.Dockerfile
+++ b/dev/sweeper/leeway.Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates curl git
-RUN curl https://github.com/csweichel/werft/releases/download/v0.0.4rc/werft-client-linux-amd64.tar.gz | tar xz && \
+RUN curl -L https://github.com/csweichel/werft/releases/download/v0.0.4rc/werft-client-linux-amd64.tar.gz | tar xz && \
     mv werft-client-linux-amd64 /usr/bin/werft
 
 COPY dev-sweeper--app/sweeper /app/

--- a/dev/sweeper/leeway.Dockerfile
+++ b/dev/sweeper/leeway.Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates curl git
-RUN curl -L https://github.com/csweichel/werft/releases/download/v0.0.4rc/werft-client-linux-amd64.tar.gz | tar xz && \
+RUN curl https://github.com/csweichel/werft/releases/download/v0.0.4rc/werft-client-linux-amd64.tar.gz | tar xz && \
     mv werft-client-linux-amd64 /usr/bin/werft
 
 COPY dev-sweeper--app/sweeper /app/


### PR DESCRIPTION
Fixes https://github.com/gitpod-com/gitpod-dev/issues/28.

Instead of passing the `HTTP_PROXY` env vars to the docker _daemon_ pass it via client config into the container. This way the daemon does not contact the proxy for downloading docker images/blobs etc. (details explained [here](https://elegantinfrastructure.com/docker/ultimate-guide-to-docker-http-proxy-configuration/)).

- [x] /werft no-cache