### PR TITLE
fix error message typo

### DIFF
--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -19,7 +19,7 @@ export enum StartPhase {
 function getPhaseTitle(phase?: StartPhase, error?: boolean) {
   switch (phase) {
     case StartPhase.Checking:
-      return !error ? "Checking" : "Oh, no! Something went wrong!1";
+      return !error ? "Checking" : "Oh, no! Something went wrong!";
     case StartPhase.Preparing:
       return "Preparing";
     case StartPhase.Creating:

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -170,7 +170,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     const isHeadless = this.state.workspace?.type !== 'regular';
     const isPrebuilt = WithPrebuild.is(this.state.workspace?.context);
     let phase = StartPhase.Preparing;
-    let title = !error ? undefined : 'Oh, no! Something went wrong!1';
+    let title = !error ? undefined : 'Oh, no! Something went wrong!';
     let statusMessage = !error
       ? <p className="text-base text-gray-400">Preparing workspace …</p>
       : <p className="text-base text-red-500 w-96">{error.message}</p>;


### PR DESCRIPTION
When there's an error, the new Gitpod UI display this message:
`Oh, no! Something went wrong!1`

That last character `1`, should not be there.