### PR TITLE
[dashboard] Harmonize confirmation dialog

### DIFF
--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import Modal from "./Modal";
+
+export default function ConfirmationModal(props: {
+    title?: string;
+    areYouSureText?: string,
+    children?: Entity | React.ReactChild[] | React.ReactChild
+    buttonText?: string,
+    buttonDisabled?: boolean,
+    visible?: boolean,
+    onClose: () => void,
+    onConfirm: () => void,
+}) {
+
+    const c: React.ReactChild[] = [
+        <p className="mt-1 mb-2 text-base text-gray-500">{props.areYouSureText || "Are you sure?"}</p>,
+    ]
+
+    const isEntity = (x: any): x is Entity => typeof x === "object" && "line1" in x;
+    if (props.children) {
+        if (isEntity(props.children)) {
+            c.push(
+                <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
+                    <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.line1}</p>
+                    {props.children.line2 && <p className="text-gray-500">{props.children.line2}</p>}
+                </div>
+            )
+        } else if (Array.isArray(props.children)) {
+            c.push(...props.children);
+        } else {
+            c.push(props.children);
+        }
+    }
+
+    const buttons = [
+        <button className="secondary" onClick={props.onClose}>Cancel</button>,
+        <button className="ml-2 danger" onClick={props.onConfirm} disabled={props.buttonDisabled}>
+            {props.buttonText || "Yes, I'm Sure"}
+        </button>,
+    ]
+
+    return (
+        <Modal
+            title={props.title || "Confirm"}
+            buttons={buttons}
+            visible={props.visible === undefined ? true : props.visible}
+            onClose={props.onClose}
+            onEnter={() => { props.onConfirm(); return true; }}
+        >
+            {c}
+        </Modal>
+    );
+}
+
+export interface Entity {
+    line1: string,
+    line2?: string,
+}

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -21,13 +21,13 @@ export default function ConfirmationModal(props: {
         <p className="mt-1 mb-2 text-base text-gray-500">{props.areYouSureText || "Are you sure?"}</p>,
     ]
 
-    const isEntity = (x: any): x is Entity => typeof x === "object" && "line1" in x;
+    const isEntity = (x: any): x is Entity => typeof x === "object" && "name" in x;
     if (props.children) {
         if (isEntity(props.children)) {
             c.push(
                 <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
-                    <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.line1}</p>
-                    {props.children.line2 && <p className="text-gray-500">{props.children.line2}</p>}
+                    <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.name}</p>
+                    {props.children.description && <p className="text-gray-500">{props.children.description}</p>}
                 </div>
             )
         } else if (Array.isArray(props.children)) {
@@ -58,6 +58,6 @@ export default function ConfirmationModal(props: {
 }
 
 export interface Entity {
-    line1: string,
-    line2?: string,
+    name: string,
+    description?: string,
 }

--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -6,11 +6,11 @@
 
 import { User } from "@gitpod/gitpod-protocol";
 import { useContext, useState } from "react";
-import Modal from "../components/Modal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import settingsMenu from "./settings-menu";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 export default function Account() {
     const { user } = useContext(UserContext);
@@ -27,22 +27,22 @@ export default function Account() {
 
     const close = () => setModal(false);
     return <div>
-        <Modal visible={modal} onClose={close}>
-            <h3 className="pb-2">Delete Account</h3>
-            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                <p className="pb-4 text-gray-900 dark:text-gray-50 text-base">You are about to permanently delete your account.</p>
-                <ol className="text-gray-500 text-sm list-outside list-decimal">
-                    <li className="ml-5">All your workspaces and related data will be deleted and cannot be restored afterwards.</li>
-                    <li className="ml-5">Your subscription will be cancelled. If you obtained a Gitpod subscription through the GitHub marketplace, you need to cancel your plan there.</li>
-                </ol>
-                <p className="pt-4 pb-2 text-gray-600 text-base font-semibold">Type your email to confirm</p>
-                <input className="w-full" type="text" onChange={e => setTypedEmail(e.target.value)}></input>
-            </div>
-            <div className="flex justify-end mt-6">
-                <button className="secondary" onClick={close}>Cancel</button>
-                <button className="ml-2 danger" onClick={deleteAccount} disabled={typedEmail !== primaryEmail}>Delete Account</button>
-            </div>
-        </Modal>
+        <ConfirmationModal
+            title="Delete Accont"
+            areYouSureText="You are about to permanently delete your account."
+            buttonText="Delete Account"
+            buttonDisabled={typedEmail !== primaryEmail}
+            visible={modal}
+            onClose={close}
+            onConfirm={deleteAccount}
+        >
+            <ol className="text-gray-500 text-sm list-outside list-decimal">
+                <li className="ml-5">All your workspaces and related data will be deleted and cannot be restored afterwards.</li>
+                <li className="ml-5">Your subscription will be cancelled. If you obtained a Gitpod subscription through the GitHub marketplace, you need to cancel your plan there.</li>
+            </ol>
+            <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">Type your email to confirm</p>
+            <input className="w-full" type="text" onChange={e => setTypedEmail(e.target.value)}></input>
+        </ConfirmationModal>
 
         <PageWithSubMenu subMenu={settingsMenu}  title='Account' subtitle='Manage account and git configuration.'>
             <h3>Profile</h3>

--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -28,7 +28,7 @@ export default function Account() {
     const close = () => setModal(false);
     return <div>
         <ConfirmationModal
-            title="Delete Accont"
+            title="Delete Account"
             areYouSureText="You are about to permanently delete your account."
             buttonText="Delete Account"
             buttonDisabled={typedEmail !== primaryEmail}

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -11,6 +11,7 @@ import Modal from "../components/Modal";
 import { getGitpodService } from "../service/service";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import settingsMenu from "./settings-menu";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 interface EnvVarModalProps {
     envVar: UserEnvVarValue;
@@ -80,10 +81,14 @@ function AddEnvVarModal(p: EnvVarModalProps) {
 }
 
 function DeleteEnvVarModal(p: { variable: UserEnvVarValue, deleteVariable: () => void, onClose: () => void }) {
-    return <Modal visible={true} onClose={p.onClose}>
-        <h3 className="mb-4">Delete Variable?</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
-            <div className="grid grid-cols-2 gap-4 px-3 text-sm text-gray-400">
+    return <ConfirmationModal
+        title="Delete Variable"
+        areYouSureText="Are you sure you want to delete this variable?"
+        buttonText="Delete Variable"
+        onClose={p.onClose}
+        onConfirm={() => { p.deleteVariable(); p.onClose(); }}
+    >
+        <div className="grid grid-cols-2 gap-4 px-3 text-sm text-gray-400">
                 <span className="truncate">Name</span>
                 <span className="truncate">Scope</span>
             </div>
@@ -91,12 +96,7 @@ function DeleteEnvVarModal(p: { variable: UserEnvVarValue, deleteVariable: () =>
                 <span className="truncate text-gray-900 dark:text-gray-50">{p.variable.name}</span>
                 <span className="truncate text-sm">{p.variable.repositoryPattern}</span>
             </div>
-        </div>
-        <div className="flex justify-end mt-6">
-            <button className="secondary" onClick={p.onClose}>Cancel</button>
-            <button className="ml-2 danger" onClick={() => { p.deleteVariable(); p.onClose(); }} >Delete Variable</button>
-        </div>
-    </Modal>;
+    </ConfirmationModal>;
 }
 
 function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -19,6 +19,7 @@ import CheckBox from '../components/CheckBox';
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import settingsMenu from "./settings-menu";
 import { SelectAccountModal } from "./SelectAccountModal";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 export default function Integrations() {
 
@@ -233,19 +234,17 @@ function GitProviders() {
         )}
 
         {disconnectModal && (
-            <Modal visible={true} onClose={() => setDisconnectModal(undefined)}>
-                <h3 className="pb-2">Disconnect Provider</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                    <p className="pb-4 text-gray-500 text-base">Are you sure you want to disconnect the following provider?</p>
-                    <div className="flex flex-col rounded-xl p-3 bg-gray-100 dark:bg-gray-800">
-                        <div className="text-gray-700 text-md font-semibold">{disconnectModal.provider.authProviderType}</div>
-                        <div className="text-gray-400 text-md">{disconnectModal.provider.host}</div>
-                    </div>
-                </div>
-                <div className="flex justify-end mt-6">
-                    <button className={"ml-2 danger secondary"} onClick={() => disconnect(disconnectModal.provider)}>Disconnect Provider</button>
-                </div>
-            </Modal>
+            <ConfirmationModal
+                title="Disconnect Provider"
+                areYouSureText="Are you sure you want to disconnect the following provider?"
+                children={{
+                    line1: disconnectModal.provider.authProviderType,
+                    line2: disconnectModal.provider.host,
+                }}
+                buttonText="Disconnect Provider"
+                onClose={() => setDisconnectModal(undefined)}
+                onConfirm={() => disconnect(disconnectModal.provider)}
+            />
         )}
 
         {editModal && (
@@ -364,20 +363,18 @@ function GitIntegrations() {
             <GitIntegrationModal mode={modal.mode} userId={user?.id || "no-user"} provider={modal.provider} onClose={() => setModal(undefined)} onUpdate={updateOwnAuthProviders} />
         )}
         {modal?.mode === "delete" && (
-            <Modal visible={true} onClose={() => setModal(undefined)}>
-                <h3 className="pb-2">Remove Integration</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                    <p className="pb-4 text-gray-500 text-base">Are you sure you want to remove the following git integration?</p>
+            <ConfirmationModal
+                title="Remove Integration"
+                areYouSureText="Are you sure you want to remove the following git integration?"
+                children={{
+                    line1: modal.provider.type,
+                    line2: modal.provider.host,
+                }}
+                buttonText="Delete Workspace"
+                onClose={() => setModal(undefined)}
+                onConfirm={() => deleteProvider(modal.provider)}
+            />
 
-                    <div className="flex flex-col rounded-xl p-3 bg-gray-100">
-                        <div className="text-gray-700 text-md font-semibold">{modal.provider.type}</div>
-                        <div className="text-gray-400 text-md">{modal.provider.host}</div>
-                    </div>
-                </div>
-                <div className="flex justify-end mt-6">
-                    <button className={"ml-2 danger secondary"} onClick={() => deleteProvider(modal.provider)}>Remove Integration</button>
-                </div>
-            </Modal>
         )}
 
         <div className="flex items-start sm:justify-between mb-2">

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -238,8 +238,8 @@ function GitProviders() {
                 title="Disconnect Provider"
                 areYouSureText="Are you sure you want to disconnect the following provider?"
                 children={{
-                    line1: disconnectModal.provider.authProviderType,
-                    line2: disconnectModal.provider.host,
+                    name: disconnectModal.provider.authProviderType,
+                    description: disconnectModal.provider.host,
                 }}
                 buttonText="Disconnect Provider"
                 onClose={() => setDisconnectModal(undefined)}
@@ -367,8 +367,8 @@ function GitIntegrations() {
                 title="Remove Integration"
                 areYouSureText="Are you sure you want to remove the following git integration?"
                 children={{
-                    line1: modal.provider.type,
-                    line2: modal.provider.host,
+                    name: modal.provider.type,
+                    description: modal.provider.host,
                 }}
                 buttonText="Delete Workspace"
                 onClose={() => setModal(undefined)}
@@ -415,7 +415,7 @@ function GitIntegrations() {
                         <span className="my-auto truncate text-gray-500 overflow-ellipsis">{ap.host}</span>
                     </div>
                     <div className="my-auto flex w-1/12 mr-4 opacity-0 group-hover:opacity-100 justify-end">
-                        <div className="self-center hover:bg-gray-200 dark:dark:bg-gray-800 rounded-md cursor-pointer w-8">
+                        <div className="self-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer w-8">
                             <ContextMenu menuEntries={gitProviderMenu(ap)}>
                                 <svg className="w-8 h-8 p-1 text-gray-600 dark:text-gray-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Actions</title><g fill="currentColor" transform="rotate(90 12 12)"><circle cx="1" cy="1" r="2" transform="translate(5 11)" /><circle cx="1" cy="1" r="2" transform="translate(11 11)" /><circle cx="1" cy="1" r="2" transform="translate(17 11)" /></g></svg>
                             </ContextMenu>

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -8,11 +8,11 @@ import { CommitContext, Workspace, WorkspaceInfo, WorkspaceInstance, WorkspaceIn
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import ContextMenu, { ContextMenuEntry } from '../components/ContextMenu';
 import moment from 'moment';
-import Modal from '../components/Modal';
 import { useState } from 'react';
 import { WorkspaceModel } from './workspace-model';
 import PendingChangesDropdown from '../components/PendingChangesDropdown';
 import Tooltip from '../components/Tooltip';
+import ConfirmationModal from '../components/ConfirmationModal';
 
 function getLabel(state: WorkspaceInstancePhase) {
     return state.substr(0,1).toLocaleUpperCase() + state.substr(1);
@@ -112,24 +112,18 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                 </ContextMenu>
             </div>
         </div>
-        {isModalVisible && <Modal visible={isModalVisible} onClose={() => setModalVisible(false)}>
-            <div>
-                <h3 className="pb-2">Delete Workspace</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-2">
-                    <p className="mt-1 mb-2 text-base">Are you sure you want to delete this workspace?</p>
-                    <div className="w-full p-4 mb-2 bg-gray-100 rounded-xl group bg-gray-100">
-                        <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{ws.id}</p>
-                        <p>{ws.description}</p>
-                    </div>
-                </div>
-                <div className="flex justify-end mt-5">
-                    <button className="danger"
-                        onClick={() => model.deleteWorkspace(ws.id)}>
-                        Delete Workspace
-                    </button>
-                </div>
-            </div>
-        </Modal>}
+        {isModalVisible && <ConfirmationModal
+            title="Delete Workspace"
+            areYouSureText="Are you sure you want to delete this workspace?"
+            children={{
+                line1: ws.id,
+                line2: ws.description,
+            }}
+            buttonText="Delete Workspace"
+            visible={isModalVisible}
+            onClose={() => setModalVisible(false)}
+            onConfirm={() => model.deleteWorkspace(ws.id)}
+        />}
     </div>;
 }
 

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -116,8 +116,8 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
             title="Delete Workspace"
             areYouSureText="Are you sure you want to delete this workspace?"
             children={{
-                line1: ws.id,
-                line2: ws.description,
+                name: ws.id,
+                description: ws.description,
             }}
             buttonText="Delete Workspace"
             visible={isModalVisible}


### PR DESCRIPTION
There are confirmation dialogs on different places where the code has be copied. In some cases, small deviations have been introduced unintentionally (slightly different shade of gray, etc.). For this reason, this PR introduces a common `ConfirmationModal`.

This fixes also #4264, and #3701.

/cc @gtsiolis 