### PR TITLE
[server] Don't use the full-workspace-backup feature flag for prebuilds

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -94,7 +94,7 @@ export class PrebuildManager {
             // }
 
             span.setTag("starting", true);
-            await this.workspaceStarter.startWorkspace({ span }, workspace, user);
+            await this.workspaceStarter.startWorkspace({ span }, workspace, user, [], {excludeFeatureFlags: ['full_workspace_backup']});
             return { wsid: workspace.id, done: false };
         } catch (err) {
             TraceContext.logError({ span }, err);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -34,6 +34,12 @@ import { DBUser } from '@gitpod/gitpod-db/lib/typeorm/entity/db-user';
 import { ScopedResourceGuard } from '../auth/resource-access';
 import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
 
+export interface StartWorkspaceOptions {
+    rethrow?: boolean;
+    forceDefaultImage?: boolean;
+    excludeFeatureFlags?: NamedWorkspaceFeatureFlag[];
+}
+
 @injectable()
 export class WorkspaceStarter {
     @inject(WorkspaceManagerClientProvider) protected readonly clientProvider: WorkspaceManagerClientProvider;
@@ -51,9 +57,10 @@ export class WorkspaceStarter {
     @inject(TheiaPluginService) protected readonly theiaService: TheiaPluginService;
     @inject(OneTimeSecretServer) protected readonly otsServer: OneTimeSecretServer;
 
-    public async startWorkspace(ctx: TraceContext, workspace: Workspace, user: User, userEnvVars?: UserEnvVar[], options: {rethrow?: boolean, forceDefaultImage?: boolean} = {rethrow: undefined, forceDefaultImage: false}): Promise<StartWorkspaceResult> {
+    public async startWorkspace(ctx: TraceContext, workspace: Workspace, user: User, userEnvVars?: UserEnvVar[], options?: StartWorkspaceOptions): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("WorkspaceStarter.startWorkspace", ctx);
 
+        options = options || {};
         try {
             // Some workspaces do not have an image source.
             // Workspaces without image source are not only legacy, but also happened due to what looks like a bug.
@@ -86,7 +93,7 @@ export class WorkspaceStarter {
             }
 
             // create and store instance
-            let instance = await this.workspaceDb.trace({ span }).storeInstance(await this.newInstance(workspace, user));
+            let instance = await this.workspaceDb.trace({ span }).storeInstance(await this.newInstance(workspace, user, options.excludeFeatureFlags || []));
             span.log({ "newInstance": instance.id });
 
             const forceRebuild = !!workspace.context.forceImageBuild;
@@ -246,7 +253,7 @@ export class WorkspaceStarter {
      *
      * @param workspace the workspace to create an instance for
      */
-    protected async newInstance(workspace: Workspace, user: User): Promise<WorkspaceInstance> {
+    protected async newInstance(workspace: Workspace, user: User, excludeFeatureFlags: NamedWorkspaceFeatureFlag[]): Promise<WorkspaceInstance> {
         const theiaVersion = this.env.theiaVersion;
         const ideImage = this.env.ideDefaultImage;
 
@@ -280,6 +287,8 @@ export class WorkspaceStarter {
         if (!!user.additionalData?.featurePreview) {
             featureFlags = featureFlags.concat(this.env.previewFeatureFlags.filter(f => !featureFlags.includes(f)));
         }
+
+        featureFlags = featureFlags.filter(f => !excludeFeatureFlags.includes(f));
 
         if (!!featureFlags) {
             // only set feature flags if there actually are any. Otherwise we waste the


### PR DESCRIPTION
This PR makes it so that even if a user has FWB enabled, their prebuilds will not be FWB.