### PR TITLE
[server] store separate email used for commits (GitHub and GitLab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## July 2021
 
 - Fix `image.context` in `.gitpod.yml` ([#4715](https://github.com/gitpod-io/gitpod/pull/4715))
+- Support custom commit email address for GitHub and GitLab (keep email private). Thanks to [@philschatz](https://github.com/philschatz) for the contribution! ([#4115](https://github.com/gitpod-io/gitpod/pull/4115))
 
 ## June 2021
 

--- a/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
+++ b/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
@@ -72,7 +72,6 @@ const end = new Date(Date.UTC(2000, 2, 1)).toISOString();
                 authProviderId: 'github.com',
                 authId: 'Sven',
                 authName: 'Sven',
-                tokens: []
             }]
         });
         await this.workspaceDb.store({

--- a/components/gitpod-db/src/typeorm/entity/db-identity.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-identity.ts
@@ -6,7 +6,7 @@
 
 import { Entity, Column, PrimaryColumn, ManyToOne, Index } from "typeorm";
 
-import { Identity, Token } from "@gitpod/gitpod-protocol";
+import { Identity, Email } from "@gitpod/gitpod-protocol";
 import { DBUser } from "./db-user";
 import { Transformer } from "../transformer";
 
@@ -33,20 +33,24 @@ export class DBIdentity implements Identity {
     })
     primaryEmail?: string;
 
-    /** @deprecated */
     @Column({
-        type: "simple-json",
-        // We want to deprecate the field without changing the schema just yet so we silence all writes and reads
-        transformer: {
-            to(value: any): any {
-                return [];
+        type: 'simple-json',
+        transformer: Transformer.compose(
+            {
+                to(value: any): any {
+                    return value;
+                },
+                from(value: any): Email[] {
+                    // We reused the 'tokens' database field. Ignore old values
+                    // in the DB and replace them with an empty array.
+                    return Email.isEmailArray(value) ? value : [];
+                }
             },
-            from(value: any): any {
-                return [];
-            }
-        }
+            Transformer.SIMPLE_JSON([])
+        ),
+        nullable: false,
     })
-    tokens: Token[];
+    additionalEmails?: Email[];
 
     @Column()
     deleted?: boolean;

--- a/components/gitpod-db/src/typeorm/migration/1624290876856-IdentityTokensToEmails.ts
+++ b/components/gitpod-db/src/typeorm/migration/1624290876856-IdentityTokensToEmails.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class IdentityTokensToEmails1624290876856 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.renameColumn("d_b_identity", "tokens", "additionalEmails");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.renameColumn("d_b_identity", "additionalEmails", "tokens");
+    }
+}

--- a/components/gitpod-db/src/typeorm/transformer.ts
+++ b/components/gitpod-db/src/typeorm/transformer.ts
@@ -6,6 +6,7 @@
 
 import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
 import { EncryptionService } from "@gitpod/gitpod-protocol/lib/encryption/encryption-service";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 
 export namespace Transformer {
@@ -45,7 +46,12 @@ export namespace Transformer {
                 return JSON.stringify(value || defaultValue);
             },
             from(value: any): any {
-                return JSON.parse(value);
+                try {
+                    return typeof value === 'object' ? value : JSON.parse(value);
+                } catch (e) {
+                    log.error(`Cannot parse JSON during TypeORM transformation. Returning default value '${JSON.stringify(defaultValue)}' instead. Value: ${JSON.stringify(value)}`, e);
+                    return defaultValue;
+                }
             }
         };
     }

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -289,8 +289,7 @@ export class TypeORMUserDBImpl implements UserDB {
         const dbUser = user as DBUser;
         // Here we need to fill the pseudo column 'user' in DBIdentity (see there for details)
         dbUser.identities.forEach(id => id.user = dbUser);
-        // TODO deprecated: Remove once we delete that column
-        dbUser.identities.forEach(id => id.tokens = []);
+        dbUser.identities.forEach(id => id.additionalEmails = id.additionalEmails || []);
         return dbUser;
     }
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -60,8 +60,6 @@ export namespace User {
         const res = { ...user };
         delete (res.additionalData);
         res.identities = res.identities.map(i => {
-            delete (i.tokens);
-
             // The user field is not in the Identity shape, but actually exists on DBIdentity.
             // Trying to push this object out via JSON RPC will fail because of the cyclic nature
             // of this field.
@@ -303,8 +301,7 @@ export interface Identity {
     authId: string;
     authName: string;
     primaryEmail?: string;
-    /** @deprecated */
-    tokens?: Token[];
+    additionalEmails?: Email[];
     /** This is a flag that triggers the HARD DELETION of this entity */
     deleted?: boolean;
     // readonly identities cannot be modified by the user
@@ -322,6 +319,26 @@ export namespace Identity {
     export function equals(id1: IdentityLookup, id2: IdentityLookup) {
         return id1.authProviderId === id2.authProviderId
             && id1.authId === id2.authId
+    }
+}
+
+export enum EmailType {
+    COMMIT = 'commit',
+    OTHER = 'other'
+}
+
+export interface Email {
+    address: string;
+    type: EmailType;
+}
+
+export namespace Email {
+    export function is(data: any): data is Email {
+        return data.hasOwnProperty('address')
+            && data.hasOwnProperty('type');
+    }
+    export function isEmailArray(data: any): data is Email[] {
+        return Array.isArray(data) && data.every(x => Email.is(x));
     }
 }
 

--- a/components/server/src/auth/auth-provider.ts
+++ b/components/server/src/auth/auth-provider.ts
@@ -6,7 +6,7 @@
 
 
 import * as express from 'express';
-import { AuthProviderInfo, User, OAuth2Config, AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { AuthProviderInfo, User, OAuth2Config, AuthProviderEntry, Email } from "@gitpod/gitpod-protocol";
 import { saveSession } from '../express-util';
 
 import { UserEnvVarValue } from "@gitpod/gitpod-protocol";
@@ -65,6 +65,7 @@ export interface AuthUser {
     readonly authId: string;
     readonly authName: string;
     readonly primaryEmail: string;
+    readonly additionalEmails?: Email[];
     readonly name?: string;
     readonly avatarUrl?: string;
 }

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -6,7 +6,7 @@
 
 import { injectable } from 'inversify';
 import * as express from "express"
-import { AuthProviderInfo } from '@gitpod/gitpod-protocol';
+import { AuthProviderInfo, EmailType } from '@gitpod/gitpod-protocol';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { GitHubScope } from "./scopes";
 import { AuthUserSetup } from "../auth/auth-provider";
@@ -98,18 +98,13 @@ export class GitHubAuthProvider extends GenericAuthProvider {
                 .map((s: string) => s.trim())
             );
 
-            const filterPrimaryEmail = (emails: typeof userEmails) => {
-                if (this.env.blockNewUsers) {
-                    // if there is any verified email with a domain that is in the blockNewUsersPassList then use this email as primary email
-                    const emailDomainInPasslist = (mail: string) => this.env.blockNewUsersPassList.some(e => mail.endsWith(`@${e}`));
-                    const result = emails.filter(e => e.verified).filter(e => emailDomainInPasslist(e.email))
-                    if (result.length > 0) {
-                        return result[0].email;
-                    }
-                }
-                // otherwise use GitHub's primary email as Gitpod's primary email
-                return emails.filter(e => e.primary)[0].email;
-            };
+            const primary = userEmails.filter(e => e.primary)[0]!;
+            const proxy = userEmails.find(e => e.email.endsWith(`@users.noreply.${this.config.host}`));
+
+            const additionalEmails = userEmails.filter(e => !e.primary && e.verified && e.visibility !== 'private').map(e => ({address: e.email, type: EmailType.OTHER}))
+            if (primary.visibility === 'private' && proxy) {
+                additionalEmails.push({ address: proxy.email, type: EmailType.COMMIT });
+            }
 
             return <AuthUserSetup>{
                 authUser: {
@@ -117,7 +112,8 @@ export class GitHubAuthProvider extends GenericAuthProvider {
                     authName: login,
                     avatarUrl: avatar_url,
                     name,
-                    primaryEmail: filterPrimaryEmail(userEmails)
+                    primaryEmail: primary.email,
+                    additionalEmails,
                 },
                 currentScopes
             }

--- a/components/server/src/gitlab/api.ts
+++ b/components/server/src/gitlab/api.ts
@@ -193,6 +193,7 @@ export namespace GitLab {
     // https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users
     export interface User extends UserSchemaDefault {
         email: string;
+        commit_email?: string;
         state: "active" | string;
         confirmed_at: string | undefined,
         private_profile: boolean;

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -7,7 +7,7 @@
 import * as express from "express";
 import { injectable } from 'inversify';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
-import { AuthProviderInfo } from '@gitpod/gitpod-protocol';
+import { AuthProviderInfo, EmailType } from '@gitpod/gitpod-protocol';
 import { GitLabScope } from "./scopes";
 import { UnconfirmedUserException } from "../auth/errors";
 import { GitLab } from "./api";
@@ -73,7 +73,7 @@ export class GitLabAuthProvider extends GenericAuthProvider {
                     throw UnconfirmedUserException.create(unconfirmedUserMessage, result);
                 }
             }
-            const { id, username, avatar_url, name, email } = result;
+            const { id, username, avatar_url, name, email, commit_email } = result;
 
             return <AuthUserSetup>{
                 authUser: {
@@ -81,7 +81,8 @@ export class GitLabAuthProvider extends GenericAuthProvider {
                     authName: username,
                     avatarUrl: avatar_url || undefined,
                     name,
-                    primaryEmail: email
+                    primaryEmail: email,
+                    additionalEmails: commit_email ? [{ "address": commit_email, "type": EmailType.COMMIT }] : [],
                 },
                 currentScopes: this.readScopesFromVerifyParams(tokenResponse)
             }

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -140,7 +140,8 @@ export class UserService {
     protected handleNewUser(newUser: User, isFirstUser: boolean) {
         if (this.env.blockNewUsers) {
             const emailDomainInPasslist = (mail: string) => this.env.blockNewUsersPassList.some(e => mail.endsWith(`@${e}`));
-            const canPass = newUser.identities.some(i => !!i.primaryEmail && emailDomainInPasslist(i.primaryEmail));
+            const canPass = newUser.identities.some(i => (!!i.primaryEmail && emailDomainInPasslist(i.primaryEmail)) ||
+                i.additionalEmails?.some(e => emailDomainInPasslist(e.address)));
 
             newUser.blocked = !canPass;
         }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1659,8 +1659,6 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         const res = { ...user };
         delete (res.additionalData);
         res.identities = res.identities.map(i => {
-            delete (i.tokens);
-
             // The user field is not in the Identity shape, but actually exists on DBIdentity.
             // Trying to push this object out via JSON RPC will fail because of the cyclic nature
             // of this field.

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -7,7 +7,7 @@
 import { CloneTargetMode, FileDownloadInitializer, GitAuthMethod, GitConfig, GitInitializer, PrebuildInitializer, SnapshotInitializer, WorkspaceInitializer } from "@gitpod/content-service/lib";
 import { CompositeInitializer, FromBackupInitializer } from "@gitpod/content-service/lib/initializer_pb";
 import { DBUser, DBWithTracing, TracedUserDB, TracedWorkspaceDB, UserDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
-import { CommitContext, Disposable, GitpodToken, GitpodTokenType, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType, DisposableCollection, AdditionalContentContext, ImageConfigFile } from "@gitpod/gitpod-protocol";
+import { CommitContext, Disposable, GitpodToken, GitpodTokenType, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType, DisposableCollection, AdditionalContentContext, ImageConfigFile, EmailType } from "@gitpod/gitpod-protocol";
 import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -728,7 +728,7 @@ export class WorkspaceStarter {
 
         const gitSpec = new GitSpec();
         gitSpec.setUsername(user.fullName || identity.authName);
-        gitSpec.setEmail(identity.primaryEmail!);
+        gitSpec.setEmail(identity.additionalEmails?.find(e => e.type === EmailType.COMMIT)?.address || identity.primaryEmail!);
         return gitSpec;
     }
 


### PR DESCRIPTION
GitLab and GitHub both have a way to specify an email address for commits that is different than the primary email used for a user account.

GitLab contains a field for the [commit email](https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) and while GitHub does not provide a similar field in their API, their Desktop client [constructs this email address](https://github.com/desktop/desktop/blob/7a7388edd069cc8e97ec6d3cdbe4d2747af5fbc4/app/src/lib/email.ts)

:crossed_fingers: :sweat_smile: that this works.

Fixes #387, #2007, #3186, #4101