### PR TITLE
[dashboard] Re-implement (pre)build logs viewers for new dashboard

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -8,7 +8,9 @@
     "moment": "^2.29.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "xterm": "^4.11.0",
+    "xterm-addon-fit": "^0.5.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.2.1",
@@ -30,8 +32,8 @@
     "eslint": "^7.21.0",
     "postcss": "^7.0.35",
     "react-scripts": "4.0.2",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.2",
     "tailwind-underline-utils": "^1.1.2",
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.2",
     "tailwindcss-filters": "^3.0.0",
     "typescript": "~4.1.2",
     "web-vitals": "^1.0.1"

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -16,6 +16,27 @@ export enum StartPhase {
   Stopped = 6,
 };
 
+function getPhaseTitle(phase?: StartPhase, error?: boolean) {
+  switch (phase) {
+    case StartPhase.Checking:
+      return !error ? "Checking" : "Oh, no! Something went wrong!1";
+    case StartPhase.Preparing:
+      return "Preparing";
+    case StartPhase.Creating:
+      return "Creating";
+    case StartPhase.Starting:
+      return "Starting";
+    case StartPhase.Running:
+      return "Starting";
+    case StartPhase.Stopping:
+      return "Stopping";
+    case StartPhase.Stopped:
+      return "Stopped";
+    default:
+      return "";
+  }
+}
+
 function ProgressBar(props: { phase: number, error: boolean }) {
   const { phase, error } = props;
   return <div className="flex mt-4 mb-6">
@@ -40,47 +61,21 @@ function ProgressBar(props: { phase: number, error: boolean }) {
 }
 
 export interface StartPageProps {
-  phase: number;
+  phase?: number;
   error?: boolean;
+  title?: string;
   children?: React.ReactNode;
 }
 
 export function StartPage(props: StartPageProps) {
-  let title = "";
   const { phase, error } = props;
-  switch (phase) {
-    case StartPhase.Checking:
-      title = "Checking";
-      if (error) {
-        // Pre-check error
-        title = "Oh, no! Something went wrong!1";
-      }
-      break;
-    case StartPhase.Preparing:
-      title = "Preparing";
-      break;
-    case StartPhase.Creating:
-      title = "Creating";
-      break;
-    case StartPhase.Starting:
-      title = "Starting";
-      break;
-    case StartPhase.Running:
-      title = "Starting";
-      break;
-    case StartPhase.Stopping:
-      title = "Stopping";
-      break;
-    case StartPhase.Stopped:
-      title = "Stopped";
-      break;
-  }
+  let title = props.title || getPhaseTitle(phase, error);
   return <div className="w-screen h-screen bg-white align-middle">
     <div className="flex flex-col mx-auto items-center h-screen">
       <div className="h-1/3"></div>
       <img src={images.gitpodIcon} className={`h-16 flex-shrink-0 ${(error || phase === StartPhase.Stopped) ? '' : 'animate-bounce'}`} />
       <h3 className="mt-8 text-xl">{title}</h3>
-      {(phase < StartPhase.Stopping) && <ProgressBar phase={phase} error={!!error} />}
+      {typeof(phase) === 'number' && phase < StartPhase.Stopping && <ProgressBar phase={phase} error={!!error} />}
       {props.children}
     </div>
   </div>;

--- a/components/dashboard/src/start/WorkspaceLogs.tsx
+++ b/components/dashboard/src/start/WorkspaceLogs.tsx
@@ -4,8 +4,80 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-export default function WorkspaceLogs() {
-  return <pre className="m-6 p-4 h-72 w-11/12 lg:w-3/5 flex-shrink-0 rounded-xl bg-gray-100">
-    ... logs ...
-  </pre>;
+import EventEmitter from 'events';
+import React from 'react';
+import { Terminal, ITerminalOptions, ITheme } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit'
+import 'xterm/css/xterm.css';
+import { DisposableCollection } from '@gitpod/gitpod-protocol';
+
+export interface WorkspaceLogsProps {
+  logsEmitter: EventEmitter;
+}
+
+export interface WorkspaceLogsState {
+}
+
+export default class WorkspaceLogs extends React.Component<WorkspaceLogsProps, WorkspaceLogsState> {
+  protected xTermParentRef: React.RefObject<HTMLDivElement>;
+  protected terminal: Terminal | undefined;
+  protected fitAddon: FitAddon | undefined;
+  
+  constructor(props: WorkspaceLogsProps) {
+    super(props);
+    this.xTermParentRef = React.createRef();
+  }
+
+  private readonly toDispose = new DisposableCollection();
+  componentDidMount() {
+    const element = this.xTermParentRef.current;
+    if (element === null) {
+      return;
+    }
+    const theme: ITheme = {
+      // background: '#F5F5F4',
+    };
+    const options: ITerminalOptions = {
+      cursorBlink: false,
+      disableStdin: true,
+      fontSize: 14,
+      theme,
+      scrollback: 9999999,
+    };
+    this.terminal = new Terminal(options);
+    this.fitAddon = new FitAddon();
+    this.terminal.loadAddon(this.fitAddon);
+    this.terminal.open(element);
+    this.props.logsEmitter.on('logs', logs => {
+      if (this.fitAddon && this.terminal && logs) {
+        this.terminal.write(logs);
+      }
+    });
+    this.toDispose.push(this.terminal);
+    this.fitAddon.fit();
+
+    // Fit terminal on window resize (debounced)
+    let timeout: NodeJS.Timeout | undefined;
+    const onWindowResize = () => {
+      clearTimeout(timeout!);
+      timeout = setTimeout(() => this.fitAddon!.fit(), 20);
+    };
+    window.addEventListener('resize', onWindowResize);
+    this.toDispose.push({
+      dispose: () => {
+        clearTimeout(timeout!);
+        window.removeEventListener('resize', onWindowResize);
+      }
+    });
+  }
+
+  componentWillUnmount() {
+    this.toDispose.dispose();
+  }
+
+  render() {
+    return <div className="mt-6 h-72 w-11/12 lg:w-3/5 rounded-xl bg-black p-6">
+      <div className="h-full w-full" ref={this.xTermParentRef}></div>
+    </div>;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21778,6 +21778,16 @@ xtend@^4.0.2:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-fit@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
+  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
+
+xterm@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.11.0.tgz#d7dabc7af5299579e4663fedf2b3a179af9aaff9"
+  integrity sha512-NeJH909WTO2vth/ZlC0gkP3AGzupbvVHVlmtrpBw56/sGFXaF9bNdKgqKa3tf8qbGvXMzL2JhCcHVklqFztIRw==
+
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"


### PR DESCRIPTION
Follow-up to https://github.com/gitpod-io/gitpod/issues/3301

TODO:

- [x] Show Docker build logs in an Xterm
- [x] Show workspace prebuild logs in an Xterm
- [x] Allow skipping a prebuild that's in progress
- [x] When the viewed prebuild is finished (successfully), create a new workspace based on it (i.e. re-implement polling)
- ~~Improve Xterm colors~~
- [x] Remove progress bar / replace title when viewing logs
- [x] Increase Xterm scrollback (make infinite?)
- [x] Show logs when starting a headless workspace (e.g. when using a `#prebuild/<repo>` URL prefix)
- ~~Move login error handling into the App's entrypoint~~