### PR TITLE
[chart] Update Role, ClusterRoleBinding, RoleBinding to v1

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -6,6 +6,7 @@ appVersion: "0.1.5"
 description: The core chart for Gitpod
 name: gitpod
 version: 0.4.0
+kubeVersion: ">=1.17.0-0"
 
 dependencies:
 - name: docker-registry

--- a/chart/templates/blobserve-rolebinding.yaml
+++ b/chart/templates/blobserve-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: blobserve
   labels:

--- a/chart/templates/cerc-unprivileged-rolebinding.yaml
+++ b/chart/templates/cerc-unprivileged-rolebinding.yaml
@@ -3,7 +3,7 @@
 
 {{ if not .Values.components.cerc.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cerc
   labels:

--- a/chart/templates/cluster-privileged-psp-clusterrole.yaml
+++ b/chart/templates/cluster-privileged-psp-clusterrole.yaml
@@ -3,7 +3,7 @@
 
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-psp:privileged
   labels:

--- a/chart/templates/cluster-restricted-root-psp-clusterrole.yaml
+++ b/chart/templates/cluster-restricted-root-psp-clusterrole.yaml
@@ -3,7 +3,7 @@
 
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-psp:restricted-root-user
   labels:

--- a/chart/templates/cluster-unprivileged-psp-clusterrole.yaml
+++ b/chart/templates/cluster-unprivileged-psp-clusterrole.yaml
@@ -3,7 +3,7 @@
 
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-psp:unprivileged
   labels:

--- a/chart/templates/cluster-unprivileged-psp-nobody-rolebinding.yaml
+++ b/chart/templates/cluster-unprivileged-psp-nobody-rolebinding.yaml
@@ -3,7 +3,7 @@
 
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-nobody
   labels:

--- a/chart/templates/content-service-rolebinding.yaml
+++ b/chart/templates/content-service-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: content-service
   labels:

--- a/chart/templates/dashboard-rolebinding.yaml
+++ b/chart/templates/dashboard-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dashboard
   labels:

--- a/chart/templates/db-migrations-restricted-root-rolebinding.yaml
+++ b/chart/templates/db-migrations-restricted-root-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: db-migrations
   labels:

--- a/chart/templates/db-restricted-root-rolebinding.yaml
+++ b/chart/templates/db-restricted-root-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: db
   labels:

--- a/chart/templates/image-builder-psp-clusterrole.yaml
+++ b/chart/templates/image-builder-psp-clusterrole.yaml
@@ -3,7 +3,7 @@
 
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-image-builder
   labels:

--- a/chart/templates/image-builder-rolebinding.yaml
+++ b/chart/templates/image-builder-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: image-builder-rb
   labels:

--- a/chart/templates/messagebus-rolebinding.yaml
+++ b/chart/templates/messagebus-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: messagebus
   labels:

--- a/chart/templates/proxy-rolebinding.yaml
+++ b/chart/templates/proxy-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: proxy
   labels:

--- a/chart/templates/registry-facade-clusterrole.yaml
+++ b/chart/templates/registry-facade-clusterrole.yaml
@@ -3,7 +3,7 @@
 
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-registry-facade
   labels:

--- a/chart/templates/registry-facade-rolebinding.yaml
+++ b/chart/templates/registry-facade-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: registry-facade
   labels:

--- a/chart/templates/server-role.yaml
+++ b/chart/templates/server-role.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: server
   labels:

--- a/chart/templates/server-rolebinding.yaml
+++ b/chart/templates/server-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: server
   labels:

--- a/chart/templates/server-unprivileged-rolebinding.yaml
+++ b/chart/templates/server-unprivileged-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: server-unprivileged
   labels:

--- a/chart/templates/workspace-role.yaml
+++ b/chart/templates/workspace-role.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: workspace
   labels:

--- a/chart/templates/workspace-rolebinding.yaml
+++ b/chart/templates/workspace-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: workspace
   labels:

--- a/chart/templates/ws-daemon-clusterrole.yaml
+++ b/chart/templates/ws-daemon-clusterrole.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-ws-daemon
   labels:

--- a/chart/templates/ws-daemon-rolebinding.yaml
+++ b/chart/templates/ws-daemon-rolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ws-daemon-rb
   labels:

--- a/chart/templates/ws-manager-bridge-rolebinding.yaml
+++ b/chart/templates/ws-manager-bridge-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ws-manager-bridge
   labels:

--- a/chart/templates/ws-manager-role.yaml
+++ b/chart/templates/ws-manager-role.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/chart/templates/ws-manager-rolebinding.yaml
+++ b/chart/templates/ws-manager-rolebinding.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ws-manager

--- a/chart/templates/ws-manager-unpriviliged-rolebinding.yaml
+++ b/chart/templates/ws-manager-unpriviliged-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ws-manager-unpriviledged
   labels:

--- a/chart/templates/ws-proxy-rolebinding.yaml
+++ b/chart/templates/ws-proxy-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ws-proxy
   labels:

--- a/chart/templates/ws-scheduler-clusterrole.yaml
+++ b/chart/templates/ws-scheduler-clusterrole.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-ws-scheduler
   labels:

--- a/chart/templates/ws-scheduler-clusterrolebinding.yaml
+++ b/chart/templates/ws-scheduler-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-ns-ws-scheduler
   labels:

--- a/dev/charts/jaeger/templates/jaeger-rolebinding.yaml
+++ b/dev/charts/jaeger/templates/jaeger-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.jaeger.roleBinding -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jaeger
   labels:

--- a/dev/charts/poolkeeper/templates/clusterrole.yaml
+++ b/dev/charts/poolkeeper/templates/clusterrole.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: poolkeeper
   labels:

--- a/dev/charts/poolkeeper/templates/clusterrolebinding.yaml
+++ b/dev/charts/poolkeeper/templates/clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.installPodSecurityPolicies -}}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: poolkeeper
   labels:


### PR DESCRIPTION
Version `v1beta1` is deprecated since `v1.17+` and unavailable in `v1.22+`

Installing the helm chart in a 1.19 or 1.20 cluster throws errors like:
`W0411 17:13:01.738238 4068999 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
`