### PR TITLE
Fix lint failure

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -78,8 +78,7 @@ func WithArgs(args []string) RunOption {
 
 // The sum of those timeBudget* times has to fit within the terminationGracePeriod of the workspace pod.
 const (
-	timeBudgetIDEShutdown    = 5 * time.Second
-	timeBudgetDaemonTeardown = 10 * time.Second
+	timeBudgetIDEShutdown = 5 * time.Second
 )
 
 const (


### PR DESCRIPTION
Remove unused constant to fix go lint checks.
This fixes the leeway build for `components/supervisor:app`. Original error that we see during build:
```sh
github.com/gitpod-io/gitpod/supervisor
pkg/supervisor/supervisor.go:82:2: `timeBudgetDaemonTeardown` is unused (deadcode)
	timeBudgetDaemonTeardown = 10 * time.Second
	^
package build failed
Reason: exit status 1
```

Example failure build: https://werft.gitpod-dev.com/job/gitpod-build-princerachit-make-gke-grafana-links-4166.10