### PR TITLE
[supervisor] Better reflect incremental prebuilds in prebuild logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## June 2021
+
+- Better reflect incremental prebuilds in prebuilt workspace logs ([#4293](https://github.com/gitpod-io/gitpod/pull/4293))
+- Run shellcheck against scripts ([#4280](https://github.com/gitpod-io/gitpod/pull/4280))
+- Implement new Project and Team DB tables and entities ([#4368](https://github.com/gitpod-io/gitpod/pull/4368))
+- On gitpod.io 404 redirect to www.gitpod.io ([#4364](https://github.com/gitpod-io/gitpod/pull/4364))
+- Fix disk space leak in ws-manager ([#4388](https://github.com/gitpod-io/gitpod/pull/4388))
+- Fix memory leak in ws-manager ([#4384](https://github.com/gitpod-io/gitpod/pull/4384))
+- Handle GitHub issues page context URL ([#4370](https://github.com/gitpod-io/gitpod/pull/4370))
+- Fix issues blocking SSH from local terminal ([#4358](https://github.com/gitpod-io/gitpod/pull/4358))
+- Fix remote tracking branch for issue context ([#4367](https://github.com/gitpod-io/gitpod/pull/4367))
+- Fix opening empty repositories ([#4337](https://github.com/gitpod-io/gitpod/pull/4337))
 
 ## May 2021
 


### PR DESCRIPTION
If a prebuild is based on another prebuild, we currently truncate & overwrite the prebuild logs, and "forget" about how long the parent prebuild took.

Instead, we should:

- Keep the parent prebuild logs (to be more transparent about incremental prebuilds and allow debugging builds)
- Log the total saved time (parent prebuild + incremental prebuild)

That's what this PR does.

### How to test

1. Click [here](https://jx-incremental-prebuild-logs.staging.gitpod-dev.com/#prebuild/https://github.com/jankeromnes/gitpod-staging-prebuilds/commit/98b4bfb6190a3bb9fb0f513ffc2bce4009177960) to trigger a full (parent) prebuild -- the printed terminal logs should look like a normal prebuild:
    - "🤙" message
    - but no "♻️" message
2. Then click [here](https://jx-incremental-prebuild-logs.staging.gitpod-dev.com/#incremental-prebuild/https://github.com/jankeromnes/gitpod-staging-prebuilds/commit/6f2aff3ebf94cf40a0c96e87bfd00b2917fc7adb) to trigger an incremental prebuild -- now the printed terminal logs should include:
    - parent prebuild logs
    - "♻️" message
    - incremental prebuild logs
    - combined "🤙" message
3. Click [here](https://jx-incremental-prebuild-logs.staging.gitpod-dev.com/#prebuild/https://github.com/jankeromnes/gitpod-staging-prebuilds/commit/7c39c1fe4e2cb52e0dde8f8040843d3f543147b4) to trigger a **long (> 1 min)** full (parent) prebuild -- after the prebuild is done, the terminal should have:
    - "🤙"
    - "🎉" (1 min)
    - but no "♻️"
4. Then click [here](https://jx-incremental-prebuild-logs.staging.gitpod-dev.com/#incremental-prebuild/https://github.com/jankeromnes/gitpod-staging-prebuilds/commit/911f08ccd7b32d3119e66126fa55ae5e55a055c0) to trigger a **long (> 1 min)** incremental prebuild -- when it's done, terminal should have:
    - parent logs
    - "♻️"
    - new logs
    - "🤙"
    - " 🎉" (still 1 min, not 2)