### PR TITLE
[dev] Re-enable BLOCK_NEW_USERS and BLOCK_NEW_USERS_PASSLIST

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -35,6 +35,9 @@ components:
     makeNewUsersAdmin: true # for development
     theiaPluginsBucketName: gitpod-core-dev-plugins
     enableLocalApp: true
+    blockNewUsers: true
+    blockNewUsersPasslist:
+    - "gitpod.io"
 
   registryFacade:
     daemonSet: true

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -145,7 +145,7 @@ export class UserService {
 
             newUser.blocked = !canPass;
         }
-        if (isFirstUser || this.env.makeNewUsersAdmin) {
+        if (!newUser.blocked && (isFirstUser || this.env.makeNewUsersAdmin)) {
             newUser.rolesOrPermissions = ['admin'];
         }
     }


### PR DESCRIPTION
This makes sure we don't give random GitHub accounts admin on our preview environments.