### PR TITLE
Implement incremental prebuilds

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -202,6 +202,14 @@ spec:
           value: {{ $comp.defaultBaseImageRegistryWhitelist | toJson | quote }}
         - name: GITPOD_DEFAULT_FEATURE_FLAGS
           value: {{ $comp.defaultFeatureFlags | toJson | quote }}
+    {{- if $comp.incrementalPrebuilds.repositoryPasslist }}
+        - name: INCREMENTAL_PREBUILDS_REPO_PASSLIST
+          value: {{ $comp.incrementalPrebuilds.repositoryPasslist | toJson | quote }}
+    {{- end }}
+    {{- if $comp.incrementalPrebuilds.commitHistory }}
+        - name: INCREMENTAL_PREBUILDS_COMMIT_HISTORY
+          value: {{ $comp.incrementalPrebuilds.commitHistory | quote }}
+    {{- end }}
         - name: AUTH_PROVIDERS_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -280,6 +280,9 @@ components:
     wsman: []
     defaultBaseImageRegistryWhitelist: []
     defaultFeatureFlags: []
+    incrementalPrebuilds:
+      repositoryPasslist: []
+      commitHistory: 100
     ports:
       http:
         expose: true

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -93,12 +93,13 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 
 	// checkout branch
 	if ws.TargetMode == RemoteBranch {
-		// create local branch based on remote
+		// create local branch based on specific remote branch
 		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/"+ws.CloneTarget); err != nil {
 			return err
 		}
 	} else if ws.TargetMode == LocalBranch {
-		if err := ws.Git(ctx, "checkout", "-b", ws.CloneTarget); err != nil {
+		// checkout local branch based on remote HEAD
+		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/HEAD"); err != nil {
 			return err
 		}
 	} else if ws.TargetMode == RemoteCommit {
@@ -106,8 +107,11 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		if err := ws.Git(ctx, "checkout", ws.CloneTarget); err != nil {
 			return err
 		}
-	} else { //nolint:staticcheck
-		// nothing to do - we're already on the remote branch
+	} else {
+		// update to remote HEAD
+		if err := ws.Git(ctx, "reset", "--hard", "origin/HEAD"); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -110,7 +110,12 @@ func (p *PrebuildInitializer) Run(ctx context.Context, mappings []archive.IDMapp
 		// If any of these cleanup operations fail that's no reason to fail ws initialization.
 		// It just results in a slightly degraded state.
 		if didStash {
-			_ = p.Git.Git(ctx, "stash", "pop")
+			err = p.Git.Git(ctx, "stash", "pop")
+			if err != nil {
+				// If restoring the stashed changes produces merge conflicts on the new Git ref, simply
+				// throw them away (they'll remain in the stash, but are likely outdated anyway).
+				_ = p.Git.Git(ctx, "reset", "--hard")
+			}
 		}
 
 		log.Debug("prebuild initializer Git operations complete")

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -149,7 +149,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
     // Successfully stopped and headless: the prebuild is done, let's try to use it!
     if (!error && workspaceInstance.status.phase === 'stopped' && this.state.workspace?.type !== 'regular') {
-      const contextUrl = this.state.workspace?.contextURL.replace('prebuild/', '')!;
+      const contextUrl = this.state.workspace?.contextURL.replace('incremental-prebuild/', '').replace('prebuild/', '')!;
       this.redirectTo(gitpodHostUrl.withContext(contextUrl).toString());
     }
 

--- a/components/gitpod-db/src/typeorm/migration/README.md
+++ b/components/gitpod-db/src/typeorm/migration/README.md
@@ -4,6 +4,7 @@ To create a new migration file, run this command in the `gitpod-db` component di
 
 ```
 yarn typeorm migrations:create -n NameOfYourMigration
+leeway run components:update-license-header
 ```
 
 Then, simply populate the `up` and `down` methods in the generated migration file.

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -813,6 +813,7 @@ export namespace SnapshotContext {
 
 export interface StartPrebuildContext extends WorkspaceContext {
     actual: WorkspaceContext;
+    commitHistory?: string[];
 }
 
 export namespace StartPrebuildContext {

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -31,6 +31,7 @@ import { GitLabApp } from "./prebuilds/gitlab-app";
 import { BitbucketApp } from "./prebuilds/bitbucket-app";
 import { IPrefixContextParser } from "../../src/workspace/context-parser";
 import { StartPrebuildContextParser } from "./prebuilds/start-prebuild-context-parser";
+import { StartIncrementalPrebuildContextParser } from "./prebuilds/start-incremental-prebuild-context-parser";
 import { WorkspaceFactory } from "../../src/workspace/workspace-factory";
 import { WorkspaceFactoryEE } from "./workspace/workspace-factory";
 import { MonitoringEndpointsAppEE } from "./monitoring-endpoint-ee";
@@ -52,6 +53,7 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(PrebuildRateLimiter).toSelf().inSingletonScope();
     bind(PrebuildQueueMaintainer).toSelf().inSingletonScope();
     bind(IPrefixContextParser).to(StartPrebuildContextParser).inSingletonScope();
+    bind(IPrefixContextParser).to(StartIncrementalPrebuildContextParser).inSingletonScope();
     bind(GithubApp).toSelf().inSingletonScope();
     bind(GithubAppRules).toSelf().inSingletonScope();
     bind(PrebuildStatusMaintainer).toSelf().inSingletonScope();

--- a/components/server/ee/src/prebuilds/start-incremental-prebuild-context-parser.ts
+++ b/components/server/ee/src/prebuilds/start-incremental-prebuild-context-parser.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { User, WorkspaceContext, StartPrebuildContext, CommitContext } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { URL } from "url";
+import { Env } from '../../../src/env';
+import { HostContextProvider } from "../../../src/auth/host-context-provider";
+import { IPrefixContextParser } from "../../../src/workspace/context-parser";
+
+@injectable()
+export class StartIncrementalPrebuildContextParser implements IPrefixContextParser {
+    @inject(Env) protected env: Env;
+    @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
+    static PREFIX = 'incremental-prebuild/';
+
+    findPrefix(user: User, context: string): string | undefined {
+        if (context.startsWith(StartIncrementalPrebuildContextParser.PREFIX)) {
+            return StartIncrementalPrebuildContextParser.PREFIX;
+        }
+    }
+
+    public async handle(user: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext> {
+        if (!CommitContext.is(context)) {
+            throw new Error("can only start incremental prebuilds on a commit context")
+        }
+
+        const host = new URL(context.repository.cloneUrl).hostname;
+        const hostContext = this.hostContextProvider.get(host);
+        const maxDepth = this.env.incrementalPrebuildsCommitHistory;
+        const result: StartPrebuildContext = {
+            title: `Prebuild of "${context.title}"`,
+            actual: context,
+            commitHistory: await (hostContext?.contextParser?.fetchCommitHistory({}, user, context.repository.cloneUrl, context.revision, maxDepth) || [])
+        };
+        return result;
+    }
+
+}

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -549,7 +549,7 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
 
             const logCtx: LogContext = { userId: user.id };
             const cloneUrl = context.repository.cloneUrl;
-            const prebuiltWorkspace = await this.workspaceDb.trace({ span }).findPrebuiltWorkspaceByCommit(context.repository.cloneUrl, context.revision);
+            const prebuiltWorkspace = await this.workspaceDb.trace({ span }).findPrebuiltWorkspaceByCommit(cloneUrl, context.revision);
             const logPayload = { mode, cloneUrl, commit: context.revision, prebuiltWorkspace };
             log.debug(logCtx, "Looking for prebuilt workspace: ", logPayload);
             if (!prebuiltWorkspace) {
@@ -568,6 +568,10 @@ export class GitpodServerEEImpl<C extends GitpodClient, S extends GitpodServer> 
                 if (mode === CreateWorkspaceMode.ForceNew) {
                     // in force mode we ignore running prebuilds as we want to start a workspace as quickly as we can.
                     return;
+                    // TODO(janx): Fall back to parent prebuild instead, if it's available:
+                    //   const buildWorkspace = await this.workspaceDb.trace({span}).findById(prebuiltWorkspace.buildWorkspaceId);
+                    //   const parentPrebuild = await this.workspaceDb.trace({span}).findPrebuildByID(buildWorkspace.basedOnPrebuildId);
+                    // Also, make sure to initialize it by both printing the parent prebuild logs AND re-runnnig the before/init/prebuild tasks.
                 }
 
                 let result: WorkspaceCreationResult = {

--- a/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
@@ -451,6 +451,13 @@ class TestBitbucketContextParser {
             "title": "gitpod/clu-sample-repo - master"
         })
     }
+
+    @test public async testFetchCommitHistory() {
+        const result = await this.parser.fetchCommitHistory({}, this.user, 'https://bitbucket.org/gitpod/sample-repository', 'dd0aef8097a7c521b8adfced795fcf96c9e598ef', 100);
+        expect(result).to.deep.equal([
+            'da2119f51b0e744cb6b36399f8433b477a4174ef',
+        ])
+    }
 }
 
 module.exports = new TestBitbucketContextParser();

--- a/components/server/src/bitbucket/bitbucket-context-parser.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.ts
@@ -259,4 +259,27 @@ export class BitbucketContextParser extends AbstractContextParser implements ICo
 
         return result;
     }
+
+    public async fetchCommitHistory(ctx: TraceContext, user: User, contextUrl: string, sha: string, maxDepth: number): Promise<string[]> {
+        const span = TraceContext.startSpan("BitbucketContextParser.fetchCommitHistory", ctx);
+        try {
+            // TODO(janx): To get more results than Bitbucket API's max pagelen (seems to be 100), pagination should be handled.
+            // The additional property 'page' may be helfpul.
+            const api = await this.api(user);
+            const { owner, repoName } = await this.parseURL(user, contextUrl);
+            const result = await api.repositories.listCommitsAt({
+                workspace: owner,
+                repo_slug: repoName,
+                revision: sha,
+                pagelen: maxDepth,
+            });
+            return result.data.values.slice(1).map((v: Schema.Commit) => v.hash);
+        } catch (e) {
+            span.log({ error: e });
+            log.error({ userId: user.id }, "Error fetching Bitbucket commit history", e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
 }

--- a/components/server/src/env.ts
+++ b/components/server/src/env.ts
@@ -46,16 +46,25 @@ export class Env extends AbstractComponentEnv {
     })()
 
     readonly previewFeatureFlags: NamedWorkspaceFeatureFlag[] = (() => {
-        const value = process.env.EXPERIMENTAL_FEATURE_FLAGS;
-        if (!value) {
-          return [];
-        }
-        const flags = JSON.parse(value);
-        if (!Array.isArray(flags)) {
-          throw new Error(`EXPERIMENTAL_FEATURE_FLAGS should be an Array: ${value}`);
-        }
-        return flags;
+        return this.parseStringArray('EXPERIMENTAL_FEATURE_FLAGS') as NamedWorkspaceFeatureFlag[];
     })();
+
+    protected parseStringArray(name: string): string[] {
+        const json = process.env[name];
+        if (!json) {
+            return [];
+        }
+        let value;
+        try {
+            value = JSON.parse(json);
+        } catch (error) {
+            throw new Error(`Could not parse ${name}: ${error}`);
+        }
+        if (!Array.isArray(value) || value.some(e => typeof e !== 'string')) {
+            throw `${name} should be an array of string: ${json}`;
+        }
+        return value;
+    }
 
     readonly gitpodRegion: string = process.env.GITPOD_REGION || 'unknown';
 
@@ -111,6 +120,15 @@ export class Env extends AbstractComponentEnv {
     // maxConcurrentPrebuildsPerRef is the maximum number of prebuilds we allow per ref type at any given time
     readonly maxConcurrentPrebuildsPerRef = Number.parseInt(process.env.MAX_CONCUR_PREBUILDS_PER_REF || '10', 10) || 10;
 
+    readonly incrementalPrebuildsRepositoryPassList: string[] = (() => {
+        try {
+            return this.parseStringArray('INCREMENTAL_PREBUILDS_REPO_PASSLIST');
+        } catch (error) {
+            console.error(error);
+            return [];
+        }
+    })()
+    readonly incrementalPrebuildsCommitHistory: number = Number.parseInt(process.env.INCREMENTAL_PREBUILDS_COMMIT_HISTORY || '100', 10) || 100;
 
     protected gitpodLayernameFromFilesystem: string | null | undefined;
     protected readGitpodLayernameFromFilesystem(): string | undefined {
@@ -140,19 +158,10 @@ export class Env extends AbstractComponentEnv {
 
     readonly blockNewUsers: boolean = this.parseBool("BLOCK_NEW_USERS");
     readonly blockNewUsersPassList: string[] = (() => {
-        const l = process.env.BLOCK_NEW_USERS_PASSLIST;
-        if (!l) {
-            return [];
-        }
         try {
-            const res = JSON.parse(l);
-            if (!Array.isArray(res) || res.some(e => typeof e !== 'string')) {
-                console.error("BLOCK_NEW_USERS_PASSLIST is not an array of string");
-                return [];
-            }
-            return res;
-        } catch (err) {
-            console.error("cannot parse BLOCK_NEW_USERS_PASSLIST", err);
+            return this.parseStringArray('BLOCK_NEW_USERS_PASSLIST');
+        } catch (error) {
+            console.error(error);
             return [];
         }
     })();
@@ -164,26 +173,17 @@ export class Env extends AbstractComponentEnv {
 
     /** defaultBaseImageRegistryWhitelist is the list of registryies users get acces to by default */
     readonly defaultBaseImageRegistryWhitelist: string[] = (() => {
-        const wljson = process.env.GITPOD_BASEIMG_REGISTRY_WHITELIST;
-        if (!wljson) {
-            return [];
-        }
-
-        return JSON.parse(wljson);
+        return this.parseStringArray('GITPOD_BASEIMG_REGISTRY_WHITELIST');
     })()
 
     readonly defaultFeatureFlags: NamedWorkspaceFeatureFlag[] = (() => {
-        const json = process.env.GITPOD_DEFAULT_FEATURE_FLAGS;
-        if (!json) {
+        try {
+            const r = (this.parseStringArray('GITPOD_DEFAULT_FEATURE_FLAGS') as NamedWorkspaceFeatureFlag[]);
+            return r.filter(e => e in WorkspaceFeatureFlags);
+        } catch (error) {
+            console.error(error);
             return [];
         }
-
-        let r = JSON.parse(json);
-        if (!Array.isArray(r)) {
-            return [];
-        }
-        r = r.filter(e => e in WorkspaceFeatureFlags);
-        return r;
     })();
 
     /** defaults to: false */

--- a/components/server/src/github/github-context-parser.spec.ts
+++ b/components/server/src/github/github-context-parser.spec.ts
@@ -320,7 +320,6 @@ class TestGithubContextParser {
         })
     }
 
-
     @test public async testCommitContext_02_notExistingCommit() {
         try {
             await this.parser.handle({}, this.user, 'https://github.com/gitpod-io/gitpod-test-repo/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
@@ -535,6 +534,14 @@ class TestGithubContextParser {
                 "path": "folder1/folder2/content2"
             }
         )
+    }
+
+    @test public async testFetchCommitHistory() {
+        const result = await this.parser.fetchCommitHistory({}, this.user, 'https://github.com/gitpod-io/gitpod-test-repo', '409ac2de49a53d679989d438735f78204f441634', 100);
+        expect(result).to.deep.equal([
+            '506e5aed317f28023994ecf8ca6ed91430e9c1a4',
+            'f5b041513bfab914b5fbf7ae55788d9835004d76',
+        ])
     }
 
 }

--- a/components/server/src/gitlab/gitlab-context-parser.spec.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.spec.ts
@@ -547,6 +547,14 @@ class TestGitlabContextParser {
         })
     }
 
+    @test public async testFetchCommitHistory() {
+        const result = await this.parser.fetchCommitHistory({}, this.user, 'https://gitlab.com/AlexTugarev/gp-test', '80948e8cc8f0e851e89a10bc7c2ee234d1a5fbe7', 100);
+        expect(result).to.deep.equal([
+            '4447fbc4d46e6fd1ee41fb1b992702521ae078eb',
+            'f2d9790f2752a794517b949c65a773eb864844cd',
+        ])
+    }
+
 }
 
 module.exports = new TestGitlabContextParser();

--- a/components/server/src/gitlab/gitlab-context-parser.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.ts
@@ -339,4 +339,24 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
             repository,
         };
     }
+
+    public async fetchCommitHistory(ctx: TraceContext, user: User, contextUrl: string, sha: string, maxDepth: number): Promise<string[]> {
+        // TODO(janx): To get more results than GitLab API's max per_page (seems to be 100), pagination should be handled.
+        const { owner, repoName } = await this.parseURL(user, contextUrl);
+        const projectId = `${owner}/${repoName}`;
+        const result = await this.gitlabApi.run<GitLab.Commit[]>(user, async g => {
+            return g.Commits.all(projectId, {
+                ref_name: sha,
+                per_page: maxDepth,
+                page: 1,
+            });
+        });
+        if (GitLab.ApiError.is(result)) {
+            if (result.message === 'GitLab responded with code 404') {
+                throw new Error(`Couldn't find commit #${sha} in repository ${projectId}.`);
+            }
+            throw result;
+        }
+        return result.slice(1).map((c: GitLab.Commit) => c.id);
+    }
 }

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -11,9 +11,10 @@ import { AuthProviderParams } from "../auth/auth-provider";
 import { URLSearchParams, URL } from "url";
 
 export interface IContextParser {
-    normalize?(contextURL: string): string | undefined
-    canHandle(user: User, context: string): boolean
-    handle(ctx: TraceContext, user: User, context: string): Promise<WorkspaceContext>
+    normalize?(contextUrl: string): string | undefined
+    canHandle(user: User, contextUrl: string): boolean
+    handle(ctx: TraceContext, user: User, contextUrl: string): Promise<WorkspaceContext>
+    fetchCommitHistory(ctx: TraceContext, user: User, contextUrl: string, commit: string, maxDepth: number): Promise<string[]>
 }
 export const IContextParser = Symbol("IContextParser")
 
@@ -73,7 +74,14 @@ export abstract class AbstractContextParser implements IContextParser {
         return lastSegment && urlSegment.endsWith('.git') ? urlSegment.substring(0, urlSegment.length - '.git'.length) : urlSegment;
     }
 
-    public abstract handle(ctx: TraceContext, user: User, context: string): Promise<WorkspaceContext>;
+    public abstract handle(ctx: TraceContext, user: User, contextUrl: string): Promise<WorkspaceContext>;
+
+    /**
+     * Fetches the commit history of a commit (used to find a relevant parent prebuild for incremental prebuilds).
+     *
+     * @returns the linear commit history starting from (but excluding) the given commit, in the same order as `git log`
+     */
+    public abstract fetchCommitHistory(ctx: TraceContext, user: User, contextUrl: string, commit: string, maxDepth: number): Promise<string[]>;
 }
 
 export interface URLParts {

--- a/components/server/src/workspace/snapshot-context-parser.ts
+++ b/components/server/src/workspace/snapshot-context-parser.ts
@@ -33,4 +33,8 @@ export class SnapshotContextParser implements IContextParser {
         }
     }
 
+    public async fetchCommitHistory(ctx: TraceContext, user: User, contextUrl: string, commit: string, maxDepth: number): Promise<string[]> {
+        throw new Error('SnapshotContextParser does not support fetching commit history');
+    }
+
 }

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -378,6 +378,8 @@ func (tm *tasksManager) watch(task *task, terminal *terminal.Term) {
 		defer stdout.Close()
 
 		fileName := tm.prebuildLogFileName(task)
+		// TODO(janx): If the file already exists (from a parent prebuild), extract its "time saved", and log that below
+		// (instead, or in addition to, the incremental prebuild time).
 		file, err := os.Create(fileName)
 		var fileWriter *bufio.Writer
 		if err != nil {


### PR DESCRIPTION
### Design doc

https://www.notion.so/gitpod/Incremental-Prebuilds-49c0a840e54348acba05677bdc450841

### How to test

- ~~Use an `io-dev` preview (e.g. https://jx-incremental-prebuilds.staging.gitpod-io-dev.com/workspaces/)~~

- Use the `#prebuild/<repo>` URL prefix to trigger a full prebuild for some commit on some repository

- Use `#incremental-prebuild/<repo>` to trigger an incremental prebuild for some (different) commit (this will automatically select a suitable parent prebuild, or fall back to a full prebuild)

- Verify that both full and incremental prebuilds work as expected (e.g. the project is prebuilt & starts as usual)

- Testing with https://github.com/jankeromnes/gitpod-staging-prebuilds may be helpful (the `.gitpod.yml` logs every task run, along with timestamp and workspace ID, and prints a summary -- e.g. 2 different workspace IDs mean "full prebuild", 3 IDs mean "incremental prebuild")

- Check incremental prebuilds in the DB (e.g. parents, commits, durations, states) like so:

```
mysql> select p.cloneUrl, substr(p.id,1,8) id, substr(w.basedOnPrebuildId,1,8) parentId, p.creationTime, substr(p.commit,1,8) commit, p.state, time_to_sec(timediff(cast(i.stoppedTime as datetime), cast(i.creationTime as datetime))) seconds
  from d_b_prebuilt_workspace p
  left join d_b_workspace w on w.id = p.buildWorkspaceId
  left join d_b_workspace_instance i on i.workspaceId = w.id
  where w.basedOnPrebuildId is not null or p.id in (select basedOnPrebuildId from d_b_workspace where id in (select buildWorkspaceId from d_b_prebuilt_workspace))
  order by p.cloneUrl, p.creationTime desc;
+-------------------------------------------------------------+----------+----------+----------------------------+----------+-----------+---------+
| cloneUrl                                                    | id       | parentId | creationTime               | commit   | state     | seconds |
+-------------------------------------------------------------+----------+----------+----------------------------+----------+-----------+---------+
| https://github.com/gitpod-io/gitpod.git                     | 676df827 | c9b671bc | 2021-05-11 14:48:54.034660 | 066200cd | building  |    NULL |
| https://github.com/gitpod-io/gitpod.git                     | c9b671bc | NULL     | 2021-05-11 14:43:29.295607 | a0a5017b | available |     450 |
| https://github.com/gitpod-io/gitpod.git                     | 0d45a1a1 | cb7566b8 | 2021-05-11 14:40:39.234595 | 79db9d8b | available |     213 |
| https://github.com/gitpod-io/gitpod.git                     | b4a03621 | cb7566b8 | 2021-05-11 14:28:54.040767 | 3e3a6cb8 | available |     262 |
| https://github.com/gitpod-io/gitpod.git                     | 142ddbf2 | cb7566b8 | 2021-05-11 14:28:16.082448 | a0a5017b | available |     234 |
| https://github.com/gitpod-io/gitpod.git                     | 62a62628 | cb7566b8 | 2021-05-11 14:20:16.920090 | 70097b6d | available |     248 |
| https://github.com/gitpod-io/gitpod.git                     | cb7566b8 | NULL     | 2021-05-11 13:46:32.152943 | 2b2702f3 | available |     612 |
| https://github.com/jankeromnes/gitpod-staging-prebuilds.git | 92979128 | 088a5082 | 2021-05-11 13:59:07.449600 | 243426ad | available |      24 |
| https://github.com/jankeromnes/gitpod-staging-prebuilds.git | 964730fb | 088a5082 | 2021-05-11 13:56:44.305709 | 6f2aff3e | available |      32 |
| https://github.com/jankeromnes/gitpod-staging-prebuilds.git | 088a5082 | NULL     | 2021-05-11 13:49:50.546575 | 98b4bfb6 | available |      46 |
| https://gitlab.com/gitlab-org/gitlab.git                    | 2e015621 | 8eef45ed | 2021-05-11 14:25:43.513453 | af8249ab | available |     429 |
| https://gitlab.com/gitlab-org/gitlab.git                    | 76e903e8 | 8eef45ed | 2021-05-11 14:15:08.733923 | c7e05e5a | available |     393 |
| https://gitlab.com/gitlab-org/gitlab.git                    | 8eef45ed | NULL     | 2021-05-11 13:51:22.791788 | 7972bd89 | available |     545 |
+-------------------------------------------------------------+----------+----------+----------------------------+----------+-----------+---------+
13 rows in set, 25 warnings (0.01 sec)
```