### PR TITLE
Initialize all $extra_cors_* variables

### DIFF
--- a/chart/config/proxy/lib.cors-server.conf
+++ b/chart/config/proxy/lib.cors-server.conf
@@ -14,3 +14,8 @@ if ($http_origin ~* ".*${PROXY_DOMAIN_REGEX}$") {
 if ($request_method = 'OPTIONS') {
 	set $cors_test   "${cors_test}+method_options";
 }
+
+# Initialize all $extra_cors_* variables
+set $extra_cors_expose_headers "";
+set $extra_cors_allowed_headers "";
+set $extra_cors_allowed_methods "";


### PR DESCRIPTION
Should fix:

```
2021/03/10 19:03:59 [warn] 82#82: *5174 using uninitialized "extra_cors_expose_headers" variable, client: 10.120.6.21, server: , request: "GET /api/gitpod HTTP/1.1", host: "gitpod"
2021/03/10 19:03:59 [warn] 82#82: *5174 using uninitialized "extra_cors_allowed_headers" variable, client: 10.120.6.21, server: , request: "GET /api/gitpod HTTP/1.1", host: "gitpod"
2021/03/10 19:03:59 [warn] 82#82: *5174 using uninitialized "extra_cors_allowed_methods" variable, client: 10.120.6.21, server: , request: "GET /api/gitpod HTTP/1.1", host: "gitpod"
```


@aledbf 