### PR TITLE
Add grpc client-side reconnection

### DIFF
--- a/chart/templates/content-service-deployment.yaml
+++ b/chart/templates/content-service-deployment.yaml
@@ -55,6 +55,8 @@ spec:
           runAsUser: 1000
 {{ include "gitpod.container.defaultEnv" $this | indent 8 }}
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
+        - name: GRPC_GO_RETRY
+          value: "on"
         volumeMounts:
         - name: config
           mountPath: "/config"

--- a/chart/templates/image-builder-deployment.yaml
+++ b/chart/templates/image-builder-deployment.yaml
@@ -118,5 +118,7 @@ spec:
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
         - name: DOCKER_HOST
           value: "tcp://localhost:2375"
+        - name: GRPC_GO_RETRY
+          value: "on"
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/templates/registry-facade-configmap.yaml
+++ b/chart/templates/registry-facade-configmap.yaml
@@ -25,7 +25,7 @@ data:
             },
             {{ end -}}
             "remoteSpecProvider": {
-                "addr": "ws-manager:{{ .Values.components.wsManager.ports.rpc.containerPort }}",
+                "addr": "dns:///ws-manager:{{ .Values.components.wsManager.ports.rpc.containerPort }}",
                 "tls": {
                     "ca": "/ws-manager-client-tls-certs/ca.crt",
                     "crt": "/ws-manager-client-tls-certs/tls.crt",

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -50,6 +50,8 @@ spec:
           runAsUser: 1000
 {{ include "gitpod.container.defaultEnv" $this | indent 8 }}
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
+        - name: GRPC_GO_RETRY
+          value: "on"
         volumeMounts:
         - name: cache
           mountPath: "/mnt/cache"

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -10,7 +10,7 @@ manager: []
 manager:
 {{- if not $comp.wsmanSkipSelf }}
 - name: "{{ template "gitpod.installation.shortname" . }}"
-  url: "ws-manager:8080"
+  url: "dns:///ws-manager:8080"
   state: "available"
   maxScore: 100
   score: 50

--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -23,7 +23,7 @@ data:
             "header": "{{- $comp.hostHeader -}}"
         },
         "workspaceInfoProviderConfig": {
-            "wsManagerAddr": "ws-manager:8080",
+            "wsManagerAddr": "dns:///ws-manager:8080",
             "reconnectInterval": "3s",
             "tls": {
                 "ca": "/ws-manager-client-tls-certs/ca.crt",

--- a/chart/templates/ws-scheduler-configmap.yaml
+++ b/chart/templates/ws-scheduler-configmap.yaml
@@ -42,7 +42,7 @@ data:
             "enabled": true,
             "driver": {
                 "wsman": {
-                    "addr": "ws-manager:8080",
+                    "addr": "dns:///ws-manager:8080",
                     "tls": {
                         "ca": "/ws-manager-client-tls-certs/ca.crt",
                         "crt": "/ws-manager-client-tls-certs/tls.crt",

--- a/components/content-service/cmd/run.go
+++ b/components/content-service/cmd/run.go
@@ -42,6 +42,11 @@ var runCmd = &cobra.Command{
 		reg.MustRegister(grpcMetrics)
 
 		grpcOpts := []grpc.ServerOption{
+			// terminate the connection if the client pings more than once every 2 seconds
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             2 * time.Second,
+				PermitWithoutStream: true,
+			}),
 			// We don't know how good our cients are at closing connections. If they don't close them properly
 			// we'll be leaking goroutines left and right. Closing Idle connections should prevent that.
 			grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionIdle: 30 * time.Minute}),

--- a/components/ee/ws-scheduler/pkg/scaler/driver.go
+++ b/components/ee/ws-scheduler/pkg/scaler/driver.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -78,7 +79,16 @@ func NewWorkspaceManagerPrescaleDriver(config WorkspaceManagerPrescaleDriverConf
 	}
 	config.WorkspaceImage = imgRef.String()
 
-	var grpcOpts []grpc.DialOption
+	grpcOpts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithBackoffMaxDelay(5 * time.Second),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                5 * time.Second,
+			Timeout:             time.Second,
+			PermitWithoutStream: true,
+		}),
+	}
+
 	if config.WsManager.TLS != nil {
 		ca := config.WsManager.TLS.CA
 		crt := config.WsManager.TLS.Certificate

--- a/components/image-builder/cmd/run.go
+++ b/components/image-builder/cmd/run.go
@@ -87,6 +87,11 @@ var runCmd = &cobra.Command{
 		}
 
 		grpcOpts := []grpc.ServerOption{
+			// terminate the connection if the client pings more than once every 2 seconds
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             2 * time.Second,
+				PermitWithoutStream: true,
+			}),
 			// We don't know how good our cients are at closing connections. If they don't close them properly
 			// we'll be leaking goroutines left and right. Closing Idle connections should prevent that.
 			grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionIdle: 30 * time.Minute}),

--- a/components/registry-facade/cmd/run.go
+++ b/components/registry-facade/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -64,7 +65,7 @@ var runCmd = &cobra.Command{
 
 		promreg := prometheus.NewRegistry()
 		gpreg := prometheus.WrapRegistererWithPrefix("gitpod_registry_facade_", promreg)
-		rtt, err := registry.NewMeasuringRegistryRoundTripper(http.DefaultTransport, prometheus.WrapRegistererWithPrefix("downstream_", gpreg))
+		rtt, err := registry.NewMeasuringRegistryRoundTripper(newDefaultTransport(), prometheus.WrapRegistererWithPrefix("downstream_", gpreg))
 		if err != nil {
 			log.WithError(err).Fatal("cannot registry metrics")
 		}
@@ -123,6 +124,23 @@ var runCmd = &cobra.Command{
 		case <-registryDoneChan:
 		}
 	},
+}
+
+func newDefaultTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: false,
+		}).DialContext,
+		MaxIdleConns:          0,
+		MaxIdleConnsPerHost:   32,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 5 * time.Second,
+		DisableKeepAlives:     true,
+	}
 }
 
 func init() {

--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -16,13 +16,14 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
 	distv2 "github.com/docker/distribution/registry/api/v2"
-	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/common-go/tracing"
-	"github.com/gitpod-io/gitpod/registry-facade/api"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opentracing/opentracing-go"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/gitpod-io/gitpod/registry-facade/api"
 )
 
 func (reg *Registry) handleBlob(ctx context.Context, r *http.Request) http.Handler {

--- a/components/registry-facade/pkg/registry/imagecfg.go
+++ b/components/registry-facade/pkg/registry/imagecfg.go
@@ -9,12 +9,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/gitpod-io/gitpod/registry-facade/api"
 	lru "github.com/hashicorp/golang-lru"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+
+	"github.com/gitpod-io/gitpod/registry-facade/api"
 )
 
 // ErrRefInvalid is returned by spec provider who cannot interpret the ref

--- a/components/registry-facade/pkg/registry/layersource.go
+++ b/components/registry-facade/pkg/registry/layersource.go
@@ -16,12 +16,13 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
-	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/registry-facade/api"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/xerrors"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/registry-facade/api"
 )
 
 const (

--- a/components/registry-facade/pkg/registry/layersource_ext_test.go
+++ b/components/registry-facade/pkg/registry/layersource_ext_test.go
@@ -10,10 +10,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry"
-	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/opencontainers/go-digest"
+
+	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry"
+	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry/mock"
 )
 
 func TestRevisioingLayerSource(t *testing.T) {

--- a/components/registry-facade/pkg/registry/manifest.go
+++ b/components/registry-facade/pkg/registry/manifest.go
@@ -20,14 +20,15 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
 	distv2 "github.com/docker/distribution/registry/api/v2"
-	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/common-go/tracing"
-	"github.com/gitpod-io/gitpod/registry-facade/api"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/gitpod-io/gitpod/registry-facade/api"
 )
 
 func (reg *Registry) handleManifest(ctx context.Context, r *http.Request) http.Handler {

--- a/components/ws-daemon/cmd/run.go
+++ b/components/ws-daemon/cmd/run.go
@@ -45,6 +45,11 @@ var runCmd = &cobra.Command{
 		reg.MustRegister(grpcMetrics)
 
 		grpcOpts := []grpc.ServerOption{
+			// terminate the connection if the client pings more than once every 2 seconds
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             2 * time.Second,
+				PermitWithoutStream: true,
+			}),
 			// We don't know how good our cients are at closing connections. If they don't close them properly
 			// we'll be leaking goroutines left and right. Closing Idle connections should prevent that.
 			grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionIdle: 30 * time.Minute}),

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -122,6 +122,11 @@ var runCmd = &cobra.Command{
 		metrics.Registry.MustRegister(grpcMetrics)
 
 		grpcOpts := []grpc.ServerOption{
+			// terminate the connection if the client pings more than once every 2 seconds
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             2 * time.Second,
+				PermitWithoutStream: true,
+			}),
 			// We don't know how good our cients are at closing connections. If they don't close them properly
 			// we'll be leaking goroutines left and right. Closing Idle connections should prevent that.
 			grpc.KeepaliveParams(keepalive.ServerParameters{MaxConnectionIdle: 30 * time.Minute}),


### PR DESCRIPTION
In case of connection errors (pod restart), reconnect.

**Example error:**
```console
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"invalid ref: rpc error: code = Unavailable desc = error reading from server: read tcp 10.0.128.131:55298-\u003e172.20.175.142:8080: read: no route to host:\n    github.com/gitpod-io/gitpod/registry-facade/pkg/registry.(*RemoteSpecProvider).GetSpec\n        github.com/gitpod-io/gitpod/registry-facade/pkg/registry/imagecfg.go:55\n  - invalid 
``` 

**How to test:**
- start a workspace and close it.
- kill `ws-manager` pod
- open a new workspace. 

Right now we only see errors in the log (and "Pulling container image …")
