### PR TITLE
[dashboard] add career tip

### DIFF
--- a/components/dashboard/src/components/productivity-tips.tsx
+++ b/components/dashboard/src/components/productivity-tips.tsx
@@ -50,7 +50,7 @@ const tips = [
     <span>See more tips &amp; tricks <a href="https://www.gitpod.io/docs/tips-and-tricks/" target="_blank" rel="noopener">here</a>.</span>,
     <span>Please submit bugs and feature requests <a href="https://github.com/gitpod-io/gitpod/issues" target="_blank" rel="noopener noreferrer">on GitHub</a>.</span>,
     <span>Install any VS Code extension with a simple drag-and-drop. <a href="https://www.gitpod.io/docs/vscode-extensions/" target="_blank" rel="noopener">See how</a>.</span>,
-    <span>Wanna help make Gitpod better? Check out the <a href="https://www.gitpod.io/careers/" target="_blank" rel="noopener">open positions</a> and apply right now!</span>,
+    <span>Wanna help make Gitpod better? <a href="https://www.gitpod.io/careers/" target="_blank" rel="noopener">Join our team </a>!</span>,
 ];
 
 export class ProductivityTips extends React.Component<{userHasCreatedWorkspaces?: boolean}, { platform?: UserPlatform }> {

--- a/components/dashboard/src/components/productivity-tips.tsx
+++ b/components/dashboard/src/components/productivity-tips.tsx
@@ -49,7 +49,8 @@ const tips = [
     <span>Check <a href="https://www.gitpod.io/docs/" target="_blank" rel="noopener">www.gitpod.io/docs/</a> to learn more.</span>,
     <span>See more tips &amp; tricks <a href="https://www.gitpod.io/docs/tips-and-tricks/" target="_blank" rel="noopener">here</a>.</span>,
     <span>Please submit bugs and feature requests <a href="https://github.com/gitpod-io/gitpod/issues" target="_blank" rel="noopener noreferrer">on GitHub</a>.</span>,
-    <span>Install any VS Code extension with a simple drag-and-drop. <a href="https://www.gitpod.io/docs/vscode-extensions/" target="_blank" rel="noopener">See how</a>.</span>
+    <span>Install any VS Code extension with a simple drag-and-drop. <a href="https://www.gitpod.io/docs/vscode-extensions/" target="_blank" rel="noopener">See how</a>.</span>,
+    <span>Wanna help make Gitpod better? Check out the <a href="https://www.gitpod.io/careers/" target="_blank" rel="noopener">open positions</a> and apply right now!</span>,
 ];
 
 export class ProductivityTips extends React.Component<{userHasCreatedWorkspaces?: boolean}, { platform?: UserPlatform }> {


### PR DESCRIPTION
This PR adds a productivity tip (things we randomly show users during the loading screen, if they have installed the browser extension):
> Wanna help make Gitpod better? Check out the [open positions](https://www.gitpod.io/careers/) and apply right now!</span>