### PR TITLE
[registry-facade] Make tag regex closer match the docker spec

### DIFF
--- a/components/registry-facade/pkg/blobserve/blobserve.go
+++ b/components/registry-facade/pkg/blobserve/blobserve.go
@@ -72,7 +72,7 @@ func NewServer(cfg Config, resolver registry.ResolverProvider) (*Server, error) 
 // Serve serves the registry on the given port
 func (reg *Server) Serve() error {
 	r := mux.NewRouter()
-	r.PathPrefix(`/{repo:[a-zA-Z0-9\/\-\.]+}:{tag:[a-z][a-z0-9-\.]+}`).MatcherFunc(isNoWebsocketRequest).HandlerFunc(reg.serve)
+	r.PathPrefix(`/{repo:[a-zA-Z0-9\/\-\.]+}:{tag:[a-z0-9][a-z0-9-\.]+}`).MatcherFunc(isNoWebsocketRequest).HandlerFunc(reg.serve)
 	r.NewRoute().HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		log.WithField("path", req.URL.Path).Warn("unmapped request")
 		http.Error(resp, http.StatusText(http.StatusNotFound), http.StatusNotFound)


### PR DESCRIPTION
Make `blobserve` also handle tags starting with numbers.