### PR TITLE
[gitpod-ide] fix for missing token validation

### DIFF
--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-git-token-provider.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-git-token-provider.ts
@@ -138,7 +138,8 @@ export class GitpodGitTokenProvider {
             const validationResult = await this.tokenValidator.checkWriteAccess(authProvider, repoFullName, tokenResult);
             const hasWriteAccess = validationResult && validationResult.writeAccessToRepo === true;
 
-            if (!hasWriteAccess) {
+            if (hasWriteAccess) {
+
                 // first of all check if the current token includes write permission
                 const isPublic = validationResult && !validationResult.isPrivateRepo;
                 const requiredScopesForGitCommand = isPublic ? authProvider.requirements!.publicRepo : authProvider.requirements!.privateRepo;
@@ -147,14 +148,14 @@ export class GitpodGitTokenProvider {
                     const messagePart = `The command "git ${gitCommand}" requires additional permissions: ${missingScopes.join(", ")}`;
                     const notificationMessage = message ? message : `${messagePart} Please try again after updating the permissions.`;
                     await this.showMessage(notificationMessage, host, missingScopes.join(','));
-                } else {
-                    // warn about missing write access
-                    const notificationMessage = `The remote repository "${repoFullName}" is not accessible with the current token.
-                    Please make sure Gitpod is authorized for the organization this repository belongs to.`;
-                    await this.showMessage(notificationMessage, host);
                 }
-            }
+            } else {
 
+                // warn about missing write access
+                const notificationMessage = `The remote repository "${repoFullName}" is not accessible with the current token.
+                Please make sure Gitpod is authorized for the organization this repository belongs to.`;
+                await this.showMessage(notificationMessage, host);
+            }
 
         }
     }


### PR DESCRIPTION
# how to test
1. start a workspace for a repo in your account on GH and make sure, you do not have granted write permissions to Gitpod
2. try to push from CLI, it should show a message to grant write permissions
3. repeat but with previously granted permissions, then it should not bother you

fixes https://github.com/gitpod-io/gitpod/issues/2343