### PR TITLE
Reconfigure Prometheus buckets for workspace startup time histograms

### DIFF
--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -18,13 +18,13 @@ export class PrometheusMetricsExporter {
             name: 'workspace_startup_time',
             help: 'The time until a workspace instance is marked running',
             labelNames: ['neededImageBuild', 'region'],
-            buckets: [6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 45, 60, 90]
+            buckets: prom.exponentialBuckets(2, 2, 10),
         });
         this.timeToFirstUserActivityHistogram = new prom.Histogram({
             name: 'first_user_activity_time',
             help: 'The time between a workspace is running and first user activity',
             labelNames: ['region'],
-            buckets: [1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30]
+            buckets: prom.exponentialBuckets(2, 2, 10),
         });
     }
 

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -52,7 +52,7 @@ func newMetrics(m *Manager) *metrics {
 			Name:      "startup_seconds",
 			Help:      "time it took for workspace pods to reach the running phase",
 			// same as components/ws-manager-bridge/src/prometheus-metrics-exporter.ts#L15
-			Buckets: []float64{6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 45, 60, 90},
+			Buckets: prometheus.ExponentialBuckets(2, 2, 10),
 		}, []string{"type"}),
 		totalStartsCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -64,7 +64,7 @@ func newMetrics(m *Manager) *metrics {
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
 			Name:      "stops_total",
-			Help:      "total number of workspaces started",
+			Help:      "total number of workspaces stopped",
 		}, []string{"reason"}),
 	}
 }


### PR DESCRIPTION
### What it does
This PR reconfigure our histogram buckets for workspace startup time. Due to Prometheus' histogram limitations, the PromQL function `histogram_quantile()` won't show meaningful data if the startup time is higher than our highest bucket. 

![image](https://user-images.githubusercontent.com/24193764/107048394-a7f54300-67a7-11eb-8f89-dbf6f656b04a.png)
On this graph, for example, we can see that the 1m50s cap can definitely represent low percentiles, e.g. the 50th, but it is constantly hitting the limit of high percentiles.

This graph also shows a really big spike that happened during an incident. We can see that the average startup time reaches 6minutes, which means that some workspaces were taking even longer to start.

With that in mind, I'm using exponential buckets to create buckets that go from 2 seconds exponentially going up to 1024(17m4s).

### How to test
Login into the gitpod installation created by the CI and start some workspaces.

Then start a workspace at gitpod.io from this PR, port-forward ws-manager metrics endpoint and check the exposed metrics. You should see the new buckets configured:

![image](https://user-images.githubusercontent.com/24193764/107053470-9ca51600-67ad-11eb-862f-59d2a03c1d9a.png)
