### PR TITLE
[core-dev] Add EE license to all core-dev installations

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -10,6 +10,9 @@ pod:
   - name: gcp-sa-release
     secret:
       secretName: gcp-sa-gitpod-release-deployer
+  - name: gpsh-coredev-license
+    secret:
+      secretName: gpsh-coredev-license
   - name: go-build-cache
     hostPath:
       path: /mnt/disks/ssd0/go-build-cache
@@ -43,6 +46,9 @@ pod:
       readOnly: true
     - name: gcp-sa-release
       mountPath: /mnt/secrets/gcp-sa-release
+      readOnly: true
+    - name: gpsh-coredev-license
+      mountPath: /mnt/secrets/gpsh-coredev
       readOnly: true
     - name: go-build-cache
       mountPath: /go-build-cache

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -149,7 +150,7 @@ func NewEvaluator(key []byte, domain string) (res *Evaluator) {
 		return &Evaluator{invalid: fmt.Sprintf("cannot verify key: %q", err)}
 	}
 
-	if domain != lic.Domain {
+	if !matchesDomain(lic.Domain, domain) {
 		return &Evaluator{invalid: "wrong domain"}
 	}
 
@@ -160,6 +161,24 @@ func NewEvaluator(key []byte, domain string) (res *Evaluator) {
 	return &Evaluator{
 		lic: lic.LicensePayload,
 	}
+}
+
+func matchesDomain(pattern, domain string) bool {
+	if pattern == "" {
+		return true
+	}
+	if domain == pattern {
+		return true
+	}
+
+	if strings.HasPrefix(pattern, "*.") && len(pattern) > 2 {
+		domainSuffix := pattern[1:]
+		if strings.HasSuffix(domain, domainSuffix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Evaluator determines what a license allows for

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -286,3 +286,30 @@ func TestEvalutorKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesDomain(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Pattern string
+		Domain  string
+		Matches bool
+	}{
+		{Name: "no domain pattern", Pattern: "", Domain: "foobar.com", Matches: true},
+		{Name: "exact match", Pattern: "foobar.com", Domain: "foobar.com", Matches: true},
+		{Name: "exact mismatch", Pattern: "foobar.com", Domain: "does-not-match.com", Matches: false},
+		{Name: "direct pattern match", Pattern: "*.foobar.com", Domain: "foobar.com", Matches: false},
+		{Name: "pattern sub match", Pattern: "*.foobar.com", Domain: "foo.foobar.com", Matches: true},
+		{Name: "direct pattern mismatch", Pattern: "*.foobar.com", Domain: "does-not-match.com", Matches: false},
+		{Name: "pattern sub mismatch", Pattern: "*.foobar.com", Domain: "foo.does-not-match.com", Matches: false},
+		{Name: "invalid pattern sub", Pattern: "foo.*.foobar.com", Domain: "foo.foobar.com", Matches: false},
+		{Name: "invalid pattern empty", Pattern: "*.", Domain: "foobar.com", Matches: false},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			act := matchesDomain(test.Pattern, test.Domain)
+			if act != test.Matches {
+				t.Errorf("unexpected domain match: expected %v, got %v", test.Matches, act)
+			}
+		})
+	}
+}

--- a/components/server/ee/src/license-source.ts
+++ b/components/server/ee/src/license-source.ts
@@ -23,9 +23,8 @@ export class DBLicenseKeySource implements LicenseKeySource {
             log.error("cannot get license key - even if you have a license, the EE features won't work", err);
         }
         return {
-            key: key || "",
+            key: key || this.env.gitpodLicense || "",
             domain: this.env.hostUrl.url.host,
         };
     }
-
 }


### PR DESCRIPTION
This PR adds an EE license to all core-dev preview environments. To this end I've extended licensor to support domain patterns in the form of `*.foobar.com` instead of just a direct domain match.
Then I've produced a single EE license for all `*.staging.gitpod-dev.com` domains and made it so that the `DBLicenseSource` falls back to the pre-existing `GITPOD_LICENSE` environment variable if no license is present in the database.

### How to test
1. Admin should work