### PR TITLE
[docs] Add the February 2021 changelog.

### DIFF
--- a/docs/changelog/2021-02/README.md
+++ b/docs/changelog/2021-02/README.md
@@ -1,0 +1,22 @@
+# February 2021
+
+## Synchronize Theia user settings with VS Code
+
+We recently launched [support for VS Code](https://www.gitpod.io/blog/root-docker-and-vscode/#vs-code).
+
+If you switch your editor to VS Code, your user settings and extensions configured in Theia will be synchronized with VS Code automatically when you start a new workspace.
+
+**Interested in using VS Code as your default editor?**
+
+You can define VS Code as your default editor in the _Feature Preview_ section in your [Gitpod Settings]().
+
+**Contributors**: [@akosyakov](https://github.com/akosyakov), [@svenefftinge](https://github.com/svenefftinge)
+
+
+## Deploy Gitpod in an air-gapped network
+
+You can now [self-host Gitpod](https://www.gitpod.io/self-hosted/) in a network that is isolated from the internet. Additional details on this feature are available in [PR #3228](https://github.com/gitpod-io/gitpod/pull/3228).
+
+_What is an air-gapped network?_: [This Wikipedia article](https://en.wikipedia.org/wiki/Air_gap_(networking)) answer that question in detail.
+
+**Contributors**: [@corneliusludmann](https://github.com/corneliusludmann), [@geropl](https://github.com/geropl)

--- a/docs/changelog/2021-02/README.md
+++ b/docs/changelog/2021-02/README.md
@@ -12,11 +12,12 @@ You can define VS Code as your default editor in the _Feature Preview_ section i
 
 **Contributors**: [@akosyakov](https://github.com/akosyakov), [@svenefftinge](https://github.com/svenefftinge)
 
+## Miscellaneous
 
-## Deploy Gitpod in an air-gapped network
-
-You can now [self-host Gitpod](https://www.gitpod.io/self-hosted/) in a network that is isolated from the internet. Additional details on this feature are available in [PR #3228](https://github.com/gitpod-io/gitpod/pull/3228).
-
-_What is an air-gapped network?_: [This Wikipedia article](https://en.wikipedia.org/wiki/Air_gap_(networking)) answer that question in detail.
-
-**Contributors**: [@corneliusludmann](https://github.com/corneliusludmann), [@geropl](https://github.com/geropl)
+* [#3087](https://github.com/gitpod-com/gitpod/pull/3087) - Remove the privileged feature flag. Thanks to [@csweichel](https://github.com/csweichel), [@akosyakov](https://github.com/akosyakov)
+* [#3175](https://github.com/gitpod-com/gitpod/pull/3175) - Fix Env Var context parsing. Thanks to [@AlexTugarev](https://github.com/AlexTugarev), [@csweichel](https://github.com/csweichel)
+* [#3177](https://github.com/gitpod-com/gitpod/pull/3177) - [supervisor] Let supervisor fail when first IDE start fails. Thanks to [@corneliusludmann](https://github.com/corneliusludmann), [@csweichel](https://github.com/csweichel)
+* [#3182](https://github.com/gitpod-com/gitpod/pull/3182) - [registry-facade] Remove feature flag. Thanks to [@csweichel](https://github.com/csweichel), [@corneliusludmann](https://github.com/corneliusludmann)
+* [#3228](https://github.com/gitpod-io/gitpod/pull/3228) - Allow air-gap Gitpod installations. Thanks to [@corneliusludmann](https://github.com/corneliusludmann), [@geropl](https://github.com/geropl)
+* Improved workspace startup time in high-load situations
+* Started to [adopt the controller framework](https://kubernetes.io/docs/concepts/architecture/controller/) which will lead to Gitpod producing less load on the Kubernetes API

--- a/docs/changelog/2021-02/README.md
+++ b/docs/changelog/2021-02/README.md
@@ -19,5 +19,5 @@ You can define VS Code as your default editor in the _Feature Preview_ section i
 * [#3177](https://github.com/gitpod-com/gitpod/pull/3177) - [supervisor] Let supervisor fail when first IDE start fails. Thanks to [@corneliusludmann](https://github.com/corneliusludmann), [@csweichel](https://github.com/csweichel)
 * [#3182](https://github.com/gitpod-com/gitpod/pull/3182) - [registry-facade] Remove feature flag. Thanks to [@csweichel](https://github.com/csweichel), [@corneliusludmann](https://github.com/corneliusludmann)
 * [#3228](https://github.com/gitpod-io/gitpod/pull/3228) - Allow air-gap Gitpod installations. Thanks to [@corneliusludmann](https://github.com/corneliusludmann), [@geropl](https://github.com/geropl)
-* Improved workspace startup time in high-load situations
-* Started to [adopt the controller framework](https://kubernetes.io/docs/concepts/architecture/controller/) which will lead to Gitpod producing less load on the Kubernetes API
+* Improved workspace startup time in high-load situations. Thanks to [@geropl](https://github.com/geropl)
+* Started to [adopt the controller framework](https://kubernetes.io/docs/concepts/architecture/controller/) which will lead to Gitpod producing less load on the Kubernetes API. Thanks to [@aledbf](https://github.com/aledbf)


### PR DESCRIPTION
Related to #3328.

A first, lightweight changelog for the February release with a focus on two user-facing features:
* Synchronize Theia user settings with VS Code
* Deploy Gitpod in an air-gapped network

Please let me know if I missed anything 🙏.

_Note_: For the next release, #2682 will automate some aspects of the changelog. At that time, a full list of all PRs will be included at the end of the release notes.