### PR TITLE
[supervisor/code] grpc tracing and terminal fixes

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -71,6 +71,8 @@ components:
             env:
             - name: THEIA_RATELIMIT_LOG
               value: "50"
+            - name: SUPERVISOR_DEBUG_ENABLE
+              value: "true"
       prebuild:
         spec:
           containers:

--- a/components/common-go/pprof/pprof.go
+++ b/components/common-go/pprof/pprof.go
@@ -15,14 +15,13 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 )
 
+// http handler path which MUST be used as a prefix to route pprof endpoint
+// since it is hardcoded inside pprof
+const Path = "/debug/pprof/"
+
 // Serve starts a new HTTP server serving pprof endpoints on the given addr
 func Serve(addr string) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof/", index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux := Handler()
 
 	log.WithField("addr", addr).Info("serving pprof service")
 	err := http.ListenAndServe(addr, mux)
@@ -31,8 +30,19 @@ func Serve(addr string) {
 	}
 }
 
+// Handler produces the pprof endpoint handler
+func Handler() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc(Path, index)
+	mux.HandleFunc(Path+"cmdline", pprof.Cmdline)
+	mux.HandleFunc(Path+"profile", pprof.Profile)
+	mux.HandleFunc(Path+"symbol", pprof.Symbol)
+	mux.HandleFunc(Path+"trace", pprof.Trace)
+	return mux
+}
+
 func index(w http.ResponseWriter, r *http.Request) {
-	if strings.HasPrefix(r.URL.Path, "/debug/pprof/") {
+	if strings.HasPrefix(r.URL.Path, Path) {
 		// according to Ian Lance Taylor it's ok to turn on mutex and block profiling
 		// when asking for the actual profile [1]. This handler implements this idea, as
 		// discussed in [2]
@@ -41,7 +51,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 		// [2] https://github.com/golang/go/issues/23401
 
 		var (
-			name          = strings.TrimPrefix(r.URL.Path, "/debug/pprof/")
+			name          = strings.TrimPrefix(r.URL.Path, Path)
 			seconds, serr = strconv.ParseInt(r.URL.Query().Get("seconds"), 10, 64)
 		)
 		if name == "mutex" {

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -2,7 +2,9 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM node:12.18.3 AS node_installer
+# we use latest major version of Node.js distributed VS Code. (see about dialog in your local VS Code)
+# ideallay we should use exact version, but it has criticla bugs in regards to grpc over http2 streams
+FROM node:12.21.0 AS node_installer
 RUN mkdir -p /ide/node/bin \
     /ide/node/include/node/ \
     /ide/node/lib/node_modules/npm/ \

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 17c1ebd3f58baefa67a76240bec4577d55f273e5
+ENV GP_CODE_COMMIT d1e895baec868644416b80c9ec83556a6a9a3311
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.1.4
+	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.2.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -193,6 +193,7 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0 h1:bM6ZAFZmc/wPFaRDi0d5L7hGEZEx/2u+Tmr2evNHDiI=

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -192,6 +192,9 @@ type WorkspaceConfig struct {
 
 	// GitpodHeadless controls whether the workspace is running headless
 	GitpodHeadless string `env:"GITPOD_HEADLESS"`
+
+	// DebugEnabled controls whether the supervisor debugging facilities (pprof, grpc tracing) shoudl be enabled
+	DebugEnable bool `env:"SUPERVISOR_DEBUG_ENABLE"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -38,6 +38,8 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/pkg/ports"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/terminal"
 	daemon "github.com/gitpod-io/gitpod/ws-daemon/api"
+
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 )
 
 var (
@@ -573,6 +575,13 @@ func startAPIEndpoint(ctx context.Context, cfg *Config, wg *sync.WaitGroup, serv
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.APIEndpointPort))
 	if err != nil {
 		log.WithError(err).Fatal("cannot start health endpoint")
+	}
+
+	if cfg.DebugEnable {
+		opts = append(opts,
+			grpc.UnaryInterceptor(grpc_logrus.UnaryServerInterceptor(log.Log)),
+			grpc.StreamInterceptor(grpc_logrus.StreamServerInterceptor(log.Log)),
+		)
 	}
 
 	m := cmux.New(l)

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/pprof"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/executor"
 	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
@@ -596,6 +597,9 @@ func startAPIEndpoint(ctx context.Context, cfg *Config, wg *sync.WaitGroup, serv
 	routes := http.NewServeMux()
 	routes.Handle("/_supervisor/v1/", http.StripPrefix("/_supervisor", restMux))
 	routes.Handle("/_supervisor/frontend", http.FileServer(http.Dir(cfg.FrontendLocation)))
+	if cfg.DebugEnable {
+		routes.Handle("/_supervisor"+pprof.Path, http.StripPrefix("/_supervisor", pprof.Handler()))
+	}
 	go http.Serve(httpMux, routes)
 
 	go m.Serve()


### PR DESCRIPTION
#### What it does

- Allow to enable pprof and grpc tracing for some environments.
- fix https://github.com/gitpod-io/gitpod/issues/3127:
  - bump up to latest Node.js 12 to pick up fixes for stale http2 streams hanging forever, see https://github.com/nodejs/node/issues/31309
  - add deadlines for all calls to supervisor
- fix https://github.com/gitpod-io/gitpod/issues/3461: don't shutdown terminals if listening failed because of internal grpc issues

Changes in VS Code: https://github.com/gitpod-io/vscode/pull/8

Additional env variables which were useful to investigate grpc over http2:
```bash
# enable @grpc/grpc-js tracing
export GRPC_NODE_VERBOSITY=DEBUG
export GRPC_NODE_TRACE=all

# enable node http2 tracing
export NODE_DEBUG=http2
```

#### How to test

- Start a workspace: https://ak-supervisor-debug-mode.staging.gitpod-dev.com/#https://github.com/gitpod-io/vscode
- check that pprof endpoint works by opening `_supervisor/debug/pprof` endpoint on a workspace origin 
- check that workspace logs contain supervisor grpc tracing logs
- try to break terminals:
  - create new user terminals and reload the page
  - check that all task and user terminals are present on each reload and operatable