### PR TITLE
[ws-daemon] log the actual error when init fails

### DIFF
--- a/components/ws-daemon/cmd/content-initializer/main.go
+++ b/components/ws-daemon/cmd/content-initializer/main.go
@@ -18,6 +18,7 @@ func main() {
 
 	err := content.RunInitializerChild()
 	if err != nil {
+		log.WithError(err).Error("content initialization failed.")
 		os.Exit(42)
 	}
 }


### PR DESCRIPTION
This adds logging to get more info about https://github.com/gitpod-io/gitpod/issues/2412