### PR TITLE
[dashboard] Update Caddy and enable pre-compressed files

### DIFF
--- a/components/dashboard/conf/Caddyfile
+++ b/components/dashboard/conf/Caddyfile
@@ -3,24 +3,14 @@
 	admin off
 }
 
-(compression) {
-	encode zstd gzip
-}
-
-(discard_log) {
-	log {
-		output discard
-	}
-}
-
 (static) {
 	@static_path {
-		path /static/*
+		path /static/* /favicon* /manifest.json
 	}
 
 	@static_asset {
 		file
-		path /static/*
+		path /static/* /favicon* /manifest.json
 	}
 
 	# static assets configure cache headers and do not check for changes
@@ -46,8 +36,6 @@
 }
 
 :80 {
-	import compression
-	import discard_log
 	import static
 	import notstatic
 
@@ -57,7 +45,9 @@
 	header -Server
 
 	root * /www
-	file_server
+	file_server {
+		precompressed gzip br
+	}
 
 	handle @static_path {
 		try_files {path}
@@ -74,8 +64,6 @@
 
 # health-check
 :8080 {
-	import discard_log
-
 	respond /live 200
 	respond /ready 200
 }

--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -2,13 +2,29 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+FROM alpine:3.13 as compress
 
-FROM caddy/caddy:2.4.0-beta.2-alpine
+RUN apk add brotli gzip
 
-COPY components-dashboard--static/conf/Caddyfile /etc/caddy/Caddyfile
 COPY components-dashboard--app/build /www
 
-RUN mkdir -p /www/static/bin
+WORKDIR /www
+
+RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.png' -o -name '*.svg' -o -name '*.map' -o -name '*.json' \) \
+  -exec /bin/sh -c 'gzip -v -f -9 -k "$1"' /bin/sh {} \;
+
+RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.png' -o -name '*.svg' -o -name '*.map' -o -name '*.json' \) \
+  -exec /bin/sh -c 'brotli -v -q 11 -o "$1.br" "$1"' /bin/sh {} \;
+
 COPY components-local-app--app/components-local-app--app-linux/local-app /www/static/bin/gitpod-local-companion-linux
 COPY components-local-app--app/components-local-app--app-darwin/local-app /www/static/bin/gitpod-local-companion-darwin
 COPY components-local-app--app/components-local-app--app-windows/local-app.exe /www/static/bin/gitpod-local-companion-windows.exe
+
+RUN for PLATFORM in linux darwin windows.exe;do \
+  gzip -v -f -9 -k "/www/static/bin/gitpod-local-companion-$PLATFORM"; \
+done
+
+FROM caddy/caddy:2.4.0-alpine
+
+COPY components-dashboard--static/conf/Caddyfile /etc/caddy/Caddyfile
+COPY --from=compress /www /www


### PR DESCRIPTION
In the last release, Caddy added a feature that allows serving [pre-compressed](https://caddyserver.com/docs/caddyfile/directives/file_server) files
(this removes the CPU overhead in every request for compression).

```console
{"level":"debug","ts":1621567273.6175573,"logger":"http.handlers.file_server","msg":"sanitized path join","site_root":"/www","request_path":"/index.html","result":"/www/index.html"}
{"level":"debug","ts":1621567273.6175954,"logger":"http.handlers.file_server","msg":"opening compressed sidecar file","filename":"/www/index.html.gz"}
{"level":"debug","ts":1621567273.9166408,"logger":"http.handlers.file_server","msg":"sanitized path join","site_root":"/www","request_path":"/favicon256.png","result":"/www/favicon256.png"}
{"level":"debug","ts":1621567273.9166927,"logger":"http.handlers.file_server","msg":"opening compressed sidecar file","filename":"/www/favicon256.png.gz"}
{"level":"debug","ts":1621567273.9270983,"logger":"http.handlers.file_server","msg":"sanitized path join","site_root":"/www","request_path":"/static/js/8.33487e98.chunk.js.map","result":"/www/static/js/8.33487e98.chunk.js.map"}
{"level":"debug","ts":1621567273.9271371,"logger":"http.handlers.file_server","msg":"opening compressed sidecar file","filename":"/www/static/js/8.33487e98.chunk.js.map.gz"}

```
