### PR TITLE
[ws-manager] Don't request 0 resources, but don't request at all

### DIFF
--- a/components/ws-manager/pkg/manager/config.go
+++ b/components/ws-manager/pkg/manager/config.go
@@ -266,19 +266,21 @@ func (r *ResourceConfiguration) ResourceList() (corev1.ResourceList, error) {
 		corev1.ResourceEphemeralStorage: r.Storage,
 	}
 
-	var (
-		l   = make(corev1.ResourceList)
-		err error
-	)
+	var l = make(corev1.ResourceList)
 	for k, v := range res {
 		if v == "" {
 			continue
 		}
 
-		l[k], err = resource.ParseQuantity(v)
+		q, err := resource.ParseQuantity(v)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", k, err)
 		}
+		if q.Value() == 0 {
+			continue
+		}
+
+		l[k] = q
 	}
 	return l, nil
 }

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -506,15 +506,15 @@ func removeVolume(pod *corev1.Pod, name string) {
 func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) (*corev1.Container, error) {
 	limits, err := m.Config.Container.Workspace.Limits.ResourceList()
 	if err != nil {
-		return nil, xerrors.Errorf("cannot parse Workspace container limits: %w", err)
+		return nil, xerrors.Errorf("cannot parse workspace container limits: %w", err)
 	}
 	requests, err := m.Config.Container.Workspace.Requests.ResourceList()
 	if err != nil {
-		return nil, xerrors.Errorf("cannot parse Workspace container requests: %w", err)
+		return nil, xerrors.Errorf("cannot parse workspace container requests: %w", err)
 	}
 	env, err := m.createWorkspaceEnvironment(startContext)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot create Workspace env: %w", err)
+		return nil, xerrors.Errorf("cannot create workspace env: %w", err)
 	}
 	sec, err := m.createDefaultSecurityContext()
 	if err != nil {

--- a/components/ws-manager/pkg/manager/create_test.go
+++ b/components/ws-manager/pkg/manager/create_test.go
@@ -27,6 +27,7 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 		PrebuildTemplate *corev1.Pod            `json:"prebuildTemplate,omitempty"`
 		ProbeTemplate    *corev1.Pod            `json:"probeTemplate,omitempty"`
 		RegularTemplate  *corev1.Pod            `json:"regularTemplate,omitempty"`
+		ResourceRequests *ResourceConfiguration `json:"resourceRequests,omitempty"`
 	}
 	type gold struct {
 		Pod   corev1.Pod `json:"reason,omitempty"`
@@ -39,6 +40,17 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 		Test: func(t *testing.T, input interface{}) interface{} {
 			manager := forTestingOnlyGetManager(t)
 			fixture := input.(*fixture)
+			if fixture.ResourceRequests != nil {
+				var (
+					cfg  = manager.Config
+					cont = cfg.Container
+					ws   = cont.Workspace
+				)
+				ws.Requests = *fixture.ResourceRequests
+				cont.Workspace = ws
+				cfg.Container = cont
+				manager.Config = cfg
+			}
 
 			fs = afero.NewMemMapFs()
 			files := []struct {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_broken_resource_request.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_broken_resource_request.golden
@@ -1,0 +1,12 @@
+{
+    "reason": {
+        "metadata": {
+            "creationTimestamp": null
+        },
+        "spec": {
+            "containers": null
+        },
+        "status": {}
+    },
+    "error": "cannot create definite workspace pod: cannot create workspace container: cannot parse workspace container requests: cpu: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
+}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_broken_resource_request.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_broken_resource_request.json
@@ -1,0 +1,30 @@
+{
+    "spec": {
+        "ideImage": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion",
+        "workspaceImage": "eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+        "initializer": {
+            "snapshot": {
+                "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"
+            }
+        },
+        "ports": [
+            {
+                "port": 8080,
+                "target": 38080
+            }
+        ],
+        "envvars": [
+            {
+                "name": "foo",
+                "value": "bar"
+            }
+        ],
+        "git": {
+            "username": "usernameGoesHere",
+            "email": "some@user.com"
+        }
+    },
+    "resourceRequests": {
+      "cpu": "foobar"
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -1,0 +1,232 @@
+{
+    "reason": {
+        "metadata": {
+            "name": "ws-test",
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/networkpolicy": "default",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            },
+            "annotations": {
+                "gitpod.io/requiredNodeServices": "ws-daemon",
+                "gitpod/admission": "admit_owner_only",
+                "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
+                "gitpod/id": "test",
+                "gitpod/imageSpec": "Cm1ldS5nY3IuaW8vZ2l0cG9kLWRldi93b3Jrc3BhY2UtYmFzZS1pbWFnZXMvZ2l0aHViLmNvbS90eXBlZm94L2dpdHBvZDo4MGE3ZDQyN2ExZmNkMzQ2ZDQyMDYwM2Q4MGEzMWQ1N2NmNzVhN2FmEjRldS5nY3IuaW8vZ2l0cG9kLWNvcmUtZGV2L2J1aWQvdGhlaWEtaWRlOnNvbWV2ZXJzaW9u",
+                "gitpod/never-ready": "true",
+                "gitpod/ownerToken": "%7J'[Of/8NDiWE+9F,I6^Jcj_1\u0026}-F8p",
+                "gitpod/servicePrefix": "foobarservice",
+                "gitpod/traceid": "",
+                "gitpod/url": "test-foobarservice-gitpod.io",
+                "prometheus.io/path": "/metrics",
+                "prometheus.io/port": "23000",
+                "prometheus.io/scrape": "true",
+                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
+            }
+        },
+        "spec": {
+            "volumes": [
+                {
+                    "name": "vol-this-theia",
+                    "hostPath": {
+                        "path": "/tmp/theia/theia-xyz",
+                        "type": "Directory"
+                    }
+                },
+                {
+                    "name": "vol-this-workspace",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test",
+                        "type": "DirectoryOrCreate"
+                    }
+                }
+            ],
+            "containers": [
+                {
+                    "name": "workspace",
+                    "image": "eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+                    "command": [
+                        "/theia/supervisor",
+                        "run"
+                    ],
+                    "ports": [
+                        {
+                            "containerPort": 23000
+                        }
+                    ],
+                    "env": [
+                        {
+                            "name": "GITPOD_REPO_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_CLI_APITOKEN",
+                            "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_ID",
+                            "value": "foobar"
+                        },
+                        {
+                            "name": "GITPOD_INSTANCE_ID",
+                            "value": "test"
+                        },
+                        {
+                            "name": "GITPOD_THEIA_PORT",
+                            "value": "23000"
+                        },
+                        {
+                            "name": "THEIA_WORKSPACE_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_HOST",
+                            "value": "gitpod.io"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_URL",
+                            "value": "test-foobarservice-gitpod.io"
+                        },
+                        {
+                            "name": "THEIA_SUPERVISOR_ENDPOINT",
+                            "value": ":22999"
+                        },
+                        {
+                            "name": "THEIA_WEBVIEW_EXTERNAL_ENDPOINT",
+                            "value": "webview-{{hostname}}"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_NAME",
+                            "value": "usernameGoesHere"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_EMAIL",
+                            "value": "some@user.com"
+                        },
+                        {
+                            "name": "foo",
+                            "value": "bar"
+                        },
+                        {
+                            "name": "GITPOD_INTERVAL",
+                            "value": "30000"
+                        },
+                        {
+                            "name": "GITPOD_MEMORY",
+                            "value": "0"
+                        }
+                    ],
+                    "resources": {
+                        "limits": {
+                            "cpu": "900m",
+                            "memory": "1G"
+                        },
+                        "requests": {
+                            "cpu": "5m"
+                        }
+                    },
+                    "volumeMounts": [
+                        {
+                            "name": "vol-this-workspace",
+                            "mountPath": "/workspace",
+                            "mountPropagation": "HostToContainer"
+                        },
+                        {
+                            "name": "vol-this-theia",
+                            "readOnly": true,
+                            "mountPath": "/theia"
+                        }
+                    ],
+                    "readinessProbe": {
+                        "httpGet": {
+                            "path": "/_supervisor/v1/status/content/wait/true",
+                            "port": 22999,
+                            "scheme": "HTTP"
+                        },
+                        "timeoutSeconds": 1,
+                        "periodSeconds": 1,
+                        "successThreshold": 1,
+                        "failureThreshold": 600
+                    },
+                    "terminationMessagePolicy": "FallbackToLogsOnError",
+                    "imagePullPolicy": "Always",
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "AUDIT_WRITE",
+                                "FSETID",
+                                "KILL",
+                                "NET_BIND_SERVICE",
+                                "SYS_PTRACE"
+                            ],
+                            "drop": [
+                                "SETPCAP",
+                                "CHOWN",
+                                "NET_RAW",
+                                "DAC_OVERRIDE",
+                                "FOWNER",
+                                "SYS_CHROOT",
+                                "SETFCAP",
+                                "SETUID",
+                                "SETGID"
+                            ]
+                        },
+                        "privileged": false,
+                        "runAsUser": 33333,
+                        "runAsGroup": 33333,
+                        "runAsNonRoot": true,
+                        "readOnlyRootFilesystem": false,
+                        "allowPrivilegeEscalation": false
+                    }
+                }
+            ],
+            "restartPolicy": "Never",
+            "serviceAccountName": "workspace",
+            "automountServiceAccountToken": false,
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "gitpod.io/theia.someversion",
+                                        "operator": "Exists"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "schedulerName": "workspace-scheduler",
+            "tolerations": [
+                {
+                    "key": "node.kubernetes.io/disk-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/memory-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/network-unavailable",
+                    "operator": "Exists",
+                    "effect": "NoExecute",
+                    "tolerationSeconds": 30
+                }
+            ],
+            "enableServiceLinks": false
+        },
+        "status": {}
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.json
@@ -1,0 +1,31 @@
+{
+    "spec": {
+        "ideImage": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion",
+        "workspaceImage": "eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+        "initializer": {
+            "snapshot": {
+                "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"
+            }
+        },
+        "ports": [
+            {
+                "port": 8080,
+                "target": 38080
+            }
+        ],
+        "envvars": [
+            {
+                "name": "foo",
+                "value": "bar"
+            }
+        ],
+        "git": {
+            "username": "usernameGoesHere",
+            "email": "some@user.com"
+        }
+    },
+    "resourceRequests": {
+      "cpu": "5m",
+      "memory": "0Gi"
+    }
+}


### PR DESCRIPTION
This PR prevents ws-manager from requesting "0" on any resource.

Prior, if we just didn't have an ephemeral storage request in ws-manager's configured, we'd request `ephemeralStorage: 0`, instead of making no request at all. This would cause undue workspace pod eviction.

This PR makes it so that if we configure `0`, or don't configure a resource at all, we make no request.