### PR TITLE
[dashboard] Prevent that the tab of “New Workspace“ changes on model changes

### DIFF
--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -27,7 +27,7 @@ type Mode = 'Recent' | 'Examples';
 export function StartWorkspaceModal(p: StartWorkspaceModalProps) {
     const computeSelection = () => p.selected || (p.recent.length > 0 ? 'Recent' : 'Examples');
     const [selection, setSelection] = useState(computeSelection());
-    useEffect(() => setSelection(computeSelection()), [p.recent, p.selected]);
+    useEffect(() => { !p.visible && setSelection(computeSelection()) }, [p.visible, p.recent, p.selected]);
 
     const list = (selection === 'Recent' ? p.recent : p.examples).map((e, i) =>
         <a key={`item-${i}-${e.title}`} href={e.startUrl} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-4 my-1">


### PR DESCRIPTION
Fixes #3764

## How to test

1. Open “New Workspaces” dialog. Verify that the “Examples” tab is active.
2. Start example workspace in new tab (Ctrl+Click)
3. The workspace appears in the list of active workspace (background). Verify that the tab in the “New Workspace” dialog does not change.
4. Close the “New Workspace” dialog.
5. Re-open the “New Workspace” dialog. Verify that the “Recent” tab is active.

https://user-images.githubusercontent.com/24960040/121860541-3bf88d80-ccf9-11eb-99b1-024e323225c5.mp4

