### PR TITLE
[registry-facade] Serve Docker manifest mediaType

### DIFF
--- a/components/registry-facade/pkg/registry/manifest.go
+++ b/components/registry-facade/pkg/registry/manifest.go
@@ -195,7 +195,23 @@ func (mh *manifestHandler) getManifest(w http.ResponseWriter, r *http.Request) {
 			manifest.Config.URLs = nil
 			manifest.Config.Size = int64(len(rawCfg))
 
-			p, _ = json.Marshal(manifest)
+			// When serving images.MediaTypeDockerSchema2Manifest we have to set the mediaType in the manifest itself.
+			// Although somewhat compatible with the OCI manifest spec (see https://github.com/opencontainers/image-spec/blob/master/manifest.md),
+			// this field is not part of the OCI Go structs. In this particular case, we'll go ahead and add it ourselves.
+			//
+			// fixes https://github.com/gitpod-io/gitpod/pull/3397
+			if desc.MediaType == images.MediaTypeDockerSchema2Manifest {
+				type ManifestWithMediaType struct {
+					ociv1.Manifest
+					MediaType string `json:"mediaType"`
+				}
+				p, _ = json.Marshal(ManifestWithMediaType{
+					Manifest:  *manifest,
+					MediaType: images.MediaTypeDockerSchema2Manifest,
+				})
+			} else {
+				p, _ = json.Marshal(manifest)
+			}
 		}
 
 		dgst := digest.FromBytes(p).String()


### PR DESCRIPTION
when serving docker v2 manifests, we need to add mediaType to the manifest.
Otherwise Docker ECR pulls fail.

supplants https://github.com/gitpod-io/gitpod/pull/3397  