### PR TITLE
Fix workspaceUrlPrefixRegex

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.spec.ts
@@ -25,5 +25,25 @@ export class GitpodHostUrlTest {
     @test public async testWithoutWorkspacePrefix() {
         expect(GitpodHostUrl.fromWorkspaceUrl("https://3000-moccasin-ferret-155799b3.ws-eu02.gitpod-staging.com/").withoutWorkspacePrefix().toString()).to.equal("https://gitpod-staging.com/");
     }
+
+    @test public async testWithoutWorkspacePrefix2() {
+        expect(GitpodHostUrl.fromWorkspaceUrl("https://gitpod-staging.com/").withoutWorkspacePrefix().toString()).to.equal("https://gitpod-staging.com/");
+    }
+
+    @test public async testWithoutWorkspacePrefix3() {
+        expect(GitpodHostUrl.fromWorkspaceUrl("https://gray-rook-5523v5d8.ws-dev.my-branch-1234.staging.gitpod-dev.com/").withoutWorkspacePrefix().toString()).to.equal("https://my-branch-1234.staging.gitpod-dev.com/");
+    }
+
+    @test public async testWithoutWorkspacePrefix4() {
+        expect(GitpodHostUrl.fromWorkspaceUrl("https://my-branch-1234.staging.gitpod-dev.com/").withoutWorkspacePrefix().toString()).to.equal("https://my-branch-1234.staging.gitpod-dev.com/");
+    }
+
+    @test public async testWithoutWorkspacePrefix5() {
+        expect(GitpodHostUrl.fromWorkspaceUrl("https://abc-nice-brunch-4224.staging.gitpod-dev.com/").withoutWorkspacePrefix().toString()).to.equal("https://abc-nice-brunch-4224.staging.gitpod-dev.com/");
+    }
+
+    @test public async testWithoutWorkspacePrefix6() {
+        expect(GitpodHostUrl.fromWorkspaceUrl("https://gray-rook-5523v5d8.ws-dev.abc-nice-brunch-4224.staging.gitpod-dev.com/").withoutWorkspacePrefix().toString()).to.equal("https://abc-nice-brunch-4224.staging.gitpod-dev.com/");
+    }
 }
 module.exports = new GitpodHostUrlTest()

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -18,7 +18,7 @@ const basewoWkspaceIDRegex = "(([a-f][0-9a-f]{7}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 const workspaceIDRegex = RegExp(`^${basewoWkspaceIDRegex}$`);
 
 // this pattern matches URL prefixes of workspaces
-const workspaceUrlPrefixRegex = RegExp(`^([0-9]{4,6}-)?${basewoWkspaceIDRegex}\.`);
+const workspaceUrlPrefixRegex = RegExp(`^([0-9]{4,6}-)?${basewoWkspaceIDRegex}\\.`);
 
 export class GitpodHostUrl {
     readonly url: URL;


### PR DESCRIPTION
Fixes the “Open Workspace” button on the stopped page.

Works for deployments like:
- https://abc-nice-brunch-4224.staging.gitpod-dev.com/

but still fails if the branch prefix looks like a workspace ID, e.g. this would still fail because `abc-brunch-4224123` is a valid workspace ID:
- https://abc-brunch-4224123.staging.gitpod-dev.com/
