### PR TITLE
[dashboard/auth] don't override scopes when trying to acquire addional

### DIFF
--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -39,13 +39,15 @@ interface OpenAuthorizeWindowParams {
     login?: boolean;
     host: string;
     scopes?: string[];
+    overrideScopes?: boolean;
     onSuccess?: (payload?: string) => void;
     onError?: (error?: string) => void;
 }
 
 async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
-    const { login, host, scopes, onSuccess, onError } = params;
+    const { login, host, scopes, overrideScopes, onSuccess, onError } = params;
     const returnTo = gitpodHostUrl.with({ pathname: 'complete-auth', search: 'message=success' }).toString();
+    const requestedScopes = scopes || [];
     const url = login
         ? gitpodHostUrl.withApi({
             pathname: '/login',
@@ -53,7 +55,7 @@ async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
         }).toString()
         : gitpodHostUrl.withApi({
             pathname: '/authorize',
-            search: `returnTo=${encodeURIComponent(returnTo)}&host=${host}&override=true&scopes=${(scopes || []).join(',')}`
+            search: `returnTo=${encodeURIComponent(returnTo)}&host=${host}${overrideScopes ? "&override=true" : ""}&scopes=${requestedScopes.join(',')}`
         }).toString();
 
     // Optimistically assume that the new window was opened.

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -158,6 +158,7 @@ function GitProviders() {
             await openAuthorizeWindow({
                 host,
                 scopes,
+                overrideScopes: true,
                 onSuccess: () => updateUser(),
                 onError: (error) => {
                     if (typeof error === "string") {


### PR DESCRIPTION
this PR fixes the authorization request for the registration of GitHub Apps.

### the problem

URL params of the authorization request were static `...&override=true&scopes=repo`, which works only for the Integration page, where we request the full set. 

### the solution

when requesting additional scopes, we should drop the `override=true` param.
