### PR TITLE
[server] enable auth for snapshot creation

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 07fe931b77d75daa0ba73f05e5e282c0f1dc1482
+ENV GP_CODE_COMMIT b16a98d1506fc5008773b4694d0553847d441674
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -242,7 +242,7 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
             }
 
             await this.guardAccess({kind: "workspaceInstance", subject: instance, workspaceOwnerID: workspace.ownerId, workspaceIsShared: workspace.shareable || false}, "get");
-            await this.guardAccess({kind: "snapshot", subject: undefined, workspaceOwnerID: workspace.ownerId}, "create");
+            await this.guardAccess({kind: "snapshot", subject: undefined, workspaceOwnerID: workspace.ownerId, workspaceID: workspace.id }, "create");
 
             const client = await this.workspaceManagerClientProvider.get(instance.region);
             const request = new TakeSnapshotRequest();

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -41,6 +41,7 @@ export interface GuardedSnapshot {
     kind: "snapshot";
     subject: Snapshot | undefined;
     workspaceOwnerID: string;
+    workspaceID?: string;
 }
 
 export interface GuardedUserStorage {
@@ -172,6 +173,9 @@ export class ScopedResourceGuard implements ResourceAccessGuard {
 }
 
 export namespace ScopedResourceGuard {
+
+    export const SNAPSHOT_WORKSPACE_SUBJECT_ID_PREFIX = 'ws-'
+
     export interface ResourceScope {
         kind: GuardedResourceKind;
         subjectID: string;
@@ -229,7 +233,13 @@ export namespace ScopedResourceGuard {
             case "gitpodToken":
                 return resource.subject.tokenHash;
             case "snapshot":
-                return resource.subject ? resource.subject.id : undefined;
+                if (resource.subject) {
+                    return resource.subject.id;
+                }
+                if (resource.workspaceID) {
+                    return SNAPSHOT_WORKSPACE_SUBJECT_ID_PREFIX + resource.workspaceID;
+                }
+                return undefined;
             case "token":
                 return resource.subject.value;
             case "user":

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -645,7 +645,7 @@ export class WorkspaceStarter {
 
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "workspace", subjectID: workspace.id, operations: ["get", "update"]}),
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "workspaceInstance", subjectID: instance.id, operations: ["get", "update", "delete"]}),
-            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "snapshot", subjectID: "*", operations: ["create", "get"]}),
+            "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "snapshot", subjectID: ScopedResourceGuard.SNAPSHOT_WORKSPACE_SUBJECT_ID_PREFIX + workspace.id, operations: ["create"]}),
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "gitpodToken", subjectID: "*", operations: ["create"]}),
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "userStorage", subjectID: "*", operations: ["create", "get", "update"]}),
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "token", subjectID: "*", operations: ["get"]}),


### PR DESCRIPTION
The problem is that for snapshot creation, we don't have a snapshot yet, and as such have to provide the workspaceID instead for the create token. This creates an ambiguity between 
```
snapshot:<snapshot ID>:create
snapshot:<workspace ID>:create
```
which has to be resolved. This solution uses a prefix if the subjectID is a workspaceID.

I refrained from creating a `SnapshotCreateResourceGuard` wire that up using a `CompositeResourceGuard` as the latter only ORs the composite guards. As such the `TokenResourceGuard` would still accept a `SnapshotResource` whose snapshotID equals the workspaceID for which the permission has been granted. So our hope that we could solve this with a local additive change was wrong. Alternatively, we could either add a `VetoCompositeResourceGuard` or put the entire filtering and matching logic into `TokenResourceGuard`. Both appeared far more invasive to me than the prefix approach.