### PR TITLE
[dashboard] Improve team members page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## June 2021
 
+- Add dodo to animals (thanks @a2br!) ([#4589](https://github.com/gitpod-io/gitpod/pull/4589))
 - Implement a new Teams UI in the dashboard (behind a feature flag). ([#4401)](https://github.com/gitpod-io/gitpod/pull/4401), )
 - Breaking Change: Make ports configured in `.gitpod.yml` private by default when no value for `visibility` is given (was public). This change is for security reasons. ([#4548](https://github.com/gitpod-io/gitpod/pull/4548))
 - Fix active workspace list in dashboard (show also older pinned workspaces) ([#4523](https://github.com/gitpod-io/gitpod/pull/4523))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - Improve backup stability when pods get evicted ([#4405](https://github.com/gitpod-io/gitpod/pull/4405))
 - Fix text color in workspaces list for dark theme ([#4410](https://github.com/gitpod-io/gitpod/pull/4410))
 - Better reflect incremental prebuilds in prebuilt workspace logs ([#4293](https://github.com/gitpod-io/gitpod/pull/4293))
+- Removing secondary class from the main CTA button to give proper weight (thanks @jordanhailey!) ([#4288](https://github.com/gitpod-io/gitpod/pull/4288)
+- Modify the "New Git Integration" experience to align with provider terminology (thanks @jordanhailey!) ([#4287](https://github.com/gitpod-io/gitpod/pull/4287)
 - Run shellcheck against scripts ([#4280](https://github.com/gitpod-io/gitpod/pull/4280))
 - Implement new Project and Team DB tables and entities ([#4368](https://github.com/gitpod-io/gitpod/pull/4368))
 - On gitpod.io 404 redirect to www.gitpod.io ([#4364](https://github.com/gitpod-io/gitpod/pull/4364))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## June 2021
 
+- Implement a new Teams UI in the dashboard (behind a feature flag). ([#4401)](https://github.com/gitpod-io/gitpod/pull/4401), )
 - Breaking Change: Make ports configured in `.gitpod.yml` private by default when no value for `visibility` is given (was public). This change is for security reasons. ([#4548](https://github.com/gitpod-io/gitpod/pull/4548))
 - Fix active workspace list in dashboard (show also older pinned workspaces) ([#4523](https://github.com/gitpod-io/gitpod/pull/4523))
 - Adding `ItemsList` component as a more maintainable and consistent way to render a list of workspaces, git integrations, environment variables, etc. ([#4454](https://github.com/gitpod-io/gitpod/pull/4454))

--- a/components/common-go/namegen/workspaceid.go
+++ b/components/common-go/namegen/workspaceid.go
@@ -199,6 +199,7 @@ var animals = []string{
 	"deer",
 	"dingo",
 	"dinosaur",
+	"dodo",
 	"dog",
 	"dolphin",
 	"donkey",

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -159,7 +159,6 @@ function App() {
                 <Route path="/integrations" exact component={Integrations} />
                 <Route path="/notifications" exact component={Notifications} />
                 <Route path="/plans" exact component={Plans} />
-                <Route path="/teams" exact component={Teams} />
                 <Route path="/variables" exact component={EnvironmentVariables} />
                 <Route path="/preferences" exact component={Preferences} />
                 <Route path="/install-github-app" exact component={InstallGitHubApp} />
@@ -189,8 +188,11 @@ function App() {
                         <p className="mt-4 text-lg text-gitpod-red">{decodeURIComponent(getURLHash())}</p>
                     </div>
                 </Route>
-                <Route path="/new-team" exact component={NewTeam} />
-                <Route path="/join-team" exact component={JoinTeam} />
+                <Route path="/teams">
+                    <Route exact path="/teams" component={Teams} />
+                    <Route exact path="/teams/new" component={NewTeam} />
+                    <Route exact path="/teams/join" component={JoinTeam} />
+                </Route>
                 {(teams || []).map(team => <Route path={`/${team.slug}`}>
                     <Route exact path={`/${team.slug}`}>
                         <Redirect to={`/${team.slug}/projects`} />

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -51,6 +51,9 @@ export default function Menu() {
     const showTeamsUI = user?.rolesOrPermissions?.includes('teams-and-projects') || window.location.hostname.endsWith('gitpod-dev.com') || window.location.hostname.endsWith('gitpod-io-dev.com');
     const team = getCurrentTeam(location, teams);
 
+    // Hide most of the top menu when in a full-page form.
+    const isMinimalUI = ['/new', '/teams/new'].includes(location.pathname);
+
     const [ teamMembers, setTeamMembers ] = useState<Record<string, TeamMemberInfo[]>>({});
     useEffect(() => {
         if (!showTeamsUI || !teams) {
@@ -161,7 +164,7 @@ export default function Menu() {
                                 <span className="flex-1 font-semibold">New Team</span>
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5"><path fill="currentColor" fill-rule="evenodd" d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z" clip-rule="evenodd" /></svg>
                             </div>,
-                            onClick: () => history.push("/new-team"),
+                            onClick: () => history.push("/teams/new"),
                         }
                     ]}>
                         <div className="flex h-full p-2 mt-0.5">
@@ -179,13 +182,13 @@ export default function Menu() {
     }
 
     return <>
-        <header className="lg:px-28 px-10 flex flex-col pt-4 space-y-4">
-            <div className="flex">
+        <header className={`lg:px-28 px-10 flex flex-col pt-4 space-y-4 ${isMinimalUI ? 'pb-4' : ''}`}>
+            <div className="flex h-10">
                 <div className="flex justify-between items-center pr-3">
                     <Link to="/">
                         <img src={gitpodIcon} className="h-6" />
                     </Link>
-                    <div className="ml-2 text-base">
+                    {!isMinimalUI && <div className="ml-2 text-base">
                         {showTeamsUI
                             ? renderTeamMenu()
                             : <nav className="flex-1">
@@ -197,13 +200,13 @@ export default function Menu() {
                                 </ul>
                             </nav>
                         }
-                    </div>
+                    </div>}
                 </div>
                 <div className="flex flex-1 items-center w-auto" id="menu">
                     <nav className="flex-1">
                         <ul className="flex flex-1 items-center justify-between text-base text-gray-700 space-x-2">
                             <li className="flex-1"></li>
-                            {rightMenu.map(entry => <li key={entry.title}>
+                            {!isMinimalUI && rightMenu.map(entry => <li key={entry.title}>
                                 <PillMenuItem name={entry.title} selected={isSelected(entry, location)} link={entry.link}/>
                             </li>)}
                         </ul>
@@ -230,7 +233,7 @@ export default function Menu() {
                     </div>
                 </div>
             </div>
-            {showTeamsUI && <div className="flex">
+            {!isMinimalUI && showTeamsUI && <div className="flex">
                 {leftMenu.map(entry => <TabMenuItem name={entry.title} selected={isSelected(entry, location)} link={entry.link}/>)}
             </div>}
         </header>

--- a/components/dashboard/src/components/ItemsList.tsx
+++ b/components/dashboard/src/components/ItemsList.tsx
@@ -22,7 +22,7 @@ export function Item(props: {
 }) {
     const headerClassName = "text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800";
     const notHeaderClassName = "rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light";
-    return <div className={`flex flex-grow flex-row w-full px-3 py-3 justify-between transition ease-in-out group ${props.header ? headerClassName : notHeaderClassName} ${props.className || ""}`}>
+    return <div className={`flex flex-grow flex-row w-full px-3 py-3 justify-between transition ease-in-out ${props.header ? headerClassName : notHeaderClassName} ${props.className || ""}`}>
         {props.children}
     </div>;
 }

--- a/components/dashboard/src/components/Tooltip.tsx
+++ b/components/dashboard/src/components/Tooltip.tsx
@@ -20,7 +20,7 @@ function Tooltip(props: TooltipProps) {
                 {props.children}
             </div>
             {expanded ?
-                <div style={{top: '-100%', left: '50%', transform: 'translate(-50%, -100%)'}} className={`mt-2 z-50 py-1 px-2 bg-gray-900 text-gray-100 text-sm absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-md truncated`}>
+                <div style={{top: '-100%', left: '50%', transform: 'translate(-50%, -100%)'}} className={`mt-2 z-50 py-1 px-2 bg-gray-900 text-gray-100 text-sm absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-md truncated whitespace-nowrap`}>
                     {props.content}
                 </div>
                 :

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -305,7 +305,7 @@ export default function NewProject() {
         </>)
     };
 
-    return (<div className="flex flex-col w-96 mt-16 mx-auto items-center">
+    return (<div className="flex flex-col w-96 mt-24 mx-auto items-center">
         <h1>New Project</h1>
         <p className="text-gray-500 text-center text-base">Projects allow you to set up and acess Prebuilds.</p>
 

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -27,7 +27,7 @@ export default function () {
             setCreationError(error);
         }
     }
-    return <div className="flex flex-col w-96 mt-16 mx-auto items-center">
+    return <div className="flex flex-col w-96 mt-24 mx-auto items-center">
         <h1>New Team</h1>
         <p className="text-gray-500 text-center text-base">Teams allow you to <strong>group multiple projects</strong>, <strong>collaborate with others</strong>, <strong>manage subscriptions</strong> with one centralized billing, and more. <a className="learn-more" href="https://www.gitpod.io/docs/teams/">Learn more</a></p>
         <form className="mt-16 w-full" onSubmit={createTeam}>

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -4,7 +4,7 @@
  * See License.enterprise.txt in the project root folder.
  */
 
-import { Team, TeamMemberInfo, TeamMembershipInvite } from "@gitpod/gitpod-protocol";
+import { Team, TeamMemberInfo, TeamMemberRole, TeamMembershipInvite } from "@gitpod/gitpod-protocol";
 
 export const TeamDB = Symbol('TeamDB');
 export interface TeamDB {
@@ -13,6 +13,8 @@ export interface TeamDB {
     findTeamsByUser(userId: string): Promise<Team[]>;
     createTeam(userId: string, name: string): Promise<Team>;
     addMemberToTeam(userId: string, teamId: string): Promise<void>;
+    setTeamMemberRole(userId: string, teamId: string, role: TeamMemberRole): Promise<void>;
+    removeMemberFromTeam(userId: string, teamId: string): Promise<void>;
     findTeamMembershipInviteById(inviteId: string): Promise<TeamMembershipInvite>;
     findGenericInviteByTeamId(teamId: string): Promise<TeamMembershipInvite | undefined>;
     resetGenericInvite(teamId: string): Promise<TeamMembershipInvite>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -10,7 +10,7 @@ import {
     Token, UserEnvVarValue, ResolvePluginsParams, PreparePluginUploadParams, Terms,
     ResolvedPlugins, Configuration, InstallPluginsParams, UninstallPluginParams, UserInfo, GitpodTokenType,
     GitpodToken, AuthProviderEntry, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo,
-    TeamMembershipInvite, Project, ProjectInfo, PrebuildInfo
+    TeamMembershipInvite, Project, ProjectInfo, PrebuildInfo, TeamMemberRole
 } from './protocol';
 import { JsonRpcProxy, JsonRpcServer } from './messaging/proxy-factory';
 import { Disposable, CancellationTokenSource } from 'vscode-jsonrpc';
@@ -114,6 +114,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getTeamMembers(teamId: string): Promise<TeamMemberInfo[]>;
     createTeam(name: string): Promise<Team>;
     joinTeam(inviteId: string): Promise<Team>;
+    setTeamMemberRole(teamId: string, userId: string, role: TeamMemberRole): Promise<void>;
+    removeTeamMember(teamId: string, userId: string): Promise<void>;
     getGenericInvite(teamId: string): Promise<TeamMembershipInvite>;
     resetGenericInvite(inviteId: string): Promise<TeamMembershipInvite>;
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -84,6 +84,8 @@ function readConfig(): RateLimiterConfig {
         "getTeamMembers": { group: "default", points: 1 },
         "createTeam": { group: "default", points: 1 },
         "joinTeam": { group: "default", points: 1 },
+        "setTeamMemberRole": { group: "default", points: 1 },
+        "removeTeamMember": { group: "default", points: 1 },
         "getGenericInvite": { group: "default", points: 1 },
         "resetGenericInvite": { group: "default", points: 1 },
         "getContentBlobUploadUrl": { group: "default", points: 1 },

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -166,9 +166,20 @@ export class OwnerResourceGuard implements ResourceAccessGuard {
             case "envVar":
                 return resource.subject.userId === this.userId;
             case "team":
-                return resource.members.some(m => m.userId === this.userId);
-            case "workspaceLog":
-                return resource.subject.ownerId === this.userId;
+                switch (operation) {
+                    case "create":
+                        // Anyone can create a new team.
+                        return true;
+                    case "get":
+                        // Only members can get infos about a team.
+                        return resource.members.some(m => m.userId === this.userId);
+                    case "update":
+                    case "delete":
+                        // Only owners can update or delete a team.
+                        return resource.members.some(m => m.userId === this.userId && m.role === "owner");
+                }
+                case "workspaceLog":
+                    return resource.subject.ownerId === this.userId;
         }
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -7,7 +7,7 @@
 import { BlobServiceClient } from "@gitpod/content-service/lib/blobs_grpc_pb";
 import { DownloadUrlRequest, DownloadUrlResponse, UploadUrlRequest, UploadUrlResponse } from '@gitpod/content-service/lib/blobs_pb';
 import { AppInstallationDB, UserDB, UserMessageViewsDB, WorkspaceDB, DBWithTracing, TracedWorkspaceDB, DBGitpodToken, DBUser, UserStorageResourcesDB, ProjectDB, TeamDB } from '@gitpod/gitpod-db/lib';
-import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, ProjectInfo, Project, ProviderRepository, PrebuildInfo } from '@gitpod/gitpod-protocol';
+import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, ProjectInfo, Project, ProviderRepository, PrebuildInfo, TeamMemberRole } from '@gitpod/gitpod-protocol';
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { AdminBlockUserRequest, AdminGetListRequest, AdminGetListResult, AdminGetWorkspacesRequest, AdminModifyPermanentWorkspaceFeatureFlagRequest, AdminModifyRoleOrPermissionRequest, WorkspaceAndInstance } from '@gitpod/gitpod-protocol/lib/admin-protocol';
 import { GetLicenseInfoResult, LicenseFeature, LicenseValidationResult } from '@gitpod/gitpod-protocol/lib/license-protocol';
@@ -1416,7 +1416,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     }
 
     public async getTeamMembers(teamId: string): Promise<TeamMemberInfo[]> {
-        this.checkUser("getTeamMemberships");
+        this.checkUser("getTeamMembers");
         const team = await this.teamDB.findTeamById(teamId);
         if (!team) {
             throw new ResponseError(ErrorCodes.NOT_FOUND, "Team not found");
@@ -1441,6 +1441,19 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         await this.teamDB.addMemberToTeam(user.id, invite.teamId);
         const team = await this.teamDB.findTeamById(invite.teamId);
         return team!;
+    }
+
+    public async setTeamMemberRole(teamId: string, userId: string, role: TeamMemberRole): Promise<void> {
+        this.checkUser("setTeamMemberRole");
+        await this.guardTeamOperation(teamId, "update");
+        await this.teamDB.setTeamMemberRole(userId, teamId, role);
+    }
+
+    public async removeTeamMember(teamId: string, userId: string): Promise<void> {
+        const user = this.checkUser("removeTeamMember");
+        // Users are free to leave any team themselves, but only owners can remove others from their teams.
+        await this.guardTeamOperation(teamId, user.id === userId ? "get" : "update");
+        await this.teamDB.removeMemberFromTeam(userId, teamId);
     }
 
     public async getGenericInvite(teamId: string): Promise<TeamMembershipInvite> {


### PR DESCRIPTION
Follow-up to https://github.com/gitpod-io/gitpod/pull/4490

- [x] Fix memberSince date
- [x] Replace paths `/new-team` and `/join-team` with `/teams/new` and `/teams/join` respectively
- [x] Hide most of the top menu when creating a new team
- [x] Implement removing team members & leaving teams
- [x] Implement searching & filtering team members
- [x] Implement changing team member roles