### PR TITLE
[mini browser] serve local files from own origin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.useLanguageServer": true
+}

--- a/chart/config/proxy/vhost.server.conf
+++ b/chart/config/proxy/vhost.server.conf
@@ -107,10 +107,10 @@ server {
 server {
     listen {{ $listen }};
     # Matches:
-    #  - (webview-)?+                   webview prefix including UUID (optional). This must be possesive (?+) to not confuse "webview-8000-a1231-..." with a valid UUID
+    #  - (webview-|browser-)?+          webview prefix including UUID (optional). This must be possesive (?+) to not confuse "webview-8000-a1231-..." with a valid UUID
     #  - (?<wsid>[a-z][0-9a-z\-]+)      workspace Id
     #  - \.ws(-[a-z0-9]+)?              workspace base domain
-    server_name ~^(webview-)?+(?<wsid>[a-z][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$;
+    server_name ~^(webview-|browser-)?+(?<wsid>[a-z][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$;
 
 {{- if $useHttps }}
     {{- if eq .Values.ingressMode "pathAndHost" }}
@@ -129,12 +129,12 @@ server {
 server {
     listen {{ $listen }};
     # Matches:
-    #  - (webview-)?+                   for now, we only support Theia webviews here! (TODO is there a - meaningful - way to generalize this?)
+    #  - (webview-|browser-)?+          for now, we only support Theia webviews here! (TODO is there a - meaningful - way to generalize this?)
     #  - (?<port>[0-9]{2,5})-           port to forward to
     #  - (?<wsid>[a-z][0-9a-z\-]+)      workspace Id
     #  - \.ws(-[a-z0-9]+)?              workspace base domain
     # "" needed because of {} (nginx syntax wart)
-    server_name "~^(webview-)?+(?<port>[0-9]{2,5})-(?<wsid>[a-z][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$";
+    server_name "~^(webview-|browser-)?+(?<port>[0-9]{2,5})-(?<wsid>[a-z][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$";
 
 {{- if $useHttps }}
     {{- if eq .Values.ingressMode "pathAndHost" }}

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-frontend-module.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-frontend-module.ts
@@ -63,6 +63,9 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 import { GitpodTaskContribution } from './gitpod-task-contribution';
 import { GitpodTaskServer, gitpodTaskServicePath } from '../common/gitpod-task-protocol';
 import { GitpodPortServer, gitpodPortServicePath } from '../common/gitpod-port-server';
+import { LocationMapper, LocationMapperService } from '@theia/mini-browser/lib/browser/location-mapper-service';
+import { GitpodLocationMapperService, SecureFileLocationMapper } from './mini-browser/gitpod-location-mapper-service';
+import { MiniBrowserEnvironment } from './mini-browser/mini-browser-environment';
 
 @injectable()
 class GitpodFrontendApplication extends FrontendApplication {
@@ -220,4 +223,11 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ConnectionStatusOptions).toConstantValue({
         offlineTimeout: 20000
     });
+
+    //#region mini-browser run local files in own origin, should be reverted after next upgrade
+    rebind(LocationMapperService).to(GitpodLocationMapperService).inSingletonScope();
+    bind(LocationMapper).to(SecureFileLocationMapper).inSingletonScope();
+    bind(MiniBrowserEnvironment).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(MiniBrowserEnvironment);
+    //#endregion
 });

--- a/components/theia/packages/gitpod-extension/src/browser/mini-browser/gitpod-location-mapper-service.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/mini-browser/gitpod-location-mapper-service.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MaybePromise } from '@theia/core/lib/common/types';
+import URI from '@theia/core/lib/common/uri';
+import { LocationMapper, LocationMapperService, FileLocationMapper as InsecureFileLocationMapper } from '@theia/mini-browser/lib/browser/location-mapper-service';
+import { inject, injectable } from 'inversify';
+import { MiniBrowserEnvironment } from './mini-browser-environment';
+
+@injectable()
+export class GitpodLocationMapperService extends LocationMapperService {
+
+    protected getContributions(): LocationMapper[] {
+        return this.contributions.getContributions().filter(c => !(c instanceof InsecureFileLocationMapper));
+    }
+
+}
+
+@injectable()
+export class SecureFileLocationMapper implements LocationMapper {
+
+    @inject(MiniBrowserEnvironment)
+    protected readonly miniBrowserEnvironment: MiniBrowserEnvironment;
+
+    canHandle(location: string): MaybePromise<number> {
+        return location.startsWith('file://') ? 1 : 0;
+    }
+
+    map(location: string): MaybePromise<string> {
+        const uri = new URI(location);
+        if (uri.scheme !== 'file') {
+            throw new Error(`Only URIs with 'file' scheme can be mapped to an URL. URI was: ${uri}.`);
+        }
+        let rawLocation = uri.path.toString();
+        if (rawLocation.charAt(0) === '/') {
+            rawLocation = rawLocation.substr(1);
+        }
+        return this.miniBrowserEnvironment.getRandomEndpoint().getRestUrl().resolve(rawLocation).toString();
+    }
+
+}

--- a/components/theia/packages/gitpod-extension/src/browser/mini-browser/mini-browser-environment.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/mini-browser/mini-browser-environment.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { Endpoint, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable, postConstruct } from 'inversify';
+import { MiniBrowserEndpoint } from '../../common/mini-browser-endpoint';
+import { v4 } from 'uuid';
+
+/**
+ * Fetch values from the backend's environment.
+ */
+@injectable()
+export class MiniBrowserEnvironment implements FrontendApplicationContribution {
+
+    protected _hostPatternPromise: Promise<string>;
+    protected _hostPattern: string;
+
+    @inject(EnvVariablesServer)
+    protected readonly environment: EnvVariablesServer;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        this._hostPatternPromise = this.environment.getValue(MiniBrowserEndpoint.HOST_PATTERN_ENV)
+            .then(envVar => envVar?.value || MiniBrowserEndpoint.HOST_PATTERN_DEFAULT);
+    }
+
+    async onStart(): Promise<void> {
+        this._hostPattern = await this._hostPatternPromise;
+    }
+
+    getEndpoint(uuid: string, hostname?: string): Endpoint {
+        return new Endpoint({
+            host: this._hostPattern
+                .replace('{{uuid}}', uuid)
+                .replace('{{hostname}}', hostname || this.getDefaultHostname()),
+        });
+    }
+
+    getRandomEndpoint(): Endpoint {
+        return this.getEndpoint(v4());
+    }
+
+    protected getDefaultHostname(): string {
+        return self.location.host;
+    }
+}

--- a/components/theia/packages/gitpod-extension/src/common/mini-browser-endpoint.ts
+++ b/components/theia/packages/gitpod-extension/src/common/mini-browser-endpoint.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+/**
+ * The mini-browser can now serve content on its own host/origin.
+ *
+ * The virtual host can be configured with this `THEIA_MINI_BROWSER_HOST_PATTERN`
+ * environment variable. `{{hostname}}` reprensents the current host, and `{{uuid}}`
+ * will be replace by a random uuid value.
+ */
+export namespace MiniBrowserEndpoint {
+    export const HOST_PATTERN_ENV = 'THEIA_MINI_BROWSER_HOST_PATTERN';
+    export const HOST_PATTERN_DEFAULT = '{{uuid}}.mini-browser.{{hostname}}';
+}

--- a/components/theia/packages/gitpod-extension/src/node/gitpod-backend-module.ts
+++ b/components/theia/packages/gitpod-extension/src/node/gitpod-backend-module.ts
@@ -44,6 +44,8 @@ import { GitpodTaskServer, GitpodTaskClient, gitpodTaskServicePath } from "../co
 import { GitpodTaskServerImpl } from "./gitpod-task-server-impl";
 import { GitpodPortServer, GitpodPortClient, gitpodPortServicePath } from "../common/gitpod-port-server";
 import { GitpodTaskTerminalProcess, GitpodTaskTerminalProcessFactory, GitpodTaskTerminalProcessOptions } from "./gitpod-task-terminal-process";
+import { MiniBrowserEndpoint } from "@theia/mini-browser/lib/node/mini-browser-endpoint";
+import { GitpodMiniBrowserEndpoint } from "./gitpod-mini-browser-endpoint";
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(ShellProcess).to(GitpodShellProcess).inTransientScope();
@@ -131,4 +133,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
             return service;
         })
     ).inSingletonScope();
+
+    //#region mini-browser run local files in own origin, should be reverted after next upgrade
+    rebind(MiniBrowserEndpoint).to(GitpodMiniBrowserEndpoint).inSingletonScope();
+    //#endregion
 });

--- a/components/theia/packages/gitpod-extension/src/node/gitpod-mini-browser-endpoint.ts
+++ b/components/theia/packages/gitpod-extension/src/node/gitpod-mini-browser-endpoint.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+const vhost = require('vhost');
+import express = require('express');
+import { MaybePromise } from '@theia/core/lib/common/types';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { MiniBrowserEndpoint } from '@theia/mini-browser/lib/node/mini-browser-endpoint';
+import { Application, Request } from 'express';
+import { injectable } from 'inversify';
+import { MiniBrowserEndpoint as MiniBrowserEndpointNS } from '../common/mini-browser-endpoint';
+
+@injectable()
+export class GitpodMiniBrowserEndpoint extends MiniBrowserEndpoint {
+
+    private attachRequestHandlerPromise: Promise<void>;
+
+    configure(app: Application): void {
+        this.attachRequestHandlerPromise = this.attachRequestHandler(app);
+    }
+
+    async onStart(): Promise<void> {
+        await Promise.all(Array.from(this.getContributions(), async handler => {
+            const extensions = await handler.supportedExtensions();
+            for (const extension of (Array.isArray(extensions) ? extensions : [extensions]).map(e => e.toLocaleLowerCase())) {
+                const existingHandler = this.handlers.get(extension);
+                if (!existingHandler || handler.priority > existingHandler.priority) {
+                    this.handlers.set(extension, handler);
+                }
+            }
+        }));
+        await this.attachRequestHandlerPromise;
+    }
+
+    async supportedFileExtensions(): Promise<Readonly<{ extension: string, priority: number }>[]> {
+        return Array.from(this.handlers.entries(), ([extension, handler]) => ({ extension, priority: handler.priority() }));
+    }
+
+    protected async attachRequestHandler(app: Application): Promise<void> {
+        const miniBrowserApp = express();
+        miniBrowserApp.get('*', async (request, response) => this.response(await this.getUri(request), response));
+        app.use(vhost(await this.getVirtualHostRegExp(), miniBrowserApp));
+    }
+
+    protected getUri(request: Request): MaybePromise<string> {
+        return FileUri.create(request.path).toString(true);
+    }
+
+    protected async getVirtualHostRegExp(): Promise<RegExp> {
+        const pattern = process.env[MiniBrowserEndpointNS.HOST_PATTERN_ENV] ?? MiniBrowserEndpointNS.HOST_PATTERN_DEFAULT;
+        const vhostRe = pattern
+            .replace('.', '\\.')
+            .replace('{{uuid}}', '.+')
+            .replace('{{hostname}}', '.+');
+        return new RegExp(vhostRe, 'i');
+    }
+}

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -589,6 +589,7 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 	result = append(result, corev1.EnvVar{Name: "THEIA_SUPERVISOR_TOKEN", Value: m.Config.TheiaSupervisorToken})
 	result = append(result, corev1.EnvVar{Name: "THEIA_SUPERVISOR_ENDPOINT", Value: fmt.Sprintf(":%d", startContext.SupervisorPort)})
 	result = append(result, corev1.EnvVar{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"})
+	result = append(result, corev1.EnvVar{Name: "THEIA_MINI_BROWSER_HOST_PATTERN", Value: "browser-{{hostname}}"})
 
 	// We don't require that Git be configured for workspaces
 	if spec.Git != nil {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "32leaves"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_duplicate_featureflag.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_duplicate_featureflag.golden
@@ -119,6 +119,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -104,6 +104,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -89,6 +89,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "32leaves"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_privileged.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_privileged.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "csweichel"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
@@ -96,6 +96,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -103,6 +103,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -104,6 +104,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -119,6 +119,10 @@
                             "value": "webview-{{hostname}}"
                         },
                         {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
                             "name": "GITPOD_GIT_USER_NAME",
                             "value": "usernameGoesHere"
                         },

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -100,6 +100,10 @@ func installWorkspaceRoutes(r *mux.Router, config *RouteHandlerConfig, ip Worksp
 	routes.HandleDirectSupervisorRoute(r.PathPrefix("/_supervisor/v1"), true)
 	routes.HandleDirectSupervisorRoute(r.PathPrefix("/_supervisor"), true)
 
+	routes.HandleDirectIDERoute(r.MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
+		return m.Vars != nil && m.Vars[foreignOriginPrefix] != ""
+	}))
+
 	routes.HandleRoot(r.NewRoute())
 }
 

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -59,7 +59,7 @@ func HostBasedRouter(header, wsHostSuffix string) WorkspaceRouter {
 type hostHeaderProvider func(req *http.Request) string
 
 func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProvider) mux.MatcherFunc {
-	r := regexp.MustCompile("^(webview-)?" + workspaceIDRegex + wsHostSuffix)
+	r := regexp.MustCompile("^(webview-|browser-)?" + workspaceIDRegex + wsHostSuffix)
 	return func(req *http.Request, m *mux.RouteMatch) bool {
 		hostname := headerProvider(req)
 		if hostname == "" {
@@ -85,7 +85,7 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 }
 
 func matchWorkspacePortHostHeader(wsHostSuffix string, headerProvider hostHeaderProvider) mux.MatcherFunc {
-	r := regexp.MustCompile("^(webview-)?" + workspacePortRegex + workspaceIDRegex + wsHostSuffix)
+	r := regexp.MustCompile("^(webview-|browser-)?" + workspacePortRegex + workspaceIDRegex + wsHostSuffix)
 	return func(req *http.Request, m *mux.RouteMatch) bool {
 		hostname := headerProvider(req)
 		if hostname == "" {

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -22,6 +22,9 @@ const (
 	// Used as key for storing the workspace ID in the requests mux.Vars() map
 	workspaceIDIdentifier = "workspaceID"
 
+	// Used as key for storing the origin prefix to fetch foreign content
+	foreignOriginPrefix = "foreignOriginPrefix"
+
 	// The header that is used to communicate the "Host" from proxy -> ws-proxy in scenarios where ws-proxy is _not_ directly exposed
 	forwardedHostnameHeader = "x-wsproxy-host"
 
@@ -80,6 +83,9 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 			m.Vars = make(map[string]string)
 		}
 		m.Vars[workspaceIDIdentifier] = workspaceID
+		if len(matches) == 3 {
+			m.Vars[foreignOriginPrefix] = matches[1]
+		}
 		return true
 	}
 }
@@ -112,6 +118,9 @@ func matchWorkspacePortHostHeader(wsHostSuffix string, headerProvider hostHeader
 		}
 		m.Vars[workspaceIDIdentifier] = workspaceID
 		m.Vars[workspacePortIdentifier] = workspacePort
+		if len(matches) == 4 {
+			m.Vars[foreignOriginPrefix] = matches[1]
+		}
 		return true
 	}
 }

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -366,6 +366,16 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			},
 		},
 		{
+			Name:       "mini browser workspace match",
+			HostHeader: "browser-efb3a500-1491-48a1-9ab4-86569a2008de" + wsHostSuffix,
+			Expected: matchResult{
+				MatchesWorkspace: true,
+				WorkspaceVars: map[string]string{
+					workspaceIDIdentifier: "efb3a500-1491-48a1-9ab4-86569a2008de",
+				},
+			},
+		},
+		{
 			Name:       "port match",
 			HostHeader: "8080-efb3a500-1491-48a1-9ab4-86569a2008de" + wsHostSuffix,
 			Expected: matchResult{

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -351,6 +351,7 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			Expected: matchResult{
 				MatchesWorkspace: true,
 				WorkspaceVars: map[string]string{
+					foreignOriginPrefix:   "",
 					workspaceIDIdentifier: "efb3a500-1491-48a1-9ab4-86569a2008de",
 				},
 			},
@@ -361,6 +362,7 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			Expected: matchResult{
 				MatchesWorkspace: true,
 				WorkspaceVars: map[string]string{
+					foreignOriginPrefix:   "webview-",
 					workspaceIDIdentifier: "efb3a500-1491-48a1-9ab4-86569a2008de",
 				},
 			},
@@ -371,6 +373,7 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			Expected: matchResult{
 				MatchesWorkspace: true,
 				WorkspaceVars: map[string]string{
+					foreignOriginPrefix:   "browser-",
 					workspaceIDIdentifier: "efb3a500-1491-48a1-9ab4-86569a2008de",
 				},
 			},
@@ -381,6 +384,7 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			Expected: matchResult{
 				MatchesPort: true,
 				PortVars: map[string]string{
+					foreignOriginPrefix:     "",
 					workspaceIDIdentifier:   "efb3a500-1491-48a1-9ab4-86569a2008de",
 					workspacePortIdentifier: "8080",
 				},
@@ -392,6 +396,19 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			Expected: matchResult{
 				MatchesPort: true,
 				PortVars: map[string]string{
+					foreignOriginPrefix:     "webview-",
+					workspaceIDIdentifier:   "efb3a500-1491-48a1-9ab4-86569a2008de",
+					workspacePortIdentifier: "8080",
+				},
+			},
+		},
+		{
+			Name:       "mini browser port match",
+			HostHeader: "browser-8080-efb3a500-1491-48a1-9ab4-86569a2008de" + wsHostSuffix,
+			Expected: matchResult{
+				MatchesPort: true,
+				PortVars: map[string]string{
+					foreignOriginPrefix:     "browser-",
 					workspaceIDIdentifier:   "efb3a500-1491-48a1-9ab4-86569a2008de",
 					workspacePortIdentifier: "8080",
 				},


### PR DESCRIPTION
- [x] /werft https

#### What it does

Serves local files from own origin to isolate them from the workspace origin.

#### How to test

##### Isolation
- Start a workspace. 
- Preview local html file.
  - Don't forget to check that changing local file updates the preview.
- Check in devtools console that there is a new origin (in drop-down box above console)
- Switch to this origin, try to run commands in console like `window.top.document.cookies` or `window.top.localStorage.getItem`, check that `window.document.cookies` does not contain anything from workspace origin

##### URLs preview

- Start a workspace with the dev server, check that preview is still working for it.

##### Webviews

- Install GitLens extension and check that the welcome page was shown.