### PR TITLE
Rename workspace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
-workspaceLocation: gitpod/gitpod-ws.theia-workspace
+workspaceLocation: gitpod/gitpod-ws.workspace
 checkoutLocation: gitpod
 ports:
   - port: 1337

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -25,7 +25,7 @@ func TestGitpodConfig(t *testing.T) {
 			Desc: "parsing",
 			Content: `
 image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
-workspaceLocation: gitpod/gitpod-ws.theia-workspace
+workspaceLocation: gitpod/gitpod-ws.workspace
 checkoutLocation: gitpod
 ports:
   - port: 1337
@@ -44,7 +44,7 @@ vscode:
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
 				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9",
-				WorkspaceLocation: "gitpod/gitpod-ws.theia-workspace",
+				WorkspaceLocation: "gitpod/gitpod-ws.workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{
 					{


### PR DESCRIPTION
This will rename the workspace name and remove the reference for Theia that also surfaces in the VS Code editor.

| VS Code in Gitpod |
|-|
| <img width="347" alt="Screenshot 2021-04-06 at 10 16 27 AM" src="https://user-images.githubusercontent.com/120486/113673136-437c3480-96c1-11eb-8566-7cfdc593d776.png"> |