### PR TITLE
[dashboard] Make sure the error thrown from getLoggedInUser takes pre…

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -62,11 +62,12 @@ function App() {
     useEffect(() => {
         (async () => {
             try {
-                const [ user, teams ] = await Promise.all([
-                    getGitpodService().server.getLoggedInUser(),
-                    getGitpodService().server.getTeams(),
-                ]);
+                const teamsPromise = getGitpodService().server.getTeams();
+
+                const user = await getGitpodService().server.getLoggedInUser();
                 setUser(user);
+
+                const teams = await teamsPromise;
                 setTeams(teams);
             } catch (error) {
                 console.error(error);


### PR DESCRIPTION
…sence before all other errors

Part of #4710 .

This ensures that we receive special error codes like "SETUP_REUQIRED" which are only emitted by getLoggedInUser, and those are not shadowed by a benign "not logged in" error.