### PR TITLE
fix(components/server): ensure a sane redirect/returnTo query param

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -612,8 +612,7 @@ export class UserController {
             return;
         }
 
-        const hostUrl = this.env.hostUrl.url as URL;
-        if (this.urlStartsWith(returnToURL, hostUrl.toString()) || this.urlStartsWith(returnToURL, this.env.brandingConfig.homepage)) {
+        if (this.urlStartsWith(returnToURL, this.env.hostUrl.toString()) || this.urlStartsWith(returnToURL, this.env.brandingConfig.homepage)) {
             return returnToURL
         }
 


### PR DESCRIPTION
Signed-off-by: Leo Di Donato <leodidonato@gmail.com>

This PR ensures the value of the `redirect` (or `returnTo`) query parameter is safe.

To do so, it strictly checks the value against the allowed URLs (rather than relying on `startsWith`).
Furthermore, it uses the `URL` interface to ensure URLs are normalized before checking them.

### On a side note

My first PR! 🎈 

Also, my first Typescript code in years and years (literally!) ... 😊 
So please be gentle with me 🙇 