### PR TITLE
[agent-smith] BPF vm mount workspace files under /workspace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-vm-mount.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -34,7 +34,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-vm-mount.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-vm-mount.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-vm-mount.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/ee/agent-smith/BUILD.yaml
+++ b/components/ee/agent-smith/BUILD.yaml
@@ -59,5 +59,5 @@ scripts:
       - components/ee/agent-smith/cmd/testbed:app
       - components/ee/agent-smith/cmd/testtarget:app
     script: |
-      sshpass -p 'root' scp -o StrictHostKeychecking=no -P 2222 ./components-ee-agent-smith--falco-bpf-probe/probe.o ./components-ee-agent-smith--app/agent-smith ./components-ee-agent-smith--example-config/example-config.json ./components-ee-agent-smith-cmd-testbed--app/testbed ./components-ee-agent-smith-cmd-testtarget--app/testtarget root@localhost:/
+      scp vm ./components-ee-agent-smith--falco-bpf-probe/probe.o ./components-ee-agent-smith--app/agent-smith ./components-ee-agent-smith--example-config/example-config.json ./components-ee-agent-smith-cmd-testbed--app/testbed ./components-ee-agent-smith-cmd-testtarget--app/testtarget root@localhost:/
       echo "copied agent-smith to /"

--- a/components/ee/agent-smith/README.md
+++ b/components/ee/agent-smith/README.md
@@ -20,7 +20,6 @@ as its BPF program to extract syscall information at runtime.
 
 ## eBPF development inside the Gitpod workspace
 
-
 ### Environment preparation
 Prepare the environment (it should've been already prepared when you started your Gitpod wrokspace)
 
@@ -36,11 +35,13 @@ Start the VM, if it was not started with your Gitpod workspace.
 leeway run components/ee/agent-smith:qemu
 ```
 
-### Build and execute
+SSH in the VM
 
-Build agent-smith and copy it in the VM
+```
+ssh vm
+```
 
-TODO: write this section
+If you now go under the `/workspace` folder in the VM, you will find all your workspace stuff.
 
 ## Falco libs BPF probe development
 
@@ -59,5 +60,4 @@ cmake -DBUILD_BPF=On ..
 cd ..
 cd driver/bpf
 make CLANG=clang-7 LLC=llc-7 -j16
-scp -P 2222 probe.o root@127.0.0.1:/root/probe.o
 ```

--- a/components/ee/agent-smith/scripts/code
+++ b/components/ee/agent-smith/scripts/code
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+command="GITPOD_THEIA_PORT=23000 /ide/bin/code $*"
+
+if [[ "${PWD}" == /workspace* ]]; then
+     command="cd ${PWD} && ${command}"
+fi
+
+ssh -p 23001 gitpod@10.0.2.2 "${command}"

--- a/components/ee/agent-smith/scripts/config
+++ b/components/ee/agent-smith/scripts/config
@@ -1,0 +1,6 @@
+Host vm
+  User root
+  Hostname 127.0.0.1
+  PreferredAuthentications publickey
+  IdentityFile  ~/.ssh/id_rsa_vm
+  Port 2222

--- a/components/ee/agent-smith/scripts/config
+++ b/components/ee/agent-smith/scripts/config
@@ -2,5 +2,6 @@ Host vm
   User root
   Hostname 127.0.0.1
   PreferredAuthentications publickey
+  StrictHostKeyChecking no
   IdentityFile  ~/.ssh/id_rsa_vm
   Port 2222

--- a/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
+++ b/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
@@ -34,9 +34,28 @@ sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in /lib/modules/"
 
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'echo "[Network]\nDHCP=ipv4" > /etc/systemd/network/20-dhcp.network'
 
-sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt remove openssh-server -y && apt install openssh-server -y'
-sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command "sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config"
-sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command "sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt update && apt remove openssh-server -y && apt install openssh-server -y'
 
+# workspace mount under /workspace
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt install sshfs -y'
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""'
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'mkdir /workspace'
+sudo virt-copy-out -a bionic-server-cloudimg-amd64.img /root/.ssh/id_rsa.pub /tmp
+cat /tmp/id_rsa.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+
+rm -f ~/.ssh/id_rsa_vm
+ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa_vm -q -N ""
+
+rm -f ~/.ssh/config
+cp "${script_dirname}/config" ~/.ssh/config
+
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in ~/.ssh/id_rsa_vm.pub:/tmp
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'cat /tmp/id_rsa_vm.pub >> /root/.ssh/authorized_keys'
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'chmod 600 /root/.ssh/authorized_keys'
+
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in "${script_dirname}/workspace.mount":/lib/systemd/system
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in "${script_dirname}/workspace.automount":/lib/systemd/system
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'systemctl enable workspace.automount'
 
 echo "BPF environment is ready"

--- a/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
+++ b/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
@@ -42,18 +42,18 @@ sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'ssh-keyge
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'mkdir /workspace'
 sudo virt-copy-out -a bionic-server-cloudimg-amd64.img /root/.ssh/id_rsa.pub /tmp
 
-mkdir -p ~/.ssh
-chmod 700 ~/.ssh
-cat /tmp/id_rsa.pub >> ~/.ssh/authorized_keys
-chmod 600 ~/.ssh/authorized_keys
+mkdir -p .ssh
+chmod 700 .ssh
+cat /tmp/id_rsa.pub >> .ssh/authorized_keys
+chmod 600 .ssh/authorized_keys
 
-rm -f ~/.ssh/id_rsa_vm
-ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa_vm -q -N ""
+rm -f .ssh/id_rsa_vm
+ssh-keygen -b 2048 -t rsa -f .ssh/id_rsa_vm -q -N ""
 
-rm -f ~/.ssh/config
-cp "${script_dirname}/config" ~/.ssh/config
+rm -f .ssh/config
+cp "${script_dirname}/config" .ssh/config
 
-sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in ~/.ssh/id_rsa_vm.pub:/tmp
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in .ssh/id_rsa_vm.pub:/tmp
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'cat /tmp/id_rsa_vm.pub >> /root/.ssh/authorized_keys'
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'chmod 600 /root/.ssh/authorized_keys'
 

--- a/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
+++ b/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
@@ -36,6 +36,9 @@ sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'echo "[Ne
 
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt update && apt remove openssh-server -y && apt install openssh-server -y'
 
+# code binary
+sudo virt-customize -a bionic-server-cloudimg-amd64.img --copy-in "${script_dirname}/code":/usr/bin
+
 # workspace mount under /workspace
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt install sshfs -y'
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""'

--- a/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
+++ b/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
@@ -41,6 +41,9 @@ sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'apt insta
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'ssh-keygen -b 2048 -t rsa -f /root/.ssh/id_rsa -q -N ""'
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'mkdir /workspace'
 sudo virt-copy-out -a bionic-server-cloudimg-amd64.img /root/.ssh/id_rsa.pub /tmp
+
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
 cat /tmp/id_rsa.pub >> ~/.ssh/authorized_keys
 chmod 600 ~/.ssh/authorized_keys
 

--- a/components/ee/agent-smith/scripts/qemu.sh
+++ b/components/ee/agent-smith/scripts/qemu.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 vmlinuz="vmlinuz-${WORKSPACE_KERNEL}"
 
 script_dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 outdir="${script_dirname}/_output"
+
+rm -Rf ~/.ssh
+cp -r "${outdir}/.ssh" ~/.ssh
 
 sudo qemu-system-x86_64 -kernel "/boot/${vmlinuz}" \
 -boot c -m 2049M -hda "${outdir}/bionic-server-cloudimg-amd64.img" \

--- a/components/ee/agent-smith/scripts/scp.sh
+++ b/components/ee/agent-smith/scripts/scp.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sshpass -p 'root' scp -o StrictHostKeychecking=no -P 2222 "$@"

--- a/components/ee/agent-smith/scripts/ssh.sh
+++ b/components/ee/agent-smith/scripts/ssh.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sshpass  -p 'root' ssh -o StrictHostKeychecking=no -p 2222 root@127.0.0.1 "$@"

--- a/components/ee/agent-smith/scripts/workspace.automount
+++ b/components/ee/agent-smith/scripts/workspace.automount
@@ -1,0 +1,10 @@
+[Unit]
+Description=Workspace automount
+ConditionPathExists=/workspace
+
+[Automount]
+Where=/workspace
+TimeoutIdleSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/components/ee/agent-smith/scripts/workspace.mount
+++ b/components/ee/agent-smith/scripts/workspace.mount
@@ -8,4 +8,4 @@ WantedBy=multi-user.target
 What=gitpod@10.0.2.2:/workspace
 Where=/workspace
 Type=fuse.sshfs
-Options=noauto,user,idmap=user,allow_other,Port=23001,IdentityFile=/root/.ssh/id_rsa
+Options=noauto,user,idmap=user,allow_other,Port=23001,IdentityFile=/root/.ssh/id_rsa,StrictHostKeyChecking=no

--- a/components/ee/agent-smith/scripts/workspace.mount
+++ b/components/ee/agent-smith/scripts/workspace.mount
@@ -8,4 +8,4 @@ WantedBy=multi-user.target
 What=gitpod@10.0.2.2:/workspace
 Where=/workspace
 Type=fuse.sshfs
-Options=noauto,user,idmap=user,allow_other,Port=23001,IdentityFile=/root/.ssh/id_rsa,StrictHostKeyChecking=no
+Options=noauto,user,idmap=user,exec,allow_other,Port=23001,IdentityFile=/root/.ssh/id_rsa,StrictHostKeyChecking=no

--- a/components/ee/agent-smith/scripts/workspace.mount
+++ b/components/ee/agent-smith/scripts/workspace.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Mount workspace inside of the VM
+
+[Install]
+WantedBy=multi-user.target
+
+[Mount]
+What=gitpod@10.0.2.2:/workspace
+Where=/workspace
+Type=fuse.sshfs
+Options=noauto,user,idmap=user,allow_other,Port=23001,IdentityFile=/root/.ssh/id_rsa

--- a/components/gitpod-protocol/go/gitpod-config_test.go
+++ b/components/gitpod-protocol/go/gitpod-config_test.go
@@ -24,7 +24,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-vm-mount.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -43,7 +43,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-build-commit.0",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:lf-workspace-vm-mount.0",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*PortsItems{

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -10,7 +10,8 @@ ENV WORKSPACE_KERNEL 5.4.0-1033-gke
 USER root
 
 ### QEMU (x86) and workspace kernel development tools
-RUN install-packages qemu qemu-system-x86 linux-image-$WORKSPACE_KERNEL libguestfs-tools sshpass
+RUN install-packages qemu qemu-system-x86 linux-image-$WORKSPACE_KERNEL libguestfs-tools openssh-sftp-server
+RUN ln -s /usr/lib/sftp-server /usr/libexec/sftp-server
 
 ### Clang and LLVM
 RUN install-packages clang-7 llvm-7


### PR DESCRIPTION
Introduces a couple of things:

- When you ssh into the BPF vm for agent smith you can find the workspace mounted at `/workspace`
- Removed the need of SSHing with the password, just `ssh vm`
- Use the `code` binary from inside the VM