### PR TITLE
[#4699] Handle error situations around /headless-logs endpoint

### DIFF
--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -27,12 +27,15 @@ export interface WorkspaceInstance {
     stoppedTime?: string;
 
     // ideUrl is the URL at which the workspace is available on the internet
+    // Note: this is nitially empty, filled during starting process!
     ideUrl: string;
 
     // region is the name of the workspace cluster this instance runs in
+    // Note: this is nitially empty, filled during starting process!
     region: string;
 
     // workspaceImage is the name of the Docker image this instance runs
+    // Note: this is nitially empty, filled during starting process!
     workspaceImage: string;
 
     // status is the latest status of the instance that we're aware of

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1183,7 +1183,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         }
 
         const sources = await this.workspaceLogService.getWorkspaceLogURLs(wsi);
-        if (!sources) {
+        if (!sources || (typeof sources.streams === "object" && Object.keys(sources.streams).length === 0)) {
             throw new ResponseError(ErrorCodes.NOT_FOUND, `Headless logs for ${instanceId} not found`);
         }
         return sources;

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -43,6 +43,10 @@ export class HeadlessLogController {
             }
 
             const user = req.user as User;
+            if (!User.is(user)) {
+                res.sendStatus(401);
+                return;
+            }
             if (user.blocked) {
                 res.sendStatus(403);
                 log.warn("blocked user attempted to fetch workspace cookie", { ...params, userId: user.id });
@@ -127,6 +131,21 @@ export class HeadlessLogController {
                 res.end();
             }
         }));
+        router.get("/", (req: express.Request, res: express.Response) => {
+            // This is an error case: every request should match the handler above
+            const user = req.user as User;
+            if (!User.is(user)) {
+                res.sendStatus(401);
+                return;
+            }
+            if (user.blocked) {
+                res.sendStatus(403);
+                return;
+            }
+
+            log.error({ userId: user.id }, "/headless-logs: malformed request", { path: req.path });
+            res.status(400);
+        });
         return router;
     }
 }

--- a/components/server/src/workspace/workspace-log-service.ts
+++ b/components/server/src/workspace/workspace-log-service.ts
@@ -53,6 +53,11 @@ export class WorkspaceLogService {
      * @param workspace
      */
     protected async listWorkspaceLogs(wsi: WorkspaceInstance): Promise<Map<string, string>> {
+        if (wsi.ideUrl === "") {
+            // if ideUrl is not yet set we're too early and we deem the workspace not ready yet: retry later!
+            throw new Error(`instance's ${wsi.id} has no ideUrl, yet`);
+        }
+
         const tasks = await new Promise<TaskStatus[]>((resolve, reject) => {
             const client = new StatusServiceClient(toSupervisorURL(wsi.ideUrl), {
                 transport: WebsocketTransport(),
@@ -79,7 +84,7 @@ export class WorkspaceLogService {
                 // this might be the case when there is no terminal for this task, yet.
                 // if we find any such case, we deem the workspace not ready yet, and try to reconnect later,
                 // to be sure to get hold of all terminals created.
-                throw new Error(`task ${t.getId} has no terminal yet`);
+                throw new Error(`instance's ${wsi.id} task ${t.getId} has no terminal yet`);
             }
             result.set(t.getId(), t.getTerminal());
         }

--- a/components/ws-manager/leeway.Dockerfile
+++ b/components/ws-manager/leeway.Dockerfile
@@ -6,7 +6,9 @@ FROM alpine:3.14
 
 # Ensure latest packages are present, like security updates.
 RUN  apk upgrade --no-cache \
-  && apk add --no-cache ca-certificates
+  # bash: for devx
+  # tar: make kubectl cp work
+  && apk add --no-cache ca-certificates bash tar
 
 COPY components-ws-manager--app/ws-manager /app/ws-manager
 ENTRYPOINT [ "/app/ws-manager" ]


### PR DESCRIPTION
Fixes #4699.

## Test

 1. create and environment variable: https://gpl-4699-headless-log.staging.gitpod-dev.com/workspaces/
   - name: PREBUILD_PARAMS
   - value: 100_1s_1m_success
   - repo: gitpod-io/gitpod
 2. run a prebuild: https://gpl-4699-headless-log.staging.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/gitpod/tree/gpl/test-prebuild
   - notice how logs work