### PR TITLE
Correct check for number of installed packages

### DIFF
--- a/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/layer.sh
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/debian/gitpod/layer.sh
@@ -10,7 +10,7 @@ set -e;
 
 # Install necessary tools only if they are not yet installed
 INSTALLED_PACKAGES=$(dpkg-query -f '${Package} ${Status}\n' -W bash-completion git | wc -l)
-if [ $INSTALLED_PACKAGES != 3 ]; then
+if [ $INSTALLED_PACKAGES != 2 ]; then
     # The first 'clean' is needed to avoid apt-get detecting package meta data changes
     # (like changed labels) which result in errors and broken builds/workspaces!
     apt-get clean && rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
Oops, I missed this as well in #3367 and #3428.

The number of packages being tested for is now 2 not 3 as a result of the vim dependency removal (sorry!).