### PR TITLE
[server] Enable kube-rbac-proxy

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -234,6 +234,7 @@ spec:
 {{- if $comp.serverContainer.env }}
 {{ toYaml $comp.serverContainer.env | indent 8 }}
 {{- end }}
+{{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       volumes:
       - name: ws-manager-client-tls-certs
         secret:

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -273,7 +273,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
         })
         this.httpServer = httpServer;
         if (this.monApp) {
-            this.monHttpServer = this.monApp.listen(9500, () => {
+            this.monHttpServer = this.monApp.listen(9500, 'localhost', () => {
                 log.info(`Monitoring server listening on port: ${(<AddressInfo>this.monHttpServer!.address()).port}`);
             });
         }


### PR DESCRIPTION
Change listen address in `node.js` server to localhost and enable `kube-rbac-proxy`