### PR TITLE
[gitpod-ext] Introduce a write-cache in GitpodUserStorageProvider

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1183,7 +1183,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     }
 
     async getUserStorageResource(options: GitpodServer.GetUserStorageResourceOptions): Promise<string> {
-        const userId = this.checkUser("getUserStorageResource").id;
+        const userId = this.checkUser("getUserStorageResource", { uri: options.uri }).id;
         const uri = options.uri;
 
         await this.guardAccess({ kind: "userStorage", uri, userID: userId }, "get");
@@ -1192,7 +1192,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     }
 
     async updateUserStorageResource(options: GitpodServer.UpdateUserStorageResourceOptions): Promise<void> {
-        const userId = this.checkAndBlockUser("updateUserStorageResource").id;
+        const userId = this.checkAndBlockUser("updateUserStorageResource", { uri: options.uri }).id;
         const uri = options.uri;
         const content = options.content;
 

--- a/components/theia/packages/gitpod-extension/src/browser/extensions/extensions-module.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/extensions/extensions-module.ts
@@ -31,6 +31,7 @@ import { ExtensionsInstaller } from './extensions-installer';
 import { GitpodPluginServer } from './gitpod-plugin-server';
 import { DisabledVSXExtensionsContribution } from './disabled-vsx-extensions-contribution';
 import { addUserInfoToSearchResult } from './search-result-enhancement';
+import { CachedUserStorage } from '../gitpod-user-storage-cached';
 
 export const extensionsModule: inversify.ContainerModuleCallBack = (bind, unbind, isBound, rebind) => {
     rebind(PluginFrontendViewContribution).toConstantValue({
@@ -132,7 +133,8 @@ export const extensionsModule: inversify.ContainerModuleCallBack = (bind, unbind
         const original = provider.createProxy<PluginServer>(pluginServerJsonRpcPath);
         const serviceProvider = ctx.container.get(GitpodServiceProvider);
         const infoService = ctx.container.get<GitpodInfoService>(GitpodInfoService);
-        return new GitpodPluginServer(original, serviceProvider, infoService);
+        const cachedUserStorage = ctx.container.get<CachedUserStorage>(CachedUserStorage);
+        return new GitpodPluginServer(original, serviceProvider, infoService, cachedUserStorage);
     }).inSingletonScope();
 
     bind(OpenVSXExtensionProvider).toDynamicValue(ctx => {

--- a/components/theia/packages/gitpod-extension/src/browser/extensions/gitpod-plugin-server.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/extensions/gitpod-plugin-server.ts
@@ -9,10 +9,15 @@ import { KeysToAnyValues, KeysToKeysToAnyValue } from "@theia/plugin-ext/lib/com
 import { CommitContext } from "@gitpod/gitpod-protocol";
 import { GitpodInfoService } from "../../common/gitpod-info";
 import { GitpodServiceProvider } from "../gitpod-service-provider";
+import { CachedUserStorage } from "../gitpod-user-storage-cached";
 
 
 export class GitpodPluginServer implements PluginServer {
-    constructor(protected orig: PluginServer, protected serviceProvider: GitpodServiceProvider, protected info: GitpodInfoService) {    
+    constructor(
+        protected orig: PluginServer,
+        protected serviceProvider: GitpodServiceProvider,
+        protected info: GitpodInfoService,
+        protected cachedUserStorage: CachedUserStorage) {    
     }
 
     deploy(pluginEntry: string, type?: PluginType): Promise<void> {
@@ -45,8 +50,7 @@ export class GitpodPluginServer implements PluginServer {
     protected async getStorage(kind: PluginStorageKind): Promise<KeysToKeysToAnyValue> {
         const uri = await this.getUri(kind);
         if (!this.localCache.has(uri)) {
-            const service = await this.serviceProvider.getService();
-            const storageString = await service.server.getUserStorageResource({ uri });
+            const storageString = await this.cachedUserStorage.read({ uri });
             let storage: KeysToKeysToAnyValue = {};
             if (storageString.trim().length > 0) {
                 try {
@@ -63,19 +67,18 @@ export class GitpodPluginServer implements PluginServer {
     protected async setStorage(storage: KeysToKeysToAnyValue, kind: PluginStorageKind): Promise<boolean> {
         const uri = await this.getUri(kind);
         this.localCache.set(uri, storage);
-        const service = await this.serviceProvider.getService();
-        service.server.updateUserStorageResource({ uri, content: JSON.stringify(storage) }).catch(e => console.error(e));
+        await this.cachedUserStorage.write({ uri, content: JSON.stringify(storage) });
         return true;
     }
 
     async setStorageValue(key: string, value: KeysToAnyValues, kind: PluginStorageKind): Promise<boolean> {
-        const storage= await this.getStorage(kind);
+        const storage = await this.getStorage(kind);
         storage[key] = value;
         return this.setStorage(storage, kind);
     }
 
     async getStorageValue(key: string, kind: PluginStorageKind): Promise<KeysToAnyValues> {
-        const storage= await this.getStorage(kind);
+        const storage = await this.getStorage(kind);
         return storage[key];
     }
 

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-frontend-module.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-frontend-module.ts
@@ -66,6 +66,7 @@ import { GitpodPortServer, gitpodPortServicePath } from '../common/gitpod-port-s
 import { LocationMapper, LocationMapperService } from '@theia/mini-browser/lib/browser/location-mapper-service';
 import { GitpodLocationMapperService, SecureFileLocationMapper } from './mini-browser/gitpod-location-mapper-service';
 import { MiniBrowserEnvironment } from './mini-browser/mini-browser-environment';
+import { CachedUserStorage } from './gitpod-user-storage-cached';
 
 @injectable()
 class GitpodFrontendApplication extends FrontendApplication {
@@ -182,6 +183,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(GitpodUserStorageProvider).toSelf().inSingletonScope();
     rebind(UserStorageContribution).to(GitpodUserStorageContribution).inSingletonScope();
+    bind(CachedUserStorage).toSelf().inSingletonScope();
 
     bind(SnapshotSupport).toSelf().inSingletonScope();
     bind(CommandContribution).toService(SnapshotSupport);

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-user-storage-cached.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-user-storage-cached.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { injectable, inject, postConstruct } from "inversify";
+import { GitpodServiceProvider } from "./gitpod-service-provider";
+import { GitpodServer } from "@gitpod/gitpod-protocol";
+import { Disposable } from "@theia/core";
+import { JsonRpcProxy } from "@gitpod/gitpod-protocol/lib/messaging/proxy-factory";
+
+/**
+ * To avoid having badly written extensions executing too much requests and putting pressure on other components we
+ * cache writes and reads to the GitpodUserStorage.
+ */
+@injectable()
+export class CachedUserStorage implements Disposable {
+
+    static INTERVAL_SECONDS = 10;
+
+    @inject(GitpodServiceProvider) protected serviceProvider: GitpodServiceProvider;
+
+    protected readonly contentCache = new Map<string, string>();
+    protected updatedSinceLastWrite = new Set<string>();
+
+    protected timout: NodeJS.Timeout | undefined;
+
+
+    @postConstruct()
+    initialize() {
+        this.startPeriodicCacheWriter(CachedUserStorage.INTERVAL_SECONDS);
+    }
+
+    async write(resource: GitpodServer.UpdateUserStorageResourceOptions): Promise<void> {
+        this.contentCache.set(resource.uri, resource.content);
+        this.updatedSinceLastWrite.add(resource.uri);
+        
+        console.count(`user storage write to: ${resource.uri}`);
+    }
+
+    async read(req: GitpodServer.GetUserStorageResourceOptions): Promise<string> {
+        const cached = this.contentCache.get(req.uri);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const dbContent = await this.getServer().getUserStorageResource(req);
+        const cachedContent = this.contentCache.get(req.uri);
+        if (cachedContent !== undefined) {
+            // Preferring cached content makes the world view of the Workspace (window) more consistent: it guarantees
+            // that it sees all writes it has done before).
+            // All data from the DB might have been overriden by other workspaces/windows.
+            return cachedContent;
+        } else {
+            this.contentCache.set(req.uri, dbContent);
+            return dbContent;
+        }
+    }
+
+    protected startPeriodicCacheWriter(intervalSeconds: number) {
+        const interval = intervalSeconds * 1000;
+
+        const performWrites = async () => {
+            const writeStart = Date.now();
+
+            const updatedUris = this.updatedSinceLastWrite;
+            this.updatedSinceLastWrite = new Set<string>();
+
+            const server = this.getServer();
+            for (const uri of updatedUris) {
+                let gotDisconnectedDuringUpdate = false;
+                let listener = server.onDidCloseConnection(_ => {
+                    gotDisconnectedDuringUpdate = true;
+                    listener.dispose();
+                });
+
+                try {
+                    const content = this.contentCache.get(uri)!;
+                    await server.updateUserStorageResource({ uri, content });
+                } catch (err) {
+                    if (gotDisconnectedDuringUpdate) {
+                        this.updatedSinceLastWrite.add(uri);
+                    } else {
+                        console.error(`failed to update '${uri}' resource`, err);
+                    }
+                } finally {
+                    listener.dispose();
+                }
+            }
+
+            const waitFor = interval - (Date.now() - writeStart);
+            this.timout = setTimeout(performWrites, waitFor > 0 ? waitFor : 0)
+        };
+        performWrites();
+    }
+
+    dispose() {
+        if (this.timout) {
+            clearTimeout(this.timout);
+            this.timout = undefined;
+        }
+    }
+
+    protected getServer(): JsonRpcProxy<GitpodServer> {
+        return this.serviceProvider.getService().server;
+    }
+}

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-user-storage-provider.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-user-storage-provider.ts
@@ -6,20 +6,19 @@
 
 import { injectable, inject } from "inversify";
 import { GitpodInfoService } from "../common/gitpod-info";
-import { GitpodServiceProvider } from "./gitpod-service-provider";
-import { GitpodService } from "@gitpod/gitpod-protocol";
 import URI from "@theia/core/lib/common/uri";
 import { Emitter, Event, Disposable } from "@theia/core";
 import { FileWriteOptions, FileSystemProviderCapabilities, FileChange, WatchOptions, Stat, FileType, FileDeleteOptions, FileOverwriteOptions, FileSystemProviderWithFileReadWriteCapability, FileChangeType, FileSystemProviderErrorCode, createFileSystemProviderError } from "@theia/filesystem/lib/common/files";
 import { EncodingService } from "@theia/core/lib/common/encoding-service";
 import { BinaryBuffer } from "@theia/core/lib/common/buffer";
 import { UserStorageUri } from "@theia/userstorage/lib/browser/user-storage-uri";
+import { CachedUserStorage } from "./gitpod-user-storage-cached";
 
 @injectable()
 export class GitpodUserStorageProvider implements FileSystemProviderWithFileReadWriteCapability {
 
     @inject(GitpodInfoService) protected infoProvider: GitpodInfoService;
-    @inject(GitpodServiceProvider) protected serviceProvider: GitpodServiceProvider;
+    @inject(CachedUserStorage) protected cachedUserStorage: CachedUserStorage;
     @inject(EncodingService) protected readonly encodingService: EncodingService;
 
     protected readonly onDidChangeFileEmitter = new Emitter<readonly FileChange[]>();
@@ -30,9 +29,9 @@ export class GitpodUserStorageProvider implements FileSystemProviderWithFileRead
 
     // TODO server could provide stats instead
     protected readonly stats = new Map<string, Stat>();
-    protected updateStat(resource: URI, value: Uint8Array): void {
-        const mtime = performance.now();
-        const existing = this.stats.get(resource.toString())
+    protected updateStat(resource: URI, value: Uint8Array, modified: boolean): void {
+        const existing = this.stats.get(resource.toString());
+        const mtime = modified || !existing ? performance.now() : existing.mtime;
         const ctime = existing && existing.ctime || mtime;
         this.stats.set(resource.toString(), {
             type: FileType.File,
@@ -51,10 +50,6 @@ export class GitpodUserStorageProvider implements FileSystemProviderWithFileRead
         return resource.withPath(relativePath).toString();
     }
 
-    protected getService(): GitpodService {
-        return this.serviceProvider.getService();
-    }
-
     async stat(resource: URI): Promise<Stat> {
         let stat = this.stats.get(resource.toString());
         if (!stat) {
@@ -68,24 +63,20 @@ export class GitpodUserStorageProvider implements FileSystemProviderWithFileRead
     }
 
     async readFile(resource: URI): Promise<Uint8Array> {
-        const service = this.getService();
-        const server = service.server;
         // TODO server could resolve binary instead
         const uri = this.toBackwardCompatibleUri(resource);
-        const content = await server.getUserStorageResource({ uri });
+        const content = await this.cachedUserStorage.read({ uri });
         const value = this.encodingService.encode(content).buffer;
-        this.updateStat(resource, value);
+        this.updateStat(resource, value, false);
         return value;
     }
 
     async writeFile(resource: URI, value: Uint8Array, opts: FileWriteOptions): Promise<void> {
-        const service = this.getService();
-        const server = service.server;
         const content = this.encodingService.decode(BinaryBuffer.wrap(value));
         // TODO server could accept binary instead
         const uri = this.toBackwardCompatibleUri(resource);
-        await server.updateUserStorageResource({ uri, content });
-        this.updateStat(resource, value);
+        await this.cachedUserStorage.write({ uri, content });
+        this.updateStat(resource, value, true);
         // TODO server could fire a notification that some resournce was changed instead
         this.onDidChangeFileEmitter.fire([{
             type: FileChangeType.UPDATED,


### PR DESCRIPTION
Reduces the load on `server`/DB in cases where extension perform a lot of writes to the user storage.

**How to test:**
1. test periodic update
   1. start a workspace
   1. watch `server` logs: `kubectl --context=core-dev -n staging-gpl-buffer-user-storage-writes logs server-`
   1. update preferences
   1. see how the `updateUserStorageResource` comes in after some time (0-10s)
1. test re-try after disconnect
   1. scale server down: `kubectl --context=core-dev -n staging-gpl-buffer-user-storage-writes scale deployment server --replicas=0`
   1. update preferences
   1. wait for >10s, notice no console errors
   1. scale server back up: `kubectl --context=core-dev -n staging-gpl-buffer-user-storage-writes scale deployment server --replicas=1`
   1. see how the `updateUserStorageResource` comes in after some time (0-10s)
1. test DB/server error (on too large data, e.g.)
   1. watch `server` logs: `kubectl --context=core-dev -n staging-gpl-buffer-user-storage-writes logs server-`
   1. update preferences with a _large_ chunk of data (some string array, for instance)
   1. notice the error in server logs and web console _once_ (does not re-appear after 10s)