### PR TITLE
Fix values.yaml of gitpod-k3s Docker image for ws-daemon

### DIFF
--- a/install/docker/examples/gitpod/docker-compose.yaml
+++ b/install/docker/examples/gitpod/docker-compose.yaml
@@ -12,4 +12,3 @@ services:
       - 80:80
     environment:
       - DOMAIN=${DOMAIN}
-      - DNSSERVER=${DNSSERVER:-}

--- a/install/docker/gitpod-image/values.yaml
+++ b/install/docker/gitpod-image/values.yaml
@@ -6,12 +6,13 @@ hostname: $DOMAIN
 authProviders: null
 
 components:
-  wsManagerNode:
-    containerdSocket: /run/k3s/containerd/containerd.sock
   wsDaemon:
-    fullWorkspaceBackup:
+    containerRuntime:
       containerd:
-          socket: /run/k3s/containerd/containerd.sock
+        socket: /run/k3s/containerd/containerd.sock
+      nodeRoots: 
+      - /var/lib
+      - /run/k3s/containerd/io.containerd.runtime.v1.linux
   workspace:
     template:
       spec:


### PR DESCRIPTION
This PR fixes the `values.yaml` file that is used in the `gitpod-k3s` Docker image for the latest config for the `ws-daemon`, esp. the config of `containerd`.