### PR TITLE
[helm] made imagePullSecrets for db-migrations and node-daemon optional

### DIFF
--- a/chart/templates/db-migrations-job.yaml
+++ b/chart/templates/db-migrations-job.yaml
@@ -33,9 +33,11 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: db-migrations
+{{- if .Values.defaults.imagePullSecrets }}
       imagePullSecrets:
 {{- range $key, $value := .Values.defaults.imagePullSecrets }}
       - name: {{ $value.name }}
+{{- end }}
 {{- end }}
       containers:
       - name: db-migrations

--- a/chart/templates/node-daemon-daemonset.yaml
+++ b/chart/templates/node-daemon-daemonset.yaml
@@ -33,9 +33,11 @@ spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: node-daemon
       enableServiceLinks: false
+{{- if .Values.defaults.imagePullSecrets }}
       imagePullSecrets:
 {{- range $key, $value := .Values.defaults.imagePullSecrets }}
       - name: {{ $value.name }}
+{{- end }}
 {{- end }}
       volumes:
       - name: theia-storage


### PR DESCRIPTION
This removes the remaining imagePullSecret that is required by `db-migrations` and `node-daemon`.