### PR TITLE
[registry-facade] Support Docker Image Manifest v2 requests

### DIFF
--- a/components/registry-facade/pkg/registry/manifest.go
+++ b/components/registry-facade/pkg/registry/manifest.go
@@ -109,7 +109,10 @@ func (mh *manifestHandler) getManifest(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 
-				if mediaType == ociv1.MediaTypeImageManifest || mediaType == "*" {
+				if mediaType == ociv1.MediaTypeImageManifest ||
+					mediaType == images.MediaTypeDockerSchema2Manifest ||
+					mediaType == "*" {
+
 					acceptType = ociv1.MediaTypeImageManifest
 					break
 				}


### PR DESCRIPTION
i.e. support `application/vnd.docker.distribution.manifest.v2+json` as value for the `Accept` header.

Fixes gitpod-io/gitpod#2714

### How to test
Notice how registry-facade does not complain about the requested manifest format, but merely about the manifest not being found:

```
curl -v -i -H "Accept: application/vnd.docker.distribution.manifest.v2+json" https://reg.csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com:30929/v2/remote/aaa88ea4-a88d-4b46-93f2-ce87530f004f/manifests/sha256:5a9c64c6a7c13fc9b25baf61856b6e8af3dd982b099266685f4a0f16a428c63b --tlsv1.2
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to reg.csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com (127.0.0.1) port 30929 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com
*  start date: Jan 18 07:13:47 2021 GMT
*  expire date: Apr 18 07:13:47 2021 GMT
*  subjectAltName: host "reg.csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com" matched cert's "*.csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55cc862bd580)
> GET /v2/remote/aaa88ea4-a88d-4b46-93f2-ce87530f004f/manifests/sha256:5a9c64c6a7c13fc9b25baf61856b6e8af3dd982b099266685f4a0f16a428c63b HTTP/2
> Host: reg.csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com:30929
> User-Agent: curl/7.58.0
> Accept: application/vnd.docker.distribution.manifest.v2+json
> 
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 404 
HTTP/2 404 
< content-type: application/json; charset=utf-8
content-type: application/json; charset=utf-8
< content-length: 70
content-length: 70
< date: Mon, 18 Jan 2021 08:22:05 GMT
date: Mon, 18 Jan 2021 08:22:05 GMT

< 
{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}
* Connection #0 to host reg.csweichel-workspace-image-pulled-2714.staging.gitpod-dev.com left intact
```