### PR TITLE
[ws-manager-bridge] Append breakline to headless status message

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -94,7 +94,7 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
                 await this.messagebus.notifyHeadlessUpdate({}, userId, workspaceId, <HeadlessLogEvent>{
                     type: HeadlessWorkspaceEventType.LogOutput,
                     workspaceID: workspaceId,
-                    text: status.message
+                    text: status.message + "\n"
                 });
             }
         } catch (e) {


### PR DESCRIPTION
Fixes gitpod-io/gitpod#2279