### PR TITLE
[proxy] Update nginx to 1.19.3 and switch to base image to alpine

### DIFF
--- a/chart/config/proxy/debug/nginx-debug-logging.conf
+++ b/chart/config/proxy/debug/nginx-debug-logging.conf
@@ -12,18 +12,18 @@
 # don't fork to background
 daemon off;
 
-include /etc/nginx/modules-enabled/*.conf;
+include /etc/nginx/modules/*.conf;
 
 events {
 }
 
 http {
-    lua_package_path "/usr/share/lua/5.1/nginx//?.lua;;";
+    lua_package_path "/usr/local/lib/lua/?/?.lua;/usr/share/lua/?/?.lua;;";
 
     log_format mylogfmt escape=none $log_message_json;
 
     access_log /dev/stdout mylogfmt;
-    error_log /dev/stderr;
+    error_log /dev/stderr info;
 
     server {
 

--- a/chart/config/proxy/nginx.conf
+++ b/chart/config/proxy/nginx.conf
@@ -1,9 +1,7 @@
 ####
 # This configuration is based on the default config shipped with nginx, tweaked for handling more parallel connections.
-user www-data;
+user nobody;
 pid /run/nginx.pid;
-
-include /etc/nginx/modules-enabled/*.conf;
 
 ##
 # Worker and event configuration
@@ -32,22 +30,26 @@ http {
 	# Remove nginx server header
 	# http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
 	server_tokens off;
+	more_clear_headers Server;
+
+    # See Move default writable paths to a dedicated directory (#119)
+    # https://github.com/openresty/docker-openresty/issues/119
+    client_body_temp_path /var/run/openresty/nginx-client-body;
+    proxy_temp_path       /var/run/openresty/nginx-proxy;
+    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
+    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
+    scgi_temp_path        /var/run/openresty/nginx-scgi;
 
 	##
 	# Logging Settings
-    log_format mylogfmt escape=none $log_message_json;
-    access_log /dev/stdout mylogfmt;
-    error_log /dev/stderr;
+	log_format mylogfmt escape=none $log_message_json;
+	access_log /dev/stdout mylogfmt;
+	error_log /dev/stderr info;
 
 	##
 	# Gzip Settings
 	##
-	gzip on;
-
-    ##
-    # Lua Settings
-    ##
-    lua_package_path "/etc/nginx/lua-prometheus/?.lua;/usr/share/lua/5.1/nginx/?.lua;;";
+	include /etc/nginx/lib.gzip-assets.conf;
 
 	##
 	# Virtual Host Configs

--- a/chart/config/proxy/vhost.server-8003-status.conf
+++ b/chart/config/proxy/vhost.server-8003-status.conf
@@ -1,7 +1,8 @@
 server {
     listen 8003;
 
-    include lib.log-headers.conf;
+    # log is disabled
+    # include lib.log-headers.conf;
 
     location = /nginx/status {
         access_log off;

--- a/chart/config/proxy/vhost.server.conf
+++ b/chart/config/proxy/vhost.server.conf
@@ -24,7 +24,8 @@ server {
     server_name health.{{ $domain }};
 
     include lib.region-headers.conf;
-    include lib.log-headers.conf;
+    # log is disabled
+    # include lib.log-headers.conf;
 
     location = /nginx/status {
         access_log off;
@@ -95,7 +96,7 @@ server {
     include lib.proxy.conf;
 
     client_max_body_size 0;
-    
+
     location / {
         auth_basic           "Docker Registry";
         auth_basic_user_file /etc/nginx/registry-auth.htpasswd;
@@ -121,7 +122,7 @@ server {
     include lib.proxy.conf;
 
     client_max_body_size 0;
-    
+
     location / {
         proxy_pass http://{{ index .Values "minio" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:9000$request_uri;
     }
@@ -164,7 +165,7 @@ server {
     {{- if eq .Values.ingressMode "pathAndHost" }}
     listen 80;
     {{- end }}
-    
+
     include lib.ssl.conf;
     include lib.https_redirect.conf;
 {{- end }}

--- a/components/dashboard/conf/nginx.conf
+++ b/components/dashboard/conf/nginx.conf
@@ -1,7 +1,7 @@
 user  nginx;
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /var/log/nginx/error.log info;
 pid        /var/run/nginx.pid;
 
 
@@ -18,7 +18,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /var/log/nginx/access.log;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -2,53 +2,49 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-# https://docs.docker.com/samples/library/nginx/
-FROM nginx:1.14.1
-
-# Purge default configuration
-RUN rm -Rf /etc/nginx/conf.d/
-# nginx config templates...
-#COPY conf/  /etc/nginx/
-# .. and startup script
-COPY startup/nginx.sh nginx.sh
-
-
-# Metrics export dependencies
-# Set fix version for install
-RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list.d/stretch-backports.list && \
-    apt-get update && apt-get -t stretch-backports install --no-install-recommends -yq \
-      #libnginx-mod-http-lua \  # For newer distros
-      # pin the latest version available for stretch-backports: https://packages.debian.org/stretch-backports/httpd/#nginx
-      nginx-extras=1.14.1-1~bpo9+1 \
-      lua-cjson \
-      lua-nginx-cookie \
-    # Remove default sites installed by nginx-extras
-    && rm -Rf /etc/nginx/sites-*/* \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
-
-COPY conf/lua-prometheus /etc/nginx/lua-prometheus
+FROM openresty/openresty:1.19.3.1-3-alpine
 
 # Debug convenience
 ENV TERM=xterm
 ENV SHELL=/bin/bash
-RUN apt-get update && apt-get install -yq \
-        vim \
-        less \
-        dnsutils \
-        curl \
-        apache2-utils \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN apk add --no-cache \
+      vim \
+      less \
+      bind-tools \
+      curl \
+      apache2-utils \
+      gettext \
+      bash
 
 # Include certbot into the proxy for HTTPS termination
-RUN curl -o /usr/bin/lama -L https://github.com/csweichel/lama/releases/download/v0.3.0/lama_0.3.0_Linux_x86_64 && \
-    chmod +x /usr/bin/lama && \
-    mkdir -p /var/www/lama/nginx && \
-    touch /var/www/lama/nginx/status && \
-    apt-get update && \
-    apt-get install -yq \
-        procps \
-        certbot \
-        python-certbot-nginx
+RUN curl -o /usr/bin/lama -sSL https://github.com/csweichel/lama/releases/download/v0.3.0/lama_0.3.0_Linux_x86_64 \
+    && chmod +x /usr/bin/lama \
+    && mkdir -p /var/www/lama/nginx \
+    && touch /var/www/lama/nginx/status
+
+RUN apk add --no-cache \
+      procps \
+      certbot \
+      certbot-nginx
+
+RUN set -e \
+    && apk add --no-cache git \
+    && cd /tmp \
+    && git clone https://github.com/cloudflare/lua-resty-cookie/ \
+    && cp lua-resty-cookie/lib/resty/*.lua /usr/local/openresty/site/lualib/ \
+    && apk del git \
+    && rm -rf /tmp/*
+
+# Update alpine packages
+RUN apk upgrade --no-cache
+
+# nginx config templates...
+#COPY conf/  /etc/nginx/
+# .. and startup script
+COPY startup/nginx.sh /nginx.sh
+
+COPY conf/lua-prometheus /etc/nginx/lua-prometheus
 
 # ip.mygitpod.com HTTPS support
 COPY nodomain-certs/* /nodomain-certs/

--- a/components/proxy/startup/nginx.sh
+++ b/components/proxy/startup/nginx.sh
@@ -23,9 +23,7 @@ replaceEnvVars() {
 
 ### nginx config
 # Clear existing config
-rm -Rf /etc/nginx/conf.d
-rm -Rf /etc/nginx/lib
-rm /etc/nginx/nginx.conf
+cp /usr/local/openresty/nginx/conf/* /etc/nginx
 
 # Copy the gitpod-core config
 # (-L does "unlink" and copies the target, not the symlink)
@@ -79,4 +77,4 @@ find . -name "*.conf"
 cd $ORG_PATH
 
 echo "Starting nginx"
-exec nginx -g "daemon off;"
+exec nginx -c /etc/nginx/nginx.conf -g "daemon off;"


### PR DESCRIPTION
Switch `nginx 1.14` to `openresty`. Only because it provides a working image with `lua-nginx-module` and a recent nginx version.
(I can also build a custom version, but I don't see any benefit)