### PR TITLE
[theia] fix installing big extensions

### DIFF
--- a/components/ide/theia/leeway.Dockerfile
+++ b/components/ide/theia/leeway.Dockerfile
@@ -38,7 +38,7 @@ ENV PATH=$PATH:/usr/bin/
 
 WORKDIR /theia
 
-ENV THEIA_APP_COMMIT 04b3d2db03f140a9a3cd463f921fe717ce6deefe
+ENV THEIA_APP_COMMIT 1ca36afb4c1b4a756d5133c06b97e01b4551bc8b
 RUN mkdir theia-app \
     && cd theia-app \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #4025: changes in Theia: https://github.com/gitpod-io/theia-app/commit/1ca36afb4c1b4a756d5133c06b97e01b4551bc8b

#### How to test

- Switch to Theia.
- Start a workspace and try to install big extensions like Java.
- Test the same on staging against GCP storage: https://github.com/gitpod-com/gitpod/pull/5295