### PR TITLE
[code] upgrade to 1.54.2

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT f75d023a0b4954d2f5d74bc7a08a713673b93969
+ENV GP_CODE_COMMIT 07fe931b77d75daa0ba73f05e5e282c0f1dc1482
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

fix #3340: It upgrade to the VS Code recovery release from last week: https://github.com/microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22February+2021+Recovery+2%22+is%3Aclosed

#### How to test

- Switch to VS Code
- Start a workspace.
- Test follwing:
  - websockets and workers are properly proxied, for instance, diff editor should be operatable
  - terminals are preserved between window reloads (both regular and tasks)
  - extension host process, check language smartness
  - extension management (installing/uninstalling)
  - code cli should open files
  - user data are sync across workspaces as well as on workspace restart, especially for extensions
  - settings should not contain any mentions of MS telemetry
  - workspace commands, i.e. F1 -> Gitpod: prefix