### PR TITLE
[dashboard] Fix workspace entry truncation

### DIFF
--- a/components/dashboard/src/components/Tooltip.tsx
+++ b/components/dashboard/src/components/Tooltip.tsx
@@ -9,14 +9,15 @@ import { useState } from 'react';
 export interface TooltipProps {
     children: React.ReactChild[] | React.ReactChild;
     content: string;
+    className?: string;
 }
 
 function Tooltip(props: TooltipProps) {
     const [expanded, setExpanded] = useState(false);
 
     return (
-        <div onMouseLeave={() => setExpanded(false)} onMouseEnter={() => setExpanded(true)} className="relative">
-            <div>
+        <div onMouseLeave={() => setExpanded(false)} onMouseEnter={() => setExpanded(true)} className={"relative " + (props.className || "")}>
+            <div className={props.className}>
                 {props.children}
             </div>
             {expanded ?

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -86,19 +86,17 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                 <WorkspaceStatusIndicator instance={desc?.latestInstance} />
             </div>
             <div className="flex flex-col w-3/12">
-                <a href={startUrl.toString()}><div className="font-medium text-gray-800 dark:text-gray-100 truncate hover:text-blue-600 dark:hover:text-blue-400">{ws.id}</div></a>
-                <a href={project ? 'https://' + project : undefined}><div className="text-sm overflow-ellipsis truncate text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">{project || 'Unknown'}</div></a>
+                <a href={startUrl.toString()}><div className="font-medium text-gray-800 dark:text-gray-100 overflow-ellipsis truncate w-full hover:text-blue-600 dark:hover:text-blue-400">{ws.id}</div></a>
+                <a href={project ? 'https://' + project : undefined}><div className="text-sm overflow-ellipsis truncate w-full text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">{project || 'Unknown'}</div></a>
             </div>
-            <div className="flex w-4/12 truncate overflow-ellipsis">
-                <div className="flex flex-col">
-                    <div className="text-gray-500 overflow-ellipsis truncate">{ws.description}</div>
-                    <a href={ws.contextURL}>
-                        <div className="text-sm text-gray-400 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">{ws.contextURL}</div>
-                    </a>
-                </div>
+            <div className="flex flex-col w-4/12">
+                <div className="text-gray-500 overflow-ellipsis truncate w-full">{ws.description}</div>
+                <a href={ws.contextURL}>
+                    <div className="text-sm text-gray-400 overflow-ellipsis truncate w-full hover:text-blue-600 dark:hover:text-blue-400">{ws.contextURL}</div>
+                </a>
             </div>
             <div className="flex flex-col items-start w-2/12">
-                <div className="text-gray-500 truncate">{currentBranch}</div>
+                <div className="text-gray-500 overflow-ellipsis truncate w-full">{currentBranch}</div>
                 <PendingChangesDropdown workspaceInstance={desc.latestInstance} />
             </div>
             <div className="flex w-2/12 self-center">

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -86,17 +86,31 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                 <WorkspaceStatusIndicator instance={desc?.latestInstance} />
             </div>
             <div className="flex flex-col w-3/12">
-                <a href={startUrl.toString()}><div className="font-medium text-gray-800 dark:text-gray-100 overflow-ellipsis truncate w-full hover:text-blue-600 dark:hover:text-blue-400">{ws.id}</div></a>
-                <a href={project ? 'https://' + project : undefined}><div className="text-sm overflow-ellipsis truncate w-full text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">{project || 'Unknown'}</div></a>
+                <Tooltip content={ws.id}>
+                    <a href={startUrl.toString()}>
+                        <div className="font-medium text-gray-800 dark:text-gray-100 overflow-ellipsis truncate w-full hover:text-blue-600 dark:hover:text-blue-400">{ws.id}</div>
+                    </a>
+                </Tooltip>
+                <Tooltip content={project || 'Unknown'}>
+                    <a href={project ? 'https://' + project : undefined}>
+                        <div className="text-sm overflow-ellipsis truncate w-full text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">{project || 'Unknown'}</div>
+                    </a>
+                </Tooltip>
             </div>
             <div className="flex flex-col w-4/12">
-                <div className="text-gray-500 overflow-ellipsis truncate w-full">{ws.description}</div>
-                <a href={ws.contextURL}>
-                    <div className="text-sm text-gray-400 overflow-ellipsis truncate w-full hover:text-blue-600 dark:hover:text-blue-400">{ws.contextURL}</div>
-                </a>
+                <Tooltip content={ws.description}>
+                    <div className="text-gray-500 overflow-ellipsis truncate w-full">{ws.description}</div>
+                </Tooltip>
+                <Tooltip content={ws.contextURL}>
+                    <a href={ws.contextURL}>
+                        <div className="text-sm text-gray-400 overflow-ellipsis truncate w-full hover:text-blue-600 dark:hover:text-blue-400">{ws.contextURL}</div>
+                    </a>
+                </Tooltip>
             </div>
             <div className="flex flex-col items-start w-2/12">
-                <div className="text-gray-500 overflow-ellipsis truncate w-full">{currentBranch}</div>
+                <Tooltip content={currentBranch} className="w-full">
+                    <div className="text-gray-500 overflow-ellipsis truncate w-full">{currentBranch}</div>
+                </Tooltip>
                 <PendingChangesDropdown workspaceInstance={desc.latestInstance} />
             </div>
             <div className="flex w-2/12 self-center">


### PR DESCRIPTION
The actual change is the commit 9f41b1d that fixes the truncation in the workspace list:

|   Before   |        This PR       | 
|:---------:|:-----------------------:|
| ![image](https://user-images.githubusercontent.com/24960040/121076119-5224bc00-c7d6-11eb-81aa-8e0cf01d40e6.png) | ![image](https://user-images.githubusercontent.com/24960040/121076045-37524780-c7d6-11eb-8009-11d5ee3ba5da.png)   |


Besides this, this PR also has the commit 4476666 that adds tooltips for the values. The rationale behind this is that it should be possible to read the whole non-truncated value somehow:

![image](https://user-images.githubusercontent.com/24960040/121076516-cd866d80-c7d6-11eb-93eb-b88d64dd5848.png)

The downside is that the tooltip is always there, no matter if truncated or not. I don't know an easy way to show the tooltip for truncated values only. If we don't like this behavior, we can drop this commit.