### PR TITLE
Add support for Cert-Manager

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -175,3 +175,6 @@ rabbitmq:
   auth:
     username: override-me
     password: override-me
+
+cert-manager:
+  enabled: true

--- a/chart/templates/builtin-registry-certs-secret.yaml
+++ b/chart/templates/builtin-registry-certs-secret.yaml
@@ -3,6 +3,22 @@
 
 {{ if (index .Values "docker-registry" "enabled") }}
 {{- $regName := include "gitpod.builtinRegistry.name" . -}}
+{{ $cm := (index .Values "cert-manager") }}
+{{- if $cm.enabled }}
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: builtin-registry-certs
+spec:
+  secretName: builtin-registry-certs
+  dnsNames: {{ ( list $regName ) | toJson }}
+  issuerRef:
+    name: {{ $cm.ca.issuerName }}
+    kind: Issuer
+    group: cert-manager.io
+
+{{- else }}
 {{- $ca := genCA "wsdaemon-ca" 365 -}}
 {{- $cert := genSignedCert (include "gitpod.fullname" . ) nil ( list $regName ) 365 $ca -}}
 apiVersion: v1
@@ -23,4 +39,5 @@ data:
   tls.crt: {{ $cert.Cert | b64enc }}
   # Docker daemon needs this file to end with .cert
   tls.cert: {{ $cert.Cert | b64enc }}
+{{- end }}
 {{- end }}

--- a/chart/templates/certmanager-ca.yaml
+++ b/chart/templates/certmanager-ca.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $cm := (index .Values "cert-manager") }}
+{{- if $cm.enabled }}
+{{- if $cm.ca.certificate.selfSigned }}
+{{ $tls := genCA "gitpod-ca" 365 }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ $cm.ca.certificate.secretName }}
+  namespace: {{ .Release.Namespace }}
+data:
+  tls.crt: {{ $tls.Cert | b64enc }}
+  tls.key: {{ $tls.Key | b64enc }}
+type: kubernetes.io/tls
+---
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $cm.ca.issuerName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ $cm.ca.certificate.secretName }}
+{{- end }}

--- a/chart/templates/ws-daemon-tlssecret.yaml
+++ b/chart/templates/ws-daemon-tlssecret.yaml
@@ -5,6 +5,21 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 {{- $altNames := list ( printf "%s.%s" (include "gitpod.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" "ws-daemon" .Release.Namespace ) ( printf "wsdaemon" ) -}}
+{{ $cm := (index .Values "cert-manager") }}
+{{- if $cm.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ws-daemon-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: ws-daemon-tls
+  dnsNames: {{ $altNames | toJson }}
+  issuerRef:
+    name: {{ $cm.ca.issuerName }}
+    kind: Issuer
+    group: cert-manager.io
+{{- else }}
 {{- $ca := genCA "wsdaemon-ca" 365 -}}
 {{- $cert := genSignedCert (include "gitpod.fullname" . ) nil $altNames 365 $ca -}}
 apiVersion: v1
@@ -22,4 +37,5 @@ data:
   ca.crt: {{ $ca.Cert | b64enc }}
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/chart/templates/ws-manager-tlssecret.yaml
+++ b/chart/templates/ws-manager-tlssecret.yaml
@@ -4,12 +4,53 @@
 {{ $comp := .Values.components.wsManager -}}
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
-{{- $altNames := list ( printf "%s.%s" (include "gitpod.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" "ws-manager" .Release.Namespace ) "ws-manager" "ws-manager-dev" -}}
-{{- $ca := genCA "wsmanager-ca" 365 -}}
-
+{{- $serverAltNames := list ( printf "%s.%s" (include "gitpod.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" "ws-manager" .Release.Namespace ) "ws-manager" "ws-manager-dev" -}}
+{{- $clientAltNames := list "registry-facade" "server" "ws-manager-bridge" "ws-scheduler" "ws-proxy" "ws-manager" -}}
 {{- $server := $comp.tls.server }}
+{{- $client := $comp.tls.client }}
+
+
+{{ $cm := (index $.Values "cert-manager") }}
+{{- if $cm.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ $server.secretName }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "gitpod.fullname" $ }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  secretName: "{{ $server.secretName }}"
+  dnsNames: {{ $serverAltNames | toJson }}
+  issuerRef:
+    name: {{ $cm.ca.issuerName }}
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ $client.secretName }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "gitpod.fullname" $ }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  secretName: "{{ $client.secretName }}"
+  dnsNames: {{ $clientAltNames | toJson }}
+  issuerRef:
+    name: {{ $cm.ca.issuerName }}
+    kind: Issuer
+    group: cert-manager.io
+{{- else }}
+{{- $ca := genCA "wsmanager-ca" 365 -}}
 {{- if not $server.crtFile }}
-{{- $cert := genSignedCert (include "gitpod.fullname" . ) nil $altNames 365 $ca -}}
+{{- $cert := genSignedCert (include "gitpod.fullname" . ) nil $serverAltNames 365 $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,13 +67,9 @@ data:
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
 {{- end }}
-
 ---
-
-{{- $client := $comp.tls.client }}
 {{- if not $client.crtFile }}
-{{- $altNames := list "registry-facade" "server" "ws-manager-bridge" "ws-scheduler" "ws-proxy" "ws-manager" -}}
-{{- $cert := genSignedCert (include "gitpod.fullname" . ) nil $altNames 365 $ca -}}
+{{- $cert := genSignedCert (include "gitpod.fullname" . ) nil $clientAltNames 365 $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -49,4 +86,5 @@ data:
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
 {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -631,3 +631,12 @@ rabbitmq:
         dest-uri: {{ $shovel.destUri | default "amqp://" | quote }}
         reconnect-delay: {{ $shovel.reconnectDelay | default 5 }}
     {{- end }}
+
+cert-manager:
+  enabled: false
+  installCRDs: true
+  ca:
+    issuerName: ca-issuer
+    certificate:
+      selfSigned: true
+      secretName: gitpod-ca-certificate


### PR DESCRIPTION
This enabled the use of Certmanager to work as a CA issuer that is used to create certificates for ws-daemon, ws-manager and the docker-registry.