### PR TITLE
[code] inline static links to blobserve

### DIFF
--- a/chart/templates/blobserve-configmap.yaml
+++ b/chart/templates/blobserve-configmap.yaml
@@ -32,6 +32,13 @@ data:
                     "replacements": [
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" },
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js" }
+                    ],
+                    "inlineStatic": [
+                        { "search": "${window.location.origin}", "replacement": "." },
+                        { "search": "value.startsWith(window.location.origin)", "replacement": "value.startsWith(window.location.origin) || value.startsWith('${ide}')" },
+                        { "search": "./out", "replacement": "${ide}/out" },
+                        { "search": "./node_modules", "replacement": "${ide}/node_modules" },
+                        { "search": "/_supervisor/frontend", "replacement": "${supervisor}" }
                     ]
                 },
                 "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}": {

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 92f328f7e7dd336f1f5b375dda5b3944a46b7d3f
+ENV GP_CODE_COMMIT ad96a5a674ce1c58635b1d4907d48100121610b9
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

#### What it does

- fix #4568

This PR allows to configure blobserve to inline static links in index.html with exposed blobserve URLs for concrete ws cluster passed from ws-proxy.

Change in Gitpod Code to allows relative source maps: https://github.com/gitpod-io/vscode/commit/ad96a5a674ce1c58635b1d4907d48100121610b9

Out-of-scope: I noticed that we have 6 sequential requests to the supervisor before showing an IDE. It would be good to reduce them or try to perform in parallel on application or transport level (use grpc-web with websocket) instead. On my connection it will save 0.3s then total loading takes around 1s.

#### How to test

- Start a workspace and check that it is functional.
- Open devtools and reload the page, you should see that there are no redirects to blobserve anymore, but index.html have already links and such links are loaded from the browser cache without any request to the server.
- Start another workspace and check in devtools that even on first opening cache is used after index.html is fetched.