### PR TITLE
Removing secondary class from the Authorize Git Provider CTA button to give proper weight. Per https://github.com/gitpod-io/gitpod/issues/4197

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -116,7 +116,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
           break;
         case ErrorCodes.NOT_AUTHENTICATED:
           statusMessage = <div className="mt-2 flex flex-col space-y-8">
-            <button className="secondary" onClick={() => {
+            <button className="" onClick={() => {
               this.tryAuthorize(error?.data.host, error?.data.scopes)
             }}>Authorize with {error.data.host}</button>
           </div>;


### PR DESCRIPTION
Per https://github.com/gitpod-io/gitpod/issues/4197

Dropping the `secondary` class, from reviewing the `components/dashboard/src/index.css` file I expect this should style the button with the following rules:

```css
button {
        @apply cursor-pointer px-4 py-2 my-auto bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-600 text-gray-100 dark:text-green-100 text-sm font-medium rounded-md focus:outline-none focus:ring transition ease-in-out;
    }
```