### PR TITLE
[build] revert removal of DO_PUBLISH env var

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -3,6 +3,7 @@ defaultTarget: components:all
 defaultArgs:
   coreYarnLockBase: ../..
   npmPublishTrigger: "false"
+  publishToNPM: true
 
 defaultVariant:
   config:

--- a/components/gitpod-protocol/BUILD.yaml
+++ b/components/gitpod-protocol/BUILD.yaml
@@ -27,6 +27,8 @@ packages:
         - ["sh", "-c", "mv scripts/* ."]
   - name: publish
     type: generic
+    env:
+      - DO_PUBLISH=${publishToNPM}
     argdeps:
       - npmPublishTrigger
     deps:

--- a/components/gitpod-protocol/scripts/publish.js
+++ b/components/gitpod-protocol/scripts/publish.js
@@ -15,6 +15,11 @@ const qualifier = process.argv[2];
 const rootDir = process.cwd();
 const pckDir = path.join(rootDir, process.argv[3]);
 
+if (process.env.DO_PUBLISH === "false") {
+    console.warn('Skipping publishing per request.');
+    process.exit(0);
+}
+
 if (process.env.NPM_AUTH_TOKEN) {
     fs.writeFileSync(path.join(pckDir, '.npmrc'), `//registry.npmjs.org/:_authToken=${process.env.NPM_AUTH_TOKEN}\n`, 'utf-8');
 } else {

--- a/components/supervisor-api/typescript-grpc/BUILD.yaml
+++ b/components/supervisor-api/typescript-grpc/BUILD.yaml
@@ -17,6 +17,8 @@ packages:
       tsconfig: tsconfig.json
   - name: publish
     type: generic
+    env:
+      - DO_PUBLISH=${publishToNPM}
     argdeps:
       - npmPublishTrigger
     deps:

--- a/components/supervisor-api/typescript-grpcweb/BUILD.yaml
+++ b/components/supervisor-api/typescript-grpcweb/BUILD.yaml
@@ -17,6 +17,8 @@ packages:
       tsconfig: tsconfig.json
   - name: publish
     type: generic
+    env:
+      - DO_PUBLISH=${publishToNPM}
     argdeps:
       - npmPublishTrigger
     deps:

--- a/components/supervisor-api/typescript-rest/BUILD.yaml
+++ b/components/supervisor-api/typescript-rest/BUILD.yaml
@@ -17,6 +17,8 @@ packages:
       tsconfig: tsconfig.json
   - name: publish
     type: generic
+    env:
+      - DO_PUBLISH=${publishToNPM}
     argdeps:
       - npmPublishTrigger
     deps:


### PR DESCRIPTION
It is to fix the build in com. If the build is green then it is fine. 