### PR TITLE
Prepare codebase for golangci-lint checks

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-test-sh.1
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-add-golangci-lint.6
 workspaceLocation: gitpod/gitpod-ws.theia-workspace
 checkoutLocation: gitpod
 ports:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.useLanguageServer": true
-}

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:wth-update-terraform-0.13.5.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-add-golangci-lint.6
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:wth-update-terraform-0.13.5.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-add-golangci-lint.6
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -4,6 +4,11 @@ defaultArgs:
   coreYarnLockBase: ../..
   publishToNPM: true
 
+defaultVariant: 
+  config:
+    go:
+      lintCommand: ["golangci-lint", "run", "--disable", "govet,typecheck"]
+
 variants:
 - name: oss
   components:

--- a/components/blobserve/pkg/blobserve/refstore.go
+++ b/components/blobserve/pkg/blobserve/refstore.go
@@ -112,7 +112,7 @@ func (store *refstore) BlobFor(ctx context.Context, ref string, readOnly bool) (
 			return nil, "", err
 		}
 		store.mu.RLock()
-		rs, exists = store.refcache[ref]
+		rs = store.refcache[ref]
 		store.mu.RUnlock()
 
 		// Even though we triggered a download, that doesn't mean

--- a/components/content-service/pkg/storage/minio.go
+++ b/components/content-service/pkg/storage/minio.go
@@ -271,6 +271,7 @@ type presignedMinIOStorage struct {
 }
 
 func (s *presignedMinIOStorage) SignDownload(ctx context.Context, bucket, object string) (info *DownloadInfo, err error) {
+	//nolint:ineffassign
 	span, ctx := opentracing.StartSpanFromContext(ctx, "minio.SignDownload")
 	defer func() {
 		if err == ErrNotFound {

--- a/components/docker-up/runc-facade/main.go
+++ b/components/docker-up/runc-facade/main.go
@@ -25,8 +25,6 @@ const (
 	cmdUnmountProc = "unmount-proc"
 )
 
-var log *logrus.Entry
-
 func main() {
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)

--- a/components/ee/cerc/pkg/cerc/receiver.go
+++ b/components/ee/cerc/pkg/cerc/receiver.go
@@ -49,6 +49,9 @@ func (r *Receiver) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 
 func defaultResponder(url, tkn string) error {
 	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
 	req.SetBasicAuth("Bearer", tkn)
 
 	client := http.Client{Timeout: 5 * time.Second}

--- a/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
@@ -453,6 +453,7 @@ func (s *Scheduler) gatherPotentialNodesFor(ctx context.Context, pod *corev1.Pod
 }
 
 func (s *Scheduler) bindPodToNode(ctx context.Context, pod *corev1.Pod, nodeName string) (err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "bindPodToNode")
 	defer tracing.FinishSpan(span, nil) // let caller decide whether this is an actual error or not
 	span.LogKV("nodeName", nodeName, "podName", pod.Name)
@@ -531,6 +532,7 @@ func (s *Scheduler) waitForCacheSync(ctx context.Context) bool {
 }
 
 func (s *Scheduler) recordSchedulingFailure(ctx context.Context, pod *corev1.Pod, failureErr error, reason string, message string) (err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "recordSchedulingFailure")
 	defer tracing.FinishSpan(span, &err)
 

--- a/components/image-builder/pkg/builder/docker.go
+++ b/components/image-builder/pkg/builder/docker.go
@@ -269,6 +269,7 @@ func (b *DockerBuilder) getBaseImageRef(ctx context.Context, bs *api.BuildSource
 }
 
 func (b *DockerBuilder) getWorkspaceImageRef(ctx context.Context, baseref string, gitpodLayerHash string, allowedAuth allowedAuthFor) (ref string, err error) {
+	//nolint:ineffassign
 	span, ctx := opentracing.StartSpanFromContext(ctx, "getWorkspaceImageRef")
 	defer tracing.FinishSpan(span, &err)
 

--- a/components/registry-facade/pkg/registry/layersource_test.go
+++ b/components/registry-facade/pkg/registry/layersource_test.go
@@ -101,12 +101,18 @@ func createFixtureFromImage(ctx context.Context, resolver remotes.Resolver, ref 
 		return nil, err
 	}
 	content[desc.Digest.Encoded()], err = json.Marshal(mf)
+	if err != nil {
+		return nil, err
+	}
 
 	cfg, err := DownloadConfig(ctx, fetcher, mf.Config)
 	if err != nil {
 		return nil, err
 	}
 	content[mf.Config.Digest.Encoded()], err = json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	return &testStaticLayerSourceFixture{
 		SourceRef: ref,

--- a/components/supervisor/cmd/rings.go
+++ b/components/supervisor/cmd/rings.go
@@ -208,7 +208,7 @@ var ring1Cmd = &cobra.Command{
 		// (cw) I have been able to reproduce this issue without newuidmap/newgidmap.
 		//      See https://gist.github.com/csweichel/3fc9d4b0752367d4a436f969c8685c06
 		runtime.LockOSThread()
-		err = unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0)
+		unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0)
 		runtime.UnlockOSThread()
 
 		tmpdir, err := ioutil.TempDir("", "supervisor")

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -95,6 +95,7 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 
 // RunInitializer runs a content initializer in a user, PID and mount namespace to isolate it from ws-daemon
 func RunInitializer(ctx context.Context, destination string, initializer *csapi.WorkspaceInitializer, remoteContent map[string]storage.DownloadInfo, opts RunInitializerOpts) (err error) {
+	//nolint:ineffassign
 	span, ctx := opentracing.StartSpanFromContext(ctx, "RunInitializer")
 	defer tracing.FinishSpan(span, &err)
 

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -332,6 +332,7 @@ func (s *Workspace) persist() error {
 }
 
 func loadWorkspace(ctx context.Context, path string) (sess *Workspace, err error) {
+	//nolint:ineffassign
 	span, ctx := opentracing.StartSpanFromContext(ctx, "loadWorkspace")
 	defer tracing.FinishSpan(span, &err)
 

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -77,6 +77,7 @@ func ServeWorkspace(uidmapper *Uidmapper) func(ctx context.Context, ws *session.
 			return nil
 		}
 
+		//nolint:ineffassign
 		span, ctx := opentracing.StartSpanFromContext(ctx, "iws.ServeWorkspace")
 		defer tracing.FinishSpan(span, &err)
 
@@ -206,7 +207,7 @@ func (wbs *InWorkspaceServiceServer) PrepareForUserNS(ctx context.Context, req *
 	// That's why we resort to exec'ing "nsenter ... mount ...".
 	mntout, err := exec.Command("nsenter", "-t", fmt.Sprint(containerPID), "-m", "--", "mount", "--make-shared", "/").CombinedOutput()
 	if err != nil {
-		log.WithField("containerPID", containerPID).WithError(err).Error("cannot make container's rootfs shared")
+		log.WithField("containerPID", containerPID).WithField("mntout", string(mntout)).WithError(err).Error("cannot make container's rootfs shared")
 		return nil, status.Errorf(codes.Internal, "cannot make container's rootfs shared")
 	}
 

--- a/components/ws-daemon/pkg/iws/uidmap.go
+++ b/components/ws-daemon/pkg/iws/uidmap.go
@@ -166,6 +166,10 @@ func (m *Uidmapper) findHostPID(containerPID, inContainerPID uint64) (uint64, er
 		p = filepath.Join(m.Config.ProcLocation, p)
 
 		pid, nspid, err := readStatusFile(filepath.Join(p, "status"))
+		if err != nil {
+			log.WithField("file", filepath.Join(p, "status")).WithError(err).Error("findHostPID: cannot read PID file")
+			continue
+		}
 		for _, nsp := range nspid {
 			if nsp == inContainerPID {
 				return pid, nil

--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -181,6 +181,7 @@ type podLifecycleIndependentState struct {
 // non-zero values of the patch. Calling this function triggers a status update. This function is
 // neither atomic, nor synchronized.
 func (m *Manager) patchPodLifecycleIndependentState(ctx context.Context, workspaceID string, patch func(*podLifecycleIndependentState) (needsUpdate bool), annotations ...*annotation) (err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "patchPodLifecycleIndependentState")
 	defer tracing.FinishSpan(span, &err)
 

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -494,6 +494,7 @@ func getTheiaServiceName(servicePrefix string) string {
 
 // MarkActive records a workspace as being active which prevents it from timing out
 func (m *Manager) MarkActive(ctx context.Context, req *api.MarkActiveRequest) (res *api.MarkActiveResponse, err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "MarkActive")
 	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
 	defer tracing.FinishSpan(span, &err)
@@ -749,6 +750,9 @@ func (m *Manager) ControlPort(ctx context.Context, req *api.ControlPortRequest) 
 		}
 
 		_, err = client.Services(m.Config.Namespace).Update(service)
+		if err != nil {
+			return nil, xerrors.Errorf("cannot update service: %w", err)
+		}
 		tracing.LogEvent(span, "port service updated")
 	}
 	if err != nil {
@@ -788,6 +792,7 @@ func portNameToVisibility(s string) api.PortVisibility {
 
 // DescribeWorkspace investigates a workspace and returns its status, and configuration
 func (m *Manager) DescribeWorkspace(ctx context.Context, req *api.DescribeWorkspaceRequest) (res *api.DescribeWorkspaceResponse, err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "DescribeWorkspace")
 	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
 	defer tracing.FinishSpan(span, &err)
@@ -1009,6 +1014,7 @@ func (m *Manager) GetWorkspaces(ctx context.Context, req *api.GetWorkspacesReque
 // If a workspace has a pod that pod is part of the returned WSO.
 // If a workspace has a PLIS that PLIS is part of the returned WSO.
 func (m *Manager) getAllWorkspaceObjects(ctx context.Context) (result []workspaceObjects, err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "getAllWorkspaceObjects")
 	defer tracing.FinishSpan(span, &err)
 
@@ -1119,6 +1125,7 @@ func isKubernetesObjNotFoundError(err error) bool {
 
 // connectToWorkspaceDaemon establishes a connection to the ws-daemon daemon running on the node of the pod/workspace.
 func (m *Manager) connectToWorkspaceDaemon(ctx context.Context, wso workspaceObjects) (wsdaemon.WorkspaceContentServiceClient, error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "connectToWorkspaceDaemon")
 	tracing.ApplyOWI(span, wso.GetOWI())
 	defer tracing.FinishSpan(span, nil)
@@ -1227,6 +1234,7 @@ func newWssyncConnectionFactory(managerConfig Configuration) (grpcpool.Factory, 
 }
 
 func (m *Manager) deleteGhostWorkspace(ctx context.Context) (err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "deleteGhostWorkspace")
 	defer tracing.FinishSpan(span, &err)
 

--- a/components/ws-manager/pkg/manager/manager_ee.go
+++ b/components/ws-manager/pkg/manager/manager_ee.go
@@ -69,6 +69,7 @@ func (m *Manager) TakeSnapshot(ctx context.Context, req *api.TakeSnapshotRequest
 
 // ControlAdmission makes a workspace accessible for everyone or for the owner only
 func (m *Manager) ControlAdmission(ctx context.Context, req *api.ControlAdmissionRequest) (res *api.ControlAdmissionResponse, err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "ControlAdmission")
 	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
 	tracing.LogRequestSafe(span, req)
@@ -115,6 +116,7 @@ func (m *Manager) ControlAdmission(ctx context.Context, req *api.ControlAdmissio
 
 // SetTimeout changes the default timeout for a running workspace
 func (m *Manager) SetTimeout(ctx context.Context, req *api.SetTimeoutRequest) (res *api.SetTimeoutResponse, err error) {
+	//nolint:ineffassign
 	span, ctx := tracing.FromContext(ctx, "SetTimeout")
 	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
 	defer tracing.FinishSpan(span, &err)

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -49,7 +49,7 @@ RUN cd /usr/local && curl -sfL https://install.goreleaser.com/github.com/golangc
 
 # leeway
 ENV LEEWAY_NESTED_WORKSPACE=true
-RUN cd /usr/bin && curl -L https://github.com/TypeFox/leeway/releases/download/v0.1.0/leeway_0.1.0_Linux_x86_64.tar.gz | tar xz
+RUN cd /usr/bin && curl -L https://github.com/TypeFox/leeway/releases/download/v0.2.0/leeway_0.2.0_Linux_x86_64.tar.gz | tar xz
 
 # dazzle
 RUN cd /usr/bin && curl -L https://github.com/32leaves/dazzle/releases/download/v0.0.3/dazzle_0.0.3_Linux_x86_64.tar.gz | tar xz

--- a/gitpod-ws.theia-workspace
+++ b/gitpod-ws.theia-workspace
@@ -53,6 +53,7 @@
       "launch": {},
       "files.exclude": {
          "**/.git": true
-      }
+    },
+    "go.lintTool": "golangci-lint"
    }
 }


### PR DESCRIPTION
This PR adds `golangci-lint` as a default go linter for the IDE and solves the most obvious linting issues.
A very meticulous review to make sure I'm handling those issues correctly would be great :slightly_smiling_face: 


There might be some extra work needed to be done here, just wanted to see it in action on a CI pipeline and then address the rest of the issues.

fixes #2566 