### PR TITLE
Enable ws-scheduler metrics collection

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -448,6 +448,10 @@ components:
         kind: "constant"
         constant:
           setpoint: 5
+    ports:
+      metrics:
+        expose: true
+        containerPort: 9500
 
   cerc:
     name: cerc


### PR DESCRIPTION
Create the metrics endpoint so Prometheus can scrape `ws-scheduler`