### PR TITLE
[werft] Create new gcp project using terraform for preview env

### DIFF
--- a/.werft/README.md
+++ b/.werft/README.md
@@ -1,0 +1,28 @@
+# Overview
+
+We use werft for our CICD pipeline. We are transforming our scripts to support various types of deployment. Here are few things you should be aware of if you decide to make changes in this directory:
+
+## Prefer Annotations over branch name based logic
+
+Using branch name to pass runtime information to werft script has several drawbacks:
+1. Branch name length has limit
+1. We endup writing complex logic around branch name parsing
+  1. It leads to bad developer experience; someone looking at the code has to rely on comments to understand cryptic parsing logic
+  1. It adds additional burden of learning about branch naming format
+
+That said, we still use branch name in special cases like releasing from a particular branch etc.
+
+Due to listed reasons we use werft annotations to pass runtime information. You can read more about annotations [here](https://github.com/csweichel/werft).
+
+## Deployments
+
+Currently all non-main branches are deployed in a preview cluster under a specific namespace. If you make changes to the source branch, the namespace is wiped and the new changes are redeployed.
+
+## Deployment target
+
+We have added a new annotation `deploytarget` to support deployment of gitpod based on the desired target. This annotation based logic is still being developed and only supports `gke` value atm.
+We will eventually deprecate the `no-preview` annotation in favour of this annotation. This readme will be updated accordingly.
+
+Future supported values for `deploytarget`:
+1. `gke`: Installs gitpod in a fresh gke cluster
+1. `namespace`: Installs gitpod in a common kubernetes preview cluster but in a specific namespace

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -488,11 +488,9 @@ function createGCProjectName(): string {
     return "gptf-" + projectName
 }
 
-// As of now we only build branches with suffix 'tf-build' in the tf preview env.
 function isTerraformPreviewEnvironment(context: any): boolean {
     let buildConfig = context.Annotations || {};
-    let branchName: string = context.Repository.ref;
-    return branchName.endsWith('tf-build') || "tf-preview" in buildConfig
+    return buildConfig["deploytarget"] === "gke"
 }
 
 function createTerraformBlockOverride(name: string): string {

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -503,8 +503,9 @@ function createGCProjectName(): string {
 
 // As of now we only build branches with suffix 'tf-build' in the tf preview env
 function isTerraformPreviewEnvironment(context: any): boolean {
+    let buildConfig = context.Annotations || {};
     let branchName: string = context.Repository.ref;
-    return branchName.endsWith('tf-build')
+    return branchName.endsWith('tf-build') || "tf-Preview" in buildConfig
 }
 
 function createTerraformBlockOverride(name: string): string {

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -10,6 +10,9 @@ pod:
   - name: gcp-sa-release
     secret:
       secretName: gcp-sa-gitpod-release-deployer
+  - name: gcp-sa-preview-manager
+    secret:
+      secretName: gcp-sa-gitpod-preview-manager
   # - name: deploy-key
   #   secret:
   #     secretName: deploy-key
@@ -39,6 +42,9 @@ pod:
       readOnly: true
     - name: gcp-sa-release
       mountPath: /mnt/secrets/gcp-sa-release
+      readOnly: true
+    - name: gcp-sa-preview-manager
+      mountPath: /mnt/secrets/gcp-sa-preview-manager
       readOnly: true
     # - name: deploy-key
     #   mountPath: /mnt/secrets/deploy-key

--- a/.werft/constants/gcp.ts
+++ b/.werft/constants/gcp.ts
@@ -1,0 +1,2 @@
+export const terraformModulePath = ".werft/gcp-preview-project/"
+export const pathToGcpSA = "/mnt/secrets/gcp-sa-preview-manager/service-account.json"

--- a/.werft/constants/gcp.ts
+++ b/.werft/constants/gcp.ts
@@ -1,2 +1,3 @@
 export const terraformModulePath = ".werft/gcp-preview-project/"
 export const pathToGcpSA = "/mnt/secrets/gcp-sa-preview-manager/service-account.json"
+export const previewTerraformEnvStateBucketName = 'gitpod-core-preview-terraform-state'

--- a/.werft/gcp-preview-project/.gitignore
+++ b/.werft/gcp-preview-project/.gitignore
@@ -1,0 +1,1 @@
+override.tf

--- a/.werft/gcp-preview-project/main.tf
+++ b/.werft/gcp-preview-project/main.tf
@@ -5,7 +5,6 @@ variable "name" {
 terraform {
   backend "gcs" {
     bucket  = "gitpod-core-preview-terraform-state"
-    #prefix  = "terraform/state"
     prefix  = "" # override me
   }
 }
@@ -32,13 +31,6 @@ data "google_dns_managed_zone" "gcp-gitpod-dev-com" {
 resource "random_id" "gitpod" {
   byte_length = 4
 }
-
-# resource "google_project_service" "project" {
-#   project = "your-project-id"
-#   service = "iam.googleapis.com"
-
-#   disable_dependent_services = true
-# }
 
 resource "google_project" "gitpod" {
   name       = var.name

--- a/.werft/gcp-preview-project/main.tf
+++ b/.werft/gcp-preview-project/main.tf
@@ -1,0 +1,92 @@
+variable "name" {
+    type = string
+}
+
+terraform {
+  backend "gcs" {
+    bucket  = "gitpod-core-preview-terraform-state"
+    #prefix  = "terraform/state"
+    prefix  = "" # override me
+  }
+}
+
+
+locals {
+  gcp = {
+    services = [
+      "dns.googleapis.com",
+    ]
+  }
+}
+
+data "google_folder" "preview_folder" {
+  folder              = "folders/749048792553"
+  lookup_organization = true
+}
+
+data "google_dns_managed_zone" "gcp-gitpod-dev-com" {
+  name    = "gcp-gitpod-dev-com"
+  project = "preview-setup"
+}
+
+resource "random_id" "gitpod" {
+  byte_length = 4
+}
+
+# resource "google_project_service" "project" {
+#   project = "your-project-id"
+#   service = "iam.googleapis.com"
+
+#   disable_dependent_services = true
+# }
+
+resource "google_project" "gitpod" {
+  name       = var.name
+  project_id = "${var.name}-${random_id.gitpod.hex}"
+  folder_id  = data.google_folder.preview_folder.name
+  billing_account = "01C05A-85FB6F-361061"
+}
+
+resource "google_project_service" "project" {
+  count   = length(local.gcp.services)
+  project = google_project.gitpod.project_id
+  service = local.gcp.services[count.index]
+  disable_on_destroy = false
+}
+
+resource "google_dns_managed_zone" "gitpod" {
+  name        = "${var.name}-${data.google_dns_managed_zone.gcp-gitpod-dev-com.name}"
+  dns_name    = "${var.name}.${data.google_dns_managed_zone.gcp-gitpod-dev-com.dns_name}"
+  description = "Preview project ${var.name}"
+  project     = google_project.gitpod.project_id
+  depends_on = [
+    google_project_service.project
+  ]
+}
+
+resource "google_dns_record_set" "gitpod" {
+  project = data.google_dns_managed_zone.gcp-gitpod-dev-com.project
+  name    = google_dns_managed_zone.gitpod.dns_name
+  type    = "NS"
+  ttl     = 60
+  managed_zone = data.google_dns_managed_zone.gcp-gitpod-dev-com.name
+  rrdatas = google_dns_managed_zone.gitpod.name_servers
+}
+
+output "dns_zone" {
+    value = google_dns_managed_zone.gitpod.name
+}
+
+output "dns_name" {
+    value = google_dns_managed_zone.gitpod.dns_name
+}
+
+output "project_name" {
+    value = google_project.gitpod.name
+}
+
+output "project_id" {
+    value = google_project.gitpod.project_id
+}
+
+

--- a/.werft/util/hash.ts
+++ b/.werft/util/hash.ts
@@ -1,0 +1,20 @@
+import { createHmac } from 'crypto';
+
+// referred from: https://security.stackexchange.com/questions/218044/how-to-generate-short-fixed-length-cryptographic-hashes/218045
+// I have kept the secret as constant 'gitpod' as we do not intend to generate any cryptic string.
+export function getXDigitsCode(message, digitCount): string {
+    if (digitCount < 1 || digitCount > 64) {
+        throw new Error("digitCount should be between 1 and 64(inclusive)")
+    }
+    const hash = createHmac('sha256', Buffer.from('gitpod', 'hex'))
+        .update(message)
+        .digest('hex');
+    const firstXHexCharacters = hash.slice(0, digitCount);
+    const int = parseInt(firstXHexCharacters, 16) % 10000;
+    let code = int.toString();
+    code =
+        Array(digitCount - code.length)
+            .fill(0)
+            .join('') + code;
+    return code;
+};

--- a/.werft/util/hash.ts
+++ b/.werft/util/hash.ts
@@ -1,17 +1,17 @@
-import { createHmac } from 'crypto';
+import { createHmac, createHash } from 'crypto';
 
 // referred from: https://security.stackexchange.com/questions/218044/how-to-generate-short-fixed-length-cryptographic-hashes/218045
-// I have kept the secret as constant 'gitpod' as we do not intend to generate any cryptic string.
-export function getXDigitsCode(message, digitCount): string {
+// and https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options
+export function getXDigitsHashCode(message: string, digitCount: number): string {
     if (digitCount < 1 || digitCount > 64) {
         throw new Error("digitCount should be between 1 and 64(inclusive)")
     }
-    const hash = createHmac('sha256', Buffer.from('gitpod', 'hex'))
-        .update(message)
-        .digest('hex');
+    const hash = createHash('sha256').update(message).digest('hex')
     const firstXHexCharacters = hash.slice(0, digitCount);
-    const int = parseInt(firstXHexCharacters, 16) % 10000;
+    // In order to reduce collision we want to use all available characters, we do it by taking a mod
+    const int = parseInt(firstXHexCharacters, 16) % (10 ** digitCount);
     let code = int.toString();
+    // If the number of chars is less than digitCount then we will prepend '0'
     code =
         Array(digitCount - code.length)
             .fill(0)


### PR DESCRIPTION
## What?
Prelim checkin to allow the creation of terraform based preview environment gcp project and subdomain.

A gcp project would be created in the following cases:
1. Annotation "deploytarget=gke" is passed to werft context

## Next Steps
1. Once we have terraform scripts for full fledged self hosted gke installation, we will add logic to call that script for actual gitpod installation
2. Project cleanup after X hours
3. build.ts file refactoring

/werft deploytarget=gke
