### PR TITLE
[ws-proxy] redirect HTTP to HTTPS

### DIFF
--- a/chart/config/proxy/lib.workspace-locations.conf
+++ b/chart/config/proxy/lib.workspace-locations.conf
@@ -15,5 +15,5 @@ location / {
     error_log off;
 
     proxy_set_header x-wsproxy-host $host;
-    proxy_pass http://wsproxy$request_uri;
+    proxy_pass https://wsproxy$request_uri;
 }

--- a/chart/config/proxy/lib.workspace-port-locations.conf
+++ b/chart/config/proxy/lib.workspace-port-locations.conf
@@ -19,7 +19,7 @@ location / {
     error_log off;
 
     proxy_set_header x-wsproxy-host $host;
-    proxy_pass http://wsproxy$request_uri;
+    proxy_pass https://wsproxy$request_uri;
 }
 {{- else }}
 

--- a/chart/config/proxy/vhost.upstreams.conf
+++ b/chart/config/proxy/vhost.upstreams.conf
@@ -22,7 +22,7 @@ upstream dashboard {
 {{- $wsProxy := .Values.components.wsProxy -}}
 {{- if (and $wsProxy (not $wsProxy.disabled)) }}
 upstream wsproxy {
-    server ws-proxy.${KUBE_NAMESPACE}.svc.cluster.local:8080;
+    server ws-proxy.${KUBE_NAMESPACE}.svc.cluster.local:9090;
 
     # Keep up to 100 connections to upstream alive and re-use them for faster responses
     keepalive 100;

--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -18,8 +18,8 @@ data:
   config.json: |-
     {
         "ingress": {
-            "address": ":{{- $comp.ports.httpProxy.containerPort -}}",
-            "https": {{ $comp.useHTTPS -}},
+            "httpAddress": ":{{- $comp.ports.httpProxy.containerPort -}}",
+            "httpsAddress": ":{{- $comp.ports.httpsProxy.containerPort -}}",
             "header": "{{- $comp.hostHeader -}}"
         },
         "workspaceInfoProviderConfig": {
@@ -32,13 +32,10 @@ data:
             }
         },
         "proxy": {
-            {{- if and $comp.useHTTPS $.Values.certificatesSecret.secretName }}
             "https": {
-                "enabled": true,
                 "crt": "/mnt/certificates/tls.crt",
                 "key": "/mnt/certificates/tls.key"
             },
-            {{- end }}
             "transportConfig": {
                 "connectTimeout": "10s",
                 "idleConnTimeout": "60s",

--- a/chart/templates/ws-proxy-networkpolicy.yaml
+++ b/chart/templates/ws-proxy-networkpolicy.yaml
@@ -20,10 +20,12 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  # Allow access to HTTP proxy port from everywhere
+  # Allow access to HTTP/HTTPS proxy ports from everywhere
   - ports:
     - protocol: TCP
       port: {{ $comp.ports.httpProxy.containerPort }}
+    - protocol: TCP
+      port: {{ $comp.ports.httpsProxy.containerPort }}
     {{ if $comp.ports.wsManagerProxy }}
     - protocol: TCP
       port: {{ $comp.ports.wsManagerProxy.containerPort }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -466,7 +466,6 @@ components:
       cpu: 100m
       memory: 64Mi
     replicas: 1
-    useHTTPS: false
     hostHeader: "x-wsproxy-host"
     wsManagerProxy:
       enabled: false
@@ -478,6 +477,9 @@ components:
       httpProxy:
         expose: true
         containerPort: 8080
+      httpsProxy:
+        expose: true
+        containerPort: 9090
       metrics:
         expose: false
         containerPort: 9500

--- a/components/ws-proxy/cmd/root.go
+++ b/components/ws-proxy/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 
-	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
@@ -55,7 +54,7 @@ func init() {
 
 // Config configures this servuce
 type Config struct {
-	Ingress                     HostBasedIngressConfig            `json:"ingress"`
+	Ingress                     proxy.HostBasedIngressConfig      `json:"ingress"`
 	Proxy                       proxy.Config                      `json:"proxy"`
 	WorkspaceInfoProviderConfig proxy.WorkspaceInfoProviderConfig `json:"workspaceInfoProviderConfig"`
 	PProfAddr                   string                            `json:"pprofAddr"`
@@ -80,23 +79,6 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
-}
-
-// HostBasedIngressConfig configures the host-based ingress
-type HostBasedIngressConfig struct {
-	Address string `json:"address"`
-	Header  string `json:"header"`
-}
-
-// Validate validates this config
-func (c *HostBasedIngressConfig) Validate() error {
-	if c == nil {
-		return xerrors.Errorf("host based ingress config is mandatory")
-	}
-	return validation.ValidateStruct(c,
-		validation.Field(&c.Address, validation.Required),
-		validation.Field(&c.Header, validation.Required),
-	)
 }
 
 // WSManagerProxyConfig configures the ws-manager TCP proxy

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -56,9 +56,8 @@ var runCmd = &cobra.Command{
 		}
 		log.Infof("workspace info provider started")
 
-		addr := cfg.Ingress.Address
-		go proxy.NewWorkspaceProxy(addr, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix), workspaceInfoProvider).MustServe()
-		log.Infof("started proxying on %s", addr)
+		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix), workspaceInfoProvider).MustServe()
+		log.Infof("started proxying on %s", cfg.Ingress.HttpAddress)
 
 		if cfg.PProfAddr != "" {
 			go pprof.Serve(cfg.PProfAddr)

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -18,7 +18,6 @@ import (
 // Config is the configuration for a WorkspaceProxy
 type Config struct {
 	HTTPS struct {
-		Enabled     bool   `json:"enabled"`
 		Key         string `json:"key"`
 		Certificate string `json:"crt"`
 	} `json:"https,omitempty"`
@@ -49,6 +48,25 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// HostBasedIngressConfig configures the host-based ingress
+type HostBasedIngressConfig struct {
+	HttpAddress  string `json:"httpAddress"`
+	HttpsAddress string `json:"httpsAddress"`
+	Header       string `json:"header"`
+}
+
+// Validate validates this config
+func (c *HostBasedIngressConfig) Validate() error {
+	if c == nil {
+		return xerrors.Errorf("host based ingress config is mandatory")
+	}
+	return validation.ValidateStruct(c,
+		validation.Field(&c.HttpAddress, validation.Required),
+		validation.Field(&c.HttpsAddress, validation.Required),
+		validation.Field(&c.Header, validation.Required),
+	)
 }
 
 // WorkspacePodConfig contains config around the workspace pod

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -257,12 +257,16 @@ func installWorkspacePortRoutes(r *mux.Router, config *RouteHandlerConfig) error
 
 	// forward request to workspace port
 	r.NewRoute().HandlerFunc(
-		proxyPass(
-			config,
-			workspacePodPortResolver,
-			withHTTPErrorHandler(showPortNotFoundPage),
-			withXFrameOptionsFilter(),
-		),
+		func(rw http.ResponseWriter, r *http.Request) {
+			r.Header.Add("X-Forwarded-Proto", "https")
+			r.Header.Add("X-Forwarded-Host", r.Host+":443")
+			proxyPass(
+				config,
+				workspacePodPortResolver,
+				withHTTPErrorHandler(showPortNotFoundPage),
+				withXFrameOptionsFilter(),
+			)(rw, r)
+		},
 	)
 
 	return nil

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -605,7 +605,13 @@ func TestRoutes(t *testing.T) {
 				router = test.Router(&cfg)
 			}
 
-			proxy := NewWorkspaceProxy(":8080", cfg, router, &fakeWsInfoProvider{infos: workspaces})
+			ingress := HostBasedIngressConfig{
+				HttpAddress:  "8080",
+				HttpsAddress: "9090",
+				Header:       "",
+			}
+
+			proxy := NewWorkspaceProxy(ingress, cfg, router, &fakeWsInfoProvider{infos: workspaces})
 			handler, err := proxy.Handler()
 			if err != nil {
 				t.Fatalf("cannot create proxy handler: %q", err)


### PR DESCRIPTION
This PR removes the `useHTTPS` switch from `ws-proxy` by making HTTPS termination enabled by default. 

The redirect of HTTP requests should fix https://github.com/gitpod-io/gitpod/issues/4124.