### PR TITLE
[agent-smith] Integrate into our build and application

### DIFF
--- a/chart/templates/agent-smith-configmap.yaml
+++ b/chart/templates/agent-smith-configmap.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.agentSmith -}}
+{{- $this := dict "root" . "gp" $.Values. "comp" $comp -}}
+{{- if not $comp.disabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-smith-config
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: agent-smith
+    kind: secret
+    stage: {{ .Values..installation.stage }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    version: "{{ .Values..version }}"
+data:
+  config.json: |
+    {}
+{{- end -}}

--- a/chart/templates/agent-smith-configmap.yaml
+++ b/chart/templates/agent-smith-configmap.yaml
@@ -21,11 +21,10 @@ data:
     {
       "blacklists": {
         "very": {
-            "binaries": ["find"],
-            "signatures": [
-              {"name":"testtarget","domain":"process","kind":"elf","pattern":"YWdlbnRTbWl0aFRlc3RUYXJnZXQ=","regexp":false}
-            ]
-          }
+          "signatures": [
+            {"name":"testtarget","domain":"process","kind":"elf","pattern":"YWdlbnRTbWl0aFRlc3RUYXJnZXQ=","regexp":false}
+          ]
         }
+      }
     }
 {{- end -}}

--- a/chart/templates/agent-smith-configmap.yaml
+++ b/chart/templates/agent-smith-configmap.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ $comp := .Values.components.agentSmith -}}
-{{- $this := dict "root" . "gp" $.Values. "comp" $comp -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -12,12 +12,20 @@ metadata:
     app: {{ template "gitpod.fullname" . }}
     component: agent-smith
     kind: secret
-    stage: {{ .Values..installation.stage }}
+    stage: {{ .Values.installation.stage }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    version: "{{ .Values..version }}"
 data:
   config.json: |
-    {}
+    {
+      "blacklists": {
+        "very": {
+            "binaries": ["find"],
+            "signatures": [
+              {"name":"testtarget","domain":"process","kind":"elf","pattern":"YWdlbnRTbWl0aFRlc3RUYXJnZXQ=","regexp":false}
+            ]
+          }
+        }
+    }
 {{- end -}}

--- a/chart/templates/agent-smith-daemonset.yaml
+++ b/chart/templates/agent-smith-daemonset.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{ $comp := .Values.components.wsDaemon -}}
+{{ $comp := .Values.components.agentSmith -}}
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- $gp := $.Values -}}
 {{- if not $comp.disabled -}}
@@ -28,8 +28,6 @@ spec:
         component: agent-smith
         kind: daemonset
         stage: {{ .Values.installation.stage }}
-      annotations:
-        # checksum/tlskey: {{ include (print $.Template.BasePath "/agent-smith-tlssecret.yaml") $ | sha256sum }}
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: agent-smith

--- a/chart/templates/agent-smith-daemonset.yaml
+++ b/chart/templates/agent-smith-daemonset.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.wsDaemon -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
+{{- $gp := $.Values -}}
+{{- if not $comp.disabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agent-smith
+  labels:
+    app: {{ template "gitpod.fullname" $ }}
+    component: agent-smith
+    kind: daemonset
+    stage: {{ .Values.installation.stage }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "gitpod.fullname" $ }}
+      component: agent-smith
+      kind: daemonset
+      stage: {{ .Values.installation.stage }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "gitpod.fullname" $ }}
+        component: agent-smith
+        kind: daemonset
+        stage: {{ .Values.installation.stage }}
+      annotations:
+        # checksum/tlskey: {{ include (print $.Template.BasePath "/agent-smith-tlssecret.yaml") $ | sha256sum }}
+    spec:
+{{ include "gitpod.workspaceAffinity" $this | indent 6 }}
+      serviceAccountName: agent-smith
+      hostPID: true
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "gitpod.comp.configMap" $this }}
+{{- if $comp.volumes }}
+{{ toYaml $comp.volumes | indent 6 }}
+{{- end }}
+      enableServiceLinks: false
+      containers:
+      - name: agent-smith
+        volumeMounts:
+        - mountPath: /config
+          name: config
+{{- if $comp.volumeMounts }}
+{{ toYaml $comp.volumeMounts | indent 8 }}
+{{- end }}
+        args: ["run", "-v", "--config", "/config/config.json"]
+        image: {{ template "gitpod.comp.imageFull" $this }}
+{{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
+{{ include "gitpod.container.resources" $this | indent 8 }}
+{{ include "gitpod.container.defaultEnv" $this | indent 8 }}
+{{ include "gitpod.container.tracingEnv" $this | indent 8 }}
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # readinessProbe:
+        #   httpGet:
+        #     port: 9999
+        #     path: "/"
+        #   initialDelaySeconds: 5
+        #   periodSeconds: 10
+        securityContext:
+          privileged: true
+          procMount: Unmasked
+{{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
+{{ toYaml .Values.defaults | indent 6 }}
+{{ end }}

--- a/chart/templates/agent-smith-networkpolicy.yaml
+++ b/chart/templates/agent-smith-networkpolicy.yaml
@@ -12,13 +12,13 @@ metadata:
     app: {{ template "gitpod.fullname" . }}
     component: agent-smith
     kind: networkpolicy
-    stage: {{ .Values..installation.stage }}
+    stage: {{ .Values.installation.stage }}
 spec:
   podSelector:
     matchLabels:
       app: {{ template "gitpod.fullname" . }}
       component: agent-smith
-      stage: {{ .Values..installation.stage }}
+      stage: {{ .Values.installation.stage }}
   policyTypes:
   - Ingress
 {{- end -}}

--- a/chart/templates/agent-smith-networkpolicy.yaml
+++ b/chart/templates/agent-smith-networkpolicy.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.agentSmith -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
+{{- if not $comp.disabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-smith-deny-all-ingress
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: agent-smith
+    kind: networkpolicy
+    stage: {{ .Values..installation.stage }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "gitpod.fullname" . }}
+      component: agent-smith
+      stage: {{ .Values..installation.stage }}
+  policyTypes:
+  - Ingress
+{{- end -}}

--- a/chart/templates/agent-smith-role-binding.yaml
+++ b/chart/templates/agent-smith-role-binding.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.agentSmith -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
+{{- if not $comp.disabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: agent-smith
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: agent-smith
+    kind: role-binding
+    stage: {{ .Values.installation.stage }}
+subjects:
+- kind: ServiceAccount
+  name: agent-smith
+roleRef:
+  kind: Role
+  name: agent-smith
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-agent-smith-rb-kube-rbac-proxy
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: agent-smith
+    kind: role-binding
+    stage: {{ .Values.installation.stage }}
+subjects:
+- kind: ServiceAccount
+  name: agent-smith
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name:  {{ .Release.Namespace }}-kube-rbac-proxy
+  apiGroup: rbac.authorization.k8s.io
+
+{{- end -}}

--- a/chart/templates/agent-smith-role.yaml
+++ b/chart/templates/agent-smith-role.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.agentSmith -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
+{{- if not $comp.disabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: agent-smith
+    kind: role
+    stage: {{ .Values..installation.stage }}
+  name: agent-smith
+rules:
+- apiGroups:
+  - "policy"
+  resources:
+  - "podsecuritypolicies"
+  verbs:
+  - "use"
+  resourceNames:
+  - "{{ .Release.Namespace }}-ns-privileged-unconfined"
+
+{{- end -}}

--- a/chart/templates/agent-smith-role.yaml
+++ b/chart/templates/agent-smith-role.yaml
@@ -11,7 +11,7 @@ metadata:
     app: {{ template "gitpod.fullname" . }}
     component: agent-smith
     kind: role
-    stage: {{ .Values..installation.stage }}
+    stage: {{ .Values.installation.stage }}
   name: agent-smith
 rules:
 - apiGroups:

--- a/chart/templates/agent-smith-service-account.yaml
+++ b/chart/templates/agent-smith-service-account.yaml
@@ -12,6 +12,6 @@ metadata:
     app: {{ template "gitpod.fullname" . }}
     component: agent-smith
     kind: service-account
-    stage: {{ .Values..installation.stage }}
+    stage: {{ .Values.installation.stage }}
 
 {{- end -}}

--- a/chart/templates/agent-smith-service-account.yaml
+++ b/chart/templates/agent-smith-service-account.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ $comp := .Values.components.agentSmith -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
+{{- if not $comp.disabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-smith
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: agent-smith
+    kind: service-account
+    stage: {{ .Values..installation.stage }}
+
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,6 +133,13 @@ previewFeatureFlags: []
 
 components:
 
+  agentSmith:
+    name: "agent-smith"
+    disabled: false
+    resources:
+      cpu: 100m
+      memory: 32Mi
+
   blobserve:
     name: "blobserve"
     disabled: false

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -31,6 +31,7 @@ packages:
       - components/content-service:docker
       - components/dashboard:docker
       - components/docker-up:docker
+      - components/ee/agent-smith:docker
       - components/ee/db-sync:docker
       - components/ee/kedge:docker
       - components/ee/payment-endpoint:docker
@@ -63,10 +64,11 @@ packages:
   - name: all-apps
     type: generic
     deps:
-      - components/blobserve:docker
-      - components/content-service:docker
+      - components/blobserve:app
+      - components/content-service:app
       - components/dashboard:app
       - components/docker-up:app
+      - components/ee/agent-smith:app
       - components/ee/db-sync:app
       - components/ee/kedge:app
       - components/ee/payment-endpoint:app

--- a/components/ee/agent-smith/BUILD.yaml
+++ b/components/ee/agent-smith/BUILD.yaml
@@ -10,7 +10,6 @@ packages:
     deps:
       - components/common-go:lib
       - components/gitpod-protocol/go:lib
-      - :falco-bpf-probe
     env:
       - CGO_ENABLED=0
       - GOOS=linux
@@ -38,8 +37,23 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/agent-smith:${version}
+  - name: example-config
+    type: generic
+    srcs:
+      - "example-config.json"
+    config:
+      commands: [["echo"]]
 scripts:
   - name: prepare-environment
     script: scripts/prepare-bpf-dev-environment.sh
   - name: qemu
     script: scripts/qemu.sh
+  - name: copy-to-qemu
+    workdir: "packages"
+    deps:
+      - :app
+      - :falco-bpf-probe
+      - :example-config
+    script: |
+      sshpass -p 'root' scp -o StrictHostKeychecking=no -P 2222 ./components-ee-agent-smith--falco-bpf-probe/probe.o ./components-ee-agent-smith--app/agent-smith ./components-ee-agent-smith--example-config/example-config.json root@localhost:/
+      echo "copied agent-smith to /"

--- a/components/ee/agent-smith/BUILD.yaml
+++ b/components/ee/agent-smith/BUILD.yaml
@@ -54,6 +54,8 @@ scripts:
       - :app
       - :falco-bpf-probe
       - :example-config
+      - components/ee/agent-smith/cmd/testbed:app
+      - components/ee/agent-smith/cmd/testtarget:app
     script: |
-      sshpass -p 'root' scp -o StrictHostKeychecking=no -P 2222 ./components-ee-agent-smith--falco-bpf-probe/probe.o ./components-ee-agent-smith--app/agent-smith ./components-ee-agent-smith--example-config/example-config.json root@localhost:/
+      sshpass -p 'root' scp -o StrictHostKeychecking=no -P 2222 ./components-ee-agent-smith--falco-bpf-probe/probe.o ./components-ee-agent-smith--app/agent-smith ./components-ee-agent-smith--example-config/example-config.json ./components-ee-agent-smith-cmd-testbed--app/testbed ./components-ee-agent-smith-cmd-testtarget--app/testtarget root@localhost:/
       echo "copied agent-smith to /"

--- a/components/ee/agent-smith/cmd/root.go
+++ b/components/ee/agent-smith/cmd/root.go
@@ -75,6 +75,10 @@ func getConfig() (*config, error) {
 		return nil, xerrors.Errorf("cannot unmarshal config: %v", err)
 	}
 
+	if cfg.ProbePath == "" {
+		cfg.ProbePath = "/app/probe.o"
+	}
+
 	return &cfg, nil
 }
 

--- a/components/ee/agent-smith/cmd/root.go
+++ b/components/ee/agent-smith/cmd/root.go
@@ -10,12 +10,10 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/gitpod-io/gitpod/agent-smith/pkg/agent"
-
 	goflag "flag"
 
+	"github.com/gitpod-io/gitpod/agent-smith/pkg/agent"
 	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 )
@@ -86,29 +84,12 @@ func getConfig() (*config, error) {
 // $ go run main.go config-schema > config-schema.json
 // And also update the examples accordingly.
 type config struct {
+	agent.Config
+
 	Namespace string `json:"namespace,omitempty"`
 
 	PProfAddr      string `json:"pprofAddr,omitempty"`
 	PrometheusAddr string `json:"prometheusAddr,omitempty"`
-
-	Blacklists        *agent.Blacklists    `json:"blacklists,omitempty"`
-	EgressTraffic     *agent.EgressTraffic `json:"egressTraffic,omitempty"`
-	ExcessiveCPUCheck *struct {
-		Threshold   float32 `json:"threshold"`
-		AverageOver int     `json:"averageOverMinutes"`
-	} `json:"excessiveCPUCheck,omitempty"`
-
-	PeriodicCheck            util.Duration        `json:"periodicCheck,omitempty"`
-	PodPolicingRetryInterval util.Duration        `json:"podPolicingRetryInterval,omitempty"`
-	PodPolicingMaxRetries    int                  `json:"podPolicingMaxRetries,omitempty"`
-	PodPolicingTimeout       util.Duration        `json:"podPolicingTimeout,omitempty"`
-	LongCheckLag             int                  `json:"longCheckLag,omitempty"`
-	SlackWebhooks            *agent.SlackWebhooks `json:"slackWebhooks,omitempty"`
-
-	Enforcement struct {
-		Default *agent.EnforcementRules           `json:"default,omitempty"`
-		PerRepo map[string]agent.EnforcementRules `json:"perRepo,omitempty"`
-	} `json:"enforcement,omitempty"`
 
 	// We have had memory leak issues with agent smith in the past due to experimental gRPC use.
 	// This upper limit causes agent smith to stop itself should it go above this limit.

--- a/components/ee/agent-smith/cmd/run.go
+++ b/components/ee/agent-smith/cmd/run.go
@@ -62,7 +62,7 @@ var runCmd = &cobra.Command{
 		}
 
 		go smith.Start(func(violation agent.InfringingWorkspace, penalties []agent.PenaltyKind) {
-			log.WithField("violation", violation).Info("Found violation")
+			log.WithField("violation", violation).WithField("penalties", penalties).Info("Found violation")
 
 			if cfg.SlackWebhooks != nil {
 				for _, i := range violation.Infringements {

--- a/components/ee/agent-smith/cmd/signature-matches.go
+++ b/components/ee/agent-smith/cmd/signature-matches.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gitpod-io/gitpod/agent-smith/pkg/signature"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/spf13/cobra"
+)
+
+// signatureElfdumpCmd represents the signatureElfdump command
+var signatureMatchesCmd = &cobra.Command{
+	Use:   "matches <binary>",
+	Short: "Finds all signatures that match the binary",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := getConfig()
+		if err != nil {
+			log.WithError(err).Fatal("cannot get config")
+		}
+		if cfg.Blacklists == nil {
+			log.WithError(err).Fatal("no signatures configured")
+		}
+
+		f, err := os.OpenFile(args[0], os.O_RDONLY, 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+
+		var res []*signature.Signature
+		for _, bl := range cfg.Blacklists.Levels() {
+			for _, s := range bl.Signatures {
+				m, err := s.Matches(f)
+				if err != nil {
+					log.WithError(err).WithField("signature", s.Name).Warn("cannot match signature")
+					continue
+				}
+				if !m {
+					log.WithField("signature", s.Name).Debug("no match")
+					continue
+				}
+				res = append(res, s)
+			}
+		}
+
+		if len(res) == 0 {
+			os.Exit(1)
+		}
+
+		for _, s := range res {
+			fmt.Println(s)
+		}
+	},
+}
+
+func init() {
+	signatureCmd.AddCommand(signatureMatchesCmd)
+}

--- a/components/ee/agent-smith/cmd/testbed/BUILD.yaml
+++ b/components/ee/agent-smith/cmd/testbed/BUILD.yaml
@@ -1,0 +1,11 @@
+packages:
+    - name: app
+      type: go
+      srcs:
+        - go.mod
+        - go.sum
+        - "**/*.go"
+      env:
+        - CGO_ENABLED=0
+      config:
+        packaging: app

--- a/components/ee/agent-smith/cmd/testbed/go.mod
+++ b/components/ee/agent-smith/cmd/testbed/go.mod
@@ -1,0 +1,3 @@
+module testbed
+
+go 1.16

--- a/components/ee/agent-smith/cmd/testbed/main.go
+++ b/components/ee/agent-smith/cmd/testbed/main.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// runCmd represents the run command
+func run(args []string) error {
+	if len(args) > 0 && args[0] == "ring1" {
+		self, err := os.Executable()
+		if err != nil {
+			return err
+		}
+		err = os.Symlink(self, "supervisor")
+		if err != nil && !os.IsExist(err) {
+			return err
+		}
+
+		cmd := exec.Command("supervisor", "run")
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if len(args) > 0 && args[0] == "run" {
+		var err error
+		cmd := exec.Command("bash")
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if len(args) > 0 && args[0] == "start" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		env := os.Environ()
+		for i, e := range env {
+			if strings.HasPrefix(e, "PATH=") {
+				env[i] += e + ":" + cwd
+			}
+		}
+		env = append(env, "GITPOD_OWNER_ID=owner-id")
+		env = append(env, "GITPOD_WORKSPACE_ID=workspace-id")
+		env = append(env, "GITPOD_INSTANCE_ID=instance-id")
+		env = append(env, "GITPOD_WORKSPACE_CONTEXT_URL=https://github.com/gitpod-io/gitpod")
+
+		cmd := exec.Command("/proc/self/exe", "ring1")
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		cmd.Env = env
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("run with \"testbed start\"")
+
+	return nil
+}
+
+func main() {
+	err := run(os.Args[1:])
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/components/ee/agent-smith/cmd/testtarget/BUILD.yaml
+++ b/components/ee/agent-smith/cmd/testtarget/BUILD.yaml
@@ -1,0 +1,11 @@
+packages:
+    - name: app
+      type: go
+      srcs:
+        - go.mod
+        - go.sum
+        - "**/*.go"
+      env:
+        - CGO_ENABLED=0
+      config:
+        packaging: app

--- a/components/ee/agent-smith/cmd/testtarget/go.mod
+++ b/components/ee/agent-smith/cmd/testtarget/go.mod
@@ -1,0 +1,3 @@
+module testtarget
+
+go 1.16

--- a/components/ee/agent-smith/cmd/testtarget/main.go
+++ b/components/ee/agent-smith/cmd/testtarget/main.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	time.Sleep(1 * time.Second)
+	agentSmithTestTarget()
+}
+
+// don't inline to produce an elf entry
+//go:noinline
+func agentSmithTestTarget() {
+	fmt.Println("something")
+}

--- a/components/ee/agent-smith/config-schema.json
+++ b/components/ee/agent-smith/config-schema.json
@@ -5,151 +5,49 @@
   "definitions": {
     "": {
       "required": [
-        "threshold",
-        "averageOverMinutes"
+        "hostURL",
+        "apiToken"
       ],
       "properties": {
-        "threshold": {
-          "type": "number"
-        },
-        "averageOverMinutes": {
-          "type": "integer"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Blacklists": {
-      "properties": {
-        "barely": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/PerLevelBlacklist"
-        },
-        "audit": {
-          "$ref": "#/definitions/PerLevelBlacklist"
-        },
-        "very": {
-          "$ref": "#/definitions/PerLevelBlacklist"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "EgressTraffic": {
-      "required": [
-        "dt",
-        "excessive",
-        "veryExcessive"
-      ],
-      "properties": {
-        "dt": {
-          "type": "integer"
-        },
-        "excessive": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/PerLevelEgressTraffic"
-        },
-        "veryExcessive": {
-          "$ref": "#/definitions/PerLevelEgressTraffic"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "PerLevelBlacklist": {
-      "properties": {
-        "binaries": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "signatures": {
-          "items": {
-            "$schema": "http://json-schema.org/draft-04/schema#",
-            "$ref": "#/definitions/Signature"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "PerLevelEgressTraffic": {
-      "required": [
-        "baseBudget",
-        "perDtThreshold"
-      ],
-      "properties": {
-        "baseBudget": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/Quantity"
-        },
-        "perDtThreshold": {
-          "$ref": "#/definitions/Quantity"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Quantity": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Signature": {
-      "required": [
-        "pattern",
-        "regexp"
-      ],
-      "properties": {
-        "name": {
+        "hostURL": {
           "type": "string"
         },
-        "domain": {
+        "apiToken": {
           "type": "string"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "pattern": {
-          "type": "string",
-          "media": {
-            "binaryEncoding": "base64"
-          }
-        },
-        "regexp": {
-          "type": "boolean"
-        },
-        "slice": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/Slice"
-        },
-        "filenames": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Slice": {
-      "properties": {
-        "start": {
-          "type": "integer"
-        },
-        "end": {
-          "type": "integer"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
     "config": {
+      "required": [
+        "gitpodAPI",
+        "namespace"
+      ],
       "properties": {
+        "gitpodAPI": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/"
+        },
         "namespace": {
+          "type": "string"
+        },
+        "blacklists": {
+          "$ref": "#/definitions/"
+        },
+        "egressTraffic": {
+          "$ref": "#/definitions/"
+        },
+        "enforcement": {
+          "$ref": "#/definitions/"
+        },
+        "excessiveCPUCheck": {
+          "$ref": "#/definitions/"
+        },
+        "slackWebhooks": {
+          "$ref": "#/definitions/"
+        },
+        "probePath": {
           "type": "string"
         },
         "pprofAddr": {
@@ -157,39 +55,6 @@
         },
         "prometheusAddr": {
           "type": "string"
-        },
-        "blacklists": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/Blacklists"
-        },
-        "egressTraffic": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/EgressTraffic"
-        },
-        "excessiveCPUCheck": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/"
-        },
-        "periodicCheck": {
-          "type": "integer"
-        },
-        "podPolicingRetryInterval": {
-          "type": "integer"
-        },
-        "podPolicingMaxRetries": {
-          "type": "integer"
-        },
-        "podPolicingTimeout": {
-          "type": "integer"
-        },
-        "longCheckLag": {
-          "type": "integer"
-        },
-        "slackWebhooks": {
-          "$ref": "#/definitions/"
-        },
-        "enforcement": {
-          "$ref": "#/definitions/"
         },
         "systemMemoryLimitMib": {
           "type": "integer"

--- a/components/ee/agent-smith/example-config.json
+++ b/components/ee/agent-smith/example-config.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "file:///workspace/gitpod/components/ee/agent-smith/config-schema.json",
+    "probePath": "./probe.o"
+}

--- a/components/ee/agent-smith/example-config.json
+++ b/components/ee/agent-smith/example-config.json
@@ -1,4 +1,12 @@
 {
     "$schema": "file:///workspace/gitpod/components/ee/agent-smith/config-schema.json",
-    "probePath": "./probe.o"
+    "probePath": "./probe.o",
+    "blacklists": {
+        "very": {
+            "binaries": ["find"],
+            "signatures": [
+                {"name":"testtarget","domain":"process","kind":"elf","pattern":"YWdlbnRTbWl0aFRlc3RUYXJnZXQ=","regexp":false}
+            ]
+        }
+    }
 }

--- a/components/ee/agent-smith/go.mod
+++ b/components/ee/agent-smith/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/alecthomas/jsonschema v0.0.0-20210413112511-5c9c23bdc720
 	github.com/ashwanthkumar/slack-go-webhook v0.0.0-20181208062437-4a19b1a876b7
 	github.com/cilium/ebpf v0.5.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20191011121108-aa519ddbe484 // indirect
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
@@ -17,11 +16,11 @@ require (
 	github.com/moul/http2curl v1.0.0 // indirect
 	github.com/parnurzeal/gorequest v0.2.15 // indirect
 	github.com/prometheus/client_golang v1.9.0
+	github.com/prometheus/procfs v0.6.0
 	github.com/spf13/cobra v0.0.3
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
-	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 )
 

--- a/components/ee/agent-smith/go.sum
+++ b/components/ee/agent-smith/go.sum
@@ -99,7 +99,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -207,7 +206,6 @@ github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -249,10 +247,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/moul/http2curl v1.0.0 h1:dRMWoAtb+ePxMlLkrCbAqh4TlPHXvoGUSQ323/9Zahs=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -335,8 +331,9 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
+github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
@@ -455,6 +452,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -490,7 +488,6 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -588,19 +585,15 @@ honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-k8s.io/api v0.20.4 h1:xZjKidCirayzX6tHONRQyTNDVIR55TYVqgATqo6ZULY=
 k8s.io/api v0.20.4/go.mod h1:++lNL1AJMkDymriNniQsWRkMDzRaX2Y/POTUi8yvqYQ=
 k8s.io/apimachinery v0.20.4 h1:vhxQ0PPUUU2Ns1b9r4/UFp13UPs8cw2iOoTjnY9faa0=
 k8s.io/apimachinery v0.20.4/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
-k8s.io/klog/v2 v2.4.0 h1:7+X0fUguPyrKEC4WjH8iGDg3laWgMo5tMnRTIGTTxGQ=
 k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
-sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/components/ee/agent-smith/leeway.Dockerfile
+++ b/components/ee/agent-smith/leeway.Dockerfile
@@ -2,12 +2,12 @@
 # Licensed under the Gitpod Enterprise Source Code License,
 # See License.enterprise.txt in the project root folder.
 
-FROM alpine:latest
+FROM alpine:3.13
 
 RUN apk add --no-cache git bash ca-certificates
-COPY components-agent-smith--app/agent-smith /app/
+COPY components-ee-agent-smith--app/agent-smith /app/
 RUN chmod +x /app/agent-smith
-COPY components-agent-smith--falco-bpf-probe/probe.o /app/probe.o
+COPY components-ee-agent-smith--falco-bpf-probe/probe.o /app/probe.o
 
 ENTRYPOINT [ "/app/agent-smith" ]
 CMD [ "-v", "help" ]

--- a/components/ee/agent-smith/pkg/agent/actions.go
+++ b/components/ee/agent-smith/pkg/agent/actions.go
@@ -6,37 +6,25 @@ package agent
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"golang.org/x/sys/unix"
 )
 
 // all functions in this file deal directly with Kubernetes and make several assumptions
 // how workspace pods look like. This code should eventually be moved to ws-manager or
 // call one of ws-manager's libraries.
 
-// getWorkspaceOwner retrieves the Gitpod user ID of the workspace owner
-// func (agent *Smith) getWorkspaceInfo() (owner, workspaceID, instanceID string) {
-// 	// todo(fntlnz): get this from the process
-// 	// they are GITPOD_WORKSPACE_ID, GITPOD_INSTANCE_ID
-// 	// maybe owner needs to be pushed via downard API
-
-// 	// This is now in those pod labels, move it to the filesystem via downard API is probably a solution
-// 	// owner = pod.Labels[wsk8s.OwnerLabel]
-// 	// workspaceID = pod.Labels[wsk8s.MetaIDLabel]
-// 	// instanceID = pod.Labels[wsk8s.WorkspaceIDLabel]
-// 	return "e7f1c402-cf64-41ed-8f9b-87246fead063", "blue-rodent-dgmnfn9f", "a6e117c2-4290-4ce0-a6df-4602fd28e1a5"
-// }
-
 // stopWorkspace stops a workspace
-func (agent *Smith) stopWorkspace(podname string) error {
-	// todo(fntlnz): stop the workspace via the kill system call on the workspace's PID 1
-	return nil
+func (agent *Smith) stopWorkspace(supervisorPID int) error {
+	return unix.Kill(supervisorPID, unix.SIGKILL)
 }
 
 // stopWorkspaceAndBlockUser stops a workspace and blocks the user (who would have guessed?)
-func (agent *Smith) stopWorkspaceAndBlockUser(podname string, ownerID string) error {
-	err := agent.stopWorkspace(podname)
+func (agent *Smith) stopWorkspaceAndBlockUser(supervisorPID int, ownerID string) error {
+	err := agent.stopWorkspace(supervisorPID)
 	if err != nil {
 		log.WithError(err).WithField("owner", ownerID).Warn("error stopping workspace")
 	}
@@ -45,6 +33,10 @@ func (agent *Smith) stopWorkspaceAndBlockUser(podname string, ownerID string) er
 }
 
 func (agent *Smith) blockUser(ownerID string) error {
+	if agent.GitpodAPI == nil {
+		return fmt.Errorf("not connected to Gitpod API")
+	}
+
 	req := protocol.AdminBlockUserRequest{
 		UserID:    ownerID,
 		IsBlocked: true,

--- a/components/ee/agent-smith/pkg/agent/actions.go
+++ b/components/ee/agent-smith/pkg/agent/actions.go
@@ -16,17 +16,17 @@ import (
 // call one of ws-manager's libraries.
 
 // getWorkspaceOwner retrieves the Gitpod user ID of the workspace owner
-func (agent *Smith) getWorkspaceInfo() (owner, workspaceID, instanceID string) {
-	// todo(fntlnz): get this from the process
-	// they are GITPOD_WORKSPACE_ID, GITPOD_INSTANCE_ID
-	// maybe owner needs to be pushed via downard API
+// func (agent *Smith) getWorkspaceInfo() (owner, workspaceID, instanceID string) {
+// 	// todo(fntlnz): get this from the process
+// 	// they are GITPOD_WORKSPACE_ID, GITPOD_INSTANCE_ID
+// 	// maybe owner needs to be pushed via downard API
 
-	// This is now in those pod labels, move it to the filesystem via downard API is probably a solution
-	// owner = pod.Labels[wsk8s.OwnerLabel]
-	// workspaceID = pod.Labels[wsk8s.MetaIDLabel]
-	// instanceID = pod.Labels[wsk8s.WorkspaceIDLabel]
-	return "e7f1c402-cf64-41ed-8f9b-87246fead063", "blue-rodent-dgmnfn9f", "a6e117c2-4290-4ce0-a6df-4602fd28e1a5"
-}
+// 	// This is now in those pod labels, move it to the filesystem via downard API is probably a solution
+// 	// owner = pod.Labels[wsk8s.OwnerLabel]
+// 	// workspaceID = pod.Labels[wsk8s.MetaIDLabel]
+// 	// instanceID = pod.Labels[wsk8s.WorkspaceIDLabel]
+// 	return "e7f1c402-cf64-41ed-8f9b-87246fead063", "blue-rodent-dgmnfn9f", "a6e117c2-4290-4ce0-a6df-4602fd28e1a5"
+// }
 
 // stopWorkspace stops a workspace
 func (agent *Smith) stopWorkspace(podname string) error {

--- a/components/ee/agent-smith/pkg/agent/agent.go
+++ b/components/ee/agent-smith/pkg/agent/agent.go
@@ -549,7 +549,7 @@ func (agent *Smith) handleExecveEvent(execve Execve) func() (*InfringingWorkspac
 
 		if len(res) == 0 {
 			fd, err := os.Open(filepath.Join("/proc", strconv.Itoa(execve.TID), "exe"))
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				log.WithError(err).WithField("path", execve.Filename).Warn("cannot open executable to check signatures")
 				return nil, nil
 			}

--- a/components/ee/agent-smith/pkg/agent/config.go
+++ b/components/ee/agent-smith/pkg/agent/config.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package agent
+
+// Config configures Agent Smith
+type Config struct {
+	GitpodAPI struct {
+		HostURL  string `json:"hostURL"`
+		APIToken string `json:"apiToken"`
+	} `json:"gitpodAPI"`
+	KubernetesNamespace string         `json:"namespace"`
+	Blacklists          *Blacklists    `json:"blacklists,omitempty"`
+	EgressTraffic       *EgressTraffic `json:"egressTraffic,omitempty"`
+	Enforcement         struct {
+		Default *EnforcementRules           `json:"default,omitempty"`
+		PerRepo map[string]EnforcementRules `json:"perRepo,omitempty"`
+	} `json:"enforcement,omitempty"`
+	ExcessiveCPUCheck *struct {
+		Threshold   float32 `json:"threshold"`
+		AverageOver int     `json:"averageOverMinutes"`
+	} `json:"excessiveCPUCheck,omitempty"`
+	SlackWebhooks *SlackWebhooks `json:"slackWebhooks,omitempty"`
+
+	ProbePath string `json:"probePath,omitempty"`
+}

--- a/components/ee/agent-smith/pkg/bpf/bpf.go
+++ b/components/ee/agent-smith/pkg/bpf/bpf.go
@@ -39,8 +39,6 @@ const (
 	gplLicense = "GPL"
 
 	defaultSnapLen = 80
-
-	fillerPrefix = "filler/"
 )
 
 // Settings is the Go representation of the settings map in the falco-libs BPF probe

--- a/components/ee/agent-smith/pkg/bpf/event_table.go
+++ b/components/ee/agent-smith/pkg/bpf/event_table.go
@@ -111,8 +111,8 @@ const (
 )
 
 type PPMNameValue struct {
-	name  *[]byte
-	value uint32
+	Name  *[]byte
+	Value uint32
 }
 
 type PPMParamInfo struct {
@@ -203,6 +203,7 @@ var (
 	CLONE_NEWCGROUP      = []byte("CLONE_NEWCGROUP")
 )
 
+//nolint:deadcode,unused,varcheck
 var cloneFlags = []PPMNameValue{
 	{&CLONE_FILES, PPM_CL_CLONE_FILES},
 	{&CLONE_FS, PPM_CL_CLONE_FS},


### PR DESCRIPTION
This PR continues agent smith and adds
- agent-smith to the usual build mechanism
- agent-smith to the helm chart
- a testbed command that mimics the process structure found in a workspace
- a testtarget command that we can use to test agent-smith's behaviour
- integration between the first syscall handler, infringement detection and penalties
- a more hamonised (w.r.t. to the other services) configuration handling