### PR TITLE
Remove unused vim requirement

### DIFF
--- a/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/layer.sh
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/layer.sh
@@ -15,12 +15,10 @@ if [ $INSTALLED_PACKAGES != 3 ]; then
     # (like changed labels) which result in errors and broken builds/workspaces!
     apt-get clean && rm -rf /var/lib/apt/lists/*;
 
-    # vim: used as Git-editor (see .bashrc-append)
     apt-get update --allow-insecure-repositories;
     apt-get install -yq \
         bash-completion \
-        git \
-        vim
+        git
 
     # Cleanup to keep the image as small as possible
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*;


### PR DESCRIPTION
`vim` should not be a requirement as it is not used in [.bashrc](https://github.com/gitpod-io/gitpod/blob/main/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/.bashrc-prepend). `gp open` is used instead.