### PR TITLE
Fix Env Var context parsing

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -86,6 +86,7 @@
     "@graphql-codegen/introspection": "^1.18.1",
     "@graphql-codegen/typescript": "^1.19.0",
     "@graphql-codegen/typescript-resolvers": "^1.18.0",
+    "@testdeck/mocha": "0.1.2",
     "@types/amqplib": "^0.5.7",
     "@types/assert": "^0.0.31",
     "@types/base-64": "^0.1.2",

--- a/components/server/src/workspace/envvar-prefix-context-parser.spec.ts
+++ b/components/server/src/workspace/envvar-prefix-context-parser.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import "reflect-metadata";
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from 'chai';
+import { EnvvarPrefixParser } from "./envvar-prefix-context-parser";
+import { WithEnvvarsContext } from "@gitpod/gitpod-protocol";
+const expect = chai.expect;
+
+@suite
+class TestEnvvarPrefixParser {
+    protected parser: EnvvarPrefixParser;
+
+    public before() {
+        this.parser = new EnvvarPrefixParser();
+    }
+
+    @test
+    public testFindPrefixGood() {
+        expect(this.findPrefix("foo=bar/http...")).to.be.equal("foo=bar/");
+        expect(this.findPrefix("foo1=bar1,foo2=bar2/http...")).to.be.equal("foo1=bar1,foo2=bar2/");
+    }
+
+    @test
+    public testFindPrefixSomewhatOk() {
+        expect(this.findPrefix("foo==bar,,foo2=bar2/http...")).to.be.equal("foo==bar,,foo2=bar2/");
+        expect(this.findPrefix("foo1=bar1,foo2=bar2/http...")).to.be.equal("foo1=bar1,foo2=bar2/");
+    }
+
+    @test
+    public testFindPrefixBad() {
+        expect(this.findPrefix("foo==bar,,/http...")).to.be.undefined;
+    }
+
+    @test
+    public async testHandleGood() {
+        expect(await this.parseAndFormat("foo=bar/")).to.deep.equal({ "foo": "bar" });
+        expect(await this.parseAndFormat("foo1=bar1,foo2=bar2/")).to.deep.equal({ "foo1": "bar1", "foo2": "bar2" });
+        expect(await this.parseAndFormat("foo1=bar1,foo2=bar2,foo3=bar3/")).to.deep.equal({ "foo1": "bar1", "foo2": "bar2", "foo3": "bar3" });
+        expect(await this.parseAndFormat("foo1=bar1,foo2=bar2,foo3=bar3,foo4=bar4/")).to.deep.equal({ "foo1": "bar1", "foo2": "bar2", "foo3": "bar3", "foo4": "bar4" });
+    }
+
+    @test
+    public async testHandleDuplicate() {
+        expect(await this.parseAndFormat("foo1=bar1,foo2=bar21,foo2=bar22/")).to.deep.equal({ "foo1": "bar1", "foo2": "bar22" });
+        expect(await this.parseAndFormat("foo1=bar11,foo1=bar12,foo3=bar31,foo3=bar32/")).to.deep.equal({ "foo1": "bar12", "foo3": "bar32" });
+    }
+
+    @test
+    public async testHandleBad() {
+        expect(await this.parseAndFormat("foo1=/")).to.be.undefined;
+        expect(await this.parseAndFormat("=bar/")).to.be.undefined;
+        expect(await this.parseAndFormat("foo1==bar1,foo2=bar2/")).to.deep.equal({ "foo2": "bar2" });
+        expect(await this.parseAndFormat("foo==bar,,foo2=bar2/")).to.deep.equal({ "foo2": "bar2" });
+        expect(await this.parseAndFormat("fo% 1=bar1,foo2=bar2/")).to.deep.equal({ "foo2": "bar2" });
+    }
+
+    protected async parseAndFormat(prefix: string) {
+        const result = await this.parser.handle(/*user=*/undefined as any, prefix, undefined as any);
+        if (WithEnvvarsContext.is(result)) {
+            const r: { [key: string]: string } = {};
+            result.envvars.forEach(e => r[e.name] = e.value);
+            return r;
+        }
+        return undefined
+    }
+
+    protected findPrefix(url: string) {
+        return this.parser.findPrefix(/*user=*/undefined as any, url);
+    }
+}
+
+module.exports = new TestEnvvarPrefixParser()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,6 +2731,18 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testdeck/core@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@testdeck/core/-/core-0.1.2.tgz#9083b6c0d6ca198ba2fe03c72cf06a52c2f9fba9"
+  integrity sha512-rggcFQqSejqtkqK1JcwZE/utD4oNsM1JMHwrYxH1PKYx0uL2cMs0Q4zMVLKw0oacIASCfkIUSdXx7rDNdCDlvA==
+
+"@testdeck/mocha@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@testdeck/mocha/-/mocha-0.1.2.tgz#5fde9a675d4e1b61bcbd3440bb8d9cb984a1f80d"
+  integrity sha512-yn3OkFUlO9EkdBkDV08bPV0r26U2FC/8KvU9FdiS0ligOsjB5Ry4sp3eUQJAFxjrGJBpih0t7rZ/GzdsgCv/EQ==
+  dependencies:
+    "@testdeck/core" "^0.1.2"
+
 "@theia/application-manager@1.5.0-next.9d2dcd0a":
   version "1.5.0-next.9d2dcd0a"
   resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.5.0-next.9d2dcd0a.tgz#1f2799959c8d214185adafbc75b496fd8c4a68e0"


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/2902

### Verify

https://at-fix-env-var-ctx.staging.gitpod-dev.com/#ABC=123,DEF=234,XYZ=345,!gnored=foo/https://github.com/gitpod-io/sveltejs-template

and test with:

```bash
gitpod /workspace/sveltejs-template $ env | grep -E 'ABC|DEF|XYZ|!gnored'
DEF=234
XYZ=345
ABC=123
```