### PR TITLE
[registry-facade] Fix config hot-reload

### DIFF
--- a/components/registry-facade/cmd/run.go
+++ b/components/registry-facade/cmd/run.go
@@ -182,9 +182,13 @@ func watchConfig(fn string, reg *registry.Registry) {
 			log.WithError(err).Warn("cannot check if config has changed")
 		}
 
+		if oldHash == "" {
+			oldHash = currentHash
+		}
 		if currentHash == oldHash {
 			continue
 		}
+		oldHash = currentHash
 
 		err = reloadConfig()
 		if err == nil {


### PR DESCRIPTION
This PR fixes the registry-facade config reload mechanism. Before this PR registry-facade would reload the configuration every 30 seconds even if nothing changed.

### How to test
1. Looking at the registry-facade logs you should NOT see `configuration was updated - reloaded static layer config`
2. After modifying the registry-facade configmap you should see `configuration was updated - reloaded static layer config` in the logs