### PR TITLE
[server] Optimize getTeamMembers (N queries → 1 query)

### DIFF
--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -4,13 +4,12 @@
  * See License.enterprise.txt in the project root folder.
  */
 
-import { Team } from "@gitpod/gitpod-protocol";
-import { DBTeamMembership } from "./typeorm/entity/db-team-membership";
+import { Team, TeamMemberInfo } from "@gitpod/gitpod-protocol";
 
 export const TeamDB = Symbol('TeamDB');
 export interface TeamDB {
     findTeamById(teamId: string): Promise<Team | undefined>;
-    findMembershipsByTeam(teamId: string): Promise<DBTeamMembership[]>;
+    findMembersByTeam(teamId: string): Promise<TeamMemberInfo[]>;
     findTeamsByUser(userId: string): Promise<Team[]>;
     createTeam(userId: string, name: string): Promise<Team>;
 }

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -205,8 +205,8 @@ export class TypeORMUserDBImpl implements UserDB {
     }
 
     public async findIdentitiesByName(identity: Identity): Promise<Identity[]> {
-        const userRepo = await this.getIdentitiesRepo();
-        const qBuilder = userRepo.createQueryBuilder('identity')
+        const repo = await this.getIdentitiesRepo();
+        const qBuilder = repo.createQueryBuilder('identity')
             .where(`identity.authProviderId = :authProviderId`, { authProviderId: identity.authProviderId })
             .andWhere(`identity.deleted != true`)
             .andWhere(`identity.authName = :authName`, { authName: identity.authName });

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -36,6 +36,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
         const typeorm = testContainer.get<TypeORM>(TypeORM);
         const mnr = await typeorm.getConnection();
         await mnr.getRepository(DBUser).delete({});
+        await mnr.getRepository(DBIdentity).delete({});
         await mnr.getRepository(DBWorkspace).delete({});
         await mnr.getRepository(DBWorkspaceInstance).delete({});
     }

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -4,8 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { GitpodToken, Snapshot, Team, Token, User, UserEnvVar, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
-import { DBTeamMembership } from '@gitpod/gitpod-db/lib/typeorm/entity/db-team-membership';
+import { GitpodToken, Snapshot, Team, TeamMemberInfo, Token, User, UserEnvVar, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 
 declare var resourceInstance: GuardedResource;
 export type GuardedResourceKind = typeof resourceInstance.kind;
@@ -83,7 +82,7 @@ export interface GuardEnvVar {
 export interface GuardedTeam {
     kind: "team";
     subject: Team;
-    memberships: DBTeamMembership[];
+    members: TeamMemberInfo[];
 }
 
 export interface GuardedGitpodToken {
@@ -157,7 +156,7 @@ export class OwnerResourceGuard implements ResourceAccessGuard {
             case "envVar":
                 return resource.subject.userId === this.userId;
             case "team":
-                return resource.memberships.some(membership => membership.userId === this.userId);
+                return resource.members.some(m => m.userId === this.userId);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4470

I've also added a test (passed! ✅) and getting team member infos still works fine:

<img width="600" alt="Screenshot 2021-06-11 at 11 18 47" src="https://user-images.githubusercontent.com/599268/121663671-f3e22c80-caa6-11eb-9523-d1548557b4b7.png">
