### PR TITLE
[server] Increase timeouts for parent prebuilds

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -800,6 +800,16 @@ export namespace WithPrebuild {
     }
 }
 
+export interface WithTimeout {
+    timeout: string;
+}
+export namespace WithTimeout {
+    export function is(context: any): context is WithTimeout {
+        return context
+            && 'timeout' in context;
+    }
+}
+
 export interface SnapshotContext extends WorkspaceContext, WithSnapshot {
     snapshotId: string;
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -6,7 +6,7 @@
 
 import { CloneTargetMode, GitAuthMethod, GitConfig, GitInitializer, PrebuildInitializer, SnapshotInitializer, WorkspaceInitializer } from "@gitpod/content-service/lib";
 import { DBUser, DBWithTracing, TracedUserDB, TracedWorkspaceDB, UserDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
-import { CommitContext, Disposable, GitpodToken, GitpodTokenType, ImageConfigFile, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType } from "@gitpod/gitpod-protocol";
+import { CommitContext, Disposable, GitpodToken, GitpodTokenType, ImageConfigFile, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, WithTimeout, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType } from "@gitpod/gitpod-protocol";
 import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -641,6 +641,8 @@ export class WorkspaceStarter {
         spec.setFeatureFlagsList(this.toWorkspaceFeatureFlags(featureFlags));
         if (workspace.type === 'regular') {
             spec.setTimeout(await userTimeoutPromise);
+        } else if (WithTimeout.is(workspace.context)) {
+            spec.setTimeout(workspace.context.timeout);
         }
         spec.setAdmission(admissionLevel);
         return spec;


### PR DESCRIPTION
Still unsure what the best approach is here:

1. Make `WorkspaceStarter.createSpec()` fetch the prebuild workspace to check for preconditions (incremental enabled && parent prebuild) before setting the custom timeout

2. Same but move the preconditions check + custom timeout value into a helper method somewhere else

3. Add some parameter on the `Workspace` shape that indicates "is a parent prebuild that should run longer"

4. Make `PrebuildManager` call `WorkspaceStarter.startWorkspace(ctx, workspace, user, options)` with a new `options` field (e.g. `customTimeout`) that gets passed to `actuallyStartWorkspace` and then to `createSpec`