### PR TITLE
[content-service] Improve naming of workspace backup functions

### DIFF
--- a/components/content-service/pkg/executor/executor.go
+++ b/components/content-service/pkg/executor/executor.go
@@ -70,7 +70,7 @@ func Execute(ctx context.Context, destination string, cfgin io.Reader, opts ...i
 	} else {
 		rs = &storage.NamedURLDownloader{
 			URLs: map[string]string{
-				storage.DefaultBackup: cfg.FromBackup,
+				storage.DefaultWorkspaceBackup: cfg.FromBackup,
 			},
 		}
 		ilr = &initializer.EmptyInitializer{}

--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -331,7 +331,7 @@ func InitializeWorkspace(ctx context.Context, location string, remoteStorage sto
 	}
 
 	// Run the initializer
-	hasBackup, err := remoteStorage.Download(ctx, location, storage.DefaultBackup)
+	hasBackup, err := remoteStorage.DownloadLatestWsSnapshot(ctx, location, storage.DefaultWorkspaceBackup)
 	if err != nil {
 		return src, xerrors.Errorf("cannot restore backup: %w", err)
 	}

--- a/components/content-service/pkg/initializer/initializer_test.go
+++ b/components/content-service/pkg/initializer/initializer_test.go
@@ -812,33 +812,33 @@ func (rs *mockGCloudStorage) EnsureExists(ctx context.Context) error {
 	return nil
 }
 
-// Download always returns false and does nothing
-func (rs *mockGCloudStorage) Download(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadLatestWsSnapshot always returns false and does nothing
+func (rs *mockGCloudStorage) DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	rs.Delegate.ObjectAccess = func(ctx context.Context, bkt, obj string) (io.ReadCloser, bool, error) {
 		log.WithField("fixture", rs.Fixture).Debug("intercepting object access")
 		f, err := os.OpenFile(rs.Fixture, os.O_RDONLY, 0644)
 		return f, false, err
 	}
 
-	return rs.Delegate.Download(ctx, destination, name)
+	return rs.Delegate.DownloadLatestWsSnapshot(ctx, destination, name)
 }
 
-// Download always returns false and does nothing
-func (rs *mockGCloudStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadLatestWsSnapshot always returns false and does nothing
+func (rs *mockGCloudStorage) DownloadWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	rs.Delegate.ObjectAccess = func(ctx context.Context, bkt, obj string) (io.ReadCloser, bool, error) {
 		f, err := os.OpenFile(rs.Fixture, os.O_RDONLY, 0644)
 		return f, false, err
 	}
 
-	return rs.Delegate.DownloadSnapshot(ctx, destination, name)
+	return rs.Delegate.DownloadWsSnapshot(ctx, destination, name)
 }
 
-func (rs *mockGCloudStorage) Qualify(name string) string {
-	return rs.Delegate.Qualify(name)
+func (rs *mockGCloudStorage) QualifyWsSnapshot(name string) string {
+	return rs.Delegate.QualifyWsSnapshot(name)
 }
 
-// Upload does nothing
-func (rs *mockGCloudStorage) Upload(ctx context.Context, source string, name string, opts ...storage.UploadOption) (string, string, error) {
+// UploadWsSnapshot does nothing
+func (rs *mockGCloudStorage) UploadWsSnapshot(ctx context.Context, source string, name string, opts ...storage.UploadOption) (string, string, error) {
 	return "", "", xerrors.Errorf("not supported")
 }
 

--- a/components/content-service/pkg/initializer/snapshot.go
+++ b/components/content-service/pkg/initializer/snapshot.go
@@ -29,7 +29,7 @@ func (s *SnapshotInitializer) Run(ctx context.Context) (src csapi.WorkspaceInitS
 
 	src = csapi.WorkspaceInitFromOther
 
-	ok, err := s.Storage.DownloadSnapshot(ctx, s.Location, s.Snapshot)
+	ok, err := s.Storage.DownloadWsSnapshot(ctx, s.Location, s.Snapshot)
 	if err != nil {
 		return src, xerrors.Errorf("snapshot initializer: %w", err)
 	}

--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -252,13 +252,13 @@ func (rs *DirectGCPStorage) fixLegacyFilenames(ctx context.Context, destination 
 	return nil
 }
 
-// Download takes the latest state from the remote storage and downloads it to a local path
-func (rs *DirectGCPStorage) Download(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadLatestWsSnapshot takes the latest state from the remote storage and downloads it to a local path
+func (rs *DirectGCPStorage) DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	return rs.download(ctx, destination, rs.bucketName(), rs.objectName(name))
 }
 
-// DownloadSnapshot downloads a snapshot. The snapshot name is expected to be one produced by Qualify
-func (rs *DirectGCPStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadWsSnapshot downloads a snapshot. The snapshot name is expected to be one produced by QualifyWsSnapshot
+func (rs *DirectGCPStorage) DownloadWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	bkt, obj, err := ParseSnapshotName(name)
 	if err != nil {
 		return false, err
@@ -280,14 +280,14 @@ func ParseSnapshotName(name string) (bkt, obj string, err error) {
 	return
 }
 
-// Qualify fully qualifies a snapshot name so that it can be downloaded using DownloadSnapshot
-func (rs *DirectGCPStorage) Qualify(name string) string {
+// QualifyWsSnapshot fully qualifies a snapshot name so that it can be downloaded using DownloadWsSnapshot
+func (rs *DirectGCPStorage) QualifyWsSnapshot(name string) string {
 	return fmt.Sprintf("%s@%s", rs.objectName(name), rs.bucketName())
 }
 
-// Upload takes all files from a local location and uploads it to the remote storage
-func (rs *DirectGCPStorage) Upload(ctx context.Context, source string, name string, opts ...UploadOption) (bucket, object string, err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GCloudBucketRemotegcpStorage.Upload")
+// UploadWsSnapshot takes all files from a local location and uploads it to the remote storage
+func (rs *DirectGCPStorage) UploadWsSnapshot(ctx context.Context, source string, name string, opts ...UploadOption) (bucket, object string, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GCloudBucketRemotegcpStorage.UploadWsSnapshot")
 	defer tracing.FinishSpan(span, &err)
 	log := log.WithFields(log.OWI(rs.Username, rs.WorkspaceName, ""))
 
@@ -303,7 +303,7 @@ func (rs *DirectGCPStorage) Upload(ctx context.Context, source string, name stri
 	}
 
 	// check if we have not yet exceeded the max number of backups
-	if name != DefaultBackup {
+	if name != DefaultWorkspaceBackup {
 		if err = rs.ensureBackupSlotAvailable(); err != nil {
 			return
 		}
@@ -560,7 +560,7 @@ func (rs *DirectGCPStorage) uploadChunk(ctx context.Context, name string, r io.R
 		return
 	}
 
-	log.WithField("name", name).WithField("duration", time.Since(start)).Debug("Upload complete")
+	log.WithField("name", name).WithField("duration", time.Since(start)).Debug("UploadWsSnapshot complete")
 }
 
 func (rs *DirectGCPStorage) deleteChunks(ctx context.Context, chunks []string) (err error) {

--- a/components/content-service/pkg/storage/gcloud_test.go
+++ b/components/content-service/pkg/storage/gcloud_test.go
@@ -19,7 +19,7 @@ func TestObjectAccessToNonExistentObj(t *testing.T) {
 			Stage:         StageDevStaging,
 		},
 	}
-	found, err := storage.Download(context.Background(), "/tmp", "foo")
+	found, err := storage.DownloadLatestWsSnapshot(context.Background(), "/tmp", "foo")
 	if err != nil {
 		t.Errorf("%+v", err)
 	}
@@ -42,29 +42,29 @@ func (rs *objDoesNotExistGCloudStorage) EnsureExists(ctx context.Context) error 
 	return nil
 }
 
-// Download always returns false and does nothing
-func (rs *objDoesNotExistGCloudStorage) Download(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadLatestWsSnapshot always returns false and does nothing
+func (rs *objDoesNotExistGCloudStorage) DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	rs.Delegate.ObjectAccess = func(ctx context.Context, bkt, obj string) (io.ReadCloser, bool, error) {
 		return nil, false, nil
 	}
 
-	return rs.Delegate.Download(ctx, destination, name)
+	return rs.Delegate.DownloadLatestWsSnapshot(ctx, destination, name)
 }
 
-// Download always returns false and does nothing
-func (rs *objDoesNotExistGCloudStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadLatestWsSnapshot always returns false and does nothing
+func (rs *objDoesNotExistGCloudStorage) DownloadWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	rs.Delegate.ObjectAccess = func(ctx context.Context, bkt, obj string) (io.ReadCloser, bool, error) {
 		return nil, false, nil
 	}
 
-	return rs.Delegate.DownloadSnapshot(ctx, destination, name)
+	return rs.Delegate.DownloadWsSnapshot(ctx, destination, name)
 }
 
-func (rs *objDoesNotExistGCloudStorage) Qualify(name string) string {
-	return rs.Delegate.Qualify(name)
+func (rs *objDoesNotExistGCloudStorage) QualifyWsSnapshot(name string) string {
+	return rs.Delegate.QualifyWsSnapshot(name)
 }
 
-// Upload does nothing
-func (rs *objDoesNotExistGCloudStorage) Upload(ctx context.Context, source string, name string, opts ...UploadOption) error {
+// UploadWsSnapshot does nothing
+func (rs *objDoesNotExistGCloudStorage) UploadWsSnapshot(ctx context.Context, source string, name string, opts ...UploadOption) error {
 	return xerrors.Errorf("not supported")
 }

--- a/components/content-service/pkg/storage/namedurl.go
+++ b/components/content-service/pkg/storage/namedurl.go
@@ -16,8 +16,8 @@ type NamedURLDownloader struct {
 	URLs map[string]string
 }
 
-// Download takes the latest state from the remote storage and downloads it to a local path
-func (d *NamedURLDownloader) Download(ctx context.Context, destination string, name string) (found bool, err error) {
+// DownloadLatestWsSnapshot takes the latest state from the remote storage and downloads it to a local path
+func (d *NamedURLDownloader) DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (found bool, err error) {
 	url, found := d.URLs[name]
 	if !found {
 		return false, nil
@@ -48,7 +48,7 @@ func (d *NamedURLDownloader) Download(ctx context.Context, destination string, n
 	return true, nil
 }
 
-// DownloadSnapshot downloads a snapshot.
-func (d *NamedURLDownloader) DownloadSnapshot(ctx context.Context, destination string, name string) (found bool, err error) {
-	return d.Download(ctx, destination, name)
+// DownloadWsSnapshot downloads a snapshot.
+func (d *NamedURLDownloader) DownloadWsSnapshot(ctx context.Context, destination string, name string) (found bool, err error) {
+	return d.DownloadLatestWsSnapshot(ctx, destination, name)
 }

--- a/components/content-service/pkg/storage/noop.go
+++ b/components/content-service/pkg/storage/noop.go
@@ -23,23 +23,23 @@ func (rs *DirectNoopStorage) EnsureExists(ctx context.Context) error {
 	return nil
 }
 
-// Download always returns false and does nothing
-func (rs *DirectNoopStorage) Download(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadLatestWsSnapshot always returns false and does nothing
+func (rs *DirectNoopStorage) DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	return false, nil
 }
 
-// DownloadSnapshot always returns false and does nothing
-func (rs *DirectNoopStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
+// DownloadWsSnapshot always returns false and does nothing
+func (rs *DirectNoopStorage) DownloadWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
 	return false, nil
 }
 
-// Qualify just returns the name
-func (rs *DirectNoopStorage) Qualify(name string) string {
+// QualifyWsSnapshot just returns the name
+func (rs *DirectNoopStorage) QualifyWsSnapshot(name string) string {
 	return name
 }
 
-// Upload does nothing
-func (rs *DirectNoopStorage) Upload(ctx context.Context, source string, name string, opts ...UploadOption) (string, string, error) {
+// UploadWsSnapshot does nothing
+func (rs *DirectNoopStorage) UploadWsSnapshot(ctx context.Context, source string, name string, opts ...UploadOption) (string, string, error) {
 	return "", "", nil
 }
 

--- a/components/content-service/pkg/storage/storage.go
+++ b/components/content-service/pkg/storage/storage.go
@@ -16,11 +16,11 @@ import (
 )
 
 const (
-	// DefaultBackup is the name of the regular backup we upload to remote storage
-	DefaultBackup = "full.tar"
+	// DefaultWorkspaceBackup is the name of the regular backup we upload to remote storage
+	DefaultWorkspaceBackup = "full.tar"
 
-	// DefaultBackupManifest is the name of the manifest of the regular default backup we upload
-	DefaultBackupManifest = "wsfull.json"
+	// DefaultWorkspaceBackupManifest is the name of the manifest of the regular default backup we upload
+	DefaultWorkspaceBackupManifest = "wsfull.json"
 
 	// FmtFullWorkspaceBackup is the format for names of full workspace backups
 	FmtFullWorkspaceBackup = "wsfull-%d.tar"
@@ -66,13 +66,13 @@ type DownloadInfo struct {
 	Size int64
 }
 
-// DirectDownloader downloads a snapshot
+// DirectDownloader downloads an object from storage
 type DirectDownloader interface {
-	// Download takes the latest state from the remote storage and downloads it to a local path
-	Download(ctx context.Context, destination string, name string) (found bool, err error)
+	// DownloadLatestWsSnapshot takes the latest state from the remote storage and downloads it to a local path
+	DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (found bool, err error)
 
-	// Downloads a snapshot. The snapshot name is expected to be one produced by Qualify
-	DownloadSnapshot(ctx context.Context, destination string, name string) (found bool, err error)
+	// DownloadWsSnapshot downloads a snapshot. The snapshot name is expected to be one produced by QualifyWsSnapshot
+	DownloadWsSnapshot(ctx context.Context, destination string, name string) (found bool, err error)
 }
 
 // DirectAccess represents a remote location where we can store data
@@ -87,11 +87,11 @@ type DirectAccess interface {
 	// EnsureExists makes sure that the remote storage location exists and can be up- or downloaded from
 	EnsureExists(ctx context.Context) error
 
-	// Fully qualifies a snapshot name so that it can be downloaded using DownloadSnapshot
-	Qualify(name string) string
+	// Fully qualifies a snapshot name so that it can be downloaded using DownloadWsSnapshot
+	QualifyWsSnapshot(name string) string
 
-	// Upload takes all files from a local location and uploads it to the remote storage
-	Upload(ctx context.Context, source string, name string, options ...UploadOption) (bucket, obj string, err error)
+	// UploadWsSnapshot takes all files from a local location and uploads it to the remote storage
+	UploadWsSnapshot(ctx context.Context, source string, name string, options ...UploadOption) (bucket, obj string, err error)
 }
 
 // UploadOptions configure remote storage upload

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -51,13 +51,13 @@ var (
 func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps storage.PresignedAccess, workspaceOwner string, initializer *csapi.WorkspaceInitializer) (rc map[string]storage.DownloadInfo, err error) {
 	rc = make(map[string]storage.DownloadInfo)
 
-	backup, err := ps.SignDownload(ctx, rs.Bucket(workspaceOwner), rs.BackupObject(storage.DefaultBackup))
+	backup, err := ps.SignDownload(ctx, rs.Bucket(workspaceOwner), rs.BackupObject(storage.DefaultWorkspaceBackup))
 	if err == storage.ErrNotFound {
 		// no backup found - that's fine
 	} else if err != nil {
 		return nil, err
 	} else {
-		rc[storage.DefaultBackup] = *backup
+		rc[storage.DefaultWorkspaceBackup] = *backup
 	}
 
 	if si := initializer.GetSnapshot(); si != nil {
@@ -303,8 +303,8 @@ func (rs *remoteContentStorage) EnsureExists(ctx context.Context) error {
 	return nil
 }
 
-// Download always returns false and does nothing
-func (rs *remoteContentStorage) Download(ctx context.Context, destination string, name string) (exists bool, err error) {
+// DownloadLatestWsSnapshot always returns false and does nothing
+func (rs *remoteContentStorage) DownloadLatestWsSnapshot(ctx context.Context, destination string, name string) (exists bool, err error) {
 	info, exists := rs.RemoteContent[name]
 	if !exists {
 		return false, nil
@@ -328,18 +328,18 @@ func (rs *remoteContentStorage) Download(ctx context.Context, destination string
 	return true, nil
 }
 
-// DownloadSnapshot always returns false and does nothing
-func (rs *remoteContentStorage) DownloadSnapshot(ctx context.Context, destination string, name string) (bool, error) {
-	return rs.Download(ctx, destination, name)
+// DownloadWsSnapshot always returns false and does nothing
+func (rs *remoteContentStorage) DownloadWsSnapshot(ctx context.Context, destination string, name string) (bool, error) {
+	return rs.DownloadLatestWsSnapshot(ctx, destination, name)
 }
 
-// Qualify just returns the name
-func (rs *remoteContentStorage) Qualify(name string) string {
+// QualifyWsSnapshot just returns the name
+func (rs *remoteContentStorage) QualifyWsSnapshot(name string) string {
 	return name
 }
 
-// Upload does nothing
-func (rs *remoteContentStorage) Upload(ctx context.Context, source string, name string, opts ...storage.UploadOption) (string, string, error) {
+// UploadWsSnapshot does nothing
+func (rs *remoteContentStorage) UploadWsSnapshot(ctx context.Context, source string, name string, opts ...storage.UploadOption) (string, string, error) {
 	return "", "", fmt.Errorf("not implemented")
 }
 


### PR DESCRIPTION
In order to distinguish content-service functions that read/write workspace backup files from generic content upload/download functions, this commit makes the names of the workspace backup functions more explicit, e.g. `DownloadLatestWsSnapshot` instead of `Download`.