### PR TITLE
[server] Add new metric for failed and successful logins

### DIFF
--- a/components/server/ee/src/monitoring-endpoint-ee.ts
+++ b/components/server/ee/src/monitoring-endpoint-ee.ts
@@ -5,13 +5,13 @@
  */
 
 import * as express from 'express';
-import * as prometheusClient from 'prom-client';
 import { WorkspaceHealthMonitoring } from './workspace/workspace-health-monitoring';
 import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
 import * as request from 'request';
 import { Span } from 'opentracing';
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { injectable, inject } from 'inversify';
+import { register } from '../../src/prometheusMetrics';
 
 @injectable()
 export class MonitoringEndpointsAppEE extends WorkspaceHealthMonitoring {
@@ -19,12 +19,10 @@ export class MonitoringEndpointsAppEE extends WorkspaceHealthMonitoring {
 
     public create(): express.Application {
         const monApp = express();
-        prometheusClient.collectDefaultMetrics({ timeout: 5000 });
-
         monApp.get('/metrics', async (req, res) => {
 	        try {
-		        res.set('Content-Type', prometheusClient.register.contentType);
-		        res.end(await prometheusClient.register.metrics());
+		        res.set('Content-Type', register.contentType);
+		        res.end(register.metrics());
 	        } catch (ex) {
     		    res.status(500).end(ex);
 	        }

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -15,6 +15,7 @@ import { HostContextProvider } from './host-context-provider';
 import { AuthProvider, AuthFlow } from './auth-provider';
 import { TokenProvider } from '../user/token-provider';
 import { AuthProviderService } from './auth-provider-service';
+import { increaseLoginCounter } from '../../src/prometheusMetrics';
 
 @injectable()
 export class Authenticator {
@@ -108,12 +109,14 @@ export class Authenticator {
             return;
         }
         if (!req.session) {
+            increaseLoginCounter("failed", authProvider.info.host)
             log.info({ }, `No session.`, { req, 'login-flow': true });
             res.redirect(this.getSorryUrl(`No session found. Please refresh the browser.`));
             return;
         }
 
         if (!authProvider.info.verified && !(await this.isInSetupMode())) {
+            increaseLoginCounter("failed", authProvider.info.host)
             log.info({ sessionId: req.sessionID }, `Login with "${host}" is not permitted.`, { req, 'login-flow': true, ap: authProvider.info });
             res.redirect(this.getSorryUrl(`Login with "${host}" is not permitted.`));
             return;

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -14,6 +14,7 @@ import { AuthFlow } from './auth-provider';
 import { HostContextProvider } from './host-context-provider';
 import { AuthProviderService } from './auth-provider-service';
 import { TosFlow } from '../terms/tos-flow';
+import { increaseLoginCounter } from '../../src/prometheusMetrics';
 
 /**
  * The login completion handler pulls the strings between the OAuth2 flow, the ToS flow, and the session management.
@@ -44,6 +45,9 @@ export class LoginCompletionHandler {
             await TosFlow.clear(request.session);
             await AuthFlow.clear(request.session);
     
+            if (authHost) {
+                increaseLoginCounter("failed", authHost)
+            } 
             log.error(logContext, `Redirect to /sorry on login`, err, { err, session: request.session });
             response.redirect(this.env.hostUrl.asSorry("Oops! Something went wrong during login.").toString());
             return;
@@ -72,6 +76,9 @@ export class LoginCompletionHandler {
         // Create Gitpod 🍪 before the redirect
         this.gitpodCookie.setCookie(response);
 
+        if (authHost) {
+                increaseLoginCounter("succeeded", authHost)
+        } 
         response.redirect(returnTo);
     }
 

--- a/components/server/src/prometheusMetrics.ts
+++ b/components/server/src/prometheusMetrics.ts
@@ -1,0 +1,19 @@
+import * as prometheusClient from 'prom-client';
+
+// Enable collection of default metrics.
+prometheusClient.collectDefaultMetrics({ timeout: 5000 });
+export const register = prometheusClient.register;
+
+const loginCounter = new prometheusClient.Counter({
+    name: 'gitpod_login_requests_total',
+    help: 'Total amount of login requests',
+    labelNames: ['status', 'auth_host'],
+    registers: [prometheusClient.register]
+});
+
+export function increaseLoginCounter(status: string, auth_host: string) {
+    loginCounter.inc({
+        status,
+        auth_host,
+    });
+}

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -26,6 +26,7 @@ import { AuthFlow } from "../auth/auth-provider";
 import { LoginCompletionHandler } from "../auth/login-completion-handler";
 import { TosCookie } from "./tos-cookie";
 import { TosFlow } from "../terms/tos-flow";
+import { increaseLoginCounter } from '../../src/prometheusMetrics';
 
 @injectable()
 export class UserController {
@@ -76,6 +77,7 @@ export class UserController {
             try {
                 await saveSession(req);
             } catch (error) {
+                increaseLoginCounter("failed", "unkown")
                 log.error(`Login failed due to session save error; redirecting to /sorry`, { req, error, clientInfo });
                 res.redirect(this.getSorryUrl("Login failed 🦄 Please try again"));
             }


### PR DESCRIPTION
This is a work-in-progress PR.

Following our discussion from last Thursday, the login metric was the one with the highest priority. This PR adds a counter metric named `gitpod_login_requests_total`, 

It has 2 labels, `status` that inform if a login request failed or not, and `oauth` that inform what was the OAuth provider used on the login request.

More information about usage, related SLI and recording rules can be found at [Notion](https://www.notion.so/gitpod/success_ratio-6c4fa74b977e444b852c77b0bbbfcd68).

---
This is literally my first time writing code in javascript/nodejs/typescript. I'm not even sure about what language I'm writing :sweat_smile:. For the one reviewing, please tell me if I'm not following best practices or if code can be optimized :) 