### PR TITLE
[server] normalize plugin names from config

### DIFF
--- a/components/server/src/theia-plugin/theia-plugin-service.ts
+++ b/components/server/src/theia-plugin/theia-plugin-service.ts
@@ -128,10 +128,10 @@ export class TheiaPluginService {
         const idx = fullPluginName.lastIndexOf('@');
         if (idx === -1) {
             return {
-                name: fullPluginName
+                name: fullPluginName.toLowerCase()
             };
         }
-        const name = fullPluginName.substring(0, idx);
+        const name = fullPluginName.substring(0, idx).toLowerCase();
         const version = fullPluginName.substr(idx + 1);
         return { name, version };
     }


### PR DESCRIPTION
#### How to test

- Start go gin workspace
- Check that go works
- Go to gitpod.yml and add:
```yml
vscode:
  extensions:
    - golang.Go
```

Latest version should be installed. You need to reload the page to see it, there is a bug that the extensions view does not reflect changes. It is regression since we rewrote UI to taslk with open vsx.