### PR TITLE
[supervisor] fix caching Not Found as OTS token

### DIFF
--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -264,7 +264,7 @@ func (c WorkspaceConfig) GetTokens(downloadOTS bool) ([]WorkspaceGitpodToken, er
 
 	if downloadOTS {
 		client := http.Client{
-			Timeout: 5 * time.Second,
+			Timeout: 30 * time.Second,
 		}
 
 		for i := range tks {
@@ -275,6 +275,9 @@ func (c WorkspaceConfig) GetTokens(downloadOTS bool) ([]WorkspaceGitpodToken, er
 			resp, err := client.Get(tks[i].TokenOTS)
 			if err != nil {
 				return nil, fmt.Errorf("cannot download token OTS: %w", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("cannot download token OTS: %d (%s)", resp.StatusCode, resp.Status)
 			}
 			tkn, err := io.ReadAll(resp.Body)
 			resp.Body.Close()


### PR DESCRIPTION
#### What it does

Gitpod Server OTS token expires after some time. If the workspace startup takes a while for some reasons then the supervisor gets Not Found, but since it does not check http status code it cached Not Found as a token. Triggering all kind of frontend issues consequently:

<img width="1904" alt="Screenshot 2021-06-23 at 10 55 25" src="https://user-images.githubusercontent.com/3082655/123045825-ceddaa00-d414-11eb-9ff7-813d81f67491.png">



#### How to test

Not sure. Expiration time is quite high, I don't understand how supervisor manages to miss the token.