### PR TITLE
[stale-bot] Adapt bot config to new label scheme

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,30 +5,23 @@ daysUntilStale: 30
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 30
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
-  - pinned
-  - bug
-  - enhancement
-  - docs
-  - fixed-not-deployed
-
-# Set to true to ignore issues in a project (defaults to false)
-exemptProjects: false
+  - "meta: never-stale"
 
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: false
+exemptMilestones: true
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: false
 
 # Label to use when marking as stale
-staleLabel: stale
+staleLabel: "meta: stale"
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
@@ -48,15 +41,14 @@ markComment: >
 limitPerRun: 30
 
 # Limit to only `issues` or `pulls`
-only: issues
+# only: issues
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-# pulls:
-#   daysUntilStale: 30
-#   markComment: >
-#     This pull request has been automatically marked as stale because it has not had
-#     recent activity. It will be closed if no further activity occurs. Thank you
-#     for your contributions.
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
 
 # issues:
 #   exemptLabels:


### PR DESCRIPTION
This PR updates the stale-bot config to make it work with our [current label scheme](https://www.notion.so/gitpod/Issue-Labels-764f3823a395448ca25dec69a49f5b87).
