### PR TITLE
Enable messagebus metrics collection

### DIFF
--- a/chart/templates/messagebus-deployment.yaml
+++ b/chart/templates/messagebus-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
       annotations:
+        prometheus.io/scrape: 'true'
 {{ include "gitpod.pod.dependsOn" $this | indent 8 }}
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -339,6 +339,9 @@ components:
       dist:
         expose: true
         containerPort: 25672
+      metrics:
+        expose: true
+        containerPort: 15692
 
   proxy:
     name: "proxy"


### PR DESCRIPTION
### What it does

This PR enables the collection of `messagebus` metrics by prometheus.


### How to test
Those changes were done manually on staging. You can see that we already have metrics there, and a [rabbitMQ dashboard](https://monitoring.gitpod-staging.com/d/Kn5xm-gZk/rabbitmq-overview?orgId=1&refresh=30s)
