### PR TITLE
[ws-scheduler] Don't loose localBindingCache info due to broken UniquePods function

### DIFF
--- a/components/ee/ws-scheduler/cmd/test-cluster-scaleup.go
+++ b/components/ee/ws-scheduler/cmd/test-cluster-scaleup.go
@@ -154,8 +154,8 @@ func playScaleupScenario(clientSet *kubernetes.Clientset, stopChan chan struct{}
 
 	// 2.3 No OutOfMemory
 	for _, p := range stateOverflow.Pods {
-		if p.Pod.Status.Phase == corev1.PodFailed && p.Pod.Status.Reason == "OutOfMemory" {
-			return xerrors.Errorf("OutOfMemory error: %s", p.Pod.Name)
+		if p.Status.Phase == corev1.PodFailed && p.Status.Reason == "OutOfMemory" {
+			return xerrors.Errorf("OutOfMemory error: %s", p.Name)
 		}
 	}
 	log.Infof("No OutOfMemory error detected")
@@ -260,9 +260,9 @@ func startTestPod(clientSet *kubernetes.Clientset, nr int, suffix string) error 
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							corev1.NodeSelectorTerm{
+							{
 								MatchExpressions: []corev1.NodeSelectorRequirement{
-									corev1.NodeSelectorRequirement{
+									{
 										Key:      "gitpod.io/workload_workspace",
 										Operator: corev1.NodeSelectorOpIn,
 										Values:   []string{"true"},
@@ -274,7 +274,7 @@ func startTestPod(clientSet *kubernetes.Clientset, nr int, suffix string) error 
 				},
 			},
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:    "main",
 					Image:   "alpine:latest",
 					Command: []string{"bash", "-c", "while true; do sleep 2; echo 'sleeping...'; done"},

--- a/components/ee/ws-scheduler/cmd/test-scheduling-pressure.go
+++ b/components/ee/ws-scheduler/cmd/test-scheduling-pressure.go
@@ -109,9 +109,9 @@ func createPod(clientSet *kubernetes.Clientset, scheduler string, namespace stri
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							corev1.NodeSelectorTerm{
+							{
 								MatchExpressions: []corev1.NodeSelectorRequirement{
-									corev1.NodeSelectorRequirement{
+									{
 										Key:      "gitpod.io/workload_workspace",
 										Operator: corev1.NodeSelectorOpIn,
 										Values:   []string{"true"},
@@ -127,7 +127,7 @@ func createPod(clientSet *kubernetes.Clientset, scheduler string, namespace stri
 				RunAsNonRoot: &boolTrue,
 			},
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:    "main",
 					Image:   "eu.gcr.io/gitpod-dev/workspace-images:7e01b3299b178278c88c5a4606bdeed09059e94e8a7a193b249606028cfd13dd",
 					Command: []string{"bash", "-c", "while true; do sleep 2; echo 'sleeping...'; done"},

--- a/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
@@ -617,7 +617,7 @@ func (c *localBindingCache) markAsScheduled(pod *corev1.Pod, nodeName string) {
 	defer c.mu.Unlock()
 
 	c.bindings[pod.Name] = &Binding{
-		Pod:      &Pod{Pod: pod},
+		Pod:      pod,
 		NodeName: nodeName,
 	}
 }

--- a/components/ee/ws-scheduler/pkg/scheduler/state_internal_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state_internal_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestUniquePods(t *testing.T) {
+	var (
+		p1     = createPod("p1", nil)
+		p2gen0 = modifyPod(createPod("p2", nil), func(p *corev1.Pod) { p.Generation = 0 })
+		p2gen1 = modifyPod(createPod("p2", nil), func(p *corev1.Pod) { p.Generation = 1 })
+		p2rev0 = modifyPod(createPod("p2", nil), func(p *corev1.Pod) { p.ResourceVersion = "0" })
+		p2rev1 = modifyPod(createPod("p2", nil), func(p *corev1.Pod) { p.ResourceVersion = "1" })
+	)
+
+	tests := []struct {
+		Name        string
+		Input       []*corev1.Pod
+		Expectation []*corev1.Pod
+	}{
+		{
+			Name:        "nil",
+			Input:       nil,
+			Expectation: nil,
+		},
+		{
+			Name:        "empty",
+			Input:       []*corev1.Pod{},
+			Expectation: []*corev1.Pod{},
+		},
+		{
+			Name:        "already unique",
+			Input:       []*corev1.Pod{p1, p2gen0},
+			Expectation: []*corev1.Pod{p1, p2gen0},
+		},
+		{
+			Name:        "not unique unique rev only",
+			Input:       []*corev1.Pod{p1, p2rev0, p2rev1},
+			Expectation: []*corev1.Pod{p1, p2rev1},
+		},
+		{
+			Name:        "not unique unique generation only",
+			Input:       []*corev1.Pod{p1, p2gen0, p2gen1},
+			Expectation: []*corev1.Pod{p1, p2gen1},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			act := uniquePods(test.Input)
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy.go
@@ -248,10 +248,10 @@ func freshWorkspaceCount(state *State, node *Node, freshSeconds int) int {
 	assignedPods := state.GetAssignedPods(node)
 	var count int
 	for _, p := range assignedPods {
-		if !isWorkspace(p.Pod) {
+		if !isWorkspace(p) {
 			continue
 		}
-		if time.Since(p.Pod.ObjectMeta.CreationTimestamp.Time).Seconds() < float64(freshSeconds) {
+		if time.Since(p.ObjectMeta.CreationTimestamp.Time).Seconds() < float64(freshSeconds) {
 			count = count + 1
 		}
 	}
@@ -303,10 +303,10 @@ func regularWorkspaceCount(state *State, node *Node) int {
 	assignedPods := state.GetAssignedPods(node)
 	var count int
 	for _, p := range assignedPods {
-		if !isWorkspace(p.Pod) {
+		if !isWorkspace(p) {
 			continue
 		}
-		if isHeadlessWorkspace(p.Pod) {
+		if isHeadlessWorkspace(p) {
 			continue
 		}
 


### PR DESCRIPTION
This PR corrects the `UniquePods` function used to build the state during scheduling.

While scheduling ws-proxy combines the `localBindingCache` with the world view of Kubernetes. To this end it uses a function called `UniquePods`, which gives newer pods preference over older ones. The `Generation` field is optional and its presence depends on the underlying Kubernetes distribution. In the official one, at least in the version we're using, that field is not present. Because of that we might not merge the bindings with the pre existing pods correctly, possibly loosing localBindingCache information.

This PR attempts to fix that using the `ResourceVersion` field. In practice this field often is a number, and we try and treat it as such.

Note: [the documentation](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions) explicitly advises against this sort of thing.
> For example, clients must not assume resource versions are numeric, and may only compare two resource version for equality (i.e. must not compare resource versions for greater-than or less-than relationships).

### Alternative designs
Because we know that the list of `s.Bindings` coming from the `localBindingCache` is always unique, and the list of pods is unique, too (it's coming from a map), we don't need a generic "unifier". Instead we can just overwrite any existing pod info with any binding info we might have, in `GetAssignedPods`.