### PR TITLE
[dashboard] Allow granting a user 20 extra hours from the admin dashboard

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -109,7 +109,7 @@ export default function UserDetail(p: { user: User }) {
                                     label: 'View Account Statement',
                                     onClick: () => setViewAccountStatement(true)
                                 }, {
-                                    label: 'Grant 20h',
+                                    label: 'Grant 20 Extra Hours',
                                     onClick: async () => {
                                         await getGitpodService().server.adminGrantExtraHours(user.id, 20);
                                         setAccountStatement(await getGitpodService().server.adminGetAccountStatement(user.id));

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -28,6 +28,7 @@ export interface AdminServer {
     adminSetProfessionalOpenSource(userId: string, shouldGetProfOSS: boolean): Promise<void>;
     adminIsStudent(userId: string): Promise<boolean>;
     adminAddStudentEmailDomain(userId: string, domain: string): Promise<void>;
+    adminGrantExtraHours(userId: string, extraHours: number): Promise<void>;
 }
 
 export interface AdminGetListRequest<T> {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -120,6 +120,7 @@ function readConfig(): RateLimiterConfig {
         "adminGetAccountStatement":  { group: "default", points: 1 },
         "adminIsStudent":  { group: "default", points: 1 },
         "adminSetProfessionalOpenSource":  { group: "default", points: 1 },
+        "adminGrantExtraHours":  { group: "default", points: 1 },
         "checkout":  { group: "default", points: 1 },
         "createPortalSession":  { group: "default", points: 1 },
         "getAccountStatement":  { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1643,6 +1643,9 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     async adminAddStudentEmailDomain(userId: string, domain: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async adminGrantExtraHours(userId: string, extraHours: number): Promise<void> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     async isStudent(): Promise<boolean> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3511.

Has no effect on Core / OSS.

How to test:
- In a IO context, go to the Admin panel*, and search for your user
- Click on "Grant 20h", and confirm that this adds 20h to your balance

---

*Reminder: If you need to set yourself as admin:
- Open the IO branch in Gitpod
- Run `kubectl port-forward statefulset/mysql 3306 &` and then `mysql -h 127.0.0.1 -p` (the password is `test`)
- Run `use gitpod` and then `select id, name, rolesOrPermissions from d_b_user;` (this shows your user ID)
- Run `update d_b_user set rolesOrPermissions = '["admin"]' where id = <ID>;` (where `<ID>` is your user ID)
- You're now admin 🎉