### PR TITLE
[server/bitbucket] create API client options explicitly for tests

### DIFF
--- a/components/server/ee/src/prebuilds/bitbucket-service.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-service.ts
@@ -7,7 +7,7 @@
 import { RepositoryService } from "../../../src/repohost/repo-service";
 import { User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from "inversify";
-import BitbucketApiFactory from "../../../src/bitbucket/bitbucket-api-factory";
+import { BitbucketApiFactory } from "../../../src/bitbucket/bitbucket-api-factory";
 import { AuthProviderParams } from "../../../src/auth/auth-provider";
 import { BitbucketApp } from "./bitbucket-app";
 import { Env } from "../../../src/env";

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -39,7 +39,7 @@
     "agent-base": "4.2.1",
     "amqplib": "^0.5.2",
     "base-64": "^0.1.0",
-    "bitbucket": "^2.1.0",
+    "bitbucket": "^2.4.2",
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
     "deep-equal": "^1.0.1",

--- a/components/server/src/bitbucket/bitbucket-api-factory.ts
+++ b/components/server/src/bitbucket/bitbucket-api-factory.ts
@@ -4,15 +4,14 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { User } from "@gitpod/gitpod-protocol";
+import { User, Token } from "@gitpod/gitpod-protocol";
 import { APIClient, Bitbucket } from "bitbucket";
-import { Options } from "bitbucket/lib/bitbucket";
 import { inject, injectable } from "inversify";
 import { AuthProviderParams } from "../auth/auth-provider";
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 
 @injectable()
-export default class BitbucketApiFactory {
+export class BitbucketApiFactory {
 
     @inject(AuthProviderParams) protected readonly config: AuthProviderParams;
     @inject(BitbucketTokenHelper) protected readonly tokenHelper: BitbucketTokenHelper;
@@ -23,21 +22,33 @@ export default class BitbucketApiFactory {
      */
     public async create(user: User): Promise<APIClient> {
         const token = await this.tokenHelper.getTokenWithScopes(user, []);
-        let options: Options;
-        if ("username" in token as any) {
-            // For unit tests we use an app password instead of an OAuth token
-            // since OAuth tokens are valid for some hours only. For unit tests
-            // the username is provided as well.
-            options = {
-                auth: {
-                    username: (token as any).username,
-                    password: token.value
-                }
-            };
-        } else {
-            options = { auth: { token: token.value } };
-        }
-        options.baseUrl = `https://api.${this.config.host}/2.0`;
-        return new Bitbucket(options);
+        return this.createBitbucket(this.baseUrl, token);
+    }
+
+    protected createBitbucket(baseUrl: string, token: Token): APIClient {
+        return new Bitbucket({
+            baseUrl,
+            auth: {
+                token: token.value
+            }
+        });
+    }
+
+    protected get baseUrl(): string {
+        return `https://api.${this.config.host}/2.0`;
+    }
+}
+
+@injectable()
+export class BasicAuthBitbucketApiFactory extends BitbucketApiFactory {
+    protected createBitbucket(baseUrl: string, token: Token): APIClient {
+        
+        return new Bitbucket({
+            baseUrl,
+            auth: {
+                username: token.username!,
+                password: token.value
+            }
+        });
     }
 }

--- a/components/server/src/bitbucket/bitbucket-container-module.ts
+++ b/components/server/src/bitbucket/bitbucket-container-module.ts
@@ -8,7 +8,7 @@ import { ContainerModule } from "inversify";
 import { AuthProvider } from "../auth/auth-provider";
 import { FileProvider, LanguagesProvider, RepositoryHost, RepositoryProvider } from "../repohost";
 import { IContextParser } from "../workspace/context-parser";
-import BitbucketApiFactory from "./bitbucket-api-factory";
+import { BitbucketApiFactory } from './bitbucket-api-factory';
 import { BitbucketAuthProvider } from "./bitbucket-auth-provider";
 import { BitbucketContextParser } from "./bitbucket-context-parser";
 import { BitbucketFileProvider } from "./bitbucket-file-provider";

--- a/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
@@ -7,18 +7,18 @@
 import { User } from "@gitpod/gitpod-protocol";
 import * as chai from 'chai';
 import { Container, ContainerModule } from "inversify";
-import { retries, suite, test, timeout } from "mocha-typescript";
+import { suite, test, timeout } from "mocha-typescript";
 import { AuthProviderParams } from "../auth/auth-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { DevData } from "../dev/dev-data";
 import { TokenProvider } from "../user/token-provider";
-import BitbucketApiFactory from "./bitbucket-api-factory";
+import { BitbucketApiFactory, BasicAuthBitbucketApiFactory } from './bitbucket-api-factory';
 import { BitbucketContextParser } from "./bitbucket-context-parser";
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 const expect = chai.expect;
 import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
 
-@suite(timeout(10000), retries(2), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET"))
+@suite.only(timeout(10000), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET"))
 class TestBitbucketContextParser {
 
     protected parser: BitbucketContextParser;
@@ -51,7 +51,7 @@ class TestBitbucketContextParser {
                 getTokenForHost: async () => DevData.createBitbucketTestToken(),
                 getFreshPortAuthenticationToken: async (user: User, workspaceId: string) => DevData.createPortAuthTestToken(workspaceId),
             });
-            bind(BitbucketApiFactory).toSelf().inSingletonScope();
+            bind(BitbucketApiFactory).to(BasicAuthBitbucketApiFactory).inSingletonScope();
             bind(HostContextProvider).toConstantValue({
                 get: (hostname: string) => { authProvider: { "Public-Bitbucket" } }
             });

--- a/components/server/src/bitbucket/bitbucket-context-parser.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.ts
@@ -11,7 +11,7 @@ import { Schema } from "bitbucket";
 import { inject, injectable } from "inversify";
 import { NotFoundError } from "../errors";
 import { AbstractContextParser, IContextParser, IssueContexts } from "../workspace/context-parser";
-import BitbucketApiFactory from "./bitbucket-api-factory";
+import { BitbucketApiFactory } from './bitbucket-api-factory';
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 
 
@@ -233,13 +233,18 @@ export class BitbucketContextParser extends AbstractContextParser implements ICo
         if (!repo) {
             throw new Error('Unknown repository.');
         }
-        const owner = repo.workspace && repo.workspace.slug || repo.full_name!.split("/")[0];
+        // full_name: string
+        // The concatenation of the repository owner's username and the slugified name, e.g. "evzijst/interruptingcow". This is the same string used in Bitbucket URLs.
+        const fullName = repo.full_name!.split("/");
+        const owner = fullName[0];
+        const name = fullName[1];
+
         const result: Repository = {
             cloneUrl: `https://${host}/${repo.full_name}.git`,
             // cloneUrl: repoQueryResult.links.html.href + ".git",
             // cloneUrl: repoQueryResult.links.clone.find((x: any) => x.name === "https").href,
             host,
-            name: repo.slug,
+            name,
             owner,
             private: !!repo.isPrivate,
             defaultBranch: repo.mainbranch ? repo.mainbranch.name : "master"

--- a/components/server/src/bitbucket/bitbucket-file-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-file-provider.spec.ts
@@ -12,7 +12,7 @@ import { AuthProviderParams } from "../auth/auth-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { DevData } from "../dev/dev-data";
 import { TokenProvider } from "../user/token-provider";
-import BitbucketApiFactory from "./bitbucket-api-factory";
+import { BitbucketApiFactory, BasicAuthBitbucketApiFactory } from './bitbucket-api-factory';
 import { BitbucketFileProvider } from "./bitbucket-file-provider";
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 const expect = chai.expect;
@@ -51,7 +51,7 @@ class TestBitbucketFileProvider {
                 getTokenForHost: async () => DevData.createBitbucketTestToken(),
                 getFreshPortAuthenticationToken: async (user: User, workspaceId: string) => DevData.createPortAuthTestToken(workspaceId),
             });
-            bind(BitbucketApiFactory).toSelf().inSingletonScope();
+            bind(BitbucketApiFactory).to(BasicAuthBitbucketApiFactory).inSingletonScope();
             bind(HostContextProvider).toConstantValue({
                 get: (hostname: string) => { authProvider: { "Public-Bitbucket" } }
             });

--- a/components/server/src/bitbucket/bitbucket-file-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-file-provider.ts
@@ -8,7 +8,7 @@ import { Commit, Repository, User } from "@gitpod/gitpod-protocol";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { inject, injectable } from 'inversify';
 import { FileProvider, MaybeContent } from "../repohost/file-provider";
-import BitbucketApiFactory from './bitbucket-api-factory';
+import { BitbucketApiFactory } from './bitbucket-api-factory';
 
 
 @injectable()

--- a/components/server/src/bitbucket/bitbucket-language-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-language-provider.spec.ts
@@ -12,7 +12,7 @@ import { AuthProviderParams } from "../auth/auth-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { DevData } from "../dev/dev-data";
 import { TokenProvider } from "../user/token-provider";
-import BitbucketApiFactory from "./bitbucket-api-factory";
+import { BitbucketApiFactory, BasicAuthBitbucketApiFactory } from "./bitbucket-api-factory";
 import { BitbucketLanguagesProvider } from "./bitbucket-language-provider";
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 const expect = chai.expect;
@@ -51,7 +51,7 @@ class TestBitbucketLanguageProvider {
                 getTokenForHost: async () => DevData.createBitbucketTestToken(),
                 getFreshPortAuthenticationToken: async (user: User, workspaceId: string) => DevData.createPortAuthTestToken(workspaceId),
             });
-            bind(BitbucketApiFactory).toSelf().inSingletonScope();
+            bind(BitbucketApiFactory).to(BasicAuthBitbucketApiFactory).inSingletonScope();
             bind(HostContextProvider).toConstantValue({
                 get: (hostname: string) => { authProvider: { "Public-Bitbucket" } }
             });

--- a/components/server/src/bitbucket/bitbucket-language-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-language-provider.ts
@@ -7,7 +7,7 @@
 import { Repository, User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from 'inversify';
 import { LanguagesProvider } from '../repohost/languages-provider';
-import BitbucketApiFactory from './bitbucket-api-factory';
+import { BitbucketApiFactory } from './bitbucket-api-factory';
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()

--- a/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
@@ -12,7 +12,7 @@ import { AuthProviderParams } from "../auth/auth-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { DevData } from "../dev/dev-data";
 import { TokenProvider } from "../user/token-provider";
-import BitbucketApiFactory from "./bitbucket-api-factory";
+import { BitbucketApiFactory, BasicAuthBitbucketApiFactory } from "./bitbucket-api-factory";
 import { BitbucketRepositoryProvider } from "./bitbucket-repository-provider";
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 const expect = chai.expect;
@@ -51,7 +51,7 @@ class TestBitbucketRepositoryProvider {
                 getTokenForHost: async () => DevData.createBitbucketTestToken(),
                 getFreshPortAuthenticationToken: async (user: User, workspaceId: string) => DevData.createPortAuthTestToken(workspaceId),
             });
-            bind(BitbucketApiFactory).toSelf().inSingletonScope();
+            bind(BitbucketApiFactory).to(BasicAuthBitbucketApiFactory).inSingletonScope();
             bind(HostContextProvider).toConstantValue({
                 get: (hostname: string) => { authProvider: { "Public-Bitbucket" } }
             });

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -8,7 +8,7 @@ import { Repository, User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from 'inversify';
 import { parseRepoUrl } from '../repohost/repo-url';
 import { RepositoryProvider } from '../repohost/repository-provider';
-import BitbucketApiFactory from './bitbucket-api-factory';
+import { BitbucketApiFactory } from './bitbucket-api-factory';
 
 @injectable()
 export class BitbucketRepositoryProvider implements RepositoryProvider {

--- a/components/theia/packages/gitpod-extension/package.json
+++ b/components/theia/packages/gitpod-extension/package.json
@@ -30,7 +30,7 @@
     "@theia/userstorage": "next",
     "@theia/vsx-registry": "next",
     "@theia/workspace": "next",
-    "bitbucket": "^2.1.0",
+    "bitbucket": "^2.4.2",
     "decompress": "^4.2.0",
     "diff": "^3.4.0",
     "filenamify": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5812,14 +5812,14 @@ bintrees@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
 
-bitbucket@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bitbucket/-/bitbucket-2.1.0.tgz#12436e329b690f922ef02322e0e5dd1bfde83dfe"
-  integrity sha512-4mv8QWPgfjoiqD3PThGkgpZ5EJgyDrpnJipRF+4Ccn8MT+K0ua/gePaRkRAIt2kHdTWsTKuLjDi4pIGxPFws7w==
+bitbucket@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/bitbucket/-/bitbucket-2.4.2.tgz#00a80d4e6193b2b383494e5563e4f01fa6b6354e"
+  integrity sha512-+JVdVm5Rug3M6+apqUJUcrrsyXgBAp8S1fRvmLBjxKrv9Mhh0AP/610x3g94wwB4Aq/H8IGS3+C6mHwrIVMpDA==
   dependencies:
     before-after-hook "^2.1.0"
     btoa-lite "^1.0.0"
-    deepmerge "^4.0.0"
+    deepmerge "^4.2.2"
     is-plain-object "^3.0.0"
     node-fetch "^2.6.0"
     url-template "^2.0.8"
@@ -7903,7 +7903,7 @@ deepmerge@2.0.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
   integrity sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==
 
-deepmerge@4.2.2, deepmerge@^4.0.0:
+deepmerge@4.2.2, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==


### PR DESCRIPTION
in tests Basic auth is used for API calls instead of Bearer tokens, this got mixed up with git authorization, where the OAuth2 token is also used for, but with a different username.

this also updates the Bitbucket API library, and applies related changes.

Fixes https://github.com/gitpod-io/gitpod/issues/2420