### PR TITLE
[self-hosted] Fix various issues around blobserve+ path based workspace access

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,8 +22,6 @@ ingressMode: noDomain
 certificatesSecret: {}
 
 imagePrefix: gcr.io/gitpod-io/
-# TODO(gpl): in which scenarios is this helpful? Can we remove?
-forceHTTPS: true
 installation:
   stage: production
   tenant: gitpod
@@ -85,6 +83,26 @@ serviceWaiter:
   imageName: "service-waiter"
 tracing: {}
 authProviders: []
+# - id: "Public-GitHub"
+#   host: "github.com"
+#   type: "GitHub"
+#   oauth:
+#     clientId: "CLIENT_ID"
+#     clientSecret: "SECRET"
+#     callBackUrl: "https://gitpod.io/auth/github/callback"
+#     settingsUrl: "https://github.com/settings/connections/applications/CLIENT_ID"
+#   description: ""
+#   icon: ""
+# - id: "Public-GitLab"
+#   host: "gitlab.com"
+#   type: "GitLab"
+#   oauth:
+#     clientId: "CLIENT_ID"
+#     clientSecret: "SECRET"
+#     callBackUrl: "https://gitpod.io/auth/gitlab/callback"
+#     settingsUrl: "https://gitlab.com/profile/applications"
+#   description: ""
+#   icon: ""
 branding:
   logo: /images/gitpod-ddd.svg
   homepage: https://www.gitpod.io/
@@ -375,7 +393,7 @@ components:
       nodeRoots: 
       - /var/lib
       - /run/containerd/io.containerd.runtime.v1.linux/k8s.io
-      #- /run/containerd/io.containerd.runtime.v2.task/k8s.io
+      # - /run/containerd/io.containerd.runtime.v2.task/k8s.io
     userNamespaces:
       shiftfsModuleLoader:
         enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,6 +83,7 @@ serviceWaiter:
   imageName: "service-waiter"
 tracing: {}
 authProviders: []
+# Example authProvider configurations below:
 # - id: "Public-GitHub"
 #   host: "github.com"
 #   type: "GitHub"
@@ -393,6 +394,7 @@ components:
       nodeRoots: 
       - /var/lib
       - /run/containerd/io.containerd.runtime.v1.linux/k8s.io
+      # On some hosts systems containerd uses different paths to store it's containers in
       # - /run/containerd/io.containerd.runtime.v2.task/k8s.io
     userNamespaces:
       shiftfsModuleLoader:

--- a/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as chai from 'chai';
+import { suite, test } from 'mocha-typescript';
+import { GitpodHostUrl } from './gitpod-host-url';
+const expect = chai.expect;
+
+@suite
+export class GitpodHostUrlTest {
+
+    @test public parseWorkspaceId_pathBased() {
+        const actual = GitpodHostUrl.fromWorkspaceUrl("http://35.223.201.195/workspace/bc77e03d-c781-4235-bca0-e24087f5e472/").workspaceId;
+        expect(actual).to.equal("bc77e03d-c781-4235-bca0-e24087f5e472");
+    }
+}
+module.exports = new GitpodHostUrlTest()

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -30,6 +30,10 @@ export class GitpodHostUrl {
         }
     }
 
+    static fromWorkspaceUrl(url: string) {
+        return new GitpodHostUrl(new URL(url));
+    }
+
     withWorkspacePrefix(workspaceId: string, region: string) {
         return this.withDomainPrefix(`${workspaceId}.ws-${region}.`);
     }

--- a/components/supervisor/frontend/src/ide/gitpod-service-client.ts
+++ b/components/supervisor/frontend/src/ide/gitpod-service-client.ts
@@ -5,7 +5,7 @@
  */
 
 import { WorkspaceInfo, Event, Emitter } from "@gitpod/gitpod-protocol";
-import { workspaceUrl, serverUrl } from "../shared/urls";
+import { workspaceUrl } from "../shared/urls";
 
 export interface GitpodServiceClient {
     readonly auth: Promise<void>;
@@ -14,12 +14,13 @@ export interface GitpodServiceClient {
 }
 
 export async function create(): Promise<GitpodServiceClient> {
-    if (!workspaceUrl.workspaceId) {
-        throw new Error(`Failed to extract a workspace id from '${window.location.href}'.`);
+    const wsUrl = workspaceUrl;
+    if (!wsUrl.workspaceId) {
+        throw new Error(`Failed to extract a workspace id from '${wsUrl.toString()}'.`);
     }
 
     //#region info
-    const listener = await window.gitpod.service.listenToInstance(workspaceUrl.workspaceId);
+    const listener = await window.gitpod.service.listenToInstance(wsUrl.workspaceId);
     //#endregion
 
     //#region auth
@@ -35,7 +36,7 @@ export async function create(): Promise<GitpodServiceClient> {
             return;
         }
         try {
-            const response = await fetch(serverUrl.asWorkspaceAuth(workspaceInstanceId).toString(), {
+            const response = await fetch(wsUrl.asStart().asWorkspaceAuth(workspaceInstanceId).toString(), {
                 credentials: 'include'
             });
             if (response.ok) {

--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -6,6 +6,7 @@
 
 import { SupervisorStatusResponse, IDEStatusResponse, ContentStatusResponse } from '@gitpod/supervisor-api-grpc/lib/status_pb'
 import { GitpodServiceClient } from './gitpod-service-client';
+import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 
 export class SupervisorServiceClient {
     readonly supervisorReady = this.checkReady('supervisor');
@@ -29,7 +30,20 @@ export class SupervisorServiceClient {
             wait = "";
         }
         try {
-            const response = await fetch(window.location.protocol + '//' + window.location.host + '/_supervisor/v1/status/' + kind + wait, { credentials: 'include' });
+            const supervisorStatusPath = "_supervisor/v1/status/" + kind + wait;
+            const wsSupervisurStatusUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href)
+                .with(url => {
+                    let pathname = url.pathname;
+                    if (pathname === "") {
+                        pathname = "/";
+                    }
+                    pathname += supervisorStatusPath;
+
+                    return {
+                        pathname
+                    };
+                });
+            const response = await fetch(wsSupervisurStatusUrl.toString(), { credentials: 'include' });
             let result;
             if (response.ok) {
                 result = await response.json();

--- a/components/supervisor/frontend/src/shared/urls.ts
+++ b/components/supervisor/frontend/src/shared/urls.ts
@@ -6,7 +6,7 @@
 
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
-export const workspaceUrl = new GitpodHostUrl(window.location.href);
+export const workspaceUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href);
 
 export const serverUrl = workspaceUrl.withoutWorkspacePrefix();
 

--- a/components/theia/app/scripts/postgenerate.js
+++ b/components/theia/app/scripts/postgenerate.js
@@ -21,7 +21,7 @@ fs.writeFileSync(filePath, `<!DOCTYPE html>
 </head>
 
 <body>
-	<script type="text/javascript" src="/_supervisor/frontend/main.js" charset="utf-8"></script>
+	<script type="text/javascript" src="./_supervisor/frontend/main.js" charset="utf-8"></script>
 	<div class="theia-preload"></div>
 	<script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
 </body>

--- a/components/theia/packages/gitpod-extension/src/browser/utils.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/utils.ts
@@ -13,7 +13,7 @@ export function getGitpodService(): GitpodService {
     return window.gitpod.service;
 }
 
-const workspaceID = new GitpodHostUrl(window.location.href).workspaceId || "unknown-workspace-id";
+const workspaceID = GitpodHostUrl.fromWorkspaceUrl(window.location.href).workspaceId || "unknown-workspace-id";
 export function getWorkspaceID() {
     return workspaceID;
 }

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -82,7 +82,7 @@ func proxyPass(config *RouteHandlerConfig, resolver targetResolver, opts ...prox
 				return xerrors.Errorf("response's request without URL")
 			}
 
-			if log.Log.Level <= logrus.DebugLevel && resp.StatusCode != http.StatusOK {
+			if log.Log.Level <= logrus.DebugLevel && resp.StatusCode >= http.StatusBadRequest {
 				dmp, _ := httputil.DumpRequest(resp.Request, false)
 				log.WithField("url", url.String()).WithField("req", dmp).WithField("status", resp.Status).Debug("proxied request failed")
 			}

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -5,7 +5,6 @@
 package proxy
 
 import (
-	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -230,11 +229,9 @@ func pathBasedTheiaRouter(r *mux.Router, wsInfoProvider WorkspaceInfoProvider, t
 	if trimPrefix == "" {
 		trimPrefix = "/"
 	}
-	if trimPrefix[len(trimPrefix)-1] != '/' {
-		trimPrefix = fmt.Sprintf("%s%s", trimPrefix, "/")
-	}
+	trimPrefix = strings.TrimSuffix(trimPrefix, "/") + "/"
 
-	regex := regexp.MustCompile("^(" + trimPrefix + ")" + workspaceIDRegex)
+	prefixedWorkspaceIDRegex := regexp.MustCompile("^(" + trimPrefix + ")" + workspaceIDRegex)
 	return r.MatcherFunc(func(req *http.Request, match *mux.RouteMatch) (res bool) {
 
 		var wsID string
@@ -256,7 +253,7 @@ func pathBasedTheiaRouter(r *mux.Router, wsInfoProvider WorkspaceInfoProvider, t
 			return true
 		}
 
-		matches := regex.FindStringSubmatch(req.URL.Path)
+		matches := prefixedWorkspaceIDRegex.FindStringSubmatch(req.URL.Path)
 		if len(matches) < 3 {
 			return false
 		}

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -226,10 +227,15 @@ func getWorkspaceCoords(req *http.Request) WorkspaceCoords {
 // PathBasedTheiaRouter routes workspaces using a /workspaceID prefix.
 // Doesn't do port routing.
 func pathBasedTheiaRouter(r *mux.Router, wsInfoProvider WorkspaceInfoProvider, trimPrefix string) *mux.Router {
+	if trimPrefix == "" {
+		trimPrefix = "/"
+	}
+	if trimPrefix[len(trimPrefix)-1] != '/' {
+		trimPrefix = fmt.Sprintf("%s%s", trimPrefix, "/")
+	}
+
+	regex := regexp.MustCompile("^(" + trimPrefix + ")" + workspaceIDRegex)
 	return r.MatcherFunc(func(req *http.Request, match *mux.RouteMatch) (res bool) {
-		if trimPrefix == "" {
-			trimPrefix = "/"
-		}
 
 		var wsID string
 		defer func() {
@@ -250,8 +256,16 @@ func pathBasedTheiaRouter(r *mux.Router, wsInfoProvider WorkspaceInfoProvider, t
 			return true
 		}
 
-		path := strings.TrimPrefix(req.URL.Path, trimPrefix)
-		wsID = strings.Split(path, "/")[0]
+		matches := regex.FindStringSubmatch(req.URL.Path)
+		if len(matches) < 3 {
+			return false
+		}
+
+		wsID = matches[2]
+		if wsID == "" {
+			return false
+		}
+
 		if wsInfoProvider.WorkspaceInfo(req.Context(), wsID) == nil {
 			log.WithFields(log.OWI("", wsID, "")).Debug("PathBasedTheiaRouter: no workspace info found")
 			return false

--- a/docs/self-hosted/install/configure-ingress.md
+++ b/docs/self-hosted/install/configure-ingress.md
@@ -11,22 +11,22 @@ There are several modes of ingress into your Gitpod installation. They mostly hi
 Compare [values.yaml](https://github.com/gitpod-io/gitpod/blob/master/chart/values.yaml) for details.
 
 
-## IngressMode: `noDomain`
+## IngressMode: `noDomain` (HTTP only)
 
  > Custom Docker registry
    For this mode to work you need to [configure a custom Docker registry](../docker-registry/) with valid HTTPS certificates.
 
  1. Create a file `values.ingress.yaml` with the following content:
     ```
-    hostname: "123-123-123-123.ip.mygitpod.com"
+    hostname: "<cluster-IP>"
     ```
-    Replace 123-123-123-123 with the external IP of your cluster.
+    Replace \<cluster-IP\> with the external IP of your cluster.
 
     Afterwards, do an `helm upgrade --install -f values.ingress.yaml gitpod .` to apply the changes.
 
     > If you don't know the external IP of your cluster try running `kubectl describe svc proxy | grep -i ingress`.
 
- 2. Now your installation is available at `https://123-123-123-123.ip.mygitpod.com`
+ 2. Now your installation is available at `http://<cluster-IP>`
 
 #####TODO
 ## IngressMode: `pathAndHost`

--- a/docs/self-hosted/install/docker-registry.md
+++ b/docs/self-hosted/install/docker-registry.md
@@ -25,7 +25,7 @@ To connect to an existing Docker registry, perform the following steps:
         registryCerts: []
         registry:
           # name must not end with a "/"
-          name: eu.gcr.io/gpl-sh-kubeup-2
+          name: your.registry.com/gitpod
           secretName: image-builder-registry-secret
           path: secrets/registry-auth.json
 
@@ -70,3 +70,16 @@ How to use Google Cloud Registry as Docker registry for Gitpod:
 
     echo "{\"auths\":{\"gcr.io\": {\"auth\": \"$(echo -n "$(echo -n "_json_key:"; cat gitpod-registry-full-key.json)" | base64 -w 0)\"}}}" > secrets/registry-auth.json
     ```
+
+    This should result in a `secrets/registry-auth.json` like this:
+    ```json
+    {
+        "auths": {
+            "gcr.io": {
+                "auth": "<long-base64-string>"
+            }
+        }
+    }
+    ```
+
+    > If you want to use the localized versions of gcr.io (eu.gcr.io, for instance) make sure to update the json file accordingly.

--- a/docs/self-hosted/install/install-on-kubernetes.md
+++ b/docs/self-hosted/install/install-on-kubernetes.md
@@ -28,7 +28,7 @@ helm dep up
 helm install gitpod .
 ```
 
- > Review the deployment worked properly by running `kubectl get pods`. Eventually all pods should be up-and-running. In case they are not have a look the the [Troubleshooting Guide](./troubleshooting.md)
+ > Review the deployment worked properly by running `kubectl get pods`. Eventually all pods should be up-and-running. In case they are not have a look the the [Troubleshooting Guide](../troubleshooting/)
  
  1. Configure [ingress into the cluster](../configure-ingress/)
 


### PR DESCRIPTION
Fixes #2570.

This PR contains various small fixes for re-enabling blobserve and path-based workspace access.

It's not complete, as we discussed stopping this effort and reduce functionality instead to relieve us from the maintenance burden. It's meant to be merge to a) document it, b) keep the minor fixes that are orthogonal on master nonetheless and c) untangle this PR from the duty to reduce the ingress variance as discussed.

# Test
it does not break preview env: http://gpl-test-sh-2.staging.gitpod-dev.com/workspaces/