### PR TITLE
[ws-manager] Properly stop workspaces again

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -449,8 +449,8 @@ func (m *Manager) stopWorkspace(ctx context.Context, workspaceID string, gracePe
 			PropagationPolicy:  &propagationPolicy,
 		},
 	)
-
 	tracing.LogEvent(span, "theia service deleted")
+
 	portsServiceErr := m.Clientset.Delete(ctx, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getPortsServiceName(servicePrefix),
@@ -481,7 +481,7 @@ func (m *Manager) stopWorkspace(ctx context.Context, workspaceID string, gracePe
 	if podErr != nil {
 		return xerrors.Errorf("stopWorkspace: %w", podErr)
 	}
-	if theiaServiceErr != nil && !isKubernetesObjNotFoundError(portsServiceErr) {
+	if theiaServiceErr != nil && !isKubernetesObjNotFoundError(theiaServiceErr) {
 		return xerrors.Errorf("stopWorkspace: %w", theiaServiceErr)
 	}
 	if portsServiceErr != nil && !isKubernetesObjNotFoundError(portsServiceErr) {

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -465,7 +465,7 @@ func (m *Manager) stopWorkspace(ctx context.Context, workspaceID string, gracePe
 	tracing.LogEvent(span, "ports service deleted")
 
 	podErr := m.Clientset.Delete(ctx,
-		&corev1.Service{
+		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pod.Name,
 				Namespace: m.Config.Namespace,


### PR DESCRIPTION
This PR makes workspace stop properly again, fixing an issue that came about in the recent move towards the Kubernetes controller framework.

### How to test
1. start a workspace
2. stop a workspace - if the workspace stops, all is well