### PR TITLE
Fix propagation of span error

### DIFF
--- a/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
+++ b/components/ee/ws-scheduler/pkg/scheduler/scheduler.go
@@ -458,7 +458,7 @@ func (s *Scheduler) selectNodeForPod(ctx context.Context, pod *corev1.Pod, ghost
 	span, ctx := tracing.FromContext(ctx, "selectNodeForPod")
 	// We deliberately DO NOT add the err to tracing here. If things actually fail the caller will trace the error.
 	// If we did trace the error here we'd just spam our traces with false positives.
-	defer tracing.FinishSpan(span, nil)
+	defer tracing.FinishSpan(span, &err)
 
 	state, err = s.buildState(ctx, pod, ghostsVisible)
 	if err != nil {

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -156,7 +156,7 @@ func (s *Workspace) MarkInitDone(ctx context.Context) (err error) {
 func (s *Workspace) WaitOrMarkForDisposal(ctx context.Context) (done bool, repo *csapi.GitStatus, err error) {
 	//nolint:ineffassign,staticcheck
 	span, ctx := opentracing.StartSpanFromContext(ctx, "workspace.WaitOrMarkForDisposal")
-	defer tracing.FinishSpan(span, nil)
+	defer tracing.FinishSpan(span, &err)
 
 	s.stateLock.Lock()
 	if s.state == WorkspaceDisposed {

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1037,7 +1037,7 @@ func (m *Monitor) deleteDanglingServices(ctx context.Context) error {
 // markTimedoutWorkspaces finds workspaces which haven't been active recently and marks them as timed out
 func (m *Monitor) markTimedoutWorkspaces(ctx context.Context) (err error) {
 	span, ctx := tracing.FromContext(ctx, "markTimedoutWorkspaces")
-	defer tracing.FinishSpan(span, nil)
+	defer tracing.FinishSpan(span, &err)
 
 	var pods corev1.PodList
 	err = m.manager.Clientset.List(ctx, &pods, workspaceObjectListOptions(m.manager.Config.Namespace))


### PR DESCRIPTION
Some spans do not contain details about errors and there are no logs, this means the only we see anything is the gitpod UI

Example of change:
![Screenshot from 2021-07-06 23-28-45](https://user-images.githubusercontent.com/161571/124695855-025b1280-deb2-11eb-8b95-d500420bb293.png)
