### PR TITLE
Allow air-gap Gitpod installations

### DIFF
--- a/chart/templates/image-builder-configmap.yaml
+++ b/chart/templates/image-builder-configmap.yaml
@@ -32,7 +32,9 @@ data:
             "gitpodLayerLoc": "/app/workspace-image-layer.tar.gz",
             "baseImageRepository": "{{ or $comp.registry.baseImageName (print (include "registry-name" $this) "/base-images") }}",
             "workspaceImageRepository": "{{ or $comp.registry.workspaceImageName (print (include "registry-name" $this) "/workspace-images") }}",
-            "imageBuildSalt": "{{ $comp.imageBuildSalt | default "" }}"
+            "imageBuildSalt": "{{ $comp.imageBuildSalt | default "" }}",
+            "alpineImage": "{{ $comp.alpineImage | default "" }}",
+            "selfBuildBaseImage": "{{ $comp.selfBuildBaseImage | default "" }}"
         },
         "refCache": {
             "interval": "6h",

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -127,6 +127,8 @@ spec:
         - name: GITPOD_GITHUB_APP_MKT_NAME
           value: "{{ $comp.github.app.marketPlaceName }}"
 {{- end }}
+        - name: GITPOD_DEFINITELY_GP_DISABLED
+          value: "{{ $comp.definitelyGpDisabled | default "false" }}"
         - name: LOG_LEVEL
           value: "trace"
         - name: NODE_ENV

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -291,6 +291,7 @@ components:
     volumes: null
     garbageCollection:
       disabled: "false"
+    definitelyGpDisabled: "false"
 
   workspace:
     ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -225,6 +225,8 @@ components:
       requests:
         cpu: 100m
         memory: 128Mi
+    alpineImage: alpine:3.9
+    selfBuildBaseImage: ""
     ports:
       rpc:
         expose: true

--- a/components/blobserve/pkg/blobserve/blobserve.go
+++ b/components/blobserve/pkg/blobserve/blobserve.go
@@ -75,7 +75,7 @@ func NewServer(cfg Config, resolver ResolverProvider) (*Server, error) {
 // Serve serves the registry on the given port
 func (reg *Server) Serve() error {
 	r := mux.NewRouter()
-	r.PathPrefix(`/{repo:[a-zA-Z0-9\/\-\.]+}:{tag:[a-z0-9][a-z0-9-\.]+}`).MatcherFunc(isNoWebsocketRequest).HandlerFunc(reg.serve)
+	r.PathPrefix(`/{repo:[a-zA-Z0-9\/\-\.\:]+}:{tag:[a-z0-9][a-z0-9-\.]+}`).MatcherFunc(isNoWebsocketRequest).HandlerFunc(reg.serve)
 	r.NewRoute().HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		log.WithField("path", req.URL.Path).Warn("unmapped request")
 		http.Error(resp, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/components/image-builder/config-schema.json
+++ b/components/image-builder/config-schema.json
@@ -28,6 +28,9 @@
         "workdir"
       ],
       "properties": {
+        "alpineImage": {
+          "type": "string"
+        },
         "baseImageRepository": {
           "type": "string"
         },
@@ -41,6 +44,9 @@
           "type": "string"
         },
         "imagebuilderRef": {
+          "type": "string"
+        },
+        "selfBuildBaseImage": {
           "type": "string"
         },
         "workdir": {

--- a/components/image-builder/example-config.json
+++ b/components/image-builder/example-config.json
@@ -5,7 +5,9 @@
         "gitpodLayerLoc": "/tmp/build/components-image-builder-workspace-image-layer--pack.588fcb85389f5c10ae444b52674654698f446a10/pack.tar",
         "baseImageRepository": "eu.gcr.io/gitpod-dev/base-images",
         "workspaceImageRepository": "eu.gcr.io/gitpod-dev/workspace-images",
-        "imageBuildSalt": "001"
+        "imageBuildSalt": "001",
+        "alpineImage": "alpine:3.9",
+        "selfBuildBaseImage": ""
     },
     "pprof": {
         "address": ":9999"

--- a/components/image-builder/pkg/builder/builder.go
+++ b/components/image-builder/pkg/builder/builder.go
@@ -97,7 +97,7 @@ func (b *DockerBuilder) Start(ctx context.Context) (err error) {
 	log.WithField("gitpodLayer", b.Config.GitpodLayerLoc).WithField("hash", b.gplayerHash).Info("computed Gitpod layer hash")
 
 	log.WithField("gitpodLayer", b.Config.GitpodLayerLoc).Info("running self-build")
-	ref, err := SelfBuild(ctx, "gitpod.io/image-builder/selfbuild", b.Config.GitpodLayerLoc, b.Docker)
+	ref, err := SelfBuild(ctx, "gitpod.io/image-builder/selfbuild", b.Config.GitpodLayerLoc, b.Config.SelfBuildBaseImage, b.Config.AlpineImage, b.Docker)
 	if err != nil {
 		log.WithError(err).Error("self-build failed")
 		return err

--- a/components/image-builder/pkg/builder/config.go
+++ b/components/image-builder/pkg/builder/config.go
@@ -36,6 +36,14 @@ type Configuration struct {
 	// generation, such that a change to this string results in a new image name and hence a rebuild.
 	// Changing this string affects base and workspace images alike.
 	ImageBuildSalt string `json:"imageBuildSalt,omitempty"`
+
+	// AlpineImage is the image that should be pulled for the selfbuild. It is a string that is used in a
+	// Dockerfile after FROM.
+	AlpineImage string `json:"alpineImage,omitempty"`
+
+	// SelfBuildBaseImage points to an image that is used as base image.
+	// Needs to be an alpine image that has `git bash openssh-client lz4 coreutils` installed.
+	SelfBuildBaseImage string `json:"selfBuildBaseImage,omitempty"`
 }
 
 // Validate validates the configuration

--- a/components/image-builder/pkg/builder/selfbuild.go
+++ b/components/image-builder/pkg/builder/selfbuild.go
@@ -21,15 +21,12 @@ import (
 )
 
 const (
-	selfbuildDockerfile = `
-FROM alpine:3.9
-
+	selfbuildDockerfileApkAdd = "RUN apk add --no-cache git bash openssh-client lz4 coreutils"
+	selfbuildDockerfileBottom = `
 # Add gitpod user for operations (e.g. checkout because of the post-checkout hook!)
 RUN addgroup -g 33333 gitpod \
     && adduser -D -h /home/gitpod -s /bin/sh -u 33333 -G gitpod gitpod \
     && echo "gitpod:gitpod" | chpasswd
-
-RUN apk add --no-cache git bash openssh-client lz4 coreutils
 
 COPY bob /bob
 COPY gitpodLayer.tar.gz /gitpodLayer.tar.gz
@@ -38,7 +35,7 @@ RUN mkdir /gitpod-layer && cd /gitpod-layer && tar xzfv /gitpodLayer.tar.gz
 )
 
 // SelfBuild builds the image of itself which the image builder requires to work
-func SelfBuild(ctx context.Context, rep, gitpodLayerLoc string, client *docker.Client) (ref string, err error) {
+func SelfBuild(ctx context.Context, rep, gitpodLayerLoc, baseImage, alpineImage string, client *docker.Client) (ref string, err error) {
 	rd, wr := io.Pipe()
 
 	gplayerhash, err := computeGitpodLayerHash(gitpodLayerLoc)
@@ -53,7 +50,7 @@ func SelfBuild(ctx context.Context, rep, gitpodLayerLoc string, client *docker.C
 
 	errchan := make(chan error)
 	go func() {
-		errchan <- writeSelfBuildContext(wr, gitpodLayerLoc)
+		errchan <- writeSelfBuildContext(wr, gitpodLayerLoc, baseImage, alpineImage)
 	}()
 
 	ref = fmt.Sprintf("%s:%s", rep, hash)
@@ -112,29 +109,29 @@ func computeGitpodLayerHash(gitpodLayerLoc string) (string, error) {
 func computeSelfbuildHash(gitpodLayerHash string) (string, error) {
 	self, err := os.Executable()
 	if err != nil {
-		return "", xerrors.Errorf("cannot compute selbuild hash: %w", err)
+		return "", xerrors.Errorf("cannot compute selfbuild hash: %w", err)
 	}
 	selfin, err := os.OpenFile(self, os.O_RDONLY, 0600)
 	if err != nil {
-		return "", xerrors.Errorf("cannot compute selbuild hash: %w", err)
+		return "", xerrors.Errorf("cannot compute selfbuild hash: %w", err)
 	}
 	defer selfin.Close()
 
 	hash := sha256.New()
 	_, err = io.Copy(hash, selfin)
 	if err != nil {
-		return "", xerrors.Errorf("cannot compute selbuild hash: %w", err)
+		return "", xerrors.Errorf("cannot compute selfbuild hash: %w", err)
 	}
 
 	_, err = fmt.Fprintf(hash, "\nbaseref=%s\n", gitpodLayerHash)
 	if err != nil {
-		return "", xerrors.Errorf("cannot compute selbuild hash: %w", err)
+		return "", xerrors.Errorf("cannot compute selfbuild hash: %w", err)
 	}
 
 	return fmt.Sprintf("%x", hash.Sum([]byte{})), nil
 }
 
-func writeSelfBuildContext(o io.WriteCloser, gitpodLayerLoc string) (err error) {
+func writeSelfBuildContext(o io.WriteCloser, gitpodLayerLoc, baseImage, alpineImage string) (err error) {
 	defer o.Close()
 
 	self, err := os.Executable()
@@ -194,15 +191,17 @@ func writeSelfBuildContext(o io.WriteCloser, gitpodLayerLoc string) (err error) 
 		return xerrors.Errorf("cannot write selfbuild context: %w", err)
 	}
 
+	dockerfile := selfbuildDockerfile(baseImage, alpineImage)
+
 	err = arc.WriteHeader(&tar.Header{
 		Name: "Dockerfile",
-		Size: int64(len(selfbuildDockerfile)),
+		Size: int64(len(dockerfile)),
 		Mode: 0755,
 	})
 	if err != nil {
 		return xerrors.Errorf("cannot write selfbuild context: %w", err)
 	}
-	_, err = arc.Write([]byte(selfbuildDockerfile))
+	_, err = arc.Write([]byte(dockerfile))
 	if err != nil {
 		return xerrors.Errorf("cannot write selfbuild context: %w", err)
 	}
@@ -210,4 +209,14 @@ func writeSelfBuildContext(o io.WriteCloser, gitpodLayerLoc string) (err error) 
 	log.Debug("self-build context sent")
 
 	return nil
+}
+
+func selfbuildDockerfile(baseImage, alpineImage string) string {
+	if len(baseImage) > 0 {
+		return fmt.Sprintf("FROM %s\n%s", baseImage, selfbuildDockerfileBottom)
+	}
+	if len(alpineImage) > 0 {
+		return fmt.Sprintf("FROM %s\n%s\n%s", alpineImage, selfbuildDockerfileApkAdd, selfbuildDockerfileBottom)
+	}
+	return fmt.Sprintf("FROM alpine\n%s\n%s", selfbuildDockerfileApkAdd, selfbuildDockerfileBottom)
 }

--- a/components/server/src/env.ts
+++ b/components/server/src/env.ts
@@ -72,6 +72,8 @@ export class Env extends AbstractComponentEnv {
     readonly githubAppCertPath: string = process.env.GITPOD_GITHUB_APP_CERT_PATH || "unknown";
     readonly githubAppMarketplaceName: string = process.env.GITPOD_GITHUB_APP_MKT_NAME || "unknown";
 
+    readonly definitelyGpDisabled: boolean = process.env.GITPOD_DEFINITELY_GP_DISABLED == "true";
+
     readonly daysBeforeGarbageCollection: number = parseInt(process.env.GITPOD_DAYS_BEFORE_GARBAGE_COLLECTION || '14', 10);
     readonly daysBeforeGarbageCollectingPrebuilds: number = parseInt(process.env.GITPOD_DAYS_BEFORE_GARBAGE_COLLECTING_PREBUILDS || '7', 10);
     readonly garbageCollectionStartDate: number = process.env.GITPOD_GARBAGE_COLLECTION_START_DATE ? 

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -210,6 +210,13 @@ export class ConfigProvider {
         const span = TraceContext.startSpan("fetchExternalGitpodFileContent", ctx);
         span.setTag("repo", `${repository.owner}/${repository.name}`);
 
+        if (this.env.definitelyGpDisabled) {
+            return {
+                content: undefined,
+                basePath: `${repository.name}`
+            };
+        }
+
         try {
             const ownerConfigBasePath = `${repository.name}/${repository.owner}`;
             const baseConfigBasePath = `${repository.name}`;

--- a/install/docker/gitpod-image/entrypoint.sh
+++ b/install/docker/gitpod-image/entrypoint.sh
@@ -11,6 +11,7 @@ mount --make-rshared /
 BASEDOMAIN=${BASEDOMAIN:-}                          # Used as Gitpod domain, `gitpod.` prefix will be added.
 DOMAIN=${DOMAIN:-}                                  # Used as Gitpod ddomain as is.
 REMOVE_NETWORKPOLICIES=${REMOVE_NETWORKPOLICIES:-}  # Remove Gitpod network policies when set to 'true'.
+HELMIMAGE=${HELMIMAGE:-alpine/helm:3.2.4}           # Image that is used for the helm install.
 
 
 mkdir -p /values
@@ -138,6 +139,7 @@ sed 's/^/    /' /values.yaml >> "$GITPOD_HELM_INSTALLER_FILE"
 
 sed -i "s/\$DOMAIN/$DOMAIN/g" "$GITPOD_HELM_INSTALLER_FILE"
 sed -i "s/\$BASEDOMAIN/$BASEDOMAIN/g" "$GITPOD_HELM_INSTALLER_FILE"
+sed -i "s+\$HELMIMAGE+$HELMIMAGE+g" "$GITPOD_HELM_INSTALLER_FILE"
 
 
 
@@ -191,9 +193,9 @@ installation_completed_hook() {
     while [ -z "$(kubectl get pods | grep gitpod-helm-installer | grep Completed)" ]; do sleep 10; done
 
     echo "Removing installer manifest ..."
-    rm -f /var/lib/rancher/k3s/server/manifests/gitpod-helm-installer.yaml
+    rm -f "$1"
 }
-installation_completed_hook &
+installation_completed_hook "$GITPOD_HELM_INSTALLER_FILE" &
 
 
 if [ "$REMOVE_NETWORKPOLICIES" = "true" ]; then

--- a/install/docker/gitpod-image/gitpod-helm-installer.yaml
+++ b/install/docker/gitpod-image/gitpod-helm-installer.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
     containers:
       - name: gitpod-helm-installer
-        image: alpine/helm:3.2.4
+        image: $HELMIMAGE
         volumeMounts:
           - name: kubeconfig
             mountPath: /root/.kube/config


### PR DESCRIPTION
This PR has some commits that make it possible to install Gitpod in an [air-gap network](https://en.wikipedia.org/wiki/Air_gap_(networking)).

## Main changes of this PR

### Allow to define an alpine image / base image for the image builder self-build

The image builder has 2 new configuration values in the `values.yaml` file: `alpineImage` and `selfBuildBaseImage`. With setting `alpineImage` one can change the alpine image that is used for the self-build, e.g. to `my-reg.example.com/alpine`. However, the self-build still needs internet access to [install some packages](https://github.com/gitpod-io/gitpod/blob/623d438ded025b5137344db915c4bb790eb4d826/components/image-builder/pkg/builder/selfbuild.go#L32). For this, one can set the value `selfBuildBaseImage` instead. It should point to an alpine image that has the packages `git bash openssh-client lz4 coreutils` already installed, e.g.:
```Dockerfile
FROM alpine
RUN apk add --no-cache git bash openssh-client lz4 coreutils
```
With a proper `selfBuildBaseImage` set, the self-build does not need internet access anymore but just access to the configured self-build base image in the local registry.

### Allow repo names with “:” in blobserve

This change is not an issue for air-gap networks in the strict sense but a general issue for own registries when they do not listen on port 80 resp. 443 but on a custom port like 5000. In this case, the blob serve does not split the image port from the tag part properly. 8d908b6 fixes this.

### Allow to disable definitely gp

Gitpod always checks the [definitely gp](https://github.com/gitpod-io/definitely-gp) repo for a Gitpod configuration. For an air-gap installation, this check can be disabled with b9dd81d.


### Allow to change the helm image used in the Gitpod k3s image
Change 4af3f33 allows to change the helm image that is used in the Gitpod k3s image.

## How to test

For the record, that's how I tested this change:

I tested the air-gap installation with the Gitpod k3s image using the following configuration:

**docker-compose.yaml:**
```
version: '3'
services:

  gitpod:
    image: eu.gcr.io/gitpod-core-dev/build/gitpod-k3s:${VERSION:-latest}
    privileged: true
    volumes:
      - gitpod-docker:/var/gitpod/docker
      - gitpod-minio:/var/gitpod/minio
      - gitpod-mysql:/var/gitpod/mysql
      - gitpod-workspaces:/var/gitpod/workspaces
      - ./values:/values
      - ./certs:/certs
      - ./air-gapped/k3s-airgap-images-amd64.tar:/var/lib/rancher/k3s/agent/images/k3s-airgap-images-amd64.tar
    ports:
      - 443:443
      - 80:80
    environment:
      - DOMAIN=${DOMAIN}
      - HELMIMAGE=registry.example.com:5000/alpine/helm:3.2.4
      - INSTALL_K3S_SKIP_DOWNLOAD=true
  
  registry:
    image: registry:2
    volumes:
      - ./registry-data:/var/lib/registry
      - ./certs:/certs
    environment:
      - REGISTRY_HTTP_TLS_CERTIFICATE=/certs/fullchain.pem
      - REGISTRY_HTTP_TLS_KEY=/certs/privkey.pem
    ports:
      - 5000:5000
    restart: always

volumes:
  gitpod-docker:
  gitpod-minio:
  gitpod-mysql:
  gitpod-workspaces:
```

**.env:**
```
DOMAIN=gitpod.example.com
VERSION=clu-gitpod-air-gap.1
```

**./values/custom-values.yaml:**
```
components:
  workspace:
    defaultImage:
      imagePrefix: "registry.example.com:5000/gitpod/"
      imageName: "workspace-full"
    pullSecret:
      secretName:
  imageBuilder:
    dindImage: registry.example.com:5000/docker:19.03-dind
    selfBuildBaseImage: registry.example.com:5000/selfbuild:latest
    registryCerts: []
    registry:
      name: registry.example.com:5000/gitpod-ws
      secretName:
  server:
    definitelyGpDisabled: "true"
docker-registry:
  enabled: false
minio:
  image:
    repository: registry.example.com:5000/minio/minio
    tag: RELEASE.2020-11-06T23-17-07Z
  accessKey: fDhEkcdeTb8Hq9VNbVJPEPFNZn6AVDAVX7hccu2y
  secretKey: fU6fm63LX4Pm64DRq9dr4nB55dr6NX9eYo8cP87Q
mysql:
  image: registry.example.com:5000/mysql
  tag: 5.7.30
  busybox:
    image: registry.example.com:5000/busybox
    tag: 1.32
imagePrefix: registry.example.com:5000/gitpod-core-dev/build/
```

- folder `./certs` has the TLS certs for the domain
- `./air-gapped/k3s-airgap-images-amd64.tar` has the images for [k3s air-gap installation](https://rancher.com/docs/k3s/latest/en/installation/airgap/#prepare-the-images-directory-and-k3s-binary) downloaded from the [releases page](https://github.com/k3s-io/k3s/releases)
- Add the Gitpod images to your local registry, e.g. with this script: `./download-images.sh clu-gitpod-air-gap.1`
**download-images.sh:**
```
#!/bin/bash

set -eu

# gcloud auth login
# gcloud auth configure-docker

LOCAL_REGISTRY=registry.example.com:5000/

GITPOD_IMAGE_REGISTRY=eu.gcr.io/
GITPOD_IMAGE_NAMESPACE=gitpod-core-dev/build/
GITPOD_IMAGE_TAG=${1:=master.62}

gitpod_images=$(cat <<EOF
blobserve
cerc
content-service
dashboard
db-migrations
docker-up
ide/code
image-builder
messagebus
proxy
registry-facade
seccomp-profile-installer
server
service-waiter
shiftfs-module-loader
supervisor
theia-ide
ws-daemon
ws-manager
ws-manager-bridge
ws-proxy
ws-scheduler
EOF
)
gitpod_images="$(echo "$gitpod_images" | sed "s+^+${GITPOD_IMAGE_REGISTRY}${GITPOD_IMAGE_NAMESPACE}+" | sed "s+$+:${GITPOD_IMAGE_TAG}+")"

misc_images=$(cat <<EOF
gitpod/workspace-full:latest
alpine:latest
alpine/helm:3.2.4
docker:19.03-dind
minio/minio:RELEASE.2020-11-06T23-17-07Z
mysql:5.7.30
busybox:1.32
EOF
)

images=$(cat <<EOF
${gitpod_images}
${misc_images}
EOF
)

export LOCAL_REGISTRY GITPOD_IMAGE_REGISTRY

mirror_image() {
    image="$1"
    echo "source:      $image"
    dest="${LOCAL_REGISTRY}$(echo "$image" | sed "s+${GITPOD_IMAGE_REGISTRY}++g")"
    echo "destination: $dest"

    docker pull "$image" > /dev/null
    docker tag "$image" "$dest" 
    docker push "$dest" > /dev/null

    echo "$image finished"
    echo ""
}

export -f mirror_image

echo "$images" | parallel -j 10 mirror_image
docker build -f ./selfbuildbase.Dockerfile -t "${LOCAL_REGISTRY}selfbuild:latest" .
docker push "${LOCAL_REGISTRY}selfbuild:latest"
```

**selfbuildbase.Dockerfile:**
```
FROM alpine
RUN apk add --no-cache git bash openssh-client lz4 coreutils
```