### PR TITLE
[helm] allow disabling network policies via installNetworkPolicies

### DIFF
--- a/chart/templates/blobserve-networkpolicy.yaml
+++ b/chart/templates/blobserve-networkpolicy.yaml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ $comp := .Values.components.blobserve -}}
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -31,3 +32,4 @@ spec:
         matchLabels:
           app: {{ template "gitpod.fullname" . }}
           component: ws-proxy
+{{- end -}}

--- a/chart/templates/content-service-networkpolicy.yaml
+++ b/chart/templates/content-service-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -19,3 +20,4 @@ spec:
   - Ingress
   ingress:
   - {}
+{{- end -}}

--- a/chart/templates/dashboard-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/dashboard-deny-all-allow-explicit-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -27,3 +28,4 @@ spec:
         matchLabels:
           app: {{ template "gitpod.fullname" . }}
           component: proxy
+{{- end -}}

--- a/chart/templates/db-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/db-deny-all-allow-explicit-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -56,3 +57,4 @@ spec:
         matchLabels:
           app: sweeper
     {{- end -}}
+{{- end -}}

--- a/chart/templates/image-builder-networkpolicy.yaml
+++ b/chart/templates/image-builder-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
         except:
         # Google Compute engine special, reserved VM metadata IP
         - 169.254.169.254/32
+{{- end -}}

--- a/chart/templates/messagebus-allow-all-networkpolicy.yaml
+++ b/chart/templates/messagebus-allow-all-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,3 +21,4 @@ spec:
   ingress:
   # allow ingress for everyone in the cluster. The workspace pods have an egress limit that prevents them from accessing the messagebus service anyways.
   - {}
+{{- end -}}

--- a/chart/templates/proxy-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/proxy-deny-all-allow-explicit-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -36,3 +37,4 @@ spec:
         matchLabels:
           app: prometheus
           component: server
+{{- end -}}

--- a/chart/templates/registry-facade-allow-all-networkpolicy.yaml
+++ b/chart/templates/registry-facade-allow-all-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,3 +21,4 @@ spec:
   ingress:
   # allow ingress for everyone in the cluster. The workspace pods have an egress limit that prevents them from accessing the registry-facade service anyways.
   - {}
+{{- end -}}

--- a/chart/templates/server-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/server-deny-all-allow-explicit-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -43,3 +44,4 @@ spec:
         matchLabels:
           app: {{ template "gitpod.fullname" . }}
           component: cerc
+{{- end -}}

--- a/chart/templates/workspace-networkpolicy-default.yaml
+++ b/chart/templates/workspace-networkpolicy-default.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -91,3 +92,4 @@ spec:
         matchLabels:
           app: gitpod
           component: proxy
+{{- end -}}

--- a/chart/templates/ws-daemon-networkpolicy.yaml
+++ b/chart/templates/ws-daemon-networkpolicy.yaml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ $comp := .Values.components.wsDaemon -}}
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -38,3 +39,4 @@ spec:
         matchLabels:
           app: prometheus
           component: server
+{{- end -}}

--- a/chart/templates/ws-manager-networkpolicy.yaml
+++ b/chart/templates/ws-manager-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -19,3 +20,4 @@ spec:
   - Ingress
   ingress:
   - {}
+{{- end -}}

--- a/chart/templates/ws-proxy-networkpolicy.yaml
+++ b/chart/templates/ws-proxy-networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ $comp := .Values.components.wsProxy -}}
-{{- if not $comp.disabled -}}
+{{- if and (not $comp.disabled) (.Values.installNetworkPolicies) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/ws-scheduler-networkpolicy.yaml
+++ b/chart/templates/ws-scheduler-networkpolicy.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if .Values.installNetworkPolicies -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -19,3 +20,4 @@ spec:
   - Ingress
   ingress:
   - {}
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,7 @@ installation:
   cluster: "00"
   shortname: ""
 license: ""
+installNetworkPolicies: true
 installPodSecurityPolicies: true
 imagePullPolicy: IfNotPresent
 resources:


### PR DESCRIPTION
You can now disable all the network policies by setting `installNetworkPolicies: false`. Useful for troubleshooting or buggy CNI. Default is `true`.
Fixes https://github.com/gitpod-io/gitpod/issues/3469