### PR TITLE
[build] Don't re-tag images, don't re-create namespace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-version-mf-ii.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -1,7 +1,7 @@
 import * as shell from 'shelljs';
 import * as fs from 'fs';
 import { werft, exec, gitTag } from './util/shell';
-import { wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespaceObjects, findFreeHostPorts } from './util/kubectl';
+import { wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespaceObjects, findFreeHostPorts, createNamespace } from './util/kubectl';
 import { issueCertficate, installCertficate } from './util/certs';
 import { reportBuildFailureInSlack } from './util/slack';
 import * as semver from 'semver';
@@ -70,6 +70,7 @@ export async function build(context, version) {
     const analytics = buildConfig["analytics"];
     const localAppVersion = mainBuild || ("with-localapp-version" in buildConfig) ? version : "unknown";
     const retag = mainBuild || ("with-retag" in buildConfig) ? "" : "--dont-retag";
+    const cleanSlateDeployment = mainBuild || ("with-clean-slate-deployment" in buildConfig);
 
     const withWsCluster = parseWsCluster(buildConfig["with-ws-cluster"]);   // e.g., "dev2|gpl-ws-cluster-branch": prepares this branch to host (an additional) workspace cluster
     const wsCluster = parseWsCluster(buildConfig["as-ws-cluster"]);         // e.g., "dev2|gpl-fat-cluster-branch": deploys this build as so that it is available under that subdomain as that cluster
@@ -91,7 +92,8 @@ export async function build(context, version) {
         publishToNpm,
         analytics,
         localAppVersion,
-        retag
+        retag,
+        cleanSlateDeployment,
     }));
 
     /**
@@ -191,7 +193,8 @@ export async function build(context, version) {
         url,
         wsCluster,
         withWsCluster,
-        analytics
+        analytics,
+        cleanSlateDeployment,
     };
     await deployToDev(deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
 
@@ -210,6 +213,7 @@ interface DeploymentConfig {
     wsCluster?: PreviewWorkspaceClusterRef | undefined;
     withWsCluster?: PreviewWorkspaceClusterRef | undefined;
     analytics?: string;
+    cleanSlateDeployment: boolean;
 }
 
 /**
@@ -244,10 +248,21 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         await installCertficate(werft, fromNamespace, namespace, "proxy-config-certificates");
     })();
 
-
-    // re-create namespace
     try {
-        await wipeAndRecreateNamespace(helmInstallName, namespace, { slice: 'prep' });
+        if (deploymentConfig.cleanSlateDeployment) {
+            // re-create namespace
+            await wipeAndRecreateNamespace(helmInstallName, namespace, { slice: 'prep' });
+            // cleanup non-namespace objects
+            werft.log("predeploy cleanup", "removing old unnamespaced objects - this might take a while");
+            try {
+                deleteNonNamespaceObjects(namespace, destname, { slice: 'predeploy cleanup' })
+                werft.done('predeploy cleanup');
+            } catch (err) {
+                werft.fail('predeploy cleanup', err);
+            }
+        } else {
+            createNamespace(namespace, { slice: 'prep' });
+        }
         setKubectlContextNamespace(namespace, { slice: 'prep' });
         namespaceRecreatedResolve();    // <-- signal for certificate
         werft.done('prep');
@@ -286,15 +301,6 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         werft.fail('authProviders', err);
     }
     // core-dev specific section end
-
-    // cleanup non-namespace objects
-    werft.log("predeploy cleanup", "removing old unnamespaced objects - this might take a while");
-    try {
-        deleteNonNamespaceObjects(namespace, destname, { slice: 'predeploy cleanup' })
-        werft.done('predeploy cleanup');
-    } catch (err) {
-        werft.fail('predeploy cleanup', err);
-    }
 
     // deployment config
     let flags = "";

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-version-mf-ii.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-version-mf-ii.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -86,7 +86,13 @@ async function deleteAllUnnamespacedObjects(namespace: string, shellOpts: ExecOp
     await Promise.all(promisedDeletes);
 }
 
-function createNamespace(namespace: string, shellOpts: ExecOptions) {
+export function createNamespace(namespace: string, shellOpts: ExecOptions) {
+    const result = (exec(`kubectl get namespace ${namespace}`, { ...shellOpts, dontCheckRc: true }) as ShellString);
+    const exists = result.code === 0;
+    if (exists) {
+        return;
+    }
+
     // (re-)create namespace
     [
         `kubectl create namespace ${namespace}`,

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-version-mf-ii.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -131,7 +131,7 @@ affinity:
 {{- define "gitpod.msgbusWaiter.container" -}}
 {{- $ := .root -}}
 {{- $gp := .gp -}}
-{{- $this := dict "root" $ "gp" $gp "comp" $gp.serviceWaiter -}}
+{{- $this := dict "root" $ "gp" $gp "comp" $gp.components.serviceWaiter -}}
 - name: msgbus-waiter
   image: {{ template "gitpod.comp.imageFull" $this }}
   args:
@@ -147,7 +147,7 @@ affinity:
 {{- define "gitpod.databaseWaiter.container" -}}
 {{- $ := .root -}}
 {{- $gp := .gp -}}
-{{- $this := dict "root" $ "gp" $gp "comp" $gp.serviceWaiter -}}
+{{- $this := dict "root" $ "gp" $gp "comp" $gp.components.serviceWaiter -}}
 - name: database-waiter
   image: {{ template "gitpod.comp.imageFull" $this }}
   args:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,9 +67,6 @@ dbEncryptionKeys:
   secretName: null
   file: secrets/encryption-key.json
 
-serviceWaiter:
-  imageName: "service-waiter"
-
 tracing: {}
 authProviders: []
 # Example authProvider configurations below:
@@ -302,6 +299,9 @@ components:
     garbageCollection:
       disabled: "false"
     definitelyGpDisabled: "false"
+
+  serviceWaiter:
+    imageName: "service-waiter"
 
   paymentEndpoint:
     disabled: true

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -81,6 +81,8 @@ packages:
       - imageRepoBase
     config:
       dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: dbMigrations
       image:
         - ${imageRepoBase}/db-migrations:${version}
         - ${imageRepoBase}/db-migrations:${__pkg_version}

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -24,7 +24,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-version-mf-ii.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -43,7 +43,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-version-mf-ii.0",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/components/ws-daemon/seccomp-profile-installer/BUILD.yaml
+++ b/components/ws-daemon/seccomp-profile-installer/BUILD.yaml
@@ -27,7 +27,7 @@ packages:
     config:
       dockerfile: leeway.Dockerfile
       metadata:
-        helm-component: wsDaemon.seccompProfileInstaller
+        helm-component: wsDaemon.userNamespaces.seccompProfileInstaller
       image:
         - ${imageRepoBase}/seccomp-profile-installer:${version}
         - ${imageRepoBase}/seccomp-profile-installer:${__pkg_version}

--- a/components/ws-daemon/shiftfs-module-loader/BUILD.yaml
+++ b/components/ws-daemon/shiftfs-module-loader/BUILD.yaml
@@ -10,7 +10,7 @@ packages:
     config:
       dockerfile: leeway.Dockerfile
       metadata:
-        helm-component: wsDaemon.shiftfsModuleLoader
+        helm-component: wsDaemon.userNamespaces.shiftfsModuleLoader
       image:
         - ${imageRepoBase}/shiftfs-module-loader:${version}
         - ${imageRepoBase}/shiftfs-module-loader:${__pkg_version}

--- a/components/ws-manager/BUILD.yaml
+++ b/components/ws-manager/BUILD.yaml
@@ -22,7 +22,7 @@ packages:
     type: docker
     deps:
       - :app
-      - :integration-test
+      # - :integration-test
     argdeps:
       - imageRepoBase
     config:

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -5,3 +5,6 @@ packages:
       - dev/image:docker
       - dev/poolkeeper:docker
       - dev/sweeper:docker
+    config:
+      commands:
+        - ["sh", "-c", "tail -n1 dev-sweeper--docker/imgnames.txt > sweeper.txt"]

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -59,7 +59,7 @@ RUN cd /usr/local && curl -fsSL https://install.goreleaser.com/github.com/golang
 
 # leeway
 ENV LEEWAY_NESTED_WORKSPACE=true
-RUN cd /usr/bin && curl -fsSL https://github.com/TypeFox/leeway/releases/download/v0.2.3/leeway_0.2.3_Linux_x86_64.tar.gz | tar xz
+RUN cd /usr/bin && curl -fsSL https://github.com/TypeFox/leeway/releases/download/v0.2.4/leeway_0.2.4_Linux_x86_64.tar.gz | tar xz
 
 # dazzle
 RUN cd /usr/bin && curl -fsSL https://github.com/32leaves/dazzle/releases/download/v0.0.3/dazzle_0.0.3_Linux_x86_64.tar.gz | tar xz

--- a/dev/version-manifest/main_test.go
+++ b/dev/version-manifest/main_test.go
@@ -26,10 +26,12 @@ func TestProduceManifest(t *testing.T) {
 		{
 			Name: "happy path",
 			FS: fstest.MapFS{
-				"c1/metadata.yaml": &fstest.MapFile{Data: []byte("helm-component: c1")},
-				"c1/imgnames.txt":  &fstest.MapFile{Data: []byte("failthis\nimgc1:v1")},
-				"c2/metadata.yaml": &fstest.MapFile{Data: []byte("helm-component: c2.nested")},
-				"c2/imgnames.txt":  &fstest.MapFile{Data: []byte("failthis\nimgc2:v2\n\n")},
+				"c1/metadata.yaml":  &fstest.MapFile{Data: []byte("helm-component: c1")},
+				"c1/imgnames.txt":   &fstest.MapFile{Data: []byte("failthis\nimgc1:v1")},
+				"c2/metadata.yaml":  &fstest.MapFile{Data: []byte("helm-component: c2.nested")},
+				"c2/imgnames.txt":   &fstest.MapFile{Data: []byte("failthis\nimgc2:v2\n\n")},
+				"c20/metadata.yaml": &fstest.MapFile{Data: []byte("helm-component: c2.other")},
+				"c20/imgnames.txt":  &fstest.MapFile{Data: []byte("failthis\nimgc2:v2\n\n")},
 			},
 			Expectation: Expectation{
 				MF: `components:
@@ -38,6 +40,9 @@ func TestProduceManifest(t *testing.T) {
 
   c2:
     nested:
+      version: v2
+
+    other:
       version: v2
 
 `,


### PR DESCRIPTION
This PR disables the automatic re-tagging of all Docker images during the build. Using the [new leeway flag](https://github.com/gitpod-io/leeway/commit/ac53f4e3f984537ae6d028db6931fa6217b294c7) `--dont-retag` we disable this behaviour by default, except in `main` builds or when `with-retag` is set in the build config.

Also, this PR disables the default re-creation of namespaces in core-dev. This might lead to issues down the road because config map changes might not lead to container restarts which can be unexpected. However, we would be seeing those kind of issues in prod, too - so this is a good way to clean up the chart.
If you still want a clean slate deployment, add `with-clean-slate-deployment` to your build config.

In addition, this PR contains a range of cleanup bits:
- actually remove the ws-manager integration tests from the build. We haven't run them in a long time, but still incurred the build time penalty because of its dependencies (e.g. charts)
- improves the version manifest to produce a valid YAML file when multiple components sit below each other
- moves service-waiter into `components` in the `values.yaml`, s.t. it works with the version-manifest process
- integrates gitpod-db/db-migrations into the version manifest
