### PR TITLE
[supervisor] don't drop last ports/tasks updates

### DIFF
--- a/components/dashboard/public/schemas/gitpod-schema.json
+++ b/components/dashboard/public/schemas/gitpod-schema.json
@@ -159,11 +159,6 @@
             "type": "string",
             "description": "Path to where the IDE's workspace should be opened."
         },
-        "privileged": {
-            "type": "boolean",
-            "deprecationMessage": "The 'privileged' property only works for privileged users.",
-            "description": "Whether the workspace is started in privileged mode."
-        },
         "gitConfig": {
             "type": [
                 "object"

--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -166,55 +166,54 @@ func TestPortsUpdateState(t *testing.T) {
 				},
 			},
 		},
-		// TODO(cw): fix this test
-		// {
-		// 	Desc: "auto expose configured ports",
-		// 	Changes: []Change{
-		// 		{
-		// 			Config: &ConfigChange{workspace: []*gitpod.PortConfig{
-		// 				{Port: 8080, Visibility: "private"},
-		// 			}},
-		// 		},
-		// 		{
-		// 			Exposed: []ExposedPort{{LocalPort: 8080, GlobalPort: 8080, Public: false, URL: "foobar"}},
-		// 		},
-		// 		{
-		// 			Exposed: []ExposedPort{{LocalPort: 8080, GlobalPort: 8080, Public: true, URL: "foobar"}},
-		// 		},
-		// 		{
-		// 			Served: []ServedPort{{8080, true}},
-		// 		},
-		// 		{
-		// 			Exposed: []ExposedPort{{LocalPort: 8080, GlobalPort: 60000, Public: true, URL: "foobar"}},
-		// 		},
-		// 		{
-		// 			Served: []ServedPort{{8080, true}, {60000, false}},
-		// 		},
-		// 		{
-		// 			Served: []ServedPort{{60000, false}},
-		// 		},
-		// 		{
-		// 			Served: []ServedPort{},
-		// 		},
-		// 		{
-		// 			Served: []ServedPort{{8080, false}},
-		// 		},
-		// 	},
-		// 	ExpectedExposure: []ExposedPort{
-		// 		{LocalPort: 8080, Public: false},
-		// 		{LocalPort: 8080, GlobalPort: 60000, Public: true},
-		// 		{LocalPort: 8080, GlobalPort: 8080, Public: true},
-		// 	},
-		// 	ExpectedUpdates: UpdateExpectation{
-		// 		{},
-		// 		[]*api.PortsStatus{{LocalPort: 8080}},
-		// 		[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 8080, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_private, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
-		// 		[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 8080, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
-		// 		[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 60000, Served: true, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
-		// 		[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 60000, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
-		// 		[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 8080, Served: true, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
-		// 	},
-		// },
+		{
+			Desc: "auto expose configured ports",
+			Changes: []Change{
+				{
+					Config: &ConfigChange{workspace: []*gitpod.PortConfig{
+						{Port: 8080, Visibility: "private"},
+					}},
+				},
+				{
+					Exposed: []ExposedPort{{LocalPort: 8080, GlobalPort: 8080, Public: false, URL: "foobar"}},
+				},
+				{
+					Exposed: []ExposedPort{{LocalPort: 8080, GlobalPort: 8080, Public: true, URL: "foobar"}},
+				},
+				{
+					Served: []ServedPort{{8080, true}},
+				},
+				{
+					Exposed: []ExposedPort{{LocalPort: 8080, GlobalPort: 60000, Public: true, URL: "foobar"}},
+				},
+				{
+					Served: []ServedPort{{8080, true}, {60000, false}},
+				},
+				{
+					Served: []ServedPort{{60000, false}},
+				},
+				{
+					Served: []ServedPort{},
+				},
+				{
+					Served: []ServedPort{{8080, false}},
+				},
+			},
+			ExpectedExposure: []ExposedPort{
+				{LocalPort: 8080, Public: false},
+				{LocalPort: 8080, GlobalPort: 60000, Public: true},
+				{LocalPort: 8080, GlobalPort: 8080, Public: true},
+			},
+			ExpectedUpdates: UpdateExpectation{
+				{},
+				[]*api.PortsStatus{{LocalPort: 8080}},
+				[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 8080, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_private, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
+				[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 8080, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
+				[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 60000, Served: true, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
+				[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 60000, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
+				[]*api.PortsStatus{{LocalPort: 8080, GlobalPort: 8080, Served: true, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, OnExposed: api.OnPortExposedAction_notify, Url: "foobar"}}},
+			},
+		},
 		{
 			Desc: "starting multiple proxies for the same served event",
 			Changes: []Change{

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -127,8 +127,9 @@ func (tm *tasksManager) updateState(doUpdate func() (changed bool)) {
 	for sub := range tm.subscriptions {
 		select {
 		case sub.updates <- updates:
-		default:
-			log.Warn("cannot to push tasks update to a subscriber")
+		case <-time.After(5 * time.Second):
+			log.Error("tasks subscription droped out")
+			sub.Close()
 		}
 	}
 }


### PR DESCRIPTION
#### What it does

Before if updates channel is full last updates will be dropped, now we wait 5 seconds and then drop the subscriber. It will reconnect and read the latest update then.

Also make sure that subscriptions access is guarded by the mutex.

#### How to test

- port tests should pass if you run 100 times (both functional and concurrent)
- ports/tasks should work