### PR TITLE
[dashboard] Re-implement a start workspace page for dashboard v2

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -48,11 +48,12 @@ function App() {
         window.location.reload(true);
       }
     }, false);
-    const hash = window.location.hash.replace(/^[#/]+/, '');
+
+    const hash = getURLHash();
     if (window.location.pathname === '/' && hash !== '') {
       return <CreateWorkspace contextUrl={hash} gitpodService={gitpodService}/>;
     }
-    if (/\/start\/?/.test(window.location.pathname)) {
+    if (/\/start\/?/.test(window.location.pathname) && hash !== '') {
       return <StartWorkspace workspaceId={hash} gitpodService={gitpodService}/>;
     }
 
@@ -83,6 +84,10 @@ function App() {
             </div>
         </BrowserRouter>
     );
+}
+
+function getURLHash () {
+  return window.location.hash.replace(/^[#/]+/, '');
 }
 
 const renderMenu = () => (

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -42,6 +42,12 @@ function App() {
         return (<Login gitpodService={gitpodService} />)
     };
 
+    window.addEventListener("hashchange", () => {
+      // Refresh on hash change if the path is '/' (new context URL)
+      if (window.location.pathname === '/') {
+        window.location.reload(true);
+      }
+    }, false);
     const hash = window.location.hash.replace(/^[#/]+/, '');
     if (window.location.pathname === '/' && hash !== '') {
       return <CreateWorkspace contextUrl={hash} gitpodService={gitpodService}/>;
@@ -49,12 +55,6 @@ function App() {
     if (/\/start\/?/.test(window.location.pathname)) {
       return <StartWorkspace workspaceId={hash} gitpodService={gitpodService}/>;
     }
-    window.addEventListener("hashchange", () => {
-      // Refresh on hash change if the path is '/' (new context URL)
-      if (window.location.pathname === '/') {
-        window.location.reload(true);
-      }
-    }, false);
 
     return (
         <BrowserRouter>

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -3,6 +3,8 @@ import Menu from './components/Menu';
 import { BrowserRouter } from "react-router-dom";
 import { Route, Switch } from "react-router";
 import { Workspaces } from './workspaces/Workspaces';
+import { CreateWorkspace } from './start/CreateWorkspace';
+import StartWorkspace from './start/StartWorkspace';
 import { Login } from './Login';
 import { UserContext } from './user-context';
 import { gitpodService } from './service/service';
@@ -39,6 +41,20 @@ function App() {
     if (!loading && !user) {
         return (<Login gitpodService={gitpodService} />)
     };
+
+    const hash = window.location.hash.replace(/^[#/]+/, '');
+    if (window.location.pathname === '/' && hash !== '') {
+      return <CreateWorkspace contextUrl={hash} gitpodService={gitpodService}/>;
+    }
+    if (/\/start\/?/.test(window.location.pathname)) {
+      return <StartWorkspace workspaceId={hash} gitpodService={gitpodService}/>;
+    }
+    window.addEventListener("hashchange", () => {
+      // Refresh on hash change if the path is '/' (new context URL)
+      if (window.location.pathname === '/') {
+        window.location.reload(true);
+      }
+    }, false);
 
     return (
         <BrowserRouter>

--- a/components/dashboard/src/components/StartPage.tsx
+++ b/components/dashboard/src/components/StartPage.tsx
@@ -1,8 +1,9 @@
 export enum StartPhase {
   Checking = 0,
   Building = 1,
-  Deploying = 2,
+  Preparing = 2,
   Starting = 3,
+  Running = 4,
 };
 
 function ProgressBar(props: { phase: number, error: boolean }) {
@@ -45,8 +46,8 @@ export function StartPage(props: StartPageProps) {
     case StartPhase.Building:
       title = "Building";
       break;
-    case StartPhase.Deploying:
-      title = "Deploying";
+    case StartPhase.Preparing:
+      title = "Preparing";
       break;
     case StartPhase.Starting:
       title = "Starting";

--- a/components/dashboard/src/components/StartPage.tsx
+++ b/components/dashboard/src/components/StartPage.tsx
@@ -7,9 +7,9 @@ export enum StartPhase {
 };
 
 function ProgressBar(props: { phase: number, error: boolean }) {
-  return <div className="flex mt-8 mb-6">
+  return <div className="flex mt-4 mb-6">
     {[1, 2, 3].map(i => {
-      let classes = 'h-2 w-10 m-2 rounded-full';
+      let classes = 'h-2 w-10 mx-1 my-2 rounded-full';
       if (i < props.phase) {
         // Already passed this phase successfully
         classes += ' bg-green-light';
@@ -52,11 +52,14 @@ export function StartPage(props: StartPageProps) {
     case StartPhase.Starting:
       title = "Starting";
       break;
+    case StartPhase.Running:
+      title = "Starting";
+      break;
   }
   return <div className="h-screen flex bg-white">
     <div className="w-full mt-40 md:mt-60 flex flex-col items-center">
       <img src="/gitpod.svg" className="h-16 flex-shrink-0" />
-      <h3 className="mt-8">{title}</h3>
+      <h3 className="mt-8 text-xl">{title}</h3>
       <ProgressBar phase={props.phase} error={!!props.error}/>
       {props.children}
     </div>

--- a/components/dashboard/src/components/StartPage.tsx
+++ b/components/dashboard/src/components/StartPage.tsx
@@ -1,0 +1,63 @@
+export enum StartPhase {
+  Checking = 0,
+  Building = 1,
+  Deploying = 2,
+  Starting = 3,
+};
+
+function ProgressBar(props: { phase: number, error: boolean }) {
+  return <div className="flex mt-8 mb-6">
+    {[1, 2, 3].map(i => {
+      let classes = 'h-2 w-10 m-2 rounded-full';
+      if (i < props.phase) {
+        // Already passed this phase successfully
+        classes += ' bg-green-light';
+      } else if (i > props.phase) {
+        // Haven't reached this phase yet
+        classes += ' bg-gray-200';
+      } else if (props.error) {
+        // This phase has failed
+        classes += ' bg-red';
+      } else {
+        // This phase is currently running
+        classes += ' bg-green-light animate-pulse';
+      }
+      return <div className={classes}/>;
+    })}
+  </div>;
+}
+
+export interface StartPageProps {
+    phase: number;
+    error?: boolean;
+    children?: React.ReactNode;
+}
+
+export function StartPage(props: StartPageProps) {
+  let title = "";
+  switch (props.phase) {
+    case StartPhase.Checking:
+      if (props.error) {
+        // Pre-check error
+        title = "Oh, no! Something went wrong!1";
+      }
+      break;
+    case StartPhase.Building:
+      title = "Building";
+      break;
+    case StartPhase.Deploying:
+      title = "Deploying";
+      break;
+    case StartPhase.Starting:
+      title = "Starting";
+      break;
+  }
+  return <div className="h-screen flex bg-white">
+    <div className="w-full mt-40 md:mt-60 flex flex-col items-center">
+      <img src="/gitpod.svg" className="h-16 flex-shrink-0" />
+      <h3 className="mt-8">{title}</h3>
+      <ProgressBar phase={props.phase} error={!!props.error}/>
+      {props.children}
+    </div>
+  </div>;
+}

--- a/components/dashboard/src/service/service.ts
+++ b/components/dashboard/src/service/service.ts
@@ -6,8 +6,8 @@
 
 import { GitpodClient, GitpodServer, GitpodServerPath, GitpodServiceImpl } from '@gitpod/gitpod-protocol';
 import { WebSocketConnectionProvider } from '@gitpod/gitpod-protocol/lib/messaging/browser/connection';
-import { createWindowMessageConnection } from '@gitpod/gitpod-protocol/lib/messaging/browser/window-connection';
-import { JsonRpcProxy, JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy-factory';
+// import { createWindowMessageConnection } from '@gitpod/gitpod-protocol/lib/messaging/browser/window-connection';
+import { JsonRpcProxy /* , JsonRpcProxyFactory */ } from '@gitpod/gitpod-protocol/lib/messaging/proxy-factory';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 // import { gitpodServiceMock } from './service-mock';
@@ -19,12 +19,13 @@ function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
     let reconnect = () => {
         console.log("WebSocket reconnect not possible.");
     }
-    if (window.top !== window.self) {
-        const connection = createWindowMessageConnection('gitpodServer', window.parent, '*');
-        const factory = new JsonRpcProxyFactory<S>();
-        proxy = factory.createProxy();
-        factory.listen(connection);
-    } else {
+    // FIXME: https://gitpod.slack.com/archives/C01KGM9BUNS/p1615456669011600
+    // if (window.top !== window.self) {
+    //     const connection = createWindowMessageConnection('gitpodServer', window.parent, '*');
+    //     const factory = new JsonRpcProxyFactory<S>();
+    //     proxy = factory.createProxy();
+    //     factory.listen(connection);
+    // } else {
         let host = gitpodHostUrl
             .asWebsocket()
             .with({ pathname: GitpodServerPath })
@@ -51,7 +52,7 @@ function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
         if (_websocket && "reconnect" in _websocket) {
             reconnect = () => { (_websocket as any).reconnect() };
         }
-    }
+    // }
     const service = new GitpodServiceImpl<C, S>(proxy);
     (service as any).reconnect = reconnect;
     return service;

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -26,7 +26,6 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
 
   constructor(props: CreateWorkspaceProps) {
     super(props);
-    window.addEventListener("hashchange", () => { window.location.reload(true); }, false);
   }
 
   componentDidMount() {

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -51,7 +51,7 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
   render() {
     const { contextUrl } = this.props;
     let phase = StartPhase.Checking;
-    let statusMessage = <p className="text-sm text-gray-400">Creating workspace …</p>;
+    let statusMessage = <p className="text-base text-gray-400">Creating workspace …</p>;
     let logsView = undefined;
 
     const error = this.state?.error;
@@ -59,17 +59,17 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
       switch (error.code) {
         case ErrorCodes.CONTEXT_PARSE_ERROR:
           statusMessage = <div className="text-center">
-            <p className="text-sm text-red">Unrecognized context: '{contextUrl}'</p>
-            <p>Learn more about <a className="text-blue" href="https://www.gitpod.io/docs/context-urls/">supported context URLs</a></p>
+            <p className="text-base text-red">Unrecognized context: '{contextUrl}'</p>
+            <p className="text-base mt-2">Learn more about <a className="text-blue" href="https://www.gitpod.io/docs/context-urls/">supported context URLs</a></p>
           </div>;
           break;
         case ErrorCodes.NOT_FOUND:
           statusMessage = <div className="text-center">
-            <p className="text-sm text-red">Not found: {contextUrl}</p>
+            <p className="text-base text-red">Not found: {contextUrl}</p>
           </div>;
           break;
         default:
-          statusMessage = <p className="text-sm text-red">Unknown Error: {JSON.stringify(this.state?.error, null, 2)}</p>;
+          statusMessage = <p className="text-base text-red">Unknown Error: {JSON.stringify(this.state?.error, null, 2)}</p>;
           break;
       }
     }
@@ -81,12 +81,12 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
 
     else if (result?.existingWorkspaces) {
       // FIXME Force create
-      statusMessage = <div className="text-sm text-gray-400">Existing workspaces:<ul>{result.existingWorkspaces.map(w => <li>→ <a className="text-blue" href={w.latestInstance?.ideUrl}>{w.workspace.id}</a></li>)}</ul></div>;
+      statusMessage = <div className="text-base text-gray-400">Existing workspaces:<ul>{result.existingWorkspaces.map(w => <li>→ <a className="text-blue" href={w.latestInstance?.ideUrl}>{w.workspace.id}</a></li>)}</ul></div>;
     }
 
     else if (result?.runningWorkspacePrebuild) {
       phase = StartPhase.Building;
-      statusMessage = <p className="text-sm text-gray-400">⚡Prebuild in progress</p>;
+      statusMessage = <p className="text-base text-gray-400">⚡Prebuild in progress</p>;
       logsView = <Suspense fallback={<div className="m-6 p-4 h-60 w-11/12 lg:w-3/5 flex-shrink-0 rounded-lg" style={{ color: '#8E8787', background: '#ECE7E5' }}>Loading...</div>}>
         <WorkspaceLogs />
       </Suspense>;
@@ -95,6 +95,14 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
     return <StartPage phase={phase} error={!!error}>
       {statusMessage}
       {logsView}
+      <button className="mt-8">Go back to dashboard</button>
+      <p className="mt-10 text-base text-gray-400 flex space-x-2">
+        <a href="https://www.gitpod.io/docs/">Docs</a>
+        <span>—</span>
+        <a href="https://status.gitpod.io/">Status</a>
+        <span>—</span>
+        <a href="https://www.gitpod.io/blog/">Blog</a>
+      </p>
     </StartPage>;
   }
 

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -1,0 +1,102 @@
+import { CreateWorkspaceMode, GitpodService, WorkspaceCreationResult } from "@gitpod/gitpod-protocol";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { StartPage, StartPhase } from "../components/StartPage";
+import StartWorkspace from "./StartWorkspace";
+import React, { Suspense } from "react";
+
+const WorkspaceLogs = React.lazy(() => import('./WorkspaceLogs'));
+
+export interface CreateWorkspaceProps {
+  contextUrl: string;
+  gitpodService: GitpodService;
+}
+
+export interface CreateWorkspaceState {
+  result?: WorkspaceCreationResult;
+  error?: CreateWorkspaceError;
+}
+
+export interface CreateWorkspaceError {
+  message?: string;
+  code?: number;
+  data?: any;
+}
+
+export class CreateWorkspace extends React.Component<CreateWorkspaceProps, CreateWorkspaceState> {
+
+  constructor(props: CreateWorkspaceProps) {
+    super(props);
+    window.addEventListener("hashchange", () => { window.location.reload(true); }, false);
+  }
+
+  componentDidMount() {
+    this.createWorkspace();
+  }
+
+  async createWorkspace() {
+    try {
+      const result = await this.props.gitpodService.server.createWorkspace({
+        contextUrl: this.props.contextUrl,
+        mode: CreateWorkspaceMode.SelectIfRunning
+      });
+      if (result.workspaceURL) {
+        window.location.href = result.workspaceURL;
+        return;
+      }
+      this.setState({ result });
+    } catch (error) {
+      this.setState({ error });
+    }
+  }
+
+  render() {
+    const { contextUrl } = this.props;
+    let phase = StartPhase.Checking;
+    let statusMessage = <p className="text-sm text-gray-400">Creating workspace …</p>;
+    let logsView = undefined;
+
+    const error = this.state?.error;
+    if (error) {
+      switch (error.code) {
+        case ErrorCodes.CONTEXT_PARSE_ERROR:
+          statusMessage = <div className="text-center">
+            <p className="text-sm text-red">Unrecognized context: '{contextUrl}'</p>
+            <p>Learn more about <a className="text-blue" href="https://www.gitpod.io/docs/context-urls/">supported context URLs</a></p>
+          </div>;
+          break;
+        case ErrorCodes.NOT_FOUND:
+          statusMessage = <div className="text-center">
+            <p className="text-sm text-red">Not found: {contextUrl}</p>
+          </div>;
+          break;
+        default:
+          statusMessage = <p className="text-sm text-red">Unknown Error: {JSON.stringify(this.state?.error, null, 2)}</p>;
+          break;
+      }
+    }
+
+    const result = this.state?.result;
+    if (result?.createdWorkspaceId) {
+      return <StartWorkspace workspaceId={result.createdWorkspaceId} gitpodService={this.props.gitpodService} />;
+    }
+
+    else if (result?.existingWorkspaces) {
+      // FIXME Force create
+      statusMessage = <div className="text-sm text-gray-400">Existing workspaces:<ul>{result.existingWorkspaces.map(w => <li>→ <a className="text-blue" href={w.latestInstance?.ideUrl}>{w.workspace.id}</a></li>)}</ul></div>;
+    }
+
+    else if (result?.runningWorkspacePrebuild) {
+      phase = StartPhase.Building;
+      statusMessage = <p className="text-sm text-gray-400">⚡Prebuild in progress</p>;
+      logsView = <Suspense fallback={<div className="m-6 p-4 h-60 w-11/12 lg:w-3/5 flex-shrink-0 rounded-lg" style={{ color: '#8E8787', background: '#ECE7E5' }}>Loading...</div>}>
+        <WorkspaceLogs />
+      </Suspense>;
+    }
+
+    return <StartPage phase={phase} error={!!error}>
+      {statusMessage}
+      {logsView}
+    </StartPage>;
+  }
+
+}

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -51,7 +51,7 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
   render() {
     const { contextUrl } = this.props;
     let phase = StartPhase.Checking;
-    let statusMessage = <p className="text-base text-gray-400">Creating workspace …</p>;
+    let statusMessage = <p className="text-base text-gray-400">Checking Context …</p>;
     let logsView = undefined;
 
     const error = this.state?.error;

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -1,0 +1,34 @@
+import { StartPage, StartPhase } from "../components/StartPage";
+import { GitpodService } from "@gitpod/gitpod-protocol";
+import React from "react";
+
+export interface StartWorkspaceProps {
+  workspaceId?: string;
+  gitpodService: GitpodService;
+}
+
+export interface StartWorkspaceState {
+  phase: StartPhase;
+}
+
+export interface StartWorkspaceError {
+  message?: string;
+  code?: number;
+  data?: any;
+}
+
+export default class StartWorkspace extends React.Component<StartWorkspaceProps, StartWorkspaceState> {
+
+  constructor(props: StartWorkspaceProps) {
+    super(props);
+    this.state = {
+      phase: StartPhase.Building,
+    };
+  }
+
+  render() {
+    return <StartPage phase={this.state.phase}>
+      <div className="text-sm text-gray-400">Workspace ID: {this.props.workspaceId}</div>
+    </StartPage>;
+  }
+}

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -1,14 +1,19 @@
-import { StartPage, StartPhase } from "../components/StartPage";
-import { GitpodService } from "@gitpod/gitpod-protocol";
 import React from "react";
+import { GitpodService, DisposableCollection, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { StartPage, StartPhase } from "../components/StartPage";
 
 export interface StartWorkspaceProps {
-  workspaceId?: string;
+  workspaceId: string;
   gitpodService: GitpodService;
 }
 
 export interface StartWorkspaceState {
   phase: StartPhase;
+  contextUrl?: string;
+  startedInstanceId?: string;
+  error?: StartWorkspaceError;
+  ideFrontendFailureCause?: string;
 }
 
 export interface StartWorkspaceError {
@@ -24,6 +29,170 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     this.state = {
       phase: StartPhase.Building,
     };
+  }
+
+  private readonly toDispose = new DisposableCollection();
+  componentWillMount() {
+    if (this.runsInIFrame()) {
+      const setStateEventListener = (event: MessageEvent) => {
+        if (event.data.type === 'setState' && 'state' in event.data && typeof event.data['state'] === 'object') {
+          // This seems to only set ideFrontendFailureCause
+          this.setState(event.data.state);
+        }
+      }
+      window.addEventListener('message', setStateEventListener, false);
+      this.toDispose.push({
+        dispose: () => window.removeEventListener('message', setStateEventListener)
+      });
+    }
+
+    try {
+      this.toDispose.push(this.props.gitpodService.registerClient(this));
+    } catch (error) {
+      this.setState({ error });
+    }
+
+    this.startWorkspace();
+  }
+
+  componentWillUnmount() {
+    this.toDispose.dispose();
+  }
+
+  async startWorkspace(restart = false, forceDefaultImage = false) {
+    const state = this.state;
+    if (state) {
+      if (!restart && (state.startedInstanceId /* || state.errorMessage */)) {
+        // We stick with a started instance until we're explicitly told not to
+        return;
+      }
+    }
+
+    const { workspaceId } = this.props;
+    try {
+      const result = await this.props.gitpodService.server.startWorkspace(workspaceId, { forceDefaultImage });
+      if (!result) {
+        throw new Error("No result!");
+      }
+      console.log("/start: started workspace instance: " + result.instanceID);
+      // redirect to workspaceURL if we are not yet running in an iframe
+      if (!this.runsInIFrame() && result.workspaceURL) {
+        this.redirectTo(result.workspaceURL);
+        return;
+      }
+      this.setState({ startedInstanceId: result.instanceID });
+      // Explicitly query state to guarantee we get at least one update
+      // (needed for already started workspaces, and not hanging in 'Starting ...' for too long)
+      this.props.gitpodService.server.getWorkspace(workspaceId).then(ws => {
+        if (ws.latestInstance) {
+          this.setState({
+            contextUrl: ws.workspace.contextURL
+          });
+          this.onInstanceUpdate(ws.latestInstance);
+        }
+      });
+    } catch (error) {
+      this.setState({ error });
+    }
+  }
+
+  async onInstanceUpdate(workspaceInstance: WorkspaceInstance) {
+    const startedInstanceId = this.state?.startedInstanceId;
+    if (workspaceInstance.workspaceId !== this.props.workspaceId || startedInstanceId !== workspaceInstance.id) {
+      return;
+    }
+
+    await this.ensureWorkspaceAuth(workspaceInstance.id);
+
+    // redirect to workspaceURL if we are not yet running in an iframe
+    // it happens this late if we were waiting for a docker build.
+    if (!this.runsInIFrame() && workspaceInstance.ideUrl) {
+      this.redirectTo(workspaceInstance.ideUrl);
+      return;
+    }
+
+    switch (workspaceInstance.status.phase) {
+      // unknown indicates an issue within the system in that it cannot determine the actual phase of
+      // a workspace. This phase is usually accompanied by an error.
+      case "unknown":
+        break;
+
+      // Preparing means that we haven't actually started the workspace instance just yet, but rather
+      // are still preparing for launch. This means we're building the Docker image for the workspace.
+      case "preparing":
+        this.props.gitpodService.server.watchWorkspaceImageBuildLogs(workspaceInstance.workspaceId);
+        this.setState({ phase: StartPhase.Building });
+        break;
+
+      // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
+      // some space within the cluster. If for example the cluster needs to scale up to accomodate the
+      // workspace, the workspace will be in Pending state until that happened.
+      case "pending":
+        this.setState({ phase: StartPhase.Preparing });
+        break;
+
+      // Creating means the workspace is currently being created. That includes downloading the images required
+      // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
+      // network speed, image size and cache states.
+      case "creating":
+        this.setState({ phase: StartPhase.Preparing });
+        break;
+
+      // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
+      // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
+      case "initializing":
+        this.setState({ phase: StartPhase.Starting });
+        break;
+
+      // Running means the workspace is able to actively perform work, either by serving a user through Theia,
+      // or as a headless workspace.
+      case "running":
+        this.setState({ phase: StartPhase.Running });
+        break;
+
+      // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
+      // When in this state, we expect it to become running or stopping anytime soon.
+      case "interrupted":
+        this.setState({ phase: StartPhase.Running });
+        break;
+
+      // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
+      case "stopping":
+        break;
+
+      // Stopped means the workspace ended regularly because it was shut down.
+      case "stopped":
+        break;
+    }
+
+  }
+
+  async ensureWorkspaceAuth(instanceID: string) {
+    if (!document.cookie.includes(`${instanceID}_owner_`)) {
+      const authURL = new GitpodHostUrl(window.location.toString()).asWorkspaceAuth(instanceID);
+      const response = await fetch(authURL.toString());
+      if (response.redirected) {
+        this.redirectTo(response.url);
+        return;
+      }
+      if (!response.ok) {
+        // getting workspace auth didn't work as planned - redirect
+        this.redirectTo(authURL.asWorkspaceAuth(instanceID, true).toString());
+        return;
+      }
+    }
+  }
+
+  redirectTo(url: string) {
+    if (this.runsInIFrame()) {
+        window.parent.postMessage({ type: 'relocate', url }, '*');
+    } else {
+        window.location.href = url;
+    }
+  }
+
+  runsInIFrame() {
+    return window.top !== window.self;
   }
 
   render() {

--- a/components/dashboard/src/start/WorkspaceLogs.tsx
+++ b/components/dashboard/src/start/WorkspaceLogs.tsx
@@ -1,0 +1,5 @@
+export default function WorkspaceLogs() {
+  return <pre className="m-6 p-4 h-60 w-11/12 lg:w-3/5 flex-shrink-0 rounded-lg" style={{ color: '#8E8787', background: '#ECE7E5' }}>
+    ... logs ...
+  </pre>;
+}

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -1,8 +1,34 @@
 // tailwind.config.js
+const colors = require('tailwindcss/colors');
+
 module.exports = {
     important: true,
     theme: {
         extend: {
+            colors: {
+                gray: colors.warmGray,
+                green: {
+                  light: '#9DD714',
+                  DEFAULT: '#58B19F',
+                  dark: '#467A45',
+                },
+                red: {
+                  light: '#EF9C9A',
+                  DEFAULT: '#CE4A3E',
+                  dark: '#B1336A',
+                },
+                blue: {
+                  light: '#75A9EC',
+                  DEFAULT: '#5C8DD6',
+                  dark: '#265583',
+                },
+                'gitpod-black': '#161616',
+                'gitpod-gray': '#8E8787',
+                'gitpod-kumquat-light': '#FFCE4F',
+                'gitpod-kumquat': '#FFB45B',
+                'gitpod-kumquat-dark': '#FF8A00',
+                'gitpod-kumquat-gradient': 'linear-gradient(137.41deg, #FFAD33 14.37%, #FF8A00 91.32%)',
+            },
             container: {
                 center: true,
             },
@@ -12,10 +38,10 @@ module.exports = {
         },
         fontFamily: {
             'sans': ['Inter', 'Helvetica', 'Arial', 'sans-serif'],
-        }
+        },
     },
     plugins: [
         require('@tailwindcss/forms'),
         // ...
     ],
-}
+};


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3301

TODO / follow-ups:
- [x] Handle Gitpod URL prefix & create new workspaces
- [x] Show workspace start progress
- [x] Show relevant status messages in-between the phases (any step that can take > 1 second)
- [ ] Show build logs
- [ ] Show prebuild logs
- [x] Show IDE once the workspace is ready
- [ ] Show when workspace is stopping, or is stopped (with uncommitted changes)