### PR TITLE
Follow Prometheus naming best practice

### DIFF
--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -34,6 +34,10 @@ spec:
         component: ws-proxy
         kind: pod
         stage: {{ .Values.installation.stage }}
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: '60095'
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-proxy

--- a/chart/templates/ws-scheduler-configmap.yaml
+++ b/chart/templates/ws-scheduler-configmap.yaml
@@ -15,6 +15,12 @@ metadata:
 data:
   config.json: |-
     {
+        "pprof": {
+            "addr": "localhost:6060"
+        },
+        "prometheus": {
+            "addr": ":9500"
+        },
         "scheduler": {
             "schedulerName": "{{ $comp.schedulerName }}",
             "namespace": "{{ .Release.Namespace }}",

--- a/chart/templates/ws-scheduler-deployment.yaml
+++ b/chart/templates/ws-scheduler-deployment.yaml
@@ -34,6 +34,10 @@ spec:
         component: ws-scheduler
         kind: pod
         stage: {{ .Values.installation.stage }}
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: '9500'
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-scheduler

--- a/components/ee/ws-scheduler/cmd/root.go
+++ b/components/ee/ws-scheduler/cmd/root.go
@@ -82,8 +82,14 @@ func getConfig() *config {
 }
 
 type config struct {
-	Scheduler scheduler.Configuration `json:"scheduler"`
-	Scaler    *scaler.Configuration   `json:"scaler,omitempty"`
+	Scheduler  scheduler.Configuration `json:"scheduler"`
+	Scaler     *scaler.Configuration   `json:"scaler,omitempty"`
+	Prometheus struct {
+		Addr string `json:"address"`
+	} `json:"prometheus"`
+	PProf struct {
+		Addr string `json:"address"`
+	} `json:"pprof"`
 }
 
 func newClientSet() (*kubernetes.Clientset, error) {

--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -6,13 +6,17 @@ package cmd
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scheduler"
 )
@@ -63,6 +67,29 @@ var runCmd = &cobra.Command{
 				log.Info("ws-scaler shut down")
 			}()
 			log.Info("ws-scaler is up and running. Stop with SIGINT or CTRL+C")
+		}
+
+		if config.Prometheus.Addr != "" {
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(
+				prometheus.NewGoCollector(),
+				prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+			)
+
+			handler := http.NewServeMux()
+			handler.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+
+			go func() {
+				err := http.ListenAndServe(config.Prometheus.Addr, handler)
+				if err != nil {
+					log.WithError(err).Error("Prometheus metrics server failed")
+				}
+			}()
+			log.WithField("addr", config.Prometheus.Addr).Info("started Prometheus metrics server")
+		}
+
+		if config.PProf.Addr != "" {
+			go pprof.Serve(config.PProf.Addr)
 		}
 
 		// Run until we're told to stop

--- a/components/ee/ws-scheduler/cmd/test-cluster-scaleup.go
+++ b/components/ee/ws-scheduler/cmd/test-cluster-scaleup.go
@@ -260,9 +260,9 @@ func startTestPod(clientSet *kubernetes.Clientset, nr int, suffix string) error 
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							corev1.NodeSelectorTerm{
+							{
 								MatchExpressions: []corev1.NodeSelectorRequirement{
-									corev1.NodeSelectorRequirement{
+									{
 										Key:      "gitpod.io/workload_workspace",
 										Operator: corev1.NodeSelectorOpIn,
 										Values:   []string{"true"},
@@ -274,7 +274,7 @@ func startTestPod(clientSet *kubernetes.Clientset, nr int, suffix string) error 
 				},
 			},
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:    "main",
 					Image:   "alpine:latest",
 					Command: []string{"bash", "-c", "while true; do sleep 2; echo 'sleeping...'; done"},

--- a/components/ee/ws-scheduler/cmd/test-scheduling-pressure.go
+++ b/components/ee/ws-scheduler/cmd/test-scheduling-pressure.go
@@ -109,9 +109,9 @@ func createPod(clientSet *kubernetes.Clientset, scheduler string, namespace stri
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							corev1.NodeSelectorTerm{
+							{
 								MatchExpressions: []corev1.NodeSelectorRequirement{
-									corev1.NodeSelectorRequirement{
+									{
 										Key:      "gitpod.io/workload_workspace",
 										Operator: corev1.NodeSelectorOpIn,
 										Values:   []string{"true"},
@@ -127,7 +127,7 @@ func createPod(clientSet *kubernetes.Clientset, scheduler string, namespace stri
 				RunAsNonRoot: &boolTrue,
 			},
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:    "main",
 					Image:   "eu.gcr.io/gitpod-dev/workspace-images:7e01b3299b178278c88c5a4606bdeed09059e94e8a7a193b249606028cfd13dd",
 					Command: []string{"bash", "-c", "while true; do sleep 2; echo 'sleeping...'; done"},

--- a/components/ee/ws-scheduler/go.mod
+++ b/components/ee/ws-scheduler/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.4
 	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 // indirect

--- a/components/registry-facade/cmd/run.go
+++ b/components/registry-facade/cmd/run.go
@@ -57,7 +57,8 @@ var runCmd = &cobra.Command{
 		}
 
 		reg := prometheus.NewRegistry()
-		rtt, err := registry.NewMeasuringRegistryRoundTripper(http.DefaultTransport, prometheus.WrapRegistererWithPrefix("downstream_", reg))
+		gpreg := prometheus.WrapRegistererWithPrefix("gitpod_registry_facade_", reg)
+		rtt, err := registry.NewMeasuringRegistryRoundTripper(http.DefaultTransport, prometheus.WrapRegistererWithPrefix("downstream_", gpreg))
 		if err != nil {
 			log.WithError(err).Fatal("cannot registry metrics")
 		}
@@ -77,7 +78,7 @@ var runCmd = &cobra.Command{
 		}
 
 		if cfg.Registry != nil {
-			reg, err := registry.NewRegistry(*cfg.Registry, resolverProvider, prometheus.WrapRegistererWithPrefix("registry_", reg))
+			reg, err := registry.NewRegistry(*cfg.Registry, resolverProvider, prometheus.WrapRegistererWithPrefix("registry_", gpreg))
 			if err != nil {
 				log.WithError(err).Fatal("cannot create registry")
 			}

--- a/components/registry-facade/pkg/registry/metrics.go
+++ b/components/registry-facade/pkg/registry/metrics.go
@@ -47,7 +47,7 @@ type metrics struct {
 
 func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 	manifestHist := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "manifest_req_sec",
+		Name:    "manifest_req_seconds",
 		Help:    "time of manifest requests made to the downstream registry",
 		Buckets: []float64{0.1, 0.5, 1, 2, 5, 10},
 	})
@@ -57,7 +57,7 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 	}
 
 	blobCounter := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "blob_req_count",
+		Name: "blob_req_total",
 		Help: "number of blob requests made to the downstream registry",
 	})
 	err = reg.Register(blobCounter)

--- a/components/ws-daemon/pkg/resources/dispatch.go
+++ b/components/ws-daemon/pkg/resources/dispatch.go
@@ -36,7 +36,7 @@ func NewDispatchListener(cfg *Config, prom prometheus.Registerer) *DispatchListe
 	}
 	prom.MustRegister(
 		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Name: "wsman_node_resource_governer_total",
+			Name: "resource_governer_total",
 			Help: "Number active workspace resource governer",
 		}, func() float64 {
 			d.mu.Lock()

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -22,7 +22,7 @@ func (m *Manager) RegisterMetrics(reg prometheus.Registerer) error {
 }
 
 const (
-	metricsNamespace          = "wsman"
+	metricsNamespace          = "gitpod_ws_manager"
 	metricsWorkspaceSubsystem = "workspace"
 )
 


### PR DESCRIPTION
This PR harmonises the custom metrics we expose, and corrects metric names to follow the [Prometheus naming best practice](https://prometheus.io/docs/practices/naming/) - thanks @ArthurSens for pointing this out :)

### What it does
- renames the following metrics:
  - `manifest_req_sec` to `gitpod_registry_facade_manifest_req_seconds`
  - `blob_req_count` to `gitpod_registry_facade_blob_req_total`
  - `wsman_workspace_*` to `gitpod_ws_manager_workspace_*`
  - `working_area_free_bytes` to `gitpod_ws_daemon_working_area_free_bytes`
  - `wsman_node_resource_governer_total` to `gitpod_ws_daemon_resource_governer_total`
- adds Prometheus and pprof support to ws-scheduler
- adds Promtheus annotations to the ws-scheduler and ws-proxy pods

### How to test
- inspect the metrics of ws-manager, ws-daemon, ws-scheduler, ws-proxy and registry-facade

### Open Questions
- @ArthurSens the metric names feel rather long now. Are we going to hit any size limit with `gitpod_registry_facade_downstream_manifest_req_seconds_bucket` (62 characters)?

### Follow up
- adapt the Grafana dashboards