### PR TITLE
[theia] add css/htm language features extensions

### DIFF
--- a/components/gitpod-protocol/data/builtin-theia-plugins.json
+++ b/components/gitpod-protocol/data/builtin-theia-plugins.json
@@ -30,9 +30,14 @@
     "url": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix"
   },
   {
-    "loc": "vscode.css-1.44.2.vsix",
-    "name": "vscode.css@1.44.2",
-    "url": "https://open-vsx.org/api/vscode/css/1.44.2/file/vscode.css-1.44.2.vsix"
+    "loc": "vscode.css-1.51.1.vsix",
+    "name": "vscode.css@1.51.1",
+    "url": "https://open-vsx.org/api/vscode/css/1.51.1/file/vscode.css-1.51.1.vsix"
+  },
+  {
+    "loc": "vscode.css-language-features-1.51.1.vsix",
+    "name": "vscode.css-language-features@1.51.1",
+    "url": "https://open-vsx.org/api/vscode/css-language-features/1.51.1/file/vscode.css-language-features-1.51.1.vsix"
   },
   {
     "loc": "vscode.debug-auto-launch-1.44.2.vsix",
@@ -70,9 +75,14 @@
     "url": "https://open-vsx.org/api/vscode/hlsl/1.44.2/file/vscode.hlsl-1.44.2.vsix"
   },
   {
-    "loc": "vscode.html-1.44.2.vsix",
-    "name": "vscode.html@1.44.2",
-    "url": "https://open-vsx.org/api/vscode/html/1.44.2/file/vscode.html-1.44.2.vsix"
+    "loc": "vscode.html-1.51.1.vsix",
+    "name": "vscode.html@1.51.1",
+    "url": "https://open-vsx.org/api/vscode/html/1.51.1/file/vscode.html-1.51.1.vsix"
+  },
+  {
+    "loc": "vscode.html-language-features-1.51.1.vsix",
+    "name": "vscode.html-language-features@1.51.1",
+    "url": "https://open-vsx.org/api/vscode/html-language-features/1.51.1/file/vscode.html-language-features-1.51.1.vsix"
   },
   {
     "loc": "vscode.ini-1.44.2.vsix",

--- a/components/theia/app/BUILD.yaml
+++ b/components/theia/app/BUILD.yaml
@@ -7,6 +7,7 @@ packages:
       - "webpack.config.js"
       - "startup.sh"
       - "**/*.ico"
+      - "patches/*.patch"
     deps:
       - components/gitpod-protocol:lib
       - components/theia/packages/gitpod-extension:lib

--- a/components/theia/app/leeway.Dockerfile
+++ b/components/theia/app/leeway.Dockerfile
@@ -37,6 +37,10 @@ RUN /theia-installer/install.sh
 COPY package-libs.sh /usr/bin/
 RUN package-libs.sh /theia/node/bin/node
 
+# patching plugin ext host process to fix css extension compatibility, see https://github.com/gitpod-io/gitpod/pull/2483
+RUN cp -r /theia/node_modules/@gitpod/gitpod-ide/patches /theia/patches 
+RUN yarn patch-package
+
 # copy native dependencies of node modules
 RUN find /theia/node_modules/ -iname *.node -exec package-libs.sh {} \;
 

--- a/components/theia/app/package.json
+++ b/components/theia/app/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.2",
   "license": "UNLICENSED",
   "dependencies": {
+    "@gitpod/gitpod-extension": "0.1.7",
+    "@gitpod/gitpod-protocol": "0.1.5",
+    "@theia/asciidoc": "next",
     "@theia/callhierarchy": "next",
     "@theia/console": "next",
     "@theia/core": "next",
@@ -32,9 +35,7 @@
     "@theia/userstorage": "next",
     "@theia/variable-resolver": "next",
     "@theia/workspace": "next",
-    "@theia/asciidoc": "next",
-    "@gitpod/gitpod-extension": "0.1.7",
-    "@gitpod/gitpod-protocol": "0.1.5"
+    "patch-package": "^6.2.2"
   },
   "devDependencies": {
     "@theia/cli": "next"
@@ -43,7 +44,8 @@
     "/lib",
     "/favicon.ico",
     "/startup.sh",
-    "/src-gen"
+    "/src-gen",
+    "/patches"
   ],
   "scripts": {
     "start": "yarn start:theia --port=23000",

--- a/components/theia/app/patches/@theia+plugin-ext+1.5.0-next.9d2dcd0a.patch
+++ b/components/theia/app/patches/@theia+plugin-ext+1.5.0-next.9d2dcd0a.patch
@@ -1,0 +1,70 @@
+diff --git a/node_modules/@theia/plugin-ext/lib/plugin/languages/completion.js b/node_modules/@theia/plugin-ext/lib/plugin/languages/completion.js
+index 1df12cc..32b63d8 100644
+--- a/node_modules/@theia/plugin-ext/lib/plugin/languages/completion.js
++++ b/node_modules/@theia/plugin-ext/lib/plugin/languages/completion.js
+@@ -152,6 +152,7 @@ var CompletionAdapter = /** @class */ (function () {
+     };
+     CompletionAdapter.prototype.convertCompletionItem = function (item, id, parentId, defaultInserting, defaultReplacing) {
+         var _a;
++        var _b;
+         if (typeof item.label !== 'string' || item.label.length === 0) {
+             console.warn('Invalid Completion Item -> must have at least a label');
+             return undefined;
+@@ -183,6 +184,9 @@ var CompletionAdapter = /** @class */ (function () {
+                 replace: Converter.fromRange(itemRange.replacing)
+             };
+         }
++        var tags = (!!((_b = item.tags) === null || _b === void 0 ? void 0 : _b.length) || item.deprecated === true)
++            ? [types_impl_1.CompletionItemTag.Deprecated]
++            : undefined;
+         return {
+             id: id,
+             parentId: parentId,
+@@ -198,7 +202,8 @@ var CompletionAdapter = /** @class */ (function () {
+             range: range,
+             additionalTextEdits: item.additionalTextEdits && item.additionalTextEdits.map(Converter.fromTextEdit),
+             command: this.commands.converter.toSafeCommand(item.command, toDispose),
+-            commitCharacters: item.commitCharacters
++            commitCharacters: item.commitCharacters,
++            tags: tags
+         };
+     };
+     CompletionAdapter.hasResolveSupport = function (provider) {
+diff --git a/node_modules/@theia/plugin-ext/lib/plugin/plugin-context.js b/node_modules/@theia/plugin-ext/lib/plugin/plugin-context.js
+index 8a80cb1..a2880be 100644
+--- a/node_modules/@theia/plugin-ext/lib/plugin/plugin-context.js
++++ b/node_modules/@theia/plugin-ext/lib/plugin/plugin-context.js
+@@ -781,6 +781,7 @@ function createAPIFactory(rpc, pluginManager, envExt, debugExt, preferenceRegist
+             Location: types_impl_1.Location,
+             LogLevel: types_impl_1.LogLevel,
+             DiagnosticTag: types_impl_1.DiagnosticTag,
++            CompletionItemTag: types_impl_1.CompletionItemTag,
+             Diagnostic: types_impl_1.Diagnostic,
+             CompletionTriggerKind: types_impl_1.CompletionTriggerKind,
+             TextEdit: types_impl_1.TextEdit,
+diff --git a/node_modules/@theia/plugin-ext/lib/plugin/types-impl.js b/node_modules/@theia/plugin-ext/lib/plugin/types-impl.js
+index f8edaf0..c393beb 100644
+--- a/node_modules/@theia/plugin-ext/lib/plugin/types-impl.js
++++ b/node_modules/@theia/plugin-ext/lib/plugin/types-impl.js
+@@ -60,7 +60,7 @@ var __read = (this && this.__read) || function (o, n) {
+     return ar;
+ };
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.CallHierarchyOutgoingCall = exports.CallHierarchyIncomingCall = exports.CallHierarchyItem = exports.UIKind = exports.WebviewPanelTargetArea = exports.OperatingSystem = exports.SelectionRange = exports.FoldingRangeKind = exports.FoldingRange = exports.ColorFormat = exports.ColorPresentation = exports.ColorInformation = exports.Color = exports.FunctionBreakpoint = exports.SourceBreakpoint = exports.Breakpoint = exports.LogLevel = exports.DebugAdapterServer = exports.DebugAdapterExecutable = exports.Task2 = exports.Task = exports.TaskScope = exports.TaskGroup = exports.ShellExecution = exports.TaskRevealKind = exports.TaskPanelKind = exports.ShellQuoting = exports.ProcessExecution = exports.ProgressLocation = exports.Progress = exports.ProgressOptions = exports.FileType = exports.FileSystemError = exports.FileChangeType = exports.CommentMode = exports.QuickInputButtons = exports.CommentThreadCollapsibleState = exports.DocumentSymbol = exports.SymbolInformation = exports.SymbolTag = exports.TreeItemCollapsibleState = exports.TreeItem = exports.WorkspaceEdit = exports.CodeAction = exports.TextDocumentSaveReason = exports.CodeActionKind = exports.CodeActionTrigger = exports.CodeLens = exports.DocumentLink = exports.DocumentHighlight = exports.DocumentHighlightKind = exports.Hover = exports.SignatureHelp = exports.SignatureHelpTriggerKind = exports.SignatureInformation = exports.ParameterInformation = exports.MarkerTag = exports.MarkerSeverity = exports.Diagnostic = exports.DiagnosticTag = exports.Location = exports.DiagnosticRelatedInformation = exports.DiagnosticSeverity = exports.CompletionList = exports.CompletionItem = exports.CompletionItemKind = exports.CompletionTriggerKind = exports.TextEdit = exports.IndentAction = exports.RelativePattern = exports.ConfigurationTarget = exports.OverviewRulerLane = exports.DecorationRangeBehavior = exports.TextEditorRevealType = exports.ThemeIcon = exports.ThemeColor = exports.SnippetString = exports.EndOfLine = exports.Selection = exports.Range = exports.Position = exports.TextEditorSelectionChangeKind = exports.ViewColumn = exports.TextEditorLineNumbersStyle = exports.StatusBarAlignment = exports.Disposable = void 0;
++exports.CallHierarchyOutgoingCall = exports.CallHierarchyIncomingCall = exports.CallHierarchyItem = exports.UIKind = exports.WebviewPanelTargetArea = exports.OperatingSystem = exports.SelectionRange = exports.FoldingRangeKind = exports.FoldingRange = exports.ColorFormat = exports.ColorPresentation = exports.ColorInformation = exports.Color = exports.FunctionBreakpoint = exports.SourceBreakpoint = exports.Breakpoint = exports.LogLevel = exports.DebugAdapterServer = exports.DebugAdapterExecutable = exports.Task2 = exports.Task = exports.TaskScope = exports.TaskGroup = exports.ShellExecution = exports.TaskRevealKind = exports.TaskPanelKind = exports.ShellQuoting = exports.ProcessExecution = exports.ProgressLocation = exports.Progress = exports.ProgressOptions = exports.FileType = exports.FileSystemError = exports.FileChangeType = exports.CommentMode = exports.QuickInputButtons = exports.CommentThreadCollapsibleState = exports.DocumentSymbol = exports.SymbolInformation = exports.SymbolTag = exports.TreeItemCollapsibleState = exports.TreeItem = exports.WorkspaceEdit = exports.CodeAction = exports.TextDocumentSaveReason = exports.CodeActionKind = exports.CodeActionTrigger = exports.CodeLens = exports.DocumentLink = exports.DocumentHighlight = exports.DocumentHighlightKind = exports.Hover = exports.SignatureHelp = exports.SignatureHelpTriggerKind = exports.SignatureInformation = exports.ParameterInformation = exports.MarkerTag = exports.MarkerSeverity = exports.Diagnostic = exports.DiagnosticTag = exports.CompletionItemTag = exports.Location = exports.DiagnosticRelatedInformation = exports.DiagnosticSeverity = exports.CompletionList = exports.CompletionItem = exports.CompletionItemKind = exports.CompletionTriggerKind = exports.TextEdit = exports.IndentAction = exports.RelativePattern = exports.ConfigurationTarget = exports.OverviewRulerLane = exports.DecorationRangeBehavior = exports.TextEditorRevealType = exports.ThemeIcon = exports.ThemeColor = exports.SnippetString = exports.EndOfLine = exports.Selection = exports.Range = exports.Position = exports.TextEditorSelectionChangeKind = exports.ViewColumn = exports.TextEditorLineNumbersStyle = exports.StatusBarAlignment = exports.Disposable = void 0;
+ /* eslint-disable no-null/no-null */
+ /* eslint-disable @typescript-eslint/no-explicit-any */
+ var uuid_1 = require("@phosphor/coreutils/lib/uuid");
+@@ -844,6 +844,12 @@ var Location = /** @class */ (function () {
+     return Location;
+ }());
+ exports.Location = Location;
++
++var CompletionItemTag;
++(function (DiagnCompletionItemTagosticTag) {
++    CompletionItemTag[CompletionItemTag["Deprecated"] = 1] = "Deprecated";
++})(CompletionItemTag = exports.CompletionItemTag || (exports.CompletionItemTag = {}));
++
+ var DiagnosticTag;
+ (function (DiagnosticTag) {
+     DiagnosticTag[DiagnosticTag["Unnecessary"] = 1] = "Unnecessary";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,6 +4074,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -6616,6 +6621,11 @@ chrome-trace-event@^1.0.2:
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -9559,6 +9569,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 first-chunk-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
@@ -9698,7 +9716,7 @@ fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
-fs-extra@^4.0.1, fs-extra@^4.0.2:
+fs-extra@^4.0.1, fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
@@ -9714,7 +9732,7 @@ fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -11391,6 +11409,13 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.5.0"
 
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -12204,6 +12229,13 @@ kind-of@^5.0.0, kind-of@^5.0.2:
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 ky-universal@^0.3.0:
   version "0.3.0"
@@ -14643,6 +14675,24 @@ passport@^0.4.1:
     passport-strategy "1.x.x"
     pause "0.0.1"
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -16892,6 +16942,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -18678,9 +18733,9 @@ uuid@^7.0.1:
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.0.0:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
-  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
#### What it does

`@theia/monaco` does not provide smartness for css/html by default anymore: https://github.com/eclipse-theia/theia/pull/7972 so we should consume them as VS Code extensions.

#### How to test

Check html/css language smartness: http://akosyakov-code-highlighting-emmet-2444.staging.gitpod-dev.com/#https://github.com/vuejs/vue-router