### PR TITLE
[server] Add kube-rbac-proxy rolebinding to SA

### DIFF
--- a/chart/templates/server-rolebinding.yaml
+++ b/chart/templates/server-rolebinding.yaml
@@ -17,3 +17,23 @@ roleRef:
   kind: Role
   name: server
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-server-rb-kube-rbac-proxy
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: server
+    kind: role-binding
+    stage: {{ .Values.installation.stage }}
+subjects:
+- kind: ServiceAccount
+  name: server
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name:  {{ .Release.Namespace }}-kube-rbac-proxy
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Server metrics scraping is broken because of a missing role binding:
```
"Failed to make webhook authenticator request: tokenreviews.authentication.k8s.io is forbidden: User "system:serviceaccount:default:server" cannot create resource "tokenreviews" in API group "authentication.k8s.io" at the cluster scope" 
```

fixes #4739

/werft no-preview