### PR TITLE
[blobserve] Use blob digest as ETag header

### DIFF
--- a/components/registry-facade/pkg/blobserve/blobserve.go
+++ b/components/registry-facade/pkg/blobserve/blobserve.go
@@ -129,6 +129,7 @@ func (reg *Server) serve(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.Header().Set("ETag", hash)
+	w.Header().Set("Cache-Control", "no-cache")
 
 	// http.FileServer has a special case where ServeFile redirects any request where r.URL.Path
 	// ends in "/index.html" to the same path, without the final "index.html".


### PR DESCRIPTION
- [x] /werft https


fix #2264: This PR makes blobserve deliver an ETag header for the files it serves.

This enables users to switch their IDEs.

### How to test
1. Enable "Feature Preview" at https://cw-blobserve-etag.staging.gitpod-dev.com/settings/
2. Start a workspace: https://cw-blobserve-etag.staging.gitpod-dev.com/#https://github.com/gitpod-io/django-locallibrary-tutorial
3. Set IDE to Code at https://cw-blobserve-etag.staging.gitpod-dev.com/settings/
4. Start another workspace: https://cw-blobserve-etag.staging.gitpod-dev.com/#https://github.com/gitpod-io/django-locallibrary-tutorial

Both workspaces should come up fine