### PR TITLE
[dashboard] Fix parsing of contextUrl to handle env vars well

### DIFF
--- a/components/dashboard/src/components/start-workspace.tsx
+++ b/components/dashboard/src/components/start-workspace.tsx
@@ -12,6 +12,7 @@ import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { ShowWorkspaceBuildLogs, WorkspaceBuildLog } from './show-workspace-build-logs';
 import { WorkspaceLogView } from './workspace-log-view';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
+import { contextUrlToUrl } from '@gitpod/gitpod-protocol/lib/util/context-url';
 import { CubeFrame } from './cube-frame';
 import { HeadlessLogEvent } from '@gitpod/gitpod-protocol/lib/headless-workspace-log';
 import { ProductivityTips } from './productivity-tips';
@@ -273,7 +274,7 @@ export class StartWorkspace extends React.Component<StartWorkspaceProps, StartWo
         }
         if (workspaceInstance.status.phase === 'stopped') {
             if (this.isHeadless && this.workspace) {
-                const contextUrl = this.workspace.contextURL.replace('prebuild/', '');
+                const contextUrl = this.workspace.contextURL.replace('prebuild/', '')!;
                 this.redirectTo(new GitpodHostUrl(window.location.toString()).withContext(contextUrl).toString());
             }
         }
@@ -443,8 +444,8 @@ export class StartWorkspace extends React.Component<StartWorkspaceProps, StartWo
 
                 const urls = new GitpodHostUrl(window.location.toString());
                 const startUrl = urls.asStart(this.props.workspaceId).toString();
-                const ctxURL = new URL(this.state.workspace?.contextURL || urls.asDashboard().toString())
-                const host = "Back to " + ctxURL.host;
+                const ctxUrl = this.state.workspace?.contextURL ? contextUrlToUrl(this.state.workspace!.contextURL)! : new URL(urls.asDashboard().toString());
+                const host = "Back to " + ctxUrl.host;
                 message = <React.Fragment>
                     <div className='message'>
                         <div style={{ display: '' }}>

--- a/components/gitpod-protocol/src/util/context-url.spec.ts
+++ b/components/gitpod-protocol/src/util/context-url.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as chai from 'chai';
+import { suite, test } from 'mocha-typescript';
+import { contextUrlToUrl } from './context-url';
+const expect = chai.expect;
+
+@suite
+export class ContextUrlTest {
+
+    @test public parseContextUrl_withEnvVar() {
+        const actual = contextUrlToUrl("passedin=test%20value/https://github.com/gitpod-io/gitpod-test-repo");
+        expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
+    }
+
+    @test public parseContextUrl_withPrebuild() {
+        const actual = contextUrlToUrl("prebuild/https://github.com/gitpod-io/gitpod-test-repo");
+        expect(actual?.host).to.equal("github.com");
+    }
+}
+module.exports = new ContextUrlTest()

--- a/components/gitpod-protocol/src/util/context-url.ts
+++ b/components/gitpod-protocol/src/util/context-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+/**
+ * The field "contextUrl" might contain prefixes like:
+ *  - envvar1=value1/...
+ *  - prebuild/...
+ * This is the analogon to the (Prefix)ContextParser structure in "server".
+ */
+export function contextUrlToUrl(contextUrl: string | undefined): URL | undefined {
+  if (contextUrl === undefined) {
+    return undefined;
+  }
+  
+  if (contextUrl.startsWith("http")) {
+    return new URL(contextUrl);
+  }
+  const finding = contextUrl.search("/http");
+  return new URL(contextUrl.substr(finding + 1));
+}

--- a/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
@@ -16,5 +16,10 @@ export class GitpodHostUrlTest {
         const actual = GitpodHostUrl.fromWorkspaceUrl("http://35.223.201.195/workspace/bc77e03d-c781-4235-bca0-e24087f5e472/").workspaceId;
         expect(actual).to.equal("bc77e03d-c781-4235-bca0-e24087f5e472");
     }
+
+    @test public parseWorkspaceId_hosts_withEnvVarsInjected() {
+        const actual = GitpodHostUrl.fromWorkspaceUrl("https://gray-grasshopper-nfbitfia.ws-eu02.gitpod-staging.com/#passedin=test%20value/https://github.com/gitpod-io/gitpod-test-repo").workspaceId;
+        expect(actual).to.equal("gray-grasshopper-nfbitfia");
+    }
 }
 module.exports = new GitpodHostUrlTest()

--- a/components/theia/packages/gitpod-extension/src/browser/githoster/git-state.ts
+++ b/components/theia/packages/gitpod-extension/src/browser/githoster/git-state.ts
@@ -12,6 +12,7 @@ import { IssueContext, CommitContext } from "@gitpod/gitpod-protocol";
 import { GitpodInfoService } from "../../common/gitpod-info";
 import { GitpodServiceProvider } from "../gitpod-service-provider";
 import { GitHosterModel } from "./model/githoster-model";
+import { contextUrlToUrl } from '@gitpod/gitpod-protocol/lib/util/context-url';
 
 @injectable()
 export abstract class GitState {
@@ -199,10 +200,12 @@ export abstract class GitState {
             }
         }
         if (CommitContext.is(ws.workspace.context)) {
-            const url = new URL(ws.workspace.contextURL);
-            return {
-                label: `${url.pathname}`,
-                url: ws.workspace.context.repository.cloneUrl.replace('.git','')
+            const url = contextUrlToUrl(ws.workspace.contextURL);
+            if (url) {
+              return {
+                  label: `${url.pathname}`,
+                  url: ws.workspace.context.repository.cloneUrl.replace('.git','')
+              }
             }
         }
         return undefined;


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3082.

## Test
 - open https://gpl-3082-gitpod-host-url.staging.gitpod-dev.com/#passedin=test%20value/https://github.com/gitpod-io/gitpod-test-repo
 - wait until workspace started up, then click your account icon (top right) and choose "Stop Workspace"
 - note how you don't stuck on a blank page