### PR TITLE
publish npm packages from main always

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -2,7 +2,7 @@
 defaultTarget: components:all
 defaultArgs:
   coreYarnLockBase: ../..
-  publishToNPM: true
+  npmPublishTrigger: "false"
 
 defaultVariant:
   config:

--- a/components/gitpod-protocol/BUILD.yaml
+++ b/components/gitpod-protocol/BUILD.yaml
@@ -27,8 +27,8 @@ packages:
         - ["sh", "-c", "mv scripts/* ."]
   - name: publish
     type: generic
-    env:
-      - DO_PUBLISH=${publishToNPM}
+    argdeps:
+      - npmPublishTrigger
     deps:
       - :lib
       - :scripts

--- a/components/gitpod-protocol/scripts/publish.js
+++ b/components/gitpod-protocol/scripts/publish.js
@@ -15,11 +15,6 @@ const qualifier = process.argv[2];
 const rootDir = process.cwd();
 const pckDir = path.join(rootDir, process.argv[3]);
 
-if (process.env.DO_PUBLISH === "false") {
-    console.warn('Skipping publishing per request.');
-    process.exit(0);
-}
-
 if (process.env.NPM_AUTH_TOKEN) {
     fs.writeFileSync(path.join(pckDir, '.npmrc'), `//registry.npmjs.org/:_authToken=${process.env.NPM_AUTH_TOKEN}\n`, 'utf-8');
 } else {

--- a/components/supervisor-api/typescript-grpc/BUILD.yaml
+++ b/components/supervisor-api/typescript-grpc/BUILD.yaml
@@ -17,8 +17,8 @@ packages:
       tsconfig: tsconfig.json
   - name: publish
     type: generic
-    env:
-      - DO_PUBLISH=${publishToNPM}
+    argdeps:
+      - npmPublishTrigger
     deps:
       - :lib
       - components/gitpod-protocol:scripts

--- a/components/supervisor-api/typescript-grpcweb/BUILD.yaml
+++ b/components/supervisor-api/typescript-grpcweb/BUILD.yaml
@@ -17,8 +17,8 @@ packages:
       tsconfig: tsconfig.json
   - name: publish
     type: generic
-    env:
-      - DO_PUBLISH=${publishToNPM}
+    argdeps:
+      - npmPublishTrigger
     deps:
       - :lib
       - components/gitpod-protocol:scripts

--- a/components/supervisor-api/typescript-rest/BUILD.yaml
+++ b/components/supervisor-api/typescript-rest/BUILD.yaml
@@ -17,8 +17,8 @@ packages:
       tsconfig: tsconfig.json
   - name: publish
     type: generic
-    env:
-      - DO_PUBLISH=${publishToNPM}
+    argdeps:
+      - npmPublishTrigger
     deps:
       - :lib
       - components/gitpod-protocol:scripts


### PR DESCRIPTION
- [x] /werft publish-to-npm

#### What it does

fix #3895: It adds a new `publish-to-npm` config option for werft. If it's missing then packages should be published only if there are src or deps changes, otherwise always. For main branch this option is always present.

#### How to test

Check logs that after each werft run packages get republished from this PR.