### PR TITLE
[server] Use 'new Probot({ logLevel })' instead of the deprecated 'LOG_LEVEL' environment variable

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -24,7 +24,7 @@ import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
 import { TracedWorkspaceDB, DBWithTracing } from '@gitpod/gitpod-db/lib/traced-db';
 import { PrebuildManager } from './prebuild-manager';
 import { PrebuildStatusMaintainer } from './prebuilt-status-maintainer';
-import { ApplicationFunctionOptions } from 'probot/lib/types';
+import { Options, ApplicationFunctionOptions } from 'probot/lib/types';
 
 /**
  * GitHub app urls:
@@ -55,7 +55,8 @@ export class GithubApp extends Probot {
         super({
             id: env.githubAppAppID,
             privateKey: GithubApp.loadPrivateKey(env.githubAppCertPath),
-            secret: env.githubAppWebhookSecret
+            secret: env.githubAppWebhookSecret,
+            logLevel: env.githubAppLogLevel as Options["logLevel"]
         });
         log.debug("Starting GitHub app integration", {
             id: env.githubAppAppID,

--- a/components/server/src/env.ts
+++ b/components/server/src/env.ts
@@ -71,6 +71,7 @@ export class Env extends AbstractComponentEnv {
     readonly githubAppAuthProviderId: string = process.env.GITPOD_GITHUB_APP_AUTH_PROVIDER_ID || "Public-GitHub";
     readonly githubAppCertPath: string = process.env.GITPOD_GITHUB_APP_CERT_PATH || "unknown";
     readonly githubAppMarketplaceName: string = process.env.GITPOD_GITHUB_APP_MKT_NAME || "unknown";
+    readonly githubAppLogLevel?: string = process.env.LOG_LEVEL;
 
     readonly definitelyGpDisabled: boolean = process.env.GITPOD_DEFINITELY_GP_DISABLED == "true";
 


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3181