### PR TITLE
[werft] CN name may not exceed 63 characters

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -359,6 +359,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
             await certificatePromise;
             werft.done('certificate');
         } catch (err) {
+            werft.log('certificate', err.toString());  // This ensures the err message is picked up by the werft UI
             werft.fail('certificate', err);
         }
     }


### PR DESCRIPTION
Fixes #3505.

### Test
 - check that a domain with _exactly_ 63 characters works: https://werft.gitpod-dev.com/job/gitpod-build-gpl-test-very-long-branch-name-that-work.1
  - check that a domain with more characters does not work: https://werft.gitpod-dev.com/job/gitpod-build-gpl-test-very-long-branch-name-thats-expected.1