### PR TITLE
fix #3797: [code] reconnect to the extension host

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT a752a8a6ceb43b9add71c7d68f56b0acbdd5dcb7
+ENV GP_CODE_COMMIT e3ac4478d45fb75589b8fe975ddba55ca1559948
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/supervisor/frontend/src/ide/ide-web-socket.ts
+++ b/components/supervisor/frontend/src/ide/ide-web-socket.ts
@@ -34,6 +34,11 @@ class IDEWebSocket extends ReconnectingWebSocket {
             this.reconnect();
         }
     }
+    static disconnectWorkspace(): void {
+        for (const socket of workspaceSockets) {
+            socket.close();
+        }
+    }
 }
 
 export function install(): void {


### PR DESCRIPTION
#### What it does

- fix #3797: [code] reconnect to the extension host

The bug is that we pass net socket from the gitpod code server to the extension host process. And passing is done by serialising the socket in parent, then closing it for parent, passing to child process and deserialising. Before doing it though we should send a final seq of the handshake in the parent. And it used to work before we introduced gzipping of web sockets, it is not synchronous. So on reconnection it never came back. On initial connection there was a delay because of the child process should be spawn so it worked most of the time. Now we are always draining a socket before passing it to the child process.

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/e3ac4478d45fb75589b8fe975ddba55ca1559948

#### How to test

- Start a workspace with VS Code.
- Open devtools.
- Check that search works and language smartness is there for js file.
- In devtools's console: `window.WebSocket.disconnectWorkspace`  to trigger reconnection, you need to wait a bit like 30 seconds
- In devtools's network tab: check that new web sockets are established (not more than 2 for workspace origin!)
- Check that search works and language smartness is there for js file.
- Check in devtools's console that VS Code is not trying to reconnect forever.