### PR TITLE
[code]  new cli commands

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT cb093bd9c2c08e46b06dd113350ec864d30679cf
+ENV GP_CODE_COMMIT 1255c858d0b0af9a11c9cc49c7cd5456e7368243
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

fix #3166: add more code CLI commands to manage extensions and open external URIs

Changes in VS Code: https://github.com/gitpod-io/vscode/pull/11

#### How to test

- Start a workspace and try:
```
code --install-extension jock.svg
code --list-extensions --show-versions
code --uninstall-extension jock.svg
code --open-external http://localhost:8000
```