### PR TITLE
[proxy] Add support for Diffie–Hellman key exchange

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -41,7 +41,7 @@ components:
 
   registryFacade:
     daemonSet: true
-  
+
   contentService:
     remoteStorage:
       blobQuota: 1073741824 # 1 GiB
@@ -83,7 +83,7 @@ components:
                 cpu: 1m
                 ephemeral-storage: 5Gi
                 memory: 4608Mi  # = 2 * 2304Mi
-  
+
   # Allow per-branch ingress from another, in-cluster proxy
   proxy:
     replicas: 1
@@ -103,6 +103,7 @@ components:
     serviceType: "ClusterIP"
     deployIngressService: false
     loadBalancerIP: null
+    sslDHParam: LS0tLS1CRUdJTiBESCBQQVJBTUVURVJTLS0tLS0KTUlJQkNBS0NBUUVBdkhsWGFIOHlyNWFJYWhmc3N5RDltTDJXL2NQZUdhWmtwdUF6dm1KamFXeEZqUFJrM2IvRworbDNJY3pTRndVVy9YN2NjU2NlZ1JzZjl1dFJKR1hWZWMyL0c1VFlETkJsNDdMQ1I1VXMvUmpsV0tHcWJTVnVhCnYxY3BsUUgvVDl4UGJ4bjE2QjhrOFZmdEVUNEgxTmhRM2lxSWtGbUk2QTZrTDJzbi9VQjdhMXYydDRjL3VpdVcKcGtNNlVaRlVoUGhhVkt6VWJsR0pTWEdnbjdiVUtGWDNQSVdLY1VHM015NmhYVWg0TzRLTXhaYWRWS051T011SApyK0JLZDdsWkx5SmlBQWRtWUtTaEpNVGUwSS9uRTlFR3Q0VHVGZVZNaXpkbHR5SWkyWEFLRUlwYjZuTFlHWjY1CkNPRkx2WFpXOTJOK0U0ZFdES1ozaHBTbk1qclptVEIvYXdJQkFnPT0KLS0tLS1FTkQgREggUEFSQU1FVEVSUy0tLS0tCg==
 
   # Enable events trace
   wsManager:

--- a/chart/config/proxy/lib.ssl.conf
+++ b/chart/config/proxy/lib.ssl.conf
@@ -6,8 +6,9 @@ ssl_certificate /etc/nginx/certificates/fullchain.pem;
 ssl_trusted_certificate /etc/nginx/certificates/fullchain.pem;
 ssl_certificate_key /etc/nginx/certificates/privkey.pem;
 
-# TODO: make dhparam optional
-# ssl_dhparam /etc/nginx/certificates/dhparams.pem;
+{{- if .Values.components.proxy.sslDHParam }}
+ssl_dhparam /etc/nginx/ssl-dhparam/dh.key;
+{{ end }}
 
 add_header Strict-Transport-Security "max-age=31557600";
 ssl_stapling on;

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -97,10 +97,14 @@ spec:
 {{- if index .Values "docker-registry" "enabled" }}
         - name: builtin-registry-auth
           mountPath: "/mnt/nginx/registry-auth"
-{{- end }}     
+{{- end }}
 {{- if $.Values.certificatesSecret.secretName }}
         - name: config-certificates
           mountPath: "/mnt/nginx/certificates"
+{{- end }}
+{{- if $comp.sslDHParam }}
+        - name: config-ssl-dhparam
+          mountPath: "/mnt/nginx/ssl-dhparam"
 {{- end }}
 {{ include "gitpod.container.configmap.volumeMounts" $this | indent 8 }}
 {{ include "gitpod.container.defaultEnv" (dict "root" . "gp" $.Values "comp" $comp "noVersion" true) | indent 8 }}
@@ -151,6 +155,11 @@ spec:
       - name: ws-proxy-config
         configMap:
           name: ws-proxy-config
+{{- end }}
+{{- if $comp.sslDHParam }}
+      - name: config-ssl-dhparam
+        secret:
+          secretName: server-proxy-ssl-dhparam
 {{- end }}
 {{- if $.Values.certificatesSecret.secretName }}
       - name: config-certificates

--- a/chart/templates/server-proxy-ssl-dhparam.yaml
+++ b/chart/templates/server-proxy-ssl-dhparam.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.components.proxy.sslDHParam -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: server-proxy-ssl-dhparam
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  dh.key: {{ .Values.components.proxy.sslDHParam }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,7 +61,7 @@ workspaceSizing:
     #     limit: 200
     #
     # if there are no buckets configured, the dynamic CPU limiting is disabled.
-    cpu: 
+    cpu:
       buckets: []
       samplingPeriod: "10s"
       controlPeriod: "15m"
@@ -298,11 +298,11 @@ components:
       http:
         containerPort: 23000
         supervisorPort: 22999
-    defaultImage: 
+    defaultImage:
       imagePrefix: "gitpod/"
       imageName: "workspace-full"
       version: "latest"
-    theiaImage: 
+    theiaImage:
       imageName: "theia-ide"
     codeImage:
       imageName: "ide/code"
@@ -350,6 +350,7 @@ components:
     dependsOn:
     - "proxy-configmap-nginx.yaml"
     - "server-proxy-apikey-secret.yaml"
+    - "server-proxy-ssl-dhparam.yaml"
     ports:
       http:
         expose: true
@@ -367,6 +368,10 @@ components:
     certbot:
       enabled: false
       email: "certificate@your-domain.com"
+    # A base64ed Diffie-Hellman parameter
+    # This can be generated with: openssl dhparam 4096 2> /dev/null | base64 -w 0
+    # http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
+    sslDHParam:
 
   wsManager:
     name: "ws-manager"
@@ -402,7 +407,7 @@ components:
       runtime: containerd
       containerd:
         socket: /run/containerd/containerd.sock
-      nodeRoots: 
+      nodeRoots:
       - /var/lib
       - /run/containerd/io.containerd.runtime.v1.linux/k8s.io
       # On some hosts systems containerd uses different paths to store it's containers in, for example:

--- a/components/proxy/startup/nginx.sh
+++ b/components/proxy/startup/nginx.sh
@@ -72,6 +72,12 @@ if [ -d /mnt/nginx/registry-auth ]; then
     cat /mnt/nginx/registry-auth/password | htpasswd -i -c /etc/nginx/registry-auth.htpasswd `cat /mnt/nginx/registry-auth/user`
 fi
 
+if [ -d /mnt/nginx/ssl-dhparam/ ]; then
+    mkdir -p /etc/nginx/ssl-dhparam;
+    cp -RL /mnt/nginx/ssl-dhparam/*.key /etc/nginx/ssl-dhparam/
+    chmod -R +r /etc/nginx/ssl-dh-param
+fi
+
 echo "Using nginx config:"
 find . -name "*.conf"
 


### PR DESCRIPTION
How to test:

- ensure the werft build is green
- ensure the in-workspace build works
- open browser https://aledbf-ssl-dhparam.staging.gitpod-dev.com/workspaces/

Currently, DHE suites not supported - https://www.ssllabs.com/ssltest/analyze.html?d=gitpod.io&hideResults=on