### PR TITLE
[ws-daemon] Improve error when content init fails

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -132,16 +132,16 @@ func (s *Status) ToAPI() *csapi.GitStatus {
 	}
 }
 
-// ErrGitOpFailed is returned by GitWithOutput if the operation fails
+// GitOpFailedError is returned by GitWithOutput if the operation fails
 // e.g. returns with a non-zero exit code.
-type ErrGitOpFailed struct {
+type GitOpFailedError struct {
 	Subcommand string
 	Args       []string
 	ExecErr    error
 	Output     string
 }
 
-func (e ErrGitOpFailed) Error() string {
+func (e GitOpFailedError) Error() string {
 	return fmt.Sprintf("git %s %s failed (%v): %v", e.Subcommand, strings.Join(e.Args, " "), e.ExecErr, e.Output)
 }
 
@@ -186,7 +186,7 @@ func (c *Client) GitWithOutput(ctx context.Context, subcommand string, args ...s
 
 	res, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, ErrGitOpFailed{
+		return nil, GitOpFailedError{
 			Args:       args,
 			ExecErr:    err,
 			Output:     string(res),

--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -87,7 +87,7 @@ func (p *PrebuildInitializer) Run(ctx context.Context, mappings []archive.IDMapp
 	if git.IsWorkingCopy(p.Git.Location) {
 		out, err := p.Git.GitWithOutput(ctx, "stash", "push", "-u")
 		if err != nil {
-			var giterr git.ErrGitOpFailed
+			var giterr git.GitOpFailedError
 			if errors.As(err, &giterr) && strings.Contains(giterr.Output, "You do not have the initial commit yet") {
 				// git stash push returns a non-zero exit code if the repository does not have a single commit.
 				// In this case that's not an error though, hence we don't want to fail here.


### PR DESCRIPTION
This PR:
- adds OWI logging to all content-initializer output produced by ws-daemon's runc content init process
- in case of content init makes the error message read: "content initializer failed" as compared to "exit code: 42"
 