### PR TITLE
[werft] No default value for integration test results

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -47,10 +47,10 @@ export async function build(context, version) {
 
     try {
         exec(`pre-commit run --from-ref origin/HEAD --to-ref HEAD`);
-        exec(`werft log result -d "validate changes" -c github-check-test conclusion success`);
+        werft.result("validate changes", "github-check-changes", "conclusion success");
         werft.done('validate-changes');
     } catch (err) {
-        exec(`werft log result -d "validate changes" -c github-check-tests conclusion failure`);
+        werft.result("validate changes", "github-check-changes", "conclusion failure");
         werft.fail('validate-changes', err);
     }
 
@@ -229,7 +229,7 @@ export async function build(context, version) {
         sweeperImage
     };
     await deployToDev(deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
-    await triggerIntegrationTests(deploymentConfig, !withIntegrationTests)
+    await triggerIntegrationTests(deploymentConfig.version, deploymentConfig.namespace, context.Owner, !withIntegrationTests)
 }
 
 interface DeploymentConfig {
@@ -426,7 +426,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 /**
  * Trigger integration tests
  */
-export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig, skip: boolean) {
+export async function triggerIntegrationTests(version: string, namespace: string, username: string, skip: boolean) {
     werft.phase(phases.TRIGGER_INTEGRATION_TESTS, "Trigger integration tests");
 
     if (skip) {
@@ -442,15 +442,15 @@ export async function triggerIntegrationTests(deploymentConfig: DeploymentConfig
         const imageVersion = exec(`docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${version} cat /versions.yaml | yq r - 'components.integrationTest.version'`, { silent: true })
             .stdout.trim();
 
-        exec(`git config --global user.name "${context.Owner}"`);
+        exec(`git config --global user.name "${username}"`);
         const annotations = [
             `version=${imageVersion}`,
-            `namespace=${deploymentConfig.namespace}`,
-            `username=${context.Owner}`,
+            `namespace=${namespace}`,
+            `username=${username}`,
             `updateGitHubStatus=gitpod-io/gitpod`
         ].map(annotation => `-a ${annotation}`).join(' ')
-        const jobId = exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.TRIGGER_INTEGRATION_TESTS}).trim();
-        werft.log(phases.TRIGGER_INTEGRATION_TESTS, `Triggered job ${jobId} - https://werft.gitpod-dev.com/job/${jobId}/logs`)
+        exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, {slice: phases.TRIGGER_INTEGRATION_TESTS}).trim();
+
         werft.done(phases.TRIGGER_INTEGRATION_TESTS);
     } catch (err) {
         werft.fail(phases.TRIGGER_INTEGRATION_TESTS, err);

--- a/.werft/util/shell.ts
+++ b/.werft/util/shell.ts
@@ -14,6 +14,9 @@ export const werft = {
         throw err;
     },
     done: (slice) => console.log(`[${slice}|DONE]`),
+    result: (description: string, channel: string, value: string) => {
+        exec(`werft log result -d "${description}" -c "${channel}" ${value}`);
+    },
 }
 
 export type ExecOptions = shell.ExecOptions & {


### PR DESCRIPTION
This renames the GitHub check for "validate changes" to `github-check-changes` so that their no longer confused/overlap with integration tests.
 
- [ ] /werft with-integration-tests