### PR TITLE
[ws-proxy] Don't reuse log entry

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -376,10 +376,11 @@ func logHandler(h http.Handler) http.Handler {
 			wsID = vars[workspaceIDIdentifier]
 			port = vars[workspacePortIdentifier]
 		)
-		entry := log.
-			WithField("workspaceId", wsID).
-			WithField("portID", port).
-			WithField("url", req.URL.String())
+		entry := logrus.Fields{
+			"workspaceId": wsID,
+			"portID":      port,
+			"url":         req.URL.String(),
+		}
 		ctx := context.WithValue(req.Context(), logContextValueKey, entry)
 		req = req.WithContext(ctx)
 
@@ -398,12 +399,12 @@ func logRouteHandlerHandler(routeHandlerName string) mux.MiddlewareFunc {
 
 func getLog(ctx context.Context) *logrus.Entry {
 	r := ctx.Value(logContextValueKey)
-	rl, ok := r.(*logrus.Entry)
+	rl, ok := r.(logrus.Fields)
 	if rl == nil || !ok {
 		return log.Log
 	}
 
-	return rl
+	return log.WithFields(rl)
 }
 
 func sensitiveCookieHandler(domain string) func(h http.Handler) http.Handler {


### PR DESCRIPTION
This PR fixes intermittent ws-proxy crashes caused by concurrent map modification of the same log entry:
![image](https://user-images.githubusercontent.com/3210701/115199190-3ca6e600-a0f3-11eb-87c8-eb6ef7c53647.png)


fixes #3974

