### PR TITLE
[ws-scheduler] Fix leak in localBindingCache, resulting in failed scheduling

### DIFF
--- a/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
@@ -219,10 +219,12 @@ func (s *Scheduler) startInformer(ctx context.Context) (schedulerQueue chan *cor
 			}
 
 			// If we see a pod that has been scheduled successfully: Delete from local scheduled_store to avoid leaking memory
-			// Note: Make sure we do not clear the entry to early, especially if the scheduling might still fail.
-			//       'nodename != "" && note: phase == "pending"' for instance might fail with 'OutOfMemory'. Removing this
-			//		entry to early might lead to us making the same mistake again.
-			if pod.Spec.NodeName != "" && pod.Status.Phase != corev1.PodPending {
+			// Note: We _might_ delete entries from localBindingCache too early here, leading to 'OutOfMemory'.
+			//       This might happen if a pod has been scheduled (phase=="pending" && nodeName!=""), we removed it, and the
+			//		scheduler cannot take that info into account because we just removed.
+			//      But we cannot implement an exception for that case, because it leads to leaking localBindingCache entries,
+			//      because some pods are removed in the "pending" phase directly.
+			if pod.Spec.NodeName != "" {
 				s.localBindingCache.delete(pod.Name)
 				log.WithField("pod", pod.Name).WithField("node", pod.Spec.NodeName).WithField("phase", pod.Status.Phase).Debug("removed from localBindingCache")
 			}

--- a/components/ee/ws-scheduler/pkg/scheduler/state.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state.go
@@ -278,13 +278,20 @@ func NodeMapToList(m map[string]*Node) []*Node {
 
 // DebugStringResourceUsage returns a debug string describing the used resources
 func (r *ResourceUsage) DebugStringResourceUsage() string {
-	usedRegularGibs := float64(r.UsedRegular.Value()/1024/1024) / float64(1024)
-	usedHeadlessGibs := float64(r.UsedHeadless.Value()/1024/1024) / float64(1024)
-	usedOtherGibs := float64(r.UsedOther.Value()/1024/1024) / float64(1024)
-	totalGibs := float64(r.Total.Value()/1024/1024) / float64(1024)
-	availableGibs := float64(r.Available.Value()/1024/1024) / float64(1024)
+	usedRegularGibs := toMiString(r.UsedRegular)
+	usedHeadlessGibs := toMiString(r.UsedHeadless)
+	usedOtherGibs := toMiString(r.UsedOther)
+	totalGibs := toMiString(r.Total)
+	availableGibs := toMiString(r.Available)
 
-	return fmt.Sprintf("used %0.03f+%0.03f+%0.3f of %0.3f, avail %0.03f GiB", usedRegularGibs, usedHeadlessGibs, usedOtherGibs, totalGibs, availableGibs)
+	return fmt.Sprintf("used %s+%s+%s of %s, avail %s Mi", usedRegularGibs, usedHeadlessGibs, usedOtherGibs, totalGibs, availableGibs)
+}
+
+func toMiString(q *res.Quantity) string {
+	cv, _ := q.AsScale(res.Mega) // we don't care about sub-meg precision because it is for displaying only
+	var out []byte
+	out, _ = cv.AsCanonicalBytes(out) // we already know the exponent as we set scale above
+	return string(out)
 }
 
 // DebugStringNodes prints available RAM per node as string for debug purposes

--- a/components/ee/ws-scheduler/pkg/scheduler/state_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/state_test.go
@@ -16,9 +16,9 @@ import (
 func TestState(t *testing.T) {
 	defaultNodeSet := func() []*corev1.Node {
 		return []*corev1.Node{
-			createNode("node1", "10Gi", "0Gi", false, 100),
-			createNode("node2", "10Gi", "0Gi", false, 100),
-			createNode("node3", "10Gi", "0Gi", true, 100),
+			createNode("node1", "10000Mi", "0Mi", false, 100),
+			createNode("node2", "10000Mi", "0Mi", false, 100),
+			createNode("node3", "10000Mi", "0Mi", true, 100),
 		}
 	}
 
@@ -35,112 +35,112 @@ func TestState(t *testing.T) {
 			RAMSafetyBuffer: "512Mi",
 			Nodes:           defaultNodeSet(),
 			Expectation: `- node1:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node2:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node3:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi`,
 		},
 		{
 			Desc:            "other pods only",
 			RAMSafetyBuffer: "512Mi",
 			Nodes:           defaultNodeSet(),
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
+				createNonWorkspacePod("existingPod1", "1500Mi", "0Mi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1000Mi", "0Mi", "node2", 10),
 			},
 			Expectation: `- node1:
-  RAM: used 0.000+0.000+1.500 of 9.500, avail 8.000 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+0+1573 of 9949, avail 8377 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node2:
-  RAM: used 0.000+0.000+1.000 of 9.500, avail 8.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+0+1049 of 9949, avail 8901 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node3:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi`,
 		},
 		{
 			Desc:            "some headless pods",
 			RAMSafetyBuffer: "512Mi",
 			Nodes:           defaultNodeSet(),
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
-				createHeadlessWorkspacePod("hp1", "1Gi", "0Gi", "node2", 10),
-				createHeadlessWorkspacePod("hp2", "2.22Gi", "0Gi", "node2", 10),
+				createNonWorkspacePod("existingPod1", "1500Mi", "0Mi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1000Mi", "0Mi", "node2", 10),
+				createHeadlessWorkspacePod("hp1", "1000Mi", "0Mi", "node2", 10),
+				createHeadlessWorkspacePod("hp2", "2220Mi", "0Mi", "node2", 10),
 			},
 			Expectation: `- node1:
-  RAM: used 0.000+0.000+1.500 of 9.500, avail 8.000 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+0+1573 of 9949, avail 8377 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node2:
-  RAM: used 0.000+3.220+1.000 of 9.500, avail 5.279 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+3377+1049 of 9949, avail 5524 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node3:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi`,
 		},
 		{
 			Desc:            "some regular pods",
 			RAMSafetyBuffer: "512Mi",
 			Nodes:           defaultNodeSet(),
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
-				createWorkspacePod("hp1", "1Gi", "0Gi", "node1", 10),
-				createWorkspacePod("hp2", "3.44Gi", "0Gi", "node1", 10),
+				createNonWorkspacePod("existingPod1", "1500Mi", "0Mi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1000Mi", "0Mi", "node2", 10),
+				createWorkspacePod("hp1", "1000Mi", "0Mi", "node1", 10),
+				createWorkspacePod("hp2", "3440Mi", "0Mi", "node1", 10),
 			},
 			Expectation: `- node1:
-  RAM: used 4.439+0.000+1.500 of 9.500, avail 3.560 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 4656+0+1573 of 9949, avail 3721 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node2:
-  RAM: used 0.000+0.000+1.000 of 9.500, avail 8.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB
+  RAM: used 0+0+1049 of 9949, avail 8901 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi
 - node3:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi`,
 		},
 		{
 			Desc:            "some regular pods with ",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "20Gi", false, 100),
-				createNode("node2", "10Gi", "10Gi", false, 100),
-				createNode("node3", "10Gi", "10Gi", true, 100),
+				createNode("node1", "10000Mi", "20000Mi", false, 100),
+				createNode("node2", "10000Mi", "10000Mi", false, 100),
+				createNode("node3", "10000Mi", "10000Mi", true, 100),
 			},
 			Pods: []*corev1.Pod{
-				createNonWorkspacePod("existingPod1", "1.5Gi", "5Gi", "node1", 10),
-				createNonWorkspacePod("existingPod2", "1Gi", "2Gi", "node2", 10),
-				createWorkspacePod("hp1", "1Gi", "5Gi", "node1", 10),
-				createWorkspacePod("hp2", "3.44Gi", "5Gi", "node1", 10),
+				createNonWorkspacePod("existingPod1", "1500Mi", "5000Mi", "node1", 10),
+				createNonWorkspacePod("existingPod2", "1000Mi", "2000Mi", "node2", 10),
+				createWorkspacePod("hp1", "1000Mi", "5000Mi", "node1", 10),
+				createWorkspacePod("hp2", "3440Mi", "5000Mi", "node1", 10),
 			},
 			Expectation: `- node1:
-  RAM: used 4.439+0.000+1.500 of 9.500, avail 3.560 GiB
-  Eph. Storage: used 10.000+0.000+5.000 of 20.000, avail 5.000 GiB
+  RAM: used 4656+0+1573 of 9949, avail 3721 Mi
+  Eph. Storage: used 10486+0+5243 of 20972, avail 5243 Mi
 - node2:
-  RAM: used 0.000+0.000+1.000 of 9.500, avail 8.500 GiB
-  Eph. Storage: used 0.000+0.000+2.000 of 10.000, avail 8.000 GiB
+  RAM: used 0+0+1049 of 9949, avail 8901 Mi
+  Eph. Storage: used 0+0+2098 of 10486, avail 8389 Mi
 - node3:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 10.000, avail 10.000 GiB`,
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 10486, avail 10486 Mi`,
 		},
 		{
 			Desc:            "bound but not listed",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "20Gi", false, 100),
+				createNode("node1", "10000Mi", "20000Mi", false, 100),
 			},
 			Bindings: []*sched.Binding{
 				{
-					Pod:      createWorkspacePod("hp1", "1Gi", "5Gi", "node1", 10),
+					Pod:      createWorkspacePod("hp1", "1000Mi", "5000Mi", "node1", 10),
 					NodeName: "node1",
 				},
 			},
 			Expectation: `- node1:
-  RAM: used 1.000+0.000+0.000 of 9.500, avail 8.500 GiB
-  Eph. Storage: used 5.000+0.000+0.000 of 20.000, avail 15.000 GiB`,
+  RAM: used 1049+0+0 of 9949, avail 8901 Mi
+  Eph. Storage: used 5243+0+0 of 20972, avail 15729 Mi`,
 		},
 	}
 

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy_test.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy_test.go
@@ -44,74 +44,74 @@ Nodes:
 		{
 			Desc:            "no node with enough RAM",
 			RAMSafetyBuffer: "512Mi",
-			Nodes:           []*corev1.Node{createNode("node1", "10Gi", "0Gi", false, 100)},
-			Pods:            []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "0Gi", "node1", 10)},
-			ScheduledPod:    createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			Nodes:           []*corev1.Node{createNode("node1", "10000Mi", "0Mi", false, 100)},
+			Pods:            []*corev1.Pod{createNonWorkspacePod("existingPod1", "8000Mi", "0Mi", "node1", 10)},
+			ScheduledPod:    createWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedError: `No node with enough resources available!
-RAM requested: 6Gi
+RAM requested: 6000Mi
 Eph. Storage requested: 0
 Nodes:
 - node1:
-  RAM: used 0.000+0.000+8.000 of 9.500, avail 1.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 0.000, avail 0.000 GiB`,
+  RAM: used 0+0+8389 of 9949, avail 1561 Mi
+  Eph. Storage: used 0+0+0 of 0, avail 0 Mi`,
 		},
 		{
 			Desc:            "single empty node",
 			RAMSafetyBuffer: "512Mi",
-			Nodes:           []*corev1.Node{createNode("node1", "10Gi", "0Gi", false, 100)},
-			ScheduledPod:    createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			Nodes:           []*corev1.Node{createNode("node1", "10000Mi", "0Mi", false, 100)},
+			ScheduledPod:    createWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode:    "node1",
 		},
 		{
 			Desc:            "two nodes, one full",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", false, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", false, 100),
 			},
-			Pods:         []*corev1.Pod{createNonWorkspacePod("existingPod1", "8Gi", "0Gi", "node1", 10)},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			Pods:         []*corev1.Pod{createNonWorkspacePod("existingPod1", "8000Mi", "0Mi", "node1", 10)},
+			ScheduledPod: createWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode: "node2",
 		},
 		{
 			Desc:            "two nodes, prefer density",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", false, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", false, 100),
 			},
-			Pods:         []*corev1.Pod{createWorkspacePod("existingPod1", "1Gi", "0Gi", "node1", 10)},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			Pods:         []*corev1.Pod{createWorkspacePod("existingPod1", "1000Mi", "0Mi", "node1", 10)},
+			ScheduledPod: createWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
 			Desc:            "three nodes, prefer with image",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", true, 100),
-				createNode("node3", "10Gi", "0Gi", false, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", true, 100),
+				createNode("node3", "10000Mi", "0Mi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "1500Mi", "0Mi", "node1", 10),
+				createWorkspacePod("existingPod2", "1000Mi", "0Mi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			ScheduledPod: createWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode: "node2",
 		},
 		{
 			Desc:            "three nodes, prefer with image in class",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", false, 100),
-				createNode("node3", "10Gi", "0Gi", true, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", false, 100),
+				createNode("node3", "10000Mi", "0Mi", true, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "1500Mi", "0Mi", "node1", 10),
+				createWorkspacePod("existingPod2", "1000Mi", "0Mi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			ScheduledPod: createWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
@@ -119,41 +119,41 @@ Nodes:
 			Desc:            "three nodes, place headless pod",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", true, 100),
-				createNode("node3", "10Gi", "0Gi", true, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", true, 100),
+				createNode("node3", "10000Mi", "0Mi", true, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "1.5Gi", "0Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "1Gi", "0Gi", "node2", 10),
-				createHeadlessWorkspacePod("hpod", "0.5Gi", "0Gi", "node3", 1000),
+				createWorkspacePod("existingPod1", "1500Mi", "0Mi", "node1", 10),
+				createWorkspacePod("existingPod2", "1000Mi", "0Mi", "node2", 10),
+				createHeadlessWorkspacePod("hpod", "500Mi", "0Mi", "node3", 1000),
 			},
-			ScheduledPod: createHeadlessWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			ScheduledPod: createHeadlessWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode: "node2",
 		},
 		{
 			Desc:            "three empty nodes, place headless pod",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", true, 100),
-				createNode("node3", "10Gi", "0Gi", true, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", true, 100),
+				createNode("node3", "10000Mi", "0Mi", true, 100),
 			},
-			ScheduledPod: createHeadlessWorkspacePod("pod", "6Gi", "0Gi", "", 1000),
+			ScheduledPod: createHeadlessWorkspacePod("pod", "6000Mi", "0Mi", "", 1000),
 			ExpectedNode: "node1",
 		},
 		{
 			Desc:            "filter full nodes, headless workspaces",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 100),
-				createNode("node2", "10Gi", "0Gi", false, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 100),
+				createNode("node2", "10000Mi", "0Mi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createHeadlessWorkspacePod("existingPod1", "4Gi", "0Gi", "node1", 10),
-				createWorkspacePod("existingPod2", "4Gi", "0Gi", "node1", 10),
+				createHeadlessWorkspacePod("existingPod1", "4000Mi", "0Mi", "node1", 10),
+				createWorkspacePod("existingPod2", "4000Mi", "0Mi", "node1", 10),
 			},
-			ScheduledPod: createWorkspacePod("pod", "4Gi", "0Gi", "", 10),
+			ScheduledPod: createWorkspacePod("pod", "4000Mi", "0Mi", "", 10),
 			ExpectedNode: "node2",
 		},
 		{
@@ -161,13 +161,13 @@ Nodes:
 			Desc:            "respect node's pod capacity",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "0Gi", false, 0),
-				createNode("node2", "10Gi", "0Gi", false, 100),
+				createNode("node1", "10000Mi", "0Mi", false, 0),
+				createNode("node2", "10000Mi", "0Mi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "4Gi", "0Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "4000Mi", "0Mi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("new pod", "4Gi", "0Gi", "node1", 10),
+			ScheduledPod: createWorkspacePod("new pod", "4000Mi", "0Mi", "node1", 10),
 			ExpectedNode: "node2",
 		},
 		{
@@ -175,13 +175,13 @@ Nodes:
 			Desc:            "respect node's ephemeral storage",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "3Gi", false, 100),
-				createNode("node2", "10Gi", "15Gi", false, 100),
+				createNode("node1", "10000Mi", "3000Mi", false, 100),
+				createNode("node2", "10000Mi", "15000Mi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "4Gi", "5Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "4000Mi", "5000Mi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("new pod", "4Gi", "5Gi", "node1", 10),
+			ScheduledPod: createWorkspacePod("new pod", "4000Mi", "5000Mi", "node1", 10),
 			ExpectedNode: "node2",
 		},
 		{
@@ -189,39 +189,39 @@ Nodes:
 			Desc:            "enough RAM but no more ephemeral storage",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "10Gi", "3Gi", false, 100),
-				createNode("node2", "10Gi", "7Gi", false, 100),
+				createNode("node1", "10000Mi", "3000Mi", false, 100),
+				createNode("node2", "10000Mi", "7000Mi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "4Gi", "5Gi", "node2", 10),
+				createWorkspacePod("existingPod1", "4000Mi", "5000Mi", "node2", 10),
 			},
-			ScheduledPod: createWorkspacePod("new pod", "4Gi", "5Gi", "node1", 10),
+			ScheduledPod: createWorkspacePod("new pod", "4000Mi", "5000Mi", "node1", 10),
 			ExpectedError: `No node with enough resources available!
-RAM requested: 4Gi
-Eph. Storage requested: 5Gi
+RAM requested: 4000Mi
+Eph. Storage requested: 5000Mi
 Nodes:
 - node2:
-  RAM: used 4.000+0.000+0.000 of 9.500, avail 5.500 GiB
-  Eph. Storage: used 5.000+0.000+0.000 of 7.000, avail 2.000 GiB
+  RAM: used 4195+0+0 of 9949, avail 5755 Mi
+  Eph. Storage: used 5243+0+0 of 7341, avail 2098 Mi
 - node1:
-  RAM: used 0.000+0.000+0.000 of 9.500, avail 9.500 GiB
-  Eph. Storage: used 0.000+0.000+0.000 of 3.000, avail 3.000 GiB`,
+  RAM: used 0+0+0 of 9949, avail 9949 Mi
+  Eph. Storage: used 0+0+0 of 3146, avail 3146 Mi`,
 		},
 		{
 			// Should prefer 1 and 2 over 3, but 1 has not enough pod slots and 2 not enough ephemeral storage
 			Desc:            "filter nodes without enough pod slots and ephemeral storage",
 			RAMSafetyBuffer: "512Mi",
 			Nodes: []*corev1.Node{
-				createNode("node1", "20Gi", "10Gi", false, 0),
-				createNode("node2", "20Gi", "10Gi", false, 100),
-				createNode("node3", "20Gi", "10Gi", false, 100),
+				createNode("node1", "20000Mi", "10000Mi", false, 0),
+				createNode("node2", "20000Mi", "10000Mi", false, 100),
+				createNode("node3", "20000Mi", "10000Mi", false, 100),
 			},
 			Pods: []*corev1.Pod{
-				createWorkspacePod("existingPod1", "4Gi", "5Gi", "node2", 10),
-				createWorkspacePod("existingPod2", "4Gi", "5Gi", "node2", 10),
-				createWorkspacePod("existingPod3", "4Gi", "5Gi", "node3", 10),
+				createWorkspacePod("existingPod1", "4000Mi", "5000Mi", "node2", 10),
+				createWorkspacePod("existingPod2", "4000Mi", "5000Mi", "node2", 10),
+				createWorkspacePod("existingPod3", "4000Mi", "5000Mi", "node3", 10),
 			},
-			ScheduledPod: createWorkspacePod("new pod", "4Gi", "5Gi", "node1", 10),
+			ScheduledPod: createWorkspacePod("new pod", "4000Mi", "5000Mi", "node1", 10),
 			ExpectedNode: "node3",
 		},
 	}


### PR DESCRIPTION
Fixes a situation where we'd leak entries in `localBindingCache` which results in situations where `ws-scheduler` thinks a node is "full" despite it still having room for pods.