### PR TITLE
Add issue form for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,23 +1,28 @@
----
-name: Bug report
-about: Create a report to help us improve
-
----
-
-<!-- ⚠️⚠️ Do Not Delete This! bug_report_template ⚠️⚠️ -->
-<!-- Please search existing issues to avoid creating duplicates. -->
-
-### Describe the bug
-<!-- A clear and concise description of what the bug is -->
-
-### Steps to reproduce
-<!-- Steps to reproduce the behavior -->
-
-### Expected behavior
-<!-- A clear and concise description of what you expected to happen -->
-
-### Additional information
-<!-- For instance, workspace IDs; URLs; relevant logs from terminals or the browser's devtool console -->
-
-### Example repository
-<!-- For instance, the repository where the error occurred -->
+name: Bug Report
+description: File a bug report
+labels: "bug"
+issue_body: true
+body:
+- type: markdown
+  attributes:
+    value: Before raising an issue, please search for existing issues to avoid creating duplicates. For questions and support please use the [community forum](https://community.gitpod.io/).
+- type: textarea
+  attributes:
+    label: Bug description
+    description: Summarize the bug encountered concisely
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: Describe the steps to reproduce the issue
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: Describe what you should see instead
+- type: textarea
+  attributes:
+    label: Example repository
+    description: If possible, please create an [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug and link it here in the bug report


### PR DESCRIPTION
### What does this PR do?

1. This change will convert the previous issue template for the bug report to an issue form. The repository has been added to the Issue Forms Alpha.
1. This will also make _Bug description_ and _Steps to reproduce_ fields required to submit a new issue.

See also [relevant discussion](https://gitpod.slack.com/archives/C01KPEPLLRY/p1612120627110700) (internal).