### PR TITLE
[helm] Remove 'version' and provide an error message if not set

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -275,7 +275,7 @@ registry.{{ .Values.hostname }}
 {{- $ := .root -}}
 {{- $gp := .gp -}}
 {{- $comp := .comp -}}
-{{- $comp.version | default $gp.version -}}
+{{- required "please specify the Gitpod version to use in your values.yaml or with the helm flag --set version=x.x.x" ($comp.version | default $gp.version) -}}
 {{- end -}}
 
 {{- define "gitpod.comp.imageRepo" -}}
@@ -329,8 +329,8 @@ storage:
   blobQuota: {{ .remoteStorage.blobQuota | default 0 }}
   minio:
     endpoint: {{ $remoteStorageMinio.endpoint | default (printf "minio.%s" $.Values.hostname) }}
-    accessKey: {{ required "minio access key is required, please add a value to your values.yaml" ($remoteStorageMinio.accessKey | default $minio.accessKey) }}
-    secretKey: {{ required "minio secret key is required, please add a value to your values.yaml" ($remoteStorageMinio.secretKey | default $minio.secretKey) }}
+    accessKey: {{ required "minio access key is required, please add a value to your values.yaml or with the helm flag --set minio.accessKey=xxxxx" ($remoteStorageMinio.accessKey | default $minio.accessKey) }}
+    secretKey: {{ required "minio secret key is required, please add a value to your values.yaml or with the helm flag --set minio.secretKey=xxxxx" ($remoteStorageMinio.secretKey | default $minio.secretKey) }}
     secure: {{ $remoteStorageMinio.secure | default ($minio.enabled | default false) }}
     region: {{ $remoteStorageMinio.region | default "local" }}
     parallelUpload: {{ $remoteStorageMinio.parallelUpload | default "" }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-version: "0.7.0"
+version: # version of Gitpod will be set by the CI job on publishing to https://charts.gitpod.io/
 
 hostname: localhost
 # ingressModes determines how Gitpod makes workspaces and their ports available. Possible values are:


### PR DESCRIPTION
This PR removes the value of the “version” property in the `charts/values.yaml` file. If this value is not set, a proper error is produced during the `helm` run.

Fixes gitpod-io/gitpod#3091