### PR TITLE
Make the garbage collection alert non-dismissible

### DIFF
--- a/components/dashboard/src/components/workspaces.tsx
+++ b/components/dashboard/src/components/workspaces.tsx
@@ -37,7 +37,6 @@ interface WorkspacesState {
 	searchString?: string;
 	featuredRepositories?: WhitelistedRepository[];
     configuration?: Configuration;
-    hideGcMessage?: boolean;
 }
 
 class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
@@ -52,13 +51,6 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 	componentWillMount() {
 		this.updateWorkspaces();
         this.listenForInstanceUpdates();
-
-        try {
-            const hideGcMessage = localStorage.getItem("hideGcMessage") === "true";
-            this.setState({ hideGcMessage });
-        } catch {
-            // local storage not supported: ignore
-        }
 
 		this.props.service.server.getFeaturedRepositories()
 			.then(repos => this.setState({ featuredRepositories: repos }))
@@ -282,7 +274,7 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 		return (
 			<Fade in={true}>
 				<Grid container spacing={8} className="workspace-list">
-                    {this.state.hideGcMessage ? undefined : gcMessage}
+                    {gcMessage}
                     <Grid item xs={12} className="search" style={showSearchBar ? {} : {display: "none"}}>
                         <Input placeholder="Search" aria-label="Search" className="input" defaultValue={this.state.searchString} onChange={this.onSearchChange}/>
 						<div className="limit">

--- a/components/dashboard/src/components/workspaces.tsx
+++ b/components/dashboard/src/components/workspaces.tsx
@@ -274,7 +274,6 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 		return (
 			<Fade in={true}>
 				<Grid container spacing={8} className="workspace-list">
-                    {gcMessage}
                     <Grid item xs={12} className="search" style={showSearchBar ? {} : {display: "none"}}>
                         <Input placeholder="Search" aria-label="Search" className="input" defaultValue={this.state.searchString} onChange={this.onSearchChange}/>
 						<div className="limit">
@@ -287,6 +286,7 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 							{limitOptions}
 						</div>
 					</Grid>
+                    {gcMessage}
 					{workspacesRows}
 					{featuredRepositories}
 				</Grid>

--- a/components/dashboard/src/components/workspaces.tsx
+++ b/components/dashboard/src/components/workspaces.tsx
@@ -19,7 +19,6 @@ import Fade from '@material-ui/core/Fade';
 import { getBlockedUrl } from '../routing';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { getGitpodConfiguration } from '../configuration';
-import Button from '@material-ui/core/Button';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 
 interface WorkspacesProps {
@@ -272,17 +271,6 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
                         <Typography component="p" >
                             Unused workspaces are automatically deleted after {this.state.configuration.daysBeforeGarbageCollection} days of inactivity. <a href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection">Learn more.</a>
                         </Typography>
-                        <Button key='dismiss-gc-message' className='button' variant='outlined' color='secondary'
-                            onClick={() => {
-                                this.setState({ hideGcMessage: true });
-                                try {
-                                    localStorage.setItem("hideGcMessage", "true");
-                                } catch {
-                                    // local storage not supported: ignore
-                                }
-                            }}>
-                            Dismiss
-                        </Button>
                     </Paper>
                 </Grid>
             );

--- a/components/dashboard/src/components/workspaces.tsx
+++ b/components/dashboard/src/components/workspaces.tsx
@@ -261,7 +261,7 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
                 <Grid item xs={12}>
                     <Paper className="gc-message">
                         <Typography component="p" >
-                            Unused workspaces are automatically deleted after {this.state.configuration.daysBeforeGarbageCollection} days of inactivity. <a href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection">Learn more.</a>
+                            Unused workspaces are automatically deleted after {this.state.configuration.daysBeforeGarbageCollection} days of inactivity. <a href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection">Learn more</a>
                         </Typography>
                     </Paper>
                 </Grid>

--- a/components/dashboard/src/components/workspaces.tsx
+++ b/components/dashboard/src/components/workspaces.tsx
@@ -286,7 +286,7 @@ class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
 							{limitOptions}
 						</div>
 					</Grid>
-                    {gcMessage}
+					{gcMessage}
 					{workspacesRows}
 					{featuredRepositories}
 				</Grid>


### PR DESCRIPTION
This will:
1. Remove the _Dismiss_ button from the garbage collection alert.
1. Move garbage collection alert below the search and pagination filters.
1. Remove trailing comma from the _Learn more_ help link.

Fix https://github.com/gitpod-io/gitpod/issues/2535

| BEFORE | AFTER |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/102130799-f6e2c400-3e59-11eb-8d97-c7140a707c40.png) | ![image](https://user-images.githubusercontent.com/120486/102130805-f813f100-3e59-11eb-971e-4d532ee07951.png) |