### PR TITLE
[dashboard] Support multiple "Recent" projects with the same title

### DIFF
--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -34,8 +34,8 @@ export function StartWorkspaceModal(p: StartWorkspaceModalProps) {
     const [selection, setSelection] = useState(computeSelection());
     useEffect(() => setSelection(computeSelection()), [p.recent, p.selected]);
 
-    const list = (selection === 'Recent' ? p.recent : p.examples).map(e =>
-        <a key={e.title} href={e.startUrl} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-4 my-1">
+    const list = (selection === 'Recent' ? p.recent : p.examples).map((e, i) =>
+        <a key={`item-${i}-${e.title}`} href={e.startUrl} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-4 my-1">
             <div className="w-full">
                 <p className="text-base text-gray-800 dark:text-gray-200 font-semibold">{e.title}</p>
                 <p>{e.description}</p>


### PR DESCRIPTION
Fixes this:

<img width="300" alt="Screenshot 2021-05-26 at 17 18 35" src="https://user-images.githubusercontent.com/599268/119766032-99e14480-beb4-11eb-8788-525631a4a6e5.png">

### Explanation

I believe using the same `key` on multiple elements in a list breaks React. This PR attempts to make the key unique.

### How to test

- Open https://jx-support-multiple-titles.staging.gitpod-dev.com/#https://github.com/jankeromnes/gitpod-staging-prebuilds
- Open https://jx-support-multiple-titles.staging.gitpod-dev.com/#https://gitlab.com/jankeromnes/gitpod-staging-prebuilds
- Click on "New Workspace" in https://jx-support-multiple-titles.staging.gitpod-dev.com/workspaces

Expected:

- No "jankeromnes/gitpod-staging-prebuilds" entry in "Examples"
- Switching multiple times between "Recent" and "Examples" should not create many "jankeromnes/gitpod-staging-prebuilds" entries