### PR TITLE
[helm,proxy] added cronjob to restart proxy deployment

### DIFF
--- a/chart/templates/proxy-restarter-cronjob.yaml
+++ b/chart/templates/proxy-restarter-cronjob.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{- if .Values.components.proxy.restarter.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: proxy-restarter
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: proxy-restarter
+    kind: cronjob
+    stage: {{ .Values.installation.stage }}
+spec:
+  # every sunday morning
+  schedule: {{ .Values.components.proxy.restarter.schedule | quote }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: kubectl
+            image: {{ .Values.components.proxy.restarter.image }}
+            command:
+            - kubectl
+            - rollout
+            - restart
+            - deployment
+            - proxy
+            - '-n'
+            - {{ .Release.Namespace }}
+          serviceAccountName: proxy-restarter
+          restartPolicy: OnFailure
+{{- end }}

--- a/chart/templates/proxy-restarter-role.yaml
+++ b/chart/templates/proxy-restarter-role.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{- if .Values.components.proxy.restarter.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: proxy-restarter
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: proxy-restarter
+    kind: role
+    stage: {{ .Values.installation.stage }}
+rules:
+  - apiGroups: ['apps']
+    resources: ['deployments']
+    verbs: ['get','patch']
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - {{ .Release.Namespace }}-ns-unprivileged
+{{- end }}

--- a/chart/templates/proxy-restarter-rolebinding.yaml
+++ b/chart/templates/proxy-restarter-rolebinding.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{- if .Values.components.proxy.restarter.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: proxy-restarter
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: proxy-restarter
+    kind: rolebinding
+    stage: {{ .Values.installation.stage }}
+subjects:
+- kind: ServiceAccount
+  name: proxy-restarter
+roleRef:
+  kind: Role
+  name: proxy-restarter
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/chart/templates/proxy-restarter-serviceaccount.yaml
+++ b/chart/templates/proxy-restarter-serviceaccount.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{- if .Values.components.proxy.restarter.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: proxy-restarter
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: proxy-restarter
+    kind: service-account
+    stage: {{ .Values.installation.stage }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -357,6 +357,11 @@ components:
     # This can be generated with: openssl dhparam 4096 2> /dev/null | base64 -w 0
     # http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
     sslDHParam:
+    # enabled cronjob to restart the proxy deployment
+    restarter:
+      enabled: false
+      schedule: '0 0 * * 0'
+      image: bitnami/kubectl:latest
 
   wsManager:
     name: "ws-manager"

--- a/install/gcp-terraform/modules/certmanager/templates/values.tpl
+++ b/install/gcp-terraform/modules/certmanager/templates/values.tpl
@@ -3,3 +3,8 @@ certificatesSecret:
   keyName: ${key_name}
   chainName: ${chain_name}
   fullChainName: ${full_chain_name}
+
+components:
+  proxy:
+    restarter:
+      enabled: true


### PR DESCRIPTION
This adds a cronjob that restartd the proxy to load new certificates.
If this approach is accepted, I would also add a variable to disable it and set the the cronjob time.

UPDATE:
- variables have been added
- empty file has been removed