### PR TITLE
ws-daemon use host network if ClusterFirstWithHostNet set

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -57,6 +57,9 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
       serviceAccountName: ws-daemon
+      {{- if eq .Values.defaults.dnsPolicy "ClusterFirstWithHostNet" }}
+      hostNetwork: true
+      {{- end }}
       hostPID: true
       volumes:
       - hostPath:


### PR DESCRIPTION
Configures the ws-daemon to use the host network when `ClusterFIrstWithHostNet` is set for the DNS policy.

Fixes #2935 

Signed-off-by: jgallucci32 <john.gallucci.iv@gmail.com>