### PR TITLE
[code] add extension tips & keywords

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 1255c858d0b0af9a11c9cc49c7cd5456e7368243
+ENV GP_CODE_COMMIT 25c80c19de2ab511b9529358c75dbd489fdccaba
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix https://github.com/gitpod-io/gitpod/issues/3391: this PR aligns extensions' tips and keywords with VS Code configuration but only for open source extensions, i.e. all proprietary related to codespaces, vscode-remote, liveshare, ai tools, vsonline, omnisharp and so on are excluded.
- also fix https://github.com/gitpod-io/gitpod/issues/3629

Changes in Code: https://github.com/gitpod-io/vscode/pull/12

#### How to test

- Start a workspace for ruby project: https://ak-code-ext-tips.staging.gitpod-dev.com/#https://github.com/gitpod-io/ruby-on-rails
- Open docker file, you should see eager notification recommendation for the docker extension, since it is marked as important tip. You can see all important tips in the VS Code PR: https://github.com/gitpod-io/vscode/pull/12
- Open ruby file, you should not see recommendations for ruby extension, but if you search in the extensions view then it should be marked now as recommended.
