### PR TITLE
upgrade to code 1.52.1

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 785b788482b7faa13bd44baed60dbef4093f7e7d
+ENV GP_CODE_COMMIT 001c337aa00d9eff6faa2c07255451d1c33602e0
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft https

#### What it does

Upgrade Code to 1.52.1: https://github.com/gitpod-io/vscode/compare/711fc3e9f4192d725005e63f192c77780306544f...fa5be467f0bb30921faeb8ac2052752dbb8147b2

#### How to test

- Switch to Code as a default IDE.
- Start a new workspace.
- Check that fs is available, language servers are working, debugging working, try to install a new extension, try to open a file with code cli, task terminals and ports should work too,
  - For instance start a Theia repo, check that task terminal is running and port is detected when it is done.
  - Open some ts file to check language support.
  - Debug uri.spec.ts with `Run Mocha Test` launch configuration.
  - Install gitlens extension.
- Stop a workspace and start again. There should be any UI glitches.