### PR TITLE
updgrade to VS Code 1.55.x

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt-get update \
     && sudo apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GP_CODE_COMMIT e3ac4478d45fb75589b8fe975ddba55ca1559948
+ENV GP_CODE_COMMIT cbe1690286445dde2260d88e6de5bce1413465c6
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #3694: updgrade to VS Code 1.55.x
- fix #3553: see https://github.com/gitpod-io/gitpod/issues/3553#issuecomment-819504638

Changes in Gitpod Code: https://github.com/gitpod-io/vscode/commit/cbe1690286445dde2260d88e6de5bce1413465c6

#### How to test

- websockets and workers are properly proxied
    - diff editor should be operatable
    - trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old websockets are closed and new opened of the same amount, it can take around 30s
- that user data are sync across workspaces as well as on workspace restart, especially for extensions
    - test that extensions from .gitpod.yml are installed without sync
    - ignore CORS issues in logs, they are not matter
- terminals are preserved and resized properly between window reloads
- workspace specific commands should work, i.e. F1 → type Gitpod prefix
- that a PR view is preloaded on the PR url, make sure that you grant process scopes for GitHub installation, namely: `user: read` and `repo`
- test gp open and preview