### PR TITLE
[dashboard] redirect users to www when logged out

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -79,7 +79,13 @@ function App() {
             }
             window.removeEventListener('storage', updateTheme);
         }
-    }, [localStorage.theme]);
+    }, []);
+
+    if ((window.location.hostname === 'gitpod.io' || window.location.hostname === 'gitpod-staging.com' || window.location.hostname.endsWith('gitpod-dev.com')) 
+        && window.location.pathname === '/' && window.location.hash === '' && !loading && !user) {
+        window.location.href = `https://www.gitpod.io`;
+        return <div></div>;
+    }
 
     if (loading) {
         return <Loading />


### PR DESCRIPTION
We want to redirect not logged in users from the root URL with no additional context provided to the website.

fixes https://github.com/gitpod-io/gitpod/issues/3898

how to test:
- Test https://se-www-redirect.staging.gitpod-dev.com/ (should redirect to https://www.gitpod.io)
- https://se-www-redirect.staging.gitpod-dev.com/workspaces/ (should not redirect)
- login
- Test https://se-www-redirect.staging.gitpod-dev.com/ (should redirect to /workspaces)
- logout (should redirect to website again)