### PR TITLE
[tests] Use TLS certs for connections to ws-manager

### DIFF
--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -141,11 +141,11 @@ func LaunchWorkspaceDirectly(it *Test, opts ...LaunchWorkspaceDirectlyOpt) (res 
 		if err != nil {
 			it.t.Fatalf("cannot find server pod: %q", err)
 		}
-		theiaImage, err := envvarFromPod(pods, "THEIA_IMAGE_REPO")
+		theiaImage, err := envvarFromPod(pods, "THEIA_IMAGE_REPO", "server")
 		if err != nil {
 			it.t.Fatal(err)
 		}
-		version, err := envvarFromPod(pods, "VERSION")
+		version, err := envvarFromPod(pods, "VERSION", "server")
 		if err != nil {
 			it.t.Fatal(err)
 		}


### PR DESCRIPTION
Fixes the ws-manager connection issues.

The tests did not start successfully, but that's a separate issue.

#### Test
 - `cd test/tests/workspace`
 - `go test -run ^TestBackup$`
 See that it does not stop with a ws-manager connection issue but actually tries to start an instance.
 