### PR TITLE
[analytics] Move Signup Tracking to correct Position in Signup Flow

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -511,6 +511,18 @@ export class UserController {
         await this.userService.updateUserEnvVarsOnLogin(user, envVars);
         await this.userService.acceptCurrentTerms(user);
         this.analytics.identify({ anonymousId: req.sessionID || "unknown", userId: user.id, });
+        this.analytics.track({ 
+            userId: user.id,
+            event: "signup",
+            properties: {
+                "auth_provider": user.identities[0].authProviderId,
+                "email": User.getPrimaryEmail(user),
+                "name": User.getName(user),
+                "full_name": user.fullName,
+                "unsubscribed": !user.allowsMarketingCommunication,
+                "blocked": user.blocked
+            }
+        });
         await this.loginCompletionHandler.complete(req, res, { user, returnToUrl: returnTo, authHost: host });
     }
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -17,7 +17,6 @@ import { TermsProvider } from "../terms/terms-provider";
 import { TokenService } from "./token-service";
 import { EmailAddressAlreadyTakenException, SelectAccountException } from "../auth/errors";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
-import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/util/analytics";
 
 export interface FindUserByIdentityStrResult {
     user: User;
@@ -55,7 +54,6 @@ export class UserService {
     @inject(Env) protected readonly env: Env;
     @inject(TermsAcceptanceDB) protected readonly termsAcceptanceDb: TermsAcceptanceDB;
     @inject(TermsProvider) protected readonly termsProvider: TermsProvider;
-    @inject(IAnalyticsWriter) protected readonly analytics: IAnalyticsWriter;
 
     /**
      * Takes strings in the form of <authHost>/<authName> and returns the matching User
@@ -145,20 +143,6 @@ export class UserService {
             const canPass = newUser.identities.some(i => !!i.primaryEmail && emailDomainInPasslist(i.primaryEmail));
 
             newUser.blocked = !canPass;
-
-            //call analytics to track user signup
-            this.analytics.track({ 
-                userId: newUser.id,
-                event: "signup",
-                properties: {
-                    "auth_provider": newUser.identities[0].authProviderId,
-                    "email": User.getPrimaryEmail(newUser),
-                    "name": User.getName(newUser),
-                    "full_name": newUser.fullName,
-                    "unsubscribed": !newUser.allowsMarketingCommunication,
-                    "blocked": newUser.blocked
-                }
-            });
         }
         if (!newUser.blocked && (isFirstUser || this.env.makeNewUsersAdmin)) {
             newUser.rolesOrPermissions = ['admin'];


### PR DESCRIPTION
Pointed out in #4300, The analytics track call should take place in `handleTosProceedForNewUser`, which is the only change in this PR.

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe