### PR TITLE
[dashboard] Allow restoring a soft-deleted workspace from the admin dashboard

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -62,7 +62,12 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                 <div className="flex w-full mt-6">
                     <Property name="User"><Link className="text-blue-400 hover:text-blue-600" to={"/admin/users/" + props.workspace.ownerId}>{user?.name || props.workspace.ownerId}</Link></Property>
                     <Property name="Sharing">{workspace.shareable ? 'Enabled' : 'Disabled'}</Property>
-                    <Property name=""><div></div></Property>
+                    <Property name="Soft Deleted" actions={(!!workspace.softDeleted && !workspace.contentDeletedTime) && [{
+                        label: 'Restore & Pin',
+                        onClick: () => {
+                            getGitpodService().server.adminRestoreSoftDeletedWorkspace(workspace.workspaceId);
+                        }
+                    }] || undefined}>{workspace.softDeleted ? `'${workspace.softDeleted}' ${moment(workspace.softDeletedTime).fromNow()}` : 'No'}</Property>
                 </div>
                 <div className="flex w-full mt-12">
                     <Property name="Latest Instance ID">

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -21,6 +21,7 @@ export interface AdminServer {
     adminGetWorkspaces(req: AdminGetWorkspacesRequest): Promise<AdminGetListResult<WorkspaceAndInstance>>;
     adminGetWorkspace(id: string): Promise<WorkspaceAndInstance>;
     adminForceStopWorkspace(id: string): Promise<void>;
+    adminRestoreSoftDeletedWorkspace(id: string): Promise<void>;
 
     adminSetLicense(key: string): Promise<void>;
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -106,6 +106,7 @@ function readConfig(): RateLimiterConfig {
         "adminGetWorkspaces": { group: "default", points: 1 },
         "adminGetWorkspace": { group: "default", points: 1 },
         "adminForceStopWorkspace": { group: "default", points: 1 },
+        "adminRestoreSoftDeletedWorkspace": { group: "default", points: 1 },
         "adminSetLicense": { group: "default", points: 1 },
 
         "validateLicense": { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1507,6 +1507,10 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }
 
+    async adminRestoreSoftDeletedWorkspace(id: string): Promise<void> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
     async adminSetLicense(key: string): Promise<void> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3163

Enterprise / SaaS feature (admin dashboard).

How to test:

1. Log in to the [IO preview](https://jx-un-soft-delete.staging.gitpod-io-dev.com/workspaces/) (see also [IO branch](https://github.com/gitpod-com/gitpod/tree/jx/un-soft-delete), [IO werft job](https://werft.gitpod-io-dev.com/job/gitpod-build-jx-un-soft-delete.4))
2. Become admin (ask me or [see how](https://github.com/gitpod-io/gitpod/pull/3929#issue-615055820))
3. Start a workspace
4. Delete the workspace
5. Go to the admin dashboard, see that the workspace has been soft-deleted (`'user'`), click to `Restore & Pin` it
6. Voilà