### PR TITLE
[ws-man] avoid 'fatal error: concurrent map read and map write'

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -915,7 +915,7 @@ func (m *Manager) dropSubscriber(dropouts []string) {
 	}
 }
 
-// onChange is the default OnChange implemntation which publishes workspace status updates to subscribers
+// onChange is the default OnChange implementation which publishes workspace status updates to subscribers
 func (m *Manager) onChange(ctx context.Context, status *api.WorkspaceStatus) {
 	log := log.WithFields(log.OWI(status.Metadata.Owner, status.Metadata.MetaId, status.Id))
 

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -102,15 +102,14 @@ func (m *metrics) OnWorkspaceStarted(tpe api.WorkspaceType) {
 
 func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 	var removeFromState bool
+	m.mu.Lock()
 	defer func() {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-
 		if removeFromState {
 			delete(m.phaseState, status.Id)
 		} else {
 			m.phaseState[status.Id] = status.Phase
 		}
+		m.mu.Unlock()
 	}()
 
 	switch status.Phase {


### PR DESCRIPTION
There was read access to a map that was not synced with concurrent write access.