### PR TITLE
[dashboard] Make Start page re-fetch workspace info after a connection drop

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -89,14 +89,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       this.setState({ startedInstanceId: result.instanceID });
       // Explicitly query state to guarantee we get at least one update
       // (needed for already started workspaces, and not hanging in 'Starting ...' for too long)
-      getGitpodService().server.getWorkspace(workspaceId).then(ws => {
-        if (ws.latestInstance) {
-          this.setState({
-            workspace: ws.workspace
-          });
-          this.onInstanceUpdate(ws.latestInstance);
-        }
-      });
+      this.fetchWorkspaceInfo();
     } catch (error) {
       console.error(error);
       if (typeof error === 'string') {
@@ -104,6 +97,26 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       }
       this.setState({ error });
     }
+  }
+
+  async fetchWorkspaceInfo() {
+    const { workspaceId } = this.props;
+    try {
+      const info = await getGitpodService().server.getWorkspace(workspaceId);
+      if (info.latestInstance) {
+        this.setState({
+          workspace: info.workspace
+        });
+        this.onInstanceUpdate(info.latestInstance);
+      }
+    } catch (error) {
+      console.error(error);
+      this.setState({ error });
+    }
+  }
+
+  notifyDidOpenConnection() {
+    this.fetchWorkspaceInfo();
   }
 
   async onInstanceUpdate(workspaceInstance: WorkspaceInstance) {


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3811

How to test:

1. Start a workspace
2. Turn off WiFi for a bit
3. Turn Wifi back on
4. Start page should catch up & not be stuck

Also:

1. Have a running workspace open
2. In a separate dashboard tab, click on "Stop" next to your workspace and immediately turn off WiFi
3. Return to the workspace tab (should show the IDE or Stopping...)
4. After a while, turn WiFi back on
5. Workspace tab should now show "Stopped" (and not the IDE, or "Stopping...", or "Starting...")