### PR TITLE
[dev-environment] Trigger rebuild of dev-environment image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:new-agent-smith.7
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:new-agent-smith.7
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:new-agent-smith.7
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:new-agent-smith.7
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -24,7 +24,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:new-agent-smith.7
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -43,7 +43,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:new-agent-smith.7",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full-vnc:latest
 
-ENV TRIGGER_REBUILD 11
+ENV TRIGGER_REBUILD 12
 
 USER root
 


### PR DESCRIPTION
```console
❯ docker run eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-workspacego.12 go version
go version go1.16.4 linux/amd64
```

```console
❯ docker run eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-trigger.4 go version
go version go1.16.5 linux/amd64
```
