### PR TITLE
[ws-scheduler] Respect ephemeral storage requests

### DIFF
--- a/components/ee/ws-scheduler/pkg/scheduler/state.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state.go
@@ -335,17 +335,24 @@ func NodeMapToList(m map[string]*Node) []*Node {
 	return nodes
 }
 
-// DebugRAMPerNodeAsStr prints available RAM per node as string for debug purposes
-func DebugRAMPerNodeAsStr(nodes []*Node) string {
-	segs := make([]string, len(nodes))
-	for i, node := range nodes {
-		usedRegularGibs := float64(node.RAM.UsedRegular.Value()/1024/1024) / float64(1024)
-		usedHeadlessGibs := float64(node.RAM.UsedHeadless.Value()/1024/1024) / float64(1024)
-		usedOtherGibs := float64(node.RAM.UsedOther.Value()/1024/1024) / float64(1024)
-		totalGibs := float64(node.RAM.Total.Value()/1024/1024) / float64(1024)
-		availableGibs := float64(node.RAM.Available.Value()/1024/1024) / float64(1024)
+// DebugStringResourceUsage returns a debug string describing the used resources
+func (ru *ResourceUsage) DebugStringResourceUsage() string {
+	usedRegularGibs := float64(ru.UsedRegular.Value()/1024/1024) / float64(1024)
+	usedHeadlessGibs := float64(ru.UsedHeadless.Value()/1024/1024) / float64(1024)
+	usedOtherGibs := float64(ru.UsedOther.Value()/1024/1024) / float64(1024)
+	totalGibs := float64(ru.Total.Value()/1024/1024) / float64(1024)
+	availableGibs := float64(ru.Available.Value()/1024/1024) / float64(1024)
 
-		segs[i] = fmt.Sprintf("- %s: used %0.03f+%0.03f+%0.3f of %0.3f, avail %0.03f GiB", node.Node.Name, usedRegularGibs, usedHeadlessGibs, usedOtherGibs, totalGibs, availableGibs)
+	return fmt.Sprintf("used %0.03f+%0.03f+%0.3f of %0.3f, avail %0.03f GiB", usedRegularGibs, usedHeadlessGibs, usedOtherGibs, totalGibs, availableGibs)
+}
+
+// DebugStringNodes prints available RAM per node as string for debug purposes
+func DebugStringNodes(nodes []*Node) string {
+	lines := make([]string, 0, len(nodes)*3)
+	for _, node := range nodes {
+		lines = append(lines, fmt.Sprintf("- %s:", node.Node.Name))
+		lines = append(lines, fmt.Sprintf("  RAM: %s", node.RAM.DebugStringResourceUsage()))
+		lines = append(lines, fmt.Sprintf("  Eph. Storage: %s", node.EphemeralStorage.DebugStringResourceUsage()))
 	}
-	return strings.Join(segs, "\n")
+	return strings.Join(lines, "\n")
 }

--- a/components/ee/ws-scheduler/pkg/scheduler/state_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state_test.go
@@ -15,9 +15,9 @@ import (
 func TestState(t *testing.T) {
 	defaultNodeSet := func() []*corev1.Node {
 		return []*corev1.Node{
-			createNode("node1", "10Gi", false, 100),
-			createNode("node2", "10Gi", false, 100),
-			createNode("node3", "10Gi", true, 100),
+			createNode("node1", "10Gi", "0Gi", false, 100),
+			createNode("node2", "10Gi", "0Gi", false, 100),
+			createNode("node3", "10Gi", "0Gi", true, 100),
 		}
 	}
 
@@ -36,8 +36,8 @@ func TestState(t *testing.T) {
 			Desc:  "other pods only",
 			Nodes: defaultNodeSet(),
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "node2", 10),
+				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
 			},
 			Expectation: "- node1: used 0.000+0.000+1.500 of 10.000, avail 8.500 GiB\n- node2: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
 		},
@@ -45,10 +45,10 @@ func TestState(t *testing.T) {
 			Desc:  "some headless pods",
 			Nodes: defaultNodeSet(),
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "node2", 10),
-				createHeadlessWorkspacePod("hp1", "1Gi", "node2", 10),
-				createHeadlessWorkspacePod("hp2", "2.22Gi", "node2", 10),
+				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
+				createHeadlessWorkspacePod("hp1", "1Gi", "0Gi", "node2", 10),
+				createHeadlessWorkspacePod("hp2", "2.22Gi", "0Gi", "node2", 10),
 			},
 			Expectation: "- node1: used 0.000+0.000+1.500 of 10.000, avail 8.500 GiB\n- node2: used 0.000+3.220+1.000 of 10.000, avail 5.779 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
 		},
@@ -56,10 +56,10 @@ func TestState(t *testing.T) {
 			Desc:  "some regular pods",
 			Nodes: defaultNodeSet(),
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "node2", 10),
-				createWorkspacePod("hp1", "1Gi", "node1", 10),
-				createWorkspacePod("hp2", "3.44Gi", "node1", 10),
+				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
+				createWorkspacePod("hp1", "1Gi", "0Gi", "node1", 10),
+				createWorkspacePod("hp2", "3.44Gi", "0Gi", "node1", 10),
 			},
 			Expectation: "- node1: used 4.439+0.000+1.500 of 10.000, avail 4.060 GiB\n- node2: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
 		},

--- a/components/ee/ws-scheduler/pkg/scheduler/state_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state_test.go
@@ -95,6 +95,29 @@ func TestState(t *testing.T) {
   RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
   Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
 		},
+		{
+			Desc: "some regular pods with ",
+			Nodes: []*corev1.Node{
+				createNode("node1", "10Gi", "20Gi", false, 100),
+				createNode("node2", "10Gi", "10Gi", false, 100),
+				createNode("node3", "10Gi", "10Gi", true, 100),
+			},
+			Pods: []*corev1.Pod{
+				createNonWorkspacePod("existingPod1", "1.5Gi", "5Gi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1Gi", "2Gi", "node2", 10),
+				createWorkspacePod("hp1", "1Gi", "5Gi", "node1", 10),
+				createWorkspacePod("hp2", "3.44Gi", "5Gi", "node1", 10),
+			},
+			Expectation: `- node1:
+  RAM: used 4.439+0.000+1.500 of 10.000, avail 4.060 GiB
+  Eph. Storage: used 10.000+0.000+5.000 of 20.000, avail 5.000 GiB
+- node2:
+  RAM: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB
+  Eph. Storage: used 0.000+0.000+2.000 of 10.000, avail 8.000 GiB
+- node3:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB`,
+		},
 	}
 
 	for _, test := range tests {

--- a/components/ee/ws-scheduler/pkg/scheduler/state_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state_test.go
@@ -28,9 +28,17 @@ func TestState(t *testing.T) {
 		Expectation string
 	}{
 		{
-			Desc:        "no pods",
-			Nodes:       defaultNodeSet(),
-			Expectation: "- node1: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB\n- node2: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
+			Desc:  "no pods",
+			Nodes: defaultNodeSet(),
+			Expectation: `- node1:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node2:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node3:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
 		},
 		{
 			Desc:  "other pods only",
@@ -39,7 +47,15 @@ func TestState(t *testing.T) {
 				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
 				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
 			},
-			Expectation: "- node1: used 0.000+0.000+1.500 of 10.000, avail 8.500 GiB\n- node2: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
+			Expectation: `- node1:
+  RAM: used 0.000+0.000+1.500 of 10.000, avail 8.500 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node2:
+  RAM: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node3:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
 		},
 		{
 			Desc:  "some headless pods",
@@ -50,7 +66,15 @@ func TestState(t *testing.T) {
 				createHeadlessWorkspacePod("hp1", "1Gi", "0Gi", "node2", 10),
 				createHeadlessWorkspacePod("hp2", "2.22Gi", "0Gi", "node2", 10),
 			},
-			Expectation: "- node1: used 0.000+0.000+1.500 of 10.000, avail 8.500 GiB\n- node2: used 0.000+3.220+1.000 of 10.000, avail 5.779 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
+			Expectation: `- node1:
+  RAM: used 0.000+0.000+1.500 of 10.000, avail 8.500 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node2:
+  RAM: used 0.000+3.220+1.000 of 10.000, avail 5.779 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node3:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
 		},
 		{
 			Desc:  "some regular pods",
@@ -61,7 +85,15 @@ func TestState(t *testing.T) {
 				createWorkspacePod("hp1", "1Gi", "0Gi", "node1", 10),
 				createWorkspacePod("hp2", "3.44Gi", "0Gi", "node1", 10),
 			},
-			Expectation: "- node1: used 4.439+0.000+1.500 of 10.000, avail 4.060 GiB\n- node2: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB\n- node3: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB",
+			Expectation: `- node1:
+  RAM: used 4.439+0.000+1.500 of 10.000, avail 4.060 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node2:
+  RAM: used 0.000+0.000+1.000 of 10.000, avail 9.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+- node3:
+  RAM: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
 		},
 	}
 
@@ -76,9 +108,9 @@ func TestState(t *testing.T) {
 			// This would intermittently break tests. We instead sort by name.
 			sort.Slice(nodes, func(i, j int) bool { return nodes[i].Node.Name < nodes[j].Node.Name })
 
-			actual := sched.DebugRAMPerNodeAsStr(nodes)
+			actual := sched.DebugStringNodes(nodes)
 			if test.Expectation != actual {
-				t.Errorf("expected RAM to be:\n%s, was:\n%s", test.Expectation, actual)
+				t.Errorf("expected debug string to be:\n%s, was:\n%s", test.Expectation, actual)
 				return
 			}
 		})

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy.go
@@ -240,8 +240,8 @@ func (s *DensityAndExperience) Select(state *State, pod *corev1.Pod) (string, er
 func fitsOnNode(pod *corev1.Pod, node *Node) bool {
 	ramReq := podRAMRequest(pod)
 	ephStorageReq := podEphemeralStorageRequest(pod)
-	return ramReq.Cmp(*node.RAM.Available) < 0 &&
-		(ephStorageReq.CmpInt64(0) == 0 || ephStorageReq.Cmp(*node.EphemeralStorage.Available) < 0)
+	return ramReq.Cmp(*node.RAM.Available) <= 0 &&
+		(ephStorageReq.CmpInt64(0) == 0 || ephStorageReq.Cmp(*node.EphemeralStorage.Available) <= 0)
 }
 
 func freshWorkspaceCount(state *State, node *Node, freshSeconds int) int {

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy.go
@@ -30,7 +30,7 @@ const (
 )
 
 const (
-	errorNoNodeWithEnoughRAMAvailable = "No node with enough RAM available!\nRequested by pod: %s\nNodes:\n%s"
+	errorNoNodeWithEnoughResourcesAvailable = "No node with enough resources available!\nRAM requested: %s\nEph. Storage requested: %s\nNodes:\n%s"
 )
 
 // Strategy is the interface that make the actual scheduling interchangable
@@ -123,15 +123,17 @@ func (e *EvenLoad) Select(state *State, pod *corev1.Pod) (string, error) {
 
 	if len(sortedNodes) == 0 {
 		requestedRAM := GetRequestedRAMForPod(pod)
-		ramPerNode := DebugRAMPerNodeAsStr(sortedNodes)
-		return "", xerrors.Errorf(errorNoNodeWithEnoughRAMAvailable, requestedRAM.String(), ramPerNode)
+		requestedEphStorage := GetRequestedEphemeralStorageForPod(pod)
+		debugStr := DebugStringNodes(sortedNodes)
+		return "", xerrors.Errorf(errorNoNodeWithEnoughResourcesAvailable, requestedRAM.String(), requestedEphStorage.String(), debugStr)
 	}
 
 	candidate := sortedNodes[0]
 	if !fitsOnNode(pod, candidate) {
 		requestedRAM := GetRequestedRAMForPod(pod)
-		ramPerNode := DebugRAMPerNodeAsStr(sortedNodes)
-		return "", xerrors.Errorf(errorNoNodeWithEnoughRAMAvailable, requestedRAM.String(), ramPerNode)
+		requestedEphStorage := GetRequestedEphemeralStorageForPod(pod)
+		debugStr := DebugStringNodes(sortedNodes)
+		return "", xerrors.Errorf(errorNoNodeWithEnoughResourcesAvailable, requestedRAM.String(), requestedEphStorage.String(), debugStr)
 	}
 
 	return candidate.Node.Name, nil
@@ -162,8 +164,9 @@ func (s *DensityAndExperience) Select(state *State, pod *corev1.Pod) (string, er
 
 	if len(candidates) == 0 {
 		requestedRAM := GetRequestedRAMForPod(pod)
-		ramPerNode := DebugRAMPerNodeAsStr(sortedNodes)
-		return "", xerrors.Errorf(errorNoNodeWithEnoughRAMAvailable, requestedRAM.String(), ramPerNode)
+		requestedEphStorage := GetRequestedEphemeralStorageForPod(pod)
+		debugStr := DebugStringNodes(sortedNodes)
+		return "", xerrors.Errorf(errorNoNodeWithEnoughResourcesAvailable, requestedRAM.String(), requestedEphStorage.String(), debugStr)
 	}
 
 	// From this point on we're safe: Choosing any of the candidates would work.

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy_test.go
@@ -37,115 +37,115 @@ func TestDensityAndExperience(t *testing.T) {
 		},
 		{
 			Desc:          "no node with enough RAM",
-			Nodes:         []*corev1.Node{createNode("node1", "10Gi", false, 100)},
-			Pods:          []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "node1", 10)},
-			ScheduledPod:  createWorkspacePod("pod", "6Gi", "", 1000),
+			Nodes:         []*corev1.Node{createNode("node1", "10Gi", "0Gi", false, 100)},
+			Pods:          []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "0Gi", "node1", 10)},
+			ScheduledPod:  createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedError: "No node with enough RAM available!\nRequested by pod: 6Gi\nNodes:\n- node1: used 0.000+0.000+8.000 of 10.000, avail 2.000 GiB",
 		},
 		{
 			Desc:         "single empty node",
-			Nodes:        []*corev1.Node{createNode("node1", "10Gi", false, 100)},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "", 1000),
+			Nodes:        []*corev1.Node{createNode("node1", "10Gi", "0Gi", false, 100)},
+			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
 			Desc: "two nodes, one full",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", false, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", false, 100),
 			},
-			Pods:         []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "node1", 10)},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "", 1000),
+			Pods:         []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "0Gi", "node1", 10)},
+			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node2",
 		},
 		{
 			Desc: "two nodes, prefer density",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", false, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", false, 100),
 			},
-			Pods:         []*corev1.Pod{createWorkspacePod("existingPod1", "1Gi", "node1", 10)},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "", 1000),
+			Pods:         []*corev1.Pod{createWorkspacePod("existingPod1", "1Gi", "0Gi", "node1", 10)},
+			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
 			Desc: "three nodes, prefer with image",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", true, 100),
-				createNode("node3", "10Gi", false, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", true, 100),
+				createNode("node3", "10Gi", "0Gi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "1.5Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "1Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
+				createWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "", 1000),
+			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node2",
 		},
 		{
 			Desc: "three nodes, prefer with image in class",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", false, 100),
-				createNode("node3", "10Gi", true, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", false, 100),
+				createNode("node3", "10Gi", "0Gi", true, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "1.5Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "1Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
+				createWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "", 1000),
+			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
 			// We musn't place headless pods on nodes without regular workspaces
 			Desc: "three nodes, place headless pod",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", true, 100),
-				createNode("node3", "10Gi", true, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", true, 100),
+				createNode("node3", "10Gi", "0Gi", true, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "1.5Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "1Gi", "node2", 10),
-				createHeadlessWorkspacePod("hpod", "0.5Gi", "node3", 1000),
+				createWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
+				createWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
+				createHeadlessWorkspacePod("hpod", "0.5Gi", "0Gi", "node3", 1000),
 			},
-			ScheduledPod: createHeadlessWorkspacePod("pod", "6Gi", "", 1000),
+			ScheduledPod: createHeadlessWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node2",
 		},
 		{
 			Desc: "three empty nodes, place headless pod",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", true, 100),
-				createNode("node3", "10Gi", true, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", true, 100),
+				createNode("node3", "10Gi", "0Gi", true, 100),
 			},
-			ScheduledPod: createHeadlessWorkspacePod("pod", "6Gi", "", 1000),
+			ScheduledPod: createHeadlessWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
 			Desc: "filter full nodes, headless workspaces",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 100),
-				createNode("node2", "10Gi", false, 100),
+				createNode("node1", "10Gi", "0Gi", false, 100),
+				createNode("node2", "10Gi", "0Gi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createHeadlessWorkspacePod("existingPod1", "4Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "4Gi", "node1", 10),
+				createHeadlessWorkspacePod("existingPod1", "4Gi", "0Gi", "node1", 10),
+				createWorkspacePod("existingPod2", "4Gi", "0Gi", "node1", 10),
 			},
-			ScheduledPod: createWorkspacePod("pod", "4Gi", "", 10),
+			ScheduledPod: createWorkspacePod("pod", "4Gi", "0Gi", "", 10),
 			ExpectedNode: "node2",
 		},
 		{
 			// Should choose node1 because it has more free RAM but chooses 2 because node1's pod capacity is depleted
 			Desc: "respect node's pod capacity",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", false, 0),
-				createNode("node2", "10Gi", false, 100),
+				createNode("node1", "10Gi", "0Gi", false, 0),
+				createNode("node2", "10Gi", "0Gi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "4Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "4Gi", "0Gi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("new pod", "4Gi", "node1", 10),
+			ScheduledPod: createWorkspacePod("new pod", "4Gi", "0Gi", "node1", 10),
 			ExpectedNode: "node2",
 		},
 	}
@@ -186,7 +186,7 @@ func TestDensityAndExperience(t *testing.T) {
 	}
 }
 
-func createNode(name string, ram string, withImage bool, podCapacity int64) *corev1.Node {
+func createNode(name string, ram string, ephemeralStorage string, withImage bool, podCapacity int64) *corev1.Node {
 	images := make([]corev1.ContainerImage, 0)
 	if withImage {
 		images = append(images, corev1.ContainerImage{
@@ -199,7 +199,8 @@ func createNode(name string, ram string, withImage bool, podCapacity int64) *cor
 		},
 		Status: corev1.NodeStatus{
 			Allocatable: corev1.ResourceList{
-				corev1.ResourceMemory: res.MustParse(ram),
+				corev1.ResourceMemory:           res.MustParse(ram),
+				corev1.ResourceEphemeralStorage: res.MustParse(ephemeralStorage),
 			},
 			Images: images,
 			Capacity: corev1.ResourceList{
@@ -209,24 +210,24 @@ func createNode(name string, ram string, withImage bool, podCapacity int64) *cor
 	}
 }
 
-func createNonWorkspacePod(name string, ram string, nodeName string, age time.Duration) *corev1.Pod {
-	return createPod(name, ram, nodeName, age, map[string]string{})
+func createNonWorkspacePod(name string, ram string, ephemeralStorage string, nodeName string, age time.Duration) *corev1.Pod {
+	return createPod(name, ram, ephemeralStorage, nodeName, age, map[string]string{})
 }
 
-func createHeadlessWorkspacePod(name string, ram string, nodeName string, age time.Duration) *corev1.Pod {
-	return createPod(name, ram, nodeName, age, map[string]string{
+func createHeadlessWorkspacePod(name string, ram string, ephemeralStorage string, nodeName string, age time.Duration) *corev1.Pod {
+	return createPod(name, ram, ephemeralStorage, nodeName, age, map[string]string{
 		"component": "workspace",
 		"headless":  "true",
 	})
 }
 
-func createWorkspacePod(name string, ram string, nodeName string, age time.Duration) *corev1.Pod {
-	return createPod(name, ram, nodeName, age, map[string]string{
+func createWorkspacePod(name string, ram string, ephemeralStorage string, nodeName string, age time.Duration) *corev1.Pod {
+	return createPod(name, ram, ephemeralStorage, nodeName, age, map[string]string{
 		"component": "workspace",
 	})
 }
 
-func createPod(name string, ram string, nodeName string, age time.Duration, labels map[string]string) *corev1.Pod {
+func createPod(name string, ram string, ephemeralStorage string, nodeName string, age time.Duration, labels map[string]string) *corev1.Pod {
 	creationTimestamp := testBaseTime.Add(age * time.Second)
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -242,7 +243,8 @@ func createPod(name string, ram string, nodeName string, age time.Duration, labe
 					Image: testWorkspaceImage,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: res.MustParse(ram),
+							corev1.ResourceMemory:           res.MustParse(ram),
+							corev1.ResourceEphemeralStorage: res.MustParse(ephemeralStorage),
 						},
 					},
 				},

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy_test.go
@@ -31,16 +31,26 @@ func TestDensityAndExperience(t *testing.T) {
 		ExpectedError string
 	}{
 		{
-			Desc:          "no node",
-			ScheduledPod:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testpod"}},
-			ExpectedError: "No node with enough RAM available!\nRequested by pod: 0\nNodes:\n",
+			Desc:         "no node",
+			ScheduledPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testpod"}},
+			ExpectedError: `No node with enough resources available!
+RAM requested: 0
+Eph. Storage requested: 0
+Nodes:
+`,
 		},
 		{
-			Desc:          "no node with enough RAM",
-			Nodes:         []*corev1.Node{createNode("node1", "10Gi", "0Gi", false, 100)},
-			Pods:          []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "0Gi", "node1", 10)},
-			ScheduledPod:  createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
-			ExpectedError: "No node with enough RAM available!\nRequested by pod: 6Gi\nNodes:\n- node1: used 0.000+0.000+8.000 of 10.000, avail 2.000 GiB",
+			Desc:         "no node with enough RAM",
+			Nodes:        []*corev1.Node{createNode("node1", "10Gi", "0Gi", false, 100)},
+			Pods:         []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "0Gi", "node1", 10)},
+			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			ExpectedError: `No node with enough resources available!
+RAM requested: 6Gi
+Eph. Storage requested: 0
+Nodes:
+- node1:
+  RAM: used 0.000+0.000+8.000 of 10.000, avail 2.000 GiB
+  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
 		},
 		{
 			Desc:         "single empty node",


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/2269.

This makes `ws-scheduler` aware of ephemeral storage. The effect is that in the beginning of scheduling a pod onto a set of nodes `ws-scheduler` filters out those nodes that does not have at least the amount of ephemeral storage requested.