### PR TITLE
[vscode] upgrade to 1.54.1

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT e4218ec694e5205d3760afcdc0bd2b08d72c6102
+ENV GP_CODE_COMMIT 2fbcb5732e782832afb686dd2cb128083a930a9c
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

It upgrade to 1.54.1. We will need to ugprade again next week, since there will be a recovery release, but we also need new changes to progress with terminals and auth.

Changes in Code: https://github.com/gitpod-io/vscode/commit/2fbcb5732e782832afb686dd2cb128083a930a9c

#### How to test

- Switch to VS Code
- Start a workspace.
- Test follwing:
  - websockets and workers are properly proxied, for instance, diff editor should be operatable
  - terminals are preserved between window reloads (both regular and tasks)
  - extension host process, check debugging and language smartness
  - extension management (installing/uninstalling)
  - code cli should open files
  - user data are sync across workspaces as well as on workspace restart, especially for extensions
  - settings should not contain any mentions of MS telemetry
  - workspace commands, i.e. F1 -> Gitpod: prefix