### PR TITLE
Add Pull request default template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,40 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+Delete this section if you do not require special test configurations.
+- [ ] Permissions - Description
+- [ ] Specific Cluster - Description
+
+# Publisher Checklist:
+- [ ] I have added relevant [Changelogs](https://github.com/gitpod-io/gitpod/blob/main/CHANGELOG.md) (mandatory for feature changes and bug fixes)
+- [ ] I have made sure that changed code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+
+# Reviewer Checklist:
+- [ ] I have reviewed relevant [Changelogs](https://github.com/gitpod-io/gitpod/blob/main/CHANGELOG.md) have been added (mandatory for feature changes and bug fixes)
+- [ ] I am convinced the changes make sense to me and I can own this change (when in doubt as clarifying questions or help from SME)


### PR DESCRIPTION
Referred to [this blog](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/) for inspiration and [github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) for instructions