### PR TITLE
[db] Improve performance of DBUserStorageResource.update(...)

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1612781029090-UserStorageUserIdChar36.ts
+++ b/components/gitpod-db/src/typeorm/migration/1612781029090-UserStorageUserIdChar36.ts
@@ -1,0 +1,12 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class UserStorageUserIdChar1612781029090 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+      await queryRunner.query("ALTER TABLE d_b_user_storage_resource MODIFY userId char(36);");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}


### PR DESCRIPTION
This does improve the performance of `update(...)` on `UserStorageResourceDBImpl` by:
 - using the `char(36)` for userId instead of `varchar(255)`
 - use `INSERT INTO ... ON DUPLICATE KEY UPDATE` instead of the update logic in the client
 
Note: The type change will trigger a index re-build and should be initiated offline.