### PR TITLE
[jaeger] fixed jaeger deployment in werft using jaeger-operator

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -338,9 +338,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 
         exec(`helm dependencies up`);
         exec(`/usr/local/bin/helm3 upgrade --install --timeout 10m -f ../.werft/values.dev.yaml ${flags} ${helmInstallName} .`);
-
-        werft.log('helm', 'installing Jaeger');
-        exec(`/usr/local/bin/helm3 upgrade --install -f ../dev/charts/jaeger/values.yaml ${flags} jaeger ../dev/charts/jaeger`);
+        exec(`kubectl apply -f ../.werft/jaeger.yaml`);
 
         if (!wsCluster) {
             werft.log('helm', 'installing Sweeper');

--- a/.werft/certs/main.tf
+++ b/.werft/certs/main.tf
@@ -25,15 +25,3 @@ provider "google" {
 provider "kubectl" {
   load_config_file       = true
 }
-
-# The kubernetes backend is brand new (https://github.com/hashicorp/terraform/issues/19525, got released with 0.13.0 7 days ago) and
-# seems to have issues with the GCP Application Default Credentials.
-# https://www.terraform.io/docs/backends/types/kubernetes.html
-# terraform {
-#     backend "kubernetes" {
-#         # We want to store .tfstate in a separate secret per branch. Since terraform does not allow this we use g'old envsubst :-|
-#         secret_suffix    = "${NAMESPACE}"
-#         namespace = "certs"
-#         load_config_file = true
-#     }
-# }

--- a/.werft/certs/versions.tf
+++ b/.werft/certs/versions.tf
@@ -1,4 +1,7 @@
 terraform {
+  backend "gcs" {
+    bucket  = "gitpod-core-dev-terraform"
+  }
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/.werft/jaeger.yaml
+++ b/.werft/jaeger.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: jaeger-psp
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - jaeger-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: jaeger
+subjects:
+  - kind: ServiceAccount
+    name: jaeger
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jaeger-psp
+---
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger
+spec:
+  strategy: allInOne
+  storage:
+    options:
+      memory:
+        max-traces: 100
+  ingress:
+    enabled: false

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -21,8 +21,8 @@ export async function issueCertficate(werft, pathToTerraform, gcpSaPath, namespa
     // Always use 'terraform apply' to make sure the certificate is present and up-to-date
     await exec(`set -x \
         && cd ${pathToTerraform} \
-        && terraform init \
         && export GOOGLE_APPLICATION_CREDENTIALS="${gcpSaPath}" \
+        && terraform init -backend-config='prefix=${namespace}'\
         && terraform apply -auto-approve \
             -var 'namespace=${namespace}' \
             -var 'dns_zone_domain=${dnsZoneDomain}' \

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -117,7 +117,6 @@ export function deleteNamespace(wait: boolean, namespace: string, shellOpts: Exe
 
 export function deleteNonNamespaceObjects(namespace, destname, shellOpts) {
     exec(`/usr/local/bin/helm3 delete gitpod-${destname} || echo gitpod-${destname} was not installed yet`, { slice: 'predeploy cleanup' });
-    exec(`/usr/local/bin/helm3 delete jaeger-${destname} || echo jaeger-${destname} was not installed yet`, { slice: 'predeploy cleanup' });
 
     let objs = [];
     ["ws-scheduler", "node-daemon", "cluster", "workspace", "jaeger", "jaeger-agent", "ws-sync", "ws-manager-node", "ws-daemon", "registry-facade"].forEach(comp =>


### PR DESCRIPTION
This make jaeger run again in preview environments using the preinstalled `jaeger-operator`. It also uses a state file for Terraform to keep the state for redeployment and dns record removal.
You can test it by deploying a new branch on `gitpod-dev`and visit the URL https://<NAMESPACE>.jaeger.gitpod-dev.com or simply https://wth-add-jaeger-to-prev.jaeger.gitpod-dev.com/.