### PR TITLE
[ws-manager] Don't complain when dangling service is already gone

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1337,7 +1337,7 @@ func (m *Monitor) deleteDanglingServices() error {
 
 		// this relies on the Kubernetes convention that endpoints have the same name as their services
 		err = servicesClient.Delete(e.Name, &metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
-		if err != nil {
+		if err != nil && !isKubernetesObjNotFoundError(err) {
 			m.OnError(xerrors.Errorf("deleteDanglingServices: %w", err))
 			continue
 		}


### PR DESCRIPTION
Resolves issues like
```
"deleteDanglingServices:
    github.com/gitpod-io/gitpod/ws-manager/pkg/manager.(*Monitor).deleteDanglingServices
        /tmp/build/gitpod-core-components-ws-manager--app.61a1febdf5b91e93e0aa14f25d707643e91a55c1/pkg/manager/monitor.go:1341
  - services "ws-88488dea-b1f4-4649-8626-ab076937ccf4-theia" not found"
```

If we're trying to delete a dangling service, and something else (e.g. a regular workspace stop) is faster, the service is gone after all.