### PR TITLE
[build] Improve build start time

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -115,7 +115,7 @@ pod:
         sleep 1
         set -Eeuo pipefail
 
-        sudo chown -R gitpod:gitpod $GOCACHE
+        sudo chown gitpod:gitpod $GOCACHE
         export GITHUB_TOKEN=$(echo $GITHUB_TOKEN | xargs)
 
         export DOCKER_HOST=tcp://$NODENAME:2375


### PR DESCRIPTION
No need to recursively chown the Go cache as all files will have been created by `gitpod:gitpod` anyways.

The chown is still needed for the first run on a new node.