### PR TITLE
[werft] Make cert creation & helm installation sequential

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -71,7 +71,7 @@ export async function issueCertficate(werft, params: IssueCertificateParams) {
             break;
         }
 
-        sleep(5000);
+        await sleep(5000);
     }
 }
 


### PR DESCRIPTION
Werft deployments are broken due to some bug in one of the dependencies. Since we [install dependencies](https://github.com/gitpod-io/gitpod/blob/main/.werft/wipe-devstaging.yaml#L38) without pinning them one of the transitive dependencies could be an issue.

We see that await keyword is not returning the promise as expected, therefore, for now we are installing gitpod  sequentially followed by certificate installation.