### PR TITLE
fix theia regressions

### DIFF
--- a/components/gitpod-protocol/data/builtin-theia-plugins.json
+++ b/components/gitpod-protocol/data/builtin-theia-plugins.json
@@ -245,9 +245,9 @@
     "url": "https://open-vsx.org/api/redhat/java/0.75.0/file/redhat.java-0.75.0.vsix"
   },
   {
-    "loc": "vscjava.vscode-java-debug-0.31.0.vsix",
-    "name": "vscjava.vscode-java-debug@0.31.0",
-    "url": "https://open-vsx.org/api/vscjava/vscode-java-debug/0.31.0/file/vscjava.vscode-java-debug-0.31.0.vsix"
+    "loc": "vscjava.vscode-java-debug-0.27.1.vsix",
+    "name": "vscjava.vscode-java-debug@0.27.1",
+    "url": "https://open-vsx.org/api/vscjava/vscode-java-debug/0.27.1/file/vscjava.vscode-java-debug-0.27.1.vsix"
   },
   {
     "loc": "vscjava.vscode-java-dependency-0.18.0.vsix",

--- a/components/theia/app/startup.sh
+++ b/components/theia/app/startup.sh
@@ -31,4 +31,4 @@ export USER=gitpod
 [ -s ~/.nvm/nvm-lazy.sh ] && source ~/.nvm/nvm-lazy.sh
 
 cd /theia/node_modules/@gitpod/gitpod-ide
-exec /theia/node/bin/gitpod-node ./src-gen/backend/main.js $*
+exec /theia/node/bin/gitpod-node ./src-gen/backend/main.js --vscode-api-version=1.53.2 $*


### PR DESCRIPTION
#### What it does

- revert java debug extension upgrade
- bump up VS Code API version to support latest vscode-languageclient

#### How to test

Everything below with using Theia of course:
- start a workspace for https://ak-fix-theia-regressions.staging.gitpod-dev.com/#https://gitlab.com/gitpod/spring-petclinic, stop the app and try to debug it instead from the debug vide
- start a workspace for https://ak-fix-theia-regressions.staging.gitpod-dev.com/#https://github.com/Circuito-io/ComponentEditor, install clangd extension, open cpp file and check that there are no notifications about failed language server + smartness is available to some extent