### PR TITLE
[chart] Set EnableServiceLinks=false

### DIFF
--- a/chart/templates/blobserve-deployment.yaml
+++ b/chart/templates/blobserve-deployment.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: blobserve
+      enableServiceLinks: false
       containers:
       - name: blobserve
         image: {{ template "gitpod.comp.imageFull" $this }}

--- a/chart/templates/cerc-deployment.yaml
+++ b/chart/templates/cerc-deployment.yaml
@@ -38,6 +38,7 @@ spec:
       serviceAccountName: cerc
       securityContext:
         runAsUser: 1000
+      enableServiceLinks: false
       containers:
       - name: cerc
         image: {{ template "gitpod.comp.imageFull" $this }}

--- a/chart/templates/content-service-deployment.yaml
+++ b/chart/templates/content-service-deployment.yaml
@@ -44,6 +44,7 @@ spec:
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: content-service
+      enableServiceLinks: false
       containers:
       - name: content-service
         image: {{ template "gitpod.comp.imageFull" $this }}

--- a/chart/templates/dashboard-deployment.yaml
+++ b/chart/templates/dashboard-deployment.yaml
@@ -39,6 +39,7 @@ spec:
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: dashboard
+      enableServiceLinks: false
       containers:
       - name: dashboard
         image: {{ template "gitpod.comp.imageFull" $this }}

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -37,6 +37,7 @@ spec:
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: db
+      enableServiceLinks: false
       containers:
       - name: cloud-sql-proxy
         securityContext:

--- a/chart/templates/db-migrations-job.yaml
+++ b/chart/templates/db-migrations-job.yaml
@@ -38,6 +38,7 @@ spec:
 {{- range $key, $value := .Values.defaults.imagePullSecrets }}
       - name: {{ $value.name }}
 {{- end }}
+      enableServiceLinks: false
       containers:
       - name: db-migrations
         image: "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" .Values "comp" $.Values.components.dbMigrations) }}"

--- a/chart/templates/image-builder-deployment.yaml
+++ b/chart/templates/image-builder-deployment.yaml
@@ -64,6 +64,7 @@ spec:
         secret:
           secretName: {{ $sec.secret }}
 {{- end }}
+      enableServiceLinks: false
       containers:
       - name: dind
         image: {{ $comp.dindImage | default "docker:19.03-dind" }}

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -74,6 +74,7 @@ spec:
       serviceAccount: proxy
       securityContext:
         runAsNonRoot: false
+      enableServiceLinks: false
       initContainers:
         - name: "sysctl"
           image: "alpine:3.13"

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: registry-facade
+      enableServiceLinks: false
 {{- if $comp.handover.enabled }}
       initContainers:
       - name: handover-ownership

--- a/chart/templates/restarter-cronjob.yaml
+++ b/chart/templates/restarter-cronjob.yaml
@@ -21,6 +21,7 @@ spec:
     spec:
       template:
         spec:
+          enableServiceLinks: false
           containers:
           - name: kubectl
             image: {{ .Values.components.restarter.image }}

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -83,6 +83,7 @@ spec:
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: server
+      enableServiceLinks: false
       initContainers:
 {{ include "gitpod.msgbusWaiter.container" $this | indent 6 }}
 {{ include "gitpod.databaseWaiter.container" $this | indent 6 }}

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -105,6 +105,7 @@ spec:
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}
+      enableServiceLinks: false
 {{- if (or $comp.userNamespaces.shiftfsModuleLoader.enabled $comp.userNamespaces.seccompProfileInstaller.enabled) }}
       initContainers:
 {{- end }}

--- a/chart/templates/ws-manager-bridge-deployment.yaml
+++ b/chart/templates/ws-manager-bridge-deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-manager-bridge
+      enableServiceLinks: false
       initContainers:
 {{ include "gitpod.databaseWaiter.container" $this | indent 6 }}
 {{ include "gitpod.msgbusWaiter.container" $this | indent 6 }}

--- a/chart/templates/ws-manager-deployment.yaml
+++ b/chart/templates/ws-manager-deployment.yaml
@@ -60,6 +60,7 @@ spec:
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}
+      enableServiceLinks: false
       containers:
       - name: ws-manager
         args: ["run", "-v", "--config", "/config/config.json"]

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         secret:
           secretName: {{ $.Values.certificatesSecret.secretName }}
 {{- end }}
+      enableServiceLinks: false
       containers:
       - name: ws-proxy
         image: {{ template "gitpod.comp.imageFull" $this }}

--- a/chart/templates/ws-scheduler-deployment.yaml
+++ b/chart/templates/ws-scheduler-deployment.yaml
@@ -50,6 +50,7 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: {{ .Values.components.wsManager.tls.client.secretName }}
+      enableServiceLinks: false
       containers:
       - name: scheduler
         args: ["run", "-v", "--config", "/config/config.json"]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -312,6 +312,7 @@ components:
     template:
       default:
         spec:
+            enableServiceLinks: false
             dnsConfig:
             nameservers:
             - 1.1.1.1

--- a/dev/charts/jaeger/templates/jaeger-deployment.yaml
+++ b/dev/charts/jaeger/templates/jaeger-deployment.yaml
@@ -29,6 +29,7 @@ spec:
       serviceAccountName: monitoring-jaeger
       securityContext:
         runAsUser: 1000
+      enableServiceLinks: false
       containers:
       - image: jaegertracing/all-in-one:1.14
         imagePullPolicy: Always

--- a/dev/charts/poolkeeper/templates/deployment.yaml
+++ b/dev/charts/poolkeeper/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       serviceAccountName: {{ include "poolkeeper.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/dev/charts/sweeper/templates/deployment.yaml
+++ b/dev/charts/sweeper/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
**How to test:** the output of the command

``` 
kubectl get pods \
  --output=jsonpath='{range .items[*]}{@.spec.enableServiceLinks}{" "}{@.metadata.name}{"\n"}{end}'
``` 

should contain true only for `messagebus`, `minio` and `mysql`
```
false blobserve-67546bd7d-fhcpq
false content-service-8b85bc586-ldhct
false dashboard-79444765cd-m7s9r
false image-builder-6987c856b-zc977
false jaeger-5b759b49cc-dgxxf
true messagebus-0
true minio-5b5c5bfbf4-nbpgp
true mysql-0
false proxy-85b4664bc5-r8qlg
false registry-facade-cbhzs
false registry-facade-mb9jx
false registry-facade-q7w6n
false registry-facade-wmkct
false server-546659b9b5-665xc
false sweeper-6bff6bf7dd-tl47k
false ws-daemon-4xrb7
false ws-daemon-k6gqb
false ws-daemon-w2fhz
false ws-daemon-xbg6w
false ws-manager-6558978946-44dsf
false ws-manager-bridge-5b7877fd94-sw825
false ws-proxy-67cd5d6969-sp7ls
false ws-scheduler-666c4d7f59-gjbjb
``` 

Starting a workspace and running the command should also return `false`


fixes #4011
fixes #4012