### PR TITLE
[ws-daemon] mknod /dev/fuse as S_IFCHR to consider major:minor

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -193,13 +193,32 @@ func main() {
 			{
 				Name:  "mknod-fuse",
 				Usage: "creates /dev/fuse",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:     "uid",
+						Required: true,
+					},
+					&cli.IntFlag{
+						Name:     "gid",
+						Required: true,
+					},
+				},
 				Action: func(c *cli.Context) error {
 					err := unix.Mknod("/dev/fuse", 0666|unix.S_IFCHR, int(unix.Mkdev(10, 229)))
 					if err != nil {
 						return err
 					}
 
-					return os.Chmod("/dev/fuse", os.FileMode(0666))
+					err = os.Chmod("/dev/fuse", os.FileMode(0666))
+					if err != nil {
+						return err
+					}
+					err = os.Chown("/dev/fuse", c.Int("uid"), c.Int("gid"))
+					if err != nil {
+						return err
+					}
+
+					return nil
 				},
 			},
 		},

--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -194,7 +194,7 @@ func main() {
 				Name:  "mknod-fuse",
 				Usage: "creates /dev/fuse",
 				Action: func(c *cli.Context) error {
-					err := unix.Mknod("/dev/fuse", 0666, int(unix.Mkdev(10, 229)))
+					err := unix.Mknod("/dev/fuse", 0666|unix.S_IFCHR, int(unix.Mkdev(10, 229)))
 					if err != nil {
 						return err
 					}

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -215,7 +216,7 @@ func (wbs *InWorkspaceServiceServer) PrepareForUserNS(ctx context.Context, req *
 	//   - https://lists.linuxcontainers.org/pipermail/lxc-devel/2014-July/009797.html
 	//   - https://lists.linuxcontainers.org/pipermail/lxc-users/2014-October/007948.html
 	err = nsinsider(wbs.Session.InstanceID, int(containerPID), func(c *exec.Cmd) {
-		c.Args = append(c.Args, "mknod-fuse")
+		c.Args = append(c.Args, "mknod-fuse", "--uid", strconv.Itoa(wsinit.GitpodUID), "--gid", strconv.Itoa(wsinit.GitpodGID))
 	})
 	if err != nil {
 		log.WithError(err).WithFields(wbs.Session.OWI()).Error("PrepareForUserNS: cannot mknod fuse")


### PR DESCRIPTION
Doing a `mount` with fuse is broken because the fuse device inside the workspace is not specifying the device type.

Actual 
```
gitpod ~ $ ls -la /dev/fuse
-rw-rw-rw- 1 root root 0 Jun 23 09:42 /dev/fuse
```

Expected

```
ls -la /dev/fuse
crw-rw-rw- 1 root root 10, 229 Jun 23 14:06 /dev/fuse
```


Note how on the actual one we miss the device type `c` and the actual mkdev `maj:min` for this reason.