### PR TITLE
Extend admin workspace search

### DIFF
--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -89,7 +89,7 @@ export function WorkspaceSearch(props: Props) {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search for name, context URL, or instance UUID" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search workspaces" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -89,7 +89,7 @@ export function WorkspaceSearch(props: Props) {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search context URLs" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search for name, context URL, or instance UUID" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -89,7 +89,7 @@ export function WorkspaceSearch(props: Props) {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search workspaces" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search Workspaces" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -301,5 +301,48 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             expect(workspaceAndInstance.instanceId).to.eq(this.wsi2.id)
         });
     }
+
+    @test(timeout(10000))
+    public async testFindAllWorkspaceAndInstances_workspaceId() {
+        await this.db.transaction(async db => {
+            await Promise.all([
+                db.store(this.ws),
+                db.storeInstance(this.wsi1),
+                db.store(this.ws2),
+                db.storeInstance(this.ws2i1),
+            ]);
+            const dbResult = await db.findAllWorkspaceAndInstances(0, 10, "workspaceId", "DESC", undefined, this.ws2.id);
+            // It should only find one workspace instance
+            expect(dbResult.total).to.eq(1);
+
+            // It should find the workspace with the queried id
+            const workspaceAndInstance = dbResult.rows[0]
+            expect(workspaceAndInstance.workspaceId).to.eq(this.ws2.id)
+        });
+    }
+
+    @test(timeout(10000))
+    public async testFindAllWorkspaceAndInstances_instanceId() {
+        await this.db.transaction(async db => {
+            await Promise.all([
+                db.store(this.ws),
+                db.storeInstance(this.wsi1),
+                db.storeInstance(this.wsi2),
+                db.store(this.ws2),
+                db.storeInstance(this.ws2i1),
+            ]);
+            const dbResult = await db.findAllWorkspaceAndInstances(0, 10, "instanceId", "DESC", undefined, this.wsi1.id);
+
+            // It should only find one workspace instance
+            expect(dbResult.total).to.eq(1);
+
+            // It should find the workspace with the queried id
+            const workspaceAndInstance = dbResult.rows[0]
+            expect(workspaceAndInstance.workspaceId).to.eq(this.ws.id)
+
+            // It should select the workspace instance that was queried, not the most recent one
+            expect(workspaceAndInstance.instanceId).to.eq(this.wsi1.id)
+        });
+    }
 }
 module.exports = new WorkspaceDBSpec()


### PR DESCRIPTION
This extends the admin workspace search so that besides searching for the context url you can for the Workspace ID or Workspace Instance ID.



See issue #3992