### PR TITLE
[ws-manager] Correctly compute NodeAffinity with `registry_facade`

### DIFF
--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -166,15 +166,6 @@
             "restartPolicy": "Never",
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {}
-                        ]
-                    }
-                }
-            },
             "schedulerName": "workspace-scheduler",
             "tolerations": [
                 {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_registryfacade.golden
@@ -180,15 +180,6 @@
             "restartPolicy": "Never",
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {}
-                        ]
-                    }
-                }
-            },
             "schedulerName": "workspace-scheduler",
             "tolerations": [
                 {


### PR DESCRIPTION
This PR makes ws-manager correctly compute node affinity when removing the affinity during registry-facade feature flag application.

This should fix scheduling situations where no explicit node affinity is added in the workspace pod templates.

- [x] /werft with-installer