### PR TITLE
[code] workspace sharing support

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 5ef446b4b19381b010df7c42ba47970a8b2bed01
+ENV GP_CODE_COMMIT 11d7256b4a55983fdd7040a7ed01866e086afc85
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

#### What it does

- fix #2812: workspace sharing support
- fix #4528

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/11d7256b4a55983fdd7040a7ed01866e086afc85

#### How to test

- Start a workspace.
- You should see `Share` status bar indicator, click on it to start sharing. You should also be able to access owner actions like stop workspace, extend timeout and so on from the command palette and menus.
- Open a workspace link by another user and check that a workspace can be accessed. Share indicator should show `Shared by {owner}`, clicking on it should not do anything. You should not be able to access owner actions.
- Go to owner window again, share indicator should show `Shared` now, clicking on it should stop sharing.
- You can also verify that there are `Share` and `Stop Sharing` commands under the main menu and the remote menu (click on remote indicator in the status bar).