### PR TITLE
[code] configure default layout according to the context

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT b16a98d1506fc5008773b4694d0553847d441674
+ENV GP_CODE_COMMIT 09a7addb43913d06c355a7c10e2ac5b2af33e016
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #2632: configure default layout for different workspace contexts

Changes in VS Code: https://github.com/gitpod-io/vscode/pull/6

Default layout is configured only after the gitpod extension is loaded, so it can trigger some UI flickering. In order to minimize this effect we decided to avoid changing as much as possible and do only following things:
- reveal terminals and explorer, we don't preview README anymore
- preload the PR view in the pr context
- reveal file or directory in the file context

#### How to test

- In settings enable Code
- In Access Control grant access to public/private repos
- whatever you test below, at least once test how it behaves on page reload and workspace restart with changed layout:
  - branch: https://ak-code-open-context.staging.gitpod-dev.com/#https://github.com/gitpod-io/go-gin-app
    - terminals and explorer should be revealed
  - file: https://ak-code-open-context.staging.gitpod-dev.com/#https://github.com/gitpod-io/go-gin-app/blob/master/templates/footer.html
    - terminals and explorer should be revealed, file should be opened and revealed in the explorer
  - dir: https://ak-code-open-context.staging.gitpod-dev.com/#https://github.com/gitpod-io/go-gin-app/blob/master/templates
    - terminals and explorer should be revealed, dir revealed in the explorer
  - commit: https://ak-code-open-context.staging.gitpod-dev.com/#https://github.com/gitpod-io/go-gin-app/commit/421240b6504fd214c85a88ecbd889734b5532968
    - terminals and explorer should be revealed
  - issue: https://ak-code-open-context.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod/issues/3470
    - terminals and explorer should be revealed
  - github pr: https://ak-code-open-context.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod/pull/3465
    - terminals and explorer should be revealed, there should be a PR view preloaded in the action bar