### PR TITLE
code: serve ext host worker from own origin

### DIFF
--- a/chart/config/proxy/vhost.server.conf
+++ b/chart/config/proxy/vhost.server.conf
@@ -132,10 +132,10 @@ server {
 server {
     listen {{ $listen }};
     # Matches:
-    #  - (webview-|browser-)?+          foreign content prefix including UUID (optional). This must be possesive (?+) to not confuse "webview-8000-a1231-..." with a valid UUID
+    #  - (webview-|browser-|extensions-)?+          foreign content prefix including UUID (optional). This must be possesive (?+) to not confuse "webview-8000-a1231-..." with a valid UUID
     #  - (?<wsid>[a-z][0-9a-z\-]+)      workspace Id or blobserve
     #  - \.ws(-[a-z0-9]+)?              workspace base domain
-    server_name ~^(webview-|browser-)?+(?<wsid>[a-z0-9][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$;
+    server_name ~^(webview-|browser-|extensions-)?+(?<wsid>[a-z0-9][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$;
 
 {{- if $useHttps }}
     {{- if eq .Values.ingressMode "pathAndHost" }}
@@ -153,12 +153,12 @@ server {
 server {
     listen {{ $listen }};
     # Matches:
-    #  - (webview-|browser-)?+          for now, we only support Theia webviews here! (TODO is there a - meaningful - way to generalize this?)
+    #  - (webview-|browser-|extensions-)?+          for now, we only support Theia webviews here! (TODO is there a - meaningful - way to generalize this?)
     #  - (?<port>[0-9]{2,5})-           port to forward to
     #  - (?<wsid>[a-z][0-9a-z\-]+)      workspace Id
     #  - \.ws(-[a-z0-9]+)?              workspace base domain
     # "" needed because of {} (nginx syntax wart)
-    server_name "~^(webview-|browser-)?+(?<port>[0-9]{2,5})-(?<wsid>[a-z0-9][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$";
+    server_name "~^(webview-|browser-|extensions-)?+(?<port>[0-9]{2,5})-(?<wsid>[a-z0-9][0-9a-z\-]+)\.ws(-[a-z0-9]+)?\.${PROXY_DOMAIN_REGEX}$";
 
 {{- if $useHttps }}
     {{- if eq .Values.ingressMode "pathAndHost" }}

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 1bca02e66c4df443f716865592fe4dec16db5d7e
+ENV GP_CODE_COMMIT fff45adc4e4a85b0944bd8a7dcb631e0018cb2c4
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -63,7 +63,7 @@ func HostBasedRouter(header, wsHostSuffix string) WorkspaceRouter {
 type hostHeaderProvider func(req *http.Request) string
 
 func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProvider) mux.MatcherFunc {
-	r := regexp.MustCompile("^(webview-|browser-)?" + workspaceIDRegex + wsHostSuffix)
+	r := regexp.MustCompile("^(webview-|browser-|extensions-)?" + workspaceIDRegex + wsHostSuffix)
 	return func(req *http.Request, m *mux.RouteMatch) bool {
 		hostname := headerProvider(req)
 		if hostname == "" {
@@ -92,7 +92,7 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 }
 
 func matchWorkspacePortHostHeader(wsHostSuffix string, headerProvider hostHeaderProvider) mux.MatcherFunc {
-	r := regexp.MustCompile("^(webview-|browser-)?" + workspacePortRegex + workspaceIDRegex + wsHostSuffix)
+	r := regexp.MustCompile("^(webview-|browser-|extensions-)?" + workspacePortRegex + workspaceIDRegex + wsHostSuffix)
 	return func(req *http.Request, m *mux.RouteMatch) bool {
 		hostname := headerProvider(req)
 		if hostname == "" {


### PR DESCRIPTION
#### What it does

- fix #2856: server ext host worker from own origin

Changes in code: https://github.com/gitpod-io/vscode/commit/d632b1f5ac26adeea5332911babeb89fc18afd2e

#### How to test

- Enable feature preview and Code.
- Start a workspace.
- Check in devtools that ext host worker is running under different origin with `extensions-` prefix:
<img width="399" alt="Screenshot 2021-02-23 at 09 39 44" src="https://user-images.githubusercontent.com/3082655/108820435-7ad4cd00-75bc-11eb-896b-dbb035f155c2.png">
