### PR TITLE
Upgrade to VS Code 1.58.2

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 6cf68cedd9ab62af8e426a364d97ed206bbe0a02
+ENV GP_CODE_COMMIT 06711200f6a3a19af94f91102fd49d921b1145db
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
#### What it does

fix #4626 It upgrades VS Code to 1.58.2.

#### How to test

Test following aspects:
- terminals are preserved and resized properly between window reloads
- extension host process: check language smartness
- extension management (installing/uninstalling)
    - install VIM extension to test web extensions
- gp open and preview
- that user data are sync across workspaces as well as on workspace restart, especially for extensions
    - test that extensions from .gitpod.yml are installed without sync
- workspace specific commands should work, i.e. F1 → type Gitpod prefix
- that a PR view is preloaded on the PR url
- websockets and workers are properly proxied
    - diff editor should be operatable
    - trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old websockets are closed and new opened of the same amount
- settings should not contain any mentions of MS telemetry
- smoke test on Chrome, FF, and Safari on Mac/iPad