### PR TITLE
[dev] Update go to 1.16.3

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go163.38
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -32,7 +32,7 @@ tasks:
   - before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build
   - name: Go
-    init: leeway exec --filter-type go -v -- go mod download
+    init: leeway exec --filter-type go -v -- go mod verify
     openMode: split-right
 vscode:
   extensions:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go163.38
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -36,7 +36,7 @@ pod:
     - bash
     - -c
     - |
-      
+
       echo "[prep] preparing config."
 
       gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
@@ -74,6 +74,6 @@ pod:
       echo "[prep|DONE]"
 
       /entrypoint.sh -kubeconfig=/config/kubeconfig -namespace={{ .Annotations.namespace }} -username=$USERNAME 2>&1 | ts "[int-tests] "
-      
+
       RC=${PIPESTATUS[0]}
       if [ $RC -eq 1 ]; then echo "[int-tests|FAIL]"; else echo "[int-tests|DONE]"; fi

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go163.38
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -22,7 +22,7 @@ pod:
       mountPath: /mnt/secrets/gcp-sa
       readOnly: true
     command:
-    - bash 
+    - bash
     - -c
     - |
       sleep 1

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go163.38
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -4,10 +4,11 @@ defaultArgs:
   coreYarnLockBase: ../..
   publishToNPM: true
 
-defaultVariant: 
+defaultVariant:
   config:
     go:
       lintCommand: ["golangci-lint", "run", "--disable", "govet,typecheck"]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
 
 variants:
 - name: oss

--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -15,7 +15,6 @@ packages:
       - ["go", "generate"]
     config:
       dontTest: true
-      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
   - name: bin-runc-facade
     type: go
     srcs:
@@ -30,7 +29,6 @@ packages:
       - ["rmdir", "runc-facade"]
     config:
       dontTest: true
-      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
   - name: bin-slirp-docker-proxy
     type: go
     srcs:
@@ -45,7 +43,6 @@ packages:
       - ["rmdir", "slirp-docker-proxy"]
     config:
       dontTest: true
-      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
   - name: app
     type: generic
     deps:

--- a/components/gitpod-protocol/go/BUILD.yaml
+++ b/components/gitpod-protocol/go/BUILD.yaml
@@ -10,5 +10,4 @@ packages:
       - GOOS=linux
     config:
       packaging: library
-      buildFlags:
-        - "-ldflags=-w"
+      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid="]

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -24,7 +24,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go163.38
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -43,7 +43,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:pluggable-workspace-cluster.9",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go163.38",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -15,9 +15,6 @@ packages:
     env:
       - CGO_ENABLED=0
       - GOOS=linux
-    config:
-      buildFlags:
-        - "-ldflags=-w"
   - name: docker
     type: docker
     srcs:

--- a/components/ws-daemon/BUILD.yaml
+++ b/components/ws-daemon/BUILD.yaml
@@ -17,6 +17,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid="]
   - name: content-initializer
     type: go
     srcs:
@@ -37,6 +38,7 @@ packages:
     config:
       packaging: app
       dontTest: true
+      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid="]
   - name: docker
     type: docker
     deps:

--- a/components/ws-manager/BUILD.yaml
+++ b/components/ws-manager/BUILD.yaml
@@ -18,7 +18,6 @@ packages:
       - GOOS=linux
     config:
       packaging: app
-      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-w -extldflags \"-static\""]
   - name: docker
     type: docker
     deps:

--- a/components/ws-proxy/BUILD.yaml
+++ b/components/ws-proxy/BUILD.yaml
@@ -17,6 +17,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid="]
   - name: docker
     type: docker
     srcs:

--- a/dev/gpctl/BUILD.yaml
+++ b/dev/gpctl/BUILD.yaml
@@ -18,3 +18,4 @@ packages:
     config:
       packaging: app
       dontTest: true
+

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -114,11 +114,13 @@ ENV PATH=/home/gitpod/.nvm/versions/node/v${GITPOD_NODE_VERSION}/bin:$PATH
 # Fix the Go version
 ENV GOPATH=$HOME/go-packages
 ENV GOROOT=$HOME/go
-RUN go get golang.org/dl/go1.16 && \
-    go1.16 download && \
-    mv $(which go1.16) $(which go)
-ENV GOPATH=/workspace/go \
-    PATH=/workspace/go/bin:$PATH
+RUN go get golang.org/dl/go1.16.3 \
+  && go1.16.3 download \
+  && mv $(which go1.16.3) $(which go)
+ENV GOPATH=/workspace/go
+ENV PATH=/workspace/go/bin:$PATH
+
+ENV GOFLAGS="-mod=readonly"
 
 ## Register leeway autocompletion in bashrc
 RUN bash -c "echo . \<\(leeway bash-completion\) >> ~/.bashrc"

--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -9,6 +9,8 @@ packages:
     env:
       - CGO_ENABLED=0
       - GOOS=linux
+    config:
+      packaging: app
   - name: docker
     type: docker
     srcs:


### PR DESCRIPTION
- Update go version to 1.16.3
- Adjust go build flags 

Why? Using pprof to find a leak (https://github.com/gitpod-io/gitpod/issues/3108) I found that it was not possible to use `pprof list`

**before this change**

```
goroutine profile: total 31
1 @ 0x40c6f4 0x46e545 0x19e2265 0x471e61
#	0x46e544	os/signal.signal_recv+0xa4	/home/gitpod/sdk/go1.16/src/runtime/sigqueue.go:168
#	0x19e2264	os/signal.loop+0x24		/home/gitpod/sdk/go1.16/src/os/signal/signal_unix.go:23

1 @ 0x43aec5 0x4068cf 0x40650b 0x1923b13 0x180be8e 0x180bf51 0x471e61
#	0x1923b12	k8s.io/client-go/tools/cache.(*sharedProcessor).run+0x52		/workspace/go/pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/shared_informer.go:628
#	0x180be8d	k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1+0x2d	/workspace/go/pkg/mod/k8s.io/apimachinery@v0.20.4/pkg/util/wait/wait.go:56
#	0x180bf50	k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1+0x50		/workspace/go/pkg/mod/k8s.io/apimachinery@v0.20.4/pkg/util/wait/wait.go:73
```

**after**

```
goroutine profile: total 162
100 @ 0x43aec5 0x44bfd7 0x16a20e8 0x16a1c57 0x471e01
#	0x16a20e7	github.com/gitpod-io/gitpod/ws-manager/pkg/manager/internal/workpool.(*EventWorkerPool).work+0x447		github.com/gitpod-io/gitpod/ws-manager/pkg/manager/internal/workpool/workpool.go:149
#	0x16a1c56	github.com/gitpod-io/gitpod/ws-manager/pkg/manager/internal/workpool.(*EventWorkerPool).workUntilStopped+0x56	github.com/gitpod-io/gitpod/ws-manager/pkg/manager/internal/workpool/workpool.go:99

3 @ 0x43aec5 0x4068cf 0x40650b 0x16b34d3 0xd8b84e 0xd8b911 0x471e01
#	0x16b34d2	k8s.io/client-go/tools/cache.(*sharedProcessor).run+0x52		k8s.io/client-go@v0.20.4/tools/cache/shared_informer.go:628
#	0xd8b84d	k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1+0x2d	k8s.io/apimachinery@v0.20.4/pkg/util/wait/wait.go:56
#	0xd8b910	k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1+0x50		k8s.io/apimachinery@v0.20.4/pkg/util/wait/wait.go:73

3 @ 0x43aec5 0x4068cf 0x40650b 0x16b7d94 0x471e01
#	0x16b7d93	k8s.io/client-go/tools/cache.(*controller).Run.func1+0x33	k8s.io/client-go@v0.20.4/tools/cache/controller.go:130
```
