### PR TITLE
[whats-new] update ideSettings if not set before

### DIFF
--- a/components/dashboard/src/WhatsNew.tsx
+++ b/components/dashboard/src/WhatsNew.tsx
@@ -22,13 +22,13 @@ export function WhatsNew(props: { visible: boolean, onClose: () => void }) {
         if (!user) {
             return;
         }
-        const additionalData = user.additionalData || {};
+        const additionalData = user.additionalData = user.additionalData || {};
         additionalData.whatsNewSeen = {
             ...additionalData.whatsNewSeen,
             [news]: new Date().toISOString()
         }
         // make sure code is set as the default IDE
-        const ideSettings = additionalData.ideSettings || {};
+        const ideSettings = additionalData.ideSettings = additionalData.ideSettings || {};
         ideSettings.defaultIde = 'code';
         await getGitpodService().server.updateLoggedInUser({
             additionalData


### PR DESCRIPTION
# what's new / ideSettings

if `additionalData` was empty before, it should now end up with populated `ideSettings` after checking the what's new modal.