### PR TITLE
Add and use OpenVSX caching proxy

### DIFF
--- a/.werft/build.js
+++ b/.werft/build.js
@@ -82,6 +82,11 @@ async function build(context, version) {
         withIntegrationTests,
     }));
 
+    const destname = version.split(".")[0];
+    const namespace = `staging-${destname}`;
+    const domain = `${destname}.staging.gitpod-dev.com`;
+    const url = `https://${domain}`;
+
     /**
      * Build
      */
@@ -102,7 +107,7 @@ async function build(context, version) {
     if (withInstaller || publishRelease) {
         exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=${imageRepo} install:all`, buildEnv);
     }
-    exec(`leeway build --werft=true -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo}`, buildEnv);
+    exec(`leeway build --werft=true -Dversion=${version} -DgitpodDomain=${domain} -DremoveSources=false -DimageRepoBase=${imageRepo}`, buildEnv);
     if (publishRelease) {
         try {
             werft.phase("publish", "checking version semver compliance...");
@@ -156,11 +161,7 @@ async function build(context, version) {
 
         return
     }
-    
-    const destname = version.split(".")[0];
-    const namespace = `staging-${destname}`;
-    const domain = `${destname}.staging.gitpod-dev.com`;
-    const url = `https://${domain}`;
+
     const deploymentConfig = {
       version,
       destname,

--- a/chart/config/proxy/vhost.server.conf
+++ b/chart/config/proxy/vhost.server.conf
@@ -157,3 +157,60 @@ server {
     include lib.workspace-port-locations.conf;
     include lib.region-headers.conf;
 }
+
+
+# https://www.nginx.com/blog/nginx-caching-guide/
+proxy_cache_path /var/www/cache levels=1:2 keys_zone=openvsx-cache:10m max_size=10g 
+                 inactive=120m use_temp_path=off;
+
+server {
+    listen {{ $listen }};
+    server_name open-vsx.{{ $domain }};
+
+{{- if $useHttps }}
+    include lib.ssl.conf;
+    include lib.https_redirect.conf;
+{{- end }}
+
+    include lib.resolver.conf;
+    include lib.region-headers.conf;
+
+    proxy_set_header Connection "";
+    proxy_set_header Host open-vsx.org;
+
+    location / {
+        proxy_cache openvsx-cache;
+        proxy_cache_methods GET HEAD POST;
+        proxy_cache_key "$request_method$request_uri$request_body$content_length";
+        proxy_ignore_headers Cache-Control Expires Vary;
+        proxy_cache_valid 30m;
+        proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+
+        add_header X-Cache-Status $upstream_cache_status;
+
+        proxy_pass https://open-vsx.org$request_uri;
+
+        set $log_message_json '{}';
+        log_by_lua_block {
+            local cjson = require("cjson")
+            local json = {
+                message="proxying open-vsx.org",
+                method=ngx.var.request_method,
+                uri=ngx.var.uri,
+                requestSize=ngx.var.request_length,
+                status=ngx.var.status,
+                responseSize=ngx.var.bytes_sent,
+                cacheStatus=ngx.var.upstream_cache_status,
+                requestBody=ngx.var.request_body,
+                requestBodyFile=ngx.var.request_body_file,
+                responseCacheControl=ngx.resp.get_headers()["Cache-Control"],
+                responseXAccelExpires=ngx.resp.get_headers()["X-Accel-Expires"],
+                responseExpires=ngx.resp.get_headers()["Expires"],
+                responseSetCookie=ngx.resp.get_headers()["Set-Cookie"],
+                responseVary=ngx.resp.get_headers()["Vary"],
+                proxyCacheKey=string.format("%s%s%s%s", ngx.var.request_method, ngx.var.request_uri, ngx.var.request_body, ngx.var.content_length),
+            }
+            ngx.var.log_message_json = cjson.encode(json)
+        }
+    }
+}

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -7,7 +7,10 @@ packages:
       - "bin/*"
     argdeps:
       - imageRepoBase
+      - gitpodDomain
     config:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ide/code:${version}
+      buildArgs:
+        OPENVSX_URL: https://open-vsx.${gitpodDomain}

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -37,6 +37,8 @@ RUN mkdir gp-code \
     && git remote add origin https://github.com/gitpod-io/vscode \
     && git fetch origin $GP_CODE_COMMIT \
     && git reset --hard FETCH_HEAD
+ARG OPENVSX_URL=https://open-vsx.org
+RUN sed -i "s+https://open-vsx.org+${OPENVSX_URL}+g" gp-code/product.json
 WORKDIR /gp-code
 RUN yarn
 RUN yarn gulp gitpod

--- a/components/server/src/theia-plugin/theia-plugin-service.ts
+++ b/components/server/src/theia-plugin/theia-plugin-service.ts
@@ -22,6 +22,7 @@ import * as request from 'request';
 const builtinExtensions: PluginIndexEntry[] = require('@gitpod/gitpod-protocol/data/builtin-theia-plugins.json');
 
 const userPluginsUri = 'user-plugins://';
+const localOpenVSXDomainPrefix = 'open-vsx.';
 
 export interface ResolvedPluginsResult {
     resolved: ResolvedPlugins
@@ -35,6 +36,11 @@ export class TheiaPluginService {
     @inject(StorageClient) protected readonly storageClient: StorageClient;
     @inject(TheiaPluginDB) protected readonly pluginDB: TheiaPluginDB;
     @inject(UserStorageResourcesDB) protected readonly userStorageResourcesDB: UserStorageResourcesDB;
+    protected readonly openVSXCachingProxyURL: string;
+
+    public constructor() {
+        this.openVSXCachingProxyURL = new GitpodHostUrl(process.env.HOST_URL).withDomainPrefix(localOpenVSXDomainPrefix).toString();
+    }
 
     /**
      * @returns a sanitized path to the plugin archive which can be used in signed URLs
@@ -233,7 +239,7 @@ export class TheiaPluginService {
         };
     }
 
-    private async resovleFromOpenVSX({ name, version }: { name: string, version?: string }, vsxRegistryUrl = 'https://open-vsx.org'): Promise<{
+    private async resovleFromOpenVSX({ name, version }: { name: string, version?: string }, vsxRegistryUrl = this.openVSXCachingProxyURL): Promise<{
         url: string
         fullPluginName: string
     } | undefined> {


### PR DESCRIPTION
This PR introduces a caching proxy for OpenVSX at https://open-vsx.gitpod.io.

**Here are some parameters that are open for discussion:**
- [ ] With the current implementation, every GET, HEAD, and PUSH call is cashed.
- [ ] Every response is cached for 30 minutes (valid time).
- [ ] A cached response is removed when not accessed for 120 minutes.
- [ ] In case of an error (timeout http_500 http_502 http_503 http_504) a stale response in the cache (of the past 120 minutes) is served.
- [ ] Cache folder has max. size of 10 GB.
- [ ] Header from upstream like Cache-Control are ignored (everything is cached for 30 minutes).
- [ ] For VSCode the OpenVSX URL is changed in the leeway.Dockerfile, Theia uses the TheiaPluginService, right? Or does Theia need a URL change as well?

**How to test:**
- Open a workspace
- Use the extensions view to search for extensions
- Observe the proxy logs: `kubectl logs -f deployment/proxy | grep proxying`, every `"cacheStatus":"HIT"` is a cached result