### PR TITLE
[db] MySQL: Set --explicit-defaults-for-timestamp=OFF

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -494,6 +494,12 @@ mysql:
   fullnameOverride: mysql
   image:
     tag: 5.7
+  primary:
+    extraEnvVars:
+      # We rely on this in our DB implementations: NULL (re-)sets configured columns to be initialized with CURRENT_TIMESTAMP.
+      # OFF is the default as documented [here](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp) (we also see this in GCP), but not for this chart.
+    - name: MYSQL_EXTRA_FLAGS
+      value: --explicit-defaults-for-timestamp=OFF
   auth:
     existingSecret: db-password
   serviceAccount:

--- a/components/gitpod-db/src/typeorm/entity/db-app-installation.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-app-installation.ts
@@ -33,6 +33,7 @@ export class DBAppInstallation implements AppInstallation {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     creationTime: string;
@@ -40,6 +41,7 @@ export class DBAppInstallation implements AppInstallation {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     lastUpdateTime: string;

--- a/components/gitpod-db/src/typeorm/entity/db-layout-data.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-layout-data.ts
@@ -19,6 +19,7 @@ export class DBLayoutData implements LayoutData {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     lastUpdatedTime: string;

--- a/components/gitpod-db/src/typeorm/entity/db-license-key.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-license-key.ts
@@ -18,6 +18,7 @@ export class DBLicenseKey {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     installationTime: string;

--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
@@ -31,6 +31,7 @@ export class DBPrebuiltWorkspace implements PrebuiltWorkspace {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     creationTime: string;

--- a/components/gitpod-db/src/typeorm/entity/db-snapshot.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-snapshot.ts
@@ -20,6 +20,7 @@ export class DBSnapshot implements Snapshot {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     creationTime: string;

--- a/components/gitpod-db/src/typeorm/entity/db-user-message-view-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-user-message-view-entry.ts
@@ -20,6 +20,7 @@ export class DBUserMessageViewEntry  {
     @Column({
         type: 'timestamp',
         precision: 6,
+        default: () => 'CURRENT_TIMESTAMP(6)',
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP
     })
     viewedAt: string;

--- a/components/gitpod-db/src/typeorm/transformer.ts
+++ b/components/gitpod-db/src/typeorm/transformer.ts
@@ -26,7 +26,11 @@ export namespace Transformer {
 
     export const MAP_ISO_STRING_TO_TIMESTAMP_DROP: ValueTransformer = {
         to(value: any): any {
-            // DROP all input values as they are set by the DB 'ON UPDATE'/ as default value
+            // DROP all input values as they are set by the DB 'ON UPDATE'/ as default value.
+            // We're relying on the system variable explicit-defaults-for-timestamp here (link: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp):
+            // `undefined` get's converted to NULL, which on the DB is turned into the configured default value for the column.
+            // In our case, that's 100% CURRENT_TIMESTAMP.
+            // This was done initially so we don't have to make fields like `creationTime` optional, or have to use two types for the same table.
             return undefined;
         },
         from(value: any): any {

--- a/components/gitpod-db/src/typeorm/transformer.ts
+++ b/components/gitpod-db/src/typeorm/transformer.ts
@@ -28,7 +28,7 @@ export namespace Transformer {
         to(value: any): any {
             // DROP all input values as they are set by the DB 'ON UPDATE'/ as default value.
             // We're relying on the system variable explicit-defaults-for-timestamp here (link: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp):
-            // `undefined` get's converted to NULL, which on the DB is turned into the configured default value for the column.
+            // `undefined` gets converted to NULL, which on the DB is turned into the configured default value for the column.
             // In our case, that's 100% CURRENT_TIMESTAMP.
             // This was done initially so we don't have to make fields like `creationTime` optional, or have to use two types for the same table.
             return undefined;


### PR DESCRIPTION
Fixes #4169.

This PR contains two commits:
 - the first is the actual fix
 - the other is a cleanup that has no compile/runtime impact. It just reduces the diff between our TypeORM config and our migrations.