### PR TITLE
[ws-proxy] Allow workspace router to match URLs from other clusters

### DIFF
--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -49,7 +49,8 @@ data:
             "gitpodInstallation": {
                 "scheme": "https",
                 "hostName": "{{- $gp.hostname -}}",
-                "workspaceHostSuffix": ".ws{{- if $gp.installation.shortname -}}-{{ $.Values.installation.shortname }}{{- end -}}.{{ $.Values.hostname }}"
+                "workspaceHostSuffix": ".ws{{- if $gp.installation.shortname -}}-{{ $.Values.installation.shortname }}{{- end -}}.{{ $.Values.hostname }}",
+                "workspaceHostSuffixRegex": {{ ($comp.workspaceHostSuffixRegex | default (printf "%s%s" "\\.ws[^\\.]*\\." ($.Values.hostname | replace "." "\\."))) | quote }}
             },
             "workspacePodConfig": {
                 "serviceTemplate": "http://ws-{{"{{ .workspaceID }}"}}-theia.{{- .Release.Namespace -}}.svc.cluster.local:{{"{{ .port }}"}}",

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -56,7 +56,7 @@ var runCmd = &cobra.Command{
 		}
 		log.Infof("workspace info provider started")
 
-		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix), workspaceInfoProvider).MustServe()
+		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), workspaceInfoProvider).MustServe()
 		log.Infof("started proxying on %s", cfg.Ingress.HttpAddress)
 
 		if cfg.PProfAddr != "" {

--- a/components/ws-proxy/example-config.json
+++ b/components/ws-proxy/example-config.json
@@ -18,7 +18,8 @@
     "gitpodInstallation": {
       "scheme": "http",
       "hostName": "gpl-portal.staging.gitpod-dev.com",
-      "workspaceHostSuffix": ".ws-dev.gpl-portal.staging.gitpod-dev.com"
+      "workspaceHostSuffix": ".ws-dev.gpl-portal.staging.gitpod-dev.com",
+      "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.gpl-portal\\.staging\\.gitpod-dev\\.com"
     },
     "workspacePodConfig": {
       "serviceTemplate": "http://ws-{{ .workspaceID }}-theia.staging-gpl-portal.svc.cluster.local:{{ .port }}",

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -96,9 +96,10 @@ func (c *WorkspacePodConfig) Validate() error {
 
 // GitpodInstallation contains config regarding the Gitpod installation
 type GitpodInstallation struct {
-	Scheme              string `json:"scheme"`
-	HostName            string `json:"hostName"`
-	WorkspaceHostSuffix string `json:"workspaceHostSuffix"`
+	Scheme                   string `json:"scheme"`
+	HostName                 string `json:"hostName"`
+	WorkspaceHostSuffix      string `json:"workspaceHostSuffix"`
+	WorkspaceHostSuffixRegex string `json:"workspaceHostSuffixRegex"`
 }
 
 // Validate validates the configuration to catch issues during startup and not at runtime

--- a/components/ws-proxy/pkg/proxy/proxy.go
+++ b/components/ws-proxy/pkg/proxy/proxy.go
@@ -81,8 +81,8 @@ func (p *WorkspaceProxy) Handler() (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
-	theiaRouter, portRouter, blobserveRouter := p.WorkspaceRouter(r, p.WorkspaceInfoProvider)
-	installWorkspaceRoutes(theiaRouter, handlerConfig, p.WorkspaceInfoProvider)
+	ideRouter, portRouter, blobserveRouter := p.WorkspaceRouter(r, p.WorkspaceInfoProvider)
+	installWorkspaceRoutes(ideRouter, handlerConfig, p.WorkspaceInfoProvider)
 	err = installWorkspacePortRoutes(portRouter, handlerConfig)
 	if err != nil {
 		return nil, err

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -27,6 +27,7 @@ import (
 const (
 	hostBasedHeader = "x-host-header"
 	wsHostSuffix    = ".test-domain.com"
+	wsHostNameRegex = "\\.test-domain\\.com"
 )
 
 var (
@@ -620,7 +621,7 @@ func TestRoutes(t *testing.T) {
 			if test.Config != nil {
 				cfg = *test.Config
 			}
-			router := HostBasedRouter(hostBasedHeader, wsHostSuffix)
+			router := HostBasedRouter(hostBasedHeader, wsHostSuffix, wsHostNameRegex)
 			if test.Router != nil {
 				router = test.Router(&cfg)
 			}

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -35,7 +35,7 @@ const (
 // WorkspaceRouter is a function that configures subrouters (one for theia, one for the exposed ports) on the given router
 // which resolve workspace coordinates (ID, port?) from each request. The contract is to store those in the request's mux.Vars
 // with the keys workspacePortIdentifier and workspaceIDIdentifier
-type WorkspaceRouter func(r *mux.Router, wsInfoProvider WorkspaceInfoProvider) (theiaRouter *mux.Router, portRouter *mux.Router, blobserveRouter *mux.Router)
+type WorkspaceRouter func(r *mux.Router, wsInfoProvider WorkspaceInfoProvider) (ideRouter *mux.Router, portRouter *mux.Router, blobserveRouter *mux.Router)
 
 // HostBasedRouter is a WorkspaceRouter that routes simply based on the "Host" header
 func HostBasedRouter(header, wsHostSuffix string) WorkspaceRouter {
@@ -51,7 +51,7 @@ func HostBasedRouter(header, wsHostSuffix string) WorkspaceRouter {
 			}
 			blobserveRouter = r.MatcherFunc(matchBlobserveHostHeader(wsHostSuffix, getHostHeader)).Subrouter()
 			portRouter      = r.MatcherFunc(matchWorkspacePortHostHeader(wsHostSuffix, getHostHeader)).Subrouter()
-			theiaRouter     = r.MatcherFunc(matchWorkspaceHostHeader(wsHostSuffix, getHostHeader)).Subrouter()
+			ideRouter       = r.MatcherFunc(matchWorkspaceHostHeader(wsHostSuffix, getHostHeader)).Subrouter()
 		)
 
 		r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -59,7 +59,7 @@ func HostBasedRouter(header, wsHostSuffix string) WorkspaceRouter {
 			log.Debugf("no match for path %s, host: %s", req.URL.Path, hostname)
 			w.WriteHeader(404)
 		})
-		return theiaRouter, portRouter, blobserveRouter
+		return ideRouter, portRouter, blobserveRouter
 	}
 }
 

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -78,7 +78,7 @@ func TestWorkspaceRouter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			r := mux.NewRouter()
-			theiaRouter, portRouter, blobserveRouter := test.Router(r, &fakeWsInfoProvider{infos: test.Infos})
+			ideRouter, portRouter, blobserveRouter := test.Router(r, &fakeWsInfoProvider{infos: test.Infos})
 			var act Expectation
 			actRecorder := func(w http.ResponseWriter, req *http.Request) {
 				defer w.WriteHeader(200)
@@ -94,9 +94,9 @@ func TestWorkspaceRouter(t *testing.T) {
 				act.AdditionalHitCount++
 			}
 
-			if theiaRouter != nil {
-				theiaRouter.HandleFunc("/", actRecorder)
-				theiaRouter.HandleFunc("/services", actRecorder)
+			if ideRouter != nil {
+				ideRouter.HandleFunc("/", actRecorder)
+				ideRouter.HandleFunc("/services", actRecorder)
 			}
 			if portRouter != nil {
 				portRouter.HandleFunc("/", actRecorder)

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestWorkspaceRouter(t *testing.T) {
+	const wsHostRegex = "\\.ws\\.gitpod\\.dev"
 	const wsHostSuffix = ".ws.gitpod.dev"
 	type Expectation struct {
 		WorkspaceID        string
@@ -37,7 +38,7 @@ func TestWorkspaceRouter(t *testing.T) {
 			Headers: map[string]string{
 				forwardedHostnameHeader: "amaranth-smelt-9ba20cc1.ws.gitpod.dev",
 			},
-			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix),
+			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix, wsHostRegex),
 			WSHostSuffix: wsHostSuffix,
 			Expected: Expectation{
 				WorkspaceID: "amaranth-smelt-9ba20cc1",
@@ -51,7 +52,7 @@ func TestWorkspaceRouter(t *testing.T) {
 			Headers: map[string]string{
 				forwardedHostnameHeader: "1234-amaranth-smelt-9ba20cc1.ws.gitpod.dev",
 			},
-			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix),
+			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix, wsHostRegex),
 			WSHostSuffix: wsHostSuffix,
 			Expected: Expectation{
 				WorkspaceID:   "amaranth-smelt-9ba20cc1",
@@ -66,7 +67,7 @@ func TestWorkspaceRouter(t *testing.T) {
 			Headers: map[string]string{
 				forwardedHostnameHeader: "blobserve.ws.gitpod.dev",
 			},
-			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix),
+			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix, wsHostRegex),
 			WSHostSuffix: wsHostSuffix,
 			Expected: Expectation{
 				Status: http.StatusOK,


### PR DESCRIPTION
This change allows the ws-proxy to accept workspace URLs from other clusters. Missing workspaces will be routed to `/start/<workspace ID>`.

Fixes #4374

## How to test
- Start a workspace
- Stop this workspace
- Open the workspace URL but change `ws-dev` to something like `ws-eu01` in the URL (ignore SSL error).
- The URL should be redirected and the workspace should start with `ws-dev` in the URL.

## Discussion

This is a pretty lightweight change that changes the `matchWorkspaceHostHeader` check to allow all workspace cluster host prefixes. An alternative would be a dedicated route for that. It would probably make the implementation cleaner but also more complex.

@geropl: What are your thoughts about this implementation?