### PR TITLE
[code] deprecate user uploaded extensions

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 11d7256b4a55983fdd7040a7ed01866e086afc85
+ENV GP_CODE_COMMIT 19c309ee89e7451ffc21df65cf3efe2e65d30e52
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

- fix #3308

It contains https://github.com/gitpod-io/gitpod/pull/4580 so should be merged afterwards.

Changes in Gitpod Code: https://github.com/gitpod-io/vscode/commit/19c309ee89e7451ffc21df65cf3efe2e65d30e52

<a href="https://www.loom.com/share/d8c0743df5cf47df95ccc24051f29357"><img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d8c0743df5cf47df95ccc24051f29357-with-play.gif"> </a>

#### How to test

- Start a workspace: https://ak-deprecate-user-extensions.staging.gitpod-dev.com/#https://github.com/akosyakov/parcel-demo
- Create gitpod.yml with user uploaded extension records for instance:
```yaml
vscode:
  extensions:
    - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
    - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==
    - ms-kubernetes-tools.vscode-kubernetes-tools@1.2.1:j58HdmA0K7d9a9sEkogZNw==
    - bajdzis.vscode-database@2.2.1:uXdjV53wtoTevFK6HOh3pQ==
    - hashicorp.terraform@2.1.1:QEP7gdWtMuY+j8RZ5OLDkA==
    - stkb.rewrap@1.13.0:yEx8nRSXlfXAHqsbkTJpdA==
    - golang.go@0.14.4:Z3iqHRuIxskc0nruY4MpEQ==
    - https://github.com/golang/vscode-go/releases/download/v0.26.0/go-0.26.0.vsix
    - https://github.com/golang/vscode-go/releases/download2/v0.26.0/go-0.26.222.vsix
```
- You should see a warning that user uploaded extensions are deprecated and a quick fix to resolve them all against Open VSX.
- Now add some invalid extensions in .gitpod.yml, you should get an error that an extension cannot be resolved.
   - Valid extension is either URL pointing to vsix file, just id, i.e. `golang.go`, or id@full-version, i.e. golang.go@0.14.4, everything else is invalid, i.e. golang.go@0
