### PR TITLE
Fix db-migrations

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1623652164640-UpdateExamples.ts
+++ b/components/gitpod-db/src/typeorm/migration/1623652164640-UpdateExamples.ts
@@ -6,7 +6,7 @@
 
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class UpdateExamples1623220362199 implements MigrationInterface {
+export class UpdateExamples1623652164640 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
         let priority = 90;


### PR DESCRIPTION
On staging, the most recent applied migrations are
```
timestamp	name
1620865190518	OAuthAuthCodeDB1620865190518
1621920691254	InitialComSetup1621920691254
1622468446118	TeamsAndProjects1622468446118
1623652164639	TeamsMembershipInvite1623652164639
```

Running db-migrations on it leads to the following error:
```
Error during migration run:
Error: New migration found: UpdateExamples1623220362199, however this migration's timestamp is not valid. Migration's timestamp should not be older then migrations already executed in the database.
    at /app/node_modules/typeorm/migration/MigrationExecutor.js:91:39
    at Array.filter (<anonymous>)
    at MigrationExecutor.<anonymous> (/app/node_modules/typeorm/migration/MigrationExecutor.js:84:59)
    at step (/app/node_modules/typeorm/migration/MigrationExecutor.js:32:23)
    at Object.next (/app/node_modules/typeorm/migration/MigrationExecutor.js:13:53)
    at fulfilled (/app/node_modules/typeorm/migration/MigrationExecutor.js:4:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
error Command failed with exit code 1.
```

This is because `UpdateExamples1623220362199` has a timestamp older than `TeamsMembershipInvite1623652164639` even though it is not yet applied.

This PR changes the timestamp of `UpdateExamples1623220362199` to be newer than then one of `TeamsMembershipInvite1623652164639`