### PR TITLE
[content-initialiser] Improve logging and OWI association

### DIFF
--- a/components/ws-daemon/cmd/content-initializer/main.go
+++ b/components/ws-daemon/cmd/content-initializer/main.go
@@ -18,7 +18,6 @@ func main() {
 
 	err := content.RunInitializerChild()
 	if err != nil {
-		log.WithError(err).Error("content init failed")
 		os.Exit(42)
 	}
 }

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	wsinit "github.com/gitpod-io/gitpod/content-service/pkg/initializer"
@@ -234,7 +235,13 @@ func RunInitializerChild() (err error) {
 		return err
 	}
 
-	span := opentracing.StartSpan("RunInitializerChild", opentracing.FollowsFrom(tracing.FromTraceID(initmsg.TraceInfo)))
+	defer func() {
+		if err != nil {
+			log.WithError(err).WithFields(initmsg.OWI).Error("content init failed")
+		}
+	}()
+
+	span := opentracing.StartSpan("RunInitializerChild", opentracing.ChildOf(tracing.FromTraceID(initmsg.TraceInfo)))
 	defer tracing.FinishSpan(span, &err)
 	ctx := opentracing.ContextWithSpan(context.Background(), span)
 


### PR DESCRIPTION
This PR improves the logging and tracing of the runc-wrapped content-initialiser.

It more directly associates the trace:
![image](https://user-images.githubusercontent.com/3210701/100999574-3a395a80-355d-11eb-880e-acdcfb76fc81.png)

And it adds OWI to the error logs should things fail.

### How to test
1. Start a workspace and look at the trace