### PR TITLE
Selective new-user blocking

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -35,6 +35,9 @@ components:
     makeNewUsersAdmin: true # for development
     theiaPluginsBucketName: gitpod-core-dev-plugins
     enableLocalApp: true
+    blockNewUsers: true
+    blockNewUsersPasslist:
+      - "gitpod.io"
 
   registryFacade:
     daemonSet: true

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -158,6 +158,8 @@ spec:
     {{- if $comp.blockNewUsers }}
         - name: BLOCK_NEW_USERS
           value: {{ $comp.blockNewUsers | quote }}
+        - name: BLOCK_NEW_USERS_PASSLIST
+          value: {{ $comp.blockNewUsersPasslist | toJson | quote }}
     {{- end }}
     {{- if $comp.makeNewUsersAdmin }}
         - name: MAKE_NEW_USERS_ADMIN

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -265,6 +265,7 @@ components:
     github:
       app: {}
     blockNewUsers: false
+    blockNewUsersPasslist: []
     runDbDeleter: true
     storage: {}
     wsman: []

--- a/components/server/src/env.ts
+++ b/components/server/src/env.ts
@@ -138,6 +138,20 @@ export class Env extends AbstractComponentEnv {
     }
 
     readonly blockNewUsers: boolean = this.parseBool("BLOCK_NEW_USERS");
+    readonly blockNewUsersPassList: string[] = (() => {
+        const l = getEnvVar("BLOCK_NEW_USERS_PASSLIST");
+        try {
+            const res = JSON.parse(l);
+            if (!Array.isArray(res) || res.some(e => typeof e !== 'string')) {
+                console.error("BLOCK_NEW_USERS_PASSLIST is not an array of string");
+                return [];
+            }
+            return res;
+        } catch (err) {
+            console.error("cannot parse BLOCK_NEW_USERS_PASSLIST", err);
+            return [];
+        }
+    })();
     readonly makeNewUsersAdmin: boolean = this.parseBool("MAKE_NEW_USERS_ADMIN");
     readonly disableDynamicAuthProviderLogin: boolean = this.parseBool("DISABLE_DYNAMIC_AUTH_PROVIDER_LOGIN");
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -140,7 +140,10 @@ export class UserService {
     }
     protected handleNewUser(newUser: User, isFirstUser: boolean) {
         if (this.env.blockNewUsers) {
-            newUser.blocked = true;
+            const emailDomainInPasslist = (mail: string) => this.env.blockNewUsersPassList.some(e => mail.endsWith(`@${e}`));
+            const canPass = newUser.identities.some(i => !!i.primaryEmail && emailDomainInPasslist(i.primaryEmail));
+
+            newUser.blocked = !canPass;
         }
         if (isFirstUser || this.env.makeNewUsersAdmin) {
             newUser.rolesOrPermissions = ['admin'];


### PR DESCRIPTION
In some Gitpod installations new users get blocked by default.  This PR adds the ability to do this new user blocking selectively based on the domain of their primary email. Supersedes #3899 

### How to test
1. Login in https://cw-newuser-passlist.staging.gitpod-dev.com/workspaces with a user with an @gitpod.io primary email - you should be able to start a workspace
2. Login in https://cw-newuser-passlist.staging.gitpod-dev.com/workspaces with a user with a different primary email - should be blocked

### ToDo before merging
- drop https://github.com/gitpod-io/gitpod/commit/7e990e0136366286033c20303d1a37f7171399fa