### PR TITLE
[supervisor] Let supervisor fail when first IDE start fails.

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -420,6 +420,12 @@ supervisorLoop:
 			err = cmd.Wait()
 			if err != nil && !(strings.Contains(err.Error(), "signal: interrupt") || strings.Contains(err.Error(), "wait: no child processes")) {
 				log.WithError(err).Warn("IDE was stopped")
+
+				ideWasReady := ideReady.Get()
+				if !ideWasReady {
+					log.WithError(err).Fatal("IDE failed to start")
+					return
+				}
 			}
 
 			ideReady.Set(false)


### PR DESCRIPTION
Let supervisor fail when first IDE start fails.

Fixes https://github.com/gitpod-io/gitpod/issues/3029

## How to test

Open this test repo: https://github.com/csweichel/test-repo/tree/broken-bashrc