### PR TITLE
[ws-manager] Less noisy marking of timed out WS in intermediate state

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1472,6 +1472,15 @@ func (m *Monitor) markTimedoutWorkspaces(ctx context.Context) (err error) {
 		}
 
 		timedout, err := m.manager.isWorkspaceTimedOut(workspaceObjects{PLIS: &plis})
+		if xerrors.Is(err, errNoPLIS) {
+			// The pod is gone and the PLIS hasn't been patched yet - there's not much we can do here, except
+			// to ignore the workspace.
+			//
+			// Note: although tempting it would be dangerous to try and patch the PLIS now, because we'd race
+			//       the stopping/stopped PLIS patching, possibly destroying state along the way. Patching the PLIS
+			//       is not an atomic operation.
+			continue
+		}
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("workspaceId=%s: %q", workspaceID, err))
 			continue

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -862,6 +862,10 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%02dh%02dm", h, m)
 }
 
+// errNoPLIS is returned by getWorkspaceStatusFromPLIS if the PLIS configMap is present, but
+// does not contain a PLIS annotation.
+var errNoPLIS = xerrors.Errorf("workspace has no pod lifecycle independent state")
+
 // getWorkspaceStatusFromPLIS tries to compute the workspace status from the pod lifecycle independent state alone.
 // For this to work the PLIS must be set and contain the last pod-based status.
 func (m *Manager) getWorkspaceStatusFromPLIS(wso workspaceObjects) (*api.WorkspaceStatus, error) {
@@ -874,7 +878,7 @@ func (m *Manager) getWorkspaceStatusFromPLIS(wso workspaceObjects) (*api.Workspa
 		return nil, xerrors.Errorf("cannot get status from pod lifecycle independent state: %w", err)
 	}
 	if plis == nil {
-		return nil, xerrors.Errorf("workspace has no pod lifecycle independent state")
+		return nil, errNoPLIS
 	}
 
 	if plis.LastPodStatus == nil {


### PR DESCRIPTION
This PR reduces the false-positive "workspace monitor error" logs we see in production.

When a workspace is stopped, there can be a time where we have neither pod nor PLIS. If Kubernetes has already deleted the pod, but ws-manager hasn't patched the PLIS yet other processes might loose state for that time. For example, `markTimedoutWorkspaces` will attempt to compute the workspace phase based on the PLIS - which hasn't been updated yet - and fail.

This PR introduces a special error path for this case whereby we do not log this event, hence reduce the noise. Functionally this change makes no difference, we still ignore that workspace (until the PLIS is patched - if that ever happens).

Note: looking at the [production logs of the last seven days](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22gitpod-191109%22%0Aresource.labels.location%3D%22europe-west1%22%0Aresource.labels.cluster_name%3D%22production--gitpod-io--europe-west1--01%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fapp%3D%22gitpod%22%0Alabels.k8s-pod%2Fcomponent%3D%22ws-manager%22%0Alabels.k8s-pod%2Fkind%3D%22pod%22%0Alabels.k8s-pod%2Fstage%3D%22production%22%0AjsonPayload.message%3D%22workspace%20monitor%20error%22%0Aseverity%3DERROR;timeRange=P7D?authuser=1&project=gitpod-191109), this particular instance of the problem accounted for 75% of all workspace monitor errors.

To solve this issue proper, we'd need to maintain a properly synchronised PLIS state within ws-manager.

Unfortunately this change is hard to test, as it's a race condition that gets triggered occasionally under load.