### PR TITLE
[caddy] proxy requests to port locations through ws proxy

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -47,3 +47,4 @@ vscode:
     - ms-kubernetes-tools.vscode-kubernetes-tools
     - stkb.rewrap
     - zxh404.vscode-proto3
+    - matthewpi.caddyfile-support

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -216,7 +216,11 @@ https://*.*.{$GITPOD_DOMAIN} {
 
 	@workspace_port header_regexp host Host ^(webview-|browser-|extensions-)?(?P<workspacePort>[0-9]{2,5})-(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @workspace_port {
-		reverse_proxy ws-{re.host.workspaceID}-ports.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:{re.host.workspacePort} {
+		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
+			transport http {
+				tls_insecure_skip_verify
+			}
+
 			import upstream_headers
 
 			header_up X-Gitpod-WorkspaceId {re.host.workspaceID}

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252
-	github.com/gorilla/handlers v1.4.2
+	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.7.4
 	github.com/prometheus/client_golang v1.9.0
 	github.com/sirupsen/logrus v1.7.0

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -76,6 +76,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
@@ -154,6 +156,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -258,6 +258,14 @@ func installWorkspacePortRoutes(r *mux.Router, config *RouteHandlerConfig) error
 	// forward request to workspace port
 	r.NewRoute().HandlerFunc(
 		func(rw http.ResponseWriter, r *http.Request) {
+			// a work-around for servers which does not respect case-insensitive headers, see https://github.com/gitpod-io/gitpod/issues/4047#issuecomment-856566526
+			for _, name := range []string{"Key", "Extensions", "Accept", "Protocol", "Version"} {
+				values := r.Header["Sec-Websocket-"+name]
+				if len(values) != 0 {
+					r.Header.Del("Sec-Websocket-" + name)
+					r.Header["Sec-WebSocket-"+name] = values
+				}
+			}
 			r.Header.Add("X-Forwarded-Proto", "https")
 			r.Header.Add("X-Forwarded-Host", r.Host+":443")
 			proxyPass(

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -207,6 +207,7 @@ func TestRoutes(t *testing.T) {
 					"Location": {
 						"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/favicon.ico",
 					},
+					"Vary": {"Accept-Encoding"},
 				},
 				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/favicon.ico\">See Other</a>.\n\n",
 			},
@@ -222,6 +223,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
 					"Location":     {"https://blobserve.ws.test-domain.com/gitpod-io/ide:latest/__files__/"},
+					"Vary":         {"Accept-Encoding"},
 				},
 				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/ide:latest/__files__/\">See Other</a>.\n\n",
 			},
@@ -238,6 +240,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"38"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "blobserve hit: /gitpod-io/ide:latest/\n",
 			},
@@ -254,6 +257,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"38"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "blobserve hit: /gitpod-io/ide:latest/\n",
 			},
@@ -271,6 +275,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"24"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "workspace hit: /?foobar\n",
 			},
@@ -288,6 +293,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"35"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "workspace hit: /not-from-blobserve\n",
 			},
@@ -305,6 +311,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"42"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "workspace hit: /not-from-failed-blobserve\n",
 			},
@@ -327,6 +334,7 @@ func TestRoutes(t *testing.T) {
 					"Access-Control-Expose-Headers":    {"Authorization"},
 					"Content-Length":                   {"37"},
 					"Content-Type":                     {"text/plain; charset=utf-8"},
+					"Vary":                             {"Accept-Encoding"},
 				},
 				Body: "workspace hit: /somewhere/in/the/ide\n",
 			},
@@ -341,6 +349,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"50"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "supervisor hit: /_supervisor/v1/status/supervisor\n",
 			},
@@ -355,6 +364,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"43"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "supervisor hit: /_supervisor/v1/status/ide\n",
 			},
@@ -366,6 +376,9 @@ func TestRoutes(t *testing.T) {
 			),
 			Expectation: Expectation{
 				Status: http.StatusUnauthorized,
+				Header: http.Header{
+					"Vary": {"Accept-Encoding"},
+				},
 			},
 		},
 		{
@@ -379,6 +392,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"47"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "supervisor hit: /_supervisor/v1/status/content\n",
 			},
@@ -394,6 +408,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
 					"Location":     {"https://test-domain.com/start/#blabla-smelt-9ba20cc1"},
+					"Vary":         {"Accept-Encoding"},
 				},
 				Body: ("<a href=\"https://test-domain.com/start/#blabla-smelt-9ba20cc1\">Found</a>.\n\n"),
 			},
@@ -408,6 +423,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
 					"Location":     {"https://test-domain.com/start/#blabla-smelt-9ba20cc1"},
+					"Vary":         {"Accept-Encoding"},
 				},
 				Body: ("<a href=\"https://test-domain.com/start/#blabla-smelt-9ba20cc1\">Found</a>.\n\n"),
 			},
@@ -423,6 +439,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Length": {"60"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "blobserve hit: /gitpod-io/supervisor:latest/worker-proxy.js\n",
 			},
@@ -438,6 +455,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
 					"Location":     {"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js"},
+					"Vary":         {"Accept-Encoding"},
 				},
 				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js\">See Other</a>.\n\n",
 			},
@@ -463,6 +481,7 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
 					"Location":     {"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js"},
+					"Vary":         {"Accept-Encoding"},
 				},
 				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js\">See Other</a>.\n\n",
 			},
@@ -542,6 +561,7 @@ func TestRoutes(t *testing.T) {
 					"Cache-Control":  {"public, max-age=31536000"},
 					"Content-Length": {"62"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Status: http.StatusOK,
 				Body:   "blobserve hit: /blobserve/gitpod-io/supervisor:latest/main.js\n",


### PR DESCRIPTION
#### What it does

- fix #4047: It is a work-around, ws-proxy does low level manipulations to web socket headers to align them with most common usages.

#### How to test

- Start a workspace for https://github.com/vaadin/skeleton-starter-flow-spring
- When the server is ready, try to create a web socket for port 35729 and connect to it from devtools. You can verify it in network tab.
   - Notice that live reloading won't work since they don't respect our preview env, only gitpod.io