### PR TITLE
[agent-smith] Tone down too verbose logging

### DIFF
--- a/chart/templates/agent-smith-configmap.yaml
+++ b/chart/templates/agent-smith-configmap.yaml
@@ -25,6 +25,9 @@ data:
             {"name":"testtarget","domain":"process","kind":"elf","pattern":"YWdlbnRTbWl0aFRlc3RUYXJnZXQ=","regexp":false}
           ]
         }
-      }
+      },
+      "pprofAddr": "localhost:6060",
+      "prometheusAddr": "localhost:9500",
+      "hostURL": "https://{{ $.Values.hostname }}"
     }
 {{- end -}}

--- a/components/ee/agent-smith/pkg/agent/agent.go
+++ b/components/ee/agent-smith/pkg/agent/agent.go
@@ -549,8 +549,15 @@ func (agent *Smith) handleExecveEvent(execve Execve) func() (*InfringingWorkspac
 
 		if len(res) == 0 {
 			fd, err := os.Open(filepath.Join("/proc", strconv.Itoa(execve.TID), "exe"))
-			if err != nil && !os.IsNotExist(err) {
-				log.WithError(err).WithField("path", execve.Filename).Warn("cannot open executable to check signatures")
+			if err != nil {
+				if os.IsNotExist(err) || strings.Contains(err.Error(), "no such process") {
+					// This happens often enough to be too spammy in the logs. Thus we use a metric instead.
+					// If agent-smith does not work as intended, this metric can be indicative of the reason.
+					agent.metrics.signatureCheckMiss.Inc()
+				} else {
+					log.WithError(err).WithField("path", execve.Filename).Warn("cannot open executable to check signatures")
+				}
+
 				return nil, nil
 			}
 			defer fd.Close()
@@ -567,7 +574,9 @@ func (agent *Smith) handleExecveEvent(execve Execve) func() (*InfringingWorkspac
 
 					m, err := sig.Matches(fd)
 					if err != nil {
-						log.WithError(err).WithField("path", execve.Filename).WithField("signature", sig.Name).Warn("cannot check signature")
+						// We use a metric instead of logging this because this happens very often for a barage of reasons.
+						// If agent-smith does not work as intended, this metric can be indicative of the reason.
+						agent.metrics.signatureCheckFailures.Inc()
 						continue
 					}
 					if !m {

--- a/components/ee/agent-smith/pkg/agent/metrics.go
+++ b/components/ee/agent-smith/pkg/agent/metrics.go
@@ -7,8 +7,10 @@ package agent
 import "github.com/prometheus/client_golang/prometheus"
 
 type metrics struct {
-	penaltyAttempts *prometheus.CounterVec
-	penaltyFailures *prometheus.CounterVec
+	penaltyAttempts        *prometheus.CounterVec
+	penaltyFailures        *prometheus.CounterVec
+	signatureCheckMiss     prometheus.Counter
+	signatureCheckFailures prometheus.Counter
 }
 
 func newAgentMetrics() *metrics {
@@ -30,6 +32,18 @@ func newAgentMetrics() *metrics {
 			Help:      "The total amount of failed attempts that agent-smith is trying to apply a penalty.",
 		}, []string{"penalty", "reason"},
 	)
+	m.signatureCheckMiss = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "gitpod",
+		Subsystem: "agent_smith",
+		Name:      "signature_check_missed_total",
+		Help:      "The total amount of times where the processes ended before we could open the executable.",
+	})
+	m.signatureCheckFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "gitpod",
+		Subsystem: "agent_smith",
+		Name:      "signature_check_failed_total",
+		Help:      "The total amount of failed signature check attempts",
+	})
 	return m
 }
 
@@ -41,6 +55,8 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 	collectors := []prometheus.Collector{
 		m.penaltyAttempts,
 		m.penaltyFailures,
+		m.signatureCheckMiss,
+		m.signatureCheckFailures,
 	}
 	for _, c := range collectors {
 		err := reg.Register(c)


### PR DESCRIPTION
This PR tones down the logs produced by agent smith and replaces some of them with metrics.

### How to test
During normal operation of agent smith hardly any logs should be produced.