### PR TITLE
Improve feature preview settings

### DIFF
--- a/components/dashboard/src/components/feature-settings.tsx
+++ b/components/dashboard/src/components/feature-settings.tsx
@@ -8,6 +8,7 @@ import * as protocol from '@gitpod/gitpod-protocol';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
 import Checkbox from '@material-ui/core/Checkbox';
+import Typography from '@material-ui/core/Typography';
 import * as React from 'react';
 import debounce = require('lodash.debounce');
 import { IDESettings } from './ide-settings';
@@ -50,11 +51,17 @@ export class FeatureSettings extends React.Component<FeatureSettingsProps, Featu
 
     render() {
         return <Grid xs={12}>
-            <div><small>This option enables a Beta preview of some of the latest functionalities and features that are being actively developed. Some of them are user-facing features while others
-                take place in the backstage, see <a href="https://www.gitpod.io/docs/feature-preview/" target="_blank">relevant documentation</a>. If you have suggestions on how we can improve a
-                feature, please provide feedback by <a href="https://github.com/gitpod-io/gitpod/issues/new/choose" target="_blank">opening an issue</a>.
-            </small></div>
-            <FormControlLabel control={<Checkbox checked={this.state.featurePreview} onChange={() => this.updateFeatureFlags(!this.state.featurePreview)} />} label={"Enable Feature Preview"} />
+            <FormControlLabel
+                control={<Checkbox color="primary" checked={this.state.featurePreview} onChange={() => this.updateFeatureFlags(!this.state.featurePreview)} />}
+                label={
+                <>
+                    Enable Feature Preview
+                    <Typography variant="caption">
+                    This will enable a beta preview of some of the latest functionalities and features that are being actively developed.&nbsp;
+                    <a href="https://www.gitpod.io/docs/feature-preview/" target="_blank">Learn more</a>
+                    </Typography>
+                </>
+                } />
             { this.state.featurePreview && <div>
                 <h4>Default IDE</h4>
                 <div><small>By default Gitpod uses Eclipse Theia as IDE. However, other IDEs may become available in the future. Choose below to try a different IDE.</small></div>

--- a/components/dashboard/src/components/user-settings.tsx
+++ b/components/dashboard/src/components/user-settings.tsx
@@ -77,6 +77,7 @@ export class UserSettings extends React.Component<UserSettingsProps, UserSetting
                 <Checkbox
                     onChange={() => this.updateTransactionalMailSettings(!allowsTransactionalMail)}
                     checked={allowsTransactionalMail}
+                    color="primary"
                 />
                 Receive important emails about changes to my account
             </Grid>
@@ -84,6 +85,7 @@ export class UserSettings extends React.Component<UserSettingsProps, UserSetting
                 <Checkbox
                     onChange={() => this.updateAllowsMarketingCommunication(!allowsMarketingCommunication)}
                     checked={allowsMarketingCommunication}
+                    color="primary"
                 />
                 Receive marketing emails (for example, the Gitpod newsletter)
             </Grid>


### PR DESCRIPTION
This will slightly improve the _Feature Preview_ settings with the following changes:
1. Remove the description from the _Feature Preview_ section as this will be included in the docs, see https://github.com/gitpod-io/website/pull/846.
1. Change the checkbox style to include a small caption.
1. Change the link to the docs following the pattern used in _Settings_, see _Git Provider Integrations_.
1. Change checkbox style for _Feature Preview_ and _Email Settings_ to use primary color so that color usage follows the theme.

| BEFORE | AFTER |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/100462096-6b83d780-30d2-11eb-9f2b-8adad9ec2370.png) | ![image](https://user-images.githubusercontent.com/120486/100462103-6d4d9b00-30d2-11eb-94d4-26df011016d8.png) |
| ![image](https://user-images.githubusercontent.com/120486/100462195-91a97780-30d2-11eb-9285-0c4c6241b8e5.png) | ![image](https://user-images.githubusercontent.com/120486/100462200-940bd180-30d2-11eb-8768-83757e510715.png) |