### PR TITLE
[ws-manager] Build a static binary and remove file system paths

### DIFF
--- a/components/ws-manager/BUILD.yaml
+++ b/components/ws-manager/BUILD.yaml
@@ -18,6 +18,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-w -extldflags \"-static\""]
   - name: docker
     type: docker
     deps:


### PR DESCRIPTION
https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies

```
-trimpath
	remove all file system paths from the resulting executable.
	Instead of absolute file system paths, the recorded file names
	will begin with either "go" (for the standard library),
	or a module path@version (when using modules),
	or a plain import path (when using GOPATH).
``` 