### PR TITLE
[teams] Fix Team Plan seat de/reactivation logic

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -13,6 +13,12 @@ pod:
   - name: gpsh-coredev-license
     secret:
       secretName: gpsh-coredev-license
+  - name: payment-provider-secret
+    secret:
+      secretName: payment-provider-secret
+  - name: payment-webhook-secret
+    secret:
+      secretName: payment-webhook-secret
   - name: go-build-cache
     hostPath:
       path: /mnt/disks/ssd0/go-build-cache
@@ -49,6 +55,12 @@ pod:
       readOnly: true
     - name: gpsh-coredev-license
       mountPath: /mnt/secrets/gpsh-coredev
+      readOnly: true
+    - name: payment-webhook-secret
+      mountPath: /mnt/secrets/payment-webhook-config
+      readOnly: true
+    - name: payment-provider-secret
+      mountPath: /mnt/secrets/payment-provider-config
       readOnly: true
     - name: go-build-cache
       mountPath: /go-build-cache

--- a/.werft/values.payment.yaml
+++ b/.werft/values.payment.yaml
@@ -1,0 +1,17 @@
+components:
+  server:
+    serverContainer:
+      volumeMounts:
+      - name: chargebee-config
+        mountPath: "/chargebee"
+        readOnly: true
+      env:
+      - name: ENABLE_PAYMENT
+        value: "true"
+    volumes:
+    - name: chargebee-config
+      secret:
+        secretName: chargebee-config
+
+  paymentEndpoint:
+    disabled: false

--- a/chart/templates/chargebee-config-secret.yaml
+++ b/chart/templates/chargebee-config-secret.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{- if .Values.payment }}
+{{- if .Values.payment.chargebee }}
+{{- if .Values.payment.chargebee.providerOptionsFile }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chargebee-config
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  providerOptions: {{ .Files.Get .Values.payment.chargebee.providerOptionsFile | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/chart/templates/payment-endpoint-deployment.yaml
+++ b/chart/templates/payment-endpoint-deployment.yaml
@@ -52,8 +52,13 @@ spec:
 {{ include "gitpod.container.defaultEnv" $this | indent 8 }}
 {{ include "gitpod.container.dbEnv" $this | indent 8 }}
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
+{{- if .Values.components.paymentEndpoint.webhookFile }}
+        - name: CHARGEBEE_WEBHOOK
+          value: '{{ .Files.Get .Values.components.paymentEndpoint.webhookFile }}'
+{{- else if .Values.components.paymentEndpoint.webhook }}
         - name: CHARGEBEE_WEBHOOK
           value: '{{ .Values.components.paymentEndpoint.webhook | toJson }}'
+{{- end }}
 {{- if $server.github.app }}
         - name: GITPOD_GITHUB_APP_ENABLED
           value: "{{ $server.github.app.enabled | default "false" }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -317,7 +317,13 @@ components:
     imageName: "service-waiter"
 
   paymentEndpoint:
+    name: "payment-endpoint"
     disabled: true
+    ports:
+      http:
+        expose: true
+        containerPort: 3002
+        servicePort: 3002
 
   workspace:
     ports:

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -500,7 +500,7 @@ function AllTeams() {
                             <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis">Purchased on {formatDate(sub?.startDate)}</span>
                         </div>
                         <div className="p-0 my-auto flex flex-col w-2/12">
-                            <span className="my-auto truncate text-gray-500 overflow-ellipsis">{slots.filter(s => s.teamSubscription.id === sub.id).length || "–"}</span>
+                            <span className="my-auto truncate text-gray-500 overflow-ellipsis">{slots.filter(s => s.state !== 'cancelled' && s.teamSubscription.id === sub.id).length || "–"}</span>
                             <span className="text-sm my-auto text-gray-400">Members</span>
                         </div>
                         <div className="p-0 my-auto flex w-4/12">
@@ -726,7 +726,7 @@ function ManageTeamModal(props: {
             <div className="overscroll-contain max-h-96 overflow-y-auto">
                 {slots.map((slot, index) => {
                     return (
-                        <Slot key={slot.id} slot={slot} inputHandler={props.slotInputHandler} />
+                        <SlotInput key={slot.id} slot={slot} inputHandler={props.slotInputHandler} />
                     )
                 })}
             </div>
@@ -744,7 +744,7 @@ interface SlotInputHandler {
     reactivate: (slot: TeamSubscriptionSlotResolved) => void;
 }
 
-function Slot(props: {
+function SlotInput(props: {
     slot: Slot,
     inputHandler: SlotInputHandler;
 }) {

--- a/components/gitpod-protocol/src/team-subscription-protocol.ts
+++ b/components/gitpod-protocol/src/team-subscription-protocol.ts
@@ -83,6 +83,9 @@ export namespace TeamSubscriptionSlot {
         }
 
     }
+    export const isActive = (slot: TeamSubscriptionSlot): boolean => {
+        return !slot.cancellationDate;
+    }
 }
 
 /**

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1123,7 +1123,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
     // Get the current number of "active" slots in a team subscription (count all "assigned" and "unassigned", but not "deactivated" or "cancelled").
     protected async tsGetActiveSlotQuantity(teamSubscriptionId: string): Promise<number> {
         const slots = await this.teamSubscriptionDB.findSlotsByTeamSubscriptionId(teamSubscriptionId);
-        return slots.filter(slot => !slot.cancellationDate).length;
+        return slots.filter(TeamSubscriptionSlot.isActive).length;
     }
 
     async tsAddSlots(teamSubscriptionId: string, addQuantity: number): Promise<void> {


### PR DESCRIPTION
Attempts to fix https://github.com/gitpod-io/gitpod/issues/4693

---

I believe our current implementation has the following problems:

- Deactivating a Team Plan Seat sets a `cancellationDate` on the `d_b_team_subscription_slot` entry and its related `d_b_subscription` entry (**good**). However, it schedules the Team Plan to have 1 fewer Seat than it currently has, effective at the end of term (**bad** -- this doesn't take into account multiple deactivations in the same period):

https://github.com/gitpod-io/gitpod/blob/8552d9e67cb888dea41f2389e44ce760a87c699e/components/server/ee/src/workspace/gitpod-server-impl.ts#L1238-L1242

- Reactivating a Team Plan Seat **also decreases** the amount of Seats (by maximum 1 each billing cycle). This is obviously wrong (as it should increase the quantity instead):

https://github.com/gitpod-io/gitpod/blob/8552d9e67cb888dea41f2389e44ce760a87c699e/components/server/ee/src/workspace/gitpod-server-impl.ts#L1254-L1258

- Our "Manage Team" modal shows the correct number of active Team Plan Seats, because if filters out Seats that are now `cancelled` (1). By contrast, the total number of Members shown for your Team Plan doesn't filter out `cancelled` Seats (2), thus reporting a too-high number of "Members" (actually "Seats"):

(1)

https://github.com/gitpod-io/gitpod/blob/97b938150a2dc6211ea8ae549f08050bf1e8159f/components/dashboard/src/settings/Teams.tsx#L717-L718

(2)

https://github.com/gitpod-io/gitpod/blob/97b938150a2dc6211ea8ae549f08050bf1e8159f/components/dashboard/src/settings/Teams.tsx#L503-L504

---

This Pull Request implements the following fixes:

- When deactivating a Seat, decrease the Team Plan Seat quantity immediately, not at the end of term. I believe this allows multiple deactivations in the same cycle, without any side effects on billing.
- When reactivating a Seat, **increase** (not decrease) the Team Plan Seat quantity immediately as well (similar effect).
- Filter out cancelled Seats in the Members total count.

### How to test

Purchase a Team Plan. You should still be able to:
- Assign & unassign Seats (without impact to billing)
- Purchase additional Seats (should add a new deferred charge in Chargebee and also increase your next bill)
- Deactivate Seats (they should remain visible until the end of term, and should also decrease your upcoming bill in Chargebee)
- Deactivate multiple Seats in the same cycle (should decrease your next bill by the correct number of Seats, not just 1)
- Reactivate not-yet-cancelled Seats (the Seat should be usable again + you should not be charged again for this already-paid Seat + your next bill should have one more Seat on it)


- [x] /werft with-payment
- [ ] /werft with-clean-slate-deployment