### PR TITLE
[supervisor info] don't fail workspace info if workspace root is removed

### DIFF
--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -604,9 +604,8 @@ func (is *InfoService) WorkspaceInfo(context.Context, *api.WorkspaceInfoRequest)
 	if contentReady {
 		stat, err := os.Stat(is.cfg.WorkspaceRoot)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		if stat.IsDir() {
+			log.WithError(err).Error("workspace info: cannot resolve the workspace root")
+		} else if stat.IsDir() {
 			resp.WorkspaceLocation = &api.WorkspaceInfoResponse_WorkspaceLocationFolder{WorkspaceLocationFolder: is.cfg.WorkspaceRoot}
 		} else {
 			resp.WorkspaceLocation = &api.WorkspaceInfoResponse_WorkspaceLocationFile{WorkspaceLocationFile: is.cfg.WorkspaceRoot}


### PR DESCRIPTION
fix #3752

#### How to test

- Start a workspace https://ak-workspace-info.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod
- Rename gitpod-ws.code-workspace
- The window should reload and open an empty workspace, but don't fail
- You can then reopen the proper workspace file via `File` -> `Open Workspace` menu item