### PR TITLE
[code] add missing web deps

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT cbe1690286445dde2260d88e6de5bce1413465c6
+ENV GP_CODE_COMMIT 9701055e7471b4d2edf281cbdb479bbb57f78e8c
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -31,4 +31,4 @@ export USER=gitpod
 [ -s ~/.nvm/nvm-lazy.sh ] && source ~/.nvm/nvm-lazy.sh
 
 cd /ide
-exec /ide/node/bin/gitpod-node --inspect=0 ./out/gitpod.js $*
+exec /ide/node/bin/gitpod-node ./out/gitpod.js $*


### PR DESCRIPTION
#### What it does

- fix #3874: web part were built with filter for native deps, not web and removed jschardet. This dep is used sometimes.

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/9701055e7471b4d2edf281cbdb479bbb57f78e8c

#### How to test

- Start a workspace.
- Check jschardet is there, it should be on this path: node_modules/jschardet/dist/jschardet.min.js
