### PR TITLE
[server/auth] check for matching auth ID

### DIFF
--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -427,6 +427,14 @@ export class GenericAuthProvider implements AuthProvider {
             if (currentGitpodUser) {
                 // user is already logged in
 
+                // check for matching auth ID
+                const currentIdentity = currentGitpodUser.identities.find(i => i.authProviderId === this.authProviderId);
+                if (currentIdentity && currentIdentity.authId !== candidate.authId) {
+                    log.warn(`User is trying to connect with another provider identity.`, { ...defaultLogPayload, authUser, candidate, currentGitpodUser: User.censor(currentGitpodUser), clientInfo });
+                    done(AuthException.create("authId-mismatch", "Auth ID does not match with existing provider identity.", {}), undefined);
+                    return;
+                }
+
                 // we need to check current provider authorizations first...
                 try {
                     await this.userService.asserNoTwinAccount(currentGitpodUser, this.host, this.authProviderId, candidate);


### PR DESCRIPTION
This PR adds a test for matching `authId` on permission update.

# how to test
1. ensure being logged in
2. switch GH account in another tab
3. go to the `Integrations` page and try to update permissions
  –> this should fail because you now trying to authorize with a different GH account
  –> same should be true for GitLab