### PR TITLE
[registry-facade] Add blob download speed metric

### DIFF
--- a/components/registry-facade/pkg/registry/registry.go
+++ b/components/registry-facade/pkg/registry/registry.go
@@ -88,7 +88,7 @@ func NewRegistry(cfg Config, newResolver ResolverProvider, reg prometheus.Regist
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	metrics, err := newMetrics(reg)
+	metrics, err := newMetrics(reg, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds a new metric `gitpod_registry_facade_registry_blob_req_bytes_second` to registry-facade which measures blob download speed towards the consumer (i.e. containerd/kubelet). The metric is a histogram with 10 buckets log scaled from 1mb/sec to 512mb/sec.

### How to test
1. Start a workspace on this branch
2. Look at the registry-facade metrics (have to look at all instances to find the correct one)