### PR TITLE
Enable product notifications for new users

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -72,7 +72,7 @@ export class TypeORMUserDBImpl implements UserDB {
             id: uuidv4(),
             creationDate: new Date().toISOString(),
             identities: [],
-            allowsMarketingCommunication: false,
+            allowsMarketingCommunication: true,
             additionalData: { ideSettings: { defaultIde: 'code' } },
         };
         await this.storeUser(user);


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/gitpod-io/gitpod/issues/4234. See also [relevant discussion](https://gitpod.slack.com/archives/C022DFDLAQL/p1621441266006600) (internal).

### How to test this

1. Go to the [preview environment](https://gt-enable-product-notifications.staging.gitpod-dev.com).
2. Sign up as a new user.
3. Go to [`/notifications`](https://gt-enable-product-notifications.staging.gitpod-dev.com/notifications).
4. You should see both _Account_ and _Product_ notifications enabled by default.

### Risk

While this is only changing a single bollean value, this could also need to remove some unessesary checks or code. If this is the case, please feel free to pick this up! 🤷 