### PR TITLE
[code] fix repo forking

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT cee6bf3c885a93cb6344da8747db3c66b6590991
+ENV GP_CODE_COMMIT e01c9d7b3bb46f68cb7d38ec3e8eb394621bba41
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- It reverts some Codespaces specific changes in VS Code to fix parsing of remote urls.

Changes in Gitpod Code: https://github.com/gitpod-io/vscode/commit/e01c9d7b3bb46f68cb7d38ec3e8eb394621bba41

#### How to test

- Start a workspace for some repo for which you don't have a fork yet, like: https://github.com/philskat/js-sort
- Create a commit and then try to push.
- You should get different notifications about missing permissions and suggestion to fork.
- Go to access control and grant missing permissions and then press fork.
- You should get a fork, and your workspace should be reconfigured to use new remote.