### PR TITLE
[self-hosted] Use GitHub releases for Self-Hosted

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-grpc.46
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-sh-gh-release.39
 workspaceLocation: gitpod/gitpod-ws.theia-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.js
+++ b/.werft/build.js
@@ -4,7 +4,7 @@ const { werft, exec, gitTag } = require('./util/shell.js');
 const { sleep } = require('./util/util.js');
 const { wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespaceObjects } = require('./util/kubectl.js');
 const { issueAndInstallCertficate } = require('./util/certs.js');
-const https = require('https');
+const { reportBuildFailureInSlack } = require('./util/slack.js');
 
 const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.json";
 
@@ -14,49 +14,7 @@ const version = parseVersion(context);
 build(context, version)
     .catch((err) => {
         if (context.Repository.ref === "refs/heads/main") {
-            const repo = context.Repository.host + "/" + context.Repository.owner + "/" + context.Repository.repo;
-            const data = JSON.stringify({
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": ":X: *build failure*\n_Repo:_ `" + repo + "`\n_Build:_ `" + context.Name + "`"
-                        },
-                        "accessory": {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Go to Werft",
-                                "emoji": true
-                            },
-                            "value": "click_me_123",
-                            "url": "https://werft.gitpod-dev.com/job/" + context.Name,
-                            "action_id": "button-action"
-                        }
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "```\n" + err + "\n```"
-                        }
-                    }
-                ]
-            });
-            const req = https.request({
-                hostname: "hooks.slack.com",
-                port: 443,
-                path: process.env.SLACK_NOTIFICATION_PATH.trim(),
-                method: "POST",
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Content-Length': data.length,
-                }
-            }, () => process.exit(1));
-            req.on('error', () => process.exit(1));
-            req.write(data);
-            req.end();
+            reportBuildFailureInSlack(context, () => process.exit(1))
         } else {
             process.exit(1);
         }

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-grpc.46
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-sh-gh-release.39
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:
@@ -73,6 +73,12 @@ pod:
         secretKeyRef:
           name: slack-path
           key: slackPath
+    # used for GitHub releases (NOTE: for some reasons the token contains a trailing \n, is trimmed below)
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-sh-release-token
+          key: token
     # - name: GITPOD_TEST_TOKEN_GITHUB
     #   valueFrom:
     #     secretKeyRef:
@@ -95,10 +101,12 @@ pod:
         sleep 1
         set -Eeuo pipefail
 
+        export GITHUB_TOKEN=$(echo $GITHUB_TOKEN | xargs)
+
         export DOCKER_HOST=tcp://$NODENAME:2375
         sudo chown -R gitpod:gitpod /workspace
 
-        npm install shelljs
+        npm install shelljs semver
         printf '{{ toJson . }}' > context.json
 
         {{- if .Annotations.debug }}

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-bump-helm.12
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-sh-gh-release.39
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/util/slack.js
+++ b/.werft/util/slack.js
@@ -1,0 +1,51 @@
+const https = require('https');
+
+function reportBuildFailureInSlack(context, onErr) {
+    const repo = context.Repository.host + "/" + context.Repository.owner + "/" + context.Repository.repo;
+    const data = JSON.stringify({
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ":X: *build failure*\n_Repo:_ `" + repo + "`\n_Build:_ `" + context.Name + "`"
+                },
+                "accessory": {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Go to Werft",
+                        "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "https://werft.gitpod-dev.com/job/" + context.Name,
+                    "action_id": "button-action"
+                }
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "```\n" + err + "\n```"
+                }
+            }
+        ]
+    });
+    const req = https.request({
+        hostname: "hooks.slack.com",
+        port: 443,
+        path: process.env.SLACK_NOTIFICATION_PATH.trim(),
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': data.length,
+        }
+    }, onErr);
+    req.on('error', () => process.exit(1));
+    req.write(data);
+    req.end();
+}
+
+module.exports = {
+    reportBuildFailureInSlack: reportBuildFailureInSlack,
+}

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-bump-helm.12
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-sh-gh-release.39
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/chart/BUILD.yaml
+++ b/chart/BUILD.yaml
@@ -9,14 +9,22 @@ packages:
       - "**/*.tpl"
       - "secrets/**/*"
       - "config/**/*"
+      # Required for semver check below
+      - test-semver.js
     argdeps:
       - version
       - imageRepoBase
     config:
       commands:
+        # Chart.version has to be semver compliant for "helm package to work".
+        # We use this in two modes:
+        #  - publishing "Gitpod Self-Hosted" releases: version _is_ semver compliant
+        #  - publishing "branch builds": version is <branch-name>.<nr> (_not_ semver compliant)
+        # To fix this locally (without poisoning the leeway upstream deps) we detect semver compliance here, and in case of non-compliance, prefix with "0.1.0-".
+        # Note: This assumes all clients of the resulting "branch builds" package do not care about the actual version used.
+        - ["sh", "-c", "(npm install semver && node test-semver.js ${version}) && yq w -i Chart.yaml version ${version} || yq w -i Chart.yaml version 0.1.0-${version}"]
+        - ["rm", "-f", "test-semver.js"]
         # set values
-        # Chart.version has to be semver compliant
-        - ["sh", "-c", "yq w -i Chart.yaml version 0.1.0-${version}"]
         - ["yq", "w", "-i", "values.yaml", "version", "${version}"]
         - ["yq", "w", "-i", "values.yaml", "imagePrefix", "${imageRepoBase}/"]
         # prepare chart
@@ -27,3 +35,17 @@ packages:
         - ["helm", "dependency", "build", "gitpod"]
         - ["helm", "package", "gitpod", "--destination", "."]
         - ["rm", "-rf", "yq", "BUILD.yaml", "original_files.txt"]
+  - name: release-tars
+    type: generic
+    argdeps:
+    - version
+    deps:
+    - chart/config/db/init:release-tar
+    - install:release-tar
+    - :helm
+    config:
+      commands:
+      # re-wrap/mv into named tars
+      - ["sh", "-c", "tar czf gitpod-database-init-${version}.tar.gz -C chart-config-db-init--release-tar . && rm -rf chart-config-db-init--release-tar"]
+      - ["sh", "-c", "tar czf gitpod-terraform-${version}.tar.gz -C install--release-tar . && rm -rf install--release-tar"]
+      - ["sh", "-c", "mv chart--helm/*.tgz gitpod-helm-${version}.tar.gz && rm -rf chart--helm"]

--- a/chart/config/db/init/BUILD.yaml
+++ b/chart/config/db/init/BUILD.yaml
@@ -8,3 +8,11 @@ packages:
     type: generic
     config:
       commands: [["ls"]]
+  - name: release-tar
+    srcs:
+     - "*.sql"
+    type: generic
+    config:
+      commands:
+      # exclude as it's for test installations only
+      - ["rm", "-f", "00-testdb-user.sql"]

--- a/chart/test-semver.js
+++ b/chart/test-semver.js
@@ -1,0 +1,4 @@
+const semver = require('semver');
+if (!semver.valid(process.argv[2])) {
+    process.exit(1)
+}

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -66,6 +66,9 @@ RUN cd /usr/bin && curl -fsSL https://github.com/csweichel/werft/releases/downlo
 # yq - jq for YAML files
 RUN cd /usr/bin && curl -fsSL https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 > yq && chmod +x yq
 
+# release helper
+RUN cd /usr/bin && curl -fsSL https://github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | tar xz
+
 ### Protobuf
 RUN set -ex \
     && tmpdir=$(mktemp -d) \

--- a/install/BUILD.yaml
+++ b/install/BUILD.yaml
@@ -7,3 +7,10 @@ packages:
       - install/docker/examples/gitpod-gitlab/gitlab:docker
       - install/docker/gitpod-image:docker
       - install/installer:docker
+  - name: release-tar
+    srcs:
+    - "aws-terraform"
+    - "gcp-terraform"
+    type: generic
+    config:
+      commands: [["ls"]]


### PR DESCRIPTION
Fixes https://www.notion.so/gitpod/Publish-Gitpod-Self-Hosted-release-fd7c8070a96a4b7db987b0710fec4e26.

This uses [`github-release`](https://github.com/c4milo/github-release) to create a new release with [some files](https://github.com/gitpod-io/gitpod/blob/37aee23e617cb8febb1334ba054c28633878b1c4/scripts/create-release-tars.sh) whenever we call our build job with `-a publish-release=true`.

### Updated docs:
 - internal Notion: https://www.notion.so/gitpod/Publish-Gitpod-Self-Hosted-release-fd7c8070a96a4b7db987b0710fec4e26

### Companion PRs:
 - https://github.com/gitpod-com/gitpod-dev/pull/49
 
 ## Test:
 - run `werft job run github gitpod-io/gitpod:gpl/sh-gh-release -j .werft/build.yaml -a publish-release=true -a version=0.8.0-test1 -a imageRepoBase=gcr.io/gitpod-io/self-hosted -f`
 
 - check if:
   - the documentation fits: https://www.notion.so/gitpod/Publish-Gitpod-Self-Hosted-release-fd7c8070a96a4b7db987b0710fec4e26
   - a release with the correct content is created at: https://github.com/gitpod-io/gitpod/releases