### PR TITLE
[ws-manager] Metrics for control ports

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -580,7 +580,7 @@ func (m *Manager) ControlPort(ctx context.Context, req *api.ControlPortRequest) 
 	notifyStatusChange := func() error {
 		// by modifying the ports service we have changed the workspace status. However, this status change is not propagated
 		// through the regular monitor mechanism as we did not modify the pod itself. We have to send out a status update
-		// outselves. Doing it ourselves lets us synchronize the status update with probing for actual availability, not just
+		// ourselves. Doing it ourselves lets us synchronize the status update with probing for actual availability, not just
 		// the service modification in Kubernetes.
 		wso := workspaceObjects{Pod: pod, PortsService: &service}
 		err := m.completeWorkspaceObjects(ctx, &wso)

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -33,6 +33,8 @@ type metrics struct {
 	startupTimeHistVec    *prometheus.HistogramVec
 	totalStartsCounterVec *prometheus.CounterVec
 	totalStopsCounterVec  *prometheus.CounterVec
+	openedPorts           *prometheus.Gauge
+	controlPortDuration       *prometheus.Histogram
 
 	mu         sync.Mutex
 	phaseState map[string]api.WorkspacePhase


### PR DESCRIPTION
When ready, this PR should introduce 2 new metrics for `ws-manager`:
* Current amount of opened ports (Gauge)
* Duration of the controlPort operation (Histogram)