### PR TITLE
Redirect to www. if 404 Not Found

### DIFF
--- a/chart/config/proxy/lib.locations.conf
+++ b/chart/config/proxy/lib.locations.conf
@@ -43,8 +43,19 @@ location / {
     add_header "Last-Modified" "";
 
     proxy_pass http://dashboard$request_uri;
+
+    # # Page Not Found
+    # Let's redirect the browser agent to the web app, if no resources are found in the locations specified here.
+    # 
+    # This is derived from the issue https://github.com/gitpod-io/gitpod/issues/2659, which
+    # was appearently caused by Twitter's link shortening. So, if the leading www is missing
+    # in the URL by accident, we will redirect to the web on 404 – Not Found.
+    error_page 404 @error_404_dashboard;
 }
 
+location @error_404_dashboard {
+    return 302 https://www.${PROXY_DOMAIN}$request_uri;
+}
 
 ##### Authentication
 # GitHub authentication callback endpoint does not like CORS headers

--- a/components/proxy/startup/nginx.sh
+++ b/components/proxy/startup/nginx.sh
@@ -17,7 +17,7 @@ cd /etc/nginx/
 
 replaceEnvVars() {
     echo "Updating $i"
-    envsubst '$KUBE_NAMESPACE,$PROXY_DOMAIN_REGEX,$PROXY_DOMAIN_COOKIE,$NAMESERVER,$SERVER_PROXY_APIKEY' < $1 > /tmp/foo;
+    envsubst '$KUBE_NAMESPACE,$PROXY_DOMAIN,$PROXY_DOMAIN_REGEX,$PROXY_DOMAIN_COOKIE,$NAMESERVER,$SERVER_PROXY_APIKEY' < $1 > /tmp/foo;
     cp -f /tmp/foo $i
 }
 


### PR DESCRIPTION
@geropl's idea from https://github.com/gitpod-io/gitpod/issues/2659#issuecomment-754723251 written in code. 🙏🏻 

The suggestion is to test this on staging and see if that fits. 

I find it hard to test on dev, because there is nothing in the ingress proxy of the dev staging to handle the `www.` URLs. (Gero mentioned, we can add this. But it's also nothing we miss ATM.)

Resolves https://github.com/gitpod-io/gitpod/issues/2659