### PR TITLE
Add version and commit-sha1 to version manifest

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -60,7 +60,9 @@ packages:
       - dev/version-manifest:app
     config:
       commands:
-        - ["sh", "-c", "dev-version-manifest--app/version-manifest > versions.yaml"]
+        - ["sh", "-c", "echo \"commit: ${__git_commit}\" > commit.yaml"]
+        - ["sh", "-c", "echo \"version: ${version}\" > versions.yaml"]
+        - ["sh", "-c", "dev-version-manifest--app/version-manifest >> versions.yaml"]
         - ["sh", "-c", "rm -r components* dev-*"]
   - name: all-apps
     type: generic

--- a/components/leeway.Dockerfile
+++ b/components/leeway.Dockerfile
@@ -3,4 +3,5 @@
 # See License-AGPL.txt in the project root for license information.
 
 FROM alpine:3.13
+COPY components--all-docker/commit.yaml /
 COPY components--all-docker/versions.yaml /


### PR DESCRIPTION
This adds the `version:`  field to the `version` docker image to the file `version.yaml`
This adds the `commit:` fields to the `version` docker image in a new file `commit.yaml`:

Example:
```
/ # cat versions.yaml 
version: main.981
components:
(...)
/ # cat commit.yaml 
commit: 4c612e2e52df097cba7e4bdd2d36facf8551fb17
```

We need the commit-sha1 in a downstream-repo to update a submodule to the right version.
I'm adding `version:` to have "complete" info about all versions.

edit 1: add the fields to `build.yaml` instead of `versions.yaml`
edit 2: put stuff into `versions.yaml` and `commit.yaml`