### PR TITLE
[admin dashboard] Add latest instance ID to workspace view

### DIFF
--- a/components/dashboard/ee/src/components/admin/workspace-view.tsx
+++ b/components/dashboard/ee/src/components/admin/workspace-view.tsx
@@ -78,6 +78,9 @@ export class WorkspaceView extends React.Component<WorkspaceViewProps, Workspace
             instanceCreationTime: {
                 name: "Last Started"
             },
+            instanceId: {
+                name: "Latest Instance ID"
+            },
             shareable: {
                 name: "Shareable",
                 render: u => !!u.shareable ? "shareable" : "not shareable"


### PR DESCRIPTION
This PR adds the latest workspace instance ID to the workspace detail view of the admin dashboard. That helps to find the pod of the running workspace (which is named after the instance ID).

![image](https://user-images.githubusercontent.com/24960040/107079856-bddb2600-67f0-11eb-8170-f0263847bacc.png)