### PR TITLE
[dashboard] Update GitLab integration settings URL

### DIFF
--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -575,7 +575,7 @@ export function GitIntegrationModal(props: ({
                 settingsUrl = `${host}/settings/developers`;
                 break;
             case "GitLab":
-                settingsUrl = `${host}/profile/applications`;
+                settingsUrl = `${host}/-/profile/applications`;
                 break;
             default: return undefined;
         }


### PR DESCRIPTION
This will update the GitLab integration settings URL in `/integrations` as these redirects were [recently removed](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/63566) due to the upcoming major release. 🦊 

See also [relevant discussion](https://gitpod.slack.com/archives/C01KGM9AW4W/p1623314426450000) (internal).