### PR TITLE
Replace editor screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Gitpod is an open-source Kubernetes application for automated and ready-to-code 
 
 Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and continuously prebuilds dev environments for all your branches. As a result, team members can instantly start coding with fresh, ephemeral and fully-compiled dev environments - no matter if you are building a new feature, want to fix a bug or do a code review.
 
-![image](https://user-images.githubusercontent.com/372735/90360227-6fc44180-e05b-11ea-8f66-71e96a836d78.png)
+![image](https://user-images.githubusercontent.com/120486/116072013-40a8aa00-a697-11eb-846b-89e6f5e1a82e.png)
 
 ## Features
 


### PR DESCRIPTION
This will replace the editor screenshot using the dark IDE theme.

Alternatively, we could a) use the light IDE theme or b) also include a dashboard screenshot but this change should suffice for now. What do you think? 🏓 

| Dashboard | Editor |
|-|-|
| ![Dashboard](https://user-images.githubusercontent.com/120486/114381680-0e298800-9b94-11eb-84aa-6c8114eb24ad.jpg) | ![Editor](https://user-images.githubusercontent.com/120486/114381687-0ff34b80-9b94-11eb-8f97-f21aaee3d5b3.jpg) |