### PR TITLE
move eBPF Terminal to background

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,14 +31,14 @@ ports:
 # Dev Theia
   - port: 13444
 tasks:
+  - name: Prepare Agent Smith BPF dev environment
+    init: leeway run components/ee/agent-smith:prepare-environment
+    command: leeway run components/ee/agent-smith:qemu
   - before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build
   - name: Go
     init: leeway exec --filter-type go -v -- go mod verify
     openMode: split-right
-  - name: Prepare Agent Smith BPF dev environment
-    init: leeway run components/ee/agent-smith:prepare-environment
-    command: leeway run components/ee/agent-smith:qemu
 vscode:
   extensions:
     - bajdzis.vscode-database


### PR DESCRIPTION
#### What it does

- fix #4477 by moving eBPF Terminal into background


#### How to test

- Start a workspace for this branch and check taht eBPF terminal is not foreground by default: https://gitpod.io#https://github.com/gitpod-io/gitpod/pull/4510