### PR TITLE
[ws-scheduler] Fix nil-deref when informer is too slow

### DIFF
--- a/components/ee/ws-scheduler/pkg/scheduler/state.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state.go
@@ -105,6 +105,12 @@ func ComputeState(nodes []*corev1.Node, pods []*corev1.Pod, bindings []*Binding)
 		podToNode[p.Name] = p.Spec.NodeName
 	}
 	for _, b := range bindings {
+		if _, exists := pds[b.Pod.Name]; !exists {
+			// We've found a binding for a pod that we don't yet see in the list of pods.
+			// This can happen if we're listing faster than the Pod informer updates.
+			pds[b.Pod.Name] = b.Pod
+		}
+
 		podToNode[b.Pod.Name] = b.NodeName
 	}
 


### PR DESCRIPTION
This PR fixes a nil-deref that can happen we're seeing a binding for a pod that is not in the total Pod list.
This can happen if the updater is slower than the lister.