### PR TITLE
[code] fix installing extensions in workspace based on postgres image

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT bcd47c10d173a0c5cb174ab7451bb5133c4e9bec
+ENV GP_CODE_COMMIT bd7b4627aa9426570398a32606bda2d9246a4e52
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -33,4 +33,8 @@ export USER=gitpod
 [ -s ~/.nvm/nvm-lazy.sh ] && source /home/gitpod/.nvm/nvm-lazy.sh
 
 cd /ide || exit
-exec /ide/node/bin/gitpod-node ./out/gitpod.js "$@"
+if [ "$SUPERVISOR_DEBUG_ENABLE" = "true" ]; then
+    exec /ide/node/bin/gitpod-node --inspect ./out/gitpod.js "$@" --verbose --log=trace
+else
+    exec /ide/node/bin/gitpod-node ./out/gitpod.js "$@"
+fi


### PR DESCRIPTION
#### What it does

- fix #4460: it is more a work around to make VS Code work when workspaces are based on postgres image. For some reason Node.js process detecting shell env hangs because of stderr although we read everything from it. See https://github.com/nodejs/node/issues/39072 We don' really need sterr pipe in this case, so I ignore it: https://github.com/gitpod-io/vscode/commit/bd7b4627aa9426570398a32606bda2d9246a4e52

#### How to test

Start following workspaces and check that eventually extensions get installed. It can take a while. It maybe that even frontend timeout and you need to reload the page.

https://ak-code-extensions.staging.gitpod-dev.com/#https://github.com/KushagraSinha2002/Resourceium
https://ak-code-extensions.staging.gitpod-dev.com/#https://github.com/connectiveproject/connective

