### PR TITLE
Stop moving provider identities between account of a user

### DIFF
--- a/components/dashboard/public/select-account/index.html
+++ b/components/dashboard/public/select-account/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--
+ Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="user-scalable=0, initial-scale=1, minimum-scale=1, width=device-width, height=device-height">
+    <!-- PWA primary color -->
+    <meta name="theme-color" content="#000000">
+    <link rel="manifest" href="/manifest.json">
+    <link rel="apple-touch-icon" type="image/png" href="/images/apple-touch-icon.png" sizes="180x180"/>
+    <link rel="icon" type="image/png" href="/images/gitpod-196x196.png" sizes="196x196"/>
+    <link rel="icon" type="image/svg+xml" href="/images/gitpod.svg" sizes="any"/>
+    <link rel="stylesheet" href="/styles.css"/>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Montserrat" />
+    <title>Select An Account - Gitpod</title>
+    <meta name="description" content="Describe your dev environment as code and get fully prebuilt, ready-to-code development environments for any GitLab, GitHub, and Bitbucket project.">
+    <meta name="keywords" content="dev environment, development environment, devops, cloud ide, github ide, gitlab ide, javascript, online ide, web ide, code review">
+  </head>
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <script crossorigin="anonymous" src="/libs/moment.min.js"></script>
+    <script crossorigin="anonymous" src="/libs/react.production.min.js"></script>
+    <script crossorigin="anonymous" src="/libs/react-dom.production.min.js"></script>
+    <script src="/select-account.js"></script>
+  </body>
+</html>

--- a/components/dashboard/public/styles.css
+++ b/components/dashboard/public/styles.css
@@ -826,7 +826,6 @@ footer .logo-icon {
 
 
 .access-control__card-container {
-    width: 31%;
     min-width: 300px;
     margin-bottom: 30px !important;
 }

--- a/components/dashboard/src/components/tos/terms-of-service.tsx
+++ b/components/dashboard/src/components/tos/terms-of-service.tsx
@@ -79,10 +79,14 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
 
     protected actionUrl = this.gitpodHost.withApi({ pathname: '/tos/proceed' }).toString();
     render() {
-        const content = this.renderMd(this.state.terms?.content);
         const acceptsTos = this.state.acceptsTos;
-        const updateMessage = this.renderMd(this.state.terms?.updateMessage);
         const update = this.state.isUpdate;
+
+        let tosContentRendered = this.renderMd(update ? this.state.terms?.updateMessage : this.state.terms?.content);
+
+        if (!update && this.state.userInfo?.authHost) {
+            tosContentRendered = tosContentRendered.replace("{{AUTH_HOST}}", this.state.userInfo?.authHost);
+        }
 
         let userSection: JSX.Element = <div></div>;
         if (this.state.userInfo) {
@@ -133,7 +137,7 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
                     <form ref={this.formRef} action={this.actionUrl} method="post" id="accept-tos-form">
                         <input type="hidden" id="flowId" name="flowId" value={this.state.flowId} />
                         <div className="tos-checks">
-                            <Typography className="tos-content" dangerouslySetInnerHTML={{ __html: update ? updateMessage : content }} />
+                            <Typography className="tos-content" dangerouslySetInnerHTML={{ __html: tosContentRendered }} />
                             <p>
                                 <label style={{ display: 'none', alignItems: 'center' }}>
                                     <Checkbox

--- a/components/dashboard/src/components/tos/terms-of-service.tsx
+++ b/components/dashboard/src/components/tos/terms-of-service.tsx
@@ -25,9 +25,11 @@ export interface TermsOfServiceProps {
 }
 interface TermsOfServiceState {
     isUpdate: boolean;
+    flowId: string;
     userInfo?: any;
     terms?: Terms;
     acceptsTos: boolean;
+    submitted: boolean;
 }
 export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOfServiceState> {
     protected gitpodHost = new GitpodHostUrl(window.location.href);
@@ -38,7 +40,9 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
         super(props);
         this.state = {
             isUpdate: false,
-            acceptsTos: false
+            acceptsTos: false,
+            submitted: false,
+            flowId: "ignore",
         };
         this.formRef = React.createRef();
         this.onDecline = this.onDecline.bind(this);
@@ -53,6 +57,7 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
         const tosHints = Cookies.getJSON('tosHints');
         this.setState({
             isUpdate: tosHints?.isUpdate === true,
+            flowId: typeof tosHints?.flowId === "string" ? tosHints?.flowId : this.state.flowId,
             userInfo: typeof tosHints?.userInfo === "object" ? tosHints?.userInfo : undefined
         });
         this.props.terms.then(terms => this.setState({ terms }));
@@ -63,10 +68,10 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
     }
 
     onAccept() {
-        this.setState({ acceptsTos: true }, () => this.doSubmit());
+        this.setState({ acceptsTos: true, submitted: true }, () => this.doSubmit());
     }
     onDecline() {
-        this.setState({ acceptsTos: false }, () => this.doSubmit());
+        this.setState({ acceptsTos: false, submitted: true }, () => this.doSubmit());
     }
     protected doSubmit() {
         this.formRef.current!.submit();
@@ -126,6 +131,7 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
                 </AppBar>
                 <div className='content content-area'>
                     <form ref={this.formRef} action={this.actionUrl} method="post" id="accept-tos-form">
+                        <input type="hidden" id="flowId" name="flowId" value={this.state.flowId} />
                         <div className="tos-checks">
                             <Typography className="tos-content" dangerouslySetInnerHTML={{ __html: update ? updateMessage : content }} />
                             <p>
@@ -148,6 +154,7 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
                                     variant='text'
                                     color={'secondary'}
                                     onClick={this.onDecline}
+                                    disabled={this.state.submitted}
                                     data-testid="decline">
                                     {'Decline and log out'}
                                 </ButtonWithProgress>
@@ -155,6 +162,7 @@ export class TermsOfService extends React.Component<TermsOfServiceProps, TermsOf
                             <ButtonWithProgress
                                 className='button'
                                 onClick={this.onAccept}
+                                disabled={this.state.submitted}
                                 variant='outlined'
                                 color={'primary'}
                                 data-testid="submit">

--- a/components/dashboard/src/select-account.tsx
+++ b/components/dashboard/src/select-account.tsx
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import "reflect-metadata";
+import * as React from 'react';
+import * as Cookies from 'js-cookie';
+
+import { createGitpodService } from './service-factory';
+import { ApplicationFrame } from "./components/page-frame";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
+
+import Avatar from "@material-ui/core/Avatar";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import { ButtonWithProgress } from "./components/button-with-progress";
+
+import { renderEntrypoint } from "./entrypoint";
+
+const service = createGitpodService();
+const accountHints = (() => {
+    try {
+        const cookie = Cookies.getJSON('SelectAccountCookie');
+        if (SelectAccountPayload.is(cookie)) {
+            return cookie;
+        }
+    } catch (error) {
+        console.log(error);
+    }
+    return undefined;
+})();
+
+export class ProceedWithAccount extends React.Component<{}, {}> {
+
+    render() {
+        if (!accountHints) {
+            // this is only expected to happen if someone goes back in browser history.
+            // in such cases we've nothing to show here, thus redirecting to /access-control
+            window.location.href = new GitpodHostUrl(window.location.href).asAccessControl().toString();
+
+            return (
+                <ApplicationFrame service={service}>
+                    <h3>Cookie 🍪 not found</h3>
+                    <h2>Redirecting to Access Control...</h2>
+                </ApplicationFrame>
+            );
+        }
+        const { currentUser, otherUser } = accountHints;
+
+        const accessControlUrl = new GitpodHostUrl(window.location.href).asAccessControl().toString();
+
+        const loginUrl = new GitpodHostUrl(window.location.href).withApi({
+            pathname: '/login/',
+            search: `host=${otherUser.authHost}&returnTo=${encodeURIComponent(accessControlUrl)}`
+        }).toString();
+
+        const logoutUrl = new GitpodHostUrl(window.location.toString()).withApi({
+            pathname: "/logout",
+            search: `returnTo=${encodeURIComponent(loginUrl)}`
+        }).toString();
+
+        const onGoBackClicked = () => {
+            window.location.href = accessControlUrl;
+        };
+        const onSwitchAccountsClicked = () => {
+            window.location.href = logoutUrl;
+        };
+
+        return (
+            <ApplicationFrame service={service}>
+                <div className='content content-area'>
+
+                    <h3 style={{ textAlign: "center" }}>Select An Account</h3>
+
+                    <Typography component="p" style={{ textAlign: "center", fontSize: "110%", marginTop: "50px" }}>
+                        You are attempting to authorize a provider that is already connected with your other account on Gitpod.
+                        <br />
+                        Please switch to the other account or disconnect the provider from your current account in Access Control.
+                    </Typography>
+
+                    <div style={{ display: "flex", marginTop: "50px", width: "100%" }}>
+                        <div style={{ flex: "50%" }}>
+                            <div style={{
+                                width: "300px",
+                                margin: "0 20px 0 auto"
+                            }}>
+                                <Typography component="p" style={{ textAlign: "center", padding: "20px", fontSize: "110%" }}>
+                                    Current account
+                                </Typography>
+                                <Card>
+                                    <CardContent
+                                        style={{
+                                            textAlign: "center"
+                                        }}
+                                    >
+                                        <div>
+                                            <Avatar
+                                                style={{
+                                                    margin: "40px auto 40px",
+                                                    width: 110,
+                                                    height: 110
+                                                }}
+                                                alt={currentUser.name} src={currentUser.avatarUrl}
+                                            />
+                                            <Typography component="p" style={{ textAlign: "center", padding: "20px", fontSize: "110%" }}>
+                                                Connected as <strong>@{currentUser.authName}</strong>
+                                                <br />
+                                                from <strong>{currentUser.authHost}</strong>
+                                            </Typography>
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            </div>
+                        </div>
+                        <div style={{ flex: "50%" }}>
+                            <div style={{
+                                width: "300px",
+                                margin: "0 auto 0 20px"
+                            }}>
+                                <Typography component="p" style={{ textAlign: "center", padding: "20px", fontSize: "110%" }}>
+                                    Other account
+                                </Typography>
+                                <Card>
+                                    <CardContent
+                                        style={{
+                                            textAlign: "center"
+                                        }}
+                                    >
+                                        <div>
+                                            <Avatar
+                                                style={{
+                                                    margin: "40px auto 40px",
+                                                    width: 110,
+                                                    height: 110
+                                                }}
+                                                alt={otherUser.name} src={otherUser.avatarUrl}
+                                            />
+                                            <Typography component="p" style={{ textAlign: "center", padding: "20px", fontSize: "110%" }}>
+                                                Connected as <strong>@{otherUser.authName}</strong>
+                                                <br />
+                                                from <strong>{otherUser.authHost}</strong>
+                                            </Typography>
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div style={{ marginTop: "100px", textAlign: "center" }}>
+                        <ButtonWithProgress
+                            className='button'
+                            onClick={onGoBackClicked}
+                            variant='outlined'
+                            color={'primary'}>
+                            {'Back To Access Control'}
+                        </ButtonWithProgress>
+
+                        <ButtonWithProgress
+                            style={{ marginLeft: "20px" }}
+                            className='button'
+                            onClick={onSwitchAccountsClicked}
+                            variant='outlined'
+                            color={'secondary'}>
+                            {'Switch To Your Other Account'}
+                        </ButtonWithProgress>
+                    </div>
+
+                </div>
+            </ApplicationFrame>
+        );
+    }
+
+}
+
+renderEntrypoint(ProceedWithAccount);

--- a/components/dashboard/webpack.entrypoints.js
+++ b/components/dashboard/webpack.entrypoints.js
@@ -12,6 +12,7 @@ module.exports = function entrypoints(srcPath, eeSrcPath, isOSSBuild) {
         'create-workspace-from-ref': `${srcPath}/create-workspace-from-ref.tsx`,
         '404': `${srcPath}/404.tsx`,
         'sorry': `${srcPath}/sorry.tsx`,
+        'select-account': `${srcPath}/select-account.tsx`,
         'blocked': `${srcPath}/blocked.tsx`,
         'bootanimation': `${srcPath}/bootanimation.ts`,
         'access-control': `${srcPath}/access-control.tsx`,

--- a/components/gitpod-protocol/src/auth.ts
+++ b/components/gitpod-protocol/src/auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export interface SelectAccountPayload {
+    currentUser: {
+        name: string;
+        avatarUrl: string;
+        authHost: string;
+        authName: string;
+        authProviderType: string;
+    },
+    otherUser: {
+        name: string;
+        avatarUrl: string;
+        authHost: string;
+        authName: string;
+        authProviderType: string;
+    }
+}
+export namespace SelectAccountPayload {
+    export function is(data: any): data is SelectAccountPayload {
+        return typeof data === "object" && "currentUser" in data && "otherUser" in data;
+    }
+}

--- a/components/server/src/auth/errors.ts
+++ b/components/server/src/auth/errors.ts
@@ -5,6 +5,7 @@
  */
 
 import { Identity } from "@gitpod/gitpod-protocol";
+import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 
 export interface TosNotAcceptedYetException extends Error {
     readonly identity: Identity;
@@ -50,6 +51,19 @@ export namespace UnconfirmedUserException {
         return AuthException.create(type, message, payload);
     }
     export function is(error: any): error is UnconfirmedUserException {
+        return AuthException.is(error) && error.authException === type;
+    }
+}
+
+export interface SelectAccountException extends AuthException {
+    payload: SelectAccountPayload;
+}
+export namespace SelectAccountException {
+    const type = "SelectAccountException";
+    export function create(message: string, payload: SelectAccountPayload) {
+        return AuthException.create(type, message, payload);
+    }
+    export function is(error: any): error is SelectAccountException {
         return AuthException.is(error) && error.authException === type;
     }
 }

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -17,8 +17,9 @@ import { format as formatURL, URL } from 'url';
 import { runInNewContext } from "vm";
 import { AuthFlow, AuthProvider } from "../auth/auth-provider";
 import { AuthProviderParams, AuthUserSetup } from "../auth/auth-provider";
-import { AuthException } from "../auth/errors";
-import { GitpodCookie } from "../auth/gitpod-cookie";
+import { AuthException, SelectAccountException } from "../auth/errors";
+import { GitpodCookie } from "./gitpod-cookie";
+import { SelectAccountCookie } from "../user/select-account-cookie";
 import { Env } from "../env";
 import { getRequestingClientInfo } from "../express-util";
 import { TokenProvider } from '../user/token-provider';
@@ -63,6 +64,7 @@ export class GenericAuthProvider implements AuthProvider {
     @inject(UserDB) protected userDb: UserDB;
     @inject(Env) protected env: Env;
     @inject(GitpodCookie) protected gitpodCookie: GitpodCookie;
+    @inject(SelectAccountCookie) protected selectAccountCookie: SelectAccountCookie;
     @inject(UserService) protected readonly userService: UserService;
     @inject(AuthProviderService) protected readonly authProviderService: AuthProviderService;
     @inject(LoginCompletionHandler) protected readonly loginCompletionHandler: LoginCompletionHandler;
@@ -336,6 +338,13 @@ export class GenericAuthProvider implements AuthProvider {
             await AuthFlow.clear(request.session);
             await TosFlow.clear(request.session);
 
+            if (SelectAccountException.is(err)) {
+                this.selectAccountCookie.set(response, err.payload);
+                const url = this.env.hostUrl.with({ pathname: '/select-account' }).toString();
+                response.redirect(url);
+                return;
+            }
+
             let message = 'Authorization failed. Please try again.';
             if (AuthException.is(err)) {
                 message = `Login was interrupted: ${err.message}`;
@@ -352,12 +361,6 @@ export class GenericAuthProvider implements AuthProvider {
         }
 
         if (flowContext) {
-
-            if (TosFlow.WithIdentity.is(flowContext)) {
-                if (User.is(request.user)) {
-                    log.error(context, `(${strategyName}) Invariant violated. Unexpected user.`, { ...defaultLogPayload, ...defaultLogPayload });
-                }
-            }
 
             if (TosFlow.WithIdentity.is(flowContext) || (TosFlow.WithUser.is(flowContext) && flowContext.termsAcceptanceRequired)) {
 
@@ -400,8 +403,6 @@ export class GenericAuthProvider implements AuthProvider {
         let currentGitpodUser: User | undefined = User.is(req.user) ? req.user : undefined;
         let candidate: Identity;
 
-        const isIdentityLinked = (user: User, candidate: Identity) => user.identities.some(i => Identity.equals(i, candidate));
-
         try {
             const tokenResponseObject = this.ensureIsObject(tokenResponse);
             const { authUser, currentScopes, envVars } = await this.fetchAuthUserSetup(accessToken, tokenResponseObject);
@@ -410,15 +411,19 @@ export class GenericAuthProvider implements AuthProvider {
 
             log.info(`(${strategyName}) Verify function called for ${authName}`, { ...defaultLogPayload, authUser });
 
-            if (currentGitpodUser) { // user is already logged in
-                if (!isIdentityLinked(currentGitpodUser, candidate)) {
-                    const userWithSameIdentity = await this.userService.findUserForLogin({ candidate });
-                    if (userWithSameIdentity) {
-                        // another Gitpod user is linked with this identity, this will change on completion, we're logging this action.
-                        log.info(`(${strategyName}) Moving identity to the current Gitpod user.`, { ...defaultLogPayload, authUser, candidate, currentGitpodUser, userWithSameIdentity, clientInfo });
-                    }
+            if (currentGitpodUser) {
+                // user is already logged in
+
+                // we need to check current provider authorizations first...
+                try {
+                    await this.userService.asserNoTwinAccount(currentGitpodUser, this.host, this.authProviderId, candidate);
+                } catch (error) {
+                    log.warn(`User is trying to connect a provider identity twice.`, { ...defaultLogPayload, authUser, candidate, currentGitpodUser: User.censor(currentGitpodUser), clientInfo });
+                    done(error, undefined);
+                    return;
                 }
-            } else { // no user session, login
+            } else {
+                // no user session present, let's initiate a login
                 currentGitpodUser = await this.userService.findUserForLogin({ candidate, primaryEmail });
             }
 

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -453,6 +453,7 @@ export class GenericAuthProvider implements AuthProvider {
                     envVars,
                     additionalIdentity: githubIdentity,
                     additionalToken: githubToken,
+                    authHost: this.host,
                     isBlocked
                 }
             }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -68,6 +68,7 @@ import { MonitoringEndpointsApp } from './monitoring-endpoints';
 import { BearerAuth } from './auth/bearer-authenticator';
 import { TermsProvider } from './terms/terms-provider';
 import { TosCookie } from './user/tos-cookie';
+import { SelectAccountCookie } from './user/select-account-cookie';
 import { BlobServiceClient } from '@gitpod/content-service/lib/blobs_grpc_pb';
 import * as grpc from "grpc";
 
@@ -86,6 +87,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(LoginCompletionHandler).toSelf().inSingletonScope();
     bind(GitpodCookie).toSelf().inSingletonScope();
     bind(TosCookie).toSelf().inSingletonScope();
+    bind(SelectAccountCookie).toSelf().inSingletonScope();
 
     bind(SessionHandlerProvider).toSelf().inSingletonScope();
     bind(Server).toSelf().inSingletonScope();

--- a/components/server/src/terms/terms-provider.ts
+++ b/components/server/src/terms/terms-provider.ts
@@ -21,11 +21,11 @@ const currentTerms: Terms = {
     updateMessage: `
 # Terms and Conditions Update
 
-Read the updated [terms](https://www.gitpod.io/self-hosted-terms/) online.
+Read the updated [terms](https://www.gitpod.io/self-hosted-terms/).
 `,
     content: `
-# Before we proceed
+# Create a new Gitpod account with {{AUTH_HOST}}
 
-Read the [terms](https://www.gitpod.io/self-hosted-terms/) online.
+Before we proceed, please read and accept the [terms](https://www.gitpod.io/self-hosted-terms/).
 `
 }

--- a/components/server/src/terms/tos-flow.ts
+++ b/components/server/src/terms/tos-flow.ts
@@ -10,8 +10,10 @@ import { saveSession } from "../express-util";
 
 
 export interface TosFlow {
+    flowId?: string;
     termsAcceptanceRequired?: boolean;
     isBlocked?: boolean;
+    authHost?: string;
 }
 export namespace TosFlow {
     export function is(data?: any): data is TosFlow {
@@ -33,7 +35,6 @@ export namespace TosFlow {
     export interface WithUser extends TosFlow {
         user: User;
         elevateScopes?: string[] | undefined;
-        authHost?: string;
         returnToUrl?: string;
     }
     export namespace WithUser {

--- a/components/server/src/user/select-account-cookie.ts
+++ b/components/server/src/user/select-account-cookie.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as express from 'express';
+import { injectable, inject } from 'inversify';
+import { Env } from '../env';
+
+@injectable()
+export class SelectAccountCookie {
+    @inject(Env) protected readonly env: Env;
+
+    set(res: express.Response, hints: object) {
+        if (res.headersSent) {
+            return;
+        }
+        res.cookie("SelectAccountCookie", JSON.stringify(hints), {
+            httpOnly: false, // we need this hint on frontend
+            domain: `${this.env.hostUrl.url.host}`,
+            maxAge: 5 * 60 * 1000 /* ms */
+        });
+    }
+
+    unset(res: express.Response) {
+        if (res.headersSent) {
+            return;
+        }
+        res.clearCookie('SelectAccountCookie', {
+            path: "/",
+            domain: `.${this.env.hostUrl.url.host}`
+        });
+    }
+}

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -95,6 +95,14 @@ export class UserController {
             this.ensureSafeReturnToParam(req);
             this.authenticator.authorize(req, res, next);
         });
+        router.get("/deauthorize", (req: express.Request, res: express.Response, next: express.NextFunction) => {
+            if (!User.is(req.user)) {
+                res.sendStatus(401);
+                return;
+            }
+            this.ensureSafeReturnToParam(req);
+            this.authenticator.deauthorize(req, res, next);
+        });
         const branding = this.env.brandingConfig;
         router.get("/logout", async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             const logContext = LogContext.from({ user: req.user, request: req });
@@ -324,9 +332,12 @@ export class UserController {
         });
         const tosFlowUserInfo = (tosFlowInfo: TosFlow) => {
             if (TosFlow.WithIdentity.is(tosFlowInfo)) {
+                tosFlowInfo.authUser.authName
                 return {
                     name: tosFlowInfo.authUser.name || tosFlowInfo.authUser.authName,
-                    avatarUrl: tosFlowInfo.authUser.avatarUrl
+                    avatarUrl: tosFlowInfo.authUser.avatarUrl,
+                    authHost: tosFlowInfo.authHost,
+                    authName: tosFlowInfo.authUser.authName,
                 }
             }
             if (TosFlow.WithUser.is(tosFlowInfo)) {


### PR DESCRIPTION
With these change Gitpod stops moving identities between accounts of a user.

# What's inside?

## Access Control

On /access-control you now see the provider identity you've connected with, and you get the option to disconnect. 

<img width="1145" alt="Screen Shot 2021-01-27 at 13 24 06" src="https://user-images.githubusercontent.com/914497/105998300-c58e2280-60ac-11eb-9151-f7688062d6aa.png">

Confirm disconnecting a provider from your account:

<img width="567" alt="Screen Shot 2021-01-27 at 13 24 22" src="https://user-images.githubusercontent.com/914497/105998457-f40bfd80-60ac-11eb-8c48-fbc989e849d3.png">

Last (or the single) provider identity is a special one, and account deletion sounds is the way how to proceed, otherwise we end up with unreachable accounts.

<img width="688" alt="Screen Shot 2021-01-27 at 13 24 33" src="https://user-images.githubusercontent.com/914497/105998532-071ecd80-60ad-11eb-8ea4-c76486d86192.png">

## Instead of moving provider identities between accounts.

Let's guide the user, and give them the options to select and manage accounts. 

When we see that a provider identity is connected to a second account, we provide as much details as ~possible~necessary to let them decide on the next step.
  * in case it wasn't clear that two accounts were created, we provide names to these provider identities
  * in general we encourage to review the accounts and decide on a main account to proceed with, i.e. disconnect from providers or even let accounts go, if they aren't wanted.

<img width="1146" alt="Screen Shot 2021-01-29 at 12 44 56" src="https://user-images.githubusercontent.com/914497/106271473-de731100-622f-11eb-9860-e5d65a27cdb0.png">
