### PR TITLE
Initial werft integration tests with observability stack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pluggable-o11y-stack"]
-	path = pluggable-o11y-stack
-	url = https://github.com/gitpod-io/pluggable-o11y-stack

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pluggable-o11y-stack"]
+	path = pluggable-o11y-stack
+	url = https://github.com/gitpod-io/pluggable-o11y-stack

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -312,7 +312,7 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
     
             werft.log('Observability Stack', 'Building YAML manifests');
             exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true \
-             CLUSTER_NAME=gitpod-core-dev \
+             CLUSTER_NAME=$(kubectl config get-clusters | tail -n 1) \
              NAMESPACE=${namespace} \
              ROOT_URL=${domain} \
              PROMETHEUS_INGRESS_NODE_PORT=${prometheusProxyPort} \

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -302,8 +302,11 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         werft.log('jsonnet', 'Clonning Observability Stack repository');
         exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-o11y-stack');
 
+        werft.log('jsonnet', 'Installing dependencies');
+        exec('cd pluggable-o11y-stack && make setup-workspace');
+
         werft.log('jsonnet', 'Building YAML manifests');
-        exec(`cd pluggable-o11y-stack && pwd && ls -lha && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
+        exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
 
         exec.log('jsonnet', 'Deploying observability stack');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -307,13 +307,13 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
             werft.log('Observability Stack', 'Installing observability stack');
     
             werft.log('Observability Stack', 'Clonning Observability Stack repository');
-            exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git');
+            exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && git checkout as/setup-custom-route');
     
             werft.log('Observability Stack', 'Installing dependencies');
             exec('cd pluggable-o11y-stack && make setup-workspace');
     
             werft.log('Observability Stack', 'Building YAML manifests');
-            exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} CLUSTER_NAME=gitpod-core-dev make build`);
+            exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} CLUSTER_NAME=gitpod-core-dev ROOT_URL=${url} make build`);
     
             werft.log('Observability Stack', 'Deploying observability stack');
             exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -299,6 +299,7 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         // Deploy Observability stack
         shell.cd("../pluggable-o11y-stack");
         werft.log('jsonnet', 'Installing observability stack');
+        exec('ls -lha');
 
         werft.log('jsonnet', 'Building YAML manifests');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -297,7 +297,7 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         werft.done('helm');
 
         // Deploy Observability stack
-        shell.cd("pluggable-o11y-stack");
+        shell.cd("../pluggable-o11y-stack");
         werft.log('jsonnet', 'Installing observability stack');
 
         werft.log('jsonnet', 'Building YAML manifests');

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -299,7 +299,9 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         // Deploy Observability stack
         shell.cd("../pluggable-o11y-stack");
         werft.log('jsonnet', 'Installing observability stack');
-        exec('ls -lha');
+
+        werft.log('jsonnet', 'Clonning Observability Stack repository');
+        exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-011y-stack');
 
         werft.log('jsonnet', 'Building YAML manifests');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -297,14 +297,13 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         werft.done('helm');
 
         // Deploy Observability stack
-        shell.cd("../pluggable-o11y-stack");
         werft.log('jsonnet', 'Installing observability stack');
 
         werft.log('jsonnet', 'Clonning Observability Stack repository');
         exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-o11y-stack');
 
         werft.log('jsonnet', 'Building YAML manifests');
-        exec(`pwd && ls -lha && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
+        exec(`cd pluggable-o11y-stack && pwd && ls -lha && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
 
         exec.log('jsonnet', 'Deploying observability stack');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -295,6 +295,19 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
 
         werft.log('helm', 'done');
         werft.done('helm');
+
+        // Deploy Observability stack
+        shell.cd("pluggable-o11y-stack");
+        werft.log('jsonnet', 'Installing observability stack');
+
+        werft.log('jsonnet', 'Building YAML manifests');
+        exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
+
+        exec.log('jsonnet', 'Deploying observability stack');
+        exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);
+
+        werft.log('jsonnet', 'done');
+        werft.done('jsonnet');
     } catch (err) {
         werft.fail('deploy', err);
     } finally {

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -177,8 +177,6 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
     const namespace = `staging-${destname}`;
     const domain = `${destname}.staging.gitpod-dev.com`;
     const url = `https://${domain}`;
-    const grafanaUrl = `${url}/grafana`;
-    const prometheusUrl = `${url}/prometheus`;
     const wsdaemonPort = `1${Math.floor(Math.random()*1000)}`;
     const registryProxyPort = `2${Math.floor(Math.random()*1000)}`;
     const grafanaProxyPort = `3${Math.floor(Math.random()*1000)}`;
@@ -307,13 +305,13 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
             werft.log('Observability Stack', 'Installing observability stack');
     
             werft.log('Observability Stack', 'Clonning Observability Stack repository');
-            exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && git checkout as/setup-custom-route');
+            exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-o11y-stack && git checkout as/setup-custom-route');
     
             werft.log('Observability Stack', 'Installing dependencies');
             exec('cd pluggable-o11y-stack && make setup-workspace');
     
             werft.log('Observability Stack', 'Building YAML manifests');
-            exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} CLUSTER_NAME=gitpod-core-dev ROOT_URL=${url} make build`);
+            exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} CLUSTER_NAME=gitpod-core-dev ROOT_URL=${domain} make build`);
     
             werft.log('Observability Stack', 'Deploying observability stack');
             exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);
@@ -321,8 +319,8 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
             werft.log('Observability Stack', 'done');
             werft.done('Observability Stack');
 
-            exec(`werft log result -d "prometheus installation" -c github url ${prometheusUrl}`);
-            exec(`werft log result -d "grafana installation" -c github url ${grafanaUrl}`);
+            exec(`werft log result -d "prometheus installation" -c github url ${url}/prometheus/graph`);
+            exec(`werft log result -d "grafana installation" -c github url ${url}/grafana/`);
         }
     } catch (err) {
         werft.fail('deploy', err);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -177,8 +177,12 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
     const namespace = `staging-${destname}`;
     const domain = `${destname}.staging.gitpod-dev.com`;
     const url = `https://${domain}`;
+    const grafanaUrl = `${url}/grafana`;
+    const prometheusUrl = `${url}/prometheus`;
     const wsdaemonPort = `1${Math.floor(Math.random()*1000)}`;
     const registryProxyPort = `2${Math.floor(Math.random()*1000)}`;
+    const grafanaProxyPort = `3${Math.floor(Math.random()*1000)}`;
+    const prometheusProxyPort = `4${Math.floor(Math.random()*1000)}`;
     const registryNodePort = `${30000 + Math.floor(Math.random()*1000)}`;
 
     // trigger certificate issuing
@@ -316,6 +320,9 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
     
             werft.log('Observability Stack', 'done');
             werft.done('Observability Stack');
+
+            exec(`werft log result -d "prometheus installation" -c github url ${prometheusUrl}`);
+            exec(`werft log result -d "grafana installation" -c github url ${grafanaUrl}`);
         }
     } catch (err) {
         werft.fail('deploy', err);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -311,7 +311,14 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
             exec('cd pluggable-o11y-stack && make setup-workspace');
     
             werft.log('Observability Stack', 'Building YAML manifests');
-            exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} CLUSTER_NAME=gitpod-core-dev ROOT_URL=${domain} make build`);
+            exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true \
+             CLUSTER_NAME=gitpod-core-dev \
+             NAMESPACE=${namespace} \
+             ROOT_URL=${domain} \
+             PROMETHEUS_INGRESS_NODE_PORT=${prometheusProxyPort} \
+             GRAFANA_INGRESS_NODE_PORT=${grafanaProxyPort} \
+             make build`
+            );
     
             werft.log('Observability Stack', 'Deploying observability stack');
             exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -301,7 +301,7 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         werft.log('jsonnet', 'Installing observability stack');
 
         werft.log('jsonnet', 'Clonning Observability Stack repository');
-        exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-011y-stack');
+        exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-o11y-stack');
 
         werft.log('jsonnet', 'Building YAML manifests');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -304,7 +304,7 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-o11y-stack');
 
         werft.log('jsonnet', 'Building YAML manifests');
-        exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
+        exec(`pwd && ls -lha && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
 
         exec.log('jsonnet', 'Deploying observability stack');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -306,7 +306,7 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         exec('cd pluggable-o11y-stack && make setup-workspace');
 
         werft.log('jsonnet', 'Building YAML manifests');
-        exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
+        exec(`cd pluggable-o11y-stack && pwd && ls -lha && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
 
         exec.log('jsonnet', 'Deploying observability stack');
         exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -297,22 +297,22 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
         werft.done('helm');
 
         // Deploy Observability stack
-        werft.log('jsonnet', 'Installing observability stack');
+        werft.log('Observability Stack', 'Installing observability stack');
 
-        werft.log('jsonnet', 'Clonning Observability Stack repository');
-        exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git && cd pluggable-o11y-stack');
+        werft.log('Observability Stack', 'Clonning Observability Stack repository');
+        exec('git clone https://github.com/gitpod-io/pluggable-o11y-stack.git');
 
-        werft.log('jsonnet', 'Installing dependencies');
+        werft.log('Observability Stack', 'Installing dependencies');
         exec('cd pluggable-o11y-stack && make setup-workspace');
 
-        werft.log('jsonnet', 'Building YAML manifests');
-        exec(`cd pluggable-o11y-stack && pwd && ls -lha && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make build`);
+        werft.log('Observability Stack', 'Building YAML manifests');
+        exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} CLUSTER_NAME=gitpod-core-dev make build`);
 
-        exec.log('jsonnet', 'Deploying observability stack');
-        exec(`IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);
+        werft.log('Observability Stack', 'Deploying observability stack');
+        exec(`cd pluggable-o11y-stack && IS_PREVIEW_ENV=true NAMESPACE=${namespace} make deploy`);
 
-        werft.log('jsonnet', 'done');
-        werft.done('jsonnet');
+        werft.log('Observability Stack', 'done');
+        werft.done('Observability Stack');
     } catch (err) {
         werft.fail('deploy', err);
     } finally {

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -179,8 +179,8 @@ async function deployToDev(version, workspaceFeatureFlags, dynamicCPULimits, reg
     const url = `https://${domain}`;
     const wsdaemonPort = `1${Math.floor(Math.random()*1000)}`;
     const registryProxyPort = `2${Math.floor(Math.random()*1000)}`;
-    const grafanaProxyPort = `3${Math.floor(Math.random()*1000)}`;
-    const prometheusProxyPort = `4${Math.floor(Math.random()*1000)}`;
+    const grafanaNodePort = `${30500 + Math.floor(Math.random()*500)}`;
+    const prometheusNodePort = `${31000 + Math.floor(Math.random()*500)}`;
     const registryNodePort = `${30000 + Math.floor(Math.random()*1000)}`;
 
     // trigger certificate issuing


### PR DESCRIPTION
PR is still a WIP

Writing an initial script to deploy the observability stack alongside every preview environment.

TODO:
- [x] Deploy Prometheus and Grafana alongside all previews by default
- [x] Add possibility to not deploy the stack
- [ ] Generate a URL for Grafana
- [ ] Generate a URL for Prometheus