### PR TITLE
[dashboard] Fix page titles

### DIFF
--- a/components/dashboard/public/index.html
+++ b/components/dashboard/public/index.html
@@ -17,7 +17,7 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Gitpod - Dashboard</title>
+    <title>Dashboard — Gitpod</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -4,6 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { useEffect } from "react";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import Header from '../components/Header';
@@ -20,6 +21,7 @@ export interface PageWithSubMenuProps {
 
 export function PageWithSubMenu(p: PageWithSubMenuProps) {
     const location = useLocation();
+    useEffect(() => { document.title = `${p.title} — Gitpod` }, []);
     return <div className="w-full">
         <Header title={p.title} subtitle={p.subtitle} />
         <div className='lg:px-28 px-10 flex pt-9'>

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -4,6 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { useEffect } from 'react';
 import gitpodIcon from '../icons/gitpod.svg';
 
 export enum StartPhase {
@@ -79,6 +80,7 @@ export interface StartWorkspaceError {
 export function StartPage(props: StartPageProps) {
   const { phase, error } = props;
   let title = props.title || getPhaseTitle(phase, error);
+  useEffect(() => { document.title = 'Starting — Gitpod' }, []);
   return <div className="w-screen h-screen align-middle">
     <div className="flex flex-col mx-auto items-center text-center h-screen">
       <div className="h-1/3"></div>

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -38,10 +38,11 @@ export default class Workspaces extends React.Component<WorkspacesProps, Workspa
 
     async componentDidMount() {
         this.workspaceModel = new WorkspaceModel(this.setWorkspaces);
+        document.title = 'Workspaces — Gitpod';
         const repos = await getGitpodService().server.getFeaturedRepositories();
         this.setState({
             repos
-        })
+        });
     }
 
     protected setWorkspaces = (workspaces: WorkspaceInfo[]) => {


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/3653

Note: This PR simply sets `document.title` in relevant places (as opposed to using something like React Helmet).

### How to test

- Open every dashboard page & verify the page title is correct