### PR TITLE
[go] Fix Go lib builds

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -8,7 +8,7 @@ defaultVariant:
   config:
     go:
       lintCommand: ["golangci-lint", "run", "--disable", "govet,typecheck"]
-      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
+      buildFlags: ["-trimpath", "-ldflags='-buildid= -w -s'"]
 
 variants:
 - name: oss


### PR DESCRIPTION
This PR fixes the Go library leeway package builds. Using `buildFlags` rather than the `buildCommand` allows the leeway default build mechanism to do its job.

That leeway doesn't rebuild packages when the variant changes is a separate problem.

### How to test
```
leeway build -c none components/common-go:lib
```