### PR TITLE
Use value that k8s uses

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -195,7 +195,7 @@ spec:
           periodSeconds: 10
         securityContext:
           privileged: true
-          procMount: Unmasked
+          procMount: Default
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}


### PR DESCRIPTION
When the chart is applied, k8s changes the value from `Unmasked` to `Default`.
To prevent misunderstandings, we should use the same value in our code.

In case the value should remain `Unmasked` and k8s needs additional pampering to stop changing it - let me know.