### PR TITLE
[dashboard] fix create workspace retry

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -72,7 +72,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
             host,
             scopes,
             onSuccess: () => {
-              window.location.href = window.location.toString();
+              window.location.reload();
             },
             onError: (error) => {
                 if (typeof error === "string") {


### PR DESCRIPTION
when authorization is required, i.e. no provider identity is found on server, we request to authorize. once this is done, we should retry creating workspace.

the location based approach to reload seems to be broken.

partial fix for https://github.com/gitpod-io/gitpod/issues/4083