### PR TITLE
[db] Make gitpod-db:dbtest-init self-contained by starting a mysql DB (if needed)

### DIFF
--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -64,7 +64,13 @@ packages:
     ephemeral: true
     config:
       commands:
+        # Check if a DB is present. If not: start one and wait until it's up
+        # Note: In CI there is a DB running as sidecar; in workspaces we're starting it once.
+        #       Re-use of the instance because of the init scripts (cmp. next step).
+        - ["sh", "-c", "mysqladmin ping -h \"$DB_HOST\" \"$DB_PORT\" -p$DB_PASSWORD -u $DB_USER --silent || (docker run -d -e MYSQL_ROOT_PASSWORD=$DB_PASSWORD -e MYSQL_TCP_PORT=$DB_PORT -p $DB_PORT:$DB_PORT mysql:5.7; while ! mysqladmin ping -h \"$DB_HOST\" -P \"$DB_PORT\" -p$DB_PASSWORD -u $DB_USER --silent; do echo \"waiting for DB...\"; sleep 2; done)"]
+        # Apply the DB initialization scripts (re-creates the "gitpod" DB if already there)
         - ["sh", "-c", "find chart-config-db-init--init-scripts -name \"*.sql\" | sort | xargs cat | mysql -h \"$DB_HOST\" -P \"$DB_PORT\" -p$DB_PASSWORD -u $DB_USER"]
+        # Run DB migrations
         - ["sh", "-c", "mkdir -p mig; cd mig; ../components-gitpod-db--migrations/install.sh"]
         - ["yarn", "--cwd", "mig/node_modules/@gitpod/gitpod-db", "typeorm", "migrations:run"]
   - name: docker


### PR DESCRIPTION
This automatically starts a test-db if there is none available.

#### Reasoning
Turns out (again) we have the `testDB` sidecar in werft for a reason: It's not straight forward to access a container on the (remote!) docker host. We'd have to use `kubectl port-forward`+ some mechanism to avoid port-overlaps for that. And all this as a special case for werft, which we wouldn't do in the workspace.
Thus I opted for the simplest solution: check if a mysql instance is already available and either a) re-use that (the actual `gitpod` DB is re-created anyways, so no chance we're polluting sth) or b) starts a fresh one. Due to the locking/de-parallelization `leeway` provides us this works nicely. :upside_down_face: 