### PR TITLE
[ws-scheduler] Introduce RAM safety buffer

### DIFF
--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -39,7 +39,10 @@ var runCmd = &cobra.Command{
 		}
 		log.Info("connected to Kubernetes")
 
-		scheduler := scheduler.NewScheduler(config.Scheduler, clientSet)
+		scheduler, err := scheduler.NewScheduler(config.Scheduler, clientSet)
+		if err != nil {
+			log.WithError(err).Fatal("cannot create scheduler")
+		}
 		schedulerCtx, cancelScheduler := context.WithCancel(context.Background())
 		err = scheduler.Start(schedulerCtx)
 		if err != nil {

--- a/components/ee/ws-scheduler/cmd/test-cluster-scaleup.go
+++ b/components/ee/ws-scheduler/cmd/test-cluster-scaleup.go
@@ -228,7 +228,9 @@ func buildCurrentState(clientSet *kubernetes.Clientset) (*scheduler.State, error
 	for i := range allPods.Items {
 		pods[i] = &allPods.Items[i]
 	}
-	state := scheduler.ComputeState(potentialNodes, pods, nil)
+
+	ramSafetyBuffer := res.MustParse("0Mi")
+	state := scheduler.ComputeState(potentialNodes, pods, nil, &ramSafetyBuffer)
 	return state, nil
 }
 

--- a/components/ee/ws-scheduler/pkg/scheduler/config.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/config.go
@@ -22,6 +22,8 @@ type Configuration struct {
 	StrategyName StrategyName `json:"strategyName"`
 	// DensityAndExperienceConfig is the (optional) config for the DensityAndExperience strategy
 	DensityAndExperienceConfig *DensityAndExperienceConfig `json:"densityAndExperienceConfig,omitempty"`
+	// RAMSafetyBuffer reduces the amount of available RAM per node and is meant to make sure we do not overbook nodes
+	RAMSafetyBuffer string `json:"ramSafetyBuffer,omitempty"`
 }
 
 // DensityAndExperienceConfig is the config for the DensityAndExperience strategy

--- a/components/ee/ws-scheduler/pkg/scheduler/scheduler_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/scheduler_test.go
@@ -93,7 +93,11 @@ func TestGatherPotentialNodesFor(t *testing.T) {
 			objs = append(objs, test.Pod)
 
 			client := fakek8s.NewSimpleClientset(objs...)
-			scheduler := NewScheduler(Configuration{}, client)
+			scheduler, err := NewScheduler(Configuration{}, client)
+			if err != nil {
+				t.Errorf("unexpected error: %+q", err)
+				return
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			scheduler.startInformer(ctx)
@@ -279,7 +283,11 @@ func TestRequiredServices(t *testing.T) {
 			}
 
 			client := fakek8s.NewSimpleClientset(objs...)
-			scheduler := NewScheduler(Configuration{}, client)
+			scheduler, err := NewScheduler(Configuration{}, client)
+			if err != nil {
+				t.Errorf("unexpected error: %+q", err)
+				return
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			scheduler.startInformer(ctx)


### PR DESCRIPTION
This feels a bit like declaring being defeated but is the only sensible solution for now, and helps us to move on and focus on more important things.

During our tests today we found that the "available RAM" `ws-scheduler` calculates per node by adding up all pods already assigned to that node is wrong, always off by only ~200MiB compared to what the `kubelet` thinks. We are ran out of ideas why this is the case.

To fix this we introduced a (configurable) `ramSafetyBuffer` which defaults to `512Mi` and is reduces the amount of allocatable RAM `ws-scheduler` "sees" per node.