### PR TITLE
[code] workspace sharing support

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 5ef446b4b19381b010df7c42ba47970a8b2bed01
+ENV GP_CODE_COMMIT 321b3d1e9ba280f1ae0f3b620037e8e119126c27
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #2812: workspace sharing support

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/e074a595b2901b745df223682ac1a9a2c04f1e35

#### How to test

- Start a workspace.
- You should see `Share` status bar indicator, click on it to start sharing.
- Open a workspace link by another user and check that a workspace can be accessed. Share indicator should show `Joined`, clicking on it should not do anything.
- Go to owner window again, share indicator should show `Shared` now, clicking on it should stop sharing.
- You can also verify that there are `Share` and `Stop Sharing` commands under the main menu and the remote menu (click on remote indicator in the status bar).