### PR TITLE
[supervisor] Gracefully close terminals on shutdown

### DIFF
--- a/components/supervisor/cmd/terminal-close.go
+++ b/components/supervisor/cmd/terminal-close.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/spf13/cobra"
+)
+
+var terminalCloseCmd = &cobra.Command{
+	Use:   "close <alias>",
+	Short: "closes a terminal",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := api.NewTerminalServiceClient(dialSupervisor())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		_, err := client.Close(ctx, &api.CloseTerminalRequest{
+			Alias: args[0],
+		})
+		if err != nil {
+			log.WithError(err).Fatal("cannot close terminals")
+		}
+	},
+}
+
+func init() {
+	terminalCmd.AddCommand(terminalCloseCmd)
+}

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -20,6 +20,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	// closeTerminaldefaultGracePeriod is the time terminal
+	// processes get between SIGTERM and SIGKILL.
+	closeTerminaldefaultGracePeriod = 10 * time.Second
+)
+
 // NewMuxTerminalService creates a new terminal service
 func NewMuxTerminalService(m *Mux) *MuxTerminalService {
 	shell := os.Getenv("SHELL")
@@ -90,7 +96,7 @@ func (srv *MuxTerminalService) OpenWithOptions(ctx context.Context, req *api.Ope
 
 // Close closes a terminal for the given alias
 func (srv *MuxTerminalService) Close(ctx context.Context, req *api.CloseTerminalRequest) (*api.CloseTerminalResponse, error) {
-	err := srv.Mux.Close(req.Alias)
+	err := srv.Mux.CloseTerminal(req.Alias, closeTerminaldefaultGracePeriod)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
This PR introduces a graceful shutdown for all supervisor managed terminals, that includes tasks.

### How it works
When supervisor shuts down it closes the terminal mux, which in turn closes all terminals.
Previously we'd just kill the terminal process. Now, we send `SIGINT` and after 10 seconds `SIGKILL`.

### How to test
1. start a workspace
2. in the terminal that started a task, run `trap "echo foo > bar.txt" INT`
3. stop the workspace. You should see
![image](https://user-images.githubusercontent.com/3210701/100466861-e4366400-30d1-11eb-831f-cc6657f26af7.png)

Bonus: you play with `/theia/supervisor terminal close`