### PR TITLE
clean up tokens on deauthorize

### DIFF
--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -196,9 +196,13 @@ export class UserService {
     }
 
     async checkTermsAccepted(user: User) {
-        const terms = this.termsProvider.getCurrent();
-        const accepted = await this.termsAcceptanceDb.getAcceptedRevision(user.id);
-        return !!accepted && (accepted.termsRevision === terms.revision);
+        // disabled terms acceptance check for now
+
+        return true;
+
+        // const terms = this.termsProvider.getCurrent();
+        // const accepted = await this.termsAcceptanceDb.getAcceptedRevision(user.id);
+        // return !!accepted && (accepted.termsRevision === terms.revision);
     }
 
     async isBlocked(params: CheckIsBlockedParams): Promise<boolean> {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -278,7 +278,8 @@ export class UserService {
 
     async deauthorize(user: User, authProviderId: string) {
         const externalIdentities = user.identities.filter(i => i.authProviderId !== TokenService.GITPOD_AUTH_PROVIDER_ID);
-        if (!externalIdentities.some(i => i.authProviderId === authProviderId)) {
+        const identity = externalIdentities.find(i => i.authProviderId === authProviderId)
+        if (!identity) {
             log.debug('Cannot deauthorize. Authorization not found.', { userId: user.id, authProviderId });
             return;
         }
@@ -286,6 +287,9 @@ export class UserService {
         if (externalIdentities.length === 1) {
             throw new Error("Cannot remove last provider authorization. Please delete account instead.");
         }
+
+        // explicitly remove associated tokens
+        await this.userDb.deleteTokens(identity);
 
         // effectively remove the provider authorization
         user.identities = user.identities.filter(i => i.authProviderId !== authProviderId);


### PR DESCRIPTION
# clean up tokens on deauthorize
fixes https://github.com/gitpod-io/gitpod/issues/3800

### how to test

1. authorize with two providers
2. disconnect one 
3. verify (in the db 🤷🏻‍♂️) that tokens are (marked as) deleted

# temporarily disable terms acceptance check in API

