### PR TITLE
[code] use last focused window to run cli commands

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 0fe6298ce72069a6021fd4354a3199ef0f3068af
+ENV GP_CODE_COMMIT cb093bd9c2c08e46b06dd113350ec864d30679cf
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #3433: Gitpod CLI does not try to guess the window anymore, but always use the last focused.

![gp_window](https://user-images.githubusercontent.com/3082655/112726556-66b71f00-8f1e-11eb-8212-b26acdf7e3cc.gif)

Changes in VS Code: https://github.com/gitpod-io/vscode/pull/10

#### How to test

- Start a workspace.
- Open several windows and try to run `gp open` in each, they should not affect each other.
- Reload windows and retry again. Window reload may leave extension host processes which did not time out yet, but it should not be matter anymore.