### PR TITLE
[image-builder] Change default garbage collector interval

### DIFF
--- a/components/image-builder/pkg/builder/gc.go
+++ b/components/image-builder/pkg/builder/gc.go
@@ -76,7 +76,12 @@ func (gc *GarbageCollector) CollectGarbage(ctx context.Context, maxAge time.Dura
 
 // Start schedules the garbage collector at regular intervals removing all artifacts older than maxAge
 func (gc *GarbageCollector) Start(ctx context.Context, maxAge time.Duration) {
-	t := time.NewTicker(maxAge / 2)
+	d := maxAge / 10
+	if d > 10*time.Minute {
+		d = 10 * time.Minute
+	}
+
+	t := time.NewTicker(d)
 
 	for {
 		gc.CollectGarbage(ctx, maxAge)


### PR DESCRIPTION
The actual value is [2h](https://github.com/gitpod-io/gitpod/blob/28e154b38d9a574f57ccca573de3638494377ee0/components/image-builder/pkg/builder/builder.go#L50)


fixes #3887