### PR TITLE
[blobserve] enable long term caching only on success

### DIFF
--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -193,7 +193,9 @@ func createDefaultTransport(config *TransportConfig) *http.Transport {
 func withLongTermCaching() proxyPassOpt {
 	return func(cfg *proxyPassConfig) {
 		cfg.appendResponseHandler(func(resp *http.Response, req *http.Request) error {
-			resp.Header.Set("Cache-Control", "public, max-age=31536000")
+			if resp.StatusCode < http.StatusBadRequest {
+				resp.Header.Set("Cache-Control", "public, max-age=31536000")
+			}
 			return nil
 		})
 	}


### PR DESCRIPTION
#### What it does

Disable caching failed requests to blobserve forever.

#### How to test

- Start a workspace, open devtools, reload the page, check that content of blobserve is served from the disk cache.