### PR TITLE
Check if .gitpod.yaml was changed before reviewers open the workspace

### DIFF
--- a/.github/workflows/check-gitpodyaml.yml
+++ b/.github/workflows/check-gitpodyaml.yml
@@ -1,0 +1,24 @@
+name: Check gitpod.yaml changes
+on:
+  push:
+    paths:
+      - ".gitpod.yml"
+      - ".github/workflows/check-gitpodyaml.yml"
+  pull_request:
+    paths:
+      - ".gitpod.yml"
+      - ".github/workflows/check-gitpodyaml.yml"
+
+jobs:
+  notify:
+    name: Build and upload model
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+          -X POST -d '{"body": ":warning: Hew reviewer! BE CAREFUL :warning: \n Review the code before opening in your Gitpod. .gitpod.yaml was changed and it might be harfmul."}' \
+          "https://api.github.com/repos/gitpod-io/gitpod/issues/${pull_number}/comments"


### PR DESCRIPTION
Informs reviewer on whether the current PR changed the .gitpod.yml file or the workfloow that does this check.

It only runs on PRs actually modifying one of those files.

I thought about doing this with werft but werft usually happens after the user start doing a review of the files so I thought that doing it in werft was not correct timing-wise.