### PR TITLE
WORKSPACE_KERNEL environment variable

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-kernel.7
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-kernel.7
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-kernel.7
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-kernel.7
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
+++ b/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
-vmlinux_url="http://security.ubuntu.com/ubuntu/pool/main/l/linux-signed-gke-5.4/linux-image-5.4.0-1033-gke_5.4.0-1033.35~18.04.1_amd64.deb"
-modules_url="http://security.ubuntu.com/ubuntu/pool/main/l/linux-gke-5.4/linux-modules-5.4.0-1033-gke_5.4.0-1033.35~18.04.1_amd64.deb"
+if [ ! "$WORKSPACE_KERNEL" == "$(uname -r)" ]; then
+    echo "The WORKSPACE_KERNEL environment variable and the current running workspace kernel are not equal, please update the WORKSPACE_KERNEL variable accordingly in the workspace dockerfile: dev/image/Dockerfile"
+    echo "WORKPACE_KERNEL=${WORKSPACE_KERNEL}"
+    echo "Current kernel=$(uname -r)"
+    exit 1
+fi
+
 img_url="https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.tar.gz"
 
 script_dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -12,8 +17,6 @@ outdir="${script_dirname}/_output"
 rm -Rf $outdir
 mkdir -p $outdir
 
-curl -L -o "${outdir}/linux-image.deb" $vmlinux_url
-curl -L -o "${outdir}/linux-modules.deb" $modules_url
 curl -L -o "${outdir}/rootfs.tar.gz" $img_url
 
 cd $outdir
@@ -25,16 +28,15 @@ qemu-img resize bionic-server-cloudimg-amd64.img +20G
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'resize2fs /dev/sda'
 
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --root-password password:root
-sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in linux-modules.deb:/root
 
-sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'dpkg -i /root/linux-modules.deb'
+# copy kernel modules
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in /lib/modules/$WORKSPACE_KERNEL:/lib/modules
 
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'echo "[Network]\nDHCP=ipv4" > /etc/systemd/network/20-dhcp.network'
 
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt remove openssh-server -y && apt install openssh-server -y'
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command "sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config"
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command "sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config"
-ar x linux-image.deb
-tar -xvf data.tar.xz
+
 
 echo "BPF environment is ready"

--- a/components/ee/agent-smith/scripts/qemu.sh
+++ b/components/ee/agent-smith/scripts/qemu.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-vmlinuz="vmlinuz-5.4.0-1033-gke"
+vmlinuz="vmlinuz-${WORKSPACE_KERNEL}"
 
 script_dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 outdir="${script_dirname}/_output"
 
-sudo qemu-system-x86_64 -kernel "${outdir}/boot/${vmlinuz}" \
+sudo qemu-system-x86_64 -kernel "/boot/${vmlinuz}" \
 -boot c -m 2049M -hda "${outdir}/bionic-server-cloudimg-amd64.img" \
 -net user \
 -smp 2 \

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -24,7 +24,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-kernel.7
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -43,7 +43,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dont-retag.2",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-kernel.7",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -5,11 +5,12 @@
 FROM gitpod/workspace-full-vnc:latest
 
 ENV TRIGGER_REBUILD 12
+ENV WORKSPACE_KERNEL 5.4.0-1033-gke
 
 USER root
 
 ### QEMU (x86) and workspace kernel development tools
-RUN install-packages qemu qemu-system-x86 linux-image-$(uname -r) libguestfs-tools sshpass
+RUN install-packages qemu qemu-system-x86 linux-image-$WORKSPACE_KERNEL libguestfs-tools sshpass
 
 ### Clang and LLVM
 RUN install-packages clang-7 llvm-7


### PR DESCRIPTION
Needed because the werft build executor and the final workspace are not
guaranteed to run the same kernel.

Also simplified the scripts by using the workspace kernel coming from
the workspace's package manager directly instead of re-downloading.