### PR TITLE
[server] Fix req route metrics

### DIFF
--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -85,7 +85,10 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
             res.send = (body) => {
                 const result = originalSend(body);
                 const method = req.method;
-                const route = req.route.path;
+                const route = req.route?.path || "";
+                if (!req.route) {
+                    log.warn(`route is undefined, url: ${req.url}`);
+                }
                 observeHttpRequestDuration(method, route, res.statusCode, (Date.now() - startTime) / 1000)
                 increaseHttpRequestCounter(method, route, res.statusCode);
                 return result;


### PR DESCRIPTION
In the log files, we can see that we have some requests where `req.route` `undefined` is. That leads to the following error:

> TypeError: Cannot read property 'path' of undefined

Unfortunately, I was not able to reproduce this error in a preview environment.

This change catches this error and logs the path of the request when this happens.

See #3976 and https://github.com/gitpod-io/gitpod/pull/3110#discussion_r614814967.