### PR TITLE
Modify the "New Git Integration" experience to align with provider terminology

### DIFF
--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -479,7 +479,12 @@ export function GitIntegrationModal(props: ({
         validate();
     }, [clientId, clientSecret])
     
-    // JH-TODO: Create new useEffect function to update the host and redirectURL values when the type value changes, restrict to running only while creating a new integration
+    useEffect(() => {
+        if (props.mode === "new") {
+            const exampleHostname = `${type.toLowerCase()}.example.com`;
+            updateHostValue(exampleHostname);
+        }
+    }, [type]);
 
     const onClose = () => props.onClose && props.onClose();
     const onUpdate = () => props.onUpdate && props.onUpdate();
@@ -571,12 +576,10 @@ export function GitIntegrationModal(props: ({
     const validate = () => {
         const errors: string[] = [];
         if (clientId.trim().length === 0) {
-            // JH-TODO: Use template literal string to display error message per provider's terminology
-            errors.push("Client ID is missing.");
+            errors.push(`${type === "GitLab" ? "Application ID" : "Client ID"} is missing.`);
         }
         if (clientSecret.trim().length === 0) {
-            // JH-TODO: Use template literal string to display error message per provider's terminology
-            errors.push("Client Secret is missing.");
+            errors.push(`${type === "GitLab" ? "Secret" : "Client Secret"} is missing.`);
         }
         if (errors.length === 0) {
             setValidationError(undefined);
@@ -659,21 +662,18 @@ export function GitIntegrationModal(props: ({
                     <div className="w-full relative">
                         <input name="redirectURL" disabled={true} readOnly={true} type="text" value={redirectURL} className="w-full pr-8" />
                         <div className="cursor-pointer" onClick={() => copyRedirectUrl()}>
-                            {/* JH-TODO: Fix Typo */}
-                            <img src={copy} title="Copy the Redirect URL to clippboard" className="absolute top-1/3 right-3" />
+                            <img src={copy} title="Copy the Redirect URL to clipboard" className="absolute top-1/3 right-3" />
                         </div>
                     </div>
                     <span className="text-gray-500 text-sm">{getRedirectUrlDescription(type, host)}</span>
                 </div>
                 <div className="flex flex-col space-y-2">
-                    {/* JH-TODO: Use template literal string to update label per provider's terminology */}
-                    <label htmlFor="clientId" className="font-medium">Client ID</label>
+                    <label htmlFor="clientId" className="font-medium">{`${type === "GitLab" ? "Application ID" : "Client ID"}`}</label>
                     <input name="clientId" type="text" value={clientId} className="w-full"
                         onChange={(e) => updateClientId(e.target.value)} />
                 </div>
                 <div className="flex flex-col space-y-2">
-                    {/* JH-TODO: Use template literal string to update label per provider's terminology */}
-                    <label htmlFor="clientSecret" className="font-medium">Client Secret</label>
+                    <label htmlFor="clientSecret" className="font-medium">{`${type === "GitLab" ? "Secret" : "Client Secret"}`}</label>
                     <input name="clientSecret" type="password" value={clientSecret} className="w-full"
                         onChange={(e) => updateClientSecret(e.target.value)} />
                 </div>

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -478,6 +478,8 @@ export function GitIntegrationModal(props: ({
         setErrorMessage(undefined);
         validate();
     }, [clientId, clientSecret])
+    
+    // JH-TODO: Create new useEffect function to update the host and redirectURL values when the type value changes, restrict to running only while creating a new integration
 
     const onClose = () => props.onClose && props.onClose();
     const onUpdate = () => props.onUpdate && props.onUpdate();
@@ -569,9 +571,11 @@ export function GitIntegrationModal(props: ({
     const validate = () => {
         const errors: string[] = [];
         if (clientId.trim().length === 0) {
+            // JH-TODO: Use template literal string to display error message per provider's terminology
             errors.push("Client ID is missing.");
         }
         if (clientSecret.trim().length === 0) {
+            // JH-TODO: Use template literal string to display error message per provider's terminology
             errors.push("Client Secret is missing.");
         }
         if (errors.length === 0) {
@@ -655,17 +659,20 @@ export function GitIntegrationModal(props: ({
                     <div className="w-full relative">
                         <input name="redirectURL" disabled={true} readOnly={true} type="text" value={redirectURL} className="w-full pr-8" />
                         <div className="cursor-pointer" onClick={() => copyRedirectUrl()}>
+                            {/* JH-TODO: Fix Typo */}
                             <img src={copy} title="Copy the Redirect URL to clippboard" className="absolute top-1/3 right-3" />
                         </div>
                     </div>
                     <span className="text-gray-500 text-sm">{getRedirectUrlDescription(type, host)}</span>
                 </div>
                 <div className="flex flex-col space-y-2">
+                    {/* JH-TODO: Use template literal string to update label per provider's terminology */}
                     <label htmlFor="clientId" className="font-medium">Client ID</label>
                     <input name="clientId" type="text" value={clientId} className="w-full"
                         onChange={(e) => updateClientId(e.target.value)} />
                 </div>
                 <div className="flex flex-col space-y-2">
+                    {/* JH-TODO: Use template literal string to update label per provider's terminology */}
                     <label htmlFor="clientSecret" className="font-medium">Client Secret</label>
                     <input name="clientSecret" type="password" value={clientSecret} className="w-full"
                         onChange={(e) => updateClientSecret(e.target.value)} />


### PR DESCRIPTION
Modifying the `GitIntegrationModal` function per #4275

The default **Provider Type** value is still "GitLab", and when GitLab is selected as the provider, the following conditional operations are applied to the form:
- Both the field label and error message instance tied to `clientId` are shown as "**Application ID**".
- Both the field label and error message instance tied to `clientSecret` are shown as "**Secret**".

**NOTE**: When the provider is not GitLab, all strings related to `clientId` and `clientSecret` are "Client ID" and "Client Secret" accordingly.

Additionally, when creating a new integration (restricted so as not to cause unexpected side effects when editing an existing integration), if the user selects a different provider, e.g. "**GitHub**",  then the **Provider Host Name** field value changes to `"github.example.com"` and the **Redirect URL** field value changes to `"https://gitpod.io/auth/github.example.com/callback"`