### PR TITLE
Fix #2232: MySQL Pod in CrashLoopBackOff #2232

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -12,6 +12,7 @@ certificatesSecret:
   chainName: tls.crt
   keyName: tls.key
 version: not-set
+forceHTTPS: false
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -12,6 +12,6 @@ dependencies:
   repository: https://helm.min.io/
   condition: minio.enabled
 - name: mysql
-  version: 1.6.3
+  version: 1.6.9
   repository: https://charts.helm.sh/stable
   condition: mysql.enabled 


### PR DESCRIPTION
Upgrade MySQL from: https://github.com/helm/charts/blob/69fd2819607dc21cd95af7aac3524a757e03f594/stable/mysql/Chart.yaml
to https://github.com/helm/charts/blob/master/stable/mysql/Chart.yaml