### PR TITLE
[werft] Check for missing license headers

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -93,6 +93,7 @@ async function build(context, version) {
     };
     const imageRepo = publishRelease ? "gcr.io/gitpod-io/self-hosted" : "eu.gcr.io/gitpod-core-dev/build";
 
+    exec(`LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || { echo "There are some license headers missing. Please run 'leeway run components:update-license-header'."; exit 1; }`)
     exec(`leeway vet --ignore-warnings`);
     exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`, buildEnv);
     if (publishRelease) {

--- a/chart/templates/server-proxy-ssl-dhparam.yaml
+++ b/chart/templates/server-proxy-ssl-dhparam.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.components.proxy.sslDHParam -}}
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ if .Values.components.proxy.sslDHParam -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/test-semver.js
+++ b/chart/test-semver.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
 const semver = require('semver');
 if (!semver.valid(process.argv[2])) {
     process.exit(1)

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
 packages:
   - name: all
     type: generic
@@ -67,9 +71,12 @@ scripts:
       grep -E "^install\/installer" $tmpdir/oss >> $tmpdir/agpl
       grep -v -f $tmpdir/agpl $tmpdir/oss > $tmpdir/mit
 
-      cat $tmpdir/ee   | while read f; do echo "$PWD/../$f"; done | addlicense -s -l gpshf .
-      cat $tmpdir/agpl | while read f; do echo "$PWD/../$f"; done | addlicense -s -l agpl  .
-      cat $tmpdir/mit  | while read f; do echo "$PWD/../$f"; done | addlicense -s -l mit   .
+      # set `export LICENCE_HEADER_CHECK_ONLY=true` to just check if all headers are there (and exit with status code 1 if not)
+      check=$([ "$LICENCE_HEADER_CHECK_ONLY" = true ] && printf "%s" '-check')
+
+      cat $tmpdir/ee   | while read f; do echo "$PWD/../$f"; done | addlicense $check -s -l gpshf . || exit 1
+      cat $tmpdir/agpl | while read f; do echo "$PWD/../$f"; done | addlicense $check -s -l agpl  . || exit 1
+      cat $tmpdir/mit  | while read f; do echo "$PWD/../$f"; done | addlicense $check -s -l mit   . || exit 1
   - name: dejson-log-output
     script: |-
       jq -Rr '. as $line |

--- a/components/content-service-api/blobs.proto
+++ b/components/content-service-api/blobs.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 

--- a/components/content-service-api/go/blobs.pb.go
+++ b/components/content-service-api/go/blobs.pb.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 

--- a/components/content-service-api/typescript/src/blobs_grpc_pb.js
+++ b/components/content-service-api/typescript/src/blobs_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 // Original file comments:
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 //

--- a/components/gitpod-protocol/src/util/context-url.spec.ts
+++ b/components/gitpod-protocol/src/util/context-url.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License-AGPL.txt in the project root for license information.
  */

--- a/components/gitpod-protocol/src/util/context-url.ts
+++ b/components/gitpod-protocol/src/util/context-url.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License-AGPL.txt in the project root for license information.
  */

--- a/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License-AGPL.txt in the project root for license information.
  */

--- a/components/registry-facade/cmd/handover.go
+++ b/components/registry-facade/cmd/handover.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 

--- a/dev/poolkeeper/cmd/root.go
+++ b/dev/poolkeeper/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/dev/poolkeeper/cmd/run.go
+++ b/dev/poolkeeper/cmd/run.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/dev/poolkeeper/leeway.Dockerfile
+++ b/dev/poolkeeper/leeway.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 

--- a/dev/poolkeeper/main.go
+++ b/dev/poolkeeper/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/dev/poolkeeper/pkg/poolkeeper/config.go
+++ b/dev/poolkeeper/pkg/poolkeeper/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/dev/poolkeeper/pkg/poolkeeper/poolkeeper.go
+++ b/dev/poolkeeper/pkg/poolkeeper/poolkeeper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/dev/poolkeeper/pkg/poolkeeper/task-keep-nodes-alive.go
+++ b/dev/poolkeeper/pkg/poolkeeper/task-keep-nodes-alive.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/dev/poolkeeper/pkg/poolkeeper/task-patch-affinity.go
+++ b/dev/poolkeeper/pkg/poolkeeper/task-patch-affinity.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 TypeFox GmbH. All rights reserved.
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 // Licensed under the Gitpod Enterprise Source Code License,
 // See License.enterprise.txt in the project root folder.
 

--- a/install/gcp-terraform/environment/full/values.yaml
+++ b/install/gcp-terraform/environment/full/values.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 certificatesSecret: {}
 
 components:

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
 set -ex
 
 for i in $(ls /tests/*.test); do


### PR DESCRIPTION
This PR checks for missing license headers during the CI werft build.

Fixes https://github.com/gitpod-io/gitpod/issues/3236

This PR also:
- Adds missing license headers in commit a41d7f5 and
- fixes some headers (TypeFox → Gitpod) in commit 5e76d95 (or is there any reason for this?)

## How to test

- Remove commit a41d7f5 → build should fail