### PR TITLE
Refactor span log helpers

### DIFF
--- a/components/common-go/tracing/tracing.go
+++ b/components/common-go/tracing/tracing.go
@@ -135,16 +135,6 @@ func FromTraceID(traceID string) opentracing.SpanContext {
 	return spanCtx
 }
 
-// LogEvent logs an event in the trace.
-func LogEvent(span opentracing.Span, name string) {
-	span.LogFields(tracelog.String("event", name))
-}
-
-// LogKV is a convenience method which logs a single key-value pair to a span
-func LogKV(span opentracing.Span, key, value string) {
-	span.LogFields(tracelog.String(key, value))
-}
-
 // LogError logs an error and marks the span as errornous
 func LogError(span opentracing.Span, err error) {
 	span.LogFields(tracelog.Error(err))
@@ -168,5 +158,5 @@ func LogMessageSafe(span opentracing.Span, name string, req proto.Message) {
 		msg = string(safeReqs)
 	}
 
-	LogKV(span, name, msg)
+	span.LogKV(name, msg)
 }

--- a/components/image-builder/pkg/resolve/resolve.go
+++ b/components/image-builder/pkg/resolve/resolve.go
@@ -60,7 +60,7 @@ func (dr *DockerRegistryResolver) Resolve(ctx context.Context, ref string, opts 
 
 	options := getOptions(opts)
 
-	tracing.LogKV(span, "original-ref", ref)
+	span.LogKV("original-ref", ref)
 
 	// The ref may be what Docker calls a "familiar" name, e.g. ubuntu:latest instead of docker.io/library/ubuntu:latest.
 	// To make this a valid digested form we first need to normalize that familiar name.
@@ -71,19 +71,19 @@ func (dr *DockerRegistryResolver) Resolve(ctx context.Context, ref string, opts 
 
 	// The reference is already in digest form we don't have to do anything
 	if _, ok := pref.(reference.Canonical); ok {
-		tracing.LogKV(span, "result", ref)
+		span.LogKV("result", ref)
 		return ref, nil
 	}
 
 	nref := pref.String()
-	tracing.LogKV(span, "normalized-ref", nref)
+	span.LogKV("normalized-ref", nref)
 
 	manifest, err := dr.Client.DistributionInspect(ctx, nref, options.Auth)
 	// do not wrap this error so that others can check if this IsErrNotFound (Docker SDK doesn't use Go2 error values)
 	if err != nil {
 		return "", err
 	}
-	tracing.LogEvent(span, "got manifest")
+	span.LogKV("event", "got manifest")
 
 	cres, err := reference.WithDigest(pref, manifest.Descriptor.Digest)
 	if err != nil {
@@ -91,7 +91,7 @@ func (dr *DockerRegistryResolver) Resolve(ctx context.Context, ref string, opts 
 	}
 	res = cres.String()
 
-	tracing.LogKV(span, "result", res)
+	span.LogKV("result", res)
 
 	return res, nil
 }

--- a/components/ws-manager/pkg/manager/manager_ee.go
+++ b/components/ws-manager/pkg/manager/manager_ee.go
@@ -36,7 +36,7 @@ func (m *Manager) TakeSnapshot(ctx context.Context, req *api.TakeSnapshotRequest
 		return nil, status.Errorf(codes.Internal, "cannot get workspace status: %q", err)
 	}
 	tracing.ApplyOWI(span, wsk8s.GetOWIFromObject(&pod.ObjectMeta))
-	tracing.LogEvent(span, "get pod")
+	span.LogKV("event", "get pod")
 
 	wso, err := m.getWorkspaceObjects(ctx, pod)
 	if err != nil {
@@ -82,7 +82,7 @@ func (m *Manager) ControlAdmission(ctx context.Context, req *api.ControlAdmissio
 		return nil, status.Errorf(codes.Internal, "cannot get workspace status: %q", err)
 	}
 	tracing.ApplyOWI(span, wsk8s.GetOWIFromObject(&pod.ObjectMeta))
-	tracing.LogEvent(span, "get pod")
+	span.LogKV("event", "get pod")
 
 	wso, err := m.getWorkspaceObjects(ctx, pod)
 	if err != nil {

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -327,7 +327,7 @@ func (m *Monitor) actOnPodEvent(ctx context.Context, status *api.WorkspaceStatus
 		}
 
 		if !wso.IsWorkspaceHeadless() {
-			tracing.LogEvent(span, "removeTraceAnnotation")
+			span.LogKV("event", "removeTraceAnnotation")
 			// once a regular workspace is up and running, we'll remove the traceID information so that the parent span
 			// ends once the workspace has started
 			err := m.manager.markWorkspace(ctx, workspaceID, deleteMark(wsk8s.TraceIDAnnotation))
@@ -556,7 +556,7 @@ func (m *Monitor) traceWorkspace(occasion string, wso *workspaceObjects) opentra
 	if wso.Pod != nil {
 		tracing.ApplyOWI(span, wsk8s.GetOWIFromObject(&wso.Pod.ObjectMeta))
 	}
-	tracing.LogKV(span, "occasion", occasion)
+	span.LogKV("occasion", occasion)
 
 	// OpenTracing does not support creating a span from a SpanContext https://github.com/opentracing/specification/issues/81.
 	// Until that changes we just finish the span immediately after calling on-change.
@@ -584,7 +584,7 @@ func (m *Monitor) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (e
 		return
 	}
 
-	tracing.LogEvent(span, "probeDone")
+	span.LogKV("event", "probeDone")
 	probeResult := *r
 	if probeResult == WorkspaceProbeStopped {
 		// Workspace probe was stopped most likely because the workspace itself was stopped.
@@ -629,7 +629,7 @@ func (m *Monitor) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (e
 	m.initializerMapLock.Lock()
 	delete(m.initializerMap, pod.Name)
 	m.initializerMapLock.Unlock()
-	tracing.LogEvent(span, "contentInitDone")
+	span.LogKV("event", "contentInitDone")
 
 	// workspace is ready - mark it as such
 	err = m.manager.markWorkspace(ctx, workspaceID, deleteMark(workspaceNeverReadyAnnotation))
@@ -918,7 +918,7 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 		gitStatus   *csapi.GitStatus
 	)
 	for i := 0; i < wsdaemonMaxAttempts; i++ {
-		tracing.LogKV(span, "attempt", strconv.Itoa(i))
+		span.LogKV("attempt", strconv.Itoa(i))
 		didSometing, gs, err := doFinalize()
 		if !didSometing {
 			// someone else is managing finalization process ... we don't have to bother

--- a/components/ws-manager/pkg/manager/probe.go
+++ b/components/ws-manager/pkg/manager/probe.go
@@ -79,25 +79,25 @@ func (p *WorkspaceReadyProbe) Run(ctx context.Context) WorkspaceProbeResult {
 			return WorkspaceProbeStopped
 		}
 
-		tracing.LogEvent(span, "probe start")
+		span.LogKV("event", "probe start")
 		resp, err := client.Get(p.readyURL)
 
 		if err != nil {
 			urlerr, ok := err.(*url.Error)
 			if !ok || !urlerr.Timeout() {
-				tracing.LogKV(span, "response", "error")
+				span.LogKV("response", "error")
 				log.WithError(err).Debug("got a non-timeout error during workspace probe")
 				time.Sleep(p.RetryDelay)
 				continue
 			}
 
 			// we've timed out - do not log this as it would spam the logs for no good reason
-			tracing.LogKV(span, "response", "timeout")
+			span.LogKV("response", "timeout")
 			continue
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			tracing.LogKV(span, "response", fmt.Sprintf("%v", resp.StatusCode))
+			span.LogKV("response", fmt.Sprintf("%v", resp.StatusCode))
 			log.WithField("url", p.readyURL).WithField("status", resp.StatusCode).Debug("workspace did not respond to ready probe with OK status")
 			time.Sleep(p.RetryDelay)
 			continue


### PR DESCRIPTION
```
Dropped 183 nodes (cum <= 3.61MB)
Showing top 10 nodes out of 25
      flat  flat%   sum%        cum   cum%
  318.73MB 44.16% 44.16%   318.73MB 44.16%  github.com/uber/jaeger-client-go.(*Span).appendLogNoLocking (inline)
  192.51MB 26.67% 70.83%   486.61MB 67.41%  github.com/gitpod-io/gitpod/common-go/tracing.LogEvent (inline)
  184.01MB 25.49% 96.32%   208.64MB 28.90%  github.com/gitpod-io/gitpod/common-go/tracing.LogKV (inline)
    1.50MB  0.21% 96.53%     4.02MB  0.56%  k8s.io/api/core/v1.(*Container).Unmarshal
         0     0% 96.53%   695.26MB 96.32%  github.com/gitpod-io/gitpod/ws-manager/pkg/manager.(*Monitor).actOnPodEvent.func2
         0     0% 96.53%   695.26MB 96.32%  github.com/gitpod-io/gitpod/ws-manager/pkg/manager.(*Monitor).probeWorkspaceReady
         0     0% 96.53%   695.26MB 96.32%  github.com/gitpod-io/gitpod/ws-manager/pkg/manager.(*Monitor).waitForWorkspaceReady
         0     0% 96.53%   695.26MB 96.32%  github.com/gitpod-io/gitpod/ws-manager/pkg/manager.(*WorkspaceReadyProbe).Run
         0     0% 96.53%    10.27MB  1.42%  github.com/gogo/protobuf/proto.Unmarshal
         0     0% 96.53%   318.73MB 44.16%  github.com/uber/jaeger-client-go.(*Span).LogFields

``` 
