### PR TITLE
[server] Add rate limiter

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -14,6 +14,22 @@ manager:
 {{- end -}}
 {{- end -}}
 
+{{ define "rate-limiter-config" -}}
+groups:
+  inWorkspaceUserAction:
+    points: 10
+    durationsSec: 2
+functions:
+  openPort:
+    group: inWorkspaceUserAction
+  closePort:
+    group: inWorkspaceUserAction
+  controlAdmission:
+    group: inWorkspaceUserAction
+  shareSnapshot:
+    group: inWorkspaceUserAction
+{{- end -}}
+
 {{ $comp := .Values.components.server -}}
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- $thisWorkspace := dict "root" . "comp" .Values.components.workspace -}}
@@ -85,6 +101,8 @@ spec:
 {{ include "gitpod.container.dbEnv" $this | indent 8 }}
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
 {{ include "gitpod.container.messagebusEnv" $this | indent 8 }}
+        - name: RATE_LIMITER_CONFIG
+          value: {{ (include "rate-limiter-config" $this) | fromYaml | toJson | quote }}
 {{- if eq .Values.ingressMode "noDomain" }}
         - name: SERVE_INSECURE_NO_DOMAIN
           value: "true"

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -25,6 +25,9 @@ export namespace ErrorCodes {
     // 410 No User
     export const SETUP_REQUIRED = 410;
 
+    // 429 Too Many Requests
+    export const TOO_MANY_REQUESTS = 429;
+
     // 430 Repository not whitelisted (custom status code)
     export const REPOSITORY_NOT_WHITELISTED = 430;
 

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -72,6 +72,7 @@
     "probot": "^10.17.2",
     "prom-client": "^10.2.0",
     "rasha": "^1.2.5",
+    "rate-limiter-flexible": "^2.2.1",
     "reflect-metadata": "^0.1.10",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { GitpodServer } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { RateLimiterMemory, RateLimiterRes } from "rate-limiter-flexible";
+
+type GitpodServerMethodType = keyof Omit<GitpodServer, "dispose" | "setClient">;
+type GroupsConfig = {
+    [key: string]: {
+        points: number,
+        durationsSec: number,
+    }
+}
+type FunctionsConfig = {
+    [K in GitpodServerMethodType]: {
+        group: string,
+        points: number,
+    }
+}
+type RateLimiterConfig = {
+    groups: GroupsConfig,
+    functions: FunctionsConfig,
+};
+
+function readConfig(): RateLimiterConfig {
+    const defaultGroups: GroupsConfig = {
+        default: {
+            points: 60000, // 1,000 calls per user per second
+            durationsSec: 60,
+        },
+    }
+    const defaultFunctions: FunctionsConfig = {
+        "getLoggedInUser": { group: "default", points: 1 },
+        "getTerms": { group: "default", points: 1 },
+        "updateLoggedInUser": { group: "default", points: 1 },
+        "getAuthProviders": { group: "default", points: 1 },
+        "getOwnAuthProviders": { group: "default", points: 1 },
+        "updateOwnAuthProvider": { group: "default", points: 1 },
+        "deleteOwnAuthProvider": { group: "default", points: 1 },
+        "getBranding": { group: "default", points: 1 },
+        "getConfiguration": { group: "default", points: 1 },
+        "getToken": { group: "default", points: 1 },
+        "getPortAuthenticationToken": { group: "default", points: 1 },
+        "deleteAccount": { group: "default", points: 1 },
+        "getClientRegion": { group: "default", points: 1 },
+        "hasPermission": { group: "default", points: 1 },
+        "getWorkspaces": { group: "default", points: 1 },
+        "getWorkspaceOwner": { group: "default", points: 1 },
+        "getWorkspaceUsers": { group: "default", points: 1 },
+        "getFeaturedRepositories": { group: "default", points: 1 },
+        "getWorkspace": { group: "default", points: 1 },
+        "isWorkspaceOwner": { group: "default", points: 1 },
+        "createWorkspace": { group: "default", points: 1 },
+        "startWorkspace": { group: "default", points: 1 },
+        "stopWorkspace": { group: "default", points: 1 },
+        "deleteWorkspace": { group: "default", points: 1 },
+        "setWorkspaceDescription": { group: "default", points: 1 },
+        "controlAdmission": { group: "default", points: 1 },
+        "updateWorkspaceUserPin": { group: "default", points: 1 },
+        "sendHeartBeat": { group: "default", points: 1 },
+        "watchWorkspaceImageBuildLogs": { group: "default", points: 1 },
+        "watchHeadlessWorkspaceLogs": { group: "default", points: 1 },
+        "isPrebuildDone": { group: "default", points: 1 },
+        "setWorkspaceTimeout": { group: "default", points: 1 },
+        "getWorkspaceTimeout": { group: "default", points: 1 },
+        "getOpenPorts": { group: "default", points: 1 },
+        "openPort": { group: "default", points: 1 },
+        "closePort": { group: "default", points: 1 },
+        "getUserMessages": { group: "default", points: 1 },
+        "updateUserMessages": { group: "default", points: 1 },
+        "getUserStorageResource": { group: "default", points: 1 },
+        "updateUserStorageResource": { group: "default", points: 1 },
+        "getEnvVars": { group: "default", points: 1 },
+        "setEnvVar": { group: "default", points: 1 },
+        "deleteEnvVar": { group: "default", points: 1 },
+        "getContentBlobUploadUrl": { group: "default", points: 1 },
+        "getContentBlobDownloadUrl": { group: "default", points: 1 },
+        "getGitpodTokens": { group: "default", points: 1 },
+        "generateNewGitpodToken": { group: "default", points: 1 },
+        "deleteGitpodToken": { group: "default", points: 1 },
+        "sendFeedback": { group: "default", points: 1 },
+        "registerGithubApp": { group: "default", points: 1 },
+        "takeSnapshot": { group: "default", points: 1 },
+        "getSnapshots": { group: "default", points: 1 },
+        "storeLayout": { group: "default", points: 1 },
+        "getLayout": { group: "default", points: 1 },
+        "preparePluginUpload": { group: "default", points: 1 },
+        "resolvePlugins": { group: "default", points: 1 },
+        "installUserPlugins": { group: "default", points: 1 },
+        "uninstallUserPlugin": { group: "default", points: 1 },
+
+        "adminGetUsers": { group: "default", points: 1 },
+        "adminGetUser": { group: "default", points: 1 },
+        "adminBlockUser": { group: "default", points: 1 },
+        "adminDeleteUser": { group: "default", points: 1 },
+        "adminModifyRoleOrPermission": { group: "default", points: 1 },
+        "adminModifyPermanentWorkspaceFeatureFlag": { group: "default", points: 1 },
+        "adminGetWorkspaces": { group: "default", points: 1 },
+        "adminGetWorkspace": { group: "default", points: 1 },
+        "adminForceStopWorkspace": { group: "default", points: 1 },
+        "adminSetLicense": { group: "default", points: 1 },
+
+        "validateLicense": { group: "default", points: 1 },
+        "getLicenseInfo": { group: "default", points: 1 },
+        "licenseIncludesFeature": { group: "default", points: 1 },
+    };
+
+    const fromEnv = JSON.parse(process.env.RATE_LIMITER_CONFIG || "{}")
+
+    return {
+        groups: { ...defaultGroups, ...fromEnv.groups },
+        functions: { ...defaultFunctions, ...fromEnv.functions }
+    };
+}
+
+export interface RateLimiter {
+    user: string
+    consume(method: string): Promise<RateLimiterRes>
+}
+
+export class UserRateLimiter {
+
+    private static instance_: UserRateLimiter;
+
+    public static instance(): UserRateLimiter {
+        if (!UserRateLimiter.instance_) {
+            UserRateLimiter.instance_ = new UserRateLimiter();
+        }
+        return UserRateLimiter.instance_;
+    }
+
+    private readonly config: RateLimiterConfig;
+    private readonly limiters: { [key: string]: RateLimiterMemory };
+
+    private constructor() {
+        this.config = readConfig();
+
+        this.limiters = {};
+        Object.keys(this.config.groups).forEach(group => {
+            this.limiters[group] = new RateLimiterMemory({
+                keyPrefix: group,
+                points: this.config.groups[group].points,
+                duration: this.config.groups[group].durationsSec,
+            });
+        });
+    }
+
+    async consume(user: string, method: string): Promise<RateLimiterRes> {
+
+        const group = this.config.functions[method as GitpodServerMethodType]?.group || "default";
+        if (group !== this.config.functions[method as GitpodServerMethodType]?.group) {
+            log.warn(`method '${method}' is not configured for a rate limiter, using 'default'`);
+        }
+
+        const limiter = this.limiters[group] || this.limiters["default"];
+        if (!(group in this.limiters)) {
+            log.warn(`method '${method}' is configured for a rate limiter '${group}' but this rate limiter does not exist, using 'default' instead`);
+        }
+
+        const points = this.config.functions[method as GitpodServerMethodType]?.points || 1
+        return await limiter.consume(user, points);
+    }
+}

--- a/components/server/src/prometheusMetrics.ts
+++ b/components/server/src/prometheusMetrics.ts
@@ -5,7 +5,7 @@ prometheusClient.collectDefaultMetrics({ timeout: 5000 });
 export const register = prometheusClient.register;
 
 const loginCounter = new prometheusClient.Counter({
-    name: 'gitpod_login_requests_total',
+    name: 'gitpod_server_login_requests_total',
     help: 'Total amount of login requests',
     labelNames: ['status', 'auth_host'],
     registers: [prometheusClient.register]
@@ -16,4 +16,46 @@ export function increaseLoginCounter(status: string, auth_host: string) {
         status,
         auth_host,
     });
+}
+
+const apiConnectionCounter = new prometheusClient.Counter({
+    name: 'gitpod_server_api_connections_total',
+    help: 'Total amount of established API connections',
+    registers: [prometheusClient.register],
+});
+
+export function increaseApiConnectionCounter() {
+    apiConnectionCounter.inc();
+}
+
+const apiConnectionClosedCounter = new prometheusClient.Counter({
+    name: 'gitpod_server_api_connections_closed_total',
+    help: 'Total amount of closed API connections',
+    registers: [prometheusClient.register],
+});
+
+export function increaseApiConnectionClosedCounter() {
+    apiConnectionClosedCounter.inc();
+}
+
+const apiCallCounter = new prometheusClient.Counter({
+    name: 'gitpod_server_api_calls_total',
+    help: 'Total amount of API calls per method',
+    labelNames: ['method', 'statusCode'],
+    registers: [prometheusClient.register],
+});
+
+export function increaseApiCallCounter(method: string, statusCode: number) {
+    apiCallCounter.inc({ method, statusCode });
+}
+
+const apiCallUserCounter = new prometheusClient.Counter({
+    name: 'gitpod_server_api_calls_user_total',
+    help: 'Total amount of API calls per user',
+    labelNames: ['method', 'user'],
+    registers: [prometheusClient.register],
+});
+
+export function increaseApiCallUserCounter(method: string, user: string) {
+    apiCallUserCounter.inc({ method, user });
 }

--- a/components/server/src/websocket-connection-manager.ts
+++ b/components/server/src/websocket-connection-manager.ts
@@ -4,17 +4,19 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { GitpodServerImpl } from "./workspace/gitpod-server-impl";
-import { GitpodServerPath, User, GitpodClient, Disposable, GitpodServer } from "@gitpod/gitpod-protocol";
-import { JsonRpcConnectionHandler, JsonRpcProxy, JsonRpcProxyFactory } from "@gitpod/gitpod-protocol/lib/messaging/proxy-factory";
+import { Disposable, GitpodClient, GitpodServer, GitpodServerPath, User } from "@gitpod/gitpod-protocol";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { ConnectionHandler } from "@gitpod/gitpod-protocol/lib/messaging/handler";
-import { MessageConnection, ResponseError, ErrorCodes as RPCErrorCodes } from "vscode-jsonrpc";
+import { JsonRpcConnectionHandler, JsonRpcProxy, JsonRpcProxyFactory } from "@gitpod/gitpod-protocol/lib/messaging/proxy-factory";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { EventEmitter } from "events";
 import * as express from "express";
-import { OwnerResourceGuard, WithResourceAccessGuard, ResourceAccessGuard, CompositeResourceAccessGuard, SharedWorkspaceAccessGuard } from "./auth/resource-access";
-import { WithFunctionAccessGuard, AllAccessFunctionGuard, FunctionAccessGuard } from "./auth/function-access";
-import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ErrorCodes as RPCErrorCodes, MessageConnection, ResponseError } from "vscode-jsonrpc";
+import { AllAccessFunctionGuard, FunctionAccessGuard, WithFunctionAccessGuard } from "./auth/function-access";
+import { RateLimiter, UserRateLimiter } from "./auth/rate-limiter";
+import { CompositeResourceAccessGuard, OwnerResourceGuard, ResourceAccessGuard, SharedWorkspaceAccessGuard, WithResourceAccessGuard } from "./auth/resource-access";
+import { increaseApiCallCounter, increaseApiConnectionClosedCounter, increaseApiConnectionCounter, increaseApiCallUserCounter } from "./prometheusMetrics";
+import { GitpodServerImpl } from "./workspace/gitpod-server-impl";
 
 export type GitpodServiceFactory<C extends GitpodClient, S extends GitpodServer> = () => GitpodServerImpl<C, S>;
 
@@ -33,13 +35,15 @@ export class WebsocketConnectionManager<C extends GitpodClient, S extends Gitpod
 
     constructor(protected readonly serverFactory: GitpodServiceFactory<C, S>) {
         this.jsonRpcConnectionHandler = new GitpodJsonRpcConnectionHandler<C>(
-            this.path, 
+            this.path,
             this.createProxyTarget.bind(this),
             this.createAccessGuard.bind(this),
+            this.createRateLimiter.bind(this),
         );
     }
 
     public onConnection(connection: MessageConnection, session?: object) {
+        increaseApiConnectionCounter();
         this.jsonRpcConnectionHandler.onConnection(connection, session);
     }
 
@@ -65,11 +69,12 @@ export class WebsocketConnectionManager<C extends GitpodClient, S extends Gitpod
                 new SharedWorkspaceAccessGuard(),
             ]);
         } else {
-            resourceGuard = {canAccess: async () => false };
+            resourceGuard = { canAccess: async () => false };
         }
 
         gitpodServer.initialize(client, clientRegion, user, resourceGuard);
         client.onDidCloseConnection(() => {
+            increaseApiConnectionClosedCounter();
             gitpodServer.dispose();
 
             this.removeServer(gitpodServer);
@@ -86,6 +91,17 @@ export class WebsocketConnectionManager<C extends GitpodClient, S extends Gitpod
                 return target[property];
             }
         });
+    }
+
+    protected createRateLimiter(request?: object): RateLimiter {
+        const expressReq = request as express.Request;
+        const user = expressReq.user as User;
+        const sessionId = expressReq.session?.id;
+        const id = user?.id || (!!sessionId ? `session-${sessionId}` : undefined) || "anonymous";
+        return {
+            user: id,
+            consume: (method) => UserRateLimiter.instance().consume(id, method),
+        }
     }
 
     public get currentConnectionCount(): number {
@@ -118,37 +134,67 @@ class GitpodJsonRpcConnectionHandler<T extends object> extends JsonRpcConnection
     constructor(
         readonly path: string,
         readonly targetFactory: (proxy: JsonRpcProxy<T>, request?: object) => any,
-        readonly accessGuard: (request?: object) => FunctionAccessGuard
-    ) { 
+        readonly accessGuard: (request?: object) => FunctionAccessGuard,
+        readonly rateLimiterFactory: (request?: object) => RateLimiter,
+    ) {
         super(path, targetFactory);
     }
 
     onConnection(connection: MessageConnection, request?: object): void {
-        const factory = new GitpodJsonRpcProxyFactory<T>(this.accessGuard(request));
+        const factory = new GitpodJsonRpcProxyFactory<T>(this.accessGuard(request), this.rateLimiterFactory(request));
         const proxy = factory.createProxy();
         factory.target = this.targetFactory(proxy, request);
         factory.listen(connection);
     }
+
+
 }
 
 class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T> {
 
-    constructor(protected readonly accessGuard: FunctionAccessGuard) { 
+    constructor(
+        protected readonly accessGuard: FunctionAccessGuard,
+        protected readonly rateLimiter: RateLimiter,
+    ) {
         super();
     }
-    
+
     protected async onRequest(method: string, ...args: any[]): Promise<any> {
+        if (!this.rateLimiter.user.startsWith("session-")) {
+            increaseApiCallUserCounter(method, this.rateLimiter.user);
+        } else {
+            increaseApiCallUserCounter(method, "anonymous");
+        }
+
+        try {
+            await this.rateLimiter.consume(method);
+        } catch (rlRejected) {
+            if (rlRejected instanceof Error) {
+                log.error("Unexpected error in the rate limiter", rlRejected);
+                increaseApiCallCounter(method, 500);
+                throw rlRejected;
+            }
+            log.warn(`Rate limiter prevents accessing method '${method}' of user '${this.rateLimiter.user} due to too many requests.`, rlRejected);
+            increaseApiCallCounter(method, ErrorCodes.TOO_MANY_REQUESTS);
+            throw new ResponseError(ErrorCodes.TOO_MANY_REQUESTS, "too many requests", { "Retry-After": String(Math.round(rlRejected.msBeforeNext / 1000)) || 1 });
+        }
+
         if (!this.accessGuard.canAccess(method)) {
-            log.error(`Request ${method} is not allowed`, {method, args});
+            log.error(`Request ${method} is not allowed`, { method, args });
+            increaseApiCallCounter(method, ErrorCodes.PERMISSION_DENIED);
             throw new ResponseError(ErrorCodes.PERMISSION_DENIED, "not allowed");
         }
 
         try {
-            return await this.target[method](...args);
+            const result = await this.target[method](...args);
+            increaseApiCallCounter(method, 200);
+            return result;
         } catch (e) {
             if (e instanceof ResponseError) {
+                increaseApiCallCounter(method, e.code);
                 log.info(`Request ${method} unsuccessful: ${e.code}/"${e.message}"`, { method, args });
             } else {
+                increaseApiCallCounter(method, 500);
                 log.error(`Request ${method} failed with internal server error`, e, { method, args });
             }
             throw e;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16318,6 +16318,11 @@ rasha@^1.2.5:
   resolved "https://registry.yarnpkg.com/rasha/-/rasha-1.2.5.tgz#72668da31dcc68ac277c5b73d610e087cd33b031"
   integrity sha512-KxtX+/fBk+wM7O3CNgwjSh5elwFilLvqWajhr6wFr2Hd63JnKTTi43Tw+Jb1hxJQWOwoya+NZWR2xztn3hCrTw==
 
+rate-limiter-flexible@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-2.2.1.tgz#acb81a3d92a0f26bf7e9767e0f96de3a89ecb3a6"
+  integrity sha512-rxCP6kDDdn0cZmVqVlF06yLU+mG3TuwaHV/fUIw3OQyYhza7pzVBtdMhUmfXbBzMS+O464XP+x33pfTDGRGYVA==
+
 raven@^2.4.2:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/raven/-/raven-2.6.4.tgz#458d4a380c8fbb59e0150c655625aaf60c167ea3"


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3141

**How to test rate limiting for open port action**
- open a workspace
- Open a bunch of ports, e.g.:
  ```sh
  $ curl -o lama.sh lama.sh && chmod +x lama.sh
  $ for i in {3000..3050}; do echo "$i"; ./lama.sh -p $i & done
  ```
- This will open 51 ports pretty quickly. See server logs and watch for messages like:
  ```
  Rate limiter prevents access to method openPort of user 67673bae-c791-471f-83ec-f8477973c8eb due to too many requests.”.
  ```
- You could also check prometheus metrics:
  ```sh
  $ kubectl port-forward server-xxx-xxx 9500 &
  $ curl localhost:9500/metrics
  ```
  Metrics should have something like this: `gitpod_server_api_calls_total{method="openPort",statusCode="429"} 141` (statusCode=429 is rate limiting)