### PR TITLE
[build] Tag images with commit that produced them

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-precommit.33
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -30,7 +30,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-precommit.33
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-precommit.33
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-precommit.33
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/blobserve/BUILD.yaml
+++ b/components/blobserve/BUILD.yaml
@@ -27,4 +27,4 @@ packages:
         helm-component: blobserve
       image:
         - ${imageRepoBase}/blobserve:${version}
-        - ${imageRepoBase}/blobserve:${__pkg_version}
+        - ${imageRepoBase}/blobserve:commit-${__git_commit}

--- a/components/blobserve/go.sum
+++ b/components/blobserve/go.sum
@@ -310,6 +310,7 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/components/content-service/BUILD.yaml
+++ b/components/content-service/BUILD.yaml
@@ -40,4 +40,4 @@ packages:
         helm-component: contentService
       image:
         - ${imageRepoBase}/content-service:${version}
-        - ${imageRepoBase}/content-service:${__pkg_version}
+        - ${imageRepoBase}/content-service:commit-${__git_commit}

--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -46,7 +46,7 @@ packages:
         helm-component: dashboard
       image:
         - ${imageRepoBase}/dashboard:${version}
-        - ${imageRepoBase}/dashboard:${__pkg_version}
+        - ${imageRepoBase}/dashboard:commit-${__git_commit}
 scripts:
   - name: telepresence
     script: |-

--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -69,4 +69,4 @@ packages:
         helm-component: workspace.dockerUp
       image:
         - ${imageRepoBase}/docker-up:${version}
-        - ${imageRepoBase}/docker-up:${__pkg_version}
+        - ${imageRepoBase}/docker-up:commit-${__git_commit}

--- a/components/ee/db-sync/BUILD.yaml
+++ b/components/ee/db-sync/BUILD.yaml
@@ -26,7 +26,7 @@ packages:
         helm-component: dbSync
       image:
         - ${imageRepoBase}/db-sync:${version}
-        - ${imageRepoBase}/db-sync:${__pkg_version}
+        - ${imageRepoBase}/db-sync:commit-${__git_commit}
   - name: dbtest
     type: yarn
     srcs:

--- a/components/ee/kedge/BUILD.yaml
+++ b/components/ee/kedge/BUILD.yaml
@@ -25,4 +25,4 @@ packages:
         helm-component: kedge
       image:
         - ${imageRepoBase}/kedge:${version}
-        - ${imageRepoBase}/kedge:${__pkg_version}
+        - ${imageRepoBase}/kedge:commit-${__git_commit}

--- a/components/ee/payment-endpoint/BUILD.yaml
+++ b/components/ee/payment-endpoint/BUILD.yaml
@@ -41,7 +41,7 @@ packages:
         helm-component: paymentEndpoint
       image:
         - ${imageRepoBase}/payment-endpoint:${version}
-        - ${imageRepoBase}/payment-endpoint:${__pkg_version}
+        - ${imageRepoBase}/payment-endpoint:commit-${__git_commit}
   - name: dbtest
     type: yarn
     srcs:

--- a/components/ee/ws-scheduler/BUILD.yaml
+++ b/components/ee/ws-scheduler/BUILD.yaml
@@ -26,7 +26,7 @@ packages:
         helm-component: wsScheduler
       image:
         - ${imageRepoBase}/ws-scheduler:${version}
-        - ${imageRepoBase}/ws-scheduler:${__pkg_version}
+        - ${imageRepoBase}/ws-scheduler:commit-${__git_commit}
 scripts:
   - name: telepresence
     script: |

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -85,7 +85,7 @@ packages:
         helm-component: dbMigrations
       image:
         - ${imageRepoBase}/db-migrations:${version}
-        - ${imageRepoBase}/db-migrations:${__pkg_version}
+        - ${imageRepoBase}/db-migrations:commit-${__git_commit}
 scripts:
 - name: db-test-env
   description: "Creates a file with env vars necessary for running DB tests. The file delets itself after being sourced. Usage: '. $(leeway run components/gitpod-db:db-test-env)'"

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -24,7 +24,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-precommit.33
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -43,7 +43,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-precommit.33",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -13,4 +13,4 @@ packages:
         helm-component: workspace.codeImage
       image:
         - ${imageRepoBase}/ide/code:${version}
-        - ${imageRepoBase}/ide/code:${__pkg_version}
+        - ${imageRepoBase}/ide/code:commit-${__git_commit}

--- a/components/ide/theia/BUILD.yaml
+++ b/components/ide/theia/BUILD.yaml
@@ -14,4 +14,4 @@ packages:
         helm-component: workspace.theiaImage
       image:
         - ${imageRepoBase}/ide/theia:${version}
-        - ${imageRepoBase}/ide/theia:${__pkg_version}
+        - ${imageRepoBase}/ide/theia:commit-${__git_commit}

--- a/components/image-builder/BUILD.yaml
+++ b/components/image-builder/BUILD.yaml
@@ -28,4 +28,4 @@ packages:
         helm-component: imageBuilder
       image:
         - ${imageRepoBase}/image-builder:${version}
-        - ${imageRepoBase}/image-builder:${__pkg_version}
+        - ${imageRepoBase}/image-builder:commit-${__git_commit}

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -79,4 +79,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/local-app:${version}
-        - ${imageRepoBase}/local-app:${__pkg_version}
+        - ${imageRepoBase}/local-app:commit-${__git_commit}

--- a/components/proxy/BUILD.yaml
+++ b/components/proxy/BUILD.yaml
@@ -12,4 +12,4 @@ packages:
         helm-component: proxy
       image:
         - ${imageRepoBase}/proxy:${version}
-        - ${imageRepoBase}/proxy:${__pkg_version}
+        - ${imageRepoBase}/proxy:commit-${__git_commit}

--- a/components/registry-facade/BUILD.yaml
+++ b/components/registry-facade/BUILD.yaml
@@ -43,4 +43,4 @@ packages:
         helm-component: registryFacade
       image:
         - ${imageRepoBase}/registry-facade:${version}
-        - ${imageRepoBase}/registry-facade:${__pkg_version}
+        - ${imageRepoBase}/registry-facade:commit-${__git_commit}

--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -32,7 +32,7 @@ packages:
         helm-component: server
       image:
         - ${imageRepoBase}/server:${version}
-        - ${imageRepoBase}/server:${__pkg_version}
+        - ${imageRepoBase}/server:commit-${__git_commit}
   - name: lib
     type: yarn
     srcs:

--- a/components/service-waiter/BUILD.yaml
+++ b/components/service-waiter/BUILD.yaml
@@ -24,4 +24,4 @@ packages:
         helm-component: serviceWaiter
       image:
         - ${imageRepoBase}/service-waiter:${version}
-        - ${imageRepoBase}/service-waiter:${__pkg_version}
+        - ${imageRepoBase}/service-waiter:commit-${__git_commit}

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -33,7 +33,7 @@ packages:
         helm-component: workspace.supervisor
       image:
         - ${imageRepoBase}/supervisor:${version}
-        - ${imageRepoBase}/supervisor:${__pkg_version}
+        - ${imageRepoBase}/supervisor:commit-${__git_commit}
   - name: dropbear
     type: generic
     config:

--- a/components/ws-daemon/BUILD.yaml
+++ b/components/ws-daemon/BUILD.yaml
@@ -53,7 +53,7 @@ packages:
         helm-component: wsDaemon
       image:
         - ${imageRepoBase}/ws-daemon:${version}
-        - ${imageRepoBase}/ws-daemon:${__pkg_version}
+        - ${imageRepoBase}/ws-daemon:commit-${__git_commit}
 scripts:
   - name: kube-exec
     description: Executes into the ws-daemon for a workspace pod in $WS

--- a/components/ws-daemon/seccomp-profile-installer/BUILD.yaml
+++ b/components/ws-daemon/seccomp-profile-installer/BUILD.yaml
@@ -30,4 +30,4 @@ packages:
         helm-component: wsDaemon.userNamespaces.seccompProfileInstaller
       image:
         - ${imageRepoBase}/seccomp-profile-installer:${version}
-        - ${imageRepoBase}/seccomp-profile-installer:${__pkg_version}
+        - ${imageRepoBase}/seccomp-profile-installer:commit-${__git_commit}

--- a/components/ws-daemon/shiftfs-module-loader/BUILD.yaml
+++ b/components/ws-daemon/shiftfs-module-loader/BUILD.yaml
@@ -13,4 +13,4 @@ packages:
         helm-component: wsDaemon.userNamespaces.shiftfsModuleLoader
       image:
         - ${imageRepoBase}/shiftfs-module-loader:${version}
-        - ${imageRepoBase}/shiftfs-module-loader:${__pkg_version}
+        - ${imageRepoBase}/shiftfs-module-loader:commit-${__git_commit}

--- a/components/ws-manager-bridge/BUILD.yaml
+++ b/components/ws-manager-bridge/BUILD.yaml
@@ -28,7 +28,7 @@ packages:
         helm-component: wsManagerBridge
       image:
         - ${imageRepoBase}/ws-manager-bridge:${version}
-        - ${imageRepoBase}/ws-manager-bridge:${__pkg_version}
+        - ${imageRepoBase}/ws-manager-bridge:commit-${__git_commit}
 scripts:
   - name: telepresence
     script: |-

--- a/components/ws-manager/BUILD.yaml
+++ b/components/ws-manager/BUILD.yaml
@@ -31,7 +31,7 @@ packages:
         helm-component: wsManager
       image:
         - ${imageRepoBase}/ws-manager:${version}
-        - ${imageRepoBase}/ws-manager:${__pkg_version}
+        - ${imageRepoBase}/ws-manager:commit-${__git_commit}
   - name: docker-debug
     type: docker
     deps:

--- a/components/ws-proxy/BUILD.yaml
+++ b/components/ws-proxy/BUILD.yaml
@@ -32,4 +32,4 @@ packages:
         helm-component: wsProxy
       image:
         - ${imageRepoBase}/ws-proxy:${version}
-        - ${imageRepoBase}/ws-proxy:${__pkg_version}
+        - ${imageRepoBase}/ws-proxy:commit-${__git_commit}

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -60,7 +60,7 @@ RUN cd /usr/local && curl -fsSL https://install.goreleaser.com/github.com/golang
 
 # leeway
 ENV LEEWAY_NESTED_WORKSPACE=true
-RUN cd /usr/bin && curl -fsSL https://github.com/TypeFox/leeway/releases/download/v0.2.4/leeway_0.2.4_Linux_x86_64.tar.gz | tar xz
+RUN cd /usr/bin && curl -fsSL https://github.com/TypeFox/leeway/releases/download/v0.2.5/leeway_0.2.5_Linux_x86_64.tar.gz | tar xz
 
 # dazzle
 RUN cd /usr/bin && curl -fsSL https://github.com/32leaves/dazzle/releases/download/v0.0.3/dazzle_0.0.3_Linux_x86_64.tar.gz | tar xz

--- a/dev/poolkeeper/BUILD.yaml
+++ b/dev/poolkeeper/BUILD.yaml
@@ -22,4 +22,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/poolkeeper:${version}
-        - ${imageRepoBase}/poolkeeper:${__pkg_version}
+        - ${imageRepoBase}/poolkeeper:commit-${__git_commit}

--- a/dev/sweeper/BUILD.yaml
+++ b/dev/sweeper/BUILD.yaml
@@ -20,4 +20,4 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/sweeper:${version}
-        - ${imageRepoBase}/sweeper:${__pkg_version}
+        - ${imageRepoBase}/sweeper:commit-${__git_commit}

--- a/install/docker/examples/gitpod-gitlab/gitlab/BUILD.yaml
+++ b/install/docker/examples/gitpod-gitlab/gitlab/BUILD.yaml
@@ -13,4 +13,4 @@ packages:
       dockerfile: Dockerfile
       image:
         - ${imageRepoBase}/gitlab-k3s:${version}
-        - ${imageRepoBase}/gitlab-k3s:${__pkg_version}
+        - ${imageRepoBase}/gitlab-k3s:commit-${__git_commit}

--- a/install/docker/gitpod-image/BUILD.yaml
+++ b/install/docker/gitpod-image/BUILD.yaml
@@ -14,4 +14,4 @@ packages:
       dockerfile: Dockerfile
       image:
         - ${imageRepoBase}/gitpod-k3s:${version}
-        - ${imageRepoBase}/gitpod-k3s:${__pkg_version}
+        - ${imageRepoBase}/gitpod-k3s:commit-${__git_commit}

--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -27,7 +27,7 @@ packages:
       dockerfile: leeway.Dockerfile
       image:
         - ${imageRepoBase}/installer:${version}
-        - ${imageRepoBase}/installer:${__pkg_version}
+        - ${imageRepoBase}/installer:commit-${__git_commit}
       buildArgs:
         VERSION: ${version}
         IMAGE_PREFIX: ${imageRepoBase}

--- a/test/BUILD.yaml
+++ b/test/BUILD.yaml
@@ -40,4 +40,4 @@ packages:
         helm-component: integrationTest
       image:
         - ${imageRepoBase}/integration-tests:${version}
-        - ${imageRepoBase}/integration-tests:${__pkg_version}
+        - ${imageRepoBase}/integration-tests:commit-${__git_commit}


### PR DESCRIPTION
With this PR we tag our images using the commit hash that produced them rather than the leeway package version.
Because we don't re-tag images in branch builds anymore those versions stay stable across core-dev re-deployments.

Once we stop re-tagging the images in main builds, the versions will be stable across main builds, too.