### PR TITLE
[supervisor] Distribute term logs with ringbuffer

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -220,13 +220,8 @@ func (tm *tasksManager) Run(ctx context.Context, wg *sync.WaitGroup) {
 		if t.config.Env != nil {
 			openRequest.Env = *t.config.Env
 		}
-		var readTimeout time.Duration
-		if !tm.config.isHeadless() {
-			readTimeout = 5 * time.Second
-		}
 		resp, err := tm.terminalService.OpenWithOptions(ctx, openRequest, terminal.TermOptions{
-			ReadTimeout: readTimeout,
-			Title:       t.title,
+			Title: t.title,
 		})
 		if err != nil {
 			taskLog.WithError(err).Error("cannot open new task terminal")
@@ -371,12 +366,10 @@ func (tm *tasksManager) watch(task *task, terminal *terminal.Term) {
 
 	var (
 		terminalLog = log.WithField("pid", terminal.Command.Process.Pid)
-		stdout      = terminal.Stdout.Listen()
+		stdout      = terminal.Stdout.Reader()
 		start       = time.Now()
 	)
 	go func() {
-		defer stdout.Close()
-
 		fileName := tm.prebuildLogFileName(task)
 		file, err := os.Create(fileName)
 		var fileWriter *bufio.Writer

--- a/components/supervisor/pkg/terminal/buffer_test.go
+++ b/components/supervisor/pkg/terminal/buffer_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package terminal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	defaultRingbufferSize = 4
+)
+
+func TestWrite(t *testing.T) {
+	type Expectation struct {
+		N     int
+		Error string
+		Buf   []byte
+	}
+	tests := []struct {
+		Name        string
+		Write       func(b *RingBuffer) (int, error)
+		Expectation Expectation
+	}{
+		{
+			Name:        "write nothing",
+			Write:       func(b *RingBuffer) (int, error) { return b.Write(nil) },
+			Expectation: Expectation{N: 0, Buf: make([]byte, defaultRingbufferSize)},
+		},
+		{
+			Name:        "write too much",
+			Write:       func(b *RingBuffer) (int, error) { return b.Write(make([]byte, 2*defaultRingbufferSize)) },
+			Expectation: Expectation{N: 2 * defaultRingbufferSize, Buf: make([]byte, defaultRingbufferSize)},
+		},
+		{
+			Name:        "write some",
+			Write:       func(b *RingBuffer) (int, error) { return b.Write(make([]byte, defaultRingbufferSize/2)) },
+			Expectation: Expectation{N: defaultRingbufferSize / 2, Buf: make([]byte, defaultRingbufferSize)},
+		},
+		{
+			Name: "write twice",
+			Write: func(b *RingBuffer) (int, error) {
+				var rn int
+				n, err := b.Write([]byte("a"))
+				if err != nil {
+					return n, err
+				}
+				rn += n
+				n, err = b.Write([]byte("b"))
+				if err != nil {
+					return n, err
+				}
+				rn += n
+				return rn, nil
+			},
+			Expectation: Expectation{
+				N:   2,
+				Buf: []byte{'a', 'b', 0x00, 0x00},
+			},
+		},
+		{
+			Name:  "write overflow",
+			Write: func(b *RingBuffer) (int, error) { return b.Write([]byte("acaba")) },
+			Expectation: Expectation{
+				N:   5,
+				Buf: []byte("caba"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := NewRingBuffer(defaultRingbufferSize)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var act Expectation
+			n, err := test.Write(b)
+			if err != nil {
+				act.Error = err.Error()
+			}
+			act.N = n
+			act.Buf = b.data
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRead(t *testing.T) {
+	type Expectation struct {
+		Output string
+		EOF    bool
+	}
+	tests := []struct {
+		Name        string
+		Size        int64
+		Input       string
+		BufSize     int64
+		Offset      int64
+		Expectation Expectation
+		Mod         func(*RingBuffer)
+	}{
+		{
+			Name:        "hello world",
+			Size:        24,
+			Input:       "hello world",
+			BufSize:     24,
+			Expectation: Expectation{Output: "hello world"},
+		},
+		{
+			Name:        "wrap around",
+			Size:        5,
+			Input:       "hello world",
+			BufSize:     24,
+			Expectation: Expectation{Output: "world"},
+		},
+		{
+			Name:        "offset > size",
+			Size:        12,
+			Input:       "",
+			Offset:      128,
+			BufSize:     24,
+			Expectation: Expectation{EOF: true},
+		},
+		{
+			Name:        "offset > write",
+			Size:        24,
+			Input:       "0123456789",
+			Offset:      12,
+			BufSize:     24,
+			Expectation: Expectation{EOF: true},
+		},
+		{
+			Name:        "offset < write",
+			Size:        24,
+			Input:       "0123456789",
+			Offset:      6,
+			BufSize:     24,
+			Expectation: Expectation{Output: "6789"},
+		},
+		{
+			Name:        "full read",
+			Size:        6,
+			Input:       "012345",
+			Offset:      0,
+			BufSize:     24,
+			Expectation: Expectation{Output: "012345"},
+		},
+		{
+			Name:        "offset 2",
+			Size:        6,
+			Input:       "012345",
+			Offset:      2,
+			BufSize:     24,
+			Expectation: Expectation{Output: "2345"},
+		},
+		{
+			Name:        "write size+1, offset 2",
+			Size:        6,
+			Input:       "012345a",
+			Offset:      2,
+			BufSize:     24,
+			Expectation: Expectation{Output: "345a"},
+		},
+		{
+			Name:        "offset size+2",
+			Size:        6,
+			Input:       "012345abcdef",
+			Offset:      8,
+			BufSize:     24,
+			Expectation: Expectation{Output: "cdef"},
+		},
+		{
+			Name:        "read all",
+			Size:        6,
+			Input:       "012345abcdef",
+			Offset:      12,
+			BufSize:     24,
+			Expectation: Expectation{EOF: true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			b, err := NewRingBuffer(test.Size)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = b.Write([]byte(test.Input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.Mod != nil {
+				test.Mod(b)
+			}
+
+			buf := make([]byte, test.BufSize)
+			n := b.Read(buf, test.Offset)
+			var act Expectation
+			if n >= 0 {
+				act.Output = string(buf[:n])
+			} else {
+				act.EOF = true
+			}
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -69,7 +69,6 @@ func (srv *MuxTerminalService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint 
 // Open opens a new terminal running the shell
 func (srv *MuxTerminalService) Open(ctx context.Context, req *api.OpenTerminalRequest) (*api.OpenTerminalResponse, error) {
 	return srv.OpenWithOptions(ctx, req, TermOptions{
-		ReadTimeout: 5 * time.Second,
 		Annotations: req.Annotations,
 	})
 }
@@ -215,8 +214,7 @@ func (srv *MuxTerminalService) Listen(req *api.ListenTerminalRequest, resp api.T
 	if !ok {
 		return status.Error(codes.NotFound, "terminal not found")
 	}
-	stdout := term.Stdout.Listen()
-	defer stdout.Close()
+	stdout := term.Stdout.Reader()
 
 	log.WithField("alias", req.Alias).Info("new terminal client")
 	defer log.WithField("alias", req.Alias).Info("terminal client left")


### PR DESCRIPTION
instead of channels. Simplifies the code and prevents readers from blocking the terminal writer.

### How to test
1. Open a terminal and produce heaps of output

### Known Defects
- terminals "die" randomly and don't produce any more output. They're still working as they take input, but their output is broken. I've seen it once that a terminal would "die" block right from the beginning. Attempts to `pprof` this have been futile. Probably something to do with the wrap around or read blocking of the ring buffer.