### PR TITLE
[dashboard] Add more navigation possibilities during stopping and stopped

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -206,7 +206,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
       case "initializing":
         phase = StartPhase.Starting;
-        statusMessage = <p className="text-base text-gray-400">{isPrebuilt ? 'Loading prebuild …' : 'Cloning repository …'}</p>;
+        statusMessage = <p className="text-base text-gray-400">{isPrebuilt ? 'Loading prebuild …' : 'Initializing content …'}</p>;
         break;
 
       // Running means the workspace is able to actively perform work, either by serving a user through Theia,
@@ -237,8 +237,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             <div className="rounded-full w-3 h-3 text-sm bg-gitpod-kumquat">&nbsp;</div>
             <div>
               <p className="text-gray-700 font-semibold">{this.state.workspaceInstance.workspaceId}</p>
-              <p className="w-56 truncate">{this.state.workspace?.contextURL}</p>
+              <a href={this.state.workspace?.contextURL}><p className="w-56 truncate hover:underline" >{this.state.workspace?.contextURL}</p></a>
             </div>
+          </div>
+          <div className="mt-10 flex">
+            <button className="mx-auto px-4 py-2 text-gray-500 bg-white font-semibold border-gray-500 hover:text-gray-700 hover:border-gray-700 hover:bg-gray-100" onClick={() => this.redirectTo(gitpodHostUrl.asDashboard().toString())}>Go to Dashboard</button>
           </div>
         </div>;
         break;
@@ -258,7 +261,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
               {pendingChanges.length > 0 &&
                 <p className="text-red-500">{pendingChanges.length} Change{pendingChanges.length === 1 ? '' : 's'}</p>
               }
-              <p className="w-56 truncate">{this.state.workspace?.contextURL}</p>
+              <a href={this.state.workspace?.contextURL}><p className="w-56 truncate hover:underline" >{this.state.workspace?.contextURL}</p></a>
             </div>
           </div>
           <div className="mt-10 flex space-x-2">


### PR DESCRIPTION
- During stopping I should be able to go back to the dashboard.
- The context URL in the workspace description element is now a link.