### PR TITLE
[ws-daemon] Add readiness probe

### DIFF
--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -5,6 +5,9 @@
 {{ $comp := .comp -}}
 {{ with .root }}
 daemon:
+  readiness:
+    enabled: true
+    addr: ":9999"
   runtime:
     namespace: {{ .Release.Namespace | quote }}
     containerRuntime:

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -175,6 +175,12 @@ spec:
           hostPort: {{ $comp.registryProxyPort }}
         - name: metrics
           containerPort: 9500
+        readinessProbe:
+          httpGet:
+            port: 9999
+            path: "/"
+          initialDelaySeconds: 5
+          periodSeconds: 10
         securityContext:
           privileged: true
           procMount: unmasked

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -21,6 +21,12 @@ type Config struct {
 		KubernetesNamespace string            `json:"namespace"`
 	} `json:"runtime"`
 
+	ReadinessSignal struct {
+		Enabled bool   `json:"enabled"`
+		Addr    string `json:"addr"`
+		Path    string `json:"path"`
+	} `json:"readiness"`
+
 	Content        content.Config      `json:"content"`
 	Uidmapper      iws.UidmapperConfig `json:"uidmapper"`
 	Resources      resources.Config    `json:"resources"`


### PR DESCRIPTION
This PR adds a readiness probe to ws-daemon.

For now, it only checks if a possible host controller ever wrote an update.
In the future, we'll tie this to the container runtime connection.

An unready ws-daemon pod will prevent ws-scheduler from scheduling workspaces onto this node, by virtue of `gitpod.io/requiredNodeServices`