### PR TITLE
[dev] Rebuild dev image with latest leeway

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-dev-env.5
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-dev-env.1
 workspaceLocation: gitpod/gitpod-ws.theia-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:at-dev-env.5
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-dev-env.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-sh-gh-release.39
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-dev-env.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-sh-gh-release.39
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-dev-env.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -21,7 +21,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-dev-env.1
 workspaceLocation: gitpod/gitpod-ws.theia-workspace
 checkoutLocation: gitpod
 ports:
@@ -40,7 +40,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-pull-latest-werft.4",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-dev-env.1",
 				WorkspaceLocation: "gitpod/gitpod-ws.theia-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full-vnc:latest
 
-ENV TRIGGER_REBUILD 7
+ENV TRIGGER_REBUILD 8
 
 USER root
 


### PR DESCRIPTION
Updates the dev image to get the [latest leeway release](https://github.com/gitpod-io/leeway/releases/tag/v0.2.0) that has [this `leeway vet` fix](https://github.com/gitpod-io/leeway/commit/fe5c3b23696e385746018f1f647a8a85761e74c3) that is needed for [`ws-manager-bridge-api`](https://github.com/gitpod-io/gitpod/pull/3533).