### PR TITLE
[supervisor] allow to enable pprof and grpc tracing

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -71,6 +71,8 @@ components:
             env:
             - name: THEIA_RATELIMIT_LOG
               value: "50"
+            - name: SUPERVISOR_DEBUG_ENABLE
+              value: "true"
       prebuild:
         spec:
           containers:

--- a/components/common-go/pprof/pprof.go
+++ b/components/common-go/pprof/pprof.go
@@ -15,20 +15,29 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 )
 
+const DefaultPath = "/debug/pprof"
+
 // Serve starts a new HTTP server serving pprof endpoints on the given addr
 func Serve(addr string) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof/", index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.Handle(DefaultPath, Handler())
 
 	log.WithField("addr", addr).Info("serving pprof service")
 	err := http.ListenAndServe(addr, mux)
 	if err != nil {
 		log.WithField("addr", addr).WithError(err).Warn("cannot serve pprof service")
 	}
+}
+
+// Handler produces the pprof endpoint handler
+func Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", index)
+	mux.HandleFunc("/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/profile", pprof.Profile)
+	mux.HandleFunc("/symbol", pprof.Symbol)
+	mux.HandleFunc("/trace", pprof.Trace)
+	return mux
 }
 
 func index(w http.ResponseWriter, r *http.Request) {

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -192,6 +192,9 @@ type WorkspaceConfig struct {
 
 	// GitpodHeadless controls whether the workspace is running headless
 	GitpodHeadless string `env:"GITPOD_HEADLESS"`
+
+	// DebugEnabled controls whether the supervisor debugging facilities (pprof, grpc tracing) shoudl be enabled
+	DebugEnable bool `env:"SUPERVISOR_DEBUG_ENABLE"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -38,6 +38,8 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/pkg/ports"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/terminal"
 	daemon "github.com/gitpod-io/gitpod/ws-daemon/api"
+
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 )
 
 var (
@@ -573,6 +575,13 @@ func startAPIEndpoint(ctx context.Context, cfg *Config, wg *sync.WaitGroup, serv
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.APIEndpointPort))
 	if err != nil {
 		log.WithError(err).Fatal("cannot start health endpoint")
+	}
+
+	if cfg.DebugEnable {
+		opts = append(opts,
+			grpc.UnaryInterceptor(grpc_logrus.UnaryServerInterceptor(log.Log)),
+			grpc.StreamInterceptor(grpc_logrus.StreamServerInterceptor(log.Log)),
+		)
 	}
 
 	m := cmux.New(l)

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/pprof"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/executor"
 	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
@@ -596,6 +597,9 @@ func startAPIEndpoint(ctx context.Context, cfg *Config, wg *sync.WaitGroup, serv
 	routes := http.NewServeMux()
 	routes.Handle("/_supervisor/v1/", http.StripPrefix("/_supervisor", restMux))
 	routes.Handle("/_supervisor/frontend", http.FileServer(http.Dir(cfg.FrontendLocation)))
+	if cfg.DebugEnable {
+		routes.Handle("/_supervisor/pprof", pprof.Handler())
+	}
 	go http.Serve(httpMux, routes)
 
 	go m.Serve()


### PR DESCRIPTION
#### What it does

Allow to enable pprof and grpc tracing for some environments.

#### How to test

- check that pprof endpoint works
- check that workspace logs contain supervisor grpc tracing logs