### PR TITLE
use new mini browser endpoint to preview local images

### DIFF
--- a/components/theia/packages/gitpod-extension/src/browser/user-message/GitpodPreviewLinkNormalizer.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/user-message/GitpodPreviewLinkNormalizer.ts
@@ -4,18 +4,26 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { inject, injectable } from 'inversify';
 import { PreviewLinkNormalizer } from "@theia/preview/lib/browser/preview-link-normalizer";
 import URI from "@theia/core/lib/common/uri";
+import { MiniBrowserEnvironment } from '../mini-browser/mini-browser-environment';
 
-
+@injectable()
 export class GitpodPreviewLinkNormalizer extends PreviewLinkNormalizer {
+
+    @inject(MiniBrowserEnvironment)
+    private readonly miniBrowserEnvironment: MiniBrowserEnvironment;
 
     normalizeLink(documentUri: URI, link: string): string {
         try {
-            if (documentUri.scheme === 'file') {
-                return super.normalizeLink(documentUri, link);
+            if (documentUri.scheme !== 'file') {
+                return documentUri.parent.resolve(link).toString();
             }
-            return documentUri.parent.resolve(link).toString();
+            if (!this.urlScheme.test(link)) {
+                const location = documentUri.parent.resolve(link).path.toString();
+                return this.miniBrowserEnvironment.getEndpoint('normalized-link').getRestUrl().resolve(location).toString();
+            }
         } catch {
             // ignore
         }


### PR DESCRIPTION
#### What it does

- fix #629: use new mini browser endpoint to preview local images

#### How to test

- Start a workspace: http://akosyakov-markdown-preview-does-629.staging.gitpod-dev.com/#https://github.com/adr/adr.github.io
   - Open a preview check that all images are rendered.
- Start Theia workspace: http://akosyakov-markdown-preview-does-629.staging.gitpod-dev.com/#https://github.com/theia-ide/theia
- Start theia workspace, open README, check that images (remote) are rendered as well.