### PR TITLE
upgrade code

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 839a6a9c0e9edc0d8d54f7241a8b1c7de4429a68
+ENV GP_CODE_COMMIT 4a92a1f011d107ced5016ec6c8905682c2e5ec7e
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft https

#### What it does

There are following fixes:
- authentication with GitHub
- Gitpod host's domain is listed as trusted
- request channel is implemented by Gitpod Code Server to provide a fallback if Code cannot connect to remote services from the browser, i.e. a workaround for https://github.com/gitpod-io/gitpod/issues/2386

Code diff: https://github.com/gitpod-io/vscode/compare/839a6a9c0e9edc0d8d54f7241a8b1c7de4429a68...4a92a1f011d107ced5016ec6c8905682c2e5ec7e

#### How to test

- Switch to Code, start a workspace.
- You should be able to preview/install extensions without errors.
- Open browser port notification should not prompt you with untrusted domain warning.
- In account menu you should see that you are authenticated with GitHub or empty if it is another auth provider, e.g. GitLab.