### PR TITLE
[registry-facade] added metrics port to daemonset

### DIFF
--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -48,6 +48,8 @@ spec:
         - name: registry
           containerPort: {{ $comp.ports.registry.containerPort }}
           hostPort: {{ $comp.ports.registry.servicePort }}
+        - name: metrics
+          containerPort: 9500
         securityContext:
           privileged: false
           runAsUser: 1000


### PR DESCRIPTION
Fixes a problem with registry-facade metrics. The port has not been added to the daemonset.