### PR TITLE
code: remove MS telemetry settings

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT bb2b2f100f6fdbeef95fde456cb654fe09da3319
+ENV GP_CODE_COMMIT 2dcc8681684ba77c0864306a4129dc638d59e4dd
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #2440: We don't support any telemetry, but some MS settings are leaking globally. This PR removes them.

The change in Code: https://github.com/gitpod-io/vscode/commit/2dcc8681684ba77c0864306a4129dc638d59e4dd

#### How to test

- Switch to Code
- Start a workspace
- Open settings and search for `telemetry`. You should not find anything.