### PR TITLE
Fix unconfirmed gitlab account detection

### DIFF
--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -86,9 +86,10 @@ export class GitLabAuthProvider extends GenericAuthProvider {
                 currentScopes: this.readScopesFromVerifyParams(tokenResponse)
             }
         } catch (error) {
-            if (error && error.response && error.response.statusText === "Forbidden") {
+            if (error && typeof error.description === "string" && error.description.includes("403 Forbidden")) {
                 // If GitLab is configured to disallow OAuth-token based API access for unconfirmed users, we need to reject this attempt
-                throw UnconfirmedUserException.create(unconfirmedUserMessage, error);
+                // 403 Forbidden  - You (@...) must accept the Terms of Service in order to perform this action. Please access GitLab from a web browser to accept these terms.
+                throw UnconfirmedUserException.create(error.description, error);
             } else {
                 log.error(`(${this.strategyName}) Reading current user info failed`, error, { accessToken, error });
                 throw error;


### PR DESCRIPTION
This PR should fix error propagation wo provide a hint in situations like https://github.com/gitpod-io/gitpod/issues/2746, so that user are able to create Gitpod accounts after verifying their Gitlab accounts.

Resolves https://github.com/gitpod-io/gitpod/issues/2747

# How to test

0. sign out from gitlab.com
1. try to create new account for the preview environment using Gitlab
  - on gitlab.com select Google to create new(!) account (which is expected to be unconfirmed)
  - see you get a meaningful error message (which is forwarded from gitlab.com)
  

<img width="1132" alt="Screen Shot 2021-01-11 at 09 29 39" src="https://user-images.githubusercontent.com/914497/104159466-a4aca880-53ef-11eb-9cfb-d9732b29e9dd.png">

