### PR TITLE
[content-service] Do not remove .docker-root

### DIFF
--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -126,6 +126,11 @@ func clearWorkspace(location string) error {
 		return err
 	}
 	for _, file := range files {
+		// do not remove docker storage.
+		if strings.HasSuffix(file, ".docker-root") {
+			continue
+		}
+
 		err = os.RemoveAll(file)
 		if err != nil {
 			return xerrors.Errorf("prebuild initializer: %w", err)


### PR DESCRIPTION
After the prebuild:
```console
gitpod /workspace/ddev-gitpod $ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
gitpod /workspace/ddev-gitpod $ docker images
REPOSITORY                        TAG                         IMAGE ID            CREATED             SIZE
drud/ddev-webserver               v1.16.7-ddev-gitpod-built   a027c9ae94f9        3 minutes ago       1.16GB
drud/ddev-dbserver-mariadb-10.3   v1.16.0-ddev-gitpod-built   0c5a74e58990        3 minutes ago       640MB
drud/ddev-ssh-agent               v1.16.0-built               1c63db0571b7        3 minutes ago       113MB
phpmyadmin                        5                           622471936dcc        4 days ago          477MB
busybox                           latest                      a9d583973f65        3 weeks ago        11.23MB
drud/ddev-webserver               v1.16.7                     48ca5db4a356        4 weeks ago         1.16GB
drud/ddev-router                  v1.16.2                     9f085cfd7877        3 months ago        243MB
drud/ddev-dbserver-mariadb-10.3   v1.16.0                     2f19a2bac03d        4 months ago        640MB
drud/ddev-ssh-agent               v1.16.0                     5995b3ec37aa        4 months ago        113MB
```

fixes https://github.com/gitpod-io/gitpod/issues/3671