### PR TITLE
Add histogram for bermuda gap

### DIFF
--- a/dev/containerd-metrics/pull-gap.go
+++ b/dev/containerd-metrics/pull-gap.go
@@ -177,6 +177,7 @@ func listenToLogs(ctx context.Context) error {
 func logGap(entry *workspaceEntry) {
 	if entry.registryFacadePullStart != nil && entry.kubeletPullStart != nil {
 		gap := entry.registryFacadePullStart.Sub(*entry.kubeletPullStart).Seconds()
+		bermudaGapDuration.WithLabelValues(entry.nodeId).Observe(gap)
 		logEntry(entry).WithField("gapInSeconds", gap).Info("Gap between kubelet pull and registry facade pull")
 		gapsLoggedSinceGC++
 	}


### PR DESCRIPTION
This PR implements an HTTP server for `containerd-metrics` and adds a histogram that observes the "Bermuda Gaps"

I've created this PR targeting @JanKoehnlein's branch `jk/containerd-metrics` just to make it easier to review. 

I'm not sure how to test this, since containerd-metrics isn't deployed to our preview environment... any tips?

Fixes #4095 