### PR TITLE
[chart] Tune rabbitmq defaults

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -537,6 +537,11 @@ rabbitmq:
       existingSecretFullChain: true
   metrics:
     enabled: true
+  extraEnvVars:
+    # Disable Speculative Scheduler Busy Waiting
+    # https://www.rabbitmq.com/runtime.html#busy-waiting
+    - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+      value: "+sbwt none +sbwtdcpu none +sbwtdio none"
   networkPolicy:
     enabled: true
     allowExternal: true
@@ -624,6 +629,8 @@ rabbitmq:
     existingSecret: load-definition
   extraConfiguration: |
     load_definitions = /app/load_definition.json
+    # Increase statistics emission interval https://www.rabbitmq.com/management.html#statistics-interval
+    collect_statistics_interval = 15000
   pdb:
     create: true
     minAvailable: 0


### PR DESCRIPTION
Using ` rabbitmq-diagnostics runtime_thread_stats` is possible to get details about the current behavior