### PR TITLE
[ws-manager] Add metric counting total open ports

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -664,9 +664,10 @@ func (m *Manager) createPortsService(workspaceID string, metaID string, serviceP
 			Name:      serviceName,
 			Namespace: m.Config.Namespace,
 			Labels: map[string]string{
-				"workspaceID":     workspaceID,
-				wsk8s.MetaIDLabel: metaID,
-				markerLabel:       "true",
+				"workspaceID":          workspaceID,
+				wsk8s.MetaIDLabel:      metaID,
+				markerLabel:            "true",
+				wsk8s.ServiceTypeLabel: "ports",
 			},
 			Annotations: annotations,
 		},

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -191,6 +191,11 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	// mandatory Theia service
 	servicePrefix := getServicePrefix(req)
 	theiaServiceName := getTheiaServiceName(servicePrefix)
+	theiaServiceLabels := make(map[string]string, len(startContext.Labels)+1)
+	for k, v := range startContext.Labels {
+		theiaServiceLabels[k] = v
+	}
+	theiaServiceLabels[wsk8s.ServiceTypeLabel] = "ide"
 	theiaService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      theiaServiceName,

--- a/components/ws-manager/pkg/manager/testdata/controlPort_changeTargetPort.nt.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_changeTargetPort.nt.golden
@@ -7,6 +7,7 @@
             "labels": {
                 "gpwsman": "true",
                 "metaID": "",
+                "serviceType": "ports",
                 "workspaceID": "foobar"
             },
             "annotations": {

--- a/components/ws-manager/pkg/manager/testdata/controlPort_createPrivate.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_createPrivate.golden
@@ -7,6 +7,7 @@
             "labels": {
                 "gpwsman": "true",
                 "metaID": "",
+                "serviceType": "ports",
                 "workspaceID": "foobar"
             },
             "annotations": {

--- a/components/ws-manager/pkg/manager/testdata/controlPort_firstOpen_withTargetPort.golden
+++ b/components/ws-manager/pkg/manager/testdata/controlPort_firstOpen_withTargetPort.golden
@@ -7,6 +7,7 @@
             "labels": {
                 "gpwsman": "true",
                 "metaID": "",
+                "serviceType": "ports",
                 "workspaceID": "foobar"
             },
             "annotations": {


### PR DESCRIPTION
This PR adds a metric for counting the total number of exposed ports across all workspaces.