### PR TITLE
[build] Don't retag main build

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -88,7 +88,7 @@ export async function build(context, version) {
     const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
     const analytics = buildConfig["analytics"];
     const localAppVersion = mainBuild || ("with-localapp-version" in buildConfig) ? version : "unknown";
-    const retag = mainBuild || ("with-retag" in buildConfig) ? "" : "--dont-retag";
+    const retag = ("with-retag" in buildConfig) ? "" : "--dont-retag";
     const cleanSlateDeployment = mainBuild || ("with-clean-slate-deployment" in buildConfig);
 
     const withWsCluster = parseWsCluster(buildConfig["with-ws-cluster"]);   // e.g., "dev2|gpl-ws-cluster-branch": prepares this branch to host (an additional) workspace cluster


### PR DESCRIPTION
This PR removes the Docker image retagging in the main build.
We can merge this once staging and prod no longer require `main.XXX` Docker images but use the version manifest.