### PR TITLE
[theia] fix plugins upload

### DIFF
--- a/components/ide/theia/leeway.Dockerfile
+++ b/components/ide/theia/leeway.Dockerfile
@@ -38,7 +38,7 @@ ENV PATH=$PATH:/usr/bin/
 
 WORKDIR /theia
 
-ENV THEIA_APP_COMMIT 1ca36afb4c1b4a756d5133c06b97e01b4551bc8b
+ENV THEIA_APP_COMMIT 1ec34c38a6f49311586c309d9f62c73a0306ef74
 RUN mkdir theia-app \
     && cd theia-app \
     && git init \


### PR DESCRIPTION
- [x] /werft storage=gcp

#### What it does

- apply https://github.com/gitpod-io/theia-app/commit/1ec34c38a6f49311586c309d9f62c73a0306ef74 to pipe actual content around proxies

~- It reverts redirecting theia plugin upload and proxy pass them instead.~

~I'm not sure why redirects does not work, but also I don't think we care at the moment whether it is redirect or not. Theia should go away rather soon.~

One theory is that nginx opens body and start buffering it before sending a redirect, so a client gets closed connection on another end. But it does not explain why small extensions are fine with redirects while big not. Relevant logs maybe:
```
2021/04/27 14:43:08 [warn] 84#84: *372 a client request body is buffered to a temporary file /var/run/openresty/nginx-client-body/0000000003 while sending to client, client: 10.60.35.159, server: ak-fix-theia-plugin-upload.staging.gitpod-dev.com, request: "PUT /plugins?id=bc127afa-c8d5-46ee-a131-8c0f567f0dc9 HTTP/1.1", host: "ak-fix-theia-plugin-upload.staging.gitpod-dev.com"
{}
```

#### How to test

- Login and configure to use Theia.
- Start a workspace and try to install Java extension.