### PR TITLE
code: better support of configured workspace extensions

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 7cb02eeb2279547b8e5ff154f463387fb77748ee
+ENV GP_CODE_COMMIT 1bca02e66c4df443f716865592fe4dec16db5d7e
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1412,7 +1412,8 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         this.checkUser("resolvePlugins")
 
         const workspace = await this.internalGetWorkspace(workspaceId, this.workspaceDb.trace({}));
-        return await this.pluginService.resolvePlugins(workspace.ownerId, params);
+        const result = await this.pluginService.resolvePlugins(workspace.ownerId, params);
+        return result.resolved;
     };
 
     installUserPlugins(params: InstallPluginsParams): Promise<boolean> {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -504,12 +504,17 @@ export class WorkspaceStarter {
             envvars.push(ev);
         }
         const addExtensionsToEnvvarPromise = this.theiaService.resolvePlugins(user.id, { config: workspace.config }).then(
-            resolvedExtensions => {
-                if (resolvedExtensions) {
-                    const ev = new EnvironmentVariable();
-                    ev.setName("GITPOD_RESOLVED_EXTENSIONS");
-                    ev.setValue(JSON.stringify(resolvedExtensions));
-                    envvars.push(ev);
+            result => {
+                if (result) {
+                    const resolvedExtensions = new EnvironmentVariable();
+                    resolvedExtensions.setName("GITPOD_RESOLVED_EXTENSIONS");
+                    resolvedExtensions.setValue(JSON.stringify(result.resolved));
+                    envvars.push(resolvedExtensions);
+
+                    const externalExtensions = new EnvironmentVariable();
+                    externalExtensions.setName("GITPOD_EXTERNAL_EXTENSIONS");
+                    externalExtensions.setValue(JSON.stringify(result.external));
+                    envvars.push(externalExtensions);
                 }
             }
         )

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -553,7 +553,7 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 	// User-defined env vars (i.e. those coming from the request)
 	if spec.Envvars != nil {
 		for _, e := range spec.Envvars {
-			if e.Name == "GITPOD_TASKS" || e.Name == "GITPOD_RESOLVED_EXTENSIONS" {
+			if e.Name == "GITPOD_TASKS" || e.Name == "GITPOD_RESOLVED_EXTENSIONS" || e.Name == "GITPOD_EXTERNAL_EXTENSIONS" {
 				result = append(result, corev1.EnvVar{Name: e.Name, Value: e.Value})
 				continue
 			} else if strings.HasPrefix(e.Name, "GITPOD_") {


### PR DESCRIPTION
#### What it does

- fix https://github.com/gitpod-io/gitpod/issues/2703: allow to add extension to .gitpod.yml. Compare to Theia, we don't support watching of .gitpod.yml and automatically install/uninstall extensions. A user can use a command to add an extension to .gitpod.yml, but changes are only applied after workspace restart or a user can install an interesting extension without synching for the current workspace. 
- fix https://github.com/gitpod-io/gitpod/issues/3045: allow to install external extensions by URL. We are not going to support hash based qualifiers of extensions in Code, but rely on Open VSX. Instead we allow users to specify URLs to external storages in order to install an extension.

Changes in code: https://github.com/gitpod-io/vscode/compare/7cb02eeb2279547b8e5ff154f463387fb77748ee...1bca02e66c4df443f716865592fe4dec16db5d7e

#### How to test

- Enable feature preview and switch to Code
- Start a workspace
- Find an extension, use context menu to add it to .gitpod.yml
- Open .gitpod.yml and check that extensions was added there and file has changes
- Add https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.8/file/dbaeumer.vscode-eslint-2.1.8.vsix url as another extension item.
- Commit and push changes to GitHub. (don't forget to give proper access rights before)
- Start a new workspace and check that both extensions are installed without synchronisation.