### PR TITLE
disable custom timeout errors in supervisor workspace web socket proxy

### DIFF
--- a/components/supervisor/frontend/src/ide/ide-web-socket.ts
+++ b/components/supervisor/frontend/src/ide/ide-web-socket.ts
@@ -17,12 +17,19 @@ function isWorkspaceOrigin(url: string): boolean {
     originUrl.protocol = window.location.protocol;
     return originUrl.origin === workspaceOrigin;
 }
+/**
+ * IDEWebSocket is a proxy to standard WebSocket
+ * which allows to control when web sockets to the workspace
+ * should be opened or closed.
+ * It should not deviate from standard WebSocket in any other way.
+ */
 class IDEWebSocket extends ReconnectingWebSocket {
     constructor(url: string, protocol?: string | string[]) {
         super(url, protocol, {
             WebSocket,
             startClosed: isWorkspaceOrigin(url) && !connected,
-            maxRetries: 0
+            maxRetries: 0,
+            connectionTimeout: 2147483647 // disable connection timeout, clients should handle it
         });
         if (isWorkspaceOrigin(url)) {
             workspaceSockets.add(this);


### PR DESCRIPTION
#### What it does

- fix 3782: disable custom timeout errors in supervisor workspace web socket proxy

#### How to test

You can try to reproduce below first in production.

- Start a workspace.
- Open the network tab in devtools, select web sockets.
- Enable 3G network profile on system level, on Mac you can use https://nshipster.com/network-link-conditioner/
- Reload the page, you should see that 2 web sockets to workspace is eventually connected. Ignore web sockets to gitpod.io and localhost.
- Do it several times.
- As a bonus try on Edge connection, you should never get a dialog with `TIMEOUT` error and after many attempts 2 web socket connection will be established.