### PR TITLE
[supervisor] Make IDE ready for headless workspaces

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -332,6 +332,7 @@ func reaper(ctx context.Context, wg *sync.WaitGroup) {
 func startAndWatchIDE(ctx context.Context, cfg *Config, wg *sync.WaitGroup, ideReady *ideReadyState) {
 	defer wg.Done()
 	if cfg.isHeadless() {
+		ideReady.Set(true)
 		return
 	}
 


### PR DESCRIPTION
This PR makes the readiness probe work again for headless workspaces.