### PR TITLE
[werft] Add flag 'storage=gcp' to use GCP storage instead of MinIO

### DIFF
--- a/.werft/values.dev.gcp-storage.yaml
+++ b/.werft/values.dev.gcp-storage.yaml
@@ -1,0 +1,44 @@
+components:
+  contentService:
+    remoteStorage:
+      kind: gcloud
+      backupTrail:
+        enabled: true
+        maxLength: 2
+      gcloud:
+        credentialsFileUpload: true
+        credentialsFile: /credentials/gitpod-dev-syncd-key.json
+        secretName: remote-storage-gcloud
+        projectId: gitpod-dev
+        region: europe-west1
+        tmpdir: /mnt/sync-tmp
+        parallelUpload: 6
+    volumes:
+      - name: gcloud-creds
+        secret:
+          secretName: remote-storage-gcloud
+    volumeMounts:
+    - mountPath: /credentials
+      name: gcloud-creds
+  wsManager:
+    volumes:
+    - name: gcloud-creds
+      secret:
+        secretName: remote-storage-gcloud
+    volumeMounts:
+    - mountPath: /credentials
+      name: gcloud-creds
+  wsDaemon:
+    volumes:
+    - name: gcloud-creds
+      secret:
+        secretName: remote-storage-gcloud
+    volumeMounts:
+    - mountPath: /credentials
+      name: gcloud-creds
+  server:
+    storage:
+      secretName: remote-storage-gcloud
+
+minio:
+  enabled: false


### PR DESCRIPTION
This change allows to deploy a preview env with GCP storage as remote storage backend instead of MinIO.

Just run with
```
/werft storage=gcp
```

See also: https://github.com/gitpod-com/gitpod/pull/5192