### PR TITLE
[dashboard] Remove margin-bottom from PageWithSubMenu

### DIFF
--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -42,7 +42,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                     })}
                 </ul>
             </div>
-            <div className='ml-32 w-full pt-1 mb-40'>
+            <div className='ml-32 w-full pt-1'>
                 {p.children}
             </div>
         </div>


### PR DESCRIPTION
Avoids unnecessary scrollbars. Fixes #3859.

Before this change, pages in the settings section do have a margin at the bottom. That leads to unnecessary scrollbars:

![image](https://user-images.githubusercontent.com/24960040/121084138-95842800-c7e0-11eb-84f3-8ca15f6c21b2.png)

Without the margin, the scrollbars disappear:

![image](https://user-images.githubusercontent.com/24960040/121084201-a765cb00-c7e0-11eb-9238-c87290d65f43.png)

Is there any good reason for the margin?

(Examples are with a canvas size of 1440x1049px.)