### PR TITLE
Properly seed the random number generator

### DIFF
--- a/install/installer/main.go
+++ b/install/installer/main.go
@@ -4,8 +4,13 @@
 
 package main
 
-import "github.com/gitpod-io/installer/cmd"
+import (
+	"github.com/gitpod-io/installer/cmd"
+	"math/rand"
+	"time"
+)
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	cmd.Execute()
 }


### PR DESCRIPTION
to reduce likelihood of S3 bucket clashes.

/werft no-preview
/werft with-installer