### PR TITLE
[ws-manager] Fix invalid Requests definitions

### DIFF
--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -121,7 +121,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -130,9 +130,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_duplicate_featureflag.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_duplicate_featureflag.golden
@@ -133,7 +133,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -142,9 +142,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -118,7 +118,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -127,9 +127,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -110,7 +110,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -119,9 +119,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "readinessProbe": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         },
                         {
                             "name": "GITPOD_HEADLESS",
@@ -130,9 +130,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         },
                         {
                             "name": "GITPOD_HEADLESS",
@@ -130,9 +130,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         },
                         {
                             "name": "GITPOD_HEADLESS",
@@ -134,9 +134,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         },
                         {
                             "name": "GITPOD_HEADLESS",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         },
                         {
                             "name": "GITPOD_HEADLESS",
@@ -130,9 +130,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -126,9 +126,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -121,7 +121,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -130,9 +130,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -117,7 +117,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         },
                         {
                             "name": "some-envvar",
@@ -130,9 +130,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -122,7 +122,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -131,9 +131,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -133,7 +133,7 @@
                         },
                         {
                             "name": "GITPOD_MEMORY",
-                            "value": "1300"
+                            "value": "999"
                         }
                     ],
                     "resources": {
@@ -142,9 +142,9 @@
                             "memory": "1G"
                         },
                         "requests": {
-                            "cpu": "1200m",
+                            "cpu": "899m",
                             "ephemeral-storage": "5Gi",
-                            "memory": "1300M"
+                            "memory": "999M"
                         }
                     },
                     "volumeMounts": [

--- a/components/ws-manager/pkg/manager/testing_test.go
+++ b/components/ws-manager/pkg/manager/testing_test.go
@@ -52,8 +52,8 @@ func forTestingOnlyGetManager(t *testing.T, objects ...runtime.Object) *Manager 
 					Memory: "1000M",
 				},
 				Requests: ResourceConfiguration{
-					CPU:     "1200m",
-					Memory:  "1300M",
+					CPU:     "899m",
+					Memory:  "999M",
 					Storage: "5Gi",
 				},
 			},


### PR DESCRIPTION
Fix validation error when tests are executed against a real API server

```
=== RUN   TestControlPort
=== RUN   TestControlPort/testdata/controlPort_changeTargetPort.nt.json
    /home/aledbf/Trabajo/github/gitpod/components/ws-manager/pkg/manager/manager_test.go:107: cannot create pod: Pod "ws-foobar" is invalid: [spec.containers[0].resources.requests: Invalid value: "1300M": must be less than or equal to memory limit, spec.containers[0].resources.requests: Invalid value: "1200m": must be less than or equal to cpu limit]
    /home/aledbf/Trabajo/github/gitpod/components/ws-manager/pkg/manager/fixtures.go:75: test routine for testdata/controlPort_changeTargetPort.nt.json returned nil - continuing
=== RUN   TestControlPort/testdata/controlPort_changeVisibility.json
    /home/aledbf/Trabajo/github/gitpod/components/ws-manager/pkg/manager/manager_test.go:107: cannot create pod: Pod "ws-foobar" is invalid: [spec.containers[0].resources.requests: Invalid value: "1200m": must be less than or equal to cpu limit, spec.containers[0].resources.requests: Invalid value: "1300M": must be less than or equal to memory limit]
    /home/aledbf/Trabajo/github/gitpod/components/ws-manager/pkg/manager/fixtures.go:75: test routine for testdata/controlPort_changeVisibility.json returned nil - continuing
```

xref: #3208