### PR TITLE
[ws-manager] Reenable housekeeping

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -142,15 +142,13 @@ func (m *Monitor) Start() error {
 		log.WithError(err).Warn("cannot mark all existing workspaces active - this will wrongly time out user's workspaces")
 	}
 
-	return nil
-}
+	go func() {
+		for range m.ticker.C {
+			m.doHousekeeping(context.Background())
+		}
+	}()
 
-// run checks the overall workspace state (on event or periodically). Run is best called as a goroutine.
-// Note: this function serializes the handling of pod/config map events per workspace, but not globally.
-func (m *Monitor) run() {
-	for range m.ticker.C {
-		go m.doHousekeeping(context.Background())
-	}
+	return nil
 }
 
 // handleEvent dispatches an event to the corresponding event handler based on the event object kind.


### PR DESCRIPTION
This PR re-enables housekeeping/timeouting.

### How to test
1. Start a workspace
2. Close the tab
3. The workspace should stop after 2 minutes