### PR TITLE
[ws-proxy] tune idle connection pool

### DIFF
--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -39,8 +39,8 @@ data:
             "transportConfig": {
                 "connectTimeout": "10s",
                 "idleConnTimeout": "60s",
-                "websocketIdleConnTimeout": "180s",
-                "maxIdleConns": 100
+                "maxIdleConns": 0,
+                "maxIdleConnsPerHost": 100
             },
             "blobServer": {
                 "scheme": "http",

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -80,6 +80,14 @@
 	header X-Gitpod-Region {$GITPOD_INSTALLATION_LONGNAME}
 }
 
+(workspace_transport) {
+	transport http {
+		tls_insecure_skip_verify
+		keepalive 60s
+		keepalive_idle_conns 100
+	}
+}
+
 # Kubernetes health-check
 :8003 {
 	respond /live 200
@@ -202,10 +210,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 		}
 
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
-			transport http {
-				tls_insecure_skip_verify
-			}
-
+			import workspace_transport
 			import upstream_headers
 
 			header_up X-WSProxy-Host       {http.request.host}
@@ -217,10 +222,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 	@workspace_port header_regexp host Host ^(webview-|browser-|extensions-)?(?P<workspacePort>[0-9]{2,5})-(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @workspace_port {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
-			transport http {
-				tls_insecure_skip_verify
-			}
-
+			import workspace_transport
 			import upstream_headers
 
 			header_up X-Gitpod-WorkspaceId {re.host.workspaceID}
@@ -232,10 +234,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 	@workspace 	header_regexp host Host ^(webview-|browser-|extensions-)?(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @workspace {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
-			transport http {
-				tls_insecure_skip_verify
-			}
-
+			import workspace_transport
 			import upstream_headers
 
 			header_up X-Gitpod-WorkspaceId {re.host.workspaceID}

--- a/components/ws-proxy/example-config.json
+++ b/components/ws-proxy/example-config.json
@@ -12,8 +12,8 @@
     "transportConfig": {
       "connectTimeout": "10s",
       "idleConnTimeout": "60s",
-      "websocketIdleConnTimeout": "180s",
-      "maxIdleConns": 100
+      "maxIdleConns": 0,
+      "maxIdleConnsPerHost": 100
     },
     "gitpodInstallation": {
       "scheme": "http",

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -138,10 +138,10 @@ func (c *BlobServerConfig) Validate() error {
 
 // TransportConfig configures the way how ws-proxy connects to it's backend services
 type TransportConfig struct {
-	ConnectTimeout           util.Duration `json:"connectTimeout"`
-	IdleConnTimeout          util.Duration `json:"idleConnTimeout"`
-	WebsocketIdleConnTimeout util.Duration `json:"websocketIdleConnTimeout"`
-	MaxIdleConns             int           `json:"maxIdleConns"`
+	ConnectTimeout      util.Duration `json:"connectTimeout"`
+	IdleConnTimeout     util.Duration `json:"idleConnTimeout"`
+	MaxIdleConns        int           `json:"maxIdleConns"`
+	MaxIdleConnsPerHost int           `json:"maxIdleConnsPerHost"`
 }
 
 // Validate validates the configuration to catch issues during startup and not at runtime
@@ -153,8 +153,8 @@ func (c *TransportConfig) Validate() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.ConnectTimeout, validation.Required),
 		validation.Field(&c.IdleConnTimeout, validation.Required),
-		validation.Field(&c.WebsocketIdleConnTimeout, validation.Required),
-		validation.Field(&c.MaxIdleConns, validation.Required, validation.Min(1)),
+		validation.Field(&c.MaxIdleConns, validation.Min(0)),
+		validation.Field(&c.MaxIdleConnsPerHost, validation.Required, validation.Min(1)),
 	)
 }
 

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -159,7 +159,8 @@ func createDefaultTransport(config *TransportConfig) *http.Transport {
 			DualStack: true,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          config.MaxIdleConns,                   // default: 100
+		MaxIdleConns:          config.MaxIdleConns,                   // default: 0 (unlimited connections in pool)
+		MaxIdleConnsPerHost:   config.MaxIdleConnsPerHost,            // default: 100 (max connections per host in pool)
 		IdleConnTimeout:       time.Duration(config.IdleConnTimeout), // default: 90s
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -56,10 +56,10 @@ var (
 
 	config = Config{
 		TransportConfig: &TransportConfig{
-			ConnectTimeout:           util.Duration(10 * time.Second),
-			IdleConnTimeout:          util.Duration(60 * time.Second),
-			WebsocketIdleConnTimeout: util.Duration(5 * time.Minute),
-			MaxIdleConns:             100,
+			ConnectTimeout:      util.Duration(10 * time.Second),
+			IdleConnTimeout:     util.Duration(60 * time.Second),
+			MaxIdleConns:        0,
+			MaxIdleConnsPerHost: 100,
 		},
 		GitpodInstallation: &GitpodInstallation{
 			HostName:            "test-domain.com",


### PR DESCRIPTION
### What it does

By default the connection pool is capped only by 2 connections per host.
If a client tries to open many connections then latency increased significantly, see https://stackoverflow.com/a/60114945/961588. This commit configures the connection pool be unlimited but capped by 100 connections per host. It was inspired by measurement in Caddy: https://github.com/caddyserver/caddy/issues/2805

I tried different values:
- 32 was giving a result over 1mins with cached data
- 100 was giving a result around 20s with cached data
- 1000 was giving a result around 30s with cached data

#### How to test

- Start a workspace for https://ak-proxy-test.staging.gitpod-dev.com/#https://github.com/gitpod-io/vscode
- Wait till VS Code compiles and tab on port 3000 opened.
- Open 3000 port first time and wait that everything is cached.
- After that reload several times again and check that each time VS Code pops up and requests does not time out.

We should also have some load testing.