### PR TITLE
[jaeger] schedule jaeger to workload nodes

### DIFF
--- a/.werft/jaeger.yaml
+++ b/.werft/jaeger.yaml
@@ -29,6 +29,15 @@ kind: Jaeger
 metadata:
   name: jaeger
 spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: dev/workload
+                operator: In
+                values:
+                  - workload
   strategy: allInOne
   storage:
     options:


### PR DESCRIPTION
This is a follow up to #4024 making sure that jaeger pods are scheduled to run only on workload nodes.