### PR TITLE
[seccomp] Allow unshare syscall

### DIFF
--- a/components/ws-daemon/seccomp-profile-installer/main.go
+++ b/components/ws-daemon/seccomp-profile-installer/main.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"log"
 	"os"
-	"syscall"
 
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -38,36 +37,9 @@ func main() {
 				"pivot_root",
 				"setdomainname",
 				"sethostname",
+				"unshare",
 			},
 			Action: specs.ActAllow,
-		},
-
-		// docker-up requires unshare(CLONE_NEWNET) to create the network namespace
-		// for Docker.
-		specs.LinuxSyscall{
-			Names:  []string{"unshare"},
-			Action: specs.ActAllow,
-			Args: []specs.LinuxSeccompArg{
-				// SCMP_CMP_MASKED_EQ - masked equal: true if (value & arg == valueTwo)
-				{
-					Index:    0,
-					Op:       specs.OpMaskedEqual,
-					Value:    syscall.CLONE_NEWNET,
-					ValueTwo: syscall.CLONE_NEWNET,
-				},
-			},
-		},
-		// docker-exec requires unshare(0).
-		specs.LinuxSyscall{
-			Names:  []string{"unshare"},
-			Action: specs.ActAllow,
-			Args: []specs.LinuxSeccompArg{
-				{
-					Index: 0,
-					Op:    specs.OpEqualTo,
-					Value: 0,
-				},
-			},
 		},
 
 		// slirp4netns requires setns, as do we for debugging


### PR DESCRIPTION
This change allows the [`unshare`](https://man7.org/linux/man-pages/man2/unshare.2.html) syscall more broadly in workspaces. Previously we'd try and tailor the seccomp profile to specific use-cases, but I don't see how this call should be used for mischievous purposes.

By allowing `unshare` we make one step closer to enabling other container tools in user-namespaced workspaces, e.g. buildkit and possibly podman. I've used this branch to run buildkit in a Gitpod workspace.

### How to review
The primary concern is that there may be ways to exploit the unshare syscall. I'm not aware of any (but absence of evidence is not evidence of absence) - and would be keen to know if anyone else is aware of potential issues this might cause.