### PR TITLE
[helm] adding restarter

### DIFF
--- a/chart/templates/restarter-configmap.yaml
+++ b/chart/templates/restarter-configmap.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: restarter-scripts
+  labels:
+    app: {{ template "gitpod.fullname" $ }}
+    component: restarter
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  run.sh: |
+    #!/usr/bin/env sh
+    {{- range .Values.components.restarter.targets }}
+    kubectl rollout restart {{ .kind }} {{ .name }} -n {{ $.Release.Namespace }}
+    {{- end }}

--- a/chart/templates/restarter-cronjob.yaml
+++ b/chart/templates/restarter-cronjob.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{- if .Values.components.proxy.restarter.enabled }}
+{{- if .Values.components.restarter.enabled }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: proxy-restarter
+  name: restarter
   labels:
     app: {{ template "gitpod.fullname" . }}
-    component: proxy-restarter
+    component: restarter
     kind: cronjob
     stage: {{ .Values.installation.stage }}
 spec:
   # every sunday morning
-  schedule: {{ .Values.components.proxy.restarter.schedule | quote }}
+  schedule: {{ .Values.components.restarter.schedule | quote }}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
@@ -23,15 +23,17 @@ spec:
         spec:
           containers:
           - name: kubectl
-            image: {{ .Values.components.proxy.restarter.image }}
+            image: {{ .Values.components.restarter.image }}
             command:
-            - kubectl
-            - rollout
-            - restart
-            - deployment
-            - proxy
-            - '-n'
-            - {{ .Release.Namespace }}
-          serviceAccountName: proxy-restarter
+            - /scripts/run.sh
+            volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          serviceAccountName: restarter
           restartPolicy: OnFailure
+          volumes:
+          - name: scripts
+            configMap:
+              name: restarter-scripts
+              defaultMode: 0555
 {{- end }}

--- a/chart/templates/restarter-role.yaml
+++ b/chart/templates/restarter-role.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{- if .Values.components.proxy.restarter.enabled }}
+{{- if .Values.components.restarter.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: proxy-restarter
+  name: restarter
   labels:
     app: {{ template "gitpod.fullname" . }}
-    component: proxy-restarter
+    component: restarter
     kind: role
     stage: {{ .Values.installation.stage }}
 rules:
   - apiGroups: ['apps']
-    resources: ['deployments']
+    resources: ['deployments','daemonsets']
     verbs: ['get','patch']
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']

--- a/chart/templates/restarter-rolebinding.yaml
+++ b/chart/templates/restarter-rolebinding.yaml
@@ -1,21 +1,21 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{- if .Values.components.proxy.restarter.enabled }}
+{{- if .Values.components.restarter.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: proxy-restarter
+  name: restarter
   labels:
     app: {{ template "gitpod.fullname" . }}
-    component: proxy-restarter
+    component: restarter
     kind: rolebinding
     stage: {{ .Values.installation.stage }}
 subjects:
 - kind: ServiceAccount
-  name: proxy-restarter
+  name: restarter
 roleRef:
   kind: Role
-  name: proxy-restarter
+  name: restarter
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/chart/templates/restarter-serviceaccount.yaml
+++ b/chart/templates/restarter-serviceaccount.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{- if .Values.components.proxy.restarter.enabled }}
+{{- if .Values.components.restarter.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: proxy-restarter
+  name: restarter
   labels:
     app: {{ template "gitpod.fullname" . }}
-    component: proxy-restarter
+    component: restarter
     kind: service-account
     stage: {{ .Values.installation.stage }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -242,6 +242,19 @@ components:
       socket: /var/lib/gitpod/registry-facade
     serviceType: "ClusterIP"
 
+  # enabled cronjob to restart the proxy deployment
+  restarter:
+    enabled: false
+    schedule: '0 0 * * 0'
+    image: bitnami/kubectl:latest
+    targets:
+    - name: proxy
+      kind: deployment
+    - name: registry-facade
+      kind: daemonset
+    - name: ws-proxy
+      kind: deployment
+
   server:
     name: "server"
     replicas: 1
@@ -358,11 +371,6 @@ components:
     # This can be generated with: openssl dhparam 4096 2> /dev/null | base64 -w 0
     # http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
     sslDHParam:
-    # enabled cronjob to restart the proxy deployment
-    restarter:
-      enabled: false
-      schedule: '0 0 * * 0'
-      image: bitnami/kubectl:latest
 
   wsManager:
     name: "ws-manager"

--- a/install/gcp-terraform/modules/certmanager/templates/values.tpl
+++ b/install/gcp-terraform/modules/certmanager/templates/values.tpl
@@ -5,6 +5,5 @@ certificatesSecret:
   fullChainName: ${full_chain_name}
 
 components:
-  proxy:
-    restarter:
-      enabled: true
+  restarter:
+    enabled: true


### PR DESCRIPTION
This replaces `proxy-restarter` with a common `restarter` that can restart any `deployment` and `daemonset`.