### PR TITLE
Gitpod self-hosted test plan

### DIFF
--- a/dev/manual-tests/self-hosted.yaml
+++ b/dev/manual-tests/self-hosted.yaml
@@ -1,0 +1,106 @@
+id: gitpod-self-hosted
+name: Gitpod Self-Hosted
+description: Manual tests to conduct before releasing Gitpod self-hosted
+testset: []
+case:
+- id: helm-installer-nodomain
+  name: helm Installer ingressMode=noDomain
+  group: helm-installer-nodomain
+  description: ""
+  steps: |
+      - Log into AWS via https://gitpod.awsapps.com/start#/
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-aws-script/
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, and install a VS Code extension, e.g. https://open-vsx.org/extension/Tyriar/sort-lines
+  mustpass: false
+  mintestercount: 1
+  annotations: {}
+- id: helm-installer-hostname
+  name: Helm Installer ingressMode=pathAndHost
+  group: helm-installer-hostname
+  description: ""
+  steps: |
+      - Log into AWS via https://gitpod.awsapps.com/start#/
+      - create a new subdomain in dns-for-playgrounds via https://www.notion.so/gitpod/GCP-Playgrounds-5b49f9c92e5c42438af73343b98253b1
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-aws-script/ using that hostname
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+      - (no need to test VS Code Extensions)
+  mustpass: false
+  mintestercount: 1
+  annotations: {}
+- id: helm-installer-subdomains
+  name: Helm Installer ingressMode=hosts
+  group: helm-installer-subdomains
+  description: ""
+  steps: |
+      - Log into AWS via https://gitpod.awsapps.com/start#/
+      - create a new subdomain in dns-for-playgrounds via https://www.notion.so/gitpod/GCP-Playgrounds-5b49f9c92e5c42438af73343b98253b1
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-aws-script/ using that hostname
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+  mustpass: false
+  mintestercount: 1
+  annotations: {}
+- id: gke-installer-nodomain
+  name: GKE Installer ingressMode=noDomain
+  group: gke-installer-nodomain
+  description: ""
+  steps: |
+      - Create a new Playground Project on GKE via https://www.notion.so/gitpod/GCP-Playgrounds-5b49f9c92e5c42438af73343b98253b1
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-gcp-script/
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, and install a VS Code extension, e.g. https://open-vsx.org/extension/Tyriar/sort-lines
+  mustpass: false
+  mintestercount: 1
+  annotations: {}
+- id: gke-installer-hostname
+  name: GKE Installer ingressMode=pathAndHost
+  group: gke-installer-hostname
+  description: ""
+  steps: |
+      - Create a new Playground Project on GKE via https://www.notion.so/gitpod/GCP-Playgrounds-5b49f9c92e5c42438af73343b98253b1
+      - create a new subdomain in dns-for-playgrounds
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-gcp-script/ using that hostname
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+      - (no need to test VS Code Extensions)
+  mustpass: false
+  mintestercount: 1
+  annotations: {}
+- id: aws-installer-nodomain
+  name: AWS Installer ingressMode=noDomain
+  group: aws-installer-nodomain
+  description: ""
+  steps: |
+      - Log into AWS via https://gitpod.awsapps.com/start#/
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-aws-script/
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, and install a VS Code extension, e.g. https://open-vsx.org/extension/Tyriar/sort-lines
+  mustpass: false
+  mintestercount: 1
+  annotations: {}
+- id: aws-installer-hostname
+  name: AWS Installer ingressMode=pathAndHost
+  group: aws-installer-hostname
+  description: ""
+  steps: |
+      - Log into AWS via https://gitpod.awsapps.com/start#/
+      - create a new subdomain in dns-for-playgrounds via https://www.notion.so/gitpod/GCP-Playgrounds-5b49f9c92e5c42438af73343b98253b1
+      - Install Gitpod in the new Playground project following https://www.gitpod.io/docs/self-hosted/latest/install/install-on-aws-script/ using that hostname
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
+      - Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
+      - Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 
+      - (no need to test VS Code Extensions)
+  mustpass: false
+  mintestercount: 1
+  annotations: {}


### PR DESCRIPTION
What we should test before we release Gitpod self-hosted.

The high-level idea is that we have 7 configurations we support today:
* vanilla k8s noDomain
* vanilla k8s workspaces via path
* vanilla k8s workspace via subdomain
* GKE noDomain
* GKE workspaces via Path
* AWS noDomain
* AWS workspaces via Path

For each of these scenarios, we check if integration works well:
* write to buckets1: Start a workspace on https://github.com/gitpod-io/spring-petclinic, modify a file, stop the workspace, start the workspace, check if the modification is still there.
* write to buckets2: Start a workspace on https://github.com/gitpod-io/spring-petclinic, and install a VS Code extension, e.g. https://open-vsx.org/extension/Tyriar/sort-lines
* proxy for port exposure: Start a workspace on https://github.com/gitpod-io/spring-petclinic, expose the port of the running application and open it in a new browser window. 
* write to image-registry: Start a workspace on https://github.com/eclipse-theia/theia and see if the image build passes. 


