### PR TITLE
[dashboard] Additional fetch pinned workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## June 2021
 
+- Fix active workspace list in dashboard (show also older pinned workspaces) ([#4523](https://github.com/gitpod-io/gitpod/pull/4523))
 - Adding `ItemsList` component as a more maintainable and consistent way to render a list of workspaces, git integrations, environment variables, etc. ([#4454](https://github.com/gitpod-io/gitpod/pull/4454))
 - Improve backup stability when pods get evicted ([#4405](https://github.com/gitpod-io/gitpod/pull/4405))
 - Fix text color in workspaces list for dark theme ([#4410](https://github.com/gitpod-io/gitpod/pull/4410))


### PR DESCRIPTION
Fixes #4488

Also fixes #4487 along the way while keeping #3879 fixed.

### How to test

See issue #4488 on how to test this. Would probably make sense to change the limit to something like 3 here:

https://github.com/gitpod-io/gitpod/blob/f378e3a6d8839499604e8863db906dc4d1cc2024/components/dashboard/src/workspaces/workspace-model.ts#L15-L15

and run
```
cd components/dashboard/ && yarn telepresence
```

(otherwise starting > 50 workspaces to these this would not be that handy)