### PR TITLE
[code] fix donwloading extensions from GCP storage

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT 0ce76acf042b084a6eb0f3c76ece0f3db2562d1c
+ENV GP_CODE_COMMIT a752a8a6ceb43b9add71c7d68f56b0acbdd5dcb7
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

Provide `*/*` as a content type, otherwise GCP rejects signed URLs.

Changes in Code: https://github.com/gitpod-io/vscode/commit/a752a8a6ceb43b9add71c7d68f56b0acbdd5dcb7

#### How to test

- We can actually test only on staging, but we should at least check that installing from Open VSX is working with:
https://ak-code-ext-from-gcp.staging.gitpod-dev.com/#https://gitlab.com/gitpod/spring-petclinic