### PR TITLE
[github] remove `read:user` from default scopes

### DIFF
--- a/components/server/src/github/scopes.ts
+++ b/components/server/src/github/scopes.ts
@@ -19,7 +19,7 @@ export namespace GitHubScope {
          * Minimal required permission.
          * GitHub's API is not restricted any further.
          */
-        DEFAULT: [EMAIL, READ_USER],
+        DEFAULT: [EMAIL],
 
         PUBLIC_REPO: [PUBLIC],
         PRIVATE_REPO: [PRIVATE],


### PR DESCRIPTION
#### What it does

Reverts changing default scopes for GitHub otherwise it breaks existing users, since they cannot grant such scope at all without relogin.

#### How to test

🤷‍♂️ 