### PR TITLE
[code] logging to track reconnection cause

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT e2eb3ee4af68d4d14c2c62f99a64c97842f9ad02
+ENV GP_CODE_COMMIT a6ceaaf126d636d6e9499dfebaf413956256e98d
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- It adds logging to determine a cause of web socket closing.
- It also changes the default websocket in VS Code Web:
  - by default VS Code will try to reconnect the websocket only if it was not closed cleanly (1000 code)
  - in our case it is better to reconnect always when workspace phase is running regardless of websocket close code
- fix #4448: makes sure that grpc-web is loaded before the local app

Changes in Gitpod Code: https://github.com/microsoft/vscode/compare/e2eb3ee4af68d4d14c2c62f99a64c97842f9ad02...a6ceaaf126d636d6e9499dfebaf413956256e98d

#### How to test

- Start a workspace.
- Run `WebSocket.disconnectWorkspace` and check web sockets are reconnected within a minute.
- Throttle network on system level, like with Edge profile, and see that web sockets still get connected and reconnected.