### PR TITLE
[wip] Test Self-Hosted noDomain

### DIFF
--- a/chart/config/proxy/lib.locations.conf
+++ b/chart/config/proxy/lib.locations.conf
@@ -70,6 +70,17 @@ location /apps {
     proxy_pass http://apiserver$request_uri;
 }
 
+##### Blobserve (ingressMode=noDomain,pathAndHost)
+{{- $wsProxy := .Values.components.wsProxy -}}
+{{- if (and $wsProxy (not $wsProxy.disabled)) }}
+location /blobserve {
+    include lib.proxy.conf;
+    include lib.cors-headers.conf;
+
+    proxy_pass http://wsproxy$request_uri;
+}
+{{- end }}
+
 
 ##### Gitpod plugins
 location /plugins {

--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -77,7 +77,13 @@ data:
             "gitpodInstallation": {
                 "scheme": "{{- template "gitpod.scheme" $this -}}",
                 "hostName": "{{- $gp.hostname -}}",
-                "workspaceHostSuffix": ".{{- if $gp.installation.shortname -}}ws-{{ $gp.installation.shortname }}{{- else -}}ws{{- end -}}.{{- $gp.hostname -}}"
+                {{- if eq .Values.ingressMode "hosts" }}
+                "workspaceHostSuffix":     ".ws{{- if $gp.installation.shortname -}}-{{ $.Values.installation.shortname }}{{- end -}}.{{ $.Values.hostname }}"
+                {{- else if eq .Values.ingressMode "pathAndHost" }}
+                "workspaceHostSuffix":     ""
+                {{- else }}
+                "workspaceHostSuffix":     ""
+                {{- end }}
             },
             "workspacePodConfig": {
                 "serviceTemplate": "http://ws-{{"{{ .workspaceID }}"}}-theia.{{- .Release.Namespace -}}.svc.cluster.local:{{"{{ .port }}"}}",

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -92,8 +92,7 @@ func (c *GitpodInstallation) Validate() error {
 
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Scheme, validation.Required),
-		validation.Field(&c.HostName, validation.Required),            // TODO IP ONLY: Check if there is any dependency. If yes, remove it.
-		validation.Field(&c.WorkspaceHostSuffix, validation.Required), // TODO IP ONLY: Check if there is any dependency. If yes, remove it.
+		validation.Field(&c.HostName, validation.Required), // TODO IP ONLY: Check if there is any dependency. If yes, remove it.
 	)
 }
 

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH=$PATH:/usr/local/kubernetes/cluster/:/usr/local/kubernetes/client/bin/
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     # really 'xenial'
     && add-apt-repository -yu "deb https://apt.kubernetes.io/ kubernetes-xenial main" \
-    && apt-get install -yq kubectl=1.13.0-00 \
+    && apt-get install -yq kubectl=1.20.0-00 \
     && kubectl completion bash > /usr/share/bash-completion/completions/kubectl \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/docs/self-hosted/install/configure-ingress.md
+++ b/docs/self-hosted/install/configure-ingress.md
@@ -11,9 +11,28 @@ There are several modes of ingress into your Gitpod installation. They mostly hi
 Compare [values.yaml](https://github.com/gitpod-io/gitpod/blob/master/chart/values.yaml) for details.
 
 
-## Example
+## IngressMode: `noDomain`
+
+ > Custom Docker registry
+   For this mode to work you need to [configure a custom Docker registry](../docker-registry/) with valid HTTPS certificates.
+
+ 1. Create a file `values.ingress.yaml` with the following content:
+    ```
+    hostname: "123-123-123-123.ip.mygitpod.com"
+    ```
+    Replace 123-123-123-123 with the external IP of your cluster.
+
+    Afterwards, do an `helm upgrade --install -f values.ingress.yaml gitpod .` to apply the changes.
+
+    > If you don't know the external IP of your cluster try running `kubectl describe svc proxy | grep -i ingress`.
+
+ 2. Now your installation is available at `https://123-123-123-123.ip.mygitpod.com`
 
 #####TODO
+## IngressMode: `pathAndHost`
+
+## IngressMode: `hosts`
+
 
 ### Domain
 Gitpod requires a domain resolvable by some nameserver (typically a public domain name, e.g. `your-domain.com`).

--- a/docs/self-hosted/install/install-on-kubernetes.md
+++ b/docs/self-hosted/install/install-on-kubernetes.md
@@ -13,7 +13,7 @@ Gitpod is installed using [Helm](https://helm.sh). The chart can be found [here]
 
 ## Installation
 
-To perform the installation run the following commands:
+To initiate the deployment run the following commands:
 
 ```console
 git clone https://github.com/gitpod-io/gitpod
@@ -23,16 +23,27 @@ helm repo add charts.gitpod.io https://charts.gitpod.io
 helm repo add stable https://charts.helm.sh/stable
 helm repo add stable https://helm.min.io/
 helm repo update
+helm dep up
 
-helm upgrade --install $(for i in $(cat configuration.txt); do echo -e "-f $i"; done) gitpod .
+helm install gitpod .
 ```
-#####TODO
+
+ > Review the deployment worked properly by running `kubectl get pods`. Eventually all pods should be up-and-running. In case they are not have a look the the [Troubleshooting Guide](./troubleshooting.md)
+ 
+ 1. Configure [ingress into the cluster](../configure-ingress/)
+
+ 2. Go to https://123-123-123-123.ip.mygitpod.com/workspace and follow the steps to setup OAuth
+
 ## Recommended Configuration
 
-
+Without further configuration the Helm chart installs a working Gitpod installation in a lot of scenarios.
+Yet, there are certain things you want to review when installing Gitpod for long term use or a bigger audience:
+* [**Database**](../database/): Configure where Gitpod stores all internal runtime data.
+* [**Storage**](../storage/): Configure where Gitpod persists workspace content.
+* [**Docker Registry**](../docker-registry/): Configure where Gitpod stores workspace images that are build at runtime.
 
 ## Customization
 
-* [**Storage**](../storage/): Configure where Gitpod stores stopped workspaces.
+Further customizations:
 * [**Kubernetes Nodes**](../nodes/): Configure file system layout and the workspace's node associativity.
 * [**Workspaces**](../workspaces/): Configure workspace sizing.


### PR DESCRIPTION
This is the result of me testing Gitpod Self-Hosted on a Kubernetes clustere installed via `kubeup`. It:
 - updates the touched config (ingress for the nodomain case, Docker Registry, Install on Kubernetes)
 - attempts to fix blobserve for "noDomain" and "pathAndHost", but this is not finished:
   - workspace requests (`/workspace/b1629b2c-ca5d-43fb-9305-e5b46df5507d/bundle.js`) are properly redirected to `blobserve` there they fail. Files are present, maybe some other content issue?
   
Once that's done this should succeed. :crossed_fingers: 