### PR TITLE
[helm,dev] set ghost workspaces to zero for dev environments

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -142,7 +142,7 @@ components:
 
   wsScheduler:
     scaler:
-      enabled: true
+      enabled: false
       controller:
         kind: "constant"
         constant:

--- a/chart/templates/ws-scheduler-configmap.yaml
+++ b/chart/templates/ws-scheduler-configmap.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{ $comp := .Values.components.wsScheduler -}}
-{{- if not $comp.disabled -}}
+{{ $comp := .Values.components.wsScheduler }}
+{{- if not $comp.disabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -55,4 +55,4 @@ data:
         }
         {{ end }}
     }
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
`ghost` workspaces create a lot of load on our dev cluster. Therefore I have disabled it for `preview-environments`.
Also removed a bug, where `apiVersion` could be merged with the comments at the top during a helm deployment.