### PR TITLE
[terraform,AWS] removed output resources

### DIFF
--- a/install/aws-terraform/modules/gitpod/main.tf
+++ b/install/aws-terraform/modules/gitpod/main.tf
@@ -21,20 +21,3 @@ resource "helm_release" "gitpod" {
   ])
 
 }
-
-#
-# Kubernetes Resources
-#
-
-# To get the external load balancer IP
-# https://www.terraform.io/docs/providers/kubernetes/d/service.html
-data "kubernetes_service" "proxy" {
-  metadata {
-    name      = "proxy"
-    namespace = helm_release.gitpod.namespace
-  }
-
-  depends_on = [
-    helm_release.gitpod
-  ]
-}

--- a/install/aws-terraform/modules/gitpod/output.tf
+++ b/install/aws-terraform/modules/gitpod/output.tf
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
- * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
- */
-
-output "external_dns" {
-  value = data.kubernetes_service.proxy.load_balancer_ingress.0.hostname
-}

--- a/install/aws-terraform/output.tf
+++ b/install/aws-terraform/output.tf
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
- * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
- */
-
-output "ingress_hostname" {
-  value = module.gitpod.external_dns
-}


### PR DESCRIPTION
This removes the output resources from the AWS installer script as it causes errors during werft deployments. To fix it in the future a AWS loadbalancer has to be created and linked to the service deployment of the `proxy`.