### PR TITLE
Make port 5090 private by default in .gitpod.yaml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,7 @@ ports:
     onOpen: ignore
   - port: 5900
     onOpen: ignore
+    visibility: private
   - port: 6080
     onOpen: ignore
     visibility: private


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>