### PR TITLE
Refine OAuth scopes for GitLab integration [ON HOLD]

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1025,12 +1025,13 @@ export interface AuthProviderInfo {
     readonly description?: string;
 
     readonly settingsUrl?: string;
-    readonly scopes?: string[];
-    readonly requirements?: {
-        readonly default: string[];
-        readonly publicRepo: string[];
-        readonly privateRepo: string[];
-    }
+    readonly scopes: AuthProviderScopes;
+}
+
+export interface AuthProviderScopes {
+    readonly default: string[];
+    readonly all: string[];
+    readonly descriptions: { [key: string]: string };
 }
 
 export interface AuthProviderEntry {

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -201,8 +201,8 @@ export class Authenticator {
         await AuthFlow.attach(req.session, { host, returnTo, overrideScopes: override });
         let wantedScopes = scopes.split(',');
         if (wantedScopes.length === 0) {
-            if (authProvider.info.requirements) {
-                wantedScopes = authProvider.info.requirements.default;
+            if (authProvider.info.scopes) {
+                wantedScopes = authProvider.info.scopes.default;
             }
         }
         // compute merged scopes
@@ -211,8 +211,8 @@ export class Authenticator {
             wantedScopes = this.mergeScopes(currentScopes, wantedScopes);
             // in case user signed in with another identity, we need to ensure the merged scopes contain
             // all default needed to for proper authentication
-            if (currentScopes.length === 0 && authProvider.info.requirements) {
-                wantedScopes = this.mergeScopes(authProvider.info.requirements.default, wantedScopes);
+            if (currentScopes.length === 0 && authProvider.info.scopes) {
+                wantedScopes = this.mergeScopes(authProvider.info.scopes.default, wantedScopes);
             }
         }
         // authorize Gitpod

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -80,7 +80,7 @@ export class GenericAuthProvider implements AuthProvider {
     }
 
     protected defaultInfo(): AuthProviderInfo {
-        const scopes = this.oauthScopes;
+        const { oauthScopes } = this;
         const { id, type, icon, host, ownerId, verified, hiddenOnDashboard, disallowLogin, description, loginContextMatcher } = this.config;
         return {
             authProviderId: id,
@@ -93,13 +93,12 @@ export class GenericAuthProvider implements AuthProvider {
             loginContextMatcher,
             disallowLogin,
             description,
-            scopes,
+            scopes: {
+                all: oauthScopes,
+                default: oauthScopes,
+                descriptions: {}
+            },
             settingsUrl: this.oauthConfig.settingsUrl,
-            requirements: {
-                default: scopes,
-                publicRepo: scopes,
-                privateRepo: scopes
-            }
         }
     }
 
@@ -119,7 +118,7 @@ export class GenericAuthProvider implements AuthProvider {
     protected get oauthConfig() {
         return this.config.oauth!;
     }
-    protected get oauthScopes() {
+    protected get oauthScopes(): string[] {
         if (!this.oauthConfig.scope) {
             return [];
         }

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -19,12 +19,7 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
     get info(): AuthProviderInfo {
         return {
             ...this.defaultInfo(),
-            scopes: BitbucketOAuthScopes.ALL,
-            requirements: {
-                default: BitbucketOAuthScopes.Requirements.DEFAULT,
-                publicRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
-                privateRepo: BitbucketOAuthScopes.Requirements.DEFAULT,
-            },
+            scopes: BitbucketOAuthScopes.definitions,
         }
     }
 
@@ -39,7 +34,7 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
             authorizationUrl: oauth.authorizationUrl || `https://${this.config.host}/site/oauth2/authorize`,
             tokenUrl: oauth.tokenUrl || `https://${this.config.host}/site/oauth2/access_token`,
             settingsUrl: oauth.settingsUrl || `https://${this.config.host}/account/settings/app-authorizations/`,
-            scope: BitbucketOAuthScopes.ALL.join(scopeSeparator),
+            scope: BitbucketOAuthScopes.definitions.default.join(scopeSeparator),
             scopeSeparator
         };
     }
@@ -49,7 +44,7 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
     }
 
     authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : BitbucketOAuthScopes.Requirements.DEFAULT);
+        super.authorize(req, res, next, scope ? scope : BitbucketOAuthScopes.definitions.default);
     }
 
     protected get baseURL() {
@@ -105,7 +100,7 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
             set.add('pullrequest');
         }
         for (const item of set.values()) {
-            if (!(BitbucketOAuthScopes.Requirements.DEFAULT.includes(item))) {
+            if (!(BitbucketOAuthScopes.definitions.default.includes(item))) {
                 set.delete(item);
             }
         }

--- a/components/server/src/bitbucket/bitbucket-context-parser.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.ts
@@ -134,7 +134,7 @@ export class BitbucketContextParser extends AbstractContextParser implements ICo
             span.log({ "request.finished": "" });
 
             if (!repo) {
-                throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+                throw await this.createNotFoundError(user, host, owner, repoName);
             }
 
             if (!more.revision)
@@ -166,6 +166,12 @@ export class BitbucketContextParser extends AbstractContextParser implements ICo
         } finally {
             span.finish();
         }
+    }
+
+    protected async createNotFoundError(user: User, host: string, owner: string, repoName: string) {
+        const authProviderId = this.authProviderId;
+        const token = await this.tokenHelper.getCurrentToken(user);
+        return NotFoundError.create(token, user, host, owner, repoName, authProviderId, []);
     }
 
     protected async handlePullRequestContext(ctx: TraceContext, user: User, host: string, owner: string, repoName: string, more: Partial<PullRequestContext> & { nr: number }): Promise<PullRequestContext> {

--- a/components/server/src/bitbucket/bitbucket-oauth-scopes.ts
+++ b/components/server/src/bitbucket/bitbucket-oauth-scopes.ts
@@ -4,6 +4,8 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { AuthProviderScopes } from "@gitpod/gitpod-protocol";
+
 // https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html
 
 export namespace BitbucketOAuthScopes {
@@ -20,12 +22,16 @@ export namespace BitbucketOAuthScopes {
     /** Create, list web hooks */
     export const WEBHOOK = "webhook"
 
-    export const ALL = [ACCOUNT_READ, REPOSITORY_READ, REPOSITORY_WRITE, PULL_REQUEST_READ, PULL_REQUEST_WRITE, WEBHOOK];
-
-    export const Requirements = {
-        /**
-         * Minimal required permission.
-         */
-        DEFAULT: ALL
-    }
+    export const definitions: AuthProviderScopes = {
+        default: [ACCOUNT_READ, REPOSITORY_READ, REPOSITORY_WRITE, PULL_REQUEST_READ, PULL_REQUEST_WRITE, WEBHOOK],
+        all: [ACCOUNT_READ, REPOSITORY_READ, REPOSITORY_WRITE, PULL_REQUEST_READ, PULL_REQUEST_WRITE, WEBHOOK],
+        descriptions: {
+            ACCOUNT_READ: "Grants read-only access to your account information.",
+            REPOSITORY_READ: "Read-only access to your repositories (note: Bitbucket doesn't support revoking scopes)",
+            REPOSITORY_WRITE: "Grants read/write access to your repositories (note: Bitbucket doesn't support revoking scopes)",
+            PULL_REQUEST_READ: "Grants read-only access to pull requests and ability to collaborate via comments, tasks, and approvals (note: Bitbucket doesn't support revoking scopes)",
+            PULL_REQUEST_WRITE: "Allows creating, merging and declining pull requests (note: Bitbucket doesn't support revoking scopes)",
+            WEBHOOK: "Allows installing webhooks (used when enabling prebuilds for a repository, note: Bitbucket doesn't support revoking scopes)",
+        }
+    };
 }

--- a/components/server/src/bitbucket/bitbucket-token-handler.ts
+++ b/components/server/src/bitbucket/bitbucket-token-handler.ts
@@ -36,7 +36,7 @@ export class BitbucketTokenHelper {
             // no token
         }
         if (requiredScopes.length === 0) {
-            requiredScopes = BitbucketOAuthScopes.Requirements.DEFAULT
+            requiredScopes = BitbucketOAuthScopes.definitions.default
         }
         throw UnauthorizedError.create(host, requiredScopes, "missing-identity");
     }

--- a/components/server/src/dev/authenticator-dev.ts
+++ b/components/server/src/dev/authenticator-dev.ts
@@ -35,6 +35,7 @@ class DummyAuthProvider implements AuthProvider {
             host: "github.com",
             icon: this.config.icon,
             description: this.config.description,
+            scopes: ({} as any)
         }
     }
     readonly host = "github.com";

--- a/components/server/src/github/api.ts
+++ b/components/server/src/github/api.ts
@@ -124,7 +124,7 @@ export class GitHubRestApi {
         if (typeof userOrToken === 'string') {
             token = userOrToken;
         } else {
-            const githubToken = await this.tokenHelper.getTokenWithScopes(userOrToken, GitHubScope.Requirements.DEFAULT);
+            const githubToken = await this.tokenHelper.getTokenWithScopes(userOrToken, GitHubScope.definitions.default);
             token = githubToken.value;
         }
         const api = new GitHub(this.getGitHubOptions(token));

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -21,12 +21,7 @@ export class GitHubAuthProvider extends GenericAuthProvider {
     get info(): AuthProviderInfo {
         return {
             ...this.defaultInfo(),
-            scopes: GitHubScope.All,
-            requirements: {
-                default: GitHubScope.Requirements.DEFAULT,
-                publicRepo: GitHubScope.Requirements.PUBLIC_REPO,
-                privateRepo: GitHubScope.Requirements.PRIVATE_REPO,
-            },
+            scopes: GitHubScope.definitions,
         }
     }
 
@@ -41,13 +36,13 @@ export class GitHubAuthProvider extends GenericAuthProvider {
             ...oauth!,
             authorizationUrl: oauth.authorizationUrl || defaultUrls.authorizationUrl,
             tokenUrl: oauth.tokenUrl || defaultUrls.tokenUrl,
-            scope: GitHubScope.All.join(scopeSeparator),
+            scope: GitHubScope.definitions.default.join(scopeSeparator),
             scopeSeparator
         };
     }
 
     authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : GitHubScope.Requirements.DEFAULT);
+        super.authorize(req, res, next, scope ? scope : GitHubScope.definitions.default);
     }
 
     /**

--- a/components/server/src/github/github-context-parser.ts
+++ b/components/server/src/github/github-context-parser.ts
@@ -86,7 +86,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             span.log({"request.finished": ""});
 
             if (result.data.repository === null) {
-                throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+                throw await this.createNotFoundError(user, host, owner, repoName);
             }
             const defaultBranch = result.data.repository.defaultBranchRef;
             const ref = defaultBranch && defaultBranch.name || undefined;
@@ -106,6 +106,12 @@ export class GithubContextParser extends AbstractContextParser implements IConte
         } finally {
             span.finish();
         }
+    }
+
+    protected async createNotFoundError(user: User, host: string, owner: string, repoName: string) {
+        const authProviderId = this.authProviderId;
+        const token = await this.tokenHelper.getCurrentToken(user);
+        return NotFoundError.create(token, user, host, owner, repoName, authProviderId, ["repo"]);
     }
 
     protected async handleTreeContext(ctx: TraceContext, user: User, host: string, owner: string, repoName: string, segments: string[]): Promise<NavigatorContext> {
@@ -148,7 +154,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
 
                 const repo = result.data.repository;
                 if (repo === null) {
-                    throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+                    throw await this.createNotFoundError(user, host, owner, repoName);
                 }
 
                 const isFile = !!(repo.path && repo.path.oid);
@@ -230,7 +236,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             span.log({"request.finished": ""});
 
             if (result.data.repository === null) {
-                throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+                throw await this.createNotFoundError(user, host, owner, repoName);
             }
 
             const commit = result.data.repository.object;
@@ -290,7 +296,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             span.log({"request.finished": ""});
 
             if (result.data.repository === null) {
-                throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+                throw await this.createNotFoundError(user, host, owner, repoName);
             }
             const pr = result.data.repository.pullRequest;
             if (pr === null) {
@@ -345,7 +351,7 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             span.log({"request.finished": ""});
 
             if (result.data.repository === null) {
-                throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+                throw await this.createNotFoundError(user, host, owner, repoName);
             }
             const issue = result.data.repository.issue;
             if (issue === null) {
@@ -360,7 +366,6 @@ export class GithubContextParser extends AbstractContextParser implements IConte
             const ref = branchRef && branchRef.name || undefined;
             const refType = ref ? "branch" : undefined;
 
-            
             return <IssueContext>{
                 title: result.data.repository.issue.title,
                 owner,

--- a/components/server/src/github/github-context-parser.ts
+++ b/components/server/src/github/github-context-parser.ts
@@ -57,9 +57,8 @@ export class GithubContextParser extends AbstractContextParser implements IConte
                     // most likely the token needs to be updated after revoking by user.
                     throw UnauthorizedError.create(this.config.host, scopes, "http-unauthorized");
                 }
-                // todo@alex: this is very unlikely. is coercing it into a valid case helpful?
-                // here, GH API responded with a 401 code, and we are missing a token. OTOH, a missing token would not lead to a request.
-                throw UnauthorizedError.create(this.config.host, GitHubScope.Requirements.PUBLIC_REPO, "missing-identity");
+                // this isn't expected to be reached, as a missing token is supposed to be handled already.
+                throw UnauthorizedError.create(this.config.host, GitHubScope.definitions.default, "missing-identity");
             }
             throw error;
         } finally {

--- a/components/server/src/github/github-token-helper.ts
+++ b/components/server/src/github/github-token-helper.ts
@@ -35,7 +35,7 @@ export class GitHubTokenHelper {
             // no token
         }
         if (requiredScopes.length === 0) {
-            requiredScopes = GitHubScope.Requirements.DEFAULT
+            requiredScopes = GitHubScope.definitions.default
         }
         throw UnauthorizedError.create(host, requiredScopes, "missing-identity");
     }

--- a/components/server/src/github/scopes.ts
+++ b/components/server/src/github/scopes.ts
@@ -4,6 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { AuthProviderScopes } from "@gitpod/gitpod-protocol";
 
 export namespace GitHubScope {
     export const EMAIL = "user:email";
@@ -12,15 +13,15 @@ export namespace GitHubScope {
     export const ORGS = "read:org";
     export const WORKFLOW = "workflow";
 
-    export const All = [EMAIL, PUBLIC, PRIVATE, ORGS, WORKFLOW];
-    export const Requirements = {
-        /**
-         * Minimal required permission.
-         * GitHub's API is not restricted any further.
-         */
-        DEFAULT: [EMAIL],
-
-        PUBLIC_REPO: [PUBLIC],
-        PRIVATE_REPO: [PRIVATE],
-    }
+    export const definitions: AuthProviderScopes = {
+        default: [EMAIL],
+        all: [EMAIL, PUBLIC, PRIVATE, ORGS, WORKFLOW],
+        descriptions: {
+            EMAIL: "Grants read-only access to the authenticated user's profile.",
+            PUBLIC: "Grants read-write access to public repositories using Git-over-HTTP.",
+            PRIVATE: "Grants read-write access to private repositories using Git-over-HTTP.",
+            ORGS: "Grants read-only access to organization membership.",
+            WORKFLOW: "Grants the ability to add and update GitHub Actions workflow files.",
+        }
+    };
 }

--- a/components/server/src/gitlab/api.ts
+++ b/components/server/src/gitlab/api.ts
@@ -27,7 +27,7 @@ export class GitLabApi {
         if (typeof userOrToken === 'string') {
             oauthToken = userOrToken;
         } else {
-            const gitlabToken = await this.tokenHelper.getTokenWithScopes(userOrToken, GitLabScope.Requirements.DEFAULT);
+            const gitlabToken = await this.tokenHelper.getTokenWithScopes(userOrToken, GitLabScope.definitions.default);
             oauthToken = gitlabToken.value;
         }
         return GitLab.create({

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -22,12 +22,7 @@ export class GitLabAuthProvider extends GenericAuthProvider {
     get info(): AuthProviderInfo {
         return {
             ...this.defaultInfo(),
-            scopes: GitLabScope.All,
-            requirements: {
-                default: GitLabScope.Requirements.DEFAULT,
-                publicRepo: GitLabScope.Requirements.REPO,
-                privateRepo: GitLabScope.Requirements.REPO,
-            },
+            scopes: GitLabScope.definitions,
         }
     }
 
@@ -43,13 +38,13 @@ export class GitLabAuthProvider extends GenericAuthProvider {
             authorizationUrl: oauth.authorizationUrl || defaultUrls.authorizationUrl,
             tokenUrl: oauth.tokenUrl || defaultUrls.tokenUrl,
             settingsUrl: oauth.settingsUrl || defaultUrls.settingsUrl,
-            scope: GitLabScope.All.join(scopeSeparator),
+            scope: GitLabScope.definitions.default.join(scopeSeparator),
             scopeSeparator
         };
     }
 
     authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
-        super.authorize(req, res, next, scope ? scope : GitLabScope.Requirements.DEFAULT);
+        super.authorize(req, res, next, scope ? scope : GitLabScope.definitions.default);
     }
 
     protected get baseURL() {

--- a/components/server/src/gitlab/gitlab-context-parser.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.ts
@@ -61,7 +61,8 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
                     // most likely the token needs to be updated after revoking by user.
                     throw UnauthorizedError.create(this.config.host, scopes, "http-unauthorized");
                 }
-                throw UnauthorizedError.create(this.config.host, GitLabScope.Requirements.REPO);
+                // this isn't expected to be reached, as a missing token is supposed to be handled already.
+                throw UnauthorizedError.create(this.config.host, GitLabScope.definitions.default);
             }
             throw error;
         } finally {

--- a/components/server/src/gitlab/gitlab-token-helper.ts
+++ b/components/server/src/gitlab/gitlab-token-helper.ts
@@ -35,7 +35,7 @@ export class GitLabTokenHelper {
             // no token
         }
         if (requiredScopes.length === 0) {
-            requiredScopes = GitLabScope.Requirements.DEFAULT
+            requiredScopes = GitLabScope.definitions.default
         }
         throw UnauthorizedError.create(host, requiredScopes, "missing-identity");
     }

--- a/components/server/src/gitlab/scopes.ts
+++ b/components/server/src/gitlab/scopes.ts
@@ -4,20 +4,25 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { AuthProviderScopes } from '@gitpod/gitpod-protocol';
 
 export namespace GitLabScope {
-    export const READ_USER = "read_user";
-    export const API = "api";
+    export const READ_USER: string = "read_user";
+    export const READ_API = "read_api";
     export const READ_REPO = "read_repository";
+    export const WRITE_REPO = "write_repository";
+    export const API = "api";
 
-    export const All = [READ_USER, API, READ_REPO];
-    export const Requirements = {
-        /**
-         * Minimal required permission.
-         * GitLab API usage requires the permission of a user.
-         */
-        DEFAULT: [READ_USER, API],
+    export const definitions: AuthProviderScopes = {
+        default: [READ_USER],
+        all: [READ_USER, READ_API, READ_REPO, WRITE_REPO, API],
+        descriptions: {
+            READ_USER: "Grants read-only access to the authenticated user's profile.",
+            READ_API: "Grants read access to the API.",
+            READ_REPO: "Grants read-only access to repositories on private projects using Git-over-HTTP.",
+            WRITE_REPO: "Grants read-write access to repositories on private projects using Git-over-HTTP.",
+            API: "Grants complete read/write access to the API.",
+        }
+    };
 
-        REPO: [API, READ_REPO],
-    }
 }

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -26,6 +26,10 @@ export abstract class AbstractContextParser implements IContextParser {
         return this.config.host;
     }
 
+    protected get authProviderId(): string {
+        return this.config.id;
+    }
+
     public normalize(contextUrl: string): string | undefined {
         let url = contextUrl.trim();
         if (url.startsWith(`${this.host}/`)) {


### PR DESCRIPTION
Resolves https://github.com/gitpod-io/gitpod/issues/1932

- [x] update scopes for OAuth App on preview environments and verify update paths
- [ ] update scopes for OAuth App on gitpod.io
- [x] require only reading email address on signup
- [x] when starting a workspace on a repo, permission update should be requested if necessary.
- [x] when trying to push to a remote repo, permission update should be offered if missing scopes can be detected.

### ON HOLD

Apparently, it's not possible to push with `write_repository` scope. While that scope works as intended for personal access tokens on gitlab.com, it does not with OAuth2 tokens. Cf. https://gitlab.com/gitlab-org/gitlab/-/issues/259254#note_506868732

*Update* I filed a bug report per request https://gitlab.com/gitlab-org/gitlab/-/issues/321359

*Update* I notified the GitLab team about closing this for now, https://gitlab.com/gitlab-org/gitlab/-/issues/259254#note_509064310