### PR TITLE
[WIP] Add helm hook for removing node labels

### DIFF
--- a/chart/templates/node-daemon-cleanup-job.yaml
+++ b/chart/templates/node-daemon-cleanup-job.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.nodeDaemon -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: node-daemon-cleanup
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: node-daemon-cleanup
+    kind: job
+    stage: {{ .Values.installation.stage }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-timeout": "0"
+spec:
+  template:
+    metadata:
+      name: node-daemon-cleanup
+      labels:
+        app: {{ template "gitpod.fullname" . }}
+        component: node-daemon-cleanup
+        kind: job
+        stage: {{ .Values.installation.stage }}
+    spec:
+      containers:
+      - name: node-daemon-cleanup
+        image: {{ template "gitpod.comp.imageFull" $this }}
+
+        command: ['sh', '-c', '/app/post-delete-cleanup.sh']
+
+      restartPolicy: Never
+      serviceAccountName: node-daemon
+      imagePullSecrets:
+{{- range $key, $value := .Values.defaults.imagePullSecrets }}
+      - name: {{ $value.name }}
+

--- a/components/node-daemon/BUILD.yaml
+++ b/components/node-daemon/BUILD.yaml
@@ -3,6 +3,7 @@ packages:
     type: docker
     srcs:
       - node-daemon.sh
+      - post-delete-cleanup.sh
     argdeps:
       - imageRepoBase
     config:

--- a/components/node-daemon/Dockerfile
+++ b/components/node-daemon/Dockerfile
@@ -10,4 +10,5 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/l
 
 WORKDIR /app
 COPY node-daemon.sh /app
+COPY post-delete-cleanup.sh /app
 ENTRYPOINT ["/bin/bash", "/app/node-daemon.sh"]

--- a/components/node-daemon/post-delete-cleanup.sh
+++ b/components/node-daemon/post-delete-cleanup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+# First check if labels are actually still present in the nodes
+if kubectl get node $EXECUTING_NODE_NAME -o template='{{ range $k, $v := .metadata.labels}}{{ $k }}{{"\n"}}{{ end }}' | grep -q "gitpod.io/theia.$VERSION"; then
+    
+    # If yes then attempt to remove them manually 
+    if kubectl patch node $EXECUTING_NODE_NAME --patch '{"metadata":{"labels":{}}}'; then
+        echo "Unmarked the node successfully"
+    else
+        # If it fails, then instruct the user to manually remove the labels before reinstallation
+        echo "Unmarking the node failed. Manually unmark it before reinstall."
+        exit -1
+    fi
+fi


### PR DESCRIPTION
This PR attempts to tackle the issue with node-daemon failing to launch while reinstalling Gitpod. As mentioned already here in the comment: https://github.com/gitpod-io/gitpod/issues/2227#issuecomment-707130419, the problem is because the labels persist after uninstalling Gitpod. Hence manual removal was required.

Here I am creating a Kubernetes job that would run a script to remove the labels. The job is attached to a Helm hook set to `post-delete`, which would trigger it as soon as a node-daemon release is deleted.

The PR is currently in WIP because I am not sure about the correct approach and is open for discussions.

Fixes #2227