### PR TITLE
[build] Reuse Go build cache

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -10,6 +10,10 @@ pod:
   - name: gcp-sa-release
     secret:
       secretName: gcp-sa-gitpod-release-deployer
+  - name: go-build-cache
+    hostPath:
+      path: /mnt/disks/ssd0/go-build-cache
+      type: DirectoryOrCreate
   # - name: deploy-key
   #   secret:
   #     secretName: deploy-key
@@ -40,6 +44,9 @@ pod:
     - name: gcp-sa-release
       mountPath: /mnt/secrets/gcp-sa-release
       readOnly: true
+    - name: go-build-cache
+      mountPath: /go-build-cache
+      readOnly: false
     # - name: deploy-key
     #   mountPath: /mnt/secrets/deploy-key
     #   readOnly: true
@@ -57,6 +64,8 @@ pod:
       {{- end }}
     - name: GOPROXY
       value: http://athens-athens-proxy.athens.svc.cluster.local:9999
+    - name: GOCACHE
+      value: /go-build-cache
     - name: WERFT_HOST
       value: "werft.werft.svc.cluster.local:7777"
     - name: NODENAME
@@ -106,6 +115,7 @@ pod:
         sleep 1
         set -Eeuo pipefail
 
+        sudo chown -R gitpod:gitpod $GOCACHE
         export GITHUB_TOKEN=$(echo $GITHUB_TOKEN | xargs)
 
         export DOCKER_HOST=tcp://$NODENAME:2375


### PR DESCRIPTION
This PR configures the werft job to re-use the Go build cache across the node. It basically places the build cache on the node instead of in the build container, thereby enabling the re-use of the build cache across multiple jobs running on the node.

This should speed up the Go builds.