### PR TITLE
[werft] Install gitpod in k3s ws cluster

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -315,14 +315,12 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         // trigger certificate issuing
         werft.log('certificate', "organizing a certificate for the preview environment...");
         await issueMetaCerts();
+        await installMetaCertificates();
         if (k3sWsCluster) {
             await issueK3sWsCerts(k3sWsProxyIP);
-        }
-        await installMetaCertificates();
-
-        if (k3sWsCluster) {
             await installWsCertificates();
         }
+
         werft.done('certificate');
 
         werft.done('prep');

--- a/.werft/util/gpctl.ts
+++ b/.werft/util/gpctl.ts
@@ -1,0 +1,43 @@
+import * as shell from 'shelljs';
+
+function buildRequiredFlags(pathToKubeConfig: string): string {
+    if (pathToKubeConfig != "") {
+        return ` --kubeconfig=${pathToKubeConfig}`
+    }
+    return ""
+}
+
+export function buildGpctlBinary() {
+    shell.exec(`cd /workspace/dev/gpctl && go build && cd -`)
+}
+
+export function printClustersList(pathToKubeConfig: string): string {
+    let cmd = `/workspace/dev/gpctl/gpctl clusters list` + buildRequiredFlags(pathToKubeConfig)
+    const result = shell.exec(cmd).trim()
+    return result
+}
+
+export function uncordonCluster(pathToKubeConfig: string, name: string): string {
+    let cmd = `/workspace/dev/gpctl/gpctl clusters uncordon --name=${name}` + buildRequiredFlags(pathToKubeConfig)
+    const result = shell.exec(cmd).trim()
+    return result
+}
+
+export function registerCluster(pathToKubeConfig: string, name: string, url: string): string {
+    let cmd = `/workspace/dev/gpctl/gpctl clusters register \
+	--name ${name} \
+	--hint-cordoned \
+	--hint-govern \
+	--tls-path ./wsman-tls \
+	--url ${url}` + buildRequiredFlags(pathToKubeConfig)
+
+    const result = shell.exec(cmd).trim()
+    return result
+}
+
+export function getClusterTLS(pathToKubeConfig: string): string {
+    let cmd = `/workspace/dev/gpctl/gpctl clusters get-tls-config` + buildRequiredFlags(pathToKubeConfig)
+    const result = shell.exec(cmd).trim()
+    return result
+}
+

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -4,10 +4,10 @@ import { exec, ExecOptions, werft } from './shell';
 
 export const IS_PREVIEW_APP_LABEL: string = "isPreviewApp";
 
-export function setKubectlContextNamespace(namespace, shellOpts) {
+export function setKubectlContextNamespace(pathToKubeConfig, namespace, shellOpts) {
     [
-        "kubectl config current-context",
-        `kubectl config set-context --current --namespace=${namespace}`
+        `export KUBECONFIG=${pathToKubeConfig} && kubectl config current-context`,
+        `export KUBECONFIG=${pathToKubeConfig} && kubectl config set-context --current --namespace=${namespace}`
     ].forEach(cmd => exec(cmd, shellOpts));
 }
 

--- a/.werft/values.disableMeta.yaml
+++ b/.werft/values.disableMeta.yaml
@@ -3,9 +3,6 @@ components:
   proxy:
     disabled: true
 
-  wsProxy:
-    hostHeader: Host
-
   wsManagerBridge:
     disabled: true
 
@@ -35,5 +32,3 @@ minio:
 mysql:
   enabled: false
 
-registry-facade:
-  enabled: false

--- a/.werft/values.k3sWsCluster.yaml
+++ b/.werft/values.k3sWsCluster.yaml
@@ -1,0 +1,175 @@
+installation:
+  stage: devstaging
+  tenant: gitpod-core
+  region: europe-west1
+  cluster: "00"
+  shortname: "k3s"
+hostname: staging.gitpod-dev.com
+imagePrefix: eu.gcr.io/gitpod-core-dev/build/
+certificatesSecret:
+  secretName: proxy-config-certificates
+version: not-set
+imagePullPolicy: Always
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: gitpod.io/workload_services
+          operator: In
+          values:
+          - "true"
+authProviders: []
+tracing:
+  endoint: http://jaeger-collector:14268/api/traces
+  samplerType: const
+  samplerParam: "1"
+
+components:
+  wsManagerBridge:
+    disabled: true
+
+  agentSmith:
+    name: "agent-smith"
+    disabled: false
+    # in preview envs, we never want DaemonSets not to be scheduled (because they don't trigger scaleup)
+    resources:
+      cpu: 1m
+      memory: 32Mi
+
+  registryFacade:
+    daemonSet: true
+    # in preview envs, we never want DaemonSets not to be scheduled (because they don't trigger scaleup)
+    resources:
+      cpu: 1m
+      memory: 32Mi
+
+  contentService:
+    remoteStorage:
+      blobQuota: 1073741824 # 1 GiB
+
+  workspace:
+    # configure GCP registry
+    pullSecret:
+      secretName: gcp-sa-registry-auth
+    affinity:
+      default: "gitpod.io/workload_workspace"
+    templates:
+      default:
+        spec:
+          dnsConfig:
+            nameservers:
+            - 1.1.1.1
+            - 8.8.8.8
+          dnsPolicy: None   # do NOT query against K8s DNS (https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)
+          env:
+          - name: THEIA_PREVENT_METADATA_ACCESS
+            value: true
+      regular:
+        spec:
+          containers:
+          - name: "workspace"
+            env:
+            - name: THEIA_RATELIMIT_LOG
+              value: "50"
+            - name: SUPERVISOR_DEBUG_ENABLE
+              value: "true"
+      prebuild:
+        spec:
+          containers:
+          - name: workspace
+            # Intended to reduce the density for prebuilds
+            resources:
+              limits:
+                cpu: "5"
+                memory: 12Gi
+              requests:
+                cpu: 1m
+                ephemeral-storage: 5Gi
+                memory: 4608Mi  # = 2 * 2304Mi
+
+  # Enable events trace
+  wsManager:
+    eventTraceLogLocation: "/tmp/evts.json"
+
+  wsDaemon:
+    hostWorkspaceArea: /mnt/disks/ssd0/workspaces
+    volumes:
+    - name: gcloud-tmp
+      hostPath:
+        path: /mnt/disks/ssd0/sync-tmp
+        type: DirectoryOrCreate
+    volumeMounts:
+    - mountPath: /mnt/sync-tmp
+      name: gcloud-tmp
+    userNamespaces:
+      fsShift: fuse
+      shiftfsModuleLoader:
+        enabled: false
+      seccompProfileInstaller:
+        enabled: true
+    # in preview envs, we never want DaemonSets not to be scheduled (because they don't trigger scaleup)
+    resources:
+      cpu: 1m
+      memory: 32Mi
+
+  wsScheduler:
+    scaler:
+      enabled: true
+      controller:
+        kind: "constant"
+        constant:
+          setpoint: 1
+
+  # Enable ws-proxy in dev
+  wsProxy:
+    useHTTPS: true
+    hostHeader: Host
+    name: "ws-proxy"
+    disabled: false
+    replicas: 1
+    serviceType: "LoadBalancer"
+    wsManagerProxy:
+      enabled: true
+    ports:
+      wsManagerProxy:
+        expose: true
+        containerPort: 8081
+        servicePort: 8081
+      httpsProxy:
+        expose: true
+        containerPort: 9090
+        servicePort: 443
+      httpProxy:
+        expose: true
+        containerPort: 8080
+        servicePort: 80
+
+  imageBuilder:
+    disabled: true
+    hostDindData: "/mnt/disks/ssd0/builder"
+    # configure GCP registry
+    registry:
+      name: eu.gcr.io/gitpod-core-dev/registry
+      secretName: gcp-sa-registry-auth
+      path: gcp-sa-registry-auth
+    registryCerts: []
+
+
+# configure GCP registry
+docker-registry:
+  enabled: false
+
+rabbitmq:
+  # ensure shovels are configured on boot
+  disabled: true
+  enabled: false
+
+cert-manager:
+  enabled: true
+
+dbMigrations:
+  disabled: true
+
+db:
+  autoMigrate: false


### PR DESCRIPTION
## What?
This PR does the following two things broadly:

1. Disable support of launching ws cluster separately in core-dev project dev cluster preview env - This was a complex procedure where you would need to create two branches and have them rely on one another
2. Support launching ws components in a separate K3s cluster

## How ?
The code has been refactored in such a way that if you provide werft flag `k3s-ws` then the deployment will occur in two different clusters:

### Dev cluster
The meta component will be deployed along with the ws components in the dev cluster. However, the static config which used to add the self cluster as a workspace target would be disabled, thus, the meta component would only work as meta clsuter.

### K3s ws cluster
A workspace cluster deployment will occur in a dedicated namespace in the k3s cluster (similar to the dev cluster). In this deployment we use external IP for ws-proxy. Hence, there is no ingress involved whilst accessing the workspace. The external IP will be created by the werft using gcloud command . I have added relevant create, get and delete permissions to the gitpod-deployer SA.

The static external IP created is named same as the namespace.

### Registration
Once the deployments have succeeded, we explicitly build the gpctl binary and then use it to register our workspace cluster to the meta cluster.

I have introduced the subdomain `*.ws-k3s.` for k3s ws cluster. For the meta i.e. dev cluster the subdomain `*.ws-dev.` remains the same.


## What's next
Unlike the deployments of dev cluster, the k3s cluster deployments are not cleaned up. I will raise another PR for this.

--werft k3s-ws