### PR TITLE
sync user data from Theia if missing in Code

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
@@ -23,7 +23,7 @@ export const enum SyncResource {
 export const ALL_SYNC_RESOURCES: SyncResource[] = [SyncResource.Settings, SyncResource.Keybindings, SyncResource.Snippets, SyncResource.Extensions, SyncResource.GlobalState];
 
 export interface IUserDataManifest {
-    latest?: Record<ServerResource, string>
+    latest: Record<ServerResource, string>
     session: string;
 }
 

--- a/components/server/src/theia-plugin/theia-plugin-service.ts
+++ b/components/server/src/theia-plugin/theia-plugin-service.ts
@@ -315,4 +315,26 @@ export class TheiaPluginService {
         return new Set<string>(json);
     }
 
+    async getCodeSyncResource(userId: string): Promise<string> {
+        interface ISyncExtension {
+            identifier: {
+                id: string
+            };
+            version?: string;
+            installed?: boolean;
+        }
+        const extensions: ISyncExtension[] = []
+        const userPlugins = await this.getUserPlugins(userId);
+        for (const userPlugin of userPlugins) {
+            const fullPluginName = this.toFullPluginName(userPlugin); // drop hash
+            const { name, version } = this.parseFullPluginName(fullPluginName);
+            extensions.push({
+                identifier: { id: name },
+                version,
+                installed: true
+            });
+        }
+        return JSON.stringify(extensions);
+    }
+
 }


### PR DESCRIPTION
#### What it does

In order to smooth the transition from Theia to Code we want to use user settings/extensions configured in Theia as a default for Code.

#### How to test

- Start a new workspace with Theia, install user extensions and change user settings.
- Switch to Code and start another workspace with it, check that user extensions/settings from Theia are installed.
- Install more extensions and change settings, start another workspace and check that all changes are applied.