### PR TITLE
[server] Implement a getAllEnvVars() method that doesn't filter on repository pattern precedence

### DIFF
--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -85,7 +85,7 @@ export default function EnvVars() {
     const [currentEnvVar, setCurrentEnvVar] = useState({ name: '', value: '', repositoryPattern: '' } as UserEnvVarValue);
     const [isAddEnvVarModalVisible, setAddEnvVarModalVisible] = useState(false);
     const update = async () => {
-        await getGitpodService().server.getEnvVars().then(r => setEnvVars(r));
+        await getGitpodService().server.getAllEnvVars().then(r => setEnvVars(r));
     }
 
     useEffect(() => {

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -80,12 +80,19 @@ function AddEnvVarModal(p: EnvVarModalProps) {
     </Modal>
 }
 
+function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
+    if (a.name === b.name) {
+        return a.repositoryPattern > b.repositoryPattern ? 1 : -1;
+    }
+    return a.name > b.name ? 1 : -1;
+}
+
 export default function EnvVars() {
     const [envVars, setEnvVars] = useState([] as UserEnvVarValue[]);
     const [currentEnvVar, setCurrentEnvVar] = useState({ name: '', value: '', repositoryPattern: '' } as UserEnvVarValue);
     const [isAddEnvVarModalVisible, setAddEnvVarModalVisible] = useState(false);
     const update = async () => {
-        await getGitpodService().server.getAllEnvVars().then(r => setEnvVars(r));
+        await getGitpodService().server.getAllEnvVars().then(r => setEnvVars(r.sort(sortEnvVars)));
     }
 
     useEffect(() => {

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -107,6 +107,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     // user env vars
     getEnvVars(): Promise<UserEnvVarValue[]>;
+    getAllEnvVars(): Promise<UserEnvVarValue[]>;
     setEnvVar(variable: UserEnvVarValue): Promise<void>;
     deleteEnvVar(variable: UserEnvVarValue): Promise<void>;
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -77,6 +77,7 @@ function readConfig(): RateLimiterConfig {
         "getUserStorageResource": { group: "default", points: 1 },
         "updateUserStorageResource": { group: "default", points: 1 },
         "getEnvVars": { group: "default", points: 1 },
+        "getAllEnvVars": { group: "default", points: 1 },
         "setEnvVar": { group: "default", points: 1 },
         "deleteEnvVar": { group: "default", points: 1 },
         "getContentBlobUploadUrl": { group: "default", points: 1 },


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3839

Context: The repository pattern precedence filtering was hoisted from theia into server in https://github.com/gitpod-io/gitpod/pull/3569, but it's not actually relevant to show users all their environment variables.