### PR TITLE
[dashboard] Hide 'stopping' & unpinned workspaces from 'Active'

### DIFF
--- a/components/dashboard/src/workspaces/workspace-model.ts
+++ b/components/dashboard/src/workspaces/workspace-model.ts
@@ -126,7 +126,7 @@ export class WorkspaceModel implements Disposable, Partial<GitpodClient> {
 
     protected isActive(info: WorkspaceInfo): boolean {
         return info.workspace.pinned ||
-            (!!info.latestInstance && info.latestInstance.status?.phase !== 'stopped');
+            (!!info.latestInstance && !['stopping', 'stopped'].includes(info.latestInstance.status?.phase));
     }
 
     public getAllFetchedWorkspaces(): Map<string, WorkspaceInfo> {


### PR DESCRIPTION
Potential solution/workaround for https://github.com/gitpod-io/gitpod/issues/3879

How to test:
- Delete a running workspace
- It should immediately disappear from the workspaces list, just like when you delete an already-stopped workspace

(It actually gets hidden and not removed, so you'll still see the "stopping" workspace in `Filter: All`, but maybe that's okay for now.)

(EDIT: Another potential difference is, if you delete a running _pinned_ workspace, it will still continue to be displayed as "stopping" in `Filter: Active` for a while. A fix for that could be to immediately un-pin when you delete.)