### PR TITLE
[ws-proxy] Wait for workspace info until the request is canceled

### DIFF
--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
+	github.com/golang/mock v1.4.3
 	github.com/google/go-cmp v0.4.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -44,6 +44,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/components/ws-proxy/pkg/proxy/auth.go
+++ b/components/ws-proxy/pkg/proxy/auth.go
@@ -37,7 +37,7 @@ func WorkspaceAuthHandler(domain string, info WorkspaceInfoProvider) mux.Middlew
 				return
 			}
 
-			ws := info.WorkspaceInfo(wsID)
+			ws := info.WorkspaceInfo(req.Context(), wsID)
 			if ws == nil {
 				log.Warn("did not find workspace info")
 				resp.WriteHeader(http.StatusNotFound)

--- a/components/ws-proxy/pkg/proxy/infoprovider_test.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider_test.go
@@ -1,0 +1,214 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	wsapi "github.com/gitpod-io/gitpod/ws-manager/api"
+	wsmock "github.com/gitpod-io/gitpod/ws-manager/api/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRemoteInfoProvider(t *testing.T) {
+	type Expectation struct {
+		WorkspaceInfo *WorkspaceInfo
+	}
+	type Step struct {
+		Update      *wsapi.SubscribeResponse
+		Action      func(*testing.T, WorkspaceInfoProvider) *Expectation
+		Expectation *Expectation
+		Parallel    bool
+		DelayUpdate time.Duration
+	}
+	tests := []struct {
+		Name  string
+		Steps []Step
+	}{
+		{
+			Name: "direct get",
+			Steps: []Step{
+				{
+					Update: &wsapi.SubscribeResponse{
+						Payload: &wsapi.SubscribeResponse_Status{Status: testWorkspaceStatus},
+					},
+				},
+				{
+					Action: func(t *testing.T, prov WorkspaceInfoProvider) *Expectation {
+						ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+						nfo := prov.WorkspaceInfo(ctx, testWorkspaceStatus.Metadata.MetaId)
+						cancel()
+
+						return &Expectation{
+							WorkspaceInfo: nfo,
+						}
+					},
+					Expectation: &Expectation{
+						WorkspaceInfo: testWorkspaceInfo,
+					},
+				},
+			},
+		},
+		{
+			Name: "wait for it",
+			Steps: []Step{
+				{
+					Parallel: true,
+					Action: func(t *testing.T, prov WorkspaceInfoProvider) *Expectation {
+						ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+						nfo := prov.WorkspaceInfo(ctx, testWorkspaceStatus.Metadata.MetaId)
+						cancel()
+
+						return &Expectation{
+							WorkspaceInfo: nfo,
+						}
+					},
+					Expectation: &Expectation{
+						WorkspaceInfo: testWorkspaceInfo,
+					},
+				},
+				{
+					Parallel:    true,
+					DelayUpdate: 10 * time.Millisecond,
+					Update: &wsapi.SubscribeResponse{
+						Payload: &wsapi.SubscribeResponse_Status{Status: testWorkspaceStatus},
+					},
+				},
+			},
+		},
+		{
+			Name: "not waiting for it",
+			Steps: []Step{
+				{
+					Parallel: true,
+					Action: func(t *testing.T, prov WorkspaceInfoProvider) *Expectation {
+						ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+						nfo := prov.WorkspaceInfo(ctx, testWorkspaceStatus.Metadata.MetaId)
+						cancel()
+
+						return &Expectation{
+							WorkspaceInfo: nfo,
+						}
+					},
+					Expectation: &Expectation{},
+				},
+				{
+					Parallel:    true,
+					DelayUpdate: 10 * time.Millisecond,
+					Update: &wsapi.SubscribeResponse{
+						Payload: &wsapi.SubscribeResponse_Status{Status: testWorkspaceStatus},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			clients := make(chan wsapi.WorkspaceManagerClient, 1)
+			defer close(clients)
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			updates := make(chan *wsapi.SubscribeResponse)
+			srv := wsmock.NewMockWorkspaceManager_SubscribeClient(ctrl)
+			srv.EXPECT().Recv().DoAndReturn(func() (*wsapi.SubscribeResponse, error) {
+				u := <-updates
+				if u == nil {
+					return nil, io.EOF
+				}
+
+				return u, nil
+			}).AnyTimes()
+			cl := wsmock.NewMockWorkspaceManagerClient(ctrl)
+			cl.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Return(srv, nil).AnyTimes()
+			cl.EXPECT().GetWorkspaces(gomock.Any(), gomock.Any()).Return(&wsapi.GetWorkspacesResponse{}, nil).AnyTimes()
+
+			prov := NewRemoteWorkspaceInfoProvider(WorkspaceInfoProviderConfig{WsManagerAddr: "target"})
+			prov.Dialer = func(target string) (io.Closer, wsapi.WorkspaceManagerClient, error) {
+				return ioutil.NopCloser(nil), cl, nil
+			}
+			err := prov.Run()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer prov.Close()
+
+			for i, step := range test.Steps {
+				// copy step because we capture the loop variable in the Run() function
+				step := step
+
+				t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+					if step.Parallel {
+						t.Parallel()
+					}
+					if step.Update != nil {
+						if step.DelayUpdate > 0 {
+							time.Sleep(step.DelayUpdate)
+						}
+
+						updates <- step.Update
+						// Give the update some time to propagate.
+						// This is not the most elegant way of doing that, but in > 10k tests it didn't fail once.
+						time.Sleep(1 * time.Millisecond)
+					}
+
+					if step.Action != nil {
+						act := step.Action(t, prov)
+						if diff := cmp.Diff(step.Expectation, act); diff != "" {
+							t.Errorf("Expectation mismatch (-want +got):\n%s", diff)
+						}
+					}
+				})
+			}
+		})
+	}
+
+}
+
+var (
+	testWorkspaceStatus = &wsapi.WorkspaceStatus{
+		Id: "e63cb5ff-f4e4-4065-8554-b431a32c0000",
+		Metadata: &wsapi.WorkspaceMetadata{
+			MetaId: "e63cb5ff-f4e4-4065-8554-b431a32c2714",
+		},
+		Auth: &wsapi.WorkspaceAuthentication{
+			Admission:  wsapi.AdmissionLevel_ADMIT_OWNER_ONLY,
+			OwnerToken: "testWorkspaceOwnerToken",
+		},
+		Phase: wsapi.WorkspacePhase_RUNNING,
+		Spec: &wsapi.WorkspaceSpec{
+			IdeImage: "testWorkspaceIDEImage",
+			Headless: false,
+			Type:     wsapi.WorkspaceType_REGULAR,
+			Url:      "https://e63cb5ff-f4e4-4065-8554-b431a32c2714.ws-eu02.gitpod.io",
+			ExposedPorts: []*wsapi.PortSpec{
+				{
+					Port:       8080,
+					Target:     38080,
+					Url:        "https://8080-e63cb5ff-f4e4-4065-8554-b431a32c2714.ws-eu02.gitpod.io/",
+					Visibility: wsapi.PortVisibility_PORT_VISIBILITY_PUBLIC,
+				},
+			},
+		},
+	}
+	testWorkspaceInfo = &WorkspaceInfo{
+		IDEImage:      testWorkspaceStatus.Spec.IdeImage,
+		Auth:          testWorkspaceStatus.Auth,
+		IDEPublicPort: "443",
+		InstanceID:    testWorkspaceStatus.Id,
+		Ports: []PortInfo{
+			{
+				PortSpec:   *testWorkspaceStatus.Spec.ExposedPorts[0],
+				PublicPort: "443",
+			},
+		},
+		URL:         testWorkspaceStatus.Spec.Url,
+		WorkspaceID: testWorkspaceStatus.Metadata.MetaId,
+	}
+)

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -450,7 +450,7 @@ func workspaceMustExistHandler(config *Config, infoProvider WorkspaceInfoProvide
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			coords := getWorkspaceCoords(req)
-			info := infoProvider.WorkspaceInfo(coords.ID)
+			info := infoProvider.WorkspaceInfo(req.Context(), coords.ID)
 			if info == nil {
 				log.WithFields(log.OWI("", coords.ID, "")).Info("no workspace info found - redirecting to start")
 				redirectURL := fmt.Sprintf("%s://%s/start/#%s", config.GitpodInstallation.Scheme, config.GitpodInstallation.HostName, coords.ID)

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -677,7 +677,7 @@ type fakeWsInfoProvider struct {
 }
 
 // GetWsInfoByID returns the workspace for the given ID
-func (p *fakeWsInfoProvider) WorkspaceInfo(workspaceID string) *WorkspaceInfo {
+func (p *fakeWsInfoProvider) WorkspaceInfo(ctx context.Context, workspaceID string) *WorkspaceInfo {
 	for _, nfo := range p.infos {
 		if nfo.WorkspaceID == workspaceID {
 			return &nfo

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -243,7 +243,7 @@ func pathBasedTheiaRouter(r *mux.Router, wsInfoProvider WorkspaceInfoProvider, t
 
 		path := strings.TrimPrefix(req.URL.Path, trimPrefix)
 		wsID = strings.Split(path, "/")[0]
-		if wsInfoProvider.WorkspaceInfo(wsID) == nil {
+		if wsInfoProvider.WorkspaceInfo(req.Context(), wsID) == nil {
 			log.WithFields(log.OWI("", wsID, "")).Debug("PathBasedTheiaRouter: no workspace info found")
 			return false
 		}


### PR DESCRIPTION
This PR makes ws-proxy wait for workspace info.
We wait for workspace info to arrive until the request context is canceled.

fixes https://github.com/gitpod-io/gitpod/issues/2299

### How to test
Place a lot of load on the system, or artificially delay the ws-man subscription e.g. using blowtorch.

Also, there's a unit test :)