### PR TITLE
Add script for convenient db-migrations in GCP

### DIFF
--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -75,6 +75,9 @@ packages:
         - ["yarn", "--cwd", "mig/node_modules/@gitpod/gitpod-db", "typeorm", "migrations:run"]
   - name: docker
     type: docker
+    srcs:
+      - migrate.sh
+      - migrate_gcp.sh
     deps:
       - :migrations
     argdeps:

--- a/components/gitpod-db/migrate.sh
+++ b/components/gitpod-db/migrate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+set -euo pipefail
+
+yarn --cwd /app/node_modules/@gitpod/gitpod-db run wait-for-db
+yarn --cwd /app/node_modules/@gitpod/gitpod-db typeorm migrations:run

--- a/components/gitpod-db/migrate_gcp.sh
+++ b/components/gitpod-db/migrate_gcp.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+# This scipt connects via Google's cloud_sql_proxy to a database and runs the db-migrations
+
+# ENV variables for configuration:
+# * GOOGLE_APPLICATION_CREDENTIALS_DATA: contents of the crendetials files that cloud_sql_proxy uses for authentication
+# * GCP_DATABASE: database name
+# * DB_PASSWORD: database password
+
+# Example usage:
+# docker run --rm \
+#            --env GOOGLE_APPLICATION_CREDENTIALS_DATA='...' \
+#            --env GCP_DATABASE="gitpod-foobar:europe-west1:gitpod-foobar-baz" \
+#            --env DB_PASSWORD="..." \
+#            gcr.io/gitpod-core-dev/build/db-migrations:x1 /app/migrate_gcp.sh
+
+set -euo pipefail
+
+echo "$GOOGLE_APPLICATION_CREDENTIALS_DATA" > /tmp/gcp.json
+
+# start the proxy and background it
+GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json cloud_sql_proxy -instances="$GCP_DATABASE=tcp:3306" &
+proxy_pid=$!
+
+# run db-migrations
+DB_PORT=3306 /app/migrate.sh
+
+# stop the proxy
+kill $proxy_pid
+wait $proxy_pid


### PR DESCRIPTION
Since gitpod-images no longer have version-based tags we can no longer run db-migrations as a side-car of a weft job (unless we pass the commit-based-tag of the db-migrations as a parameter to the job). 

This PR enables us to 
* run db-migrations via `docker run` from the werft job
* get rid of some super-nasty process-syntonisation-code that was used for job-sidecar-communication

Related: https://github.com/gitpod-com/gitpod/pull/5564, https://github.com/gitpod-com/gitpod/issues/5560, https://github.com/gitpod-com/gitpod/pull/5559

This changes introduces `node` instead of `node-slim` as the base image because `slim` misses `wget` and ssl-certs that are being used by the proxy.

To test run:

```
docker run --rm \
            --env GOOGLE_APPLICATION_CREDENTIALS_DATA='...' \
            --env GCP_DATABASE="gitpod-foobar:europe-west1:gitpod-foobar-baz" \
            --env DB_PASSWORD="..." \
            gcr.io/gitpod-core-dev/build/db-migrations:x1 /app/migrate_gcp.sh
```