### PR TITLE
Revert "[helm] Mark all pods that require HTTPS certs"

### DIFF
--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -14,7 +14,6 @@ metadata:
     component: proxy
     kind: deployment
     stage: {{ .Values.installation.stage }}
-    gitpod.io/requiresCerts: 'true'
 spec:
   selector:
     matchLabels:
@@ -22,7 +21,6 @@ spec:
       component: proxy
       kind: pod
       stage: {{ .Values.installation.stage }}
-      gitpod.io/requiresCerts: 'true'
   replicas: {{ $comp.replicas | default 1 }}
   strategy:
     type: RollingUpdate
@@ -46,7 +44,6 @@ spec:
         component: proxy
         kind: pod
         stage: {{ .Values.installation.stage }}
-        gitpod.io/requiresCerts: 'true'
     spec:
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccount: proxy

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -14,7 +14,6 @@ metadata:
     kind: deployment
     stage: {{ .Values.installation.stage }}
     gitpod.io/nodeService: registry-facade
-    gitpod.io/requiresCerts: 'true'
 spec:
   selector:
     matchLabels:
@@ -23,7 +22,6 @@ spec:
       kind: pod
       stage: {{ .Values.installation.stage }}
       gitpod.io/nodeService: registry-facade
-      gitpod.io/requiresCerts: 'true'
   template:
     metadata:
       name: registry-facade
@@ -33,7 +31,6 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
         gitpod.io/nodeService: registry-facade
-        gitpod.io/requiresCerts: 'true'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/path: "/metrics"

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -13,7 +13,6 @@ metadata:
     component: ws-proxy
     kind: deployment
     stage: {{ .Values.installation.stage }}
-    gitpod.io/requiresCerts: 'true'
 spec:
   selector:
     matchLabels:
@@ -21,7 +20,6 @@ spec:
       component: ws-proxy
       kind: pod
       stage: {{ .Values.installation.stage }}
-      gitpod.io/requiresCerts: 'true'
   replicas: {{ $comp.replicas | default 1 }}
   strategy:
     type: RollingUpdate
@@ -36,7 +34,6 @@ spec:
         component: ws-proxy
         kind: pod
         stage: {{ .Values.installation.stage }}
-        gitpod.io/requiresCerts: 'true'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
This reverts commit f6fd300c11369b0dd66d2e8857143ebe31fd5c34 so that staging and prod deploy again.

/werft no-preview