### PR TITLE
[self-hosted] [helm] allow the use of Kubernetes TLS secrets for http-certs

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
+You can now directly use a secret of type `kubernetes.io/tls` for your `certificatesSecret` instead of manually packing your certificates
+into an `Opaque` secret with `fullChainName` / `keyName` / `chainName` entries. This older packing method will become deprecated.
+Please migrate to the Kubernetes TLS Secret format. See https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets for details.
+{{- end }}

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -165,13 +165,18 @@ spec:
       - name: config-certificates
         secret:
           secretName: {{ $.Values.certificatesSecret.secretName }}
-{{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
           items:
+{{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
           - key: {{ $.Values.certificatesSecret.fullChainName }}
             path: fullchain.pem
           - key: {{ $.Values.certificatesSecret.chainName }}
             path: chain.pem
           - key: {{ $.Values.certificatesSecret.keyName }}
+            path: privkey.pem
+{{- else }}
+          - key: tls.crt
+            path: fullchain.pem
+          - key: tls.key
             path: privkey.pem
 {{- end }}
 {{- end }}

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -122,13 +122,18 @@ spec:
       - name: https-certificates
         secret:
           secretName: {{ .Values.certificatesSecret.secretName }}
-          {{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
           items:
+          {{- if (and $.Values.certificatesSecret.fullChainName $.Values.certificatesSecret.chainName $.Values.certificatesSecret.keyName) }}
           - key: {{ $.Values.certificatesSecret.fullChainName }}
             path: fullchain.pem
           - key: {{ $.Values.certificatesSecret.chainName }}
             path: chain.pem
           - key: {{ $.Values.certificatesSecret.keyName }}
+            path: privkey.pem
+          {{- else }}
+          - key: tls.crt
+            path: fullchain.pem
+          - key: tls.key
             path: privkey.pem
           {{- end }}
       {{- end }}


### PR DESCRIPTION
Hi, I am closing #3199 and opening this instead after adding more stuff on my own git fork...
I just realized I had forgotten about the registry facade which is not a preview anymore; that should now work....

Anyway:
- fixes #3183
- you don't have to package your certificate manually, which helps for cert-manager and other such tools
- I check if fullchain.pem and privkey.pem are in the `certificatesSecret` secret; if they are I accept them and ask in the `NOTES.txt` to switch to using Kubernetes TLS Secret ; otherwise I assume they have `tls.crt` `tls.key`.