### PR TITLE
[monitoring,registry-facade] added annottations

### DIFF
--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -31,6 +31,10 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
         gitpod.io/nodeService: registry-facade
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: '9500'
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: registry-facade


### PR DESCRIPTION
These annotations needs to be added to the daemonset in order to get scraped by prometheus.
```
prometheus.io/path: /metrics
prometheus.io/port: "9500"
prometheus.io/scrape: "true"
```