### PR TITLE
UUID fixes

### DIFF
--- a/components/ee/cerc/go.mod
+++ b/components/ee/cerc/go.mod
@@ -4,9 +4,9 @@ go 1.14
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+	github.com/google/uuid v1.1.1
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/prometheus/client_golang v1.1.0
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/components/ee/cerc/go.sum
+++ b/components/ee/cerc/go.sum
@@ -37,6 +37,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -95,8 +97,6 @@ github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURm
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/components/ee/cerc/pkg/cerc/cerc.go
+++ b/components/ee/cerc/pkg/cerc/cerc.go
@@ -17,7 +17,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 )
@@ -203,10 +203,13 @@ const (
 )
 
 func (r *runner) Probe() (*probe, error) {
-
 	log.WithField("pathway", r.P.Name).Debug("probe started")
 
-	tkn := uuid.NewV4().String()
+	uid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+	tkn := uid.String()
 
 	r.C.Reporter.ProbeStarted(r.P.Name)
 

--- a/components/ee/ws-scheduler/pkg/scaler/scaler.go
+++ b/components/ee/ws-scheduler/pkg/scaler/scaler.go
@@ -124,9 +124,9 @@ func (s *Scaler) scalingPeriod(ctx context.Context) (err error) {
 
 	// Create as many buffer pods as configured
 	for i := 0; i < s.Config.BufferFactor; i++ {
-		uuid, uuidErr := uuid.NewUUID()
-		if uuidErr != nil {
-			return uuidErr
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return err
 		}
 		pod := renderBufferPod(s.Config, uuid.String(), staticBufferLabels())
 		log.Debugf("created buffer pod: %s", pod.Name)


### PR DESCRIPTION
This PR fixes two minor issues:
- it moves cerc to the same UUID package the other Go components use (mitigating [this CVE](https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMSATORIGOUUID-72488) in the process)
- it makes the scaler use UUIDv4 rather than v1 - this really is a drive-by fix :D