### PR TITLE
Enable having integration tests run as a PR pre-merge check

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -403,13 +403,15 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
  * Trigger integration tests
  */
 export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig) {
+    werft.phase(phases.INTEGRATION_TESTS, "Integration tests");
     exec(`git config --global user.name "${context.Owner}"`);
     const annotations = [
         `version=${deploymentConfig.version}`,
         `namespace=${deploymentConfig.namespace}`,
         `username=${context.Owner}`,
     ].map(annotation => `-a ${annotation}`).join(' ')
-    exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`);
+    exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
+    werft.done(phases.INTEGRATION_TESTS);
 }
 
 interface PreviewWorkspaceClusterRef {

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -411,7 +411,8 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
     const annotations = [
         `version=${deploymentConfig.version}`,
         `namespace=${deploymentConfig.namespace}`,
-        `username=${context.Owner}`
+        `username=${context.Owner}`,
+        `updateGitHubStatus=gitpod-io/gitpod`
     ].map(annotation => `-a ${annotation}`).join(' ')
     const jobId = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS}).trim();
     werft.log(phases.INTEGRATION_TESTS, `Triggered job ${jobId} - https://werft.gitpod-dev.com/job/${jobId}/logs`)

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -409,6 +409,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         `version=${deploymentConfig.version}`,
         `namespace=${deploymentConfig.namespace}`,
         `username=${context.Owner}`,
+        `annotationStatusUpdate=true`
     ].map(annotation => `-a ${annotation}`).join(' ')
     const job = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
     werft.log(phases.INTEGRATION_TESTS, `Job: ${job}`)

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -409,7 +409,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         `version=${deploymentConfig.version}`,
         `namespace=${deploymentConfig.namespace}`,
         `username=${context.Owner}`,
-        `annotationStatusUpdate=true`
+        `updateGitHubStatus=gitpod-io/gitpod`
     ].map(annotation => `-a ${annotation}`).join(' ')
     const job = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
     werft.log(phases.INTEGRATION_TESTS, `Job: ${job}`)

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -402,7 +402,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
         // If we're skipping integration tests we're still marking the Github Check as succeeded as this allows us to
         // have a break-glass mechanism to merge a PR without running integration tests
-        exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion neutral`);
+        exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion success`);
         werft.done(phases.INTEGRATION_TESTS);
         return
     }

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -401,7 +401,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
     if (skip) {
         werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
         // If we're skipping integration tests we're still marking the Github Check as succeeded as this allows us to
-        // have a break-glass mechanism to merge a PR even if integration tests fail for some reason.
+        // have a break-glass mechanism to merge a PR without running integration tests
         exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion success`);
         werft.done(phases.INTEGRATION_TESTS);
         return

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -410,7 +410,8 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         `namespace=${deploymentConfig.namespace}`,
         `username=${context.Owner}`,
     ].map(annotation => `-a ${annotation}`).join(' ')
-    exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
+    const job = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
+    werft.log(phases.INTEGRATION_TESTS, `Job: ${job}`)
     werft.done(phases.INTEGRATION_TESTS);
 }
 

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -20,6 +20,11 @@ build(context, version)
         }
     });
 
+// Werft phases
+const phases = {
+    INTEGRATION_TESTS: 'integration tests'
+}
+
 export function parseVersion(context) {
     let buildConfig = context.Annotations || {};
     const explicitVersion = buildConfig.version;
@@ -199,7 +204,9 @@ export async function build(context, version) {
         exec(`git config --global user.name "${context.Owner}"`);
         exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml -a version=${deploymentConfig.version} -a namespace=${deploymentConfig.namespace} github`);
     } else {
-        werft.phase("integration tests", "Skipping integration tests");
+        werft.phase(phases.INTEGRATION_TESTS, "Integration tests");
+        werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
+        werft.done(phases.INTEGRATION_TESTS);
     }
 }
 

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -399,7 +399,9 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
     werft.phase(phases.INTEGRATION_TESTS, "Integration tests");
 
     if (skip) {
+        werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
         exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion success`);
+        werft.done(phases.INTEGRATION_TESTS);
         return
     }
 

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -402,7 +402,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
         // If we're skipping integration tests we're still marking the Github Check as succeeded as this allows us to
         // have a break-glass mechanism to merge a PR without running integration tests
-        exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion success`);
+        exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion skipped`);
         werft.done(phases.INTEGRATION_TESTS);
         return
     }

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -201,8 +201,7 @@ export async function build(context, version) {
     await deployToDev(deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
 
     if (withIntegrationTests) {
-        exec(`git config --global user.name "${context.Owner}"`);
-        exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml -a version=${deploymentConfig.version} -a namespace=${deploymentConfig.namespace} github`);
+        await triggerIntegrationTests(deploymentConfig)
     } else {
         werft.phase(phases.INTEGRATION_TESTS, "Integration tests");
         werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
@@ -398,6 +397,14 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
             werft.fail('certificate', err);
         }
     }
+}
+
+/**
+ * Trigger integration tests
+ */
+export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig) {
+    exec(`git config --global user.name "${context.Owner}"`);
+    exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml -a version=${deploymentConfig.version} -a namespace=${deploymentConfig.namespace} github`);
 }
 
 interface PreviewWorkspaceClusterRef {

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -404,7 +404,12 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
  */
 export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig) {
     exec(`git config --global user.name "${context.Owner}"`);
-    exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml -a version=${deploymentConfig.version} -a namespace=${deploymentConfig.namespace} github`);
+    const annotations = [
+        `version=${deploymentConfig.version}`,
+        `namespace=${deploymentConfig.namespace}`,
+        `username=${context.Owner}`,
+    ].map(annotation => `-a ${annotation}`).join(' ')
+    exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`);
 }
 
 interface PreviewWorkspaceClusterRef {

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -411,8 +411,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
     const annotations = [
         `version=${deploymentConfig.version}`,
         `namespace=${deploymentConfig.namespace}`,
-        `username=${context.Owner}`,
-        `updateGitHubStatus=gitpod-io/gitpod`
+        `username=${context.Owner}`
     ].map(annotation => `-a ${annotation}`).join(' ')
     const jobId = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS}).trim();
     werft.log(phases.INTEGRATION_TESTS, `Triggered job ${jobId} - https://werft.gitpod-dev.com/job/${jobId}/logs`)

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -398,13 +398,10 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig, skip: boolean) {
     werft.phase(phases.TRIGGER_INTEGRATION_TESTS, "Trigger integration tests");
 
-    // If we're skipping integration tests we wont trigger the job, which in turn won't create the
-    // ci/werft/run-integration-tests Github Check.
-    //
-    // If a *required* Github Check isn't present you are still allowed to merge the PR.
-    //
-    // This gives us a break-glass mechanism to merge a PR without running integration tests
     if (skip) {
+        // If we're skipping integration tests we wont trigger the job, which in turn won't create the
+        // ci/werft/run-integration-tests Github Check. As ci/werft/run-integration-tests is a required
+        // check this means you can't merge your PR without override checks.
         werft.log(phases.TRIGGER_INTEGRATION_TESTS, "Skipped integration tests")
         werft.done(phases.TRIGGER_INTEGRATION_TESTS);
         return

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -409,7 +409,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         `namespace=${deploymentConfig.namespace}`,
         `username=${context.Owner}`,
     ].map(annotation => `-a ${annotation}`).join(' ')
-    exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`);
+    exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`);
 }
 
 interface PreviewWorkspaceClusterRef {

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -414,8 +414,8 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         `username=${context.Owner}`,
         `updateGitHubStatus=gitpod-io/gitpod`
     ].map(annotation => `-a ${annotation}`).join(' ')
-    const job = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
-    werft.log(phases.INTEGRATION_TESTS, `Job ID: ${job}`)
+    const jobId = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
+    werft.log(phases.INTEGRATION_TESTS, `Triggered job ${jobId} - https://werft.gitpod-dev.com/job/${jobId}/logs`)
     werft.done(phases.INTEGRATION_TESTS);
 }
 

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -400,6 +400,8 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
 
     if (skip) {
         werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
+        // If we're skipping integration tests we're still marking the Github Check as succeeded as this allows us to
+        // have a break-glass mechanism to merge a PR even if integration tests fail for some reason.
         exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion success`);
         werft.done(phases.INTEGRATION_TESTS);
         return

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -198,6 +198,8 @@ export async function build(context, version) {
     if (withIntegrationTests) {
         exec(`git config --global user.name "${context.Owner}"`);
         exec(`werft run --follow-with-prefix="int-tests: " --remote-job-path .werft/run-integration-tests.yaml -a version=${deploymentConfig.version} -a namespace=${deploymentConfig.namespace} github`);
+    } else {
+        werft.phase("integration tests", "Skipping integration tests");
     }
 }
 

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -199,7 +199,7 @@ export async function build(context, version) {
         analytics
     };
     await deployToDev(deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
-    await triggerIntegrationTests(deploymentConfig, skip=!withIntegrationTests)
+    await triggerIntegrationTests(deploymentConfig, !withIntegrationTests)
 }
 
 interface DeploymentConfig {

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -414,7 +414,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         `username=${context.Owner}`,
         `updateGitHubStatus=gitpod-io/gitpod`
     ].map(annotation => `-a ${annotation}`).join(' ')
-    const jobId = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS});
+    const jobId = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.INTEGRATION_TESTS}).trim();
     werft.log(phases.INTEGRATION_TESTS, `Triggered job ${jobId} - https://werft.gitpod-dev.com/job/${jobId}/logs`)
     werft.done(phases.INTEGRATION_TESTS);
 }

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -402,7 +402,7 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         werft.log(phases.INTEGRATION_TESTS, "Skipped integration tests")
         // If we're skipping integration tests we're still marking the Github Check as succeeded as this allows us to
         // have a break-glass mechanism to merge a PR without running integration tests
-        exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion skipped`);
+        exec(`werft log result -d "${phases.INTEGRATION_TESTS}" -c github-check-integration-tests conclusion neutral`);
         werft.done(phases.INTEGRATION_TESTS);
         return
     }

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -77,9 +77,9 @@ pod:
 
       RC=${PIPESTATUS[0]}
       if [ $RC -eq 1 ]; then
-        echo '[conclusion|RESULT] {"payload":"failure","channels":["github-check-integration-test"],"description":"integration tests"}'
+        echo '[conclusion|RESULT] {"payload":"failure","channels":["github-check-integration-tests"],"description":"integration tests"}'
         echo "[int-tests|FAIL]"
       else
-        echo '[conclusion|RESULT] {"payload":"success","channels":["github-check-integration-test"],"description":"integration tests"}'
+        echo '[conclusion|RESULT] {"payload":"success","channels":["github-check-integration-tests"],"description":"integration tests"}'
         echo "[int-tests|DONE]"
       fi

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -76,4 +76,10 @@ pod:
       /entrypoint.sh -kubeconfig=/config/kubeconfig -namespace={{ .Annotations.namespace }} -username=$USERNAME 2>&1 | ts "[int-tests] "
 
       RC=${PIPESTATUS[0]}
-      if [ $RC -eq 1 ]; then echo "[int-tests|FAIL]"; else echo "[int-tests|DONE]"; fi
+      if [ $RC -eq 1 ]; then
+        echo '[conclusion|RESULT] {"payload":"failure","channels":["github-check-integration-test"],"description":"integration tests"}'
+        echo "[int-tests|FAIL]"
+      else
+        echo '[conclusion|RESULT] {"payload":"success","channels":["github-check-integration-test"],"description":"integration tests"}'
+        echo "[int-tests|DONE]"
+      fi

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -77,9 +77,7 @@ pod:
 
       RC=${PIPESTATUS[0]}
       if [ $RC -eq 1 ]; then
-        echo '[conclusion|RESULT] {"payload":"failure","channels":["github-check-integration-tests"],"description":"integration tests"}'
         echo "[int-tests|FAIL]"
       else
-        echo '[conclusion|RESULT] {"payload":"success","channels":["github-check-integration-tests"],"description":"integration tests"}'
         echo "[int-tests|DONE]"
       fi


### PR DESCRIPTION
This PR is a step towards running integration tests on all PRs and have it be a requirement for merging.

Specifically this PR introduces the following changes:

- Trigger the integration test job without using the `--follow-with-prefix` - this allows the build job to succeed independently of the the result of the integration tests.
- The job is triggered in such a way that a `ci/werft/run-integration-tests` commit check will be created (this was made possible by making changes to Werft, thanks @csweichel)

After this is merged we can

- Configure Github to have `ci/werft/run-integration-tests` be a required check. That means people can't merge a PR unless the check succeed. This should only be done once we run integration tests by default.