### PR TITLE
[preview envs] Fix workspace deletion

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -91,26 +91,18 @@ export async function build(context, version) {
      * Build
      */
     werft.phase("build", "build running");
-    // Build using the dev-http-cache gitpod-dev to make 'yarn install' more stable
-    const buildEnvOpts = {
-        env: {
-            ...process.env,
-            "HTTP_PROXY": "http://dev-http-cache:3129",
-            "HTTPS_PROXY": "http://dev-http-cache:3129",
-        }
-    };
     const imageRepo = publishRelease ? "gcr.io/gitpod-io/self-hosted" : "eu.gcr.io/gitpod-core-dev/build";
 
     exec(`LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || { echo "[build|FAIL] There are some license headers missing. Please run 'leeway run components:update-license-header'."; exit 1; }`)
     exec(`leeway vet --ignore-warnings`);
-    exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`, buildEnvOpts);
+    exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`);
     if (publishRelease) {
         exec(`gcloud auth activate-service-account --key-file "/mnt/secrets/gcp-sa-release/service-account.json"`);
     }
     if (withInstaller || publishRelease) {
-        exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=${imageRepo} install:all`, buildEnvOpts);
+        exec(`leeway build --werft=true -c ${cacheLevel} ${dontTest ? '--dont-test':''} -Dversion=${version} -DimageRepoBase=${imageRepo} install:all`);
     }
-    exec(`leeway build --werft=true -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo}`, buildEnvOpts);
+    exec(`leeway build --werft=true -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo}`);
     if (publishRelease) {
         try {
             werft.phase("publish", "checking version semver compliance...");

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -106,13 +106,9 @@ pod:
         export DOCKER_HOST=tcp://$NODENAME:2375
         sudo chown -R gitpod:gitpod /workspace
 
-        npm install shelljs semver
+        npm install shelljs semver ts-node typescript @types/shelljs @types/node @types/semver
         printf '{{ toJson . }}' > context.json
 
-        {{- if .Annotations.debug }}
-        node --inspect-brk .werft/build.js
-        {{- else }}
-        node --inspect .werft/build.js
-        {{- end }}
+        npx ts-node .werft/build.ts
 sidecars:
 - testdb

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -1,7 +1,7 @@
-const { exec } = require('./shell');
-const { sleep } = require('./util.js');
+import { exec } from './shell';
+import { sleep } from './util';
 
-async function issueCertficate(werft, pathToTerraform, gcpSaPath, namespace, dnsZoneDomain, domain, ip, additionalWsSubdomains) {
+export async function issueCertficate(werft, pathToTerraform, gcpSaPath, namespace, dnsZoneDomain, domain, ip, additionalWsSubdomains) {
     const subdomains = ["", "*.", "*.ws-dev."];
     if (Array.isArray(subdomains)) {
         for (const sd of additionalWsSubdomains) {
@@ -19,7 +19,7 @@ async function issueCertficate(werft, pathToTerraform, gcpSaPath, namespace, dns
             -var 'dns_zone_domain=${dnsZoneDomain}' \
             -var 'domain=${domain}' \
             -var 'public_ip=${ip}' \
-            -var 'subdomains=[${subdomains.map(s => `"${s}"`).join(", ")}]'`, {slice: 'certificate', async: true});
+            -var 'subdomains=[${subdomains.map(s => `"${s}"`).join(", ")}]'`, { slice: 'certificate', async: true });
 
     werft.log('certificate', `waiting until certificate certs/${namespace} is ready...`)
     let notReadyYet = true;
@@ -35,7 +35,7 @@ async function issueCertficate(werft, pathToTerraform, gcpSaPath, namespace, dns
     }
 }
 
-async function installCertficate(werft, fromNamespace, toNamespace, certificateSecretName) {
+export async function installCertficate(werft, fromNamespace, toNamespace, certificateSecretName) {
     werft.log('certificate', `copying certificate from "certs/${fromNamespace}" to "${toNamespace}/${certificateSecretName}"`);
     // certmanager is configured to create a secret in the namespace "certs" with the name "${namespace}".
     exec(`kubectl get secret ${fromNamespace} --namespace=certs -o yaml \
@@ -45,9 +45,4 @@ async function installCertficate(werft, fromNamespace, toNamespace, certificateS
         | yq d - 'metadata.creationTimestamp' \
         | sed 's/${fromNamespace}/${certificateSecretName}/g' \
         | kubectl apply --namespace=${toNamespace} -f -`);
-}
-
-module.exports = {
-    issueCertficate,
-    installCertficate,
 }

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -1,14 +1,14 @@
-const { exec } = require('./shell');
+import { exec } from './shell';
 
 
-function setKubectlContextNamespace(namespace, shellOpts) {
+export function setKubectlContextNamespace(namespace, shellOpts) {
     [
         "kubectl config current-context",
         `kubectl config set-context --current --namespace=${namespace}`
     ].forEach(cmd => exec(cmd, shellOpts));
 }
 
-function wipeAndRecreateNamespace(namespace, shellOpts) {
+export function wipeAndRecreateNamespace(namespace, shellOpts) {
     removePodFinalizers(namespace, shellOpts);
     deleteAllWorkspaces(namespace, shellOpts);
 
@@ -61,7 +61,7 @@ function deleteNamespace(namespace, shellOpts, wait) {
     }
 }
 
-function deleteNonNamespaceObjects(namespace, destname, shellOpts) {
+export function deleteNonNamespaceObjects(namespace, destname, shellOpts) {
     exec(`/usr/local/bin/helm3 delete gitpod-${destname} || echo gitpod-${destname} was not installed yet`, {slice: 'predeploy cleanup'});
     exec(`/usr/local/bin/helm3 delete jaeger-${destname} || echo jaeger-${destname} was not installed yet`, {slice: 'predeploy cleanup'});
 
@@ -79,11 +79,4 @@ function deleteNonNamespaceObjects(namespace, destname, shellOpts) {
     objs.forEach(o => {
         exec(`kubectl delete ${o.kind} ${o.obj}`, shellOpts);
     });
-}
-
-
-module.exports = {
-    setKubectlContextNamespace,
-    wipeAndRecreateNamespace,
-    deleteNonNamespaceObjects,
 }

--- a/.werft/util/slack.ts
+++ b/.werft/util/slack.ts
@@ -1,6 +1,6 @@
-const https = require('https');
+import * as https from 'https';
 
-function reportBuildFailureInSlack(context, err, onErr) {
+export function reportBuildFailureInSlack(context, err, onErr) {
     const repo = context.Repository.host + "/" + context.Repository.owner + "/" + context.Repository.repo;
     const data = JSON.stringify({
         "blocks": [
@@ -44,8 +44,4 @@ function reportBuildFailureInSlack(context, err, onErr) {
     req.on('error', onErr);
     req.write(data);
     req.end();
-}
-
-module.exports = {
-    reportBuildFailureInSlack: reportBuildFailureInSlack,
 }

--- a/.werft/util/util.js
+++ b/.werft/util/util.js
@@ -1,9 +1,0 @@
-async function sleep(millis) {
-    return Promise((resolve) => {
-        setTimeout(resolve, millis);
-    });
-}
-
-module.exports = {
-    sleep
-}

--- a/.werft/util/util.ts
+++ b/.werft/util/util.ts
@@ -1,0 +1,5 @@
+export async function sleep(millis: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, millis);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "license": "UNLICENSED",
     "devDependencies": {
         "@types/node": "^10.14.8",
+        "@types/shelljs": "^0.8.8",
         "concurrently": "^5.3.0",
         "envfile": "^2.1.1",
         "json": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,7 +4252,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@^7.1.1":
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
   integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
@@ -4671,6 +4671,14 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/sharedworker/-/sharedworker-0.0.29.tgz#69ce70764a0380f4c27ae036f6f9c4e2c75dbdac"
   integrity sha512-vdlrZJKGrAedfcMt4Tn8gIa3tJxRhrTtwfEu9jmVtaCZHgbensRMEbpkZ+dY/6WpE12a8K00KaQnJV0lH9ZmdA==
+
+"@types/shelljs@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.8.tgz#e439c69929b88a2c8123c1a55e09eb708315addf"
+  integrity sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/sonic-boom@*":
   version "0.7.0"


### PR DESCRIPTION
Fixes #3803.

This should improve the robustness of our preview deployments. But more importantly, it moves our werft scripts from JS to TS. This already fixed multiple small and one bigger bug. It also opens the door for more refactorings in the near future:
 - use the same set of utilities (confidently), or
 - have one set of deployment scripts/jobs alltogether in `core`, with minimal configuration on top for `com`
 
 The PR does by design not add _all_ types but only the most basic/necessary to compile to not add even more noise.
 