### PR TITLE
[ws-daemon] Reintroduce the working_area_free_bytes metric

### DIFF
--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -27,7 +27,7 @@ import (
 )
 
 // NewDaemon produces a new daemon
-func NewDaemon(config Config, prom prometheus.Registerer) (*Daemon, error) {
+func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 	clientset, err := newClientSet(config.Runtime.Kubeconfig)
 	if err != nil {
 
@@ -50,7 +50,7 @@ func NewDaemon(config Config, prom prometheus.Registerer) (*Daemon, error) {
 		return nil, xerrors.Errorf("NODENAME env var isn't set")
 	}
 	dsptch, err := dispatch.NewDispatch(containerRuntime, clientset, config.Runtime.KubernetesNamespace, nodename,
-		resources.NewDispatchListener(&config.Resources, prom),
+		resources.NewDispatchListener(&config.Resources, reg),
 		&Containerd4214Workaround{},
 	)
 	if err != nil {
@@ -64,6 +64,7 @@ func NewDaemon(config Config, prom prometheus.Registerer) (*Daemon, error) {
 		containerRuntime,
 		dsptch.WorkspaceExistsOnNode,
 		&iws.Uidmapper{Config: config.Uidmapper, Runtime: containerRuntime},
+		reg,
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create content service: %w", err)


### PR DESCRIPTION
This PR reintroduces the `working_area_free_bytes` metric in ws-daemon.

It got lost in the ws-manager-node/ws-sync merger.

### How to test
1. Check which metrics ws-daemon exports, you should see something like
```
# HELP working_area_free_bytes Amount of free disk space in the working area
# TYPE working_area_free_bytes gauge
working_area_free_bytes{hostname="gke-dev-workload-7fd27879-t6xd"} 3.34090350592e+11
```