### PR TITLE
align Node.js version with desktop VS Code

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM node:12.18.3 AS node_installer
+FROM node:12.14.1 AS node_installer
 RUN mkdir -p /ide/node/bin \
     /ide/node/include/node/ \
     /ide/node/lib/node_modules/npm/ \

--- a/components/theia/app/leeway.Dockerfile
+++ b/components/theia/app/leeway.Dockerfile
@@ -5,7 +5,7 @@
 
 ################ Alpine ####################
 # copy nodejs from the official alpine-based image because of https://github.com/TypeFox/gitpod/issues/2579
-FROM node:12.18.3-alpine AS node_installer
+FROM node:12.14.1-alpine AS node_installer
 RUN mkdir -p /theia/node/bin \
     /theia/node/include/node/ \
     /theia/node/lib/node_modules/npm/ \


### PR DESCRIPTION
- [x] /werft https

#### What it does

- fix #2435: align Node.js version with desktop VS Code for better compatibility of VS Code extensions

#### How to test

- Start a workspace with Theia, install https://open-vsx.org/extension/laike9m/cyberbrain and check that it gets activated without any errors.
- Do the same for Code. It won't be possible to install this extension, since we have to upgrade Code, but workspace should start and installing other extensions should work.