### PR TITLE
[code] use 0 cols and rows as default pty size

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 9701055e7471b4d2edf281cbdb479bbb57f78e8c
+ENV GP_CODE_COMMIT cee6bf3c885a93cb6344da8747db3c66b6590991
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #3553: the pty can produce data before the initial size is provided, so instead of setting (1, 1) as initial size, we set (0, 0) meaning that pty should use internal default which later get overridden by the initial size

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/cee6bf3c885a93cb6344da8747db3c66b6590991

#### How to test

- Start a workspace.
- Emulate slow connection on OS level, start a new terminal.
- You should not see anything like `your 131072x1 screen size is bogus. expect trouble`
- Some content thought can be resized bogusly since it was produced before the initial resize but after that the size should be correct. You can verify current size with `stty -a`