### PR TITLE
Revert "[core-dev] Block all new users but @gitpod.io"

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -35,9 +35,6 @@ components:
     makeNewUsersAdmin: true # for development
     theiaPluginsBucketName: gitpod-core-dev-plugins
     enableLocalApp: true
-    blockNewUsers: true
-    blockNewUsersPasslist:
-      - "gitpod.io"
 
   registryFacade:
     daemonSet: true


### PR DESCRIPTION
This reverts commit ded9df568824936e5bccd57f7b46dbbef83824a0.

Reason: https://github.com/gitpod-io/gitpod/pull/4073 was merged without doing this:

> ### ToDo before merging
> - drop https://github.com/gitpod-io/gitpod/commit/7e990e0136366286033c20303d1a37f7171399fa