### PR TITLE
[server] Add trackEvent to support dashboard analytics

### DIFF
--- a/components/gitpod-protocol/src/analytics.ts
+++ b/components/gitpod-protocol/src/analytics.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Without } from "./util/without";
+
+export const IAnalyticsWriter = Symbol("IAnalyticsWriter");
+
+type Identity =
+    | { userId: string | number }
+    | { userId?: string | number; anonymousId: string | number };
+
+interface Message {
+    messageId?: string;
+}
+
+export type IdentifyMessage = Message & Identity & {
+    traits?: any;
+    timestamp?: Date;
+    context?: any;
+};
+
+export type TrackMessage = Message & Identity & {
+    event: string;
+    properties?: any;
+    timestamp?: Date;
+    context?: any;
+};
+
+export type RemoteTrackMessage = Without<TrackMessage, "timestamp" | "userId" | "anonymousId">;
+
+export interface IAnalyticsWriter {
+
+    identify(msg: IdentifyMessage): void;
+
+    track(msg: TrackMessage): void;
+
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -25,6 +25,7 @@ import { Emitter } from './util/event';
 import { AccountStatement, CreditAlert } from './accounting-protocol';
 import { GithubUpgradeURL, PlanCoupon } from './payment-protocol';
 import { TeamSubscription, TeamSubscriptionSlot, TeamSubscriptionSlotResolved } from './team-subscription-protocol';
+import { RemoteTrackMessage } from './analytics';
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -212,6 +213,11 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     createProject(params: CreateProjectParams): Promise<Project>;
     getProjects(teamId: string): Promise<ProjectInfo[]>;
     getPrebuilds(teamId: string, project: string): Promise<PrebuildInfo[]>;
+
+    /**
+     * Analytics
+     */
+    trackEvent(event: RemoteTrackMessage): Promise<void>;
 }
 
 export interface CreateProjectParams {

--- a/components/gitpod-protocol/src/util/analytics.ts
+++ b/components/gitpod-protocol/src/util/analytics.ts
@@ -5,30 +5,9 @@
  */
 
 import Analytics = require("analytics-node");
+import { IAnalyticsWriter, IdentifyMessage, TrackMessage } from "../analytics";
 import { log } from './logging';
 
-export const IAnalyticsWriter = Symbol("IAnalyticsWriter");
-
-type Identity =
-    | { userId: string | number }
-    | { userId?: string | number; anonymousId: string | number };
-
-interface Message {
-    messageId?: string;
-}
-
-export type IdentifyMessage = Message & Identity & {
-    traits?: any;
-    timestamp?: Date;
-    context?: any;
-};
-
-export type TrackMessage = Message & Identity & {
-    event: string;
-    properties?: any;
-    timestamp?: Date;
-    context?: any;
-};
 
 export function newAnalyticsWriterFromEnv(): IAnalyticsWriter {
     switch (process.env.GITPOD_ANALYTICS_WRITER) {
@@ -39,14 +18,6 @@ export function newAnalyticsWriterFromEnv(): IAnalyticsWriter {
         default:
             return new NoAnalyticsWriter();
     }
-}
-
-export interface IAnalyticsWriter {
-
-    identify(msg: IdentifyMessage): void;
-
-    track(msg: TrackMessage): void;
-
 }
 
 class SegmentAnalyticsWriter implements IAnalyticsWriter {

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -15,7 +15,7 @@ import { HostContextProvider } from './host-context-provider';
 import { AuthProviderService } from './auth-provider-service';
 import { TosFlow } from '../terms/tos-flow';
 import { increaseLoginCounter } from '../../src/prometheus-metrics';
-import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
+import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
 
 /**
  * The login completion handler pulls the strings between the OAuth2 flow, the ToS flow, and the session management.

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -163,6 +163,8 @@ function readConfig(): RateLimiterConfig {
         "createProject":  { group: "default", points: 1 },
         "getProjects":  { group: "default", points: 1 },
         "getPrebuilds":  { group: "default", points: 1 },
+
+        "trackEvent":  { group: "default", points: 1 },
     };
 
     const fromEnv = JSON.parse(process.env.RATE_LIMITER_CONFIG || "{}")

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -71,12 +71,13 @@ import { ContentServiceStorageClient } from './storage/content-service-client';
 import { IDEPluginServiceClient } from '@gitpod/content-service/lib/ideplugin_grpc_pb';
 import { GitTokenScopeGuesser } from './workspace/git-token-scope-guesser';
 import { GitTokenValidator } from './workspace/git-token-validator';
-import { newAnalyticsWriterFromEnv, IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
+import { newAnalyticsWriterFromEnv } from '@gitpod/gitpod-protocol/lib/util/analytics';
 import { OAuthController } from './oauth-server/oauth-controller';
 import { ImageBuildPrefixContextParser } from './workspace/imagebuild-prefix-context-parser';
 import { AdditionalContentPrefixContextParser } from './workspace/additional-content-prefix-context-parser';
 import { WorkspaceLogService } from './workspace/workspace-log-service';
 import { HeadlessLogController } from './workspace/headless-log-controller';
+import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Env).toSelf().inSingletonScope();

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -24,7 +24,7 @@ import { GitpodToken, GitpodTokenType, User } from "@gitpod/gitpod-protocol";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { AuthFlow } from "../auth/auth-provider";
 import { LoginCompletionHandler } from "../auth/login-completion-handler";
-import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/util/analytics";
+import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { TosCookie } from "./tos-cookie";
 import { TosFlow } from "../terms/tos-flow";
 import { increaseLoginCounter } from '../../src/prometheus-metrics';

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -14,7 +14,7 @@ import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-pr
 import { StopWorkspaceRequest, StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { WorkspaceDeletionService } from "../workspace/workspace-deletion-service";
 import { AuthProviderService } from "../auth/auth-provider-service";
-import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
+import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
 
 @injectable()
 export class UserDeletionService {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -8,7 +8,7 @@ import { CloneTargetMode, FileDownloadInitializer, GitAuthMethod, GitConfig, Git
 import { CompositeInitializer, FromBackupInitializer } from "@gitpod/content-service/lib/initializer_pb";
 import { DBUser, DBWithTracing, TracedUserDB, TracedWorkspaceDB, UserDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
 import { CommitContext, Disposable, GitpodToken, GitpodTokenType, IssueContext, NamedWorkspaceFeatureFlag, PullRequestContext, RefType, SnapshotContext, StartWorkspaceResult, User, UserEnvVar, UserEnvVarValue, WithEnvvarsContext, WithPrebuild, Workspace, WorkspaceContext, WorkspaceImageSource, WorkspaceImageSourceDocker, WorkspaceImageSourceReference, WorkspaceInstance, WorkspaceInstanceConfiguration, WorkspaceInstanceStatus, WorkspaceProbeContext, Permission, HeadlessLogEvent, HeadlessWorkspaceEventType, DisposableCollection, AdditionalContentContext, ImageConfigFile, EmailType } from "@gitpod/gitpod-protocol";
-import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/util/analytics';
+import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { BuildRegistryAuth, BuildRegistryAuthSelective, BuildRegistryAuthTotal, BuildRequest, BuildResponse, BuildSource, BuildSourceDockerfile, BuildSourceReference, BuildStatus, ImageBuilderClientProvider, ResolveBaseImageRequest, ResolveWorkspaceImageRequest } from "@gitpod/image-builder/lib";

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -13,7 +13,7 @@ import { UserDB } from "@gitpod/gitpod-db/lib/user-db";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { HeadlessLogEvent } from "@gitpod/gitpod-protocol/lib/headless-workspace-log";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/util/analytics";
+import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { TracedWorkspaceDB, TracedUserDB, DBWithTracing } from '@gitpod/gitpod-db/lib/traced-db';
 import { PrometheusMetricsExporter } from "./prometheus-metrics-exporter";
 import { ClientProvider, WsmanSubscriber } from "./wsman-subscriber";

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -20,7 +20,8 @@ import { filePathTelepresenceAware } from '@gitpod/gitpod-protocol/lib/env';
 import { WorkspaceManagerClientProvider } from '@gitpod/ws-manager/lib/client-provider';
 import { WorkspaceManagerClientProviderCompositeSource, WorkspaceManagerClientProviderDBSource, WorkspaceManagerClientProviderSource } from '@gitpod/ws-manager/lib/client-provider-source';
 import { ClusterService, ClusterServiceServer } from './cluster-service-server';
-import { IAnalyticsWriter, newAnalyticsWriterFromEnv } from '@gitpod/gitpod-protocol/lib/util/analytics';
+import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
+import { newAnalyticsWriterFromEnv } from '@gitpod/gitpod-protocol/lib/util/analytics';
 
 export const containerModule = new ContainerModule(bind => {
 


### PR DESCRIPTION
This PR adds a `trackEvent` call to the Gitpod server to enable analytics event propagation from the dashboard.

fixes #4728
