### PR TITLE
[Teams] Fix quantity type conversion

### DIFF
--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -616,7 +616,7 @@ function AddMembersModal(props: {
             <div className="flex flex-col space-y-2 pb-4">
                 <label htmlFor="quantity" className="font-medium">Members</label>
                 <select name="quantity" value={quantity} className="rounded-md w-full border-2 border-gray-400"
-                    onChange={(e) => setQuantity(e.target.value as any)}>
+                    onChange={(e) => setQuantity(parseInt(e.target.value || '1', 10))}>
                     {quantities.map(n => (
                         <option key={`quantity-${n}`} value={n}>{n}</option>
                     ))}
@@ -684,7 +684,7 @@ function NewTeamModal(props: {
             <div className="flex flex-col space-y-2">
                 <label htmlFor="quantity" className="font-medium">Members</label>
                 <select name="quantity" value={quantity} className="rounded-md w-full border-2 border-gray-400"
-                    onChange={(e) => setQuantity(e.target.value as any)}>
+                    onChange={(e) => setQuantity(parseInt(e.target.value || '1', 10))}>
                     {quantities.map(n => (
                         <option key={`quantity-${n}`} value={n}>{n}</option>
                     ))}


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3865

Explanation:
- `element.value` is always a string in HTML
- When we select a non-default value from the Team Plan Seat quantity selector, it changes `quantity` to a string in the React state
- Somewhere in checkout, something like `newQuantity = originalQuantity + extraQuantity` happens -- when `extraQuantity` is a string, it coerces `originalQuantity` to a string, and then just appends the extra digits