### PR TITLE
[theia] add read timeout for extensions content download

### DIFF
--- a/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-deployer.ts
+++ b/components/theia/packages/gitpod-extension/src/node/extensions/gitpod-plugin-deployer.ts
@@ -310,7 +310,10 @@ export class GitpodPluginDeployer implements GitpodPluginService {
                     // Content-Type has to match exactly
                     'Content-Type': '*/*',
                 },
+                // if we cannot establish connection in 5s then try again in 2s 5 times
+                // if we cannot read then timeout in 5s
                 maxAttempts: 5,
+                timeout: 5000,
                 retryDelay: 2000,
                 retryStrategy: requestretry.RetryStrategies.HTTPOrNetworkError
             }, (err, response) => {


### PR DESCRIPTION
#### What it does

- Avoid stalling extensions deployment on hanging extension content pull.

#### How to test

- Start a workspace and check extensions are deployed.