### PR TITLE
[vscode] support port preview

### DIFF
--- a/components/gitpod-cli/cmd/url.go
+++ b/components/gitpod-cli/cmd/url.go
@@ -40,7 +40,7 @@ will print the URL of a service/server exposed on port 8080.`,
 			return
 		}
 
-		fmt.Println(getWorkspaceURL(port))
+		fmt.Println(GetWorkspaceURL(port))
 	},
 }
 
@@ -48,7 +48,7 @@ func init() {
 	rootCmd.AddCommand(urlCmd)
 }
 
-func getWorkspaceURL(port int) (url string) {
+func GetWorkspaceURL(port int) (url string) {
 	wsurl := os.Getenv("GITPOD_WORKSPACE_URL")
 	if port == 0 {
 		return wsurl

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 845053f04b5d9efd17f6f7626ba362925bd0bfe5
+ENV GP_CODE_COMMIT f75d023a0b4954d2f5d74bc7a08a713673b93969
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \
@@ -62,3 +62,4 @@ ENV GITPOD_ENV_SET_EDITOR code
 ENV GITPOD_ENV_SET_VISUAL "$GITPOD_ENV_SET_EDITOR"
 ENV GITPOD_ENV_SET_GP_OPEN_EDITOR "$GITPOD_ENV_SET_EDITOR"
 ENV GITPOD_ENV_SET_GIT_EDITOR "$GITPOD_ENV_SET_EDITOR --wait"
+ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER "code --command gitpod.api.preview"


### PR DESCRIPTION
#### What it does

- fix #2806: integrate the simple browser as a preview for ports
- fix #3382: configure VS Code to provide `gp preview`

Changes in VS Code: https://github.com/gitpod-io/vscode/compare/845053f04b5d9efd17f6f7626ba362925bd0bfe5...f75d023a0b4954d2f5d74bc7a08a713673b93969

#### How to test

- Switch to VS Code
- Start a workspace
- Open .gitpod.yml and add 9090 port
- In terminal run `curl lama.sh | LAMA_PORT=9090 sh` and check that notification pops up with working preview button
- Now change .gitpod.yml for the same port to auto show preview, restart the command in terminal
- Now go to the port view and check there is a working action to preview the port
- From the command line try `gp preview https://localhost:9090` and `gp preview $(gp url 9090)` both should work by opening an external port URL, not localhost!