### PR TITLE
temp fix: terraform-provider-kubernetes

### DIFF
--- a/install/gcp-terraform/environment/full/providers.tf
+++ b/install/gcp-terraform/environment/full/providers.tf
@@ -27,9 +27,10 @@ provider "helm" {
 }
 
 provider "kubectl" {
-  load_config_file = "false"
-
   host                   = module.kubernetes.cluster.endpoint
   token                  = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(module.kubernetes.cluster.master_auth[0].cluster_ca_certificate)
+	load_config_file = "false"
+	# See https://github.com/hashicorp/terraform/issues/26211#issuecomment-770456033
+	version = "~> 1.10.0"
 }

--- a/install/gcp-terraform/environment/installer/providers.tf
+++ b/install/gcp-terraform/environment/installer/providers.tf
@@ -10,11 +10,12 @@ provider "google" {
 data "google_client_config" "provider" {}
 
 provider "kubernetes" {
-  load_config_file = "false"
-
   host                   = module.kubernetes.cluster.endpoint
   token                  = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(module.kubernetes.cluster.master_auth[0].cluster_ca_certificate)
+  load_config_file = "false"
+  # See https://github.com/hashicorp/terraform/issues/26211#issuecomment-770456033
+  version = "~> 1.10.0"
 }
 
 provider "helm" {


### PR DESCRIPTION
See https://github.com/hashicorp/terraform/issues/26211#issuecomment-770456033

```
provider "google" {
  project = var.project
  region  = var.region
}

data "google_client_config" "provider" {}

provider "kubernetes" {
  load_config_file = "false"
  host                   = module.kubernetes.cluster.endpoint
  token                  = data.google_client_config.provider.access_token
  cluster_ca_certificate = base64decode(module.kubernetes.cluster.master_auth[0].cluster_ca_certificate)
}

provider "helm" {
  kubernetes {
    host                   = module.kubernetes.cluster.endpoint
    token                  = data.google_client_config.provider.access_token
    cluster_ca_certificate = base64decode(module.kubernetes.cluster.master_auth[0].cluster_ca_certificate)
  }
}
```

Exception:

```
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.


Error: Unsupported argument

  on providers.tf line 16, in provider "kubernetes":
  16:   load_config_file = "false"

An argument named "load_config_file" is not expected here.

!!
!! terraform failed:
!!      "exit status 1"
!!
```