### PR TITLE
[code] try install extension from .gitpod.yml

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 25c80c19de2ab511b9529358c75dbd489fdccaba
+ENV GP_CODE_COMMIT 17d867153c14d112c84ec95d6f91dce68c76b810
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT b53b81aac809a0b2acba4637aaf6c375ffd1bb07
+ENV GP_CODE_COMMIT 614b3c729e6fa822ed9aef75886d7497b2edcdfb
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 17d867153c14d112c84ec95d6f91dce68c76b810
+ENV GP_CODE_COMMIT ca51093353db615882966d1b48be856f21eb3ae8
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT ca51093353db615882966d1b48be856f21eb3ae8
+ENV GP_CODE_COMMIT 4e7aa6e7fd244fb6d316a575fecc6c70d2cf66fb
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 4e7aa6e7fd244fb6d316a575fecc6c70d2cf66fb
+ENV GP_CODE_COMMIT b53b81aac809a0b2acba4637aaf6c375ffd1bb07
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

When Open VSX is not available, Gitpod server times out to resolve URLs of vscode extensions. In this case Gitpod Code Server will try to resolve them again using internal APIs and install missing extensions.

Changes in Gitpod Code Server: https://github.com/gitpod-io/vscode/pull/14

#### How to test

- https://ak-code-install-ext.staging.gitpod-dev.com/#https://gitlab.com/gitpod/spring-petclinic
- wait a bit, if Open VSX is not available it can take a while, but eventually busy indicator should go away from the extensions view and you should see that all java extensions are installed
