### PR TITLE
Allow the Cluster-Autoscaler to evict blobserve

### DIFF
--- a/chart/templates/blobserve-deployment.yaml
+++ b/chart/templates/blobserve-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         stage: {{ .Values.installation.stage }}
         gitpod.io/nodeService: blobserve
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/path: "/metrics"
         prometheus.io/port: '9500'


### PR DESCRIPTION
Fixes gitpod-io/gitpod#3389