### PR TITLE
Remove unusued vim

### DIFF
--- a/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/layer.sh
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/layer.sh
@@ -9,7 +9,7 @@
 set -e;
 
 # Install necessary tools only if they are not yet installed
-INSTALLED_PACKAGES=$(dpkg-query -f '${Package} ${Status}\n' -W bash-completion git vim | wc -l)
+INSTALLED_PACKAGES=$(dpkg-query -f '${Package} ${Status}\n' -W bash-completion git | wc -l)
 if [ $INSTALLED_PACKAGES != 3 ]; then
     # The first 'clean' is needed to avoid apt-get detecting package meta data changes
     # (like changed labels) which result in errors and broken builds/workspaces!


### PR DESCRIPTION
Further to https://github.com/gitpod-io/gitpod/pull/3367 I realised I missed the vim check, this should also be removed.

/werft no-preview