### PR TITLE
[server] Update GitLab library

### DIFF
--- a/components/gitpod-db/package.json
+++ b/components/gitpod-db/package.json
@@ -39,6 +39,6 @@
     "mocha-typescript": "^1.1.17",
     "chai": "^4.2.0",
     "ts-node": "<7.0.0",
-    "typescript": "^3.1.3"
+    "typescript": "^3.9.3"
   }
 }

--- a/components/gitpod-messagebus/package.json
+++ b/components/gitpod-messagebus/package.json
@@ -29,6 +29,6 @@
     "@types/amqplib": "^0.5.7",
     "@types/uuid": "^3.4.5",
     "rimraf": "^2.6.1",
-    "typescript": "^3.1.3"
+    "typescript": "^3.9.3"
   }
 }

--- a/components/server/ee/src/prebuilds/gitlab-service.ts
+++ b/components/server/ee/src/prebuilds/gitlab-service.ts
@@ -33,11 +33,11 @@ export class GitlabService extends RepositoryService {
     async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {
         const api = await this.api.create(user);
         const { owner, repoName } = await this.gitlabContextParser.parseURL(user, cloneUrl);
-        const response = await api.Projects.show(`${owner}/${repoName}`);
+        const response = (await api.Projects.show(`${owner}/${repoName}`)) as unknown as GitLab.Project;
         if (GitLab.ApiError.is(response)) {
             throw response;
         }
-        const hooks = await api.ProjectHooks.all(response.id) as GitLab.ProjectHook[];
+        const hooks = (await api.ProjectHooks.all(response.id)) as unknown as GitLab.ProjectHook[];
         if (GitLab.ApiError.is(hooks)) {
             throw hooks;
         }

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -49,7 +49,7 @@
     "express-mysql-session": "^2.1.0",
     "express-session": "^1.15.6",
     "fs-extra": "^6.0.1",
-    "gitlab": "^14.2.2",
+    "@gitbeaker/node": "^25.6.0",
     "google-protobuf": "^3.8.0-rc.1",
     "graphql": "^14.6.0",
     "graphql-tools": "^4.0.7",

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -36,6 +36,7 @@
     "@gitpod/ws-manager": "0.1.5",
     "@google-cloud/storage": "^2.5.0",
     "@octokit/rest": "16.35.0",
+    "agent-base": "4.2.1",
     "amqplib": "^0.5.2",
     "base-64": "^0.1.0",
     "bitbucket": "^2.1.0",

--- a/components/server/src/gitlab/api.ts
+++ b/components/server/src/gitlab/api.ts
@@ -7,7 +7,10 @@
 import { injectable, inject } from "inversify";
 import { User } from "@gitpod/gitpod-protocol"
 
-import { Gitlab as GitlabBundle, Users, Projects, Repositories, Branches, MergeRequests, Issues, Tags, ProjectHooks, Commits, RepositoryFiles, UserSchema, ProjectSchema } from "gitlab";
+import { Gitlab } from "@gitbeaker/node";
+import { Projects, Users, Commits, ProjectHooks, Repositories, Branches, Tags, MergeRequests, Issues, RepositoryFiles } from "@gitbeaker/core";
+import { ProjectSchemaDefault } from "@gitbeaker/core/dist/types/services/Projects";
+import { UserSchemaDefault } from "@gitbeaker/core/dist/types/services/Users";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { GitLabScope } from "./scopes";
 import { AuthProviderParams } from "../auth/auth-provider";
@@ -60,8 +63,8 @@ export class GitLabApi {
     }
 }
 export namespace GitLab {
-    export function create(options: { host: string, oauthToken: string }) {
-        return new GitlabBundle(options) as GitLab.Api;
+    export function create(options: { host: string, oauthToken: string }): GitLab.Api {
+        return new Gitlab(options) as unknown as Api;
     }
     export interface Api {
         Users: Users;
@@ -91,7 +94,7 @@ export namespace GitLab {
     /**
      * https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/projects.md#get-single-project
      */
-    export interface Project extends ProjectSchema {
+    export interface Project extends ProjectSchemaDefault {
         visibility: 'public' | 'private' | 'internal';
         archived: boolean;
         path: string; // "diaspora-project-site"
@@ -105,6 +108,8 @@ export namespace GitLab {
         forks_count: number;
         star_count: number;
         forked_from_project?: Project;
+        default_branch: string;
+        web_url: string;
     }
     export interface TreeObject {
         id: string;
@@ -176,7 +181,7 @@ export namespace GitLab {
         merge_requests_count: number;
     }
     // https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users
-    export interface User extends UserSchema {
+    export interface User extends UserSchemaDefault {
         email: string;
         state: "active" | string;
         confirmed_at: string | undefined,

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -63,7 +63,7 @@ export class GitLabAuthProvider extends GenericAuthProvider {
         });
         const getCurrentUser = async () => {
             const response = await api.Users.current();
-            return response as GitLab.User;
+            return response as unknown as GitLab.User;
         }
         const unconfirmedUserMessage = "Please confirm your GitLab account and try again.";
         try {

--- a/components/server/src/gitlab/gitlab-context-parser.spec.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.spec.ts
@@ -12,7 +12,7 @@ import { GitlabContextParser } from './gitlab-context-parser';
 import { User } from "@gitpod/gitpod-protocol";
 import { ContainerModule, Container } from "inversify";
 import { DevData } from "../dev/dev-data";
-import { GitLabApi } from "./api";
+import { GitLabApi, GitLab } from "./api";
 import { AuthProviderParams } from "../auth/auth-provider";
 import { NotFoundError } from "../errors";
 import { GitLabTokenHelper } from "./gitlab-token-helper";
@@ -71,13 +71,12 @@ class TestGitlabContextParser {
         }
     }
 
-    @test.only public async testTreeContext_01() {
+    @test public async testTreeContext_01() {
         const result = await this.parser.handle({}, this.user, 'https://gitlab.com/AlexTugarev/gp-test');
         expect(result).to.deep.include({
             "ref": "master",
             "refType": "branch",
             "path": "",
-            "revision": "3cbb7be8212f00bcbea6a2ff9ae889219b391e63",
             "isFile": false,
             "repository": {
                 "host": "gitlab.com",
@@ -88,6 +87,26 @@ class TestGitlabContextParser {
                 "private": false
             },
             "title": "AlexTugarev/gp-test - master"
+        })
+    }
+
+    @test public async testTreeContext_01_regression() {
+        const result = await this.parser.handle({}, this.user, 'https://gitlab.com/gitlab-org/gitlab');
+        console.log("result")
+        expect(result).to.deep.include({
+            "ref": "master",
+            "refType": "branch",
+            "path": "",
+            "isFile": false,
+            "repository": {
+                "host": "gitlab.com",
+                "owner": "gitlab-org",
+                "name": "gitlab",
+                "cloneUrl": "https://gitlab.com/gitlab-org/gitlab.git",
+                "defaultBranch": "master",
+                "private": false
+            },
+            "title": "gitlab-org/gitlab - master"
         })
     }
 
@@ -217,7 +236,11 @@ class TestGitlabContextParser {
             // ensure that an error has been thrown
             chai.assert.fail();
         } catch (e) {
-            expect(e.message).contains("Couldn't find commit");
+            if (GitLab.ApiError.is(e)) {
+                expect(e.httpError?.description).equals("404 Commit Not Found");
+            } else {
+                chai.assert.fail("Unknown Error: " + JSON.stringify(e));
+            }
         }
     }
 

--- a/components/server/src/gitlab/gitlab-context-parser.spec.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.spec.ts
@@ -20,6 +20,9 @@ import { TokenProvider } from "../user/token-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
 
+
+import "../patch-agent-base";
+
 @suite(timeout(10000), retries(2), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_GITLAB"))
 class TestGitlabContextParser {
 
@@ -68,7 +71,7 @@ class TestGitlabContextParser {
         }
     }
 
-    @test public async testTreeContext_01() {
+    @test.only public async testTreeContext_01() {
         const result = await this.parser.handle({}, this.user, 'https://gitlab.com/AlexTugarev/gp-test');
         expect(result).to.deep.include({
             "ref": "master",

--- a/components/server/src/gitlab/gitlab-context-parser.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.ts
@@ -127,7 +127,7 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
             if (UnauthorizedError.is(error)) {
                 throw error;
             }
-            log.error({ userId: user.id }, error);
+            // log.error({ userId: user.id }, error);
             throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, host, owner, repoName);
         }
     }
@@ -209,7 +209,6 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
         }
 
         if (branchOrTagObject === undefined) {
-            log.error({ userId: user.id }, `Error finding tag/branch for context: ${owner}/${repoName}/tree/${segments.join('/')}.`);
             throw new Error(`Cannot find tag/branch for context: ${owner}/${repoName}/tree/${segments.join('/')}.`);
         }
 
@@ -225,7 +224,6 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
             return g.MergeRequests.show(`${owner}/${repoName}`, nr);
         });
         if (GitLab.ApiError.is(result)) {
-            log.error({ userId: user.id }, result);
             throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, host, owner, repoName);
         }
         const sourceProjectId = result.source_project_id;
@@ -299,7 +297,6 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
             return g.Issues.show(`${owner}/${repoName}`, nr);
         });
         if (GitLab.ApiError.is(result)) {
-            log.error({ userId: user.id }, result);
             throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, host, owner, repoName);
         }
         const context = await ctxPromise;
@@ -316,7 +313,6 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
     protected async handleCommitContext(user: User, host: string, owner: string, repoName: string, sha: string): Promise<NavigatorContext> {
         const repository = await this.fetchRepo(user, `${owner}/${repoName}`);
         if (GitLab.ApiError.is(repository)) {
-            log.error({ userId: user.id }, repository);
             throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, host, owner, repoName);
         }
         const commit = await this.fetchCommit(user, `${owner}/${repoName}`, sha);

--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -89,3 +89,7 @@ export async function start(container: Container) {
         await server.stop();
     });
 }
+
+// The module `agent-base@4.2.1` contains a bad patch for nodejs, this should fix it.
+// cf. https://github.com/gitpod-io/gitpod/pull/2375
+import "./patch-agent-base";

--- a/components/server/src/patch-agent-base.ts
+++ b/components/server/src/patch-agent-base.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+const url = require('url');
+const https = require('https');
+
+// preserve originals
+const originalRequestFn = https.request;
+const originalGetFn = https.get;
+
+// require the evil;
+// we assume, as nodejs will cache it, it won't we evaluated/loaded a second time
+// so we pre-emptively fix the things right afterwards.
+require('agent-base');
+
+https.request = originalRequestFn;
+https.get = originalGetFn;
+
+console.log("done patching the patch from `agent-base@4.2.1`");

--- a/components/ws-manager-bridge/package.json
+++ b/components/ws-manager-bridge/package.json
@@ -41,7 +41,7 @@
     "@types/express": "^4.11.1",
     "@types/google-protobuf": "^3.2.7",
     "tslint": "^5.9.1",
-    "typescript": "^3.1.3",
+    "typescript": "^3.9.3",
     "watch": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "lerna": "^2.5.1",
         "rimraf": "^2.6.2",
         "ts-node": "<7.0.0",
-        "typescript": "^3.1.3"
+        "typescript": "^3.9.3"
     },
     "scripts": {
         "build": "leeway exec --filter-type yarn --components -- yarn build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,6 +1514,35 @@
     ts-node "^8"
     tslib "^1"
 
+"@gitbeaker/core@^25.6.0":
+  version "25.6.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-25.6.0.tgz#97d5ccc5d61bab6b678bec280036d594d275931e"
+  integrity sha512-+CohJNsbZiPl7jPgw7PHt5t0JIIV9NngObOskY1Ww8jef7SqaKpz0NsbSDawuWFBdmXApMpK81AEfASKtVI+cw==
+  dependencies:
+    "@gitbeaker/requester-utils" "^25.6.0"
+    form-data "^3.0.0"
+    li "^1.3.0"
+    xcase "^2.0.1"
+
+"@gitbeaker/node@^25.6.0":
+  version "25.6.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-25.6.0.tgz#2baa1c7d653111751f6297299f9e78e37f403e39"
+  integrity sha512-zv7BVmphyOUtIkwU8/iH8z6F8AC2Hy56f/DpwhgB602qhKDRFwf/d7wze7VD5j65i0kIzgnSrxgdtosW7V9wsw==
+  dependencies:
+    "@gitbeaker/core" "^25.6.0"
+    "@gitbeaker/requester-utils" "^25.6.0"
+    got "^11.7.0"
+    xcase "^2.0.1"
+
+"@gitbeaker/requester-utils@^25.6.0":
+  version "25.6.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-25.6.0.tgz#001a432a48460bb5196a02ed71763eb707a1a01e"
+  integrity sha512-jD8cHbAZPR6+cB3HiukQxcqIKF5VkHtqg2m+Ns6ROE1pb0oRn10D/a9J1lZOXC9Jz2tQOBMWfHlplbmFFdB6Og==
+  dependencies:
+    form-data "^3.0.0"
+    query-string "^6.13.3"
+    xcase "^2.0.1"
+
 "@google-cloud/common@^0.32.0":
   version "0.32.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.32.1.tgz#6a32c340172cea3db6674d0e0e34e78740a0073f"
@@ -2330,10 +2359,22 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
+"@sindresorhus/is@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.0.tgz#2ff674e9611b45b528896d820d3d7a812de2f0e4"
+  integrity sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==
+
 "@stroncium/procfs@^1.0.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@stroncium/procfs/-/procfs-1.2.1.tgz#6b9be6fd20fb0a4c20e99a8695e083c699bb2b45"
   integrity sha512-X1Iui3FUNZP18EUvysTHxt+Avu2nlVzyf90YM8OYgP6SGzTzzX/0JgObfO1AQQDzuZtNNz29bVh8h5R97JrjxA==
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
+  integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
+  dependencies:
+    defer-to-connect "^2.0.0"
 
 "@theia/application-manager@1.5.0-next.9d2dcd0a":
   version "1.5.0-next.9d2dcd0a"
@@ -2988,6 +3029,16 @@
     "@types/long" "*"
     "@types/node" "*"
 
+"@types/cacheable-request@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
 "@types/caseless@*":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
@@ -3167,6 +3218,11 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz#551a4589b6ee2cc9c1dff08056128aec29b94880"
   integrity sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA==
 
+"@types/http-cache-semantics@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
 "@types/is-glob@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/is-glob/-/is-glob-4.0.1.tgz#a93eec1714172c8eb3225a1cc5eb88c2477b7d00"
@@ -3196,6 +3252,13 @@
   dependencies:
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
+
+"@types/keyv@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/lodash.debounce@4.0.3":
   version "4.0.3"
@@ -3524,6 +3587,13 @@
   dependencies:
     "@types/node" "*"
     "@types/request" "*"
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/rimraf@^2.0.2":
   version "2.0.2"
@@ -6200,6 +6270,11 @@ cache-manager@^2.4.0:
     async "1.5.2"
     lru-cache "4.0.0"
 
+cacheable-lookup@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz#049fdc59dffdd4fc285e8f4f82936591bd59fec3"
+  integrity sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==
+
 cacheable-request@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
@@ -6211,6 +6286,19 @@ cacheable-request@^2.1.1:
     lowercase-keys "1.0.0"
     normalize-url "2.0.1"
     responselike "1.0.2"
+
+cacheable-request@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
+  integrity sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^2.0.0"
 
 call-me-maybe@^1.0.1:
   version "1.0.1"
@@ -6676,7 +6764,7 @@ clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
-clone-response@1.0.2:
+clone-response@1.0.2, clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
   dependencies:
@@ -7707,6 +7795,13 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
@@ -7841,6 +7936,11 @@ defaults@^1.0.3:
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
+  integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
 define-properties@^1.1.2, define-properties@^1.1.3, define-properties@~1.1.2:
   version "1.1.3"
@@ -9818,6 +9918,13 @@ get-stream@^4.0.0:
   dependencies:
     pump "^3.0.0"
 
+get-stream@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  dependencies:
+    pump "^3.0.0"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -10149,6 +10256,23 @@ google-protobuf@^3.8.0-rc.1:
   version "3.8.0-rc.1"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.8.0-rc.1.tgz#cd22a63ff8c16d46d872ba84b61f0882e270a005"
   integrity sha512-4GDqS1fsxtXqDJoISikYWJqxRcUu7421Tp58//Qzog+aK5u0KHqsNw1dZC1TebMbyaOCHL0CfsBr2/t+e9QBFg==
+
+got@^11.7.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.0.tgz#be0920c3586b07fd94add3b5b27cb28f49e6545f"
+  integrity sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.1"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
 
 got@^6.7.1:
   version "6.7.1"
@@ -10760,6 +10884,11 @@ http-cache-semantics@3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
 
+http-cache-semantics@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
+  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -10827,6 +10956,14 @@ http-signature@~1.2.0:
 http-status-codes@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.3.0.tgz#9cd0e71391773d0671b489d41cbc5094aa4163b6"
+
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.0-beta.5.2"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz#8b923deb90144aea65cf834b016a340fc98556f3"
+  integrity sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -11837,6 +11974,11 @@ json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -12031,6 +12173,13 @@ keyv@3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
+keyv@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"
+  integrity sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==
+  dependencies:
+    json-buffer "3.0.1"
+
 killable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -12145,17 +12294,6 @@ less@^3.0.3:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/less/-/less-3.9.0.tgz#b7511c43f37cf57dc87dffd9883ec121289b1474"
   integrity sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==
-  dependencies:
-    clone "^2.1.2"
-  optionalDependencies:
-    errno "^0.1.1"
-    graceful-fs "^4.1.2"
-    image-size "~0.5.0"
-    mime "^1.4.1"
-    mkdirp "^0.5.0"
-    promise "^7.1.1"
-    request "^2.83.0"
-    source-map "~0.6.0"
 
 leven@^3.1.0:
   version "3.1.0"
@@ -12651,6 +12789,11 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
 lru-cache@4.0.0:
   version "4.0.0"
   resolved "http://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz#b5cbf01556c16966febe54ceec0fb4dc90df6c28"
@@ -13037,6 +13180,11 @@ mimic-response@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -13789,6 +13937,11 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalize-url@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -14167,6 +14320,11 @@ p-cancelable@^0.3.0:
 p-cancelable@^0.4.0:
   version "0.4.1"
   resolved "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
+
+p-cancelable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
+  integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
 p-debounce@^2.1.0:
   version "2.1.0"
@@ -15301,6 +15459,15 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.13.3:
+  version "6.13.7"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
+  integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 query-string@^6.9.0:
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.11.1.tgz#ab021f275d463ce1b61e88f0ce6988b3e8fe7c2c"
@@ -15325,6 +15492,11 @@ querystringify@^2.0.0:
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -16115,6 +16287,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve-alpn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
+  integrity sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -16172,6 +16349,13 @@ responselike@1.0.2:
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
   dependencies:
     lowercase-keys "^1.0.0"
+
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -18103,11 +18287,6 @@ typescript@^3.0.3, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@^3.1.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 typescript@^3.9.3:
   version "3.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4148,7 +4148,7 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
 
-agent-base@4, agent-base@^4.1.0:
+agent-base@4, agent-base@4.2.1, agent-base@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   dependencies:
@@ -11060,6 +11060,7 @@ ignore@^5.1.4:
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+  integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -12294,6 +12295,17 @@ less@^3.0.3:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/less/-/less-3.9.0.tgz#b7511c43f37cf57dc87dffd9883ec121289b1474"
   integrity sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==
+  dependencies:
+    clone "^2.1.2"
+  optionalDependencies:
+    errno "^0.1.1"
+    graceful-fs "^4.1.2"
+    image-size "~0.5.0"
+    mime "^1.4.1"
+    mkdirp "^0.5.0"
+    promise "^7.1.1"
+    request "^2.83.0"
+    source-map "~0.6.0"
 
 leven@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This updates the GitLab library to `@gitbeaker/node@25.6.0`, which "unfortunately" reveals a big issue with a dependency `agent-base@4.2.1` to our code base, which eagerly messes around with node's `https.request` function and finally breaks the new GitLab library. So, this required another patch for now.

The upstream issue with the `agent-base` module is https://github.com/TooTallNate/node-agent-base/pull/36. 

We should try to get rid of this bad dependency.

## Test

http://at-gitlab-api.staging.gitpod-dev.com/#https://gitlab.com/gitlab-org/gitlab