### PR TITLE
[ws-manager] mknod /dev/net/tun

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -207,6 +207,19 @@ func main() {
 					return os.Chmod("/dev/fuse", os.FileMode(0666))
 				},
 			},
+			{
+				Name:  "mknod-devnettun",
+				Usage: "creates /dev/net/tun",
+				Action: func(c *cli.Context) error {
+					_ = os.MkdirAll("/dev/net", 0755)
+					err := unix.Mknod("/dev/net/tun", 0666, int(unix.Mkdev(10, 200)))
+					if err != nil {
+						return err
+					}
+
+					return os.Chmod("/dev/net/tun", os.FileMode(0666))
+				},
+			},
 		},
 	}
 

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -221,6 +221,13 @@ func (wbs *InWorkspaceServiceServer) PrepareForUserNS(ctx context.Context, req *
 		log.WithError(err).WithFields(wbs.Session.OWI()).Error("PrepareForUserNS: cannot mknod fuse")
 		return nil, status.Errorf(codes.Internal, "cannot prepare FUSE")
 	}
+	err = nsinsider(wbs.Session.InstanceID, int(containerPID), func(c *exec.Cmd) {
+		c.Args = append(c.Args, "mknod-devnettun")
+	})
+	if err != nil {
+		log.WithError(err).WithFields(wbs.Session.OWI()).Error("PrepareForUserNS: cannot create /dev/net/tun")
+		return nil, status.Errorf(codes.Internal, "cannot create /dev/net/tun")
+	}
 
 	_ = os.MkdirAll(filepath.Join(wbs.Session.ServiceLocDaemon, "mark"), 0755)
 	mountpoint := filepath.Join(wbs.Session.ServiceLocNode, "mark")

--- a/components/ws-manager/go.sum
+++ b/components/ws-manager/go.sum
@@ -262,8 +262,11 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/gomodifytags v1.13.0/go.mod h1:TbUyEjH1Zo0GkJd2Q52oVYqYcJ0eGNqG8bsiOb75P9c=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -1052,6 +1055,7 @@ golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiT
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20180824175216-6c1c5e93cdc1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -305,7 +305,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 	//   - the TAP driver documentation says so (see https://www.kernel.org/doc/Documentation/networking/tuntap.txt)
 	//   - systemd's nspawn does the same thing (if it's good enough for them, it's good enough for us)
 	var (
-		devType          = corev1.HostPathFile
 		hostPathOrCreate = corev1.HostPathDirectoryOrCreate
 		daemonVolumeName = "daemon-mount"
 	)
@@ -328,15 +327,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			RestartPolicy: corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{
 				workspaceVolume,
-				{
-					Name: "dev-net-tun",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/dev/net/tun",
-							Type: &devType,
-						},
-					},
-				},
 				{
 					Name: daemonVolumeName,
 					VolumeSource: corev1.VolumeSource{
@@ -489,10 +479,6 @@ func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) 
 				MountPath:        workspaceDir,
 				ReadOnly:         false,
 				MountPropagation: &mountPropagation,
-			},
-			{
-				MountPath: "/dev/net/tun",
-				Name:      "dev-net-tun",
 			},
 			{
 				MountPath:        "/.workspace",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -156,10 +149,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -150,10 +143,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -44,13 +44,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -153,10 +146,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -38,13 +38,6 @@
         "spec": {
             "volumes": [
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -143,10 +136,6 @@
                         }
                     },
                     "volumeMounts": [
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
-                        },
                         {
                             "name": "daemon-mount",
                             "mountPath": "/.workspace",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/foobar-daemon",
@@ -156,10 +149,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/foobar-daemon",
@@ -156,10 +149,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/foobar-daemon",
@@ -160,10 +153,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/foobar-daemon",
@@ -160,10 +153,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/foobar-daemon",
@@ -156,10 +149,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -152,10 +145,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -156,10 +149,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -156,10 +149,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -44,13 +44,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -157,10 +150,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -43,13 +43,6 @@
                     }
                 },
                 {
-                    "name": "dev-net-tun",
-                    "hostPath": {
-                        "path": "/dev/net/tun",
-                        "type": "File"
-                    }
-                },
-                {
                     "name": "daemon-mount",
                     "hostPath": {
                         "path": "/tmp/workspaces/test-daemon",
@@ -152,10 +145,6 @@
                             "name": "vol-this-workspace",
                             "mountPath": "/workspace",
                             "mountPropagation": "HostToContainer"
-                        },
-                        {
-                            "name": "dev-net-tun",
-                            "mountPath": "/dev/net/tun"
                         },
                         {
                             "name": "daemon-mount",


### PR DESCRIPTION
This change reduces the requirements towards the node a workspace runs on. Instead of mounting `/dev/net/tun` we `mknod` it.

###  How to test
`docker run --rm -it alpine:latest`