### PR TITLE
Some hardening for dynamic Auth Providers

### DIFF
--- a/components/server/src/auth/host-context-provider-impl.ts
+++ b/components/server/src/auth/host-context-provider-impl.ts
@@ -106,6 +106,7 @@ export class HostContextProviderImpl implements HostContextProvider {
 
     get(hostname: string): HostContext | undefined {
         this.ensureInitialized();
+        hostname = hostname.toLowerCase();
         const hostContext = this.fixedHosts.get(hostname) || this.dynamicHosts.get(hostname);
         if (!hostContext) {
             log.debug("No HostContext for " + hostname);

--- a/components/server/src/auth/host-context-provider.ts
+++ b/components/server/src/auth/host-context-provider.ts
@@ -10,6 +10,7 @@ import { AuthProviderParams } from "./auth-provider";
 export const HostContextProvider = Symbol("HostContextProvider");
 
 export interface HostContextProvider {
+    init(): Promise<void>;
     getAll(): HostContext[];
     get(hostname: string): HostContext | undefined;
 }

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -36,6 +36,7 @@ import { PeriodicDbDeleter } from '@gitpod/gitpod-db/lib/periodic-deleter';
 import { OneTimeSecretServer } from './one-time-secret-server';
 import { GitpodClient, GitpodServer } from '@gitpod/gitpod-protocol';
 import { BearerAuth } from './auth/bearer-authenticator';
+import { HostContextProvider } from './auth/host-context-provider';
 
 @injectable()
 export class Server<C extends GitpodClient, S extends GitpodServer> {
@@ -62,6 +63,8 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
 
     @inject(BearerAuth) protected readonly bearerAuth: BearerAuth;
 
+    @inject(HostContextProvider) protected readonly hostCtxProvider: HostContextProvider;
+
     protected readonly eventEmitter = new EventEmitter();
     protected app?: express.Application;
     protected httpServer?: http.Server;
@@ -82,6 +85,9 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
 
         // Install passport
         await this.authenticator.init(app);
+
+        // Ensure that host contexts of dynamic auth providers are initialized.
+        await this.hostCtxProvider.init();
 
         // Websocket for client connection
         const websocketConnectionHandler = this.websocketConnectionHandler;


### PR DESCRIPTION
This PR fixes some issues with handling of dynamic Auth Providers:
* adding simple validation of hostnames
* ensure unique hosts in set of dynamic Auth Providers
* ensure dynamic Auth Providers are ready on server starts accepting connections