### PR TITLE
[werft] Add sweeper cleanup logic for k3s ws cluster

### DIFF
--- a/.werft/util/gcloud.ts
+++ b/.werft/util/gcloud.ts
@@ -1,23 +1,32 @@
 import { werft, exec } from './shell';
 import { sleep } from './util';
 
-export async function deleteExternalIp(name: string, namespace: string) {
-    werft.log("wipe", `address describe returned: ${name}`)
-    werft.log("wipe", `found external static IP with matching name ${namespace}, will delete it`)
+export async function deleteExternalIp(phase: string, name: string, region = "europe-west1") {
+    const ip = getExternalIp(name)
+    werft.log(phase, `address describe returned: ${ip}`)
+    if (ip.indexOf("ERROR:") != -1 || ip == "") {
+        werft.log(phase, `no external static IP with matching name ${name} found`)
+        return
+    }
 
-    const cmd = `gcloud compute addresses delete ${namespace} --region europe-west1 --quiet`
+    werft.log(phase, `found external static IP with matching name ${name}, will delete it`)
+    const cmd = `gcloud compute addresses delete ${name} --region ${region} --quiet`
     let attempt = 0;
     for (attempt = 0; attempt < 10; attempt++) {
         let result = exec(cmd);
         if (result.code === 0 && result.stdout.indexOf("Error") == -1) {
-            werft.log("wipe", `external ip with name ${namespace} and ip ${name} deleted`);
+            werft.log(phase, `external ip with name ${name} and ip ${ip} deleted`);
             break;
         } else {
-            werft.log("wipe", `external ip with name ${namespace} and ip ${name} could not be deleted, will reattempt`)
+            werft.log(phase, `external ip with name ${name} and ip ${ip} could not be deleted, will reattempt`)
         }
         await sleep(5000)
     }
     if (attempt == 10) {
-        werft.log("wipe", `could not delete the external ip with name ${namespace} and ip ${name}`)
+        werft.log(phase, `could not delete the external ip with name ${name} and ip ${ip}`)
     }
+}
+
+function getExternalIp(name: string, region = "europe-west1"){
+    return exec(`gcloud compute addresses describe ${name} --region ${region}| grep 'address:' | cut -c 10-`, { silent: true }).trim();
 }

--- a/.werft/util/gcloud.ts
+++ b/.werft/util/gcloud.ts
@@ -1,8 +1,8 @@
 import { werft, exec } from './shell';
 import { sleep } from './util';
 
-export async function deleteExternalIp(k3sWsProxyIP: string, namespace: string) {
-    werft.log("wipe", `address describe returned: ${k3sWsProxyIP}`)
+export async function deleteExternalIp(name: string, namespace: string) {
+    werft.log("wipe", `address describe returned: ${name}`)
     werft.log("wipe", `found external static IP with matching name ${namespace}, will delete it`)
 
     const cmd = `gcloud compute addresses delete ${namespace} --region europe-west1 --quiet`
@@ -10,14 +10,14 @@ export async function deleteExternalIp(k3sWsProxyIP: string, namespace: string) 
     for (attempt = 0; attempt < 10; attempt++) {
         let result = exec(cmd);
         if (result.code === 0 && result.stdout.indexOf("Error") == -1) {
-            werft.log("wipe", `external ip with name ${namespace} and ip ${k3sWsProxyIP} deleted`);
+            werft.log("wipe", `external ip with name ${namespace} and ip ${name} deleted`);
             break;
         } else {
-            werft.log("wipe", `external ip with name ${namespace} and ip ${k3sWsProxyIP} could not be deleted, will reattempt`)
+            werft.log("wipe", `external ip with name ${namespace} and ip ${name} could not be deleted, will reattempt`)
         }
         await sleep(5000)
     }
     if (attempt == 10) {
-        werft.log("wipe", `could not delete the external ip with name ${namespace} and ip ${k3sWsProxyIP}`)
+        werft.log("wipe", `could not delete the external ip with name ${namespace} and ip ${name}`)
     }
 }

--- a/.werft/util/gcloud.ts
+++ b/.werft/util/gcloud.ts
@@ -1,0 +1,23 @@
+import { werft, exec } from './shell';
+import { sleep } from './util';
+
+export async function deleteExternalIp(k3sWsProxyIP: string, namespace: string) {
+    werft.log("wipe", `address describe returned: ${k3sWsProxyIP}`)
+    werft.log("wipe", `found external static IP with matching name ${namespace}, will delete it`)
+
+    const cmd = `gcloud compute addresses delete ${namespace} --region europe-west1 --quiet`
+    let attempt = 0;
+    for (attempt = 0; attempt < 10; attempt++) {
+        let result = exec(cmd);
+        if (result.code === 0 && result.stdout.indexOf("Error") == -1) {
+            werft.log("wipe", `external ip with name ${namespace} and ip ${k3sWsProxyIP} deleted`);
+            break;
+        } else {
+            werft.log("wipe", `external ip with name ${namespace} and ip ${k3sWsProxyIP} could not be deleted, will reattempt`)
+        }
+        await sleep(5000)
+    }
+    if (attempt == 10) {
+        werft.log("wipe", `could not delete the external ip with name ${namespace} and ip ${k3sWsProxyIP}`)
+    }
+}

--- a/.werft/util/gcloud.ts
+++ b/.werft/util/gcloud.ts
@@ -27,6 +27,6 @@ export async function deleteExternalIp(phase: string, name: string, region = "eu
     }
 }
 
-function getExternalIp(name: string, region = "europe-west1"){
+function getExternalIp(name: string, region = "europe-west1") {
     return exec(`gcloud compute addresses describe ${name} --region ${region}| grep 'address:' | cut -c 10-`, { silent: true }).trim();
 }

--- a/.werft/wipe-devstaging.ts
+++ b/.werft/wipe-devstaging.ts
@@ -1,13 +1,15 @@
-import { werft } from './util/shell';
+import { werft, exec } from './util/shell';
 import { wipePreviewEnvironment, listAllPreviewNamespaces } from './util/kubectl';
+import  * as fs from 'fs';
+import { sleep } from './util/util';
 
 
-async function wipeDevstaging() {
+async function wipeDevstaging(pathToKubeConfig: string) {
     const namespace_raw = process.env.NAMESPACE;
     const namespaces: string[] = [];
     if (namespace_raw === "<no value>" || !namespace_raw) {
         werft.log('wipe', "Going to wipe all namespaces");
-        listAllPreviewNamespaces("")
+        listAllPreviewNamespaces(pathToKubeConfig)
             .map(ns => namespaces.push(ns));
     } else {
         werft.log('wipe', `Going to wipe namespace ${namespace_raw}`);
@@ -15,9 +17,57 @@ async function wipeDevstaging() {
     }
 
     for (const namespace of namespaces) {
-        await wipePreviewEnvironment("", "gitpod", namespace, { slice: 'wipe' });
+        await wipePreviewEnvironment(pathToKubeConfig, "gitpod", namespace, { slice: 'wipe' });
     }
-    werft.done('wipe');
 }
 
-wipeDevstaging()
+async function deleteExternalIp(k3sWsProxyIP: string, namespace: string) {
+    werft.log("wipe", `address describe returned: ${k3sWsProxyIP}`)
+    werft.log("wipe", `found external static IP with matching name ${namespace}, will delete it`)
+
+    const cmd = `gcloud compute addresses delete ${namespace} --region europe-west1 --quiet`
+    let attempt = 0;
+    for (attempt = 0; attempt < 10; attempt++) {
+        let result = exec(cmd);
+        if (result.code === 0 && result.stdout.indexOf("Error") == -1) {
+            werft.log("wipe", `external ip with name ${namespace} and ip ${k3sWsProxyIP} deleted`);
+            break;
+        } else {
+            werft.log("wipe", `external ip with name ${namespace} and ip ${k3sWsProxyIP} could not be deleted, will reattempt`)
+        }
+        await sleep(5000)
+    }
+    if (attempt == 10) {
+        werft.log("wipe", `could not delete the external ip with name ${namespace} and ip ${k3sWsProxyIP}`)
+    }
+}
+
+// if we have "/workspace/k3s-external.yaml" present that means a k3s ws cluster
+// exists, therefore, delete corresponding preview deployment from that cluster too
+// NOTE: Even for a non k3s ws deployment we will attempt to clean the preview.
+// This saves us from writing complex logic of querying meta cluster for registered workspaces
+// Since we use the same namespace to deploy in both dev and k3s cluster, this is safe
+async function k3sCleanup() {
+    if (fs.existsSync("/workspace/k3s-external.yaml")) {
+        werft.log("wipe", "found /workspace/k3s-external.yaml, assuming k3s ws cluster deployment exists, will attempt to wipe it")
+        await wipeDevstaging("/workspace/k3s-external.yaml")
+        const namespace_raw = process.env.NAMESPACE;
+
+        // Since werft creates static external IP for ws-proxy of k3s using gcloud
+        // we delete it here. We retry because the ws-proxy-service which binds to this IP might not be deleted immediately
+        const k3sWsProxyIP = exec(`gcloud compute addresses describe ${namespace_raw} --region europe-west1 | grep 'address:' | cut -c 10-`, { silent: true }).trim();
+        if (k3sWsProxyIP.indexOf("ERROR:") == -1 && k3sWsProxyIP != "") {
+            deleteExternalIp(k3sWsProxyIP, namespace_raw)
+        } else {
+            werft.log("wipe", `no external static IP with matching name ${namespace_raw} found`)
+        }
+    }
+}
+
+// sweeper runs in the dev cluster so we need to delete the k3s cluster first and then delete self contained namespace
+k3sCleanup().then(()=>{
+    wipeDevstaging("")
+})
+
+
+werft.done('wipe');

--- a/.werft/wipe-devstaging.ts
+++ b/.werft/wipe-devstaging.ts
@@ -45,9 +45,11 @@ async function k3sCleanup() {
     }
 }
 
+// clean up the dev cluster in gitpod-core-dev
 async function devCleanup() {
     await wipePreviewCluster("")
 }
+
 // sweeper runs in the dev cluster so we need to delete the k3s cluster first and then delete self contained namespace
 k3sCleanup().then(() => {
     devCleanup()

--- a/.werft/wipe-devstaging.ts
+++ b/.werft/wipe-devstaging.ts
@@ -34,12 +34,8 @@ async function k3sCleanup() {
 
         // Since werft creates static external IP for ws-proxy of k3s using gcloud
         // we delete it here. We retry because the ws-proxy-service which binds to this IP might not be deleted immediately
-        const k3sWsProxyIP = exec(`gcloud compute addresses describe ${namespace_raw} --region europe-west1 | grep 'address:' | cut -c 10-`, { silent: true }).trim();
-        if (k3sWsProxyIP.indexOf("ERROR:") == -1 && k3sWsProxyIP != "") {
-            deleteExternalIp(k3sWsProxyIP, namespace_raw)
-        } else {
-            werft.log("wipe", `no external static IP with matching name ${namespace_raw} found`)
-        }
+        const k3sWsProxyIP =
+            deleteExternalIp("wipe", namespace_raw)
     } else {
         werft.log("wipe", `file /workspace/k3s-external.yaml does not exist, no cleanup for k3s cluster`)
     }

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -34,6 +34,7 @@ pod:
 
       export NAMESPACE="{{ .Annotations.namespace }}"
       sudo chown -R gitpod:gitpod /workspace
+      kubectl get secret k3sdev -n werft -ojsonpath='{.data}' | jq -r .[] | base64 -d > /workspace/k3s-external.yaml
 
       npm install shelljs semver ts-node typescript @types/shelljs @types/node @types/semver
       npx ts-node .werft/wipe-devstaging.ts


### PR DESCRIPTION
# What?

When running wipe job do the following:
- determine is k3s-external.yaml exists, if it does then delete this preview env with the same logic as that of dev. And also delete the external IP that was created by werft for the ws-proxy in this cluster. Otherwise go to next step
- Delete preview env in the dev cluster

# Testing
To test this out I manually edited the sweeper deploy and added arg`--timeout=5m` to trigger wipe job instantly. The cleanup succeeded

[Reference job in a different branch](https://werft.gitpod-dev.com/job/gitpod-wipe-devstaging-prs-sweeper-n-meta-ws-disable.0/raw)


 - [ ] /werft k3s-ws
 - [ ] /werft with-clean-slate-deployment
