### PR TITLE
Use the same color for checkbox and radio inputs in settings

### DIFF
--- a/components/dashboard/src/components/feature-settings.tsx
+++ b/components/dashboard/src/components/feature-settings.tsx
@@ -24,7 +24,7 @@ export class FeatureSettings extends React.Component<FeatureSettingsProps> {
         const { featurePreview } = this;
         return <Grid xs={12}>
             <FormControlLabel
-                control={<Checkbox color="primary" checked={featurePreview} onChange={this.updateFeatureFlags} />}
+                control={<Checkbox color="default" checked={featurePreview} onChange={this.updateFeatureFlags} />}
                 label={
                     <>
                         Enable Feature Preview

--- a/components/dashboard/src/components/ide-settings.tsx
+++ b/components/dashboard/src/components/ide-settings.tsx
@@ -40,7 +40,7 @@ export class IDESettings extends React.Component<IDESettingsProps> {
     private renderRadio(label: string, value: IDEKind) {
         const checked = value === this.value;
         return <Grid item xs={12}>
-            <FormControlLabel control={<Radio />} label={label} value={value} checked={checked} onChange={this.updateDefaultIde} />
+            <FormControlLabel control={<Radio color="default" />} label={label} value={value} checked={checked} onChange={this.updateDefaultIde} />
             {value === 'image' && <Input value={this.image} onChange={this.updateDefaultIde} />}
         </Grid>;
     }

--- a/components/dashboard/src/components/user-settings.tsx
+++ b/components/dashboard/src/components/user-settings.tsx
@@ -27,7 +27,7 @@ export class UserSettings extends React.Component<UserSettingsProps> {
                 <Checkbox
                     onChange={this.updateTransactionalMailSettings}
                     checked={!disallowTransactionalEmails}
-                    color="primary"
+                    color="default"
                 />
                 Receive important emails about changes to my account
             </Grid>
@@ -35,7 +35,7 @@ export class UserSettings extends React.Component<UserSettingsProps> {
                 <Checkbox
                     onChange={this.updateAllowsMarketingCommunication}
                     checked={allowsMarketingCommunication}
-                    color="primary"
+                    color="default"
                 />
                 Receive marketing emails (for example, the Gitpod newsletter)
             </Grid>


### PR DESCRIPTION
This is a minor follow-up from https://github.com/gitpod-io/gitpod/pull/2319 that aligns checkbox and radio inputs in settings.

| BEFORE | AFTER |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/100634312-d08c3700-3337-11eb-84af-9ee39bc1b5aa.png) | ![image](https://user-images.githubusercontent.com/120486/100634432-f580aa00-3337-11eb-8a5b-2bf4f149e314.png) |
| ![image](https://user-images.githubusercontent.com/120486/100634361-e4d03400-3337-11eb-978d-4feaaafb074a.png) | ![image](https://user-images.githubusercontent.com/120486/100634446-fc0f2180-3337-11eb-94c7-fb34ddf00559.png) |

FWIW, this opts for using the default color instead of the primary color because the primary color is different for the controls involved.

| Current | Using primary color | Using default color |
|-|-|-|
| ![image](https://user-images.githubusercontent.com/120486/100634979-9e2f0980-3338-11eb-9ce2-69b929a40b78.png) | ![image](https://user-images.githubusercontent.com/120486/100635024-ad15bc00-3338-11eb-9977-14a5adcb2749.png) | ![image](https://user-images.githubusercontent.com/120486/100634925-8e172a00-3338-11eb-9c23-3e753ee206ee.png) |