### PR TITLE
Add tests for findAllWorkspaceAndInstances

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,21 @@
             "request": "attach",
             "port": 32991,
             "mode": "remote"
+        },
+        {
+            // This will run the db-test yarn target in the gitpod-db component.
+            // This allows you to set breakpoints in your tests and step through
+            // them with the VSCode debugger.
+            "type": "node",
+            "request": "launch",
+            "name": "gitpod-db-tests",
+            "cwd": "${workspaceFolder}/components/gitpod-db",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["db-test"],
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
         }
     ]
 }

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -683,7 +683,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl extends AbstractWorkspaceDB
             queryBuilder.andWhere("ownerId = :ownerId", { ownerId });
         }
         if (searchTerm) {
-            queryBuilder.andWhere("(contextUrl LIKE :searchTerm OR description LIKE :searchTerm)", { searchTerm });
+            queryBuilder.andWhere("(contextURL LIKE :searchTerm OR description LIKE :searchTerm)", { searchTerm });
         }
         if (minCreationTime) {
             queryBuilder.andWhere("creationTime >= :minCreationTime", { minCreationTime: minCreationTime.toISOString() });
@@ -705,14 +705,14 @@ export abstract class AbstractTypeORMWorkspaceDBImpl extends AbstractWorkspaceDB
             joinConditionParams.ownerId = ownerId;
         }
         if (!!searchTerm) {
-            joinConditions.push(`ws.contextUrl LIKE '%${searchTerm}%'`);
+            joinConditions.push(`ws.contextURL LIKE '%${searchTerm}%'`);
         }
 
         let orderField: string = orderBy;
         switch (orderField) {
             case "workspaceId": orderField = "ws.id"; break;
             case "instanceId": orderField = "wsi.id"; break;
-            case "contextURL": orderField = "ws.contextUrl"; break;
+            case "contextURL": orderField = "ws.contextURL"; break;
             case "workspaceCreationTime": orderField = "ws.creationTime"; break;
             case "instanceCreationTime": orderField = "wsi.creationTime"; break;
             case "phase": orderField = "wsi.status->>phase"; break;

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -232,5 +232,17 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             expect(dbResult.length).to.eq(0);
         });
     }
+
+    @test(timeout(10000))
+    public async testFindAllWorkspaceAndInstances_contextUrl() {
+        await this.db.transaction(async db => {
+            await Promise.all([
+                db.store(this.ws),
+                db.storeInstance(this.wsi1)
+            ]);
+            const dbResult = await db.findAllWorkspaceAndInstances(0, 10, "contextURL", "DESC", undefined, this.ws.contextURL);
+            expect(dbResult.total).to.eq(1);
+        });
+    }
 }
 module.exports = new WorkspaceDBSpec()

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -79,6 +79,40 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
         },
         deleted: false
     };
+    readonly ws2: Workspace = {
+        id: '2',
+        type: 'regular',
+        creationTime: this.timeWs,
+        config: {
+            ports: [],
+            image: '',
+            tasks: []
+        },
+        context: { title: 'example' },
+        contextURL: 'https://github.com/gitpod-io/gitpod',
+        description: 'Gitpod',
+        ownerId: '12345'
+    };
+    readonly ws2i1: WorkspaceInstance = {
+        workspaceId: this.ws2.id,
+        id: '4',
+        ideUrl: 'example.org',
+        region: 'unknown',
+        workspaceImage: 'abc.io/test/image:123',
+        creationTime: this.timeBefore,
+        startedTime: undefined,
+        deployedTime: undefined,
+        stoppedTime: undefined,
+        status: {
+            phase: "preparing",
+            conditions: {},
+        },
+        configuration: {
+            theiaVersion: "unknown",
+            ideImage: "unknown"
+        },
+        deleted: false
+    };
 
     async before() {
         await this.wipeRepo();
@@ -249,10 +283,22 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
         await this.db.transaction(async db => {
             await Promise.all([
                 db.store(this.ws),
-                db.storeInstance(this.wsi1)
+                db.storeInstance(this.wsi1),
+                db.storeInstance(this.wsi2),
+                db.store(this.ws2),
+                db.storeInstance(this.ws2i1),
             ]);
             const dbResult = await db.findAllWorkspaceAndInstances(0, 10, "contextURL", "DESC", undefined, this.ws.contextURL);
+            // It should only find one workspace instance
             expect(dbResult.total).to.eq(1);
+
+            const workspaceAndInstance = dbResult.rows[0]
+
+            // It should find the workspace that uses the queried context url
+            expect(workspaceAndInstance.workspaceId).to.eq(this.ws.id)
+
+            // It should select the workspace instance that was most recently created
+            expect(workspaceAndInstance.instanceId).to.eq(this.wsi2.id)
         });
     }
 }

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -234,6 +234,17 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
     }
 
     @test(timeout(10000))
+    public async testFindAllWorkspaces_contextUrl() {
+        await this.db.transaction(async db => {
+            await Promise.all([
+                db.store(this.ws)
+            ]);
+            const dbResult = await db.findAllWorkspaces(0, 10, "contextURL", "DESC", undefined, this.ws.contextURL);
+            expect(dbResult.total).to.eq(1);
+        });
+    }
+
+    @test(timeout(10000))
     public async testFindAllWorkspaceAndInstances_contextUrl() {
         await this.db.transaction(async db => {
             await Promise.all([


### PR DESCRIPTION
While working on https://github.com/gitpod-io/gitpod/issues/3992 I was trying to add a few DB tests. 

Before making changes to the code I wanted to create a basic test for the existing functionality, but unfortunately the test failed with a rather obscure error message

```
Cannot read property 'databaseName' of undefined
```

Turns out that TypeORM column names are case sensitive when used for ordering. In this case we used contextUrl and it should have been contextURL.

While column names in mysql are case insensitive I also fixed one other occurrence of contextUrl even though it is not necessary; but using the column names makes it easier to find when searching for references etc.

I also added a launch configuration for executing the db tests with the debugger enabled so you can step through them.