### PR TITLE
default to code in feature preview

### DIFF
--- a/components/dashboard/src/components/feature-settings.tsx
+++ b/components/dashboard/src/components/feature-settings.tsx
@@ -49,6 +49,13 @@ export class FeatureSettings extends React.Component<FeatureSettingsProps> {
     private updateFeatureFlags = () => {
         const additionalData = (this.props.user.additionalData || {});
         additionalData.featurePreview = !this.featurePreview;
+        if (additionalData.featurePreview) {
+            const settings = additionalData.ideSettings || {};
+            if (!('defaultIde' in settings)) {
+                settings.defaultIde = 'code';
+            }
+            additionalData.ideSettings = settings;
+        }
         this.props.onChange({ additionalData });
     };
 


### PR DESCRIPTION
#### What it does

fix #2801: Sets Code as a default if a user enables feature preview.

#### How to test

- Enable feature preview and check that Code is selected. You can also start a workspace to verify.
- Switch toggle to Theia and check that Theia is actually used.