### PR TITLE
[code] wait for extension host to activate cli server

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 19c309ee89e7451ffc21df65cf3efe2e65d30e52
+ENV GP_CODE_COMMIT 6b591c22617b64c540c71bcb8585f02f7d62b06e
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

#### What it does

-  fix #4036

This PR alignes with the behaviour which had before in Theia, namely, Code CLI waits till there is at least one client before sending a command without any timeouts.

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/6b591c22617b64c540c71bcb8585f02f7d62b06e

#### How to test

- Start a workspace: https://akosyakov-gp-open-preview-should-4036.staging.gitpod-dev.com/#https://github.com/akosyakov/parcel-demo
- Check that editor for index.js and preview for 1234 port has been started by task terminal
- Open another window for the same workspace
- Run gp open and preview in both terminals and check that current window always react