### PR TITLE
[supervisor] backoff port auto expose on deadline exceeded

### DIFF
--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -562,7 +562,10 @@ func (tep *testExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
 	return tep.Changes, tep.Error
 }
 
-func (tep *testExposedPorts) Expose(ctx context.Context, local, global uint32, public bool) error {
+func (tep *testExposedPorts) Run(ctx context.Context) {
+}
+
+func (tep *testExposedPorts) Expose(ctx context.Context, local, global uint32, public bool) <-chan error {
 	tep.mu.Lock()
 	defer tep.mu.Unlock()
 

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -263,17 +263,12 @@ func createGitpodService(cfg *Config, tknsrv api.TokenServiceServer) *gitpod.API
 	return gitpodService
 }
 
-func createExposedPortsImpl(cfg *Config, gitpodService *gitpod.APIoverJSONRPC) (res ports.ExposedPortsInterface) {
+func createExposedPortsImpl(cfg *Config, gitpodService *gitpod.APIoverJSONRPC) ports.ExposedPortsInterface {
 	if gitpodService == nil {
 		log.Error("auto-port exposure won't work")
 		return &ports.NoopExposedPorts{}
 	}
-
-	return &ports.GitpodExposedPorts{
-		WorkspaceID: cfg.WorkspaceID,
-		InstanceID:  cfg.WorkspaceInstanceID,
-		C:           gitpodService,
-	}
+	return ports.NewGitpodExposedPorts(cfg.WorkspaceID, cfg.WorkspaceInstanceID, gitpodService)
 }
 
 func configureGit(cfg *Config) {

--- a/gitpod-ws.theia-workspace
+++ b/gitpod-ws.theia-workspace
@@ -1,6 +1,7 @@
 {
    "folders": [
       { "path": "." },
+      { "path": "components/gitpod-protocol" },
       { "path": "components/blobserve" },
       { "path": "components/common-go" },
       { "path": "components/content-service" },


### PR DESCRIPTION
#### What it does

Right now we are trying to auto expose ports each 5s from the supervisor. This PR implements the backoff with 1.5 factor up to half a minute delay. 

#### How to test

- start a workspace and listen to its logs
- run in the terminal:
```
$ curl lama.sh | LAMA_PORT=9090 sh
Ctrl+C
$ curl lama.sh | LAMA_PORT=9091 sh
```
In logs, you should see that first port gets exposed immediately. For the second port you should see many retries with 1.5 factor and after 1m it gets exposed too.