### PR TITLE
[registry-facade] Support zero-downtime updates

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -56,6 +56,7 @@ async function build(context, version) {
     const dynamicCPULimits = "dynamic-cpu-limits" in buildConfig;
     const withInstaller = "with-installer" in buildConfig || masterBuild;
     const noPreview = "no-preview" in buildConfig || publishRelease;
+    const registryFacadeHandover = "registry-facade-handover" in buildConfig;
     werft.log("job config", JSON.stringify({
         buildConfig,
         version,
@@ -67,6 +68,7 @@ async function build(context, version) {
         workspaceFeatureFlags,
         dynamicCPULimits,
         noPreview,
+        registryFacadeHandover,
     }));
 
     /**
@@ -111,7 +113,7 @@ async function build(context, version) {
         werft.phase("deploy", "not deploying");
         console.log("no-preview or publish-release is set");
     } else {
-        await deployToDev(version, previewWithHttps, workspaceFeatureFlags, dynamicCPULimits);
+        await deployToDev(version, previewWithHttps, workspaceFeatureFlags, dynamicCPULimits, registryFacadeHandover);
     }
 }
 
@@ -119,7 +121,7 @@ async function build(context, version) {
 /**
  * Deploy dev
  */
-async function deployToDev(version, previewWithHttps, workspaceFeatureFlags, dynamicCPULimits) {
+async function deployToDev(version, previewWithHttps, workspaceFeatureFlags, dynamicCPULimits, registryFacadeHandover) {
     werft.phase("deploy", "deploying to dev");
     const destname = version.split(".")[0];
     const namespace = `staging-${destname}`;
@@ -239,6 +241,11 @@ async function deployToDev(version, previewWithHttps, workspaceFeatureFlags, dyn
     if (dynamicCPULimits) {
         flags+=` -f ../.werft/values.variant.cpuLimits.yaml`;
     }
+    if (registryFacadeHandover) {
+        flags+=` --set components.registryFacade.handover.enabled=true`;
+        flags+=` --set components.registryFacade.handover.socket=/var/lib/gitpod/registry-facade-${namespace}`;
+    }
+
     // const pathToVersions = `${shell.pwd().toString()}/versions.yaml`;
     // if (fs.existsSync(pathToVersions)) {
     //     flags+=` -f ${pathToVersions}`;

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -196,7 +196,7 @@ async function deployToDev(version, previewWithHttps, workspaceFeatureFlags, dyn
         exec(`/usr/local/bin/helm3 delete jaeger-${destname} || echo jaeger-${destname} was not installed yet`, {slice: 'predeploy cleanup'});
 
         let objs = [];
-        ["ws-scheduler", "node-daemon", "cluster", "workspace", "jaeger", "jaeger-agent", "ws-sync", "ws-manager-node", "ws-daemon"].forEach(comp => 
+        ["ws-scheduler", "node-daemon", "cluster", "workspace", "jaeger", "jaeger-agent", "ws-sync", "ws-manager-node", "ws-daemon", "registry-facade"].forEach(comp => 
             ["ClusterRole", "ClusterRoleBinding", "PodSecurityPolicy"].forEach(kind =>
                 shell
                     .exec(`kubectl get ${kind} -l component=${comp} --no-headers -o=custom-columns=:metadata.name | grep ${namespace}-ns`)

--- a/chart/templates/cluster-restricted-root-podsecuritypolicy.yaml
+++ b/chart/templates/cluster-restricted-root-podsecuritypolicy.yaml
@@ -39,6 +39,7 @@ spec:
     - 'secret'
     - 'emptyDir'
     - 'persistentVolumeClaim'
+    - 'hostPath'
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/chart/templates/registry-facade-clusterrole.yaml
+++ b/chart/templates/registry-facade-clusterrole.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ if .Values.installPodSecurityPolicies -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ .Release.Namespace }}-ns-registry-facade
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: cluster
+    kind: clusterrole
+    stage: {{ .Values.installation.stage }}
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+    - {{ .Release.Namespace }}-ns-registry-facade
+{{- end -}}

--- a/chart/templates/registry-facade-configmap.yaml
+++ b/chart/templates/registry-facade-configmap.yaml
@@ -17,7 +17,11 @@ data:
     {
         {{ if .Values.components.workspace.pullSecret.secretName -}}"dockerAuth": "/mnt/pull-secret.json",{{- end }}
         "registry": {
+            {{- if $comp.handover.enabled }}
+            "port": {{ $comp.ports.registry.servicePort }},
+            {{- else }}
             "port": {{ $comp.ports.registry.containerPort }},
+            {{- end }}
             {{- if (or .Values.certificatesSecret.secretName $comp.certificatesSecret.secretName) }}
             {{- if (or .Values.certificatesSecret.certManager $comp.certificatesSecret.certManager) }}
             "tls": {

--- a/chart/templates/registry-facade-configmap.yaml
+++ b/chart/templates/registry-facade-configmap.yaml
@@ -45,7 +45,11 @@ data:
                     "ref": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.dockerUp) }}",
                     "type": "image"
                 }
-            ]
+            ],
+            "handover": {
+                "enabled": {{ $comp.handover.enabled }},
+                "sockets": "/mnt/handover"
+            }
         },
         "pprofAddr": ":6060",
         "prometheusAddr": ":9500"

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -38,6 +38,21 @@ spec:
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: registry-facade
+{{- if $comp.handover.enabled }}
+      initContainers:
+      - name: handover-ownership
+        image: {{ template "gitpod.comp.imageFull" $this }}
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "chown -R 1000:1000 /mnt/handover"
+        volumeMounts:
+        - name: handover
+          mountPath: "/mnt/handover"
+        securityContext:
+          privileged: false
+          runAsUser: 0
+{{- end }}
       containers:
       - name: registry-facade
         image: {{ template "gitpod.comp.imageFull" $this }}
@@ -56,11 +71,15 @@ spec:
 {{ include "gitpod.container.defaultEnv" $this | indent 8 }}
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
         volumeMounts:
+        - name: cache
+          mountPath: "/mnt/cache"
         - name: config
           mountPath: "/mnt/config"
           readOnly: true
-        - name: cache
-          mountPath: "/mnt/cache"
+        {{- if $comp.handover.enabled }}
+        - name: handover
+          mountPath: "/mnt/handover"
+        {{- end }}
         {{- if .Values.components.workspace.pullSecret.secretName }}
         - name: pull-secret
           mountPath: /mnt/pull-secret.json
@@ -76,6 +95,12 @@ spec:
       - name: config
         configMap:
           name: {{ template "gitpod.comp.configMap" $this }}
+      {{- if $comp.handover.enabled }}
+      - name: handover
+        hostPath:
+          path: {{ $comp.handover.socket | quote }}
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if .Values.components.workspace.pullSecret.secretName }}
       - name: pull-secret
         secret:

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -53,6 +53,9 @@ spec:
           privileged: false
           runAsUser: 0
 {{- end }}
+      {{- if $comp.handover.enabled }}
+      hostNetwork: true
+      {{- end }}
       containers:
       - name: registry-facade
         image: {{ template "gitpod.comp.imageFull" $this }}
@@ -61,10 +64,15 @@ spec:
 {{ include "gitpod.container.resources" $this | indent 8 }}
         ports:
         - name: registry
+          {{- if $comp.handover.enabled }}
+          # if hostNetwork == true then containerPort == hostPort
+          containerPort: {{ $comp.ports.registry.servicePort }}
+          {{- else }}
           containerPort: {{ $comp.ports.registry.containerPort }}
           hostPort: {{ $comp.ports.registry.servicePort }}
         - name: metrics
           containerPort: 9500
+          {{- end }}
         securityContext:
           privileged: false
           runAsUser: 1000

--- a/chart/templates/registry-facade-podsecuritypolicy.yaml
+++ b/chart/templates/registry-facade-podsecuritypolicy.yaml
@@ -8,7 +8,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Release.Namespace }}-ns-restricted-root-user
+  name: {{ .Release.Namespace }}-ns-registry-facade
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: cluster
@@ -35,10 +35,8 @@ spec:
   # Allow core volume types.
   volumes:
     - 'configMap'
-    - 'projected'
     - 'secret'
     - 'emptyDir'
-    - 'persistentVolumeClaim'
     - 'hostPath'
   hostNetwork: true
   hostIPC: false
@@ -47,9 +45,7 @@ spec:
   - min: 30000
     max: 33000
   runAsUser:
-    ### TODO root proxy
     rule: 'RunAsAny'
-    ### TODO root proxy
   seLinux:
     # This policy assumes the nodes are using AppArmor rather than SELinux.
     rule: 'RunAsAny'

--- a/chart/templates/registry-facade-rolebinding.yaml
+++ b/chart/templates/registry-facade-rolebinding.yaml
@@ -15,5 +15,5 @@ subjects:
   name: registry-facade
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Namespace }}-ns-psp:restricted-root-user
+  name: {{ .Release.Namespace }}-ns-registry-facade
   apiGroup: rbac.authorization.k8s.io

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -235,6 +235,9 @@ components:
         servicePort: 3000
     svcLabels:
       feature: registry
+    handover:
+      enabled: false
+      socket: /var/lib/gitpod/registry-facade
     serviceType: "ClusterIP"
 
   server:

--- a/components/registry-facade/cmd/handover.go
+++ b/components/registry-facade/cmd/handover.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry"
+	"github.com/spf13/cobra"
+)
+
+// debugHandover represents the run command
+var debugHandover = &cobra.Command{
+	Use:   "handover <socket-dir>",
+	Short: "Attempts to get the listener socket from a registry-facade - and offers it back up for someone else",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		l, err := registry.ReceiveHandover(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		if l == nil {
+			log.Warn("received no listener")
+			return nil
+		}
+
+		log.Info("handover successfull - holding listener for someone else")
+
+		hoctx, cancelHO := context.WithCancel(context.Background())
+		defer cancelHO()
+
+		ho, err := registry.OfferHandover(hoctx, args[0], l, nil)
+		if err != nil {
+			return err
+		}
+
+		log.Info("waiting for someone else to handover to - stop with Ctrl+C")
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+		select {
+		case didHO := <-ho:
+			if didHO {
+				<-ho
+			}
+		case <-sigChan:
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(debugHandover)
+}

--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.34.0
 	gotest.tools/v3 v3.0.3 // indirect

--- a/components/registry-facade/pkg/handover/handover.go
+++ b/components/registry-facade/pkg/handover/handover.go
@@ -1,0 +1,139 @@
+package handover
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
+)
+
+// OfferHandover opens a Unix socket on socketFN and waits for another process to ask
+// for the listeners socket file descriptor. Once that happens, it closes the Unix socket and returns.
+// If the context is canceled before someone asks for the listener's socket,
+// this function returns context.Canceled.
+func OfferHandover(ctx context.Context, socketFN string, l *net.TCPListener) error {
+	skt, err := net.Listen("unix", socketFN)
+	if err != nil {
+		return xerrors.Errorf("cannot create handover socket: %w", err)
+	}
+	defer skt.Close()
+
+	done := make(chan struct{})
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		recv, err := skt.Accept()
+		if err != nil {
+			return xerrors.Errorf("cannot accept incoming handover connection: %w", err)
+		}
+		defer recv.Close()
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		listenConn := recv.(*net.UnixConn)
+		err = sendListener(listenConn, l)
+		if err != nil {
+			return xerrors.Errorf("cannot send listener: %w", err)
+		}
+
+		defer close(done)
+		return nil
+	})
+	eg.Go(func() error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-done:
+			return nil
+		}
+	})
+	return eg.Wait()
+}
+
+// ReceiveHandover requests a net.Listener handover from a Unix socket on socketFN.
+// If the context cancels before the transfer is complete, context.Canceled is returned.
+func ReceiveHandover(ctx context.Context, socketFN string) (l net.Listener, err error) {
+	conn, err := net.Dial("unix", socketFN)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	return receiveListener(ctx, conn.(*net.UnixConn))
+}
+
+// sendListener sends a copy of a TCP listener's file descriptor to a Unix socket.
+// Callers should close l upon successful return of this function.
+// Use in conjunction with receiveListener().
+func sendListener(conn *net.UnixConn, l *net.TCPListener) error {
+	connf, err := conn.File()
+	if err != nil {
+		return err
+	}
+	defer connf.Close()
+	sktfd := int(connf.Fd())
+
+	lf, err := l.File()
+	if err != nil {
+		return err
+	}
+	lfd := int(lf.Fd())
+
+	rights := unix.UnixRights(lfd)
+	return unix.Sendmsg(sktfd, nil, rights, nil, 0)
+}
+
+// receiveListener attempts to receieve a file descriptor from a Unix socket,
+// and turns that fd into a net.Listener. This function makes several assumptions
+// about the nature of the messages it receives:
+//   - there is exactly one control message,
+//     that contains exactly one SCM_RIGHTS message,
+//     that contains exaxtly one file descriptor.
+//   - the received file descriptor is a listening socket, s.t. we can call net.FileListener on it.
+func receiveListener(ctx context.Context, conn *net.UnixConn) (l net.Listener, err error) {
+	buf := make([]byte, unix.CmsgSpace(4))
+
+	connf, err := conn.File()
+	if err != nil {
+		return nil, err
+	}
+	defer connf.Close()
+	connfd := int(connf.Fd())
+
+	recvC := make(chan error, 1)
+	go func() {
+		_, _, _, _, err := unix.Recvmsg(connfd, nil, buf, 0)
+		recvC <- err
+	}()
+	select {
+	case err = <-recvC:
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := unix.ParseSocketControlMessage(buf)
+	if err != nil {
+		return nil, err
+	}
+	if len(msgs) != 1 {
+		return nil, fmt.Errorf("expected a single socket control message")
+	}
+
+	fds, err := unix.ParseUnixRights(&msgs[0])
+	if err != nil {
+		return nil, err
+	}
+	if len(fds) == 0 {
+		return nil, fmt.Errorf("expected a single socket FD")
+	}
+
+	return net.FileListener(os.NewFile(uintptr(fds[0]), ""))
+}

--- a/components/registry-facade/pkg/handover/handover.go
+++ b/components/registry-facade/pkg/handover/handover.go
@@ -84,6 +84,7 @@ func sendListener(conn *net.UnixConn, l *net.TCPListener) error {
 	}
 	lfd := int(lf.Fd())
 
+	// UnixRights encodes a set of open file descriptors into a socket control message for sending to another process.
 	rights := unix.UnixRights(lfd)
 	return unix.Sendmsg(sktfd, nil, rights, nil, 0)
 }

--- a/components/registry-facade/pkg/handover/handover_test.go
+++ b/components/registry-facade/pkg/handover/handover_test.go
@@ -1,0 +1,49 @@
+package handover_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/registry-facade/pkg/handover"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestHandover(t *testing.T) {
+	socketFN := filepath.Join(os.TempDir(), fmt.Sprintf("handover-test-%d.sock", time.Now().UnixNano()))
+
+	l, err := net.Listen("tcp", ":44444")
+	if err != nil {
+		t.Fatalf("cannot start test listener: %q", err)
+	}
+	defer l.Close()
+	tcpL := l.(*net.TCPListener)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return handover.OfferHandover(ctx, socketFN, tcpL)
+	})
+	eg.Go(func() error {
+		// give the handover offer some time to start
+		time.Sleep(1 * time.Millisecond)
+		l, err := handover.ReceiveHandover(ctx, socketFN)
+		if err != nil {
+			return err
+		}
+		if l == nil {
+			return fmt.Errorf("l was nil")
+		}
+		l.Close()
+		return nil
+	})
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds live socket handover support to registry-facade. Through this method we can update registry-facade without any downtime. The process is described in https://github.com/gitpod-io/gitpod/issues/2512.

To make  the handover work, we have to run registry-facade in the `hostNetwork`. Otherwise we'd attempt to re-use a socket in a network namespace that no longer exists. Hence, by default handover support is disabled.

### How to test
TODO(cw)

### Open Questions
- Kubernetes just merged support for surge rollouts in daemonSets yet ([KEP](https://github.com/kubernetes/enhancements/pull/1590), [PR](https://github.com/kubernetes/kubernetes/pull/96375)). It will take a while until that becomes generally available. Until then we need some other convenient way to facilitate the handover, e.g. a separate daemonSet that can be deployed prior to the update. How would that look like? Would that be its own chart?

- [x] /werft https
- [x] /werft registry-facade-handover