### PR TITLE
security: move security.txt to website from gitpod-io/gitpod

### DIFF
--- a/components/dashboard/conf/conf.d/server-80.conf
+++ b/components/dashboard/conf/conf.d/server-80.conf
@@ -2,6 +2,8 @@ server {
     listen 80 default_server;
     absolute_redirect off;
 
+    rewrite ^/.well-known/security.txt/?$ https://www.gitpod.io/.well-known/security.txt permanent;
+
     rewrite ^/environment-variables/?$ /settings/ permanent;
 
     location / {

--- a/components/dashboard/public/.well-known/security.txt
+++ b/components/dashboard/public/.well-known/security.txt
@@ -1,4 +1,0 @@
-Contact: security@gitpod.io
-Preferred-Languages: en, de
-Canonical: https://gitpod.io/.well-known/security.txt
-Hiring: https://typefox.io/career


### PR DESCRIPTION
**currently**

1. Accessing `www.gitpod.io/security` or `https://www.gitpod.io/.well-known/security.txt` is 404
1. Accessing `https://gitpod.io/security.txt` functions but the hiring link in https://github.com/gitpod-io/gitpod/blob/c8526aeff02a354c1b0a5845bde07b36fa455ae6/components/dashboard/public/.well-known/security.txt is out of date.

**changes**

- Permanent redirect of `.well-known/security.txt` to the website and can be updated remotely, at any time, in the case of self-hosted scenarios. See https://github.com/gitpod-io/website/pull/1023 for more information.