### PR TITLE
[chart] Update authorization apiVersion to v1 (deprecation)

### DIFF
--- a/chart/templates/agent-smith-role.yaml
+++ b/chart/templates/agent-smith-role.yaml
@@ -4,7 +4,7 @@
 {{ $comp := .Values.components.agentSmith -}}
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/chart/templates/db-sync-unprivileged-rolebinding.yaml
+++ b/chart/templates/db-sync-unprivileged-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: db-sync
   labels:

--- a/chart/templates/kedge-role.yaml
+++ b/chart/templates/kedge-role.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kedge
   labels:

--- a/chart/templates/kedge-rolebinding.yaml
+++ b/chart/templates/kedge-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kedge
   labels:

--- a/chart/templates/kedge-unpriviliged-rolebinding.yaml
+++ b/chart/templates/kedge-unpriviliged-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kedge-unprivileged
   labels:

--- a/chart/templates/payment-endpoint-rolebinding.yaml
+++ b/chart/templates/payment-endpoint-rolebinding.yaml
@@ -5,7 +5,7 @@
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: payment-endpoint
   labels:


### PR DESCRIPTION
```console
W0619 17:57:44.849744 2912464 warnings.go:70] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
```