### PR TITLE
fix #2368: fallback to vi if gp open fails for EDITOR

### DIFF
--- a/components/gitpod-cli/go.sum
+++ b/components/gitpod-cli/go.sum
@@ -68,6 +68,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
@@ -100,6 +102,8 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20181122213734-04b5d21e00f1 h1:bsEj/LXbv3BCtkp/rBj9Wi/0Nde4OMaraIZpndHAhdI=

--- a/components/gitpod-cli/pkg/theialib/service.go
+++ b/components/gitpod-cli/pkg/theialib/service.go
@@ -70,6 +70,11 @@ type request struct {
 	Params interface{} `json:"params"`
 }
 
+var (
+	// ErrNotFound is returned when an object is not found
+	ErrNotFound = fmt.Errorf("not found")
+)
+
 func (service *HTTPTheiaService) sendRequest(req request) ([]byte, error) {
 	<-service.ideReady
 	if service.ideError != nil {
@@ -101,6 +106,8 @@ func (service *HTTPTheiaService) sendRequest(req request) ([]byte, error) {
 
 	if resp.StatusCode == 403 {
 		return nil, fmt.Errorf("not authenticated")
+	} else if resp.StatusCode == 404 {
+		return nil, ErrNotFound
 	} else if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("invalid request: %v", resp.StatusCode)
 	}


### PR DESCRIPTION
- [x] /werft https

#### What it does

It's a temporary workaround for `gp open` to use `vi` for Gitpod Code. Later it would be generalized and Gitpod Code CLI will be used instead, i.e. as described in https://github.com/gitpod-io/gitpod/pull/2372#issuecomment-737164069

#### How to test

- Start a workspace.
- Create a commit.
- Do an interactive commit.
- For Theia, a Theia editor should be opened, for Code, vi editor.