### PR TITLE
Removing secondary class from the main CTA button to give proper weight.

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -116,7 +116,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
           break;
         case ErrorCodes.NOT_AUTHENTICATED:
           statusMessage = <div className="mt-2 flex flex-col space-y-8">
-            <button className="secondary" onClick={() => {
+            <button className="" onClick={() => {
               this.tryAuthorize(error?.data.host, error?.data.scopes)
             }}>Authorize with {error.data.host}</button>
           </div>;


### PR DESCRIPTION
Per #4197, same code as #4286 with shorter branch name to avoid build error.