### PR TITLE
[proxy] Cleanup caddy plugin build

### DIFF
--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -2,11 +2,44 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM aledbf/caddy-http2:0.5
+FROM golang:1.16 as builder
+
+RUN curl -fsSL https://github.com/caddyserver/xcaddy/releases/download/v0.1.9/xcaddy_0.1.9_linux_amd64.tar.gz \
+  | tar -xzv -C /usr/local/bin/ xcaddy
+
+WORKDIR /plugins
+
+COPY plugins/go.* /plugins/
+
+RUN go mod download
+
+COPY plugins /plugins
+
+# the fork contains two changes:
+# - configure http/2 server
+# - update golang.org/x/net go dependency
+# TODO (aledbf): use upstream once the fixes are applied.
+RUN git clone -b http2 https://github.com/aledbf/caddy caddy-fork
+
+# build caddy
+RUN xcaddy build \
+  --output /caddy \
+  --with github.com/caddyserver/caddy/v2=$PWD/caddy-fork \
+  --with github.com/gitpod-io/gitpod/proxy/plugins=/plugins
+
+FROM alpine:3.13
+
+# Ensure latest packages are present, like security updates.
+RUN  apk upgrade --no-cache \
+  && apk add --no-cache ca-certificates bash
 
 # Debug convenience
 ENV TERM=xterm
 ENV SHELL=/bin/bash
 
+COPY --from=builder /caddy /usr/bin/caddy
+
 COPY conf/Caddyfile /etc/caddy/Caddyfile
 COPY conf/vhost.empty /etc/caddy/vhosts/vhost.empty
+
+CMD [ "caddy", "run", "-config", "/etc/caddy/Caddyfile" ]

--- a/components/proxy/plugins/cors_origin.go
+++ b/components/proxy/plugins/cors_origin.go
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package workspace
+package plugins
 
 import (
 	"fmt"

--- a/components/proxy/plugins/go.mod
+++ b/components/proxy/plugins/go.mod
@@ -1,0 +1,8 @@
+module github.com/gitpod-io/gitpod/proxy/plugins
+
+go 1.16
+
+require (
+	github.com/caddyserver/caddy/v2 v2.4.1
+	github.com/rs/cors v1.7.0
+)

--- a/components/proxy/plugins/workspace/go.mod
+++ b/components/proxy/plugins/workspace/go.mod
@@ -1,8 +1,0 @@
-module github.com/gitpod-io/gitpod/proxy/plugins/workspace
-
-go 1.16
-
-require (
-	github.com/caddyserver/caddy/v2 v2.4.0
-	github.com/rs/cors v1.6.0
-)

--- a/components/proxy/plugins/workspace_download.go
+++ b/components/proxy/plugins/workspace_download.go
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package workspace
+package plugins
 
 import (
 	"fmt"


### PR DESCRIPTION
Changes:
- Improve build process for local changes in plugins
- Point to temporal Caddy fork
- Build binary using [xcaddy](https://github.com/caddyserver/xcaddy)

Also, after the migration and this PR, this is a test in https://www.webpagetest.org/

![4f145571-7d3c-45ff-9046-0bbb2463dec7](https://user-images.githubusercontent.com/161571/118908593-b5b27c80-b8ef-11eb-9b08-3263adf36dff.png)
