### PR TITLE
[code] support .gitpod.yml

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 5f659262e9d1784ee935f0ef806c2bbef842f663
+ENV GP_CODE_COMMIT bb2b2f100f6fdbeef95fde456cb654fe09da3319
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does 

- fix #2585 include yaml extesnion as a built-in in order to support .gitpod.yml

#### How to test

- Enable Code, start a workspace and check that .gitpod.yml has proper support like content assist and hovers.