### PR TITLE
[dashboard] Re-implement 'Start with Default Image' button in workspace image build view

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -348,7 +348,7 @@ function ImageBuildView(props: ImageBuildViewProps) {
     <Suspense fallback={<div />}>
       <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
     </Suspense>
-    <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>Start with Default Image</button>
+    <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>Continue with Default Image</button>
   </StartPage>;
 }
 

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -186,7 +186,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       // Preparing means that we haven't actually started the workspace instance just yet, but rather
       // are still preparing for launch. This means we're building the Docker image for the workspace.
       case "preparing":
-        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} />;
+        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={() => this.startWorkspace(true, true)} />;
 
       // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
       // some space within the cluster. If for example the cluster needs to scale up to accomodate the
@@ -252,7 +252,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       case "stopped":
         phase = StartPhase.Stopped;
         if (this.state.hasImageBuildLogs) {
-          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} phase={phase} error={error} />;
+          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={() => this.startWorkspace(true, true)} phase={phase} error={error} />;
         }
         if (!isHeadless && this.state.workspaceInstance.status.conditions.timeout) {
           title = 'Timed Out';
@@ -314,7 +314,14 @@ function PendingChangesDropdown(props: { workspaceInstance?: WorkspaceInstance }
   </ContextMenu>;
 }
 
-function ImageBuildView(props: { workspaceId: string, phase?: StartPhase, error?: StartWorkspaceError }) {
+interface ImageBuildViewProps {
+  workspaceId: string;
+  onStartWithDefaultImage: () => void;
+  phase?: StartPhase;
+  error?: StartWorkspaceError;
+}
+
+function ImageBuildView(props: ImageBuildViewProps) {
   const logsEmitter = new EventEmitter();
 
   useEffect(() => {
@@ -341,6 +348,7 @@ function ImageBuildView(props: { workspaceId: string, phase?: StartPhase, error?
     <Suspense fallback={<div />}>
       <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
     </Suspense>
+    <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>Start with Default Image</button>
   </StartPage>;
 }
 

--- a/components/dashboard/src/start/WorkspaceLogs.tsx
+++ b/components/dashboard/src/start/WorkspaceLogs.tsx
@@ -72,7 +72,7 @@ export default class WorkspaceLogs extends React.Component<WorkspaceLogsProps, W
 
   componentDidUpdate() {
     if (this.terminal && this.props.errorMessage) {
-      this.terminal.write('\n' + this.props.errorMessage);
+      this.terminal.write(`\n\u001b[38;5;196m${this.props.errorMessage}\u001b[0m`);
     }
   }
 


### PR DESCRIPTION
How to test:

- https://jx-start-with-default-image.staging.gitpod-dev.com/#https://github.com/jankeromnes/gitpod-build-error
- Image build should fail, button should still give you a workspace