### PR TITLE
[ws-scheduler] Match pprof/prometheus config shapes

### DIFF
--- a/components/ee/ws-scheduler/cmd/root.go
+++ b/components/ee/ws-scheduler/cmd/root.go
@@ -85,10 +85,10 @@ type config struct {
 	Scheduler  scheduler.Configuration `json:"scheduler"`
 	Scaler     *scaler.Configuration   `json:"scaler,omitempty"`
 	Prometheus struct {
-		Addr string `json:"address"`
+		Addr string `json:"addr"`
 	} `json:"prometheus"`
 	PProf struct {
-		Addr string `json:"address"`
+		Addr string `json:"addr"`
 	} `json:"pprof"`
 }
 

--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -44,12 +44,13 @@ var runCmd = &cobra.Command{
 			log.WithError(err).Fatal("cannot create scheduler")
 		}
 		schedulerCtx, cancelScheduler := context.WithCancel(context.Background())
-		err = scheduler.Start(schedulerCtx)
-		if err != nil {
-			log.WithError(err).Fatal("cannot start scheduler")
-			cancelScheduler()
-			return
-		}
+		go func() {
+			err = scheduler.Start(schedulerCtx)
+			if err != nil {
+				cancelScheduler()
+				log.WithError(err).Fatal("cannot start scheduler")
+			}
+		}()
 		defer func() {
 			log.Info("ws-scheduler interrupted; shutting down...")
 			cancelScheduler()

--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -56,7 +56,6 @@ var runCmd = &cobra.Command{
 			scheduler.WaitForShutdown()
 			log.Info("ws-scheduler shut down")
 		}()
-		log.Info("ws-scheduler is up and running. Stop with SIGINT or CTRL+C")
 
 		if config.Scaler != nil {
 			scaler := scaler.NewScaler(*config.Scaler, clientSet)
@@ -69,7 +68,7 @@ var runCmd = &cobra.Command{
 				scaler.WaitForShutdown()
 				log.Info("ws-scaler shut down")
 			}()
-			log.Info("ws-scaler is up and running. Stop with SIGINT or CTRL+C")
+			log.Info("scaler is up and running")
 		}
 
 		if config.Prometheus.Addr != "" {
@@ -94,6 +93,8 @@ var runCmd = &cobra.Command{
 		if config.PProf.Addr != "" {
 			go pprof.Serve(config.PProf.Addr)
 		}
+
+		log.Info("🗓️ ws-scheduler is up and running. Stop with SIGINT or CTRL+C")
 
 		// Run until we're told to stop
 		sigChan := make(chan os.Signal, 1)

--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gitpod-io/gitpod/common-go/pprof"
-	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scheduler"
 )
 
@@ -59,17 +58,7 @@ var runCmd = &cobra.Command{
 		}()
 
 		if config.Scaler != nil {
-			scaler := scaler.NewScaler(*config.Scaler, clientSet)
-			scalerCtx, cancelScaler := context.WithCancel(context.Background())
-			scaler.Start(scalerCtx)
-
-			defer func() {
-				log.Info("ws-scaler interrupted; shutting down...")
-				cancelScaler()
-				scaler.WaitForShutdown()
-				log.Info("ws-scaler shut down")
-			}()
-			log.Info("scaler is up and running")
+			log.Warn("the scaler is currently broken and will not be started")
 		}
 
 		if config.Prometheus.Addr != "" {

--- a/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
@@ -224,7 +224,6 @@ func (s *Scheduler) startInformer(ctx context.Context) (schedulerQueue chan *cor
 			//		entry to early might lead to us making the same mistake again.
 			if pod.Spec.NodeName != "" && pod.Status.Phase != corev1.PodPending {
 				s.localBindingCache.delete(pod.Name)
-				log.WithField("pod", pod.Name).WithField("node", pod.Spec.NodeName).WithField("phase", pod.Status.Phase).Debug("removed from localBindingCache")
 			}
 
 			if pod.Status.Phase == corev1.PodFailed && pod.Status.Reason == "OutOfMemory" {


### PR DESCRIPTION
This PR makes the ws-scheduler configuration for pprof and Prometheus match the config shapes.

It also
- fixes an issue during ws-scheduler startup which would block scaler, pprof and prometheus from starting
- makes the logs less noisy
- introduces an emoji 🗓️ in the startup message