### PR TITLE
[supervisor] thread safe listening to terminals

### DIFF
--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -217,8 +217,8 @@ func (srv *MuxTerminalService) Listen(req *api.ListenTerminalRequest, resp api.T
 	errchan := make(chan error, 1)
 	messages := make(chan *api.ListenTerminalResponse, 1)
 	go func() {
-		buf := make([]byte, 4096)
 		for {
+			buf := make([]byte, 4096)
 			n, err := stdout.Read(buf)
 			if err == io.EOF {
 				break


### PR DESCRIPTION
#### What it does

grpc is buffering messages to deal with back pressure, so we cannot reuse buffer to read data from the terminal.

#### How to test

Try `ls -l` may times (like 100 🤪 ) in some workspace with many files. It should produce the same result each time.