### PR TITLE
support installing extensions directly from open vsx

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,3 +42,4 @@ vscode:
     - bajdzis.vscode-database@2.2.1:uXdjV53wtoTevFK6HOh3pQ==
     - hashicorp.terraform@2.1.1:QEP7gdWtMuY+j8RZ5OLDkA==
     - stkb.rewrap@1.13.0:yEx8nRSXlfXAHqsbkTJpdA==
+    - vscode.go@1.44.2:cdX/iz4Up633rbR9eGzr4Q==

--- a/chart/config/proxy/lib.gitpod-plugins.conf
+++ b/chart/config/proxy/lib.gitpod-plugins.conf
@@ -33,6 +33,10 @@ set $qs "${query_string}";
 set $api_key ${SERVER_PROXY_APIKEY};
 set_by_lua_block $api_key_encoded { return ngx.encode_args({token = ngx.var.api_key}) }
 
+# Content-Type has to match exactly with the `getSignedUrl` request from gcloud-storage-client.ts
+# otherwise the upload will fail with a "signature does not match" error.
+proxy_set_header Content-Type '*/*';
+
 if ($action = preflight) {
     set $targetUrl "no-url";
     access_by_lua_block {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -496,6 +496,7 @@ export interface PreparePluginUploadParams {
 export interface ResolvePluginsParams {
     config?: WorkspaceConfig
     builtins?: ResolvedPlugins
+    vsxRegistryUrl?: string
 }
 
 export interface InstallPluginsParams {

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 4a92a1f011d107ced5016ec6c8905682c2e5ec7e
+ENV GP_CODE_COMMIT 20ded0d97c41cb686098d14b9e1f0533177300d1
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-deployer.ts
+++ b/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-deployer.ts
@@ -31,6 +31,7 @@ import { WorkspaceConfig, ResolvedPlugins, ResolvedPlugin, InstallPluginsParams,
 import filenamify = require('filenamify');
 import { ApplicationPackage } from '@theia/application-package/lib/application-package';
 import { PluginIndexEntry } from '@gitpod/gitpod-protocol/lib/theia-plugins';
+import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
 
 @injectable()
 export class GitpodPluginDeployer implements GitpodPluginService {
@@ -61,6 +62,9 @@ export class GitpodPluginDeployer implements GitpodPluginService {
 
     @inject(ApplicationPackage)
     protected readonly pkg: ApplicationPackage;
+
+    @inject(VSXEnvironment)
+    private readonly vsxEnvironment: VSXEnvironment;
 
     constructor() {
         this.downloadPath = path.resolve(os.tmpdir(), 'download-vscode-extensions');
@@ -257,10 +261,11 @@ export class GitpodPluginDeployer implements GitpodPluginService {
 
     protected async resolvePlugins(): Promise<ResolvedPlugins | undefined> {
         try {
+            const vsxRegistryUri = await this.vsxEnvironment.getRegistryUri();
             const value: GitpodPluginClient = this.clients.values().next().value;
             if (value) {
                 const config = await this.parse();
-                const resolved = await value.resolve({ config, builtins: this.getBuiltins() });
+                const resolved = await value.resolve({ config, builtins: this.getBuiltins(), vsxRegistryUrl: vsxRegistryUri.toString() });
                 return resolved;
             }
         } catch (e) {
@@ -306,10 +311,6 @@ export class GitpodPluginDeployer implements GitpodPluginService {
             requestretry({
                 url,
                 method: 'GET',
-                headers: {
-                    // Content-Type has to match exactly
-                    'Content-Type': '*/*',
-                },
                 // if we cannot establish connection in 5s then try again in 2s 5 times
                 // if we cannot read then timeout in 5s
                 maxAttempts: 5,
@@ -353,9 +354,6 @@ export class GitpodPluginDeployer implements GitpodPluginService {
                 .pipe(request.put({
                     url: targetUrl,
                     headers: {
-                        // Content-Type has to match exactly with the `getSignedUrl` request from gcloud-storage-client.ts
-                        // otherwise the upload will fail with a "signature does not match" error.
-                        'Content-Type': '*/*',
                         'Content-Length': stat.size
                     }
                 }, (err, response) => {

--- a/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-locator-impl.ts
+++ b/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-locator-impl.ts
@@ -30,7 +30,7 @@ export class GitpodPluginLocatorImpl implements GitpodPluginLocator {
             if (pck && pck.publisher && pck.name && pck.version) {
                 await this.decompressVSCodeBuiltInExtension(extensionPath);
                 const { publisher, name, version } = pck;
-                const fullPluginName = `${publisher}.${name}@${version}`;
+                const fullPluginName = `${publisher}.${name}@${version}`.toLowerCase();
                 const resolvedExtensionPath = path.join(extensionsPath, filenamify(fullPluginName));
                 await fs.remove(resolvedExtensionPath);
                 await fs.rename(extensionPath, resolvedExtensionPath);


### PR DESCRIPTION
- [x] /werft https

#### What it does

It allows to use the following syntax in `.gitpod.yml` to install extensions directly from the Open VSX Registry on the IDE startup:
- the latest version: `${namespace}.${name}`, e.g. `golang.Go`
- a pinned version: `${namespace}.${name}@${version}`, e.g. `golang.Go@0.19.1`

diff in Code: https://github.com/gitpod-io/vscode/compare/4a92a1f...20ded0d

#### How to test

- Try to open this branch in Theia and Code all extensions should be installed: https://ak-ext-direct-from-open-vsx.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod/pull/2493
- Install a new extension in Theia and check that it is installed, do it for both user and workspace extensions.
  - Commit changes to .gipod.yml and start a new workspace. Uploaded extensions should be installed too.

#### Out of scope

- Currently Code does not observe `.gitpod.yml` and does not auto update it on extensions installation/uninstallation. It would be addressed later. There is no an indicator for user extensions in the extension view for now too.