### PR TITLE
Implement automatic regeneration of AWS ECR tokens

### DIFF
--- a/install/aws-full-terraform/modules/registry/templates/regenerate-ecr.tpl
+++ b/install/aws-full-terraform/modules/registry/templates/regenerate-ecr.tpl
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Set the AWS auth environment variables
+AWS_DEFAULT_REGION=${region}
+AWS_SECRET_ACCESS_KEY=${secret_key}
+AWS_ACCESS_KEY_ID=${access_key}
+
+# Generate the auth token from the aws account 
+TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken'`
+
+# Delete the original secret
+kubectl delete secret --ignore-not-found ${secret_name}
+
+# Generate the new docker registry auth config
+CONFIGJSON='{"auths": {"%s": {"auth": "%s"}}}\n'
+UPDATEDCONFIG=$(printf "$CONFIGJSON" "${host}" "$TOKEN")
+echo $UPDATEDCONFIG > /tmp/config.json
+
+# Create a new kubernetes secret with the updated auth token
+kubectl create secret generic ${secret_name} \
+    --from-file=.dockerconfigjson=/tmp/config.json \
+    --type=kubernetes.io/dockerconfigjson
+
+# Update the default service account
+kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"'${secret_name}'"}]}'
+
+echo "Token regeneration complete"

--- a/install/aws-terraform/modules/registry/main.tf
+++ b/install/aws-terraform/modules/registry/main.tf
@@ -106,3 +106,57 @@ data "template_file" "gitpod_registry_values" {
     secret_name = local.secret_name
   }
 }
+
+esource "aws_iam_user" "gitpod_registry" {
+  name = "${var.project.name}-registry"
+
+  tags = {
+    project = var.project.name
+  }
+}
+
+resource "aws_iam_access_key" "gitpod_registry" {
+  user = aws_iam_user.gitpod_registry.name
+}
+
+data "template_file" "ecr_regeneration_script" {
+    template = file("${path.module}/template/regenerate-ecr.tpl")
+    vars = {
+        host = "${aws_ecr_repository.gitpod_registry.registry_id}.dkr.ecr.${var.region}.amazonaws.com"
+        secret_name = local.secret_name
+        region = var.region
+        access_key = aws_iam_access_key.gitpod_registry.id
+        secret_key = aws_iam_access_key.gitpod_registry.secret
+    }
+}
+
+resource "kubernetes_cron_job" "ecr_regeneration_cron" {
+  metadata {
+    name = "ecr_regeneration_cron"
+  }
+  spec {
+    concurrency_policy            = "Allow"
+    failed_jobs_history_limit     = 1
+    schedule                      = "0 */6 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 3
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "ecr-cred-helper"
+              image   = "odaniait/aws-kubectl:latest"
+              command = ["/bin/sh", "-c", data.template_file.ecr_regeneration_script.rendered]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/install/aws-terraform/modules/registry/templates/regenerate-ecr.tpl
+++ b/install/aws-terraform/modules/registry/templates/regenerate-ecr.tpl
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Set the AWS auth environment variables
+AWS_DEFAULT_REGION=${region}
+AWS_SECRET_ACCESS_KEY=${secret_key}
+AWS_ACCESS_KEY_ID=${access_key}
+
+# Generate the auth token from the aws account 
+TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken'`
+
+# Delete the original secret
+kubectl delete secret --ignore-not-found ${secret_name}
+
+# Generate the new docker registry auth config
+CONFIGJSON='{"auths": {"%s": {"auth": "%s"}}}\n'
+UPDATEDCONFIG=$(printf "$CONFIGJSON" "${host}" "$TOKEN")
+echo $UPDATEDCONFIG > /tmp/config.json
+
+# Create a new kubernetes secret with the updated auth token
+kubectl create secret generic ${secret_name} \
+    --from-file=.dockerconfigjson=/tmp/config.json \
+    --type=kubernetes.io/dockerconfigjson
+
+# Update the default service account
+kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"'${secret_name}'"}]}'
+
+echo "Token regeneration complete"


### PR DESCRIPTION
This PR contains a mechanism for regeneration of AWS ECR tokens to evade their expiry after 12 hours.
Earlier this was a manual task, that required manual deletion of secret, fetching the new token and again creating a secret. For this process, a Kubernetes cron job resource has been added. It runs a script containing the above instructions after 6 hours.

For configuring the aws-cli within the pod, the given aws iam user credentials are used from the terraform resources.

Suggestions are welcome for this implementation.

Fixes #1900 