### PR TITLE
[ws-manager] Field metadata.namespace cannot be empty

### DIFF
--- a/components/ws-manager/pkg/manager/manager_test.go
+++ b/components/ws-manager/pkg/manager/manager_test.go
@@ -73,13 +73,14 @@ func TestControlPort(t *testing.T) {
 				manager.Config.WorkspacePortURLTemplate = "{{ .Host }}:{{ .IngressPort }}"
 			}
 
-			manager.Config.Namespace = ""
+			manager.Config.Namespace = "default"
 			startCtx, err := forTestingOnlyCreateStartWorkspaceContext(manager, fixture.Request.Id, api.WorkspaceType_REGULAR)
 			if err != nil {
 				t.Errorf("cannot create test pod start context; this is a bug in the unit test itself: %v", err)
 				return nil
 			}
 			pod, err := manager.createDefiniteWorkspacePod(startCtx)
+			pod.Namespace = manager.Config.Namespace
 			if err != nil {
 				t.Errorf("cannot create test pod; this is a bug in the unit test itself: %v", err)
 				return nil

--- a/components/ws-manager/pkg/manager/testdata/controlPort_changeTargetPort.nt.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_changeTargetPort.nt.golden
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_changeTargetPort.nt.json
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_changeTargetPort.nt.json
@@ -3,6 +3,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-prefixthis-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_changeVisibility.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_changeVisibility.golden
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_changeVisibility.json
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_changeVisibility.json
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_createPrivate.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_createPrivate.golden
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_firstClose.json
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_firstClose.json
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-prefixthis-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_firstOpen_withTargetPort.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_firstOpen_withTargetPort.golden
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_secondOpen_withTargetPort.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_secondOpen_withTargetPort.golden
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",

--- a/components/ws-manager/pkg/manager/testdata/controlPort_secondOpen_withTargetPort.json
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_secondOpen_withTargetPort.json
@@ -2,6 +2,7 @@
     "portsService": {
         "metadata": {
             "name": "ws-serviceprefix-ports",
+            "namespace": "default",
             "creationTimestamp": null,
             "labels": {
                 "gpwsman": "true",


### PR DESCRIPTION
Fix validation error when tests are executed against a real API server
```
=== RUN   TestControlPort/testdata/controlPort_changeTargetPort.nt.json
    /home/aledbf/Trabajo/github/gitpod/components/ws-manager/pkg/manager/manager_test.go:107: cannot create pod: an empty namespace may not be set during creation
    /home/aledbf/Trabajo/github/gitpod/components/ws-manager/pkg/manager/fixtures.go:75: test routine for testdata/controlPort_changeTargetPort.nt.json returned nil - continuing
```

xref: #3208