### PR TITLE
Allow configuration of GitLab with Relative URLs

### DIFF
--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -144,7 +144,7 @@ export class AuthProviderService {
     protected callbackUrl = (host: string) => {
         const pathname = `/auth/${host}/callback`;
         if (this.env.devBranch) {
-            // for example: https://staging.gitpod-dev.com/auth/gitlab.com/callback
+            // for example: https://staging.gitpod-dev.com/auth/mydomain.com/gitlab/callback
             return this.env.hostUrl.withoutDomainPrefix(1).with({ pathname }).toString();
         }
         return this.env.hostUrl.with({ pathname }).toString();

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1480,7 +1480,11 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     }
 
     // from https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address/106223#106223
-    protected validHostNameRegexp = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+    // adapted to allow for hostnames
+    //   from [foo.bar] pumped up to [foo.(foo.)bar]
+    // and also for a trailing path segments
+    //   for example [foo.bar/gitlab]
+    protected validHostNameRegexp = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(\/([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]))?$/;
 
     async updateOwnAuthProvider({ entry }: GitpodServer.UpdateOwnAuthProviderParams): Promise<void> {
         let userId: string;

--- a/components/theia/packages/gitpod-extension/src/browser/gitpod-git-token-provider.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/gitpod-git-token-provider.ts
@@ -61,7 +61,13 @@ export class GitpodGitTokenProvider {
     async getGitToken(params: GetGitTokenParams): Promise<GetGitTokenResult> {
         const validationParams: TokenValidationParams = { ...params };
 
-        const token = await this.getTokenFromServer(params.host);
+        let token = await this.getTokenFromServer(params.host);
+        if (!token && params.repoURL) {
+            const url = new URL(params.repoURL);
+            const pathSegments = url.pathname.split("/");
+            const hostAndPath = `${url.host}/${pathSegments[0] || pathSegments[1]}`;
+            token = await this.getTokenFromServer(hostAndPath);
+        }
         if (token) {
             const tokenUser = token.username || "oauth2";
             // if required scopes are missing, we can validate async


### PR DESCRIPTION
Adding self-hosted GitLab with relative URLs does work 🎉 

Manually cloning a repository and pushing changes back works as well.

<img width="1098" alt="Screen Shot 2021-01-28 at 08 37 42" src="https://user-images.githubusercontent.com/914497/106105332-1d2b9d00-6144-11eb-84cc-4812b079409a.png">

Also, the parser is adapted to support starting workspaces for such URLs.

<img width="1288" alt="Screen Shot 2021-01-29 at 08 48 32" src="https://user-images.githubusercontent.com/914497/106246775-f1291e00-620e-11eb-8799-c1f90a1e6bac.png">
