### PR TITLE
[gitpod.yml] Remove deprecated openModes split-top and split-bottom

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -116,10 +116,8 @@
                     "openMode": {
                         "type": "string",
                         "enum": [
-                            "split-top",
                             "split-left",
                             "split-right",
-                            "split-bottom",
                             "tab-before",
                             "tab-after"
                         ],


### PR DESCRIPTION
The openModes `split-top` and `split-bottom` are deprecated because VSCode does not support them. See also https://www.gitpod.io/docs/references/gitpod-yml#tasksnopenmode.

Fixes #4340