### PR TITLE
Rewrite webview URL in blobserve

### DIFF
--- a/chart/templates/blobserve-configmap.yaml
+++ b/chart/templates/blobserve-configmap.yaml
@@ -28,7 +28,11 @@ data:
                 },
                 "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) }}": {
                     "prePull": ["{{- template "gitpod.comp.version" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) -}}"],
-                    "workdir": "/ide"
+                    "workdir": "/ide",
+                    "replacements": [
+                        { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" },
+                        { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js" }
+                    ]
                 },
                 "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}": {
                     "prePull": ["{{- template "gitpod.comp.version" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) -}}"],

--- a/components/blobserve/pkg/blobserve/blobserve.go
+++ b/components/blobserve/pkg/blobserve/blobserve.go
@@ -38,8 +38,9 @@ type Config struct {
 	Port    int           `json:"port"`
 	Timeout util.Duration `json:"timeout,omitempty"`
 	Repos   map[string]struct {
-		PrePull []string `json:"prePull,omitempty"`
-		Workdir string   `json:"workdir,omitempty"`
+		PrePull      []string            `json:"prePull,omitempty"`
+		Workdir      string              `json:"workdir,omitempty"`
+		Replacements []StringReplacement `json:"replacements,omitempty"`
 	} `json:"repos"`
 	// AllowAnyRepo enables users to access any repo/image, irregardles if they're listed in the
 	// ref config or not.
@@ -48,6 +49,12 @@ type Config struct {
 		Location string `json:"location"`
 		MaxSize  int64  `json:"maxSizeBytes,omitempty"`
 	} `json:"blobSpace"`
+}
+
+type StringReplacement struct {
+	Path        string `json:"path"`
+	Search      string `json:"search"`
+	Replacement string `json:"replacement"`
 }
 
 // NewServer creates a new blob server

--- a/components/blobserve/pkg/blobserve/blobspace_test.go
+++ b/components/blobserve/pkg/blobserve/blobspace_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package blobserve
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_diskBlobspace_modifyFile(t *testing.T) {
+	type Args struct {
+		blobName string
+		filename string
+		mod      FileModifier
+	}
+	tests := []struct {
+		Name     string
+		Args     Args
+		Expected string
+	}{
+		{
+			Name: "replace content",
+			Args: Args{
+				blobName: "b1",
+				filename: "f1",
+				mod: func(in io.Reader, out io.Writer) error {
+					_, err := out.Write([]byte("foo"))
+					return err
+				},
+			},
+			Expected: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			tmp, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmp)
+
+			os.MkdirAll(filepath.Join(tmp, "b1"), 0755)
+			ioutil.WriteFile(filepath.Join(tmp, "b1", "f1"), []byte("hello world"), 0600)
+
+			b := &diskBlobspace{
+				Location: tmp,
+			}
+			err = b.modifyFile(tt.Args.blobName, tt.Args.filename, tt.Args.mod)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctnt, err := ioutil.ReadFile(filepath.Join(tmp, "b1", "f1"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.Expected, string(ctnt)); diff != "" {
+				t.Errorf("modifyFile() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_modifySearchAndReplace(t *testing.T) {
+	type args struct {
+		Search  string
+		Replace string
+	}
+	tests := []struct {
+		Name     string
+		Args     args
+		Input    string
+		Expected string
+	}{
+		{
+			Name: "happy path",
+			Args: args{
+				Search:  "foobar",
+				Replace: "baz",
+			},
+			Input:    "hello world\nthis is foobar\ncool beans",
+			Expected: "hello world\nthis is baz\ncool beans",
+		},
+		{
+			Name: "across lines",
+			Args: args{
+				Search:  "foo\nbar",
+				Replace: "baz",
+			},
+			Input:    "hello world\nthis is foo\nbar\ncool beans",
+			Expected: "hello world\nthis is baz\ncool beans",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			err := modifySearchAndReplace(tt.Args.Search, tt.Args.Replace)(bytes.NewReader([]byte(tt.Input)), buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tt.Expected, buf.String()); diff != "" {
+				t.Errorf("modifySearchAndReplace() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/blobserve/pkg/blobserve/refstore_test.go
+++ b/components/blobserve/pkg/blobserve/refstore_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestBlobFor(t *testing.T) {
 	const (
-		refDescriptor = "test"
+		refDescriptor = "gitpod.io/test:tag"
 		hashManifest  = "5de870aced7e6c182a10e032e94de15893c95edd80d9cc20348b0f1627826d93"
 		hashLayer     = "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"
 	)
@@ -85,7 +85,7 @@ func TestBlobFor(t *testing.T) {
 
 				// fetching again with an empty fake fetcher should work just fine - everything is cached now
 				s.Resolver = func() remotes.Resolver { return &fakeFetcher{} }
-				_, hash, err := s.BlobFor(context.Background(), "test", false)
+				_, hash, err := s.BlobFor(context.Background(), refDescriptor, false)
 
 				if diff := cmp.Diff(hashLayer, hash); diff != "" {
 					t.Errorf("unexpected blob hash (-want +got):\n%s", diff)
@@ -242,7 +242,7 @@ func TestBlobFor(t *testing.T) {
 				return err
 			},
 			Expectation: Expectation{
-				Refcache: map[string]string{"test": "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"},
+				Refcache: map[string]string{refDescriptor: "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"},
 				Content:  map[string]blobstate{"4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714": blobReady},
 			},
 		},
@@ -265,7 +265,7 @@ func TestBlobFor(t *testing.T) {
 				return nil
 			},
 			Expectation: Expectation{
-				Refcache: map[string]string{"test": "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"},
+				Refcache: map[string]string{refDescriptor: "4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714"},
 				Content:  map[string]blobstate{"4970405cb2a3a461cc00fd755712beded51919d7e69270d7d10d0dcf5e209714": blobReady},
 			},
 		},
@@ -443,7 +443,7 @@ func (s *inMemoryBlobspace) Get(name string) (fs http.FileSystem, state blobstat
 	return nil, s.Content[name]
 }
 
-func (s *inMemoryBlobspace) AddFromTarGzip(ctx context.Context, name string, in io.Reader) (err error) {
+func (s *inMemoryBlobspace) AddFromTarGzip(ctx context.Context, name string, in io.Reader, modifications map[string]FileModifier) (err error) {
 	return s.Adder(ctx, name, in)
 }
 

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 5007ab7a882c9a2d67db864ef5cdd125e79eb8f1
+ENV GP_CODE_COMMIT 92f328f7e7dd336f1f5b375dda5b3944a46b7d3f
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
This PR adds the ability to modify files in blobserve. We use this to replace `vscode-webview.net` in Code to make webviews work in firefox.