### PR TITLE
[helm] [self-hosted] correct proxy deployment to use `kubernetes.io/tls` secrets

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
+You can now directly use a secret of type `kubernetes.io/tls` for your `certificatesSecret` instead of manually packing your certificates
+into an `Opaque` secret with `fullChainName` / `keyName` / `chainName` entries. This older packing method will become deprecated.
+Please migrate to the Kubernetes TLS Secret format. See https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets for details.
+{{- end }}

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -156,13 +156,18 @@ spec:
       - name: config-certificates
         secret:
           secretName: {{ $.Values.certificatesSecret.secretName }}
-{{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
           items:
+{{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
           - key: {{ $.Values.certificatesSecret.fullChainName }}
             path: fullchain.pem
           - key: {{ $.Values.certificatesSecret.chainName }}
             path: chain.pem
           - key: {{ $.Values.certificatesSecret.keyName }}
+            path: privkey.pem
+{{- else }}
+          - key: tls.crt
+            path: fullchain.pem
+          - key: tls.key
             path: privkey.pem
 {{- end }}
 {{- end }}


### PR DESCRIPTION
I am suggesting this as a fix to #3183 
Instead of fetching from an `existingSecret` various keys, you could use the Kubernetes `kubernetes.io/tls` secret type. Only `fullchain.pem` aka `tls.crt` and `privkey.pem` aka `tls.key` seem to be in use in the templates, the current documentations asks for more: https://www.gitpod.io/docs/self-hosted/latest/install/configure-ingress/
See https://github.com/gitpod-io/gitpod/blob/master/chart/config/proxy/lib.ssl.conf . `ssl_dhparam` also seems to be off?
You would need to edit your current existing secret, this is a **breaking** **change!**
Please feel absolutely free to close, this is only intended as a suggestion on how to fix... The documentation for the ingress would need to be changed too.

**EDIT:** I now just check if `fullchain.pem`  and `privkey.pem` are in the secret and assume `tls.crt` and `tls.key` are there if it isn't the case. That's a non breaking change.