### PR TITLE
[dashboard] Fix error messages in workspace create & start pages

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -86,17 +86,17 @@ export class CreateWorkspace extends React.Component<CreateWorkspaceProps, Creat
       switch (error.code) {
         case ErrorCodes.CONTEXT_PARSE_ERROR:
           statusMessage = <div className="text-center">
-            <p className="text-base text-red">Unrecognized context: '{contextUrl}'</p>
+            <p className="text-base text-red-500">Unrecognized context: '{contextUrl}'</p>
             <p className="text-base mt-2">Learn more about <a className="text-blue" href="https://www.gitpod.io/docs/context-urls/">supported context URLs</a></p>
           </div>;
           break;
         case ErrorCodes.NOT_FOUND:
           statusMessage = <div className="text-center">
-            <p className="text-base text-red">Not found: {contextUrl}</p>
+            <p className="text-base text-red-500">Not found: {contextUrl}</p>
           </div>;
           break;
         default:
-          statusMessage = <p className="text-base text-red">Unknown Error: {JSON.stringify(this.state?.error, null, 2)}</p>;
+          statusMessage = <p className="text-base text-red-500 w-96">Unknown Error: {JSON.stringify(this.state?.error, null, 2)}</p>;
           break;
       }
     }

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -50,7 +50,7 @@ function ProgressBar(props: { phase: number, error: boolean }) {
         classes += ' bg-gray-200';
       } else if (error) {
         // This phase has failed
-        classes += ' bg-red';
+        classes += ' bg-red-500';
       } else {
         // This phase is currently running
         classes += ' bg-green-400 animate-pulse';

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -170,8 +170,10 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     const isHeadless = this.state.workspace?.type !== 'regular';
     const isPrebuilt = WithPrebuild.is(this.state.workspace?.context);
     let phase = StartPhase.Preparing;
-    let title = undefined;
-    let statusMessage = <p className="text-base text-gray-400">Preparing workspace …</p>;
+    let title = !error ? undefined : 'Oh, no! Something went wrong!1';
+    let statusMessage = !error
+      ? <p className="text-base text-gray-400">Preparing workspace …</p>
+      : <p className="text-base text-red-500 w-96">{error.message}</p>;
 
     switch (this.state?.workspaceInstance?.status.phase) {
       // unknown indicates an issue within the system in that it cannot determine the actual phase of
@@ -254,7 +256,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             <div>
               <p className="text-gray-700 font-semibold">{this.state.workspaceInstance.workspaceId}</p>
               {pendingChanges.length > 0 &&
-                <p className="text-red">{pendingChanges.length} Change{pendingChanges.length === 1 ? '' : 's'}</p>
+                <p className="text-red-500">{pendingChanges.length} Change{pendingChanges.length === 1 ? '' : 's'}</p>
               }
               <p className="w-56 truncate">{this.state.workspace?.contextURL}</p>
             </div>
@@ -269,6 +271,16 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
     return <StartPage phase={phase} error={!!error} title={title}>
       {statusMessage}
+      {error && <div>
+        <button className="mt-8 px-4 py-2 text-gray-500 bg-white font-semibold border-gray-500 hover:text-gray-700 hover:bg-gray-100 hover:border-gray-700" onClick={() => this.redirectTo(gitpodHostUrl.asDashboard().toString())}>Go back to dashboard</button>
+        <p className="mt-14 text-base text-gray-400 flex space-x-2">
+          <a href="https://www.gitpod.io/docs/">Docs</a>
+          <span>—</span>
+          <a href="https://status.gitpod.io/">Status</a>
+          <span>—</span>
+          <a href="https://www.gitpod.io/blog/">Blog</a>
+        </p>
+      </div>}
     </StartPage>;
   }
 }


### PR DESCRIPTION
- The `text-red` and `bg-red` classes don't work -- replace them with `...-red-500`
- Actually display `error.message` in start page if there is an error