### PR TITLE
[content-service] Update several values.yaml files with new remoteStorage config

### DIFF
--- a/chart/templates/content-service-deployment.yaml
+++ b/chart/templates/content-service-deployment.yaml
@@ -62,9 +62,15 @@ spec:
         - name: config
           mountPath: "/config"
           readOnly: true
+{{- if $comp.volumeMounts }}
+{{ toYaml $comp.volumeMounts | indent 8 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ template "gitpod.comp.configMap" $this }}
+{{- if $comp.volumes }}
+{{ toYaml $comp.volumes | indent 6 }}
+{{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -767,10 +767,13 @@ func (s *PresignedGCPStorage) DiskUsage(ctx context.Context, bucket string, pref
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
+
 	var total int64
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
-		Prefix:    prefix,
-		Delimiter: "/",
+		Prefix: prefix,
 	})
 	for {
 		attrs, err := it.Next()

--- a/docs/self-hosted/install/storage.md
+++ b/docs/self-hosted/install/storage.md
@@ -20,7 +20,7 @@ For more complex use case we recommend configuring more permanent means of persi
  1. Create a file `values.custom.yaml` with this content:
     ```yaml
     components:
-      wsDaemon:
+      contentService:
         remoteStorage:
           kind: minio
           minio:

--- a/install/aws-full-terraform/modules/storage/templates/values.tpl
+++ b/install/aws-full-terraform/modules/storage/templates/values.tpl
@@ -1,7 +1,5 @@
 components:
-  wsDaemon:
-    hostWorkspaceArea: /var/gitpod/workspaces
-    name: "ws-daemon"
+  contentService:
     remoteStorage:
       kind: minio
       minio:

--- a/install/aws-terraform/main.tf
+++ b/install/aws-terraform/main.tf
@@ -64,7 +64,7 @@ module "gitpod" {
     
     components:
       # Necessary to make minio send the right header to S3 (region headers must match)
-      wsDaemon:
+      contentService:
         remoteStorage:
           minio:
             region: ${var.region}

--- a/install/aws-terraform/modules/storage/templates/values.tpl
+++ b/install/aws-terraform/modules/storage/templates/values.tpl
@@ -1,7 +1,5 @@
 components:
-  wsDaemon:
-    hostWorkspaceArea: /var/gitpod/workspaces
-    name: ws-daemon
+  contentService:
     remoteStorage:
       kind: minio
       minio:

--- a/install/gcp-terraform/modules/storage/templates/values.tpl
+++ b/install/gcp-terraform/modules/storage/templates/values.tpl
@@ -2,6 +2,22 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 components:
+
+  contentService:
+    remoteStorage:
+      kind: gcloud
+      backupTrail:
+        enabled: true
+        maxLength: 3
+      gcloud:
+        parallelUpload: 6
+        maximumBackupSize: 32212254720 # 30 GiB
+        projectId: ${project}
+        region: ${region}
+        credentialsFile: /credentials/key.json
+        tmpdir: /mnt/sync-tmp
+        parallelUpload: 6
+
   wsDaemon:
     name: "ws-daemon"
     hostWorkspaceArea: /var/gitpod/workspaces
@@ -18,20 +34,6 @@ components:
         enabled: false
         imageName: "shiftfs-module-loader"
     registryProxyPort: 8081
-    remoteStorage:
-      kind: gcloud
-      backupTrail:
-        enabled: true
-        maxLength: 3
-      gcloud:
-        parallelUpload: 6
-        maximumBackupSize: 32212254720 # 30 GiB
-        projectId: ${project}
-        region: ${region}
-        credentialsFile: /credentials/key.json
-        tmpdir: /mnt/sync-tmp
-        parallelUpload: 6
-
     volumes:
     - name: gcloud-creds
       secret:


### PR DESCRIPTION
This PR updates several values.yaml files. It also fixes the content-server for the GCP storage.

Fixes gitpod-io/gitpod#3052