### PR TITLE
[code] complete validations of extensions in .gitpod.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## June 2021
 
+- Complete validations of VS Code extensions in .gitpod.yml ([#4645](https://github.com/gitpod-io/gitpod/pull/4645)):
+
+| Check | Quick Fixes |
+| --- | --- |
+| Deprecated user uploaded extensions | Resolve them against Open VSX |
+| Extensions cannot be found in Open VSX | Remove from .gitpod.yml or search for them in Open VSX |
+| Extensions URLs cannot be resolved to valid VSIX files | N/A |
+| Extensions is installed for the workspace but missing in .gitpod.yml | Add to .gitpod.yml or uninstall |
+| Extensions is uninstalled but present in .gitpod.yml | Remove from .gitpod.yml or install as no synced |
+
 - Add dodo to animals (thanks @a2br!) ([#4589](https://github.com/gitpod-io/gitpod/pull/4589))
 - Implement a new Teams UI in the dashboard (behind a feature flag). ([#4401)](https://github.com/gitpod-io/gitpod/pull/4401), )
 - Breaking Change: Make ports configured in `.gitpod.yml` private by default when no value for `visibility` is given (was public). This change is for security reasons. ([#4548](https://github.com/gitpod-io/gitpod/pull/4548))

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 6b591c22617b64c540c71bcb8585f02f7d62b06e
+ENV GP_CODE_COMMIT d876a1ddea6be01fca9bbc373d21d0ac4c56d2c3
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does 

- fix #4642

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/d876a1ddea6be01fca9bbc373d21d0ac4c56d2c3

There are now following validations and quick fixes:
| Check | Quick Fixes |
| --- | --- |
| Deprecated user uploaded extensions | Resolve them against Open VSX |
| Extensions cannot be found in Open VSX | Remove from .gitpod.yml or search for them in Open VSX |
| Extensions URLs cannot be resolved to valid VSIX files | N/A |
| Extensions is installed for the workspace but missing in .gitpod.yml | Add to .gitpod.yml or uninstall |
| Extensions is uninstalled but present in .gitpod.yml | Remove from .gitpod.yml or install as no synced |

#### How to test

- Start a workspace: https://ak-deprecate-user-extensions.staging.gitpod-dev.com/#https://github.com/akosyakov/parcel-demo
- Create gitpod.yml with user uploaded extension records for instance:
```yaml
vscode:
  extensions:
    - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
    - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==
    - ms-kubernetes-tools.vscode-kubernetes-tools@1.2.1:j58HdmA0K7d9a9sEkogZNw==
    - bajdzis.vscode-database@2.2.1:uXdjV53wtoTevFK6HOh3pQ==
    - hashicorp.terraform@2.1.1:QEP7gdWtMuY+j8RZ5OLDkA==
    - stkb.rewrap@1.13.0:yEx8nRSXlfXAHqsbkTJpdA==
    - golang.go@0.14.4:Z3iqHRuIxskc0nruY4MpEQ==
    - https://github.com/golang/vscode-go/releases/download/v0.26.0/go-0.26.0.vsix
    - https://github.com/golang/vscode-go/releases/download2/v0.26.0/go-0.26.222.vsix
```
- Play with it, try to install and uninstall some extensions, and check that validations (quick fixes) pop up as described above.