### PR TITLE
[helm] added default values for wsProxy

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -462,6 +462,10 @@ components:
       memory: 64Mi
     replicas: 1
     useHTTPS: false
+    ingress:
+      portRange:
+        start: 10000
+        end: 11000
     ports:
       httpProxy:
         expose: true


### PR DESCRIPTION
This solves the following problem: https://community.gitpod.io/t/cant-deploy-gitpod-on-a-kubernetes-cluster/2317/2
