### PR TITLE
[preview-env] Fix wipedevstaging job

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -225,7 +225,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 
     // re-create namespace
     try {
-        wipeAndRecreateNamespace(helmInstallName, namespace, { slice: 'prep' });
+        await wipeAndRecreateNamespace(helmInstallName, namespace, { slice: 'prep' });
         setKubectlContextNamespace(namespace, { slice: 'prep' });
         namespaceRecreatedResolve();    // <-- signal for certificate
         werft.done('prep');

--- a/.werft/util/shell.ts
+++ b/.werft/util/shell.ts
@@ -29,7 +29,7 @@ export type ExecResult = {
 // exec executes a command and throws an exception if that command exits with a non-zero exit code
 export function exec(command: string): shell.ShellString;
 export function exec(command: string, options: ExecOptions & { async?: false }): shell.ShellString;
-export function exec(command: string, options: ExecOptions & { async: true }): ChildProcess;
+export function exec(command: string, options: ExecOptions & { async: true }): Promise<ExecResult>;
 export function exec(command: string, options: ExecOptions): shell.ShellString | ChildProcess;
 export function exec(cmd: string, options?: ExecOptions): ChildProcess | shell.ShellString | Promise<ExecResult> {
     if (options && options.slice) {

--- a/.werft/wipe-devstaging.ts
+++ b/.werft/wipe-devstaging.ts
@@ -1,0 +1,23 @@
+import { werft } from './util/shell';
+import { wipePreviewEnvironment, listAllPreviewNamespaces } from './util/kubectl';
+
+
+async function wipeDevstaging() {
+    const namespace_raw = process.env.NAMESPACE;
+    const namespaces: string[] = [];
+    if (namespace_raw === "<no value>" || !namespace_raw) {
+        werft.log('wipe', "Going to wipe all namespaces");
+        listAllPreviewNamespaces()
+            .map(ns => namespaces.push(ns));
+    } else {
+        werft.log('wipe', `Going to wipe namespace ${namespace_raw}`);
+        namespaces.push(namespace_raw);
+    }
+
+    for (const namespace of namespaces) {
+        await wipePreviewEnvironment("gitpod", namespace, { slice: 'wipe' });
+    }
+    werft.done('wipe');
+}
+
+wipeDevstaging()

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -32,20 +32,8 @@ pod:
       gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
       gcloud container clusters get-credentials dev --zone europe-west1-b --project gitpod-core-dev
 
-      NAMESPACE="{{ .Annotations.namespace }}"
-      if [ "$NAMESPACE" = "<no value>" ]; then
-        NAMESPACE=""
-        echo "Going to wipe all namespaces"
-      else
-        echo "Going to wipe namespace '$NAMESPACE'"
-      fi
+      export NAMESPACE="{{ .Annotations.namespace }}"
+      sudo chown -R gitpod:gitpod /workspace
 
-      for obj in clusterrole clusterrolebinding podsecuritypolicy namespace; do
-        werft log phase $obj Deleting old ${obj}...
-        OBJS_FILE=$(mktemp)
-        kubectl get $obj --no-headers -o=custom-columns=:metadata.name | grep -e staging -e testing | (grep "$NAMESPACE" || true) | tee "$OBJS_FILE"
-        if [ $(cat "$OBJS_FILE" | wc -l) -gt 0 ]; then
-          cat "$OBJS_FILE" | xargs kubectl delete $obj
-        fi
-        werft log phase $obj Deleted old ${obj}.
-      done
+      npm install shelljs semver ts-node typescript @types/shelljs @types/node @types/semver
+      npx ts-node .werft/wipe-devstaging.ts


### PR DESCRIPTION
Fix #3952.

### Test
 1. observe that this namespace was deployed properly (incl. sweeper): https://werft.gitpod-dev.com/job/gitpod-build-gpl-fix-namespace-deletion.2
 2. I then modified `deployment sweeper` so that it points to this branch (`gpl/fix-namespace-deletion`) and had a `--timeout 5m`
 3. observe that the job ran successfully: https://werft.gitpod-dev.com/job/gitpod-wipe-devstaging-gpl-fix-namespace-deletion.4
 4. observe that the namespace was completely removed (`kubectl get namespaces`)