### PR TITLE
[common-log] Enable change of log level at runtime

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -186,6 +186,8 @@ env:
   value: {{ template "gitpod.installation.longname" . }}
 - name: GITPOD_INSTALLATION_SHORTNAME
   value: {{ template "gitpod.installation.shortname" . }}
+- name: LOG_LEVEL
+  value: {{ $gp.log.level | default "debug" | lower | quote }}
 {{- end -}}
 
 {{- define "gitpod.container.analyticsEnv" -}}

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -137,8 +137,6 @@ spec:
 {{- end }}
         - name: GITPOD_DEFINITELY_GP_DISABLED
           value: "{{ $comp.definitelyGpDisabled | default "false" }}"
-        - name: LOG_LEVEL
-          value: "trace"
         - name: NODE_ENV
           value: "{{ .Values.installation.stage }}"
         - name: SERVER_VERSION

--- a/chart/templates/ws-manager-bridge-deployment.yaml
+++ b/chart/templates/ws-manager-bridge-deployment.yaml
@@ -61,8 +61,6 @@ spec:
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
 {{ include "gitpod.container.analyticsEnv" $this | indent 8 }}
 {{ include "gitpod.container.messagebusEnv" $this | indent 8 }}
-        - name: LOG_LEVEL
-          value: "trace"
         - name: WSMAN_BRIDGE_CONFIGPATH
           value: /config/ws-manager-bridge.json
       volumes:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,6 +9,7 @@ certificatesSecret:
   secretName: https-certificates
 
 imagePrefix: gcr.io/gitpod-io/self-hosted/
+
 installation:
   stage: production
   tenant: gitpod
@@ -20,6 +21,11 @@ license: ""
 installNetworkPolicies: true
 installPodSecurityPolicies: true
 imagePullPolicy: IfNotPresent
+
+# configure default log level
+log:
+  level: trace
+
 resources:
   default:
     cpu: 100m

--- a/components/blobserve/cmd/root.go
+++ b/components/blobserve/cmd/root.go
@@ -5,10 +5,12 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 
+	containerd_log "github.com/containerd/containerd/log"
 	"github.com/spf13/cobra"
 
 	"github.com/gitpod-io/gitpod/blobserve/pkg/blobserve"
@@ -30,6 +32,9 @@ var rootCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, jsonLog, jsonLog)
+
+		// configure containerd log with gitpod-io configuration
+		containerd_log.WithLogger(context.Background(), log.Log)
 	},
 }
 

--- a/components/common-go/log/handler.go
+++ b/components/common-go/log/handler.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+type logLevel struct {
+	Level string `json:"level"`
+}
+
+func LevelHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		reportLogLevel(Log.Logger.Level.String(), w, r)
+		return
+	}
+
+	if r.Method != http.MethodPost && r.Method != http.MethodPut {
+		http.Error(w, r.Method+" unsupported", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot decode request: %v", err), http.StatusPreconditionFailed)
+		return
+	}
+
+	if len(body) == 0 {
+		http.Error(w, "invalid request", http.StatusPreconditionFailed)
+		return
+	}
+
+	var req logLevel
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot decode request: %v", err), http.StatusPreconditionFailed)
+		return
+	}
+
+	newLevel, err := logrus.ParseLevel(req.Level)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	Log.Logger.SetLevel(newLevel)
+	reportLogLevel(Log.Logger.Level.String(), w, r)
+}
+
+func reportLogLevel(level string, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	//nolint
+	w.Write([]byte(fmt.Sprintf(`{"level": "%v"}`, level)))
+}

--- a/components/common-go/log/handler_test.go
+++ b/components/common-go/log/handler_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package log
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLevelHandler(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Method      string
+		Body        []byte
+		Expectation string
+		Error       string
+	}{
+		{"report default level", http.MethodGet, nil, `{"level": "info"}`, ""},
+		{"change level to info", http.MethodPost, []byte(`{"level": "info"}`), `{"level": "info"}`, ""},
+		{"change level to debug", http.MethodPut, []byte(`{"level": "debug"}`), `{"level": "debug"}`, ""},
+		{"invalid level", http.MethodPost, []byte(`{"level": "something invalid"}`), "", `not a valid logrus Level: "something invalid"`},
+		{"invalid method", http.MethodDelete, nil, "", "DELETE unsupported"},
+		{"empty body", http.MethodPost, []byte(""), "", "invalid request"},
+		{"invalid json", http.MethodPost, []byte("{"), "", "cannot decode request: unexpected end of JSON input"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			req, err := http.NewRequest(test.Method, "/debug/level", bytes.NewReader(test.Body))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(LevelHandler)
+
+			handler.ServeHTTP(rr, req)
+
+			if test.Error == "" {
+				if rr.Body.String() != test.Expectation {
+					t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), test.Expectation)
+				}
+
+				return
+			}
+
+			if rr.Code == http.StatusOK {
+				t.Errorf("handler returned should not return StatusOK")
+				return
+			}
+
+			msg := strings.ReplaceAll(rr.Body.String(), "\n", "")
+			if msg != test.Error {
+				t.Errorf(`handler returned wrong error: got '%v' want '%v'`, msg, test.Error)
+			}
+		})
+	}
+}

--- a/components/common-go/log/redact_test.go
+++ b/components/common-go/log/redact_test.go
@@ -2,12 +2,10 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package log_test
+package log
 
 import (
 	"testing"
-
-	"github.com/gitpod-io/gitpod/common-go/log"
 )
 
 func TestRedactJSON(t *testing.T) {
@@ -22,7 +20,7 @@ func TestRedactJSON(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		res, err := log.RedactJSON([]byte(test.Input))
+		res, err := RedactJSON([]byte(test.Input))
 		if err != nil {
 			t.Errorf("test %d failed: %v", i, err)
 			continue

--- a/components/common-go/pprof/pprof.go
+++ b/components/common-go/pprof/pprof.go
@@ -38,6 +38,9 @@ func Handler() *http.ServeMux {
 	mux.HandleFunc(Path+"profile", pprof.Profile)
 	mux.HandleFunc(Path+"symbol", pprof.Symbol)
 	mux.HandleFunc(Path+"trace", pprof.Trace)
+
+	mux.HandleFunc("/debug/logging", log.LevelHandler)
+
 	return mux
 }
 

--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
 	sched "github.com/gitpod-io/gitpod/ws-scheduler/pkg/scheduler"

--- a/components/ee/ws-scheduler/pkg/scheduler/strategy.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/strategy.go
@@ -9,11 +9,11 @@ import (
 	"sort"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	"github.com/gitpod-io/gitpod/common-go/log"
 )
 
 // StrategyName is the type that identifies strategies

--- a/components/ws-daemon/cmd/client-init.go
+++ b/components/ws-daemon/cmd/client-init.go
@@ -8,9 +8,9 @@ import (
 	"context"
 
 	"github.com/alecthomas/repr"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/ws-daemon/api"
 )

--- a/components/ws-daemon/nsinsider/pkg/nsenter/nsexec.c
+++ b/components/ws-daemon/nsinsider/pkg/nsenter/nsexec.c
@@ -114,7 +114,11 @@ void nsexec(void)
 	if (in_init == NULL || *in_init == '\0')
 		return;
 
-	write_log(DEBUG, "nsexec started");
+	char *log_level = getenv("LOG_LEVEL");
+	if (!log_level || strlen(log_level) == 0)
+		log_level = "INFO";
+
+	write_log(log_level, "nsexec started");
 
 	/*
 	 * Make the process non-dumpable, to avoid various race conditions that
@@ -129,31 +133,31 @@ void nsexec(void)
 
 	char *mntnsfd = getenv("_LIBNSENTER_MNTNSFD");
 	if (mntnsfd != NULL) {
-		write_log(DEBUG, "join mnt namespace: %s", mntnsfd);
+		write_log(log_level, "join mnt namespace: %s", mntnsfd);
 		join_ns(mntnsfd, CLONE_NEWNS);
 	}
 
 	char *rootfd = getenv("_LIBNSENTER_ROOTFD");
 	if (rootfd != NULL) {
-		write_log(DEBUG, "chroot: %s", rootfd);
+		write_log(log_level, "chroot: %s", rootfd);
 		fchdir(atoi(rootfd));
 		chroot(".");
 	}
 	char *cwdfd = getenv("_LIBNSENTER_CWDFD");
 	if (cwdfd != NULL) {
-		write_log(DEBUG, "chcwd: %s", cwdfd);
+		write_log(log_level, "chcwd: %s", cwdfd);
 		fchdir(atoi(cwdfd));
 	}
 
 	char *netnsfd = getenv("_LIBNSENTER_NETNSFD");
 	if (netnsfd != NULL) {
-		write_log(DEBUG, "join net namespace: %s", netnsfd);
+		write_log(log_level, "join net namespace: %s", netnsfd);
 		join_ns(netnsfd, CLONE_NEWNET);
 	}
 
 	char *pidnsfd = getenv("_LIBNSENTER_PIDNSFD");
 	if (pidnsfd != NULL) {
-		write_log(DEBUG, "join pid namespace: %s", pidnsfd);
+		write_log(log_level, "join pid namespace: %s", pidnsfd);
 		join_ns(pidnsfd, CLONE_NEWPID);
 	}
 

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -224,7 +224,12 @@ func RunInitializer(ctx context.Context, destination string, initializer *csapi.
 		return err
 	}
 
-	cmd = exec.Command("runc", "--root", "state", "--debug", "--log-format", "json", "run", "gogogo")
+	var withDebug string
+	if log.Log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		withDebug = "--debug"
+	}
+
+	cmd = exec.Command("runc", "--root", "state", withDebug, "--log-format", "json", "run", "gogogo")
 	cmd.Dir = tmpdir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/components/ws-manager/cmd/root.go
+++ b/components/ws-manager/cmd/root.go
@@ -11,16 +11,17 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/gitpod-io/gitpod/common-go/grpc"
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
 	"github.com/gitpod-io/gitpod/ws-manager/pkg/manager"
-	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (

--- a/dev/poolkeeper/cmd/root.go
+++ b/dev/poolkeeper/cmd/root.go
@@ -9,15 +9,14 @@ import (
 	"fmt"
 	"os"
 
-	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
-
 	"github.com/gitpod-io/gitpod/poolkeeper/pkg/poolkeeper"
 )
 

--- a/dev/poolkeeper/cmd/run.go
+++ b/dev/poolkeeper/cmd/run.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/poolkeeper/pkg/poolkeeper"
 )
 

--- a/install/installer/cmd/bash.go
+++ b/install/installer/cmd/bash.go
@@ -10,9 +10,10 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/gitpod-io/installer/pkg/sources"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/gitpod-io/installer/pkg/sources"
 )
 
 // bashCmd represents the gcp command

--- a/install/installer/pkg/gcp/gcp.go
+++ b/install/installer/pkg/gcp/gcp.go
@@ -13,9 +13,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gitpod-io/installer/pkg/terraform"
 	"github.com/gitpod-io/installer/pkg/ui"
-	log "github.com/sirupsen/logrus"
 )
 
 var availableRegions = []string{


### PR DESCRIPTION
Allow the change of log level at runtime using the pprof port with a new endpoint.

*Using port-forward:*

**Get current level**
`curl localhost:6060/debug/logging`

**Change level**
`curl localhost:6060/debug/logging -d '{"level":"info"}'`

default value is `trace` (current value)

Also configures containerd log (logrus) with gitpod-io log settings
