### PR TITLE
[analytics] Include internal user creation Date on signup call

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -519,6 +519,7 @@ export class UserController {
                 "email": User.getPrimaryEmail(user),
                 "name": User.getName(user),
                 "full_name": user.fullName,
+                "created_at": user.creationDate,
                 "unsubscribed": !user.allowsMarketingCommunication,
                 "blocked": user.blocked
             }


### PR DESCRIPTION
When tracking the user signup, we want to send the exact datetime when the user was created in order to be consistent with the current practice

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe