### PR TITLE
Avoid already exists errors for ClusterRoleBinding

### DIFF
--- a/chart/templates/blobserve-rolebinding.yaml
+++ b/chart/templates/blobserve-rolebinding.yaml
@@ -23,7 +23,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: blobserve-kube-rbac-proxy
+  name: {{ .Release.Namespace }}-blobserve-kube-rbac-proxy
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: blobserve

--- a/chart/templates/image-builder-rolebinding.yaml
+++ b/chart/templates/image-builder-rolebinding.yaml
@@ -23,7 +23,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: image-builder-kube-rbac-proxy
+  name: {{ .Release.Namespace }}-image-builder-kube-rbac-proxy
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: image-builder

--- a/chart/templates/registry-facade-rolebinding.yaml
+++ b/chart/templates/registry-facade-rolebinding.yaml
@@ -23,7 +23,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: registry-facade-kube-rbac-proxy
+  name: {{ .Release.Namespace }}-registry-facade-kube-rbac-proxy
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: registry-facade

--- a/chart/templates/ws-daemon-rolebinding.yaml
+++ b/chart/templates/ws-daemon-rolebinding.yaml
@@ -23,7 +23,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: ws-daemon-rb-kube-rbac-proxy
+  name: {{ .Release.Namespace }}-ws-daemon-rb-kube-rbac-proxy
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: ws-daemon

--- a/chart/templates/ws-manager-rolebinding.yaml
+++ b/chart/templates/ws-manager-rolebinding.yaml
@@ -23,7 +23,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ws-manager-kube-rbac-proxy
+  name: {{ .Release.Namespace }}-ws-manager-kube-rbac-proxy
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: ws-manager


### PR DESCRIPTION
to avoid failures installing gitpod in multiple namespaces (gitpod-com)