### PR TITLE
[helm] Fix reverse proxy for builtin registry

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -273,10 +273,16 @@ env:
 
 {{- define "gitpod.builtinRegistry.name" -}}
 {{- if .Values.components.imageBuilder.registry.bypassProxy -}}
-{{ index .Values "docker-registry" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ include "gitpod.builtinRegistry.internal_name" . }}
 {{- else -}}
 registry.{{ .Values.hostname }}
 {{- end -}}
+{{- end -}}
+
+{{- define "gitpod.builtinRegistry.internal_name" -}}
+{{- $ := .root -}}
+{{- $gp := .gp -}}
+{{ index .Values "docker-registry" "fullnameOverride" }}.{{ .Release.Namespace }}.{{ $gp.installation.kubedomain | default "svc.cluster.local" }}
 {{- end -}}
 
 {{- define "gitpod.comp.version" -}}

--- a/chart/templates/builtin-registry-certs-secret.yaml
+++ b/chart/templates/builtin-registry-certs-secret.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ if (index .Values "docker-registry" "enabled") }}
-{{- $regName := include "gitpod.builtinRegistry.name" . -}}
+{{- $regName := include "gitpod.builtinRegistry.internal_name" . -}}
 {{ $cm := (index .Values "cert-manager") }}
 {{- if $cm.enabled }}
 

--- a/chart/templates/proxy-configmap.yaml
+++ b/chart/templates/proxy-configmap.yaml
@@ -34,7 +34,7 @@ data:
 {{ $t := set . "password" (randAlphaNum 20) }}
 {{- end }}
   vhost.docker-registry: |
-    https://minio.{$GITPOD_DOMAIN} {
+    https://registry.{$GITPOD_DOMAIN} {
       import enable_log
       import remove_server_header
       import ssl_configuration
@@ -43,8 +43,11 @@ data:
         {{ .username }} {{ bcrypt .password | b64enc }}
       }
 
-      reverse_proxy https://{{ index .Values "docker-registry" "fullnameOverride" }}.{{ .Release.Namespace }}.{$KUBE_DOMAIN} {
+      reverse_proxy https://{{ include "gitpod.builtinRegistry.internal_name" . }} {
         flush_interval -1
+        transport http {
+          tls_trusted_ca_certs /etc/caddy/registry-certs/ca.crt
+        }
       }
     }
 {{- end }}

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -73,6 +73,8 @@ spec:
 {{- if index .Values "docker-registry" "enabled" }}
         - name: builtin-registry-auth
           mountPath: "/etc/caddy/registry-auth"
+        - name: builtin-registry-certs
+          mountPath: "/etc/caddy/registry-certs"
 {{- end }}
         - name: config-certificates
           mountPath: "/etc/caddy/certificates"
@@ -95,6 +97,9 @@ spec:
       - name: builtin-registry-auth
         secret:
           secretName: builtin-registry-auth
+      - name: builtin-registry-certs
+        secret:
+          secretName: builtin-registry-certs
 {{- end }}
       - name: config-certificates
         secret:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -215,9 +215,12 @@ components:
       # By default, the builtin registry is accessed through the proxy.
       # If bypassProxy is true, the builtin registry is accessed via <registry-name>.<namespace>.svc.cluster.local directly.
       bypassProxy: false
-    registryCerts:
-    - name: builtin
-      secret: builtin-registry-certs
+    # When your registry uses self-signed certs (that's the default) and you set `bypassProxy: true`,
+    # then you should set the certs here like this:
+    # registryCerts:
+    #   - name: builtin
+    #     secret: builtin-registry-certs
+    registryCerts: []
     dindImage: docker:19.03-dind
     dindMtu: ""
     dindResources:


### PR DESCRIPTION
With the new proxy implementation with Caddy, the access to the built-in registry is over Caddy which serves the registry with the main proxy certificates instead of the registry certificates (SSL termination). That has the following implications:

- Caddy accesses the registry via https://registry.default.svc.cluster.local. That means the self-signed cert of the registry needs this domain instead of https://registry.my-gitpod.example.com.
- Caddy needs to trust the self-singed certs of the registry (needs to know the CA).
- The dind of the image builder does not need the registry certs since the certs that Caddy uses are (need to be) trusted certs and not self-signed certs (as long as bypassProxy is not set).

I tested this on k3s with [this setting](https://github.com/corneliusludmann/gitpod-k3s-droplet/tree/gitpod-0-10-0) and verified that the preview env still works.

**Alternatives:** The alternative would be to change the behavior of Caddy so that the proxy does not terminate SSL but does a raw redirect to the registry as it was in nginx (when this is possible with Caddy).

See also #4710

/cc @solomonope due to self-hosted
/cc @aledbf since you implemented the Caddy config