### PR TITLE
[server] Fix image config context path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## July 2021
+
+- Fix `image.context` in `.gitpod.yml` ([#4715](https://github.com/gitpod-io/gitpod/pull/4715))
+
 ## June 2021
 
 - Complete validations of VS Code extensions in .gitpod.yml ([#4645](https://github.com/gitpod-io/gitpod/pull/4645)):

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -7,7 +7,7 @@
 import { CloneTargetMode, FileDownloadInitializer, GitAuthMethod, GitConfig, GitInitializer, PrebuildInitializer, SnapshotInitializer, WorkspaceInitializer } from "@gitpod/content-service/lib";
 import { CompositeInitializer, FromBackupInitializer } from "@gitpod/content-service/lib/initializer_pb";
 import { DBUser, DBWithTracing, TracedUserDB, TracedWorkspaceDB, UserDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
-import { CommitContext, Disposable, GitpodToken, GitpodTokenType, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType, DisposableCollection, AdditionalContentContext } from "@gitpod/gitpod-protocol";
+import { CommitContext, Disposable, GitpodToken, GitpodTokenType, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType, DisposableCollection, AdditionalContentContext, ImageConfigFile } from "@gitpod/gitpod-protocol";
 import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
@@ -28,6 +28,7 @@ import { TokenProvider } from "../user/token-provider";
 import { UserService } from "../user/user-service";
 import { ImageSourceProvider } from "./image-source-provider";
 import { MessageBusIntegration } from "./messagebus-integration";
+import * as path from 'path';
 
 export interface StartWorkspaceOptions {
     rethrow?: boolean;
@@ -374,8 +375,9 @@ export class WorkspaceStarter {
                     disp.push(disposable);
                 }
 
-                let contextPath = checkoutLocation;
-                let dockerFilePath = checkoutLocation + '/' + imgsrc.dockerFilePath;
+                const context = (workspace.config.image as ImageConfigFile).context;
+                const contextPath = !!context ? path.join(checkoutLocation, context) : checkoutLocation;
+                const dockerFilePath = path.join(checkoutLocation, imgsrc.dockerFilePath);
 
                 const file = new BuildSourceDockerfile();
                 file.setContextPath(contextPath);


### PR DESCRIPTION
This line has been lost in commit https://github.com/gitpod-io/gitpod/commit/66539b0f4b1cc0be717d7bb10f18da225b844e90:
https://github.com/gitpod-io/gitpod/commit/66539b0f4b1cc0be717d7bb10f18da225b844e90#diff-b1c591e18af598ccba93b570ce7c97dece0988c9109a6d3be82bbe0df1fbd619L363

Tested with this repo: https://github.com/corneliusludmann/gitpod-playground/tree/gitpod-yml-with-image-context

Fixes https://github.com/gitpod-io/gitpod/issues/4678