### PR TITLE
[static-theia-server] Explicitly mark Theia copy as done

### DIFF
--- a/components/theia/static-server/main.go
+++ b/components/theia/static-server/main.go
@@ -53,6 +53,7 @@ func (fs FileSystem) Open(path string) (http.File, error) {
 }
 
 func main() {
+	log.Init("static-server", "", true, true)
 	flag.Parse()
 
 	if *copyTo != "" {

--- a/gitpod-ws.theia-workspace
+++ b/gitpod-ws.theia-workspace
@@ -1,6 +1,6 @@
 {
    "folders": [
-      { "path": "" },
+      { "path": "." },
       { "path": "components/common-go" },
       { "path": "components/content-service" },
       { "path": "components/ee/cerc" },


### PR DESCRIPTION
This PR makes static-theia-server explicitly mark a copy as done. This way, when we redeploy the same version or node-daemon restarts it does not leave a failed version on the node and mark the node as ready.