### PR TITLE
[code] remove oldest machine resources on max payload error

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT cc3c72f4a1321040668a55883bde66c4e4080c4a
+ENV GP_CODE_COMMIT a17670ba5af14e0faf3a6927983468d28fda235b
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

#### What it does

- fix #3277 by removing the oldest machine on too large payload

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/a17670ba5af14e0faf3a6927983468d28fda235b

#### How to test

The second commit limits the max payload for machine resource to 2 machines. So if you start 3-4 workspaces you should see only 2 machines (#3 and #4) in synced machines view (F1 -> Open View -> Synced Machines), first 2 machines should be removed. I will drop the last commit before merging.