### PR TITLE
[code] proxy fetch in web workers

### DIFF
--- a/components/supervisor/frontend/public/worker-proxy.js
+++ b/components/supervisor/frontend/public/worker-proxy.js
@@ -15,8 +15,28 @@
     var originalImportScripts = self.importScripts;
     // hash contains the original worker URL to be used as a base URI to resolve script URLs
     var baseURI = decodeURI(location.hash.substr(1));
-    self.importScripts = function (scriptUrl) {
-        return originalImportScripts(new URL(scriptUrl, baseURI).toString());
+
+    self.importScripts = function (...scriptUrls) {
+        return originalImportScripts(...scriptUrls.map(scriptUrl => new URL(scriptUrl, baseURI).toString()));
     }
+
+    var originalFetch = self.fetch;
+    self.fetch = function (input, init) {
+        if (typeof input === 'string') {
+            return originalFetch(new URL(input, baseURI).toString(), init);
+        }
+        return originalFetch(input, init);
+    }
+
+    var originalRequest = self.Request;
+    function RequestProxy(input, init) {
+        if (typeof input === 'string') {
+            return new originalRequest(new URL(input, baseURI).toString(), init);
+        }
+        return new originalRequest(input, init);
+    }
+    RequestProxy.prototype = Object.create(originalRequest)
+    self.Request = RequestProxy;
+
     originalImportScripts(baseURI);
 })();


### PR DESCRIPTION
#### What it does

- fix #4063: VS Code switched to use fetch instead of importScripts to load additional scripts becuase latter hangs on Safari sometimes, so we should proxy former as well

#### How to test

- Start a workspace with VS Code.
- Check that diff editors are working.
- Check that opening the output channel does not trigger load of errors, also link resolution should work.
- Test in Chrome, FF and Safari.