### PR TITLE
[proxy] Agressively cache resources under /static

### DIFF
--- a/chart/config/proxy/lib.locations.conf
+++ b/chart/config/proxy/lib.locations.conf
@@ -23,8 +23,15 @@ location / {
     include lib.cors-headers.conf;
 
     # ### Caching
-    # Dashboard only servces static resources, which should be cached agressively.
-    # But on deployment those should be invalidated within a short time frame.
+    # Dashboard serves static assets, most of which ca be cached agressively because they are unique per version:
+    # Their content hash is included in the path. Those are served under /static.
+    location /static {
+        add_header Cache-Control "public, max-age=31536000";
+
+        proxy_pass http://dashboard$request_uri;
+    }
+    # Other assets may change over time. Especially during deployment those might get invalidated within a short time frame.
+    # Thus we want clients to check if their cached versions are still up-to-date on each request.
     # nginx by default sets 'etag' and 'last-modified' header (based on content hash and ctime/mtime).
     #
     # # Cache-Control


### PR DESCRIPTION
Enables aggressive caching for all assets that are "immutable" (e.g., have a content hash as part of their URL).

This is the basis for #2127. Further candidates:
 - move `/images` under webpack control and `require` those to get content hashes for those as well
 - favicons under `/`

### Assumption:
This PR assumes those are located under `/static`.
~Is that true?~ Yes.