### PR TITLE
[content-init] Don't set a remote tracking branch when creating a local branch for an issue context

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -120,7 +120,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		}
 	} else if ws.TargetMode == LocalBranch {
 		// checkout local branch based on remote HEAD
-		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/HEAD"); err != nil {
+		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/HEAD", "--no-track"); err != nil {
 			return err
 		}
 	} else if ws.TargetMode == RemoteCommit {


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4366

### How to test

Option 1:

- Click [here](https://jx-fix-issue-upstream.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod/issues/4366) to open an issue in Gitpod
- Make a commit
- Verify that clicking "Push/Pull" in the bottom status bar offers to create a new branch, and doesn't offer to push to `origin/main`

(⚠️ Don't actually push your commit to the Gitpod repo 😅)

Option 2:

- In any Git clone, run `git checkout -B test-branch1 origin/HEAD` -- observe that `test-branch1` has a remote tracking branch set to `origin/main`
- Next, run `git checkout -B test-branch2 origin/HEAD --no-track` -- observe that `test-branch2` doesn't have a remote tracking branch (just like when you run `git checkout -B test-branch0`)
- You can see this in `git branch -vv` as well