### PR TITLE
[preview environments] Some quality-of-(dev)live improvements

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -26,6 +26,15 @@ tracing:
   samplerParam: "1"
 
 components:
+
+  agentSmith:
+    name: "agent-smith"
+    disabled: false
+    # in preview envs, we never want DaemonSets not to be scheduled (because they don't trigger scaleup)
+    resources:
+      cpu: 1m
+      memory: 32Mi
+
   server:
     replicas: 1
     makeNewUsersAdmin: true # for development
@@ -38,6 +47,10 @@ components:
 
   registryFacade:
     daemonSet: true
+    # in preview envs, we never want DaemonSets not to be scheduled (because they don't trigger scaleup)
+    resources:
+      cpu: 1m
+      memory: 32Mi
 
   contentService:
     remoteStorage:
@@ -132,6 +145,10 @@ components:
         enabled: true
       seccompProfileInstaller:
         enabled: true
+    # in preview envs, we never want DaemonSets not to be scheduled (because they don't trigger scaleup)
+    resources:
+      cpu: 1m
+      memory: 32Mi
 
   wsScheduler:
     scaler:

--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -163,6 +163,29 @@ minio:
   serviceAccount:
     name: ws-daemon
     create: false
+  # make sure the pod ends up where it's supposed to stay
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: dev/workload
+            operator: In
+            values:
+            - "workload"
+
+mysql:
+  primary:
+    # make sure the pod ends up where it's supposed to stay
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: dev/workload
+              operator: In
+              values:
+              - "workload"
 
 rabbitmq:
   # ensure shovels are configured on boot
@@ -172,6 +195,16 @@ rabbitmq:
   auth:
     username: override-me
     password: override-me
+  # make sure the pod ends up where it's supposed to stay
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: dev/workload
+            operator: In
+            values:
+            - "workload"
 
 cert-manager:
   enabled: true

--- a/dev/charts/sweeper/values.yaml
+++ b/dev/charts/sweeper/values.yaml
@@ -23,7 +23,8 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-        - matchExpressions:
-          - key: cloud.google.com/gke-nodepool
-            operator: In
-            values: ["services"]
+      - matchExpressions:
+        - key: dev/workload
+          operator: In
+          values:
+          - "workload"


### PR DESCRIPTION
This PR:
 - ensures all pods stay on the NodePool they should
 - thus enabling us to down-scale as planned (and thus cycle nodes regularly, which greatly increases stability)
 - make sure we never fail because of "less CPU" for DaemonSets (agent-smith, ws-daemon, registry-facade)