### PR TITLE
[#2658] Basic integration tests

### DIFF
--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -5,6 +5,9 @@ args:
 - name: namespace
   desc: "The namespace to run the integration test against"
   required: true
+- name: username
+  desc: "The username to run the integration test with"
+  required: false
 pod:
   serviceAccount: werft
   nodeSelector:
@@ -62,9 +65,15 @@ pod:
       cp -R /config/gcloud /root/.config/gcloud
       export GOOGLE_APPLICATION_CREDENTIALS=/config/gcloud/legacy_credentials/gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json
       echo "[prep] received config."
+
+      USERNAME="{{ .Annotations.username }}"
+      if [[ "$USERNAME" == "<no value>" ]]; then
+        USERNAME=""
+      fi
+      echo "[prep] using username: $USERNAME"
       echo "[prep|DONE]"
 
-      /entrypoint.sh -kubeconfig=/config/kubeconfig -namespace={{ .Annotations.namespace }} 2>&1 | ts "[int-tests] "
+      /entrypoint.sh -kubeconfig=/config/kubeconfig -namespace={{ .Annotations.namespace }} -username=$USERNAME 2>&1 | ts "[int-tests] "
       
       RC=${PIPESTATUS[0]}
       if [ $RC -eq 1 ]; then echo "[int-tests|FAIL]"; else echo "[int-tests|DONE]"; fi

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -1,0 +1,70 @@
+args:
+- name: version
+  desc: "The version of the integration tests to use"
+  required: true
+- name: namespace
+  desc: "The namespace to run the integration test against"
+  required: true
+pod:
+  serviceAccount: werft
+  nodeSelector:
+    dev/workload: builds
+  imagePullSecrets:
+  - name: eu-gcr-io-pull-secret
+  volumes:
+  - name: gcp-sa
+    secret:
+      secretName: gcp-sa-gitpod-dev-deployer
+  - name: config
+    emptyDir: {}
+  initContainers:
+  - name: gcloud
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-bump-helm.12
+    workingDir: /workspace
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: gcp-sa
+      mountPath: /mnt/secrets/gcp-sa
+      readOnly: true
+    - name: config
+      mountPath: /config
+      readOnly: false
+    command:
+    - bash
+    - -c
+    - |
+      
+      echo "[prep] preparing config."
+
+      gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
+      cp -R /home/gitpod/.config/gcloud /config/gcloud
+      cp /home/gitpod/.kube/config /config/kubeconfig
+
+      echo "[prep] copied config..."
+  containers:
+  - name: tests
+    image: eu.gcr.io/gitpod-core-dev/build/integration-tests:{{ .Annotations.version }}
+    workingDir: /workspace
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: config
+      mountPath: /config
+      readOnly: true
+    command:
+    - /bin/bash
+    - -c
+    - |
+      sleep 1
+      set -Eeuo pipefail
+
+      echo "[prep] receiving config..."
+      mkdir /root/.config
+      cp -R /config/gcloud /root/.config/gcloud
+      export GOOGLE_APPLICATION_CREDENTIALS=/config/gcloud/legacy_credentials/gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json
+      echo "[prep] received config."
+      echo "[prep|DONE]"
+
+      /entrypoint.sh -kubeconfig=/config/kubeconfig -namespace={{ .Annotations.namespace }} 2>&1 | ts "[int-tests] "
+      
+      RC=${PIPESTATUS[0]}
+      if [ $RC -eq 1 ]; then echo "[int-tests|FAIL]"; else echo "[int-tests|DONE]"; fi

--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -124,6 +124,8 @@ func (rc *ReconnectingWebsocket) Dial() {
 		case err := <-rc.errCh:
 			log.WithError(err).WithField("url", rc.url).Warn("connection has been closed, reconnecting...")
 			conn.Close()
+
+			time.Sleep(1 * time.Second)
 			conn = rc.connect()
 		}
 	}

--- a/test/BUILD.yaml
+++ b/test/BUILD.yaml
@@ -28,6 +28,8 @@ packages:
       dontTest: true
   - name: docker
     type: docker
+    srcs:
+      - entrypoint.sh
     deps:
       - :app
     argdeps:

--- a/test/README.md
+++ b/test/README.md
@@ -16,3 +16,16 @@ Such tests are for example:
                    They communicate with the test using net/rpc.
 - API access: to all internal APIs, including ws-manager, ws-daemon, image-builder, registry-facade, server
 - DB access to the Gitpod DB
+
+## Run
+
+There is a [werft job](../.werft/run-integration-tests.yaml) that runs the integration tests against `core-dev` preview environments.
+
+ > For tests that require an existing user the framework tries to automatically select one from the DB.
+ > - On preview envs make sure to create one before running tests against it!
+ > - If it's important to use a certain user (with fixed settings, for example) pass the additional `username` parameter.
+
+Example command:
+```
+werft job run github -j .werft/run-integration-tests.yaml -a namespace=staging-gpl-2658-int-tests -a version=gpl-2658-int-tests.57 -f
+```

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -ex
+
+for i in $(ls /tests/*.test); do
+    $i $*;
+done

--- a/test/go.sum
+++ b/test/go.sum
@@ -106,6 +106,7 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gitpod-io/gitpod v0.6.0-beta3 h1:WGLut/rxCjgg+RDHzMzu1jgztbIlQU8U/aFm4bVudmc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/test/leeway.Dockerfile
+++ b/test/leeway.Dockerfile
@@ -7,8 +7,11 @@ FROM alpine:3.13
 # Ensure latest packages are present, like security updates.
 RUN  apk upgrade --no-cache \
   && apk add --no-cache ca-certificates
+  
+# convenience scripting tools
+RUN apk add --no-cache bash moreutils
 
 COPY test--app/bin /tests
 ENV PATH=$PATH:/tests
-RUN sh -c "echo '#!/bin/sh' > /entrypoint.sh; echo 'set -ex' >> /entrypoint.sh; echo 'for i in \$(ls /tests/*.test); do \$i \$*; done' >> /entrypoint.sh; chmod +x /entrypoint.sh"
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,14 +66,25 @@ type ComponentAPI struct {
 		BlobServiceClient csapi.BlobServiceClient
 	}
 	dbStatus struct {
-		Port     int
-		Password string
-		DB       *sql.DB
+		Config *DBConfig
+		DB     *sql.DB
 	}
 	imgbldStatus struct {
 		Port   int
 		Client imgbldr.ImageBuilderClient
 	}
+}
+
+type DBConfig struct {
+	Host        string
+	Port        int32
+	ForwardPort *ForwardPort
+	Password    string
+}
+
+type ForwardPort struct {
+	PodName    string
+	RemotePort int32
 }
 
 // Supervisor provides a gRPC connection to a workspace's supervisor
@@ -370,81 +382,31 @@ func (c *ComponentAPI) DB() *sql.DB {
 		c.t.t.Fatalf("cannot access database: %q", rerr)
 	}()
 
-	if c.dbStatus.Port == 0 {
-		svc, err := c.t.clientset.CoreV1().Services(c.t.namespace).Get(context.Background(), "db", metav1.GetOptions{})
+	if c.dbStatus.Config == nil {
+		config, err := c.findDBConfig()
 		if err != nil {
 			rerr = err
 			return nil
 		}
-		pods, err := c.t.clientset.CoreV1().Pods(c.t.namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String(),
-		})
-		if err != nil {
-			rerr = err
-			return nil
-		}
-		if len(pods.Items) == 0 {
-			rerr = xerrors.Errorf("no pods for service %s found", svc.Name)
-			return nil
-		}
-		var pod *corev1.Pod
-		for _, p := range pods.Items {
-			if p.Spec.NodeName == "" {
-				// no node means the pod can't be ready
-				continue
-			}
-			var isReady bool
-			for _, cond := range p.Status.Conditions {
-				if cond.Type == corev1.PodReady {
-					isReady = cond.Status == corev1.ConditionTrue
-					break
-				}
-			}
-			if !isReady {
-				continue
-			}
+		c.dbStatus.Config = config
+	}
+	config := c.dbStatus.Config
 
-			pod = &p
-			break
-		}
-		if pod == nil {
-			rerr = xerrors.Errorf("no active pod for service %s found", svc.Name)
-			return nil
-		}
-
-		localPort, err := getFreePort()
-		if err != nil {
-			rerr = err
-			return nil
-		}
+	// if configured: setup local port-forward to DB pod
+	if config.ForwardPort != nil {
 		ctx, cancel := context.WithCancel(context.Background())
-		ready, errc := forwardPort(ctx, c.t.restConfig, c.t.namespace, pod.Name, fmt.Sprintf("%d:3306", localPort))
+		ready, errc := forwardPort(ctx, c.t.restConfig, c.t.namespace, config.ForwardPort.PodName, fmt.Sprintf("%d:%d", config.Port, config.ForwardPort.RemotePort))
 		select {
-		case err = <-errc:
+		case err := <-errc:
 			cancel()
 			rerr = err
 			return nil
 		case <-ready:
 		}
 		c.t.closer = append(c.t.closer, func() error { cancel(); return nil })
-
-		c.dbStatus.Port = localPort
-	}
-	if c.dbStatus.Password == "" {
-		sct, err := c.t.clientset.CoreV1().Secrets(c.t.namespace).Get(context.Background(), "db-password", metav1.GetOptions{})
-		if err != nil {
-			rerr = err
-			return nil
-		}
-		pwd, ok := sct.Data["mysql-root-password"]
-		if !ok {
-			rerr = xerrors.Errorf("no mysql-root-password data present in secret %s", sct.Name)
-			return nil
-		}
-		c.dbStatus.Password = string(pwd)
 	}
 
-	db, err := sql.Open("mysql", fmt.Sprintf("gitpod:%s@tcp(127.0.0.1:%d)/gitpod", c.dbStatus.Password, c.dbStatus.Port))
+	db, err := sql.Open("mysql", fmt.Sprintf("gitpod:%s@tcp(%s:%d)/gitpod", config.Password, config.Host, config.Port))
 	if err != nil {
 		rerr = err
 		return nil
@@ -453,6 +415,127 @@ func (c *ComponentAPI) DB() *sql.DB {
 	c.dbStatus.DB = db
 	c.t.closer = append(c.t.closer, db.Close)
 	return db
+}
+
+func (c *ComponentAPI) findDBConfig() (*DBConfig, error) {
+	config, err := c.findDBConfigFromPodEnv("server")
+	if err != nil {
+		return nil, err
+	}
+
+	// here we _assume_ that "config" points to a service: find us a concrete DB pod to forward to
+	svc, err := c.t.clientset.CoreV1().Services(c.t.namespace).Get(context.Background(), config.Host, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// find remotePort
+	var remotePort int32
+	for _, p := range svc.Spec.Ports {
+		if p.Port == config.Port {
+			remotePort = p.TargetPort.IntVal
+			if remotePort == 0 {
+				remotePort = p.Port
+			}
+			break
+		}
+	}
+	if remotePort == 0 {
+		return nil, fmt.Errorf("no ports found on service: %s", svc.Name)
+	}
+
+	// find pod to forward to
+	pods, err := c.t.clientset.CoreV1().Pods(c.t.namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no pods for service %s found", svc.Name)
+	}
+	var pod *corev1.Pod
+	for _, p := range pods.Items {
+		if p.Spec.NodeName == "" {
+			// no node means the pod can't be ready
+			continue
+		}
+		var isReady bool
+		for _, cond := range p.Status.Conditions {
+			if cond.Type == corev1.PodReady {
+				isReady = cond.Status == corev1.ConditionTrue
+				break
+			}
+		}
+		if !isReady {
+			continue
+		}
+
+		pod = &p
+		break
+	}
+	if pod == nil {
+		return nil, fmt.Errorf("no active pod for service %s found", svc.Name)
+	}
+
+	localPort, err := getFreePort()
+	if err != nil {
+		return nil, err
+	}
+	config.Port = int32(localPort)
+	config.ForwardPort = &ForwardPort{
+		RemotePort: remotePort,
+		PodName:    pod.Name,
+	}
+	config.Host = "127.0.0.1"
+
+	return config, nil
+}
+
+func (c *ComponentAPI) findDBConfigFromPodEnv(componentName string) (*DBConfig, error) {
+	lblSelector := fmt.Sprintf("component=%s", componentName)
+	list, err := c.t.clientset.CoreV1().Pods(c.t.namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: lblSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) == 0 {
+		return nil, fmt.Errorf("no pods found for: %s", lblSelector)
+	}
+	pod := list.Items[0]
+
+	var password string
+	var port int32
+	var host string
+OuterLoop:
+	for _, c := range pod.Spec.Containers {
+		for _, v := range c.Env {
+			if v.Name == "DB_PASSWORD" {
+				password = v.Value
+			} else if v.Name == "DB_PORT" {
+				pPort, err := strconv.Atoi(v.Value)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing DB_PORT '%s' on pod %s!", v.Value, pod.Name)
+				}
+				port = int32(pPort)
+			} else if v.Name == "DB_HOST" {
+				host = v.Value
+			}
+			if password != "" && port != 0 && host != "" {
+				break OuterLoop
+			}
+		}
+	}
+	if password == "" || port == 0 || host == "" {
+		return nil, fmt.Errorf("could not find complete DBConfig on pod %s!", pod.Name)
+	}
+	config := DBConfig{
+		Host:     host,
+		Port:     port,
+		Password: password,
+	}
+	return &config, nil
 }
 
 // ImageBuilder provides access to the image builder service.

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -214,7 +214,7 @@ func (c *ComponentAPI) createGitpodToken(user string) (tkn string, err error) {
 		row *sql.Row
 	)
 	if user == "" {
-		row = db.QueryRow(`SELECT id FROM d_b_user WHERE NOT id = "` + gitpodBuiltinUserID + `"`)
+		row = db.QueryRow(`SELECT id FROM d_b_user WHERE NOT id = "` + gitpodBuiltinUserID + `" AND blocked = FALSE AND markedDeleted = FALSE`)
 	} else {
 		row = db.QueryRow("SELECT id FROM d_b_user WHERE name = ?", user)
 	}

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -40,18 +40,23 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-const cfgflagDefault = "$HOME/.kube/config"
+const cfgFlagDefault = "$HOME/.kube/config"
 
 var (
-	cfgflag = flag.String("kubeconfig", cfgflagDefault, "path to the kubeconfig file, use \"in-cluster\" to make use of in cluster Kubernetes config")
+	cfgFlag       = flag.String("kubeconfig", cfgFlagDefault, "path to the kubeconfig file, use \"in-cluster\" to make use of in cluster Kubernetes config")
+	namespaceFlag = flag.String("namespace", "", "namespace to execute the test against. Defaults to the one configured in \"kubeconfig\".")
 )
 
 // NewTest produces a new integration test instance
 func NewTest(t *testing.T) *Test {
 	flag.Parse()
 
-	kubeconfig := *cfgflag
-	if kubeconfig == cfgflagDefault {
+	kubeconfig := *cfgFlag
+	namespaceOverride := *namespaceFlag
+	t.Logf("kubeconfig: %s", kubeconfig)
+	t.Logf("namespaceOverride: %s", namespaceOverride)
+
+	if kubeconfig == cfgFlagDefault {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			t.Fatal("cannot determine user home dir", err)
@@ -68,6 +73,10 @@ func NewTest(t *testing.T) *Test {
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		t.Fatal("cannot connecto Kubernetes", err)
+	}
+
+	if namespaceOverride != "" {
+		ns = namespaceOverride
 	}
 
 	return &Test{

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -45,13 +45,15 @@ const cfgFlagDefault = "$HOME/.kube/config"
 var (
 	cfgFlag       = flag.String("kubeconfig", cfgFlagDefault, "path to the kubeconfig file, use \"in-cluster\" to make use of in cluster Kubernetes config")
 	namespaceFlag = flag.String("namespace", "", "namespace to execute the test against. Defaults to the one configured in \"kubeconfig\".")
+	usernameFlag  = flag.String("username", "", "username to execute the tests with. Chooses one automatically if left blank.")
 )
 
 // NewTest produces a new integration test instance
-func NewTest(t *testing.T) *Test {
+func NewTest(t *testing.T, timeout time.Duration) (*Test, context.Context) {
 	flag.Parse()
 	kubeconfig := *cfgFlag
 	namespaceOverride := *namespaceFlag
+	username := *usernameFlag
 
 	if kubeconfig == cfgFlagDefault {
 		home, err := os.UserHomeDir()
@@ -76,12 +78,16 @@ func NewTest(t *testing.T) *Test {
 		ns = namespaceOverride
 	}
 
+	ctx, ctxCancel := context.WithTimeout(context.Background(), timeout)
 	return &Test{
 		t:          t,
 		clientset:  client,
 		restConfig: restConfig,
 		namespace:  ns,
-	}
+		ctx:        ctx,
+		ctxCancel:  ctxCancel,
+		username:   username,
+	}, ctx
 }
 
 // GetKubeconfig loads kubernetes connection config from a kubeconfig file
@@ -124,23 +130,35 @@ type Test struct {
 	clientset  kubernetes.Interface
 	restConfig *rest.Config
 	namespace  string
+	ctx        context.Context
 
-	closer []func() error
-	api    *ComponentAPI
+	closer    []func() error
+	ctxCancel func()
+	api       *ComponentAPI
+
+	// username contains the string passed to the test per flag. Might be empty.
+	username string
 }
 
 // Done must be called after the test has run. It cleans up instrumentation
 // and modifications made by the test.
-func (t *Test) Done() {
+func (it *Test) Done() {
+	it.ctxCancel()
+
 	// Much "defer", we run the closer in reversed order. This way, we can
 	// append to this list quite naturally, and still break things down in
 	// the correct order.
-	for i := len(t.closer) - 1; i >= 0; i-- {
-		err := t.closer[i]()
+	for i := len(it.closer) - 1; i >= 0; i-- {
+		err := it.closer[i]()
 		if err != nil {
-			t.t.Logf("cleanup failed: %q", err)
+			it.t.Logf("cleanup failed: %q", err)
 		}
 	}
+}
+
+// Username returns the username passed to the test per flag. Might be empty.
+func (it *Test) Username() string {
+	return it.username
 }
 
 // InstrumentOption configures an Instrument call
@@ -171,7 +189,7 @@ func WithInstanceID(instanceID string) InstrumentOption {
 // The binary is copied to the destination pod, started and port-forwarded. Then we
 // create an RPC client.
 // Test.Done() will stop the agent and port-forwarding.
-func (t *Test) Instrument(component ComponentType, agentName string, opts ...InstrumentOption) (agent *rpc.Client, err error) {
+func (it *Test) Instrument(component ComponentType, agentName string, opts ...InstrumentOption) (agent *rpc.Client, err error) {
 	var options instrumentOptions
 	for _, o := range opts {
 		err := o(&options)
@@ -183,21 +201,21 @@ func (t *Test) Instrument(component ComponentType, agentName string, opts ...Ins
 	expectedBinaryName := fmt.Sprintf("gitpod-integration-test-%s-agent", agentName)
 	agentLoc, _ := exec.LookPath(expectedBinaryName)
 	if agentLoc == "" {
-		agentLoc, err = t.buildAgent(agentName)
+		agentLoc, err = it.buildAgent(agentName)
 		if err != nil {
 			return nil, err
 		}
 		defer os.Remove(agentLoc)
 
-		t.t.Log("agent compiled at", agentLoc)
+		it.t.Log("agent compiled at", agentLoc)
 	}
 
-	podName, containerName, err := t.selectPod(component, options.SPO)
+	podName, containerName, err := it.selectPod(component, options.SPO)
 	if err != nil {
 		return nil, err
 	}
 	tgtFN := filepath.Base(agentLoc)
-	err = t.uploadAgent(agentLoc, tgtFN, podName, containerName)
+	err = it.uploadAgent(agentLoc, tgtFN, podName, containerName)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +228,7 @@ func (t *Test) Instrument(component ComponentType, agentName string, opts ...Ins
 	execErrs := make(chan error, 1)
 	go func() {
 		defer close(execErrs)
-		execErr := t.executeAgent(filepath.Join("/tmp", tgtFN), podName, containerName, localAgentPort)
+		execErr := it.executeAgent(filepath.Join("/tmp", tgtFN), podName, containerName, localAgentPort)
 		if err != nil {
 			execErrs <- execErr
 		}
@@ -227,7 +245,7 @@ func (t *Test) Instrument(component ComponentType, agentName string, opts ...Ins
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		if err == nil {
-			t.closer = append(t.closer, func() error {
+			it.closer = append(it.closer, func() error {
 				cancel()
 				return nil
 			})
@@ -235,7 +253,7 @@ func (t *Test) Instrument(component ComponentType, agentName string, opts ...Ins
 			cancel()
 		}
 	}()
-	fwdReady, fwdErr := forwardPort(ctx, t.restConfig, t.namespace, podName, strconv.Itoa(localAgentPort))
+	fwdReady, fwdErr := forwardPort(ctx, it.restConfig, it.namespace, podName, strconv.Itoa(localAgentPort))
 	select {
 	case <-fwdReady:
 	case err = <-execErrs:
@@ -262,7 +280,7 @@ func (t *Test) Instrument(component ComponentType, agentName string, opts ...Ins
 		return nil, err
 	}
 
-	t.closer = append(t.closer, func() error {
+	it.closer = append(it.closer, func() error {
 		err := res.Call(MethodTestAgentShutdown, new(TestAgentShutdownRequest), new(TestAgentShutdownResponse))
 		if err != nil && strings.Contains(err.Error(), "connection is shut down") {
 			return nil
@@ -347,12 +365,12 @@ func forwardPort(ctx context.Context, config *rest.Config, namespace, pod, port 
 	return
 }
 
-func (t *Test) executeAgent(tgtPath string, pod, container string, port int) (err error) {
-	restClient := t.clientset.CoreV1().RESTClient()
+func (it *Test) executeAgent(tgtPath string, pod, container string, port int) (err error) {
+	restClient := it.clientset.CoreV1().RESTClient()
 	req := restClient.Post().
 		Resource("pods").
 		Name(pod).
-		Namespace(t.namespace).
+		Namespace(it.namespace).
 		SubResource("exec").
 		Param("container", container)
 	req.VersionedParams(&corev1.PodExecOptions{
@@ -364,7 +382,7 @@ func (t *Test) executeAgent(tgtPath string, pod, container string, port int) (er
 		TTY:       true,
 	}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(t.restConfig, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(it.restConfig, "POST", req.URL())
 	if err != nil {
 		return err
 	}
@@ -376,7 +394,7 @@ func (t *Test) executeAgent(tgtPath string, pod, container string, port int) (er
 	})
 }
 
-func (t *Test) uploadAgent(srcFN, tgtFN string, pod, container string) (err error) {
+func (it *Test) uploadAgent(srcFN, tgtFN string, pod, container string) (err error) {
 	stat, err := os.Stat(srcFN)
 	if err != nil {
 		return xerrors.Errorf("cannot upload agent: %w", err)
@@ -389,11 +407,11 @@ func (t *Test) uploadAgent(srcFN, tgtFN string, pod, container string) (err erro
 
 	tarIn, tarOut := io.Pipe()
 
-	restClient := t.clientset.CoreV1().RESTClient()
+	restClient := it.clientset.CoreV1().RESTClient()
 	req := restClient.Post().
 		Resource("pods").
 		Name(pod).
-		Namespace(t.namespace).
+		Namespace(it.namespace).
 		SubResource("exec").
 		Param("container", container)
 	req.VersionedParams(&corev1.PodExecOptions{
@@ -405,7 +423,7 @@ func (t *Test) uploadAgent(srcFN, tgtFN string, pod, container string) (err erro
 		TTY:       false,
 	}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(t.restConfig, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(it.restConfig, "POST", req.URL())
 	if err != nil {
 		return xerrors.Errorf("cannot upload agent: %w", err)
 	}

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -50,11 +50,8 @@ var (
 // NewTest produces a new integration test instance
 func NewTest(t *testing.T) *Test {
 	flag.Parse()
-
 	kubeconfig := *cfgFlag
 	namespaceOverride := *namespaceFlag
-	t.Logf("kubeconfig: %s", kubeconfig)
-	t.Logf("namespaceOverride: %s", namespaceOverride)
 
 	if kubeconfig == cfgFlagDefault {
 		home, err := os.UserHomeDir()

--- a/test/tests/examples/db_test.go
+++ b/test/tests/examples/db_test.go
@@ -6,12 +6,13 @@ package examples
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
 )
 
 func TestBuiltinUserExists(t *testing.T) {
-	it := integration.NewTest(t)
+	it, _ := integration.NewTest(t, 30*time.Second)
 	defer it.Done()
 
 	db := it.API().DB()

--- a/test/tests/examples/server_test.go
+++ b/test/tests/examples/server_test.go
@@ -14,11 +14,8 @@ import (
 )
 
 func TestServerAccess(t *testing.T) {
-	it := integration.NewTest(t)
+	it, ctx := integration.NewTest(t, 5*time.Second)
 	defer it.Done()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
 	server := it.API().GitpodServer()
 	res, err := server.GetLoggedInUser(ctx)
@@ -29,11 +26,8 @@ func TestServerAccess(t *testing.T) {
 }
 
 func TestStartWorkspace(t *testing.T) {
-	it := integration.NewTest(t)
+	it, ctx := integration.NewTest(t, 5*time.Minute)
 	defer it.Done()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	server := it.API().GitpodServer()
 	resp, err := server.CreateWorkspace(ctx, &protocol.CreateWorkspaceOptions{
@@ -61,8 +55,6 @@ func TestStartWorkspace(t *testing.T) {
 		t.Fatal("CreateWorkspace did not start the workspace")
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
 	it.WaitForWorkspace(ctx, nfo.LatestInstance.ID)
 
 	t.Logf("workspace is running: instanceID=%s", nfo.LatestInstance.ID)

--- a/test/tests/examples/wsmanager_test.go
+++ b/test/tests/examples/wsmanager_test.go
@@ -5,7 +5,6 @@
 package examples
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -14,12 +13,10 @@ import (
 )
 
 func TestGetWorkspaces(t *testing.T) {
-	it := integration.NewTest(t)
+	it, ctx := integration.NewTest(t, 5*time.Second)
 	defer it.Done()
 
 	wsman := it.API().WorkspaceManager()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	_, err := wsman.GetWorkspaces(ctx, &api.GetWorkspacesRequest{})
 	if err != nil {
 		t.Fatal(err)

--- a/test/tests/storage/content-service_test.go
+++ b/test/tests/storage/content-service_test.go
@@ -5,7 +5,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,12 +60,10 @@ func TestUploadUrl(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			it := integration.NewTest(t)
+			it, ctx := integration.NewTest(t, 15*time.Second)
 			defer it.Done()
 
 			bs := it.API().BlobService()
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-			defer cancel()
 			resp, err := bs.UploadUrl(ctx, &api.UploadUrlRequest{OwnerId: test.InputOwnerID, Name: test.InputName})
 			if err != nil && test.ExpectedErrorCode == codes.OK {
 				t.Fatal(err)
@@ -104,12 +101,10 @@ func TestDownloadUrl(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			it := integration.NewTest(t)
+			it, ctx := integration.NewTest(t, 5*time.Second)
 			defer it.Done()
 
 			bs := it.API().BlobService()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
 			resp, err := bs.DownloadUrl(ctx, &api.DownloadUrlRequest{OwnerId: test.InputOwnerID, Name: test.InputName})
 			if err != nil && test.ExpectedErrorCode == codes.OK {
 				t.Fatal(err)
@@ -132,14 +127,12 @@ func TestDownloadUrl(t *testing.T) {
 }
 
 func TestUploadDownloadBlob(t *testing.T) {
-	it := integration.NewTest(t)
+	it, ctx := integration.NewTest(t, 5*time.Second)
 	defer it.Done()
 
 	blobContent := fmt.Sprintf("Hello Blobs! It's %s!", time.Now())
 
 	bs := it.API().BlobService()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	resp, err := bs.UploadUrl(ctx, &api.UploadUrlRequest{OwnerId: gitpodBuiltinUserID, Name: "test-blob"})
 	if err != nil {
 		t.Fatal(err)
@@ -164,11 +157,8 @@ func TestUploadDownloadBlob(t *testing.T) {
 
 // TestUploadDownloadBlobViaServer uploads a blob via server → content-server and downloads it afterwards
 func TestUploadDownloadBlobViaServer(t *testing.T) {
-	it := integration.NewTest(t)
+	it, ctx := integration.NewTest(t, 10*time.Second)
 	defer it.Done()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	blobContent := fmt.Sprintf("Hello Blobs! It's %s!", time.Now())
 

--- a/test/tests/storage/content-service_test.go
+++ b/test/tests/storage/content-service_test.go
@@ -65,7 +65,7 @@ func TestUploadUrl(t *testing.T) {
 			defer it.Done()
 
 			bs := it.API().BlobService()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			resp, err := bs.UploadUrl(ctx, &api.UploadUrlRequest{OwnerId: test.InputOwnerID, Name: test.InputName})
 			if err != nil && test.ExpectedErrorCode == codes.OK {

--- a/test/tests/storage/storage_test.go
+++ b/test/tests/storage/storage_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCreateBucket(t *testing.T) {
-	it := integration.NewTest(t)
+	it, _ := integration.NewTest(t, 30*time.Second)
 	defer it.Done()
 
 	rsa, err := it.Instrument(integration.ComponentWorkspaceDaemon, "daemon")

--- a/test/tests/workspace/common/git-client.go
+++ b/test/tests/workspace/common/git-client.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package common
+
+import (
+	"fmt"
+	"net/rpc"
+	"strings"
+
+	agent "github.com/gitpod-io/gitpod/test/tests/workspace/workspace_agent/api"
+)
+
+type GitClient struct {
+	*rpc.Client
+}
+
+func Git(rsa *rpc.Client) GitClient {
+	return GitClient{rsa}
+}
+
+func (g GitClient) GetBranch(workspaceRoot string) (string, error) {
+	var resp agent.ExecResponse
+	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     workspaceRoot,
+		Command: "git",
+		Args:    []string{"rev-parse", "--abbrev-ref", "HEAD"},
+	}, &resp)
+	if err != nil {
+		return "", fmt.Errorf("getBranch error: %w", err)
+	}
+	if resp.ExitCode != 0 {
+		return "", fmt.Errorf("getBranch rc!=0: %d", resp.ExitCode)
+	}
+	return strings.Trim(resp.Stdout, " \t\n"), nil
+}
+
+func (g GitClient) Add(dir string, files ...string) error {
+	args := []string{"add"}
+	if files == nil {
+		args = append(args, ".")
+	} else {
+		args = append(args, files...)
+	}
+	var resp agent.ExecResponse
+	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     dir,
+		Command: "git",
+		Args:    args,
+	}, &resp)
+	if err != nil {
+		return err
+	}
+	if resp.ExitCode != 0 {
+		return fmt.Errorf("commit returned rc: %d", resp.ExitCode)
+	}
+	return nil
+}
+
+func (g GitClient) Commit(dir string, message string, all bool) error {
+	args := []string{"commit", "-m", message}
+	if all {
+		args = append(args, "--all")
+	}
+	var resp agent.ExecResponse
+	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     dir,
+		Command: "git",
+		Args:    args,
+	}, &resp)
+	if err != nil {
+		return err
+	}
+	if resp.ExitCode != 0 {
+		return fmt.Errorf("commit returned rc: %d", resp.ExitCode)
+	}
+	return nil
+}
+
+func (g GitClient) Push(dir string, force bool, moreArgs ...string) error {
+	args := []string{"push"}
+	if moreArgs != nil {
+		args = append(args, moreArgs...)
+	}
+	if force {
+		args = append(args, "--force")
+	}
+	var resp agent.ExecResponse
+	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     dir,
+		Command: "git",
+		Args:    args,
+	}, &resp)
+	if err != nil {
+		return err
+	}
+	if resp.ExitCode != 0 {
+		return fmt.Errorf("commit returned rc: %d", resp.ExitCode)
+	}
+	return nil
+}

--- a/test/tests/workspace/content_test.go
+++ b/test/tests/workspace/content_test.go
@@ -17,13 +17,10 @@ import (
 
 // TestBackup tests a basic start/modify/restart cycle
 func TestBackup(t *testing.T) {
-	it := integration.NewTest(t)
+	it, ctx := integration.NewTest(t, 5*time.Minute)
 	defer it.Done()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	ws := integration.LaunchWorkspaceDirectly(it, ctx)
+	ws := integration.LaunchWorkspaceDirectly(it)
 	rsa, err := it.Instrument(integration.ComponentWorkspace, "workspace", integration.WithInstanceID(ws.Req.Id))
 	if err != nil {
 		t.Fatal(err)
@@ -52,11 +49,9 @@ func TestBackup(t *testing.T) {
 		return
 	}
 
-	wctx, wcancel := context.WithTimeout(ctx, 60*time.Second)
-	defer wcancel()
-	it.WaitForWorkspaceStop(wctx, ws.Req.Id)
+	it.WaitForWorkspaceStop(ws.Req.Id)
 
-	ws = integration.LaunchWorkspaceDirectly(it, ctx, integration.WithRequestModifier(func(w *wsapi.StartWorkspaceRequest) error {
+	ws = integration.LaunchWorkspaceDirectly(it, integration.WithRequestModifier(func(w *wsapi.StartWorkspaceRequest) error {
 		w.ServicePrefix = ws.Req.ServicePrefix
 		w.Metadata.MetaId = ws.Req.Metadata.MetaId
 		w.Metadata.Owner = ws.Req.Metadata.Owner

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/tests/workspace/common"
+)
+
+type ContextTest struct {
+	Skip           bool
+	Name           string
+	ContextURL     string
+	WorkspaceRoot  string
+	ExpectedBranch string
+}
+
+func TestGitHubContexts(t *testing.T) {
+	tests := []ContextTest{
+		{
+			Name:           "open repository",
+			ContextURL:     "github.com/gitpod-io/gitpod",
+			WorkspaceRoot:  "/workspace/gitpod",
+			ExpectedBranch: "main",
+		},
+		{
+			Name:           "open branch",
+			ContextURL:     "github.com/gitpod-io/gitpod-test-repo/tree/integration-test-1",
+			WorkspaceRoot:  "/workspace/gitpod-test-repo",
+			ExpectedBranch: "integration-test-1",
+		},
+		{
+			Skip:           true, // user-dependant result not supported atm
+			Name:           "open issue",
+			ContextURL:     "github.com/gitpod-io/gitpod-test-repo/issues/88",
+			WorkspaceRoot:  "/workspace/gitpod-test-repo",
+			ExpectedBranch: "geropl/integration-tests-test-context-88",
+		},
+		{
+			Name:           "open tag",
+			ContextURL:     "github.com/gitpod-io/gitpod-test-repo/tree/integration-test-context-tag",
+			WorkspaceRoot:  "/workspace/gitpod-test-repo",
+			ExpectedBranch: "HEAD",
+		},
+	}
+	runContextTests(t, tests)
+}
+
+func TestGitLabContexts(t *testing.T) {
+	tests := []ContextTest{
+		{
+			Name:           "open repository",
+			ContextURL:     "gitlab.com/AlexTugarev/gp-test",
+			WorkspaceRoot:  "/workspace/gp-test",
+			ExpectedBranch: "master",
+		},
+		{
+			Name:           "open branch",
+			ContextURL:     "gitlab.com/AlexTugarev/gp-test/tree/wip",
+			WorkspaceRoot:  "/workspace/gp-test",
+			ExpectedBranch: "wip",
+		},
+		{
+			Skip:           true, // user-dependant result not supported atm
+			Name:           "open issue",
+			ContextURL:     "gitlab.com/AlexTugarev/gp-test/issues/1",
+			WorkspaceRoot:  "/workspace/gp-test",
+			ExpectedBranch: "geropl/write-a-readme-1",
+		},
+		{
+			Name:           "open tag",
+			ContextURL:     "gitlab.com/AlexTugarev/gp-test/merge_requests/2",
+			WorkspaceRoot:  "/workspace/gp-test",
+			ExpectedBranch: "wip2",
+		},
+	}
+	runContextTests(t, tests)
+}
+
+func runContextTests(t *testing.T, tests []ContextTest) {
+	for _, test := range tests {
+		t.Run(test.ContextURL, func(t *testing.T) {
+			if test.Skip {
+				t.SkipNow()
+			}
+			// TODO(geropl) Why does this not work? Logs hint to a race around bucket creation...?
+			// t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			it := integration.NewTest(t)
+			defer it.Done()
+
+			nfo, stopWS := integration.LaunchWorkspaceFromContextURL(it, ctx, test.ContextURL)
+			defer stopWS(false) // we do not wait for stopped here as it does not matter for this test case and speeds things up
+
+			wctx, wcancel := context.WithTimeout(ctx, 1*time.Minute)
+			defer wcancel()
+			it.WaitForWorkspace(wctx, nfo.LatestInstance.ID)
+
+			rsa, err := it.Instrument(integration.ComponentWorkspace, "workspace", integration.WithInstanceID(nfo.LatestInstance.ID))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rsa.Close()
+
+			// get actual from workspace
+			git := common.Git(rsa)
+			actBranch, err := git.GetBranch(test.WorkspaceRoot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rsa.Close()
+
+			if actBranch != test.ExpectedBranch {
+				t.Fatalf("expected branch '%s', got '%s'!", test.ExpectedBranch, actBranch)
+			}
+		})
+	}
+}

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -5,7 +5,6 @@
 package workspace_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -14,13 +13,10 @@ import (
 )
 
 func TestWorkspaceInstrumentation(t *testing.T) {
-	it := integration.NewTest(t)
+	it, _ := integration.NewTest(t, 5*time.Minute)
 	defer it.Done()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	nfo, stopWs := integration.LaunchWorkspaceFromContextURL(it, ctx, "github.com/gitpod-io/gitpod")
+	nfo, stopWs := integration.LaunchWorkspaceFromContextURL(it, "github.com/gitpod-io/gitpod")
 	defer stopWs(true)
 
 	rsa, err := it.Instrument(integration.ComponentWorkspace, "workspace", integration.WithInstanceID(nfo.LatestInstance.ID))
@@ -42,12 +38,9 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 }
 
 func TestLaunchWorkspaceDirectly(t *testing.T) {
-	it := integration.NewTest(t)
+	it, _ := integration.NewTest(t, 5*time.Minute)
 	defer it.Done()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	nfo := integration.LaunchWorkspaceDirectly(it, ctx)
-	defer integration.DeleteWorkspace(it, ctx, nfo.Req.Id)
+	nfo := integration.LaunchWorkspaceDirectly(it)
+	defer integration.DeleteWorkspace(it, nfo.Req.Id)
 }

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -5,7 +5,9 @@
 package workspace_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
 	agent "github.com/gitpod-io/gitpod/test/tests/workspace/workspace_agent/api"
@@ -15,8 +17,11 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 	it := integration.NewTest(t)
 	defer it.Done()
 
-	nfo := integration.LaunchWorkspaceFromContextURL(it, "github.com/gitpod-io/gitpod")
-	defer integration.DeleteWorkspace(it, nfo.LatestInstance.ID)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	nfo, stopWs := integration.LaunchWorkspaceFromContextURL(it, ctx, "github.com/gitpod-io/gitpod")
+	defer stopWs(true)
 
 	rsa, err := it.Instrument(integration.ComponentWorkspace, "workspace", integration.WithInstanceID(nfo.LatestInstance.ID))
 	if err != nil {
@@ -40,6 +45,9 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 	it := integration.NewTest(t)
 	defer it.Done()
 
-	nfo := integration.LaunchWorkspaceDirectly(it)
-	defer integration.DeleteWorkspace(it, nfo.Req.Id)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	nfo := integration.LaunchWorkspaceDirectly(it, ctx)
+	defer integration.DeleteWorkspace(it, ctx, nfo.Req.Id)
 }

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace_test
+
+import (
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/tests/workspace/common"
+	agent "github.com/gitpod-io/gitpod/test/tests/workspace/workspace_agent/api"
+)
+
+type GitTest struct {
+	Skip          bool
+	Name          string
+	ContextURL    string
+	WorkspaceRoot string
+	Action        GitFunc
+}
+
+type GitFunc func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) error
+
+func TestGitActions(t *testing.T) {
+	tests := []GitTest{
+		{
+			Name:          "create, add and commit",
+			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/tree/integration-test/commit-and-push",
+			WorkspaceRoot: "/workspace/gitpod-test-repo",
+			Action: func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) (err error) {
+
+				var resp agent.ExecResponse
+				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+					Dir:     workspaceRoot,
+					Command: "bash",
+					Args: []string{
+						"-c",
+						"echo \"another test run...\" >> file_to_commit.txt",
+					},
+				}, &resp)
+				if err != nil {
+					return err
+				}
+				err = git.Add(workspaceRoot)
+				if err != nil {
+					return err
+				}
+				err = git.Commit(workspaceRoot, "automatic test commit", false)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+		{
+			Skip:          true,
+			Name:          "create, add and commit and PUSH",
+			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/tree/integration-test/commit-and-push",
+			WorkspaceRoot: "/workspace/gitpod-test-repo",
+			Action: func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) (err error) {
+
+				var resp agent.ExecResponse
+				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+					Dir:     workspaceRoot,
+					Command: "bash",
+					Args: []string{
+						"-c",
+						"echo \"another test run...\" >> file_to_commit.txt",
+					},
+				}, &resp)
+				if err != nil {
+					return err
+				}
+				err = git.Add(workspaceRoot)
+				if err != nil {
+					return err
+				}
+				err = git.Commit(workspaceRoot, "automatic test commit", false)
+				if err != nil {
+					return err
+				}
+				err = git.Push(workspaceRoot, false)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	}
+	runGitTests(t, tests)
+}
+
+func runGitTests(t *testing.T, tests []GitTest) {
+	for _, test := range tests {
+		t.Run(test.ContextURL, func(t *testing.T) {
+			if test.Skip {
+				t.SkipNow()
+			}
+
+			it, ctx := integration.NewTest(t, 5*time.Minute)
+			defer it.Done()
+
+			nfo, stopWS := integration.LaunchWorkspaceFromContextURL(it, test.ContextURL)
+			defer stopWS(false)
+
+			it.WaitForWorkspace(ctx, nfo.LatestInstance.ID)
+
+			rsa, err := it.Instrument(integration.ComponentWorkspace, "workspace", integration.WithInstanceID(nfo.LatestInstance.ID))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rsa.Close()
+
+			git := common.Git(rsa)
+			test.Action(rsa, git, test.WorkspaceRoot)
+
+			rsa.Close()
+		})
+	}
+}

--- a/test/tests/workspace/tasks_test.go
+++ b/test/tests/workspace/tasks_test.go
@@ -44,11 +44,8 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			it := integration.NewTest(t)
+			it, ctx := integration.NewTest(t, 5*time.Minute)
 			defer it.Done()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
 
 			addInitTask := func(swr *wsmanapi.StartWorkspaceRequest) error {
 				tasks, err := json.Marshal([]gitpod.TasksItems{test.Task})
@@ -62,10 +59,10 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 				return nil
 			}
 
-			nfo := integration.LaunchWorkspaceDirectly(it, ctx,
+			nfo := integration.LaunchWorkspaceDirectly(it,
 				integration.WithRequestModifier(addInitTask),
 			)
-			defer integration.DeleteWorkspace(it, ctx, nfo.Req.Id)
+			defer integration.DeleteWorkspace(it, nfo.Req.Id)
 
 			conn := it.API().Supervisor(nfo.Req.Id)
 			statusService := supervisor.NewStatusServiceClient(conn)

--- a/test/tests/workspace/workspace_agent/api/api.go
+++ b/test/tests/workspace/workspace_agent/api/api.go
@@ -26,3 +26,15 @@ type WriteFileRequest struct {
 // WriteFileResponse is the response for WriteFile
 type WriteFileResponse struct {
 }
+
+type ExecRequest struct {
+	Dir     string
+	Command string
+	Args    []string
+}
+
+type ExecResponse struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}

--- a/test/tests/workspace/workspace_agent/main.go
+++ b/test/tests/workspace/workspace_agent/main.go
@@ -5,7 +5,11 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
 	"github.com/gitpod-io/gitpod/test/tests/workspace/workspace_agent/api"
@@ -41,5 +45,37 @@ func (*WorkspaceAgent) WriteFile(req *api.WriteFileRequest, resp *api.WriteFileR
 	}
 
 	*resp = api.WriteFileResponse{}
+	return
+}
+
+// Exec executes a command in the workspace
+func (*WorkspaceAgent) Exec(req *api.ExecRequest, resp *api.ExecResponse) (err error) {
+	cmd := exec.Command(req.Command, req.Args...)
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+	if req.Dir != "" {
+		cmd.Dir = req.Dir
+	}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+
+	var rc int
+	if err != nil {
+		exitError, ok := err.(*exec.ExitError)
+		if !ok {
+			fullCommand := strings.Join(append([]string{req.Command}, req.Args...), " ")
+			return fmt.Errorf("%s: %w", fullCommand, err)
+		}
+		rc = exitError.ExitCode()
+	}
+
+	*resp = api.ExecResponse{
+		ExitCode: rc,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}
 	return
 }


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/2658 to some extend, see [here](https://github.com/gitpod-io/gitpod/issues/2658#issuecomment-793574031) for caveats.

The changes include:
 - werft job (core)
 - werft job (io, see companion PR)
 - tests now are now runnable against all environments (e.g., devstaging, staging and prod)
 - you can choose a `user` to run with (for now, until we have the "setup GitHub/GitLab test user (credentials)" story solved
 - basic context/Git integration tests


### Companion PRs:
 - https://github.com/gitpod-com/gitpod/pull/5177

- [ ] /werft with-integration-tests=true