### PR TITLE
Remove deprecated config attribute

### DIFF
--- a/install/aws-full-terraform/providers.tf
+++ b/install/aws-full-terraform/providers.tf
@@ -14,7 +14,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.gitpod_cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.gitpod_cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.default.token
-#   load_config_file       = false
+  load_config_file       = false
 }
 
 provider "helm" {
@@ -22,7 +22,6 @@ provider "helm" {
     host                   = data.aws_eks_cluster.gitpod_cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.gitpod_cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.default.token
-    load_config_file       = false
   }
 }
 

--- a/install/aws-full-terraform/providers.tf
+++ b/install/aws-full-terraform/providers.tf
@@ -14,7 +14,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.gitpod_cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.gitpod_cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.default.token
-  load_config_file       = false
+#   load_config_file       = false
 }
 
 provider "helm" {

--- a/install/aws-terraform/providers.tf
+++ b/install/aws-terraform/providers.tf
@@ -22,7 +22,6 @@ provider "helm" {
     host                   = data.aws_eks_cluster.gitpod_cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.gitpod_cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.default.token
-    load_config_file       = false
   }
 }
 

--- a/install/gcp-terraform/environment/full/providers.tf
+++ b/install/gcp-terraform/environment/full/providers.tf
@@ -20,8 +20,6 @@ provider "kubernetes" {
 
 provider "helm" {
   kubernetes {
-    load_config_file = "false"
-
     host                   = module.kubernetes.cluster.endpoint
     token                  = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(module.kubernetes.cluster.master_auth[0].cluster_ca_certificate)

--- a/install/gcp-terraform/environment/installer/providers.tf
+++ b/install/gcp-terraform/environment/installer/providers.tf
@@ -19,8 +19,6 @@ provider "kubernetes" {
 
 provider "helm" {
   kubernetes {
-    load_config_file = "false"
-
     host                   = module.kubernetes.cluster.endpoint
     token                  = data.google_client_config.provider.access_token
     cluster_ca_certificate = base64decode(module.kubernetes.cluster.master_auth[0].cluster_ca_certificate)


### PR DESCRIPTION
This PR removes the deprecated `load_config_file` argument from the Kubernetes section of the helm provider as per https://registry.terraform.io/providers/hashicorp/helm/latest/docs.