### PR TITLE
[bpf] Reduce QEMU disk size

### DIFF
--- a/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
+++ b/components/ee/agent-smith/scripts/prepare-bpf-dev-environment.sh
@@ -23,7 +23,7 @@ cd "$outdir"
 
 tar -xvf rootfs.tar.gz
 
-qemu-img resize bionic-server-cloudimg-amd64.img +20G
+qemu-img resize --preallocation=off bionic-server-cloudimg-amd64.img +20G
 
 sudo virt-customize -a bionic-server-cloudimg-amd64.img --run-command 'resize2fs /dev/sda'
 


### PR DESCRIPTION
Fixes #4763.

This was shorter than I thought. :see_no_evil:  Reduces from 22GB -> 2.4GB:
![image](https://user-images.githubusercontent.com/32448529/125104010-36fee200-e0dd-11eb-9acf-404fdaa45617.png)
