### PR TITLE
[ws-manager] Fix ghost workspaces

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -137,7 +137,7 @@ components:
 
   wsScheduler:
     scaler:
-      enabled: false
+      enabled: true
       controller:
         kind: "constant"
         constant:

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -465,7 +465,7 @@ func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) 
 	)
 
 	if startContext.Request.Type == api.WorkspaceType_GHOST {
-		command[1] = "ghost"
+		command = []string{"/.supervisor/supervisor", "ghost"}
 		readinessProbe = nil
 	}
 

--- a/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
@@ -62,7 +62,7 @@
                     "name": "workspace",
                     "image": "registry-facade:8080/remote/foobar",
                     "command": [
-                        "/.supervisor/workspacekit",
+                        "/.supervisor/supervisor",
                         "ghost"
                     ],
                     "ports": [


### PR DESCRIPTION
This PR fixes ghost workspaces that broke when we made user namespaces the default.

### How to test
1. Check that ghosts run
```
$ kubectl get pods -l component=workspace
NAME                                         READY   STATUS    RESTARTS   AGE
ghost-f2553e3f-d29e-4790-9302-e0bb0e3fc278   1/1     Running   0          25s
```