### PR TITLE
Remove deprecated config from terraform kubernetes provider

### DIFF
--- a/install/aws-full-terraform/providers.tf
+++ b/install/aws-full-terraform/providers.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.gitpod_cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.gitpod_cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.default.token
-  load_config_file       = false
 }
 
 provider "helm" {

--- a/install/aws-terraform/providers.tf
+++ b/install/aws-terraform/providers.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.gitpod_cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.gitpod_cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.default.token
-  load_config_file       = false
 }
 
 provider "helm" {


### PR DESCRIPTION
This PR removes the deprecated `load_config_file` attribute from the Terraform Kubernetes provider.