### PR TITLE
[supervisor] Make ports configured in .gitpod.yml private by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## June 2021
 
+- Breaking Change: Make ports configured in `.gitpod.yml` private by default when no value for `visibility` is given (was public). This change is for security reasons. ([#4548](https://github.com/gitpod-io/gitpod/pull/4548))
 - Fix active workspace list in dashboard (show also older pinned workspaces) ([#4523](https://github.com/gitpod-io/gitpod/pull/4523))
 - Adding `ItemsList` component as a more maintainable and consistent way to render a list of workspaces, git integrations, environment variables, etc. ([#4454](https://github.com/gitpod-io/gitpod/pull/4454))
 - Improve backup stability when pods get evicted ([#4405](https://github.com/gitpod-io/gitpod/pull/4405))

--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -34,8 +34,8 @@
                             "private",
                             "public"
                         ],
-                        "default": "public",
-                        "description": "Whether the port visibility should be private or public. 'public' (default) will allow everyone with the port URL to access the port. 'private' will only allow users with workspace access to access the port."
+                        "default": "private",
+                        "description": "Whether the port visibility should be private or public. 'private' (default) will only allow users with workspace access to access the port. 'public' will allow everyone with the port URL to access the port."
                     },
                     "name": {
                         "type": "string",

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1073,9 +1073,9 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
 
     protected portVisibilityToProto(visibility: PortVisibility | undefined): ProtoPortVisibility {
         switch (visibility) {
+            default:    // the default for requests is: private
             case 'private':
                 return ProtoPortVisibility.PORT_VISIBILITY_PRIVATE;
-            default:    // the default for requests is: public
             case 'public':
                 return ProtoPortVisibility.PORT_VISIBILITY_PUBLIC;
         }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -606,7 +606,7 @@ export class WorkspaceStarter {
 
             spec.setPort(p.port);
             spec.setTarget(target);
-            spec.setVisibility(p.visibility == 'private' ? PortVisibility.PORT_VISIBILITY_PRIVATE : PortVisibility.PORT_VISIBILITY_PUBLIC);
+            spec.setVisibility(p.visibility == 'public' ? PortVisibility.PORT_VISIBILITY_PUBLIC : PortVisibility.PORT_VISIBILITY_PRIVATE);
             return spec;
         }).filter(spec => !!spec) as PortSpec[];
 

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -342,9 +342,9 @@ func (pm *Manager) nextState(ctx context.Context) map[uint32]*managedPort {
 				return
 			}
 			mp.GlobalPort = port
-			mp.Visibility = api.PortVisibility_public
-			if config.Visibility == "private" {
-				mp.Visibility = api.PortVisibility_private
+			mp.Visibility = api.PortVisibility_private
+			if config.Visibility == "public" {
+				mp.Visibility = api.PortVisibility_public
 			}
 			public := mp.Visibility == api.PortVisibility_public
 			pm.autoExpose(ctx, mp, public)
@@ -396,7 +396,7 @@ func (pm *Manager) nextState(ctx context.Context) map[uint32]*managedPort {
 		if mp.Exposed || configured {
 			public = mp.Visibility == api.PortVisibility_public
 		} else {
-			public = exists && config.Visibility != "private"
+			public = exists && config.Visibility == "public"
 		}
 
 		pm.autoExpose(ctx, mp, public)

--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -128,7 +128,7 @@ func TestPortsUpdateState(t *testing.T) {
 				},
 			},
 			ExpectedExposure: []ExposedPort{
-				{LocalPort: 8080, GlobalPort: 8080, Public: true},
+				{LocalPort: 8080, GlobalPort: 8080},
 				{LocalPort: 9229, GlobalPort: 9229},
 				{LocalPort: 9229, GlobalPort: 60000},
 			},
@@ -159,7 +159,7 @@ func TestPortsUpdateState(t *testing.T) {
 				{Served: []ServedPort{{"0100007F", 4040, true}, {"00000000", 60000, false}}},
 			},
 			ExpectedExposure: []ExposedPort{
-				{LocalPort: 4040, GlobalPort: 60000, Public: true},
+				{LocalPort: 4040, GlobalPort: 60000},
 			},
 			ExpectedUpdates: UpdateExpectation{
 				{},

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -750,14 +750,14 @@ func portNameToVisibility(s string) api.PortVisibility {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
 		// old or wrong port name: return default
-		return api.PortVisibility_PORT_VISIBILITY_PUBLIC
+		return api.PortVisibility_PORT_VISIBILITY_PRIVATE
 	}
 
 	// parse (or public as fallback: important for backwards compatibility during rollout)
 	visibilitStr := fmt.Sprintf("PORT_VISIBILITY_%s", strings.ToUpper(parts[1]))
 	i32Value, present := api.PortVisibility_value[visibilitStr]
 	if !present {
-		return api.PortVisibility_PORT_VISIBILITY_PUBLIC
+		return api.PortVisibility_PORT_VISIBILITY_PRIVATE
 	}
 	return api.PortVisibility(i32Value)
 }

--- a/components/ws-manager/pkg/manager/testdata/status_interrupted.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_interrupted.golden
@@ -14,13 +14,11 @@
             "exposed_ports": [
                 {
                     "port": 5900,
-                    "target": 35900,
-                    "visibility": 1
+                    "target": 35900
                 },
                 {
                     "port": 8080,
-                    "target": 38080,
-                    "visibility": 1
+                    "target": 38080
                 }
             ]
         },

--- a/components/ws-manager/pkg/manager/testdata/status_regularStart_Initializing00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_regularStart_Initializing00.golden
@@ -13,8 +13,7 @@
             "url": "http://10.0.0.114:8082",
             "exposed_ports": [
                 {
-                    "port": 8080,
-                    "visibility": 1
+                    "port": 8080
                 }
             ]
         },

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
@@ -13,8 +13,7 @@
             "url": "http://10.0.0.114:8082",
             "exposed_ports": [
                 {
-                    "port": 8080,
-                    "visibility": 1
+                    "port": 8080
                 }
             ]
         },


### PR DESCRIPTION
Fixes #4159

### How to test
- Open https://corneliusludmann-never-make-ports-4159.staging.gitpod-dev.com/#https://github.com/corneliusludmann/gitpod-playground/tree/test-port-visibility
- `F1` → View: Show Remote Explorer
- Verify that port 8081 is the only port that is public (it's explicitly configured to be public in the .gitpod.yml file)