### PR TITLE
[local companion app] Add to dashboard

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -4,6 +4,7 @@ defaultArgs:
   coreYarnLockBase: ../..
   npmPublishTrigger: "false"
   publishToNPM: true
+  localAppVersion: unknown
 
 defaultVariant:
   config:

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -39,6 +39,7 @@ metadata:
     component: proxy
     kind: deployment
     stage: {{ .Values.installation.stage }}
+    gitpod.io/requiresCerts: 'true'
 spec:
   selector:
     matchLabels:
@@ -46,6 +47,7 @@ spec:
       component: proxy
       kind: pod
       stage: {{ .Values.installation.stage }}
+      gitpod.io/requiresCerts: 'true'
   replicas: {{ $comp.replicas | default 1 }}
   strategy:
     type: RollingUpdate
@@ -69,6 +71,7 @@ spec:
         component: proxy
         kind: pod
         stage: {{ .Values.installation.stage }}
+        gitpod.io/requiresCerts: 'true'
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccount: proxy

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -14,6 +14,7 @@ metadata:
     kind: deployment
     stage: {{ .Values.installation.stage }}
     gitpod.io/nodeService: registry-facade
+    gitpod.io/requiresCerts: 'true'
 spec:
   selector:
     matchLabels:
@@ -22,6 +23,7 @@ spec:
       kind: pod
       stage: {{ .Values.installation.stage }}
       gitpod.io/nodeService: registry-facade
+      gitpod.io/requiresCerts: 'true'
   template:
     metadata:
       name: registry-facade
@@ -31,6 +33,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
         gitpod.io/nodeService: registry-facade
+        gitpod.io/requiresCerts: 'true'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/path: "/metrics"

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     component: ws-proxy
     kind: deployment
     stage: {{ .Values.installation.stage }}
+    gitpod.io/requiresCerts: 'true'
 spec:
   selector:
     matchLabels:
@@ -20,6 +21,7 @@ spec:
       component: ws-proxy
       kind: pod
       stage: {{ .Values.installation.stage }}
+      gitpod.io/requiresCerts: 'true'
   replicas: {{ $comp.replicas | default 1 }}
   strategy:
     type: RollingUpdate
@@ -34,6 +36,7 @@ spec:
         component: ws-proxy
         kind: pod
         stage: {{ .Values.installation.stage }}
+        gitpod.io/requiresCerts: 'true'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/path: "/metrics"

--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -36,6 +36,7 @@ packages:
     deps:
       - :app
       - :static
+      - components/local-app:app
     argdeps:
       - imageRepoBase
     config:

--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -7,3 +7,8 @@ FROM caddy/caddy:2.4.0-beta.2-alpine
 
 COPY components-dashboard--static/conf/Caddyfile /etc/caddy/Caddyfile
 COPY components-dashboard--app/build /www
+
+RUN mkdir -p /www/static/bin
+COPY components-local-app--app/components-local-app--app-linux/local-app /www/static/bin/gitpod-local-companion-linux
+COPY components-local-app--app/components-local-app--app-darwin/local-app /www/static/bin/gitpod-local-companion-darwin
+COPY components-local-app--app/components-local-app--app-windows/local-app.exe /www/static/bin/gitpod-local-companion-windows.exe

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -14,11 +14,14 @@ packages:
         - go.sum
         - "**/*.go"
       deps:
+        - :version
         - components/supervisor-api/go:lib
         - components/gitpod-protocol/go:lib
       env:
         - CGO_ENABLED=0
         - GOOS=linux
+      prep:
+        - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
       config:
         packaging: app
     - name: app-darwin
@@ -28,11 +31,14 @@ packages:
         - go.sum
         - "**/*.go"
       deps:
+        - :version
         - components/supervisor-api/go:lib
         - components/gitpod-protocol/go:lib
       env:
         - CGO_ENABLED=0
         - GOOS=darwin
+      prep:
+        - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
       config:
         packaging: app
     - name: app-windows
@@ -42,13 +48,24 @@ packages:
         - go.sum
         - "**/*.go"
       deps:
+        - :version
         - components/supervisor-api/go:lib
         - components/gitpod-protocol/go:lib
       env:
         - CGO_ENABLED=0
         - GOOS=windows
+      prep:
+        - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
       config:
         packaging: app
+    - name: version
+      type: generic
+      argdeps:
+        - localAppVersion
+      config:
+        commands:
+          - ["sh", "-c", "echo '${localAppVersion}' > version.txt"]
+          - ["echo", "Local App Version: ${localAppVersion}"]
     - name: docker
       type: docker
       deps:

--- a/components/local-app/main.go
+++ b/components/local-app/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	_ "embed"
+
 	"context"
 	"errors"
 	"log"
@@ -19,11 +21,20 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+var (
+	// Version : current version
+	Version string = strings.TrimSpace(version)
+	//go:embed version.txt
+	version string
+)
+
 func main() {
 	app := cli.App{
-		Name:                 "gitpod",
+		Name:                 "gitpod-local-companion",
+		Usage:                "connect your Gitpod workspaces",
 		Action:               DefaultCommand("run"),
 		EnableBashCompletion: true,
+		Version:              Version,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "gitpod-host",

--- a/components/local-app/version.txt
+++ b/components/local-app/version.txt
@@ -1,0 +1,1 @@
+set-during-build


### PR DESCRIPTION
This PR makes the local companion app available from the dashboard, i.e. adds it to the `public/` assets.

It also sets the version during build by overwriting a `version.go` file instead of using ldflags. This way we can set the ldflags globally in the `WORKSPACE.yaml`.


### How to test
```bash
# Download the local companion app binary from the dashboard
curl -OL https://cw-lca-dashboard-dl.staging.gitpod-dev.com/static/bin/gitpod-local-companion-linux

# Run the app and check its version
chmod +x gitpod-local-companion-linux
./gitpod-local-companion-linux -v
```