### PR TITLE
[code] fix externalisation of already external URLs

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT c4646a76fb5abdd6e0b5a96efb1f74f5b3ed209d
+ENV GP_CODE_COMMIT 705321fef71b9119ecc09fb8ac78e6c064d8e563
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #4426: I used by mistake `openExternal` for already external URL which will produced a bogus URL, now `openExternal` is used always for desired local URL, i.e.
   - before for 3000 workspace port and 6000 local port I would produce external URL `localhost:6000` and then call openExternal for it which will externalise it again and since there is no tunnel for 6000 it would give exposed URL of 6000
   - now I call `openExternal` for `localhost:3000` regardless of local port

Changes in Code: https://github.com/gitpod-io/vscode/commit/705321fef71b9119ecc09fb8ac78e6c064d8e563

#### How to test

- Install and start local app:

```bash
# mac
curl -OL https://ak-random-remote-port.staging.gitpod-dev.com/static/bin/gitpod-local-companion-darwin
# linux
# curl -OL https://ak-random-remote-port.staging.gitpod-dev.com/static/bin/gitpod-local-companion-linux
# windows
# curl -OL https://ak-random-remote-port.staging.gitpod-dev.com/static/bin/gitpod-local-companion-windows

chmod +x ./gitpod-local-companion-darwin
GITPOD_HOST=https://ak-random-remote-port.staging.gitpod-dev.com ./gitpod-local-companion-darwin --mock-keyring
```

- Start first workspace: https://ak-random-remote-port.staging.gitpod-dev.com/#https://github.com/TypeFox/monaco-languageclient
  - For this workspace local port 3000 should be used for tunneling. Verify that previewing and opening browser tab gives you localhost:3000
- Start second workspace in parallel: https://ak-random-remote-port.staging.gitpod-dev.com/#https://github.com/TypeFox/monaco-languageclient
  - For this workspace local port 3000 cannot be already used, so random port should be used. This info should be reflected in the port view like `3000:${randomPort}` mapping. Verify that this random port is used to preview and open in browser tab.
<img width="385" alt="Screenshot 2021-06-09 at 09 43 57" src="https://user-images.githubusercontent.com/3082655/121294689-3cfb7a80-c907-11eb-82c3-3add5e4b7937.png">
