### PR TITLE
[server/auth] ensure safe returnTo param

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -81,6 +81,7 @@ export class UserController {
             }
 
             // Proceed with login
+            this.ensureSafeReturnToParam(req);
             await this.authenticator.authenticate(req, res, next);
         });
         router.get("/authorize", (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -88,6 +89,7 @@ export class UserController {
                 res.sendStatus(401);
                 return;
             }
+            this.ensureSafeReturnToParam(req);
             this.authenticator.authorize(req, res, next);
         });
         const branding = this.env.brandingConfig;
@@ -481,6 +483,10 @@ export class UserController {
                 return;
             }
         }
+    }
+
+    protected ensureSafeReturnToParam(req: express.Request) {
+        req.query.returnTo = this.getSafeReturnToParam(req);
     }
 
     protected getSafeReturnToParam(req: express.Request) {


### PR DESCRIPTION
This PR closes an open redirect issue. AFAIK this is problem if an attacker would fake a Gitpod-like website and make people use links with redirects to it. The fake website could potentially ask user to enter sensitive information.

Allowing for Gitpod homepage URLs comes in parallel via https://github.com/gitpod-io/gitpod/pull/2692. ✔️ 

# how to test
0. log in & log out without errors.
1. should login and start a workspace: http://at-returnto.staging.gitpod-dev.com/api/login?host=github.com&returnTo=http://at-returnto.staging.gitpod-dev.com/#https://github.com/gitpod-io/django-locallibrary-tutorial
2. log out.
3. should open the dashboard: http://at-returnto.staging.gitpod-dev.com/api/login?host=github.com&returnTo=https://github.com/gitpod-io/gitpod/pull/2879