### PR TITLE
[werft] K3s ws cluster register wait on dependent pods

### DIFF
--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -180,3 +180,7 @@ export function findFreeHostPorts(pathToKubeConfig: string, ranges: PortRange[],
     }
     return results;
 }
+
+export function waitForDeploymentToSucceed(pathToKubeConfig: string, name: string, namespace: string, type: string) {
+    exec(`export KUBECONFIG=${pathToKubeConfig} && kubectl rollout status ${type} ${name} -n ${namespace}`)
+}


### PR DESCRIPTION
The meta cluster should be up and running, specifically `ws-manager-bridge` before we attempt to register the k3s ws cluster. This PR waits for the deployment rollout to succeed.


- [x] /werft k3s-ws