### PR TITLE
try fixes for missing mediatype in registry facade

### DIFF
--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -170,7 +170,7 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 	tracing.FinishSpan(span, &err)
 }
 
-func (bh *blobHandler) downloadManifest(ctx context.Context, ref string) (res *ociv1.Manifest, fetcher remotes.Fetcher, err error) {
+func (bh *blobHandler) downloadManifest(ctx context.Context, ref string) (res *Manifest, fetcher remotes.Fetcher, err error) {
 	_, desc, err := bh.Resolver.Resolve(ctx, ref)
 	if err != nil {
 		// ErrInvalidAuthorization
@@ -267,7 +267,7 @@ func (pbs proxyingBlobSource) GetBlob(ctx context.Context, spec *api.ImageSpec, 
 type configBlobSource struct {
 	Fetcher        remotes.Fetcher
 	Spec           *api.ImageSpec
-	Manifest       *ociv1.Manifest
+	Manifest       *Manifest
 	ConfigModifier ConfigModifier
 
 	cfg []byte


### PR DESCRIPTION
we've been experimenting with self-hosted gitpod (using tag 0.8.0v1) and have run into what seems to be a blocking bug in the registry facade service when running against a docker ecr registry. support for docker image manifest v2 was added in #2958; this, however, is not working for us, as we get the following error:

```
docker pull 52.207.68.255:3000/remote/815a94e8-82f7-4065-9177-2d7adc1bbbad
Using default tag: latest
Error response from daemon: mediaType in manifest should be 'application/vnd.docker.distribution.manifest.v2+json' not ''
```

it seems that the [top level `mediaType` field](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list-field-descriptions) on the manifest returned from the registry facade is missing. it exists in the config object and as a top level field for each layer, but not as a field in the manifest root itself:

```json
{
    "schemaVersion": 2,
    "config": {
        "mediaType": "application/vnd.docker.container.image.v1+json",
        "digest": "sha256:1599499eadf67c6a85fa4867ada814dcb2247a76feceeba48ebb003a99da714b",
        "size": 12139
    },
    "layers": [
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:83ee3a23efb7c75849515a6d46551c608b255d8402a4d3753752b88e0dc188fa",
            "size": 28565893
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:db98fc6f11f08950985a203e07755c3262c680d00084f601e7304b768c83b3b1",
            "size": 843
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:f611acd52c6cad803b06b5ba932e4aabd0f2d0d5a4d050c81de2832fcb781274",
            "size": 162
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:517e35088c4652d78db7d23a2605b86ec91c824d524c58bdc7ecaf05db3bfbbd",
            "size": 7783835
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:f0e31ec90ed873da5d5b54e9bcdcb32b2b4a03612cb08dbe354e9f8842ca4149",
            "size": 3624446
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:20f2ba9e7306bef4cc992bd04f172f3e1b020bcf1dcbae0c1e9c5141223c7efc",
            "size": 60675974
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:5d7997822b0651c24b1a8653936bd3c71460e5674e6b751eca2e14bbe7e12938",
            "size": 136804324
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:1bf27ad68fd765e772d472e19af199efcbd22bff7ee3431f0749109855b8b5ba",
            "size": 461
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:ca356bde106b81ea027c57f0bd0cab9730e7e538a275b62f76998a238e995ffe",
            "size": 238514358
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:f696484b247b0912c738103cb3a880ac8ee3e76367484ed2d75cab3f6677eb48",
            "size": 18635781
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:c270e2a605c49dd6c85c6b8de30c5c27c5e09baaa17104c5eff64dc9de6b7946",
            "size": 4156
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:984996b2e0e206bbbd32ad3a9ebc809c718b35e550424538f55acddd98a76d4d",
            "size": 1937
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:459dc123458d275d8f35dd86d05cb82dd5e185f39620e948f083c94401c6858b",
            "size": 2031
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:f19b4f68c4ac065989d198044a9d846dc6bc190ddd40fda1cb3fab96502c02d5",
            "size": 97266399
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:dbbb96bd5de197036208b8cfb9777f7c54d4417de37c9cad35889f44f5c8110e",
            "size": 14656535
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:bab832c95a818c0212772fc38cd0c694bd4fa0346e69cda196f55ac7ccbefb90",
            "size": 828
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:198bcafd223ea8568365f3cc82b75a2414a2be1450101c8512c82824a75de67e",
            "size": 630
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:afcd32219aed673807bda5b43bc4101e98b7983dd44a54f4138516d9e2c83bf3",
            "size": 507262011
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:35d45fd51355adf9805ee0c347b17fb5f1d49f1f66e9d24c9f8075f598537835",
            "size": 62822056
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:ffb2533883da94ad80b577876ba1613f1b238d51a2db4e9da57be5c296d671df",
            "size": 239766934
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:01405b8909cee0ec1a1ef14ba20cc6636f9fb4f09d834cdea6844764870b8e7f",
            "size": 408212735
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:74d4302f9eae5d95a3a9de93ea83af1d2a9151557a846aaff1155cea65134faf",
            "size": 89930957
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:431784e6a52b5ea93b57aef76df4b6c769166ff10e5dc8878db0c5696b7361fa",
            "size": 558
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:1df9c49f81348f8584bee91fdc11888ace9516b09779338aed5561feb57643b2",
            "size": 3939148
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:269bca558337f11115c0511509e3d3860b6358a632bb41da591af87554baa845",
            "size": 134838430
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:40ceaabead16b798085ed129023613405bb1ea036d181623a475fb3145afdc3f",
            "size": 93495082
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:2ce3e586ef278c1bc2556f08d68b528e1b056103c42b946256e4fb9d623926af",
            "size": 184
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:d98ba406a9cfeb8e5cc8e0d8f085bcfb71b61c9cade4e9034f155406c0fb6cdc",
            "size": 173976664
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:c7e68d06fb1294e54ddce4c4cba374ace7de4b3b8b6c39ab530df749cef7f044",
            "size": 130637496
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:840d17c16b8d6f9837db4b135565763d386d798e733e104d9158dc01e6c3eccd",
            "size": 135463370
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:d6a714d63bd62b9577baf7cdf980d8946e4f8d1ff156add0af7b243d663bbdfd",
            "size": 5020033
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:c966f56d48ed4d22108983129bf2cde34f05bdc110ed733ec3bbc90e7c5d966e",
            "size": 2615436
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:d0eca6a03f0de21cb0716d3b6df960540be017ce26357fffc35e3039c9dc6841",
            "size": 333624
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:5a3d0db7a4bff65dccea50b704be4c5ce3733b11b6dfe7da887f7dd7d5104197",
            "size": 5314
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:95e058e079d48ad6c71c346ae9aae55f914b8d8a0d6c781ce78c5867d6ee3de6",
            "size": 1511
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:3a5bf1168e6da517d296af5b7db0ef406d112c52b9e193b92f44168cb2336182",
            "size": 5556833
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:335728cdc8f392cdf2b26cf7ce8fe7cd52e98b5261f09f66e442f681cc214783",
            "size": 2209
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:3833af9d15816b5141b280324567ed8dc17ffc4041335f22d0df6a64cf4ef471",
            "size": 615
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:3c43275f2d31979e57404999b721512010e1c605ea143c0678fd87ebd4ecbbe7",
            "size": 2661
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:aaf9854c4305416dc4513f54f668a8719cc40a45ce860ae6a3875b57c7cce9a8",
            "size": 86261726
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:98dc6606273ef956851afce1e7e280c58f9a6055e865b95012c1096f750d2d29",
            "size": 124
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:b0fd0c1f967c2cd7a8e44d0b385397f9e0ef72a4e8e9e9fd26a29ca14135a508",
            "size": 258
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:53c7c87a7e44ca9df215cc41471133f689353a795b2034d9036dcf084031b33b",
            "size": 115178752
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:e44875891303d647c3966a93107c36286b1262f0d6d118e4514109d1e36c7988",
            "size": 5683363
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:8fb616e11b5feb2851358443093cd0764278c8c00e2940ab2aa1bdcdedb09865",
            "size": 5237803
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:ae1098c9108fc31b6a2490b6318ae293e6f87254cade9b632b6fd6bd17b21e04",
            "size": 335
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:a66823bc21c16973fdd305211beee1f9b129f7174806635c445dd16a78c1cada",
            "size": 220
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:221e52d67fc72683ba2d32ba865f644edff6b1ab5322f3f15dd461652bbe7f09",
            "size": 218383
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:ed1a40b6e03677d770a142d56a16b5bdc0c64681810ee46ad2468cb5f4cc8329",
            "size": 5683358
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:f361a36d2dce8ef2c89ba3b6fd2f12a0b78e72af492bdaed4c6c19fc79a7cb4d",
            "size": 227
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:dc465e1678dcf72a39f3a4ab1877c172a5e89147010b1a91492594b918f59370",
            "size": 4389027
        },
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "digest": "sha256:7d7515e6989e5584c0847ec51246ddff1d3ba04d5934f94312ecaa7c1e35f693",
            "size": 5237844
        }
    ]
}
```

we're experimenting with some hacky fixes to get things rolling on our end but wanted to open the PR in the meantime to get some eyes from the gitpod team as it seems like a more widespread issue.

mentions of this bug:
- https://community.gitpod.io/t/preview-dev-net-tun/2819/5