### PR TITLE
[dashboard] Don't show 'Continue with Default Image' button while the build is still running

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -201,7 +201,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       // Preparing means that we haven't actually started the workspace instance just yet, but rather
       // are still preparing for launch. This means we're building the Docker image for the workspace.
       case "preparing":
-        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={e => { (e.target as HTMLButtonElement).disabled = true; this.startWorkspace(true, true); }} />;
+        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} />;
 
       // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
       // some space within the cluster. If for example the cluster needs to scale up to accomodate the
@@ -267,7 +267,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       case "stopped":
         phase = StartPhase.Stopped;
         if (this.state.hasImageBuildLogs) {
-          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={e => { (e.target as HTMLButtonElement).disabled = true; this.startWorkspace(true, true); }} phase={phase} error={error} />;
+          const restartWithDefaultImage = (event: React.MouseEvent) => {
+            (event.target as HTMLButtonElement).disabled = true;
+            this.startWorkspace(true, true);
+          }
+          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={restartWithDefaultImage} phase={phase} error={error} />;
         }
         if (!isHeadless && this.state.workspaceInstance.status.conditions.timeout) {
           title = 'Timed Out';
@@ -297,7 +301,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
 interface ImageBuildViewProps {
   workspaceId: string;
-  onStartWithDefaultImage: (event: React.MouseEvent) => void;
+  onStartWithDefaultImage?: (event: React.MouseEvent) => void;
   phase?: StartPhase;
   error?: StartWorkspaceError;
 }
@@ -329,7 +333,7 @@ function ImageBuildView(props: ImageBuildViewProps) {
     <Suspense fallback={<div />}>
       <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
     </Suspense>
-    <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>Continue with Default Image</button>
+    {!!props.onStartWithDefaultImage && <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>Continue with Default Image</button>}
   </StartPage>;
 }
 

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -201,7 +201,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       // Preparing means that we haven't actually started the workspace instance just yet, but rather
       // are still preparing for launch. This means we're building the Docker image for the workspace.
       case "preparing":
-        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={() => this.startWorkspace(true, true)} />;
+        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={e => { (e.target as HTMLButtonElement).disabled = true; this.startWorkspace(true, true); }} />;
 
       // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
       // some space within the cluster. If for example the cluster needs to scale up to accomodate the
@@ -267,7 +267,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       case "stopped":
         phase = StartPhase.Stopped;
         if (this.state.hasImageBuildLogs) {
-          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={() => this.startWorkspace(true, true)} phase={phase} error={error} />;
+          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={e => { (e.target as HTMLButtonElement).disabled = true; this.startWorkspace(true, true); }} phase={phase} error={error} />;
         }
         if (!isHeadless && this.state.workspaceInstance.status.conditions.timeout) {
           title = 'Timed Out';
@@ -297,7 +297,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
 interface ImageBuildViewProps {
   workspaceId: string;
-  onStartWithDefaultImage: () => void;
+  onStartWithDefaultImage: (event: React.MouseEvent) => void;
   phase?: StartPhase;
   error?: StartWorkspaceError;
 }


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3777

While going down the rabbit hole of trying to fix the `Continue with Default Image` button while a build is still running in https://github.com/gitpod-io/gitpod/pull/3993, we realized that running Docker builds cannot be interrupted. `image-builder` simply wasn't designed for that.

So we have 3 choices:

1. Change `image-builder` so that it can interrupt builds that are currently in progress

2. Just start a new workspace instance while the old instance is still building, and live with having two instances in this case (breaks many assumptions in the code)

3. Remove the `Continue with Default Image` button while the build is still running, for now (this was also the case in the previous dashboard design -- button only showed up when the build finished / failed)

This PR implements choice 3.

How to test:

- Log into https://jx-dont-continue-with-default-img.staging.gitpod-dev.com/login
- Open https://jx-dont-continue-with-default-img.staging.gitpod-dev.com/#https://github.com/jankeromnes/gitpod-hanging-build and verify that there is no `Continue with Default Image` button (Docker build will hang for 1h)
- Open https://jx-dont-continue-with-default-img.staging.gitpod-dev.com/#https://github.com/jankeromnes/gitpod-build-error and verify that there is a `Continue with Default Image` button and that it works (Docker build will quickly fail)