### PR TITLE
[chart] Allow configuration of shovels at boot time

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -166,6 +166,10 @@ minio:
     create: false
 
 rabbitmq:
+  # ensure shovels are configured on boot
+  shovels:
+    - name: messagebus-0
+      srcUri: "amqp://$USERNAME:$PASSWORD@messagebus-0"
   auth:
     username: override-me
     password: override-me

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -512,6 +512,9 @@ mysql:
 
 rabbitmq:
   fullnameOverride: "messagebus"
+  # non-standard configuration
+  # defined by gitpod.io
+  shovels: []
   persistence:
     enabled: false
   replicaCount: 1
@@ -541,6 +544,7 @@ rabbitmq:
           "vhosts": [{
             "name": "/"
           }],
+          "parameters": {{ tpl (.Values.shovelsTemplate) . | fromYamlArray | toJson }},
           "permissions": [{
             "user": {{ .Values.auth.username | quote }},
             "vhost": "/",
@@ -553,25 +557,25 @@ rabbitmq:
             "vhost": "/",
             "type": "topic",
             "durable": true,
-            "auto_delete": false,
+            "auto_delete": false
           }, {
             "name": "gitpod.ws.local",
             "vhost": "/",
             "type": "topic",
             "durable": true,
-            "auto_delete": false,
+            "auto_delete": false
           }, {
             "name": "wsman",
             "vhost": "/",
             "type": "topic",
             "durable": false,
-            "auto_delete": false,
+            "auto_delete": false
           }, {
             "name": "consensus-leader",
             "vhost": "/",
             "type": "fanout",
             "durable": false,
-            "auto_delete": false,
+            "auto_delete": false
           }],
           "bindings": [{
             "source": "gitpod.ws.local",
@@ -614,3 +618,22 @@ rabbitmq:
     create: true
     minAvailable: 0
     maxUnavailable: 1
+  shovelsTemplate: |
+    {{ $auth := .Values.auth }}
+    {{- range $index, $shovel := .Values.shovels }}
+    - name: {{ $shovel.name | default (randAlphaNum 20) | quote }}
+      vhost: "/"
+      component: "shovel"
+      value:
+        ack-mode: "on-publish"
+        src-delete-after: "never"
+        src-exchange: {{ $shovel.srcExchange | default "gitpod.ws.local" | quote }}
+        src-exchange-key: {{ $shovel.srcExchangeKey | default "#" | quote  }}
+        src-protocol: "amqp091"
+        src-uri: {{ $shovel.srcUri | replace "$USERNAME" $auth.username | replace "$PASSWORD" $auth.password | quote }}
+        dest-add-forward-headers: {{ $shovel.destAddForwardHeaders | default true }}
+        dest-exchange: {{ $shovel.destExchange | default "gitpod.ws" | quote }}
+        dest-protocol: "amqp091"
+        dest-uri: {{ $shovel.destUri | default "amqp://" | quote }}
+        reconnect-delay: {{ $shovel.reconnectDelay | default 5 }}
+    {{- end }}


### PR DESCRIPTION
How to test:

- Deploy
- Check `messagebus-0` pod does not contains errors
- Use port-forward to access the UI `kubectl port-forward messagebus-0 15672`
- Download broker definitions: `Overview` -> `Download broker definitions`
- Check `parameters` contains a shovel definition:
```json
...
"parameters": [{
  "value": {
    "ack-mode": "on-publish",
    "dest-add-forward-headers": true,
    "dest-exchange": "gitpod.ws",
    "dest-protocol": "amqp091",
    "dest-uri": "amqp://",
    "reconnect-delay": 5,
    "src-delete-after": "never",
    "src-exchange": "gitpod.ws.local",
    "src-exchange-key": "#",
    "src-protocol": "amqp091",
    "src-uri": "amqp://override-me:override-me@messagebus-0"
  },
  "vhost": "/",
  "component": "shovel",
  "name": "messagebus-0"
}],
...
```