### PR TITLE
Add `/ide/bin` to PATH in bashrc prepend

### DIFF
--- a/components/image-builder/workspace-image-layer/gitpod-layer/amazon/gitpod/.bashrc-prepend
+++ b/components/image-builder/workspace-image-layer/gitpod-layer/amazon/gitpod/.bashrc-prepend
@@ -27,6 +27,8 @@ if [ ! -d "/ide/bin/" ]; then
     alias code='gp open'
 fi
 
+export PATH=/ide/bin:$PATH
+
 export GEM_HOME=/workspace/.rvm
 export GEM_PATH=$GEM_HOME:$GEM_PATH
 export PATH=/workspace/.rvm/bin:$PATH


### PR DESCRIPTION
# What

This PR adds a PATH export for `/ide/bin` to the bashrc prepend

# Background

Fixes #3821
