### PR TITLE
Add telemetry to help debug workspace start failures

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -181,6 +181,7 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 			reason = "timeout"
 		} else if status.Conditions.Failed != "" {
 			reason = "failed"
+			log.WithField("failure", status.Conditions.Failed).Error("workspace stopped due to a failure")
 		} else {
 			reason = "regular-stop"
 		}


### PR DESCRIPTION
As part for https://github.com/gitpod-io/observability/issues/90 I'm writing a runbook for an SLO-based alert for workspace start failures.

I believe it would be useful to be able to get a log line whenever we increment `gitpod_ws_manager_workspace_stops_total{reason="failed"}` with more context that might help shed some light on why workspaces are failing to start.