### PR TITLE
[server] Improve observability regarding communication with messagebus

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -99,6 +99,5 @@ const messagebusTopicReads = new prometheusClient.Counter({
 export function increaseMessagebusTopicReads(topic: string) {
     messagebusTopicReads.inc({
         topic,
-        status,
     })
 }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -88,3 +88,17 @@ const httpRequestDuration = new prometheusClient.Histogram({
 export function observeHttpRequestDuration(method: string, route: string, statusCode: number, durationInSeconds: number) {
     httpRequestDuration.observe({ method, route, statusCode }, durationInSeconds);
 }
+
+const messagebusTopicReads = new prometheusClient.Counter({
+   name: 'gitpod_server_topic_reads_total',
+   help: 'The amount of reads from messagebus topics.',
+   labelNames: ['topic'],
+   registers: [prometheusClient.register]
+});
+
+export function increaseMessagebusTopicReads(topic: string) {
+    messagebusTopicReads.inc({
+        topic,
+        status,
+    })
+}

--- a/components/server/src/workspace/messagebus-integration.ts
+++ b/components/server/src/workspace/messagebus-integration.ts
@@ -118,7 +118,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         const listener = new HeadlessWorkspaceLogListener(this.messageBusHelper, callback, workspaceID);
         const cancellationTokenSource = new CancellationTokenSource()
         this.listen(listener, cancellationTokenSource.token);
-        increaseMessagebusTopicReads(listener.topic.name)
+        increaseMessagebusTopicReads('headless_workspace_log')
         return Disposable.create(() => cancellationTokenSource.cancel())
     }
 
@@ -126,7 +126,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         const listener = new PrebuildUpdatableQueueListener(callback);
         const cancellationTokenSource = new CancellationTokenSource()
         this.listen(listener, cancellationTokenSource.token);
-        increaseMessagebusTopicReads('listener.topic.name');
+        increaseMessagebusTopicReads('prebuild_updatable_queue');
         return Disposable.create(() => cancellationTokenSource.cancel())
     }
 
@@ -134,7 +134,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         const listener = new WorkspaceInstanceUpdateListener(this.messageBusHelper, callback, userId);
         const cancellationTokenSource = new CancellationTokenSource()
         this.listen(listener, cancellationTokenSource.token);
-        increaseMessagebusTopicReads(listener.topic.name);
+        increaseMessagebusTopicReads('workspace_instance_update');
         return Disposable.create(() => cancellationTokenSource.cancel())
     }
 

--- a/components/server/src/workspace/messagebus-integration.ts
+++ b/components/server/src/workspace/messagebus-integration.ts
@@ -13,6 +13,7 @@ import { Channel, Message } from "amqplib";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import * as opentracing from "opentracing";
 import { CancellationTokenSource } from "vscode-ws-jsonrpc";
+import { increaseMessagebusTopicReads } from '../prometheus-metrics';
 
 export class WorkspaceInstanceUpdateListener extends AbstractTopicListener<WorkspaceInstance> {
 
@@ -117,6 +118,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         const listener = new HeadlessWorkspaceLogListener(this.messageBusHelper, callback, workspaceID);
         const cancellationTokenSource = new CancellationTokenSource()
         this.listen(listener, cancellationTokenSource.token);
+        increaseMessagebusTopicReads(listener.topic.name)
         return Disposable.create(() => cancellationTokenSource.cancel())
     }
 
@@ -124,6 +126,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         const listener = new PrebuildUpdatableQueueListener(callback);
         const cancellationTokenSource = new CancellationTokenSource()
         this.listen(listener, cancellationTokenSource.token);
+        increaseMessagebusTopicReads('listener.topic.name');
         return Disposable.create(() => cancellationTokenSource.cancel())
     }
 
@@ -131,6 +134,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         const listener = new WorkspaceInstanceUpdateListener(this.messageBusHelper, callback, userId);
         const cancellationTokenSource = new CancellationTokenSource()
         this.listen(listener, cancellationTokenSource.token);
+        increaseMessagebusTopicReads(listener.topic.name);
         return Disposable.create(() => cancellationTokenSource.cancel())
     }
 


### PR DESCRIPTION
When ready, this PR will include a counter metric that increases every time `server` tries to read a topic from `messagebus` and also log when it fails to do so.

Fixes #3578 