### PR TITLE
[proxy] Trigger build to update openssl

### DIFF
--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM openresty/openresty:1.19.3.1-3-alpine
 
+ENV TRIGGER_REBUILD 1
+
 # Debug convenience
 ENV TERM=xterm
 ENV SHELL=/bin/bash


### PR DESCRIPTION
Force proxy build to address openssl CVE https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3450

cc @meysholdt @csweichel @svenefftinge 