### PR TITLE
[code] fix resolution of external URI

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT bd7b4627aa9426570398a32606bda2d9246a4e52
+ENV GP_CODE_COMMIT 5ee0238977bd53abbe6fbdddff54dfbcd6aed7a3
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #4513: When we convert local URL to external URL (available form the local machine) then we should no drop path, query or fragment: https://github.com/gitpod-io/vscode/commit/5ee0238977bd53abbe6fbdddff54dfbcd6aed7a3

#### How to test

- Since https://open-vsx.org/extension/James-Yu/latex-workshop is not adopted to run in remote context, you need to install the Gitpod Local Companion first, follow: https://www.gitpod.io/blog/local-app#installation
- Run the Gitpod Local Companion against prev env with:
```
GITPOD_HOST=https://akosyakov-this-content-is-blocked-4513.staging.gitpod-dev.com ./gitpod-local-companion-darwin --mock-keyring
```
- Now start a workspace: https://akosyakov-this-content-is-blocked-4513.staging.gitpod-dev.com/#https://github.com/jemand771/Vorlage-Latex/commit/62f11a70ac709171f7087c820712fb861d855163
- Click build (in the status bar) and wait for it to complete (5-10 seconds)
- open the Latex/main.tex file (or any other .tex file, if you want)
- Click view (the pdf icon, not the reload one). A splitscreen-like tab should open, displaying the error message from above.
- You should get something like:
<img width="1904" alt="Screenshot 2021-06-21 at 08 17 00" src="https://user-images.githubusercontent.com/3082655/122702767-86ce5400-d269-11eb-8298-774bf4abab81.png">
