### PR TITLE
Update codecov configuration to allow partial uploads

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -5,6 +5,9 @@ import { wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespac
 import { issueCertficate, installCertficate } from './util/certs';
 import { reportBuildFailureInSlack } from './util/slack';
 import * as semver from 'semver';
+import * as util from 'util';
+
+const readDir = util.promisify(fs.readdir)
 
 const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.json";
 
@@ -153,7 +156,18 @@ export async function build(context, version) {
     werft.phase('coverage', 'uploading code coverage to codecov');
     const parent_commit = exec(`git rev-parse HEAD^`, { silent: true }).stdout.trim();;
     try {
-        exec(`codecov -N "${parent_commit}" --dir "${coverageOutput}"`);
+        // if we don't remove the go directory codecov will scan it recursively
+        exec(`sudo rm -rf go`);
+        const coverageFiles = await readDir(coverageOutput);
+        for (let index = 0; index < coverageFiles.length; index++) {
+            const file = coverageFiles[index];
+            if (file.indexOf("-coverage.out") == -1) {
+                continue
+            }
+            let flag = file.substring(0, file.length - "-coverage.out".length);
+            exec(`codecov -N "${parent_commit}" --flags=${flag} --file "${coverageOutput}/${file}"`);
+        }
+
         werft.done('coverage');
     } catch (err) {
         werft.fail('coverage', err);

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,109 @@
+# curl --data-binary @codecov.yml https://codecov.io/validate
+codecov:
+  require_ci_to_pass: yes # wait for all other statuses to pass before sending its status
+  branch: main
+  # strict_yaml_branch: main
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...100"         # less than 40% having a red background
+
+comment:
+  layout: "reach,diff,flags"
+  behavior: default         #  update, if exists. Otherwise post new.
+  require_changes: true     # if true: only post the comment if coverage changes
+  require_base: no          # [yes :: must have a base report to post]
+  require_head: yes         # [yes :: must have a head report to post]
+
+flags:
+  components-blobserve-app:
+    paths:
+      - components/blobserve/
+  components-common-go-lib:
+    paths:
+      - components/common-go/
+  components-content-service-app:
+    paths:
+      - components/content-service/
+  components-dashboard-app:
+    paths:
+      - components/dashboard/
+  components-ee-agent-smith-app:
+    paths:
+      - components/ee/agent-smith/
+  components-ee-kedge-app:
+    paths:
+      - components/ee/kedge/
+  components-ee-ws-scheduler-app:
+    paths:
+      - components/ee/ws-scheduler/
+  components-gitpod-cli-app:
+    paths:
+      - components/gitpod-cli/
+  components-gitpod-protocol-go-lib:
+    paths:
+      - components/gitpod-protocol/go/
+  components-image-builder-app:
+    paths:
+      - components/image-builder/
+  components-licensor-app:
+    paths:
+      - components/licensor/
+  components-local-app-api-go-lib:
+    paths:
+      - components/local-app-api/go/
+  components-local-app-app-linux:
+    paths:
+      - components/local-app/
+  components-registry-facade-app:
+    paths:
+      - components/registry-facade/
+  components-registry-facade-api-go-lib:
+    paths:
+      - components/registry-facade-api/
+  components-service-waiter-app:
+    paths:
+      - components/service-waiter/
+  components-supervisor-app:
+    paths:
+      - components/supervisor/
+  components-supervisor-api-go-lib:
+    paths:
+      - components/supervisor-api/go/
+  components-workspacekit-app:
+    paths:
+      - components/workspacekit/
+  components-ws-daemon-api-go-lib:
+    paths:
+      - components/ws-daemon-api/go/
+  components-ws-daemon-nsinsider-app:
+    paths:
+      - components/ws-daemon/nsinsider/
+  components-ws-daemon-seccomp-profile-installer-app:
+    paths:
+      - components/ws-daemon/seccomp-profile-installer/
+  components-ws-daemon-app:
+    paths:
+      - components/ws-daemon/
+  components-ws-manager-bridge-app:
+    paths:
+      - components/ws-manager-bridge/
+  components-ws-manager-app:
+    paths:
+      - components/ws-manager/
+  dev-blowtorch-app:
+    paths:
+      - dev/blowtorch/
+  dev-loadgen-app:
+    paths:
+      - dev/loadgen/
+  dev-poolkeeper-app:
+    paths:
+      - dev/poolkeeper/
+  dev-sweeper-app:
+    paths:
+      - dev/sweeper/
+  dev-version-manifest-app:
+    paths:
+      - dev/version-manifest/


### PR DESCRIPTION
Because the project is a monorepo and we use leeway to build (packages are built in isolation), we end up with a small coverage report file. Unfortunately, this creates a problem with the report in codecov.io introducing a fluctuation of the coverage (at the level project).

This PR refactors the upload of the report to include the context (package) of the change to only update a particular directory in the repository tree.