### PR TITLE
[ws-daemon] Improve ws-daemon logs

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -251,7 +251,7 @@ func main() {
 	log.Init("nsinsider", "", true, true)
 	err := app.Run(os.Args)
 	if err != nil {
-		log.WithField("instanceId", os.Getenv("GITPOD_INSTANCE_ID")).Fatal(err)
+		log.WithField("instanceId", os.Getenv("GITPOD_INSTANCE_ID")).WithField("args", os.Args).Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This PR improves the logging of `ws-daemon` and `nsinsider` so that we can understand the impact of the critical logs in prod.

Helps debugging #4784.