### PR TITLE
[werft] set google terraform plugin to version 3.63.0

### DIFF
--- a/.werft/certs/versions.tf
+++ b/.werft/certs/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "3.63.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"


### PR DESCRIPTION
DNS could not be overwritten in the newer version of the Google Terraform plugin.