### PR TITLE
fix fetching onigasm from blobserve

### DIFF
--- a/chart/config/proxy/vhost.server.conf
+++ b/chart/config/proxy/vhost.server.conf
@@ -103,12 +103,12 @@ server {
 }
 {{ end -}}
 
-# Workspaces
+# Workspaces/Blobserve - proxy passing to WS proxy
 server {
     listen {{ $listen }};
     # Matches:
-    #  - (webview-|browser-)?+          webview prefix including UUID (optional). This must be possesive (?+) to not confuse "webview-8000-a1231-..." with a valid UUID
-    #  - (?<wsid>[a-z][0-9a-z\-]+)      workspace Id
+    #  - (webview-|browser-)?+          foreign content prefix including UUID (optional). This must be possesive (?+) to not confuse "webview-8000-a1231-..." with a valid UUID
+    #  - (?<wsid>[a-z][0-9a-z\-]+)      workspace Id or blobserve
     #  - \.ws(-[a-z0-9]+)?              workspace base domain
     server_name ~^(webview-|browser-)?+(?<wsid>[a-z][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$;
 
@@ -120,7 +120,6 @@ server {
     include lib.https_redirect.conf;
 {{- end }}
 
-    include lib.cors-server.conf;
     include lib.workspace-locations.conf;
     include lib.region-headers.conf;
     include lib.log-headers.conf;
@@ -147,24 +146,4 @@ server {
 
     include lib.workspace-port-locations.conf;
     include lib.region-headers.conf;
-}
-
-server {
-    listen {{ $listen }};
-    # Matches:
-    #  - \.ws(-[a-z0-9]+)?              workspace base domain
-    server_name "~^blobserve\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$";
-
-{{- if $useHttps }}
-    {{- if eq .Values.ingressMode "pathAndHost" }}
-    listen 80;
-    {{- end }}
-
-    include lib.ssl.conf;
-    include lib.https_redirect.conf;
-{{- end }}
-
-    include lib.cors-server.conf;
-    include lib.region-headers.conf;
-    include lib.log-headers.conf;
 }

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -241,9 +241,9 @@ func installBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig) {
 	r.Use(handlers.CompressHandler)
 	r.Use(logRouteHandlerHandler("BlobserveRootHandler"))
 	r.Use(handlers.CORS(
-		// CORS headers are stored in the browser cache, we cannot be specific here to allow resuse between workspaces
+		// CORS headers are stored in the browser cache, we cannot be specific here to allow reuse between workspaces
 		handlers.AllowedOrigins([]string{"*"}),
-		handlers.AllowedMethods([]string{"GET"}),
+		handlers.AllowedMethods([]string{"GET", "OPTIONS"}),
 	))
 
 	targetResolver := func(cfg *Config, req *http.Request) (tgt *url.URL, err error) {


### PR DESCRIPTION
#### What it does

- fix #2444: allow CORS for preflight requests on the blobserve endpoint

#### How to test

- Start a workspace, check that syntax highlighting is there.
- Open the network tab in the devtools, filter by wasm and check that requests are successful.