### PR TITLE
[registry-facade] Add metrics for manifest and blob access

### DIFF
--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -67,8 +67,12 @@ func (reg *Registry) handleBlob(ctx context.Context, r *http.Request) http.Handl
 		"GET":  http.HandlerFunc(blobHandler.getBlob),
 		"HEAD": http.HandlerFunc(blobHandler.getBlob),
 	}
+	res := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reg.metrics.BlobCounter.Inc()
+		mhandler.ServeHTTP(w, r)
+	})
 
-	return mhandler
+	return res
 }
 
 type blobHandler struct {

--- a/components/registry-facade/pkg/registry/metrics.go
+++ b/components/registry-facade/pkg/registry/metrics.go
@@ -1,0 +1,71 @@
+package registry
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// NewMeasuringRegistryRoundTripper produces a round tripper that exposes registry access metrics
+func NewMeasuringRegistryRoundTripper(delegate http.RoundTripper, reg prometheus.Registerer) (http.RoundTripper, error) {
+	metrics, err := newMetrics(reg)
+	if err != nil {
+		return nil, err
+	}
+	return &measuringRegistryRoundTripper{
+		delegate: delegate,
+		metrics:  metrics,
+	}, nil
+}
+
+type measuringRegistryRoundTripper struct {
+	delegate http.RoundTripper
+	metrics  *metrics
+}
+
+func (m *measuringRegistryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t0 := time.Now()
+	resp, err := m.delegate.RoundTrip(req)
+	dt := time.Since(t0)
+
+	if strings.Contains(req.URL.Path, "/manifests/") {
+		m.metrics.ManifestHist.Observe(dt.Seconds())
+	} else if strings.Contains(req.URL.Path, "/blobs/") {
+		m.metrics.BlobCounter.Inc()
+	}
+
+	return resp, err
+}
+
+// Metrics combine custom metrics exported by registry facade
+type metrics struct {
+	ManifestHist prometheus.Histogram
+	BlobCounter  prometheus.Counter
+}
+
+func newMetrics(reg prometheus.Registerer) (*metrics, error) {
+	manifestHist := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "manifest_req_sec",
+		Help:    "time of manifest requests made to the downstream registry",
+		Buckets: []float64{0.1, 0.5, 1, 2, 5, 10},
+	})
+	err := reg.Register(manifestHist)
+	if err != nil {
+		return nil, err
+	}
+
+	blobCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "blob_req_count",
+		Help: "number of blob requests made to the downstream registry",
+	})
+	err = reg.Register(blobCounter)
+	if err != nil {
+		return nil, err
+	}
+	return &metrics{
+		ManifestHist: manifestHist,
+		BlobCounter:  blobCounter,
+	}, nil
+}


### PR DESCRIPTION
This PR adds manifest and blob pull metrics to registry-facade.

### How to test
1. Check which metrics a registry-facade exposes. You should see something like
```
# HELP downstream_blob_req_count number of blob requests made to the downstream registry
# TYPE downstream_blob_req_count counter
downstream_blob_req_count 18
# HELP downstream_manifest_req_sec time of manifest requests made to the downstream registry
# TYPE downstream_manifest_req_sec histogram
downstream_manifest_req_sec_bucket{le="0.1"} 0
downstream_manifest_req_sec_bucket{le="0.5"} 20
downstream_manifest_req_sec_bucket{le="1"} 20
downstream_manifest_req_sec_bucket{le="2"} 20
downstream_manifest_req_sec_bucket{le="5"} 20
downstream_manifest_req_sec_bucket{le="10"} 20
downstream_manifest_req_sec_bucket{le="+Inf"} 20
downstream_manifest_req_sec_sum 4.264129102000001
downstream_manifest_req_sec_count 20
# HELP registry_blob_req_count number of blob requests made to the downstream registry
# TYPE registry_blob_req_count counter
registry_blob_req_count 4
# HELP registry_manifest_req_sec time of manifest requests made to the downstream registry
# TYPE registry_manifest_req_sec histogram
registry_manifest_req_sec_bucket{le="0.1"} 0
registry_manifest_req_sec_bucket{le="0.5"} 2
registry_manifest_req_sec_bucket{le="1"} 2
registry_manifest_req_sec_bucket{le="2"} 3
registry_manifest_req_sec_bucket{le="5"} 3
registry_manifest_req_sec_bucket{le="10"} 3
registry_manifest_req_sec_bucket{le="+Inf"} 3
registry_manifest_req_sec_sum 1.5229932529999999
registry_manifest_req_sec_count 3
```