### PR TITLE
[content-service] Fix nil-deref in error log

### DIFF
--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -903,7 +903,7 @@ func (p *PresignedGCPStorage) DeleteObject(ctx context.Context, bucket string, q
 	if query.Name != "" {
 		err = client.Bucket(bucket).Object(query.Name).Delete(ctx)
 		if err != nil {
-			log.WithField("bucket", bucket).WithField("object", query.Name).Error(err)
+			log.WithField("bucket", bucket).WithField("object", query.Name).WithError(err).Error("cannot delete objects")
 			if err == gcpstorage.ErrBucketNotExist || err == gcpstorage.ErrObjectNotExist {
 				return ErrNotFound
 			}
@@ -929,12 +929,12 @@ func (p *PresignedGCPStorage) DeleteObject(ctx context.Context, bucket string, q
 			break
 		}
 		if err != nil {
-			log.WithField("bucket", bucket).WithField("object", attrs.Name).Error(err)
+			log.WithField("bucket", bucket).WithError(err).Error("cannot delete objects")
 			return err
 		}
 		err = b.Object(attrs.Name).Delete(ctx)
 		if err != nil {
-			log.WithField("bucket", bucket).WithField("object", attrs.Name).Error(err)
+			log.WithField("bucket", bucket).WithField("object", attrs.Name).WithError(err).Error("cannot delete objects")
 		}
 	}
 


### PR DESCRIPTION
Fixes
```
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xbcfbb8] goroutine 4047 [running]: github.com/gitpod-io/gitpod/content-service/pkg/storage.(*PresignedGCPStorage).DeleteObject(0xc0004b4d00, 0xf462b8, 0xc000217710, 0xc0001fe140, 0x35, 0xc00044ef98, 0x0, 0x0) github.com/gitpod-io/gitpod/content-service/pkg/storage/gcloud.go:932
```