### PR TITLE
[admin] Fix adminRestoreSoftDeletedWorkspace

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -62,12 +62,13 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                 <div className="flex w-full mt-6">
                     <Property name="User"><Link className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400" to={"/admin/users/" + props.workspace.ownerId}>{user?.name || props.workspace.ownerId}</Link></Property>
                     <Property name="Sharing">{workspace.shareable ? 'Enabled' : 'Disabled'}</Property>
-                    <Property name="Soft Deleted" actions={(!!workspace.softDeleted && !workspace.contentDeletedTime) && [{
+                    <Property name="Soft Deleted" actions={(!!workspace.softDeleted && !workspace.contentDeletedTime) ? [{
                         label: 'Restore & Pin',
-                        onClick: () => {
-                            getGitpodService().server.adminRestoreSoftDeletedWorkspace(workspace.workspaceId);
+                        onClick: async () => {
+                            await getGitpodService().server.adminRestoreSoftDeletedWorkspace(workspace.workspaceId);
+                            await reload();
                         }
-                    }] || undefined}>{workspace.softDeleted ? `'${workspace.softDeleted}' ${moment(workspace.softDeletedTime).fromNow()}` : 'No'}</Property>
+                    }] : undefined}>{workspace.softDeleted ? `'${workspace.softDeleted}' ${moment(workspace.softDeletedTime).fromNow()}` : 'No'}</Property>
                 </div>
                 <div className="flex w-full mt-12">
                     <Property name="Latest Instance ID">

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -619,7 +619,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
 
         const span = opentracing.globalTracer().startSpan("adminRestoreSoftDeletedWorkspace");
         await this.workspaceDb.trace({ span }).transaction(async db => {
-            const ws = await this.internalGetWorkspace(id, db);
+            const ws = await db.findById(id);
+            if (!ws) {
+                throw new ResponseError(ErrorCodes.NOT_FOUND, `No workspace with id '${id}' found.`);
+            }
             if (!ws.softDeleted) {
                 return;
             }


### PR DESCRIPTION
The “Restore & Pin” link in the admin portal does not work. This PR fixes the rights check.

![image](https://user-images.githubusercontent.com/24960040/125295754-d6161a80-e325-11eb-902f-e57d963cf610.png)

### How to test

1. Login with a user A. This user is the admin user.
2. Login in another session (e.g. incognito window) with another user B. This user is a normal user.
3. Start & stop a workspace with user B. Delete this workspace.
4. Look for this workspace in the admin dashboard with user A. There should be a “Restore & Pin” link. Click it!
5. Verify that the “Soft Deleted” column updates to “No” immediately for user A.
6. Verify that user B has the workspace in the list of active workspaces (pinned).

It's important to do this with 2 users because in the previous implementation the problem was, that you can restore your own workspace only (due to the rights check).

Fixes #4583