### PR TITLE
[chart] Migrate mysql from stable repository

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -6,10 +6,10 @@ dependencies:
   repository: https://helm.min.io/
   version: 8.0.7
 - name: mysql
-  repository: https://charts.helm.sh/stable
-  version: 1.6.9
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.5.1
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 8.11.4
-digest: sha256:870b60fff36fb9c2868887cf688931ef1a2ef47c493c46fe27df63d53a71ed7b
-generated: "2021-03-23T19:53:58.841384532-03:00"
+digest: sha256:9cbb115287d3731701c556ac1b16be374e8079afda5911a98b551de7c3f04a2f
+generated: "2021-04-06T15:40:05.531453033-04:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -17,8 +17,8 @@ dependencies:
   repository: https://helm.min.io/
   condition: minio.enabled
 - name: mysql
-  version: 1.6.9
-  repository: https://charts.helm.sh/stable
+  version: 8.5.1
+  repository: https://charts.bitnami.com/bitnami
   condition: mysql.enabled
 - name: rabbitmq
   version: 8.11.4

--- a/chart/templates/db-service.yaml
+++ b/chart/templates/db-service.yaml
@@ -12,7 +12,7 @@ metadata:
     kind: service
     stage: {{ .Values.installation.stage }}
 spec:
-  ports: 
+  ports:
   - protocol: TCP
     port: 3306
     targetPort: 3306
@@ -26,7 +26,7 @@ spec:
     component: {{ $comp.name }}
     kind: pod
     {{- else }}
-    app: mysql
+    app.kubernetes.io/name: mysql
     {{- end }}
   type: {{ $comp.serviceType }}
   sessionAffinity: None

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -506,18 +506,16 @@ minio:
 mysql:
   enabled: true
   fullnameOverride: mysql
-  testFramework:
-    enabled: false
-  existingSecret: db-password
+  image:
+    tag: 5.7
+  auth:
+    existingSecret: db-password
   serviceAccount:
+    create: false
     name: db
-  extraVolumes: |
-    - name: init-scripts
-      configMap:
-        name: db-init-scripts
-  extraVolumeMounts: |
-    - mountPath: /docker-entrypoint-initdb.d
-      name: init-scripts
+  initdbScriptsConfigMap: db-init-scripts
+  volumePermissions:
+    enabled: true
 
 rabbitmq:
   fullnameOverride: "messagebus"


### PR DESCRIPTION
Stable helm repository is deprecated since [November 2020](https://github.com/helm/charts#deprecation-timeline)