### PR TITLE
[ws-proxy] Don't leak workspace info Go routines

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -482,10 +482,7 @@ func workspaceMustExistHandler(config *Config, infoProvider WorkspaceInfoProvide
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			coords := getWorkspaceCoords(req)
-			// it might take some time until the event comes in. Let's wait for it at most 3 secs.
-			ctx, cancel := context.WithTimeout(req.Context(), 3*time.Second)
-			defer cancel()
-			info := infoProvider.WorkspaceInfo(ctx, coords.ID)
+			info := infoProvider.WorkspaceInfo(req.Context(), coords.ID)
 			if info == nil {
 				log.WithFields(log.OWI("", coords.ID, "")).Info("no workspace info found - redirecting to start")
 				redirectURL := fmt.Sprintf("%s://%s/start/#%s", config.GitpodInstallation.Scheme, config.GitpodInstallation.HostName, coords.ID)


### PR DESCRIPTION
This PR explicitly cancels the WaitFor calls for workspace info. Prior, if a request was made for a non-existent workspace we might leak Go routines. This would happen if the server request context isn't canceled for some reason (we're not timing them out in general).

### How to test
@geropl and I ran a load test against a patched ws-proxy and observed pprof at the same time. Go routines did not go beyond expected limits, and did go down afterwards.