### PR TITLE
enable debugging of a single VS Code extension

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 705321fef71b9119ecc09fb8ac78e6c064d8e563
+ENV GP_CODE_COMMIT e2eb3ee4af68d4d14c2c62f99a64c97842f9ad02
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #3245: enable debugging of a single VS Code extension

Changes in Code: https://github.com/gitpod-io/vscode/commit/e2eb3ee4af68d4d14c2c62f99a64c97842f9ad02

Important: We should wait merging till https://github.com/gitpod-io/gitpod/pull/4444 is merged

#### How to test

- Start a workspace: https://ak-debug-vscode-ext.staging.gitpod-dev.com/#https://github.com/bhadreshdesai/bd-helloworld
- Run `npm install`
- Go to debug view and run `Run Extension` configuration
- Another window should open, try to run `Hello World` command