### PR TITLE
[build] Produce version manifest

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -8,6 +8,25 @@ packages:
     argdeps:
       - version
     deps:
+      - :all-docker
+      - :docker-versions
+      - dev/blowtorch:app
+      - dev/gpctl:app
+      - dev/loadgen:app
+  - name: docker-versions
+    type: docker
+    config:
+      dockerfile: leeway.Dockerfile
+      image:
+        - ${imageRepoBase}/versions:${version}
+    deps:
+      - :all-docker
+  - name: all-docker
+    type: generic
+    argdeps:
+      - version
+      - imageRepoBase
+    deps:
       - components/blobserve:docker
       - components/content-service:docker
       - components/dashboard:docker
@@ -36,10 +55,11 @@ packages:
       - components/ws-manager-bridge:docker
       - components/ws-manager:docker
       - components/ws-proxy:docker
-      - dev/blowtorch:app
-      - dev/gpctl:app
-      - dev/loadgen:app
       - test:docker
+    config:
+      commands:
+        - ["sh", "-c", "(find . -name imgnames.txt | while read f; do tail -n1 $f; done) > versions.txt"]
+        - ["sh", "-c", "rm -r components*"]
   - name: all-apps
     type: generic
     deps:

--- a/components/blobserve/BUILD.yaml
+++ b/components/blobserve/BUILD.yaml
@@ -25,3 +25,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/blobserve:${version}
+        - ${imageRepoBase}/blobserve:${__pkg_version}

--- a/components/content-service/BUILD.yaml
+++ b/components/content-service/BUILD.yaml
@@ -38,3 +38,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/content-service:${version}
+        - ${imageRepoBase}/content-service:${__pkg_version}

--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -43,6 +43,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/dashboard:${version}
+        - ${imageRepoBase}/dashboard:${__pkg_version}
 scripts:
   - name: telepresence
     script: |-

--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -67,3 +67,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/docker-up:${version}
+        - ${imageRepoBase}/docker-up:${__pkg_version}

--- a/components/ee/db-sync/BUILD.yaml
+++ b/components/ee/db-sync/BUILD.yaml
@@ -24,6 +24,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/db-sync:${version}
+        - ${imageRepoBase}/db-sync:${__pkg_version}
   - name: dbtest
     type: yarn
     srcs:

--- a/components/ee/kedge/BUILD.yaml
+++ b/components/ee/kedge/BUILD.yaml
@@ -22,3 +22,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/kedge:${version}
+        - ${imageRepoBase}/kedge:${__pkg_version}

--- a/components/ee/payment-endpoint/BUILD.yaml
+++ b/components/ee/payment-endpoint/BUILD.yaml
@@ -2,7 +2,7 @@ packages:
   - name: app
     type: yarn
     srcs:
-      - "src/**/*.ts" 
+      - "src/**/*.ts"
       - "test/**/*.ts"
       - "test/fixtures/**/*"
       - package.json
@@ -38,6 +38,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/payment-endpoint:${version}
+        - ${imageRepoBase}/payment-endpoint:${__pkg_version}
 scripts:
   - name: telepresence
     script: |-

--- a/components/ee/ws-scheduler/BUILD.yaml
+++ b/components/ee/ws-scheduler/BUILD.yaml
@@ -24,6 +24,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ws-scheduler:${version}
+        - ${imageRepoBase}/ws-scheduler:${__pkg_version}
 scripts:
   - name: telepresence
     script: |

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -77,3 +77,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/db-migrations:${version}
+        - ${imageRepoBase}/db-migrations:${__pkg_version}

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -11,3 +11,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ide/code:${version}
+        - ${imageRepoBase}/ide/code:${__pkg_version}

--- a/components/ide/theia/BUILD.yaml
+++ b/components/ide/theia/BUILD.yaml
@@ -12,3 +12,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ide/theia:${version}
+        - ${imageRepoBase}/ide/theia:${__pkg_version}

--- a/components/image-builder/BUILD.yaml
+++ b/components/image-builder/BUILD.yaml
@@ -26,3 +26,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/image-builder:${version}
+        - ${imageRepoBase}/image-builder:${__pkg_version}

--- a/components/leeway.Dockerfile
+++ b/components/leeway.Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+FROM alpine:3.13
+COPY components--all-docker/versions.txt /

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -1,81 +1,82 @@
 packages:
-    - name: app
-      type: generic
-      config:
-        commands: [["echo"]]
-      deps:
-        - :app-linux
-        - :app-darwin
-        - :app-windows
-    - name: app-linux
-      type: go
-      srcs:
-        - go.mod
-        - go.sum
-        - "**/*.go"
-      deps:
-        - :version
-        - components/supervisor-api/go:lib
-        - components/gitpod-protocol/go:lib
-        - components/local-app-api/go:lib
-      env:
-        - CGO_ENABLED=0
-        - GOOS=linux
-      prep:
-        - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
-      config:
-        packaging: app
-    - name: app-darwin
-      type: go
-      srcs:
-        - go.mod
-        - go.sum
-        - "**/*.go"
-      deps:
-        - :version
-        - components/supervisor-api/go:lib
-        - components/gitpod-protocol/go:lib
-        - components/local-app-api/go:lib
-      env:
-        - CGO_ENABLED=0
-        - GOOS=darwin
-      prep:
-        - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
-      config:
-        packaging: app
-    - name: app-windows
-      type: go
-      srcs:
-        - go.mod
-        - go.sum
-        - "**/*.go"
-      deps:
-        - :version
-        - components/supervisor-api/go:lib
-        - components/gitpod-protocol/go:lib
-        - components/local-app-api/go:lib
-      env:
-        - CGO_ENABLED=0
-        - GOOS=windows
-      prep:
-        - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
-      config:
-        packaging: app
-    - name: version
-      type: generic
-      argdeps:
-        - localAppVersion
-      config:
-        commands:
-          - ["sh", "-c", "echo '${localAppVersion}' > version.txt"]
-          - ["echo", "Local App Version: ${localAppVersion}"]
-    - name: docker
-      type: docker
-      deps:
-        - :app
-      argdeps:
-        - imageRepoBase
-      config:
-        dockerfile: leeway.Dockerfile
-        image:
-          - ${imageRepoBase}/local-app:${version}
+  - name: app
+    type: generic
+    config:
+      commands: [["echo"]]
+    deps:
+      - :app-linux
+      - :app-darwin
+      - :app-windows
+  - name: app-linux
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=linux
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: app-darwin
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=darwin
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: app-windows
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=windows
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: version
+    type: generic
+    argdeps:
+      - localAppVersion
+    config:
+      commands:
+        - ["sh", "-c", "echo '${localAppVersion}' > version.txt"]
+        - ["echo", "Local App Version: ${localAppVersion}"]
+  - name: docker
+    type: docker
+    deps:
+      - :app
+    argdeps:
+      - imageRepoBase
+    config:
+      dockerfile: leeway.Dockerfile
+      image:
+        - ${imageRepoBase}/local-app:${version}
+        - ${imageRepoBase}/local-app:${__pkg_version}

--- a/components/registry-facade/BUILD.yaml
+++ b/components/registry-facade/BUILD.yaml
@@ -41,3 +41,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/registry-facade:${version}
+        - ${imageRepoBase}/registry-facade:${__pkg_version}

--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -30,6 +30,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/server:${version}
+        - ${imageRepoBase}/server:${__pkg_version}
   - name: lib
     type: yarn
     srcs:

--- a/components/service-waiter/BUILD.yaml
+++ b/components/service-waiter/BUILD.yaml
@@ -22,3 +22,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/service-waiter:${version}
+        - ${imageRepoBase}/service-waiter:${__pkg_version}

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -31,6 +31,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/supervisor:${version}
+        - ${imageRepoBase}/supervisor:${__pkg_version}
   - name: dropbear
     type: generic
     config:

--- a/components/ws-daemon/BUILD.yaml
+++ b/components/ws-daemon/BUILD.yaml
@@ -51,6 +51,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ws-daemon:${version}
+        - ${imageRepoBase}/ws-daemon:${__pkg_version}
 scripts:
   - name: kube-exec
     description: Executes into the ws-daemon for a workspace pod in $WS

--- a/components/ws-daemon/seccomp-profile-installer/BUILD.yaml
+++ b/components/ws-daemon/seccomp-profile-installer/BUILD.yaml
@@ -28,3 +28,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/seccomp-profile-installer:${version}
+        - ${imageRepoBase}/seccomp-profile-installer:${__pkg_version}

--- a/components/ws-daemon/shiftfs-module-loader/BUILD.yaml
+++ b/components/ws-daemon/shiftfs-module-loader/BUILD.yaml
@@ -11,3 +11,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/shiftfs-module-loader:${version}
+        - ${imageRepoBase}/shiftfs-module-loader:${__pkg_version}

--- a/components/ws-manager-bridge/BUILD.yaml
+++ b/components/ws-manager-bridge/BUILD.yaml
@@ -26,6 +26,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ws-manager-bridge:${version}
+        - ${imageRepoBase}/ws-manager-bridge:${__pkg_version}
 scripts:
   - name: telepresence
     script: |-

--- a/components/ws-manager/BUILD.yaml
+++ b/components/ws-manager/BUILD.yaml
@@ -29,6 +29,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ws-manager:${version}
+        - ${imageRepoBase}/ws-manager:${__pkg_version}
   - name: docker-debug
     type: docker
     deps:

--- a/components/ws-proxy/BUILD.yaml
+++ b/components/ws-proxy/BUILD.yaml
@@ -30,3 +30,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/ws-proxy:${version}
+        - ${imageRepoBase}/ws-proxy:${__pkg_version}

--- a/dev/poolkeeper/BUILD.yaml
+++ b/dev/poolkeeper/BUILD.yaml
@@ -22,3 +22,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/poolkeeper:${version}
+        - ${imageRepoBase}/poolkeeper:${__pkg_version}

--- a/dev/sweeper/BUILD.yaml
+++ b/dev/sweeper/BUILD.yaml
@@ -20,3 +20,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/sweeper:${version}
+        - ${imageRepoBase}/sweeper:${__pkg_version}

--- a/install/docker/examples/gitpod-gitlab/gitlab/BUILD.yaml
+++ b/install/docker/examples/gitpod-gitlab/gitlab/BUILD.yaml
@@ -13,3 +13,4 @@ packages:
       dockerfile: Dockerfile
       image:
         - ${imageRepoBase}/gitlab-k3s:${version}
+        - ${imageRepoBase}/gitlab-k3s:${__pkg_version}

--- a/install/docker/gitpod-image/BUILD.yaml
+++ b/install/docker/gitpod-image/BUILD.yaml
@@ -14,3 +14,4 @@ packages:
       dockerfile: Dockerfile
       image:
         - ${imageRepoBase}/gitpod-k3s:${version}
+        - ${imageRepoBase}/gitpod-k3s:${__pkg_version}

--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -28,6 +28,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/installer:${version}
+        - ${imageRepoBase}/installer:${__pkg_version}
       buildArgs:
         VERSION: ${version}
         IMAGE_PREFIX: ${imageRepoBase}

--- a/test/BUILD.yaml
+++ b/test/BUILD.yaml
@@ -38,3 +38,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/integration-tests:${version}
+        - ${imageRepoBase}/integration-tests:${__pkg_version}


### PR DESCRIPTION
This PR introduces a version manifest as build result where the versions stay stable even though the build version itself changed using leeway package versions. To this end, all `docker` packages build with `__pkg_version` and we extract this version into a text file after the build.

With this version manifest we can deploy without having to swap all container all the time.

### How to test
```
docker run --rm -it eu.gcr.io/gitpod-core-dev/build/versions:cw-versions.1 cat /versions.txt
```