### PR TITLE
[ws-manager] Dispose workspace when container termination is not propagated

### DIFF
--- a/components/common-go/kubernetes/kubernetes.go
+++ b/components/common-go/kubernetes/kubernetes.go
@@ -53,6 +53,10 @@ const (
 
 	// RequiredNodeServicesAnnotation lists all Gitpod services required on the node
 	RequiredNodeServicesAnnotation = "gitpod.io/requiredNodeServices"
+
+	// ContainerIsGoneAnnotation is used as workaround for containerd https://github.com/containerd/containerd/pull/4214
+	// which might cause workspace container status propagation to fail, which in turn would keep a workspace running indefinitely.
+	ContainerIsGoneAnnotation = "gitpod.io/containerIsGone"
 )
 
 // WorkspaceSupervisorEndpoint produces the supervisor endpoint of a workspace.

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -386,6 +386,11 @@ func (m *Monitor) actOnPodEvent(ctx context.Context, status *api.WorkspaceStatus
 				break
 			}
 		}
+		if _, gone := wso.Pod.Annotations[wsk8s.ContainerIsGoneAnnotation]; !terminated && gone {
+			// workaround for https://github.com/containerd/containerd/pull/4214 which can prevent pod status
+			// propagation. ws-daemon observes the pods and propagates this state out-of-band via the annotation.
+			terminated = true
+		}
 		if terminated {
 			go m.finalizeWorkspaceContent(ctx, wso)
 		}


### PR DESCRIPTION
In some situations the workspace container termination isn't propagated to the Kubernetes data plane. In those cases, ws-manager would never actually dispose the workspace.

We've seen this issue before and introduced a workspace in ws-daemon, that would then force-delete the pod in the data plane. This PR introduces an annotation to explicitly communicate that the container is gone and that ws-manager should trigger content disposal.

This issue should only arise in environments that run an old version of containerd, still affected by https://github.com/containerd/containerd/pull/4214