### PR TITLE
[dashboard] proxy gitpod service in iframe

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -6,39 +6,37 @@
 
 import { GitpodClient, GitpodServer, GitpodServerPath, GitpodService, GitpodServiceImpl } from '@gitpod/gitpod-protocol';
 import { WebSocketConnectionProvider } from '@gitpod/gitpod-protocol/lib/messaging/browser/connection';
-// import { createWindowMessageConnection } from '@gitpod/gitpod-protocol/lib/messaging/browser/window-connection';
-// import { JsonRpcProxy /* , JsonRpcProxyFactory */ } from '@gitpod/gitpod-protocol/lib/messaging/proxy-factory';
+import { createWindowMessageConnection } from '@gitpod/gitpod-protocol/lib/messaging/browser/window-connection';
+import { JsonRpcProxyFactory } from '@gitpod/gitpod-protocol/lib/messaging/proxy-factory';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 
 export const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
 
 function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
-    // let proxy: JsonRpcProxy<S>;
-    // FIXME: https://gitpod.slack.com/archives/C01KGM9BUNS/p1615456669011600
-    // if (window.top !== window.self) {
-    //     const connection = createWindowMessageConnection('gitpodServer', window.parent, '*');
-    //     const factory = new JsonRpcProxyFactory<S>();
-    //     proxy = factory.createProxy();
-    //     factory.listen(connection);
-    // } else {
-        let host = gitpodHostUrl
-            .asWebsocket()
-            .with({ pathname: GitpodServerPath })
-            .withApi();
+    if (window.top !== window.self && process.env.NODE_ENV === 'production') {
+        const connection = createWindowMessageConnection('gitpodServer', window.parent, '*');
+        const factory = new JsonRpcProxyFactory<S>();
+        const proxy = factory.createProxy();
+        factory.listen(connection);
+        return new GitpodServiceImpl<C, S>(proxy);
+    }
+    let host = gitpodHostUrl
+        .asWebsocket()
+        .with({ pathname: GitpodServerPath })
+        .withApi();
 
-        const connectionProvider = new WebSocketConnectionProvider();
-        let numberOfErrors = 0;
-        const { proxy, webSocket } = connectionProvider.createProxy2<S>(host.toString(), undefined, {
-            onerror: (event: any) => {
-                log.error(event);
-                if (numberOfErrors++ === 5) {
-                    alert('We are having trouble connecting to the server.\nEither you are offline or websocket connections are blocked.');
-                }
+    const connectionProvider = new WebSocketConnectionProvider();
+    let numberOfErrors = 0;
+    const { proxy, webSocket } = connectionProvider.createProxy2<S>(host.toString(), undefined, {
+        onerror: (event: any) => {
+            log.error(event);
+            if (numberOfErrors++ === 5) {
+                alert('We are having trouble connecting to the server.\nEither you are offline or websocket connections are blocked.');
             }
-        });
+        }
+    });
 
-    // }
     const service = new GitpodServiceImpl<C, S>(proxy);
     (service as any).reconnect = () => {
         const ws = (webSocket as any);
@@ -63,7 +61,7 @@ function reconnectGitpodService() {
     if (service.reconnect) {
         service.reconnect();
     } else {
-        console.log("WebSocket reconnect not possible.")
+        console.error("WebSocket reconnect not possible.")
     }
 }
 


### PR DESCRIPTION
#### What it does

react-sciprts only transpiles all dependencies to es5 in production mode, in dev mode they do nothing for faster turnarounds. This PR enables proxying of the gitpod service in iframe only in the production mode.

#### How to test

- Start a workspace, open devtools, check that loading screen is rendered without errors and there is only one pending ws connection to the gitpod server.
- Telepresence in the dashboard, reload the page, check that loading screen is still rendered without errors, but now there are 2 ws connections.