### PR TITLE
don't run ports and IDE in headless workspaces

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -178,6 +178,9 @@ func Run(options ...RunOption) {
 	go taskManager.Run(ctx, &wg)
 	go func() {
 		defer wg.Done()
+		if cfg.isHeadless() {
+			return
+		}
 		portMgmt.Run()
 	}()
 
@@ -328,6 +331,9 @@ func reaper(ctx context.Context, wg *sync.WaitGroup) {
 
 func startAndWatchIDE(ctx context.Context, cfg *Config, wg *sync.WaitGroup, ideReady *ideReadyState) {
 	defer wg.Done()
+	if cfg.isHeadless() {
+		return
+	}
 
 	type status int
 	const (


### PR DESCRIPTION
#### What it does

There is no need to run IDE and ports management during prebuilds, only for regular workspaces.

#### How to test

- Start a prebuild which make use of `gp url`. For instance for gitlab repo. It should be successful.
- Regular workspaces should start normally and ports should work for them