### PR TITLE
[dashboard] Don't show workspaces with zero instances as 'active'

### DIFF
--- a/components/dashboard/src/workspaces/workspace-model.ts
+++ b/components/dashboard/src/workspaces/workspace-model.ts
@@ -126,7 +126,7 @@ export class WorkspaceModel implements Disposable, Partial<GitpodClient> {
     
     protected isActive(info: WorkspaceInfo): boolean {
         return info.workspace.pinned || 
-            info.latestInstance?.status?.phase !== 'stopped';
+            (!!info.latestInstance && info.latestInstance.status?.phase !== 'stopped');
     }
 
     public getAllFetchedWorkspaces(): Map<string, WorkspaceInfo> {


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3780

This isn't a normal case, but apparently it can happen that a workspace has zero instances if it fails at the wrong time during creation (as probably happened to me in the bug).