### PR TITLE
[content-service] Retry git clone

### DIFF
--- a/components/content-service/go.mod
+++ b/components/content-service/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go/storage v1.14.0
 	github.com/Microsoft/hcsshim v0.8.15 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containerd/continuity v0.0.0-20210315143101-93e15499afd5 // indirect
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/content-service/api v0.0.0-00010101000000-000000000000

--- a/components/content-service/go.sum
+++ b/components/content-service/go.sum
@@ -118,6 +118,7 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8n
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=


### PR DESCRIPTION
This change introduces an exponential backoff retry of `git clone`. It retries until a [timeout of 5 minutes](https://github.com/gitpod-io/gitpod/blob/7f5c95995802b7c8aece23f456f740e34ccc744b/components/content-service/pkg/initializer/git.go#L96-L96) (we could also use another timeout duration if someone has another proposal).

Fixes #4203

#### How to test

To be honest, I have no idea how to test this. A good start is to verify that it is still possible to start a workspace, though.