### PR TITLE
[server] Handle `releases/tag/<tag>` in GitHub context parser

### DIFF
--- a/components/server/src/github/github-context-parser.spec.ts
+++ b/components/server/src/github/github-context-parser.spec.ts
@@ -283,6 +283,27 @@ class TestGithubContextParser {
         )
     }
 
+    @test public async testReleasesContext_tag_01() {
+        const result = await this.parser.handle({}, this.user, 'https://github.com/gitpod-io/gitpod/releases/tag/v0.9.0');
+        expect(result).to.deep.include(
+            {
+                "ref": "v0.9.0",
+                "refType": "tag",
+                "isFile": false,
+                "path": "",
+                "title": "gitpod-io/gitpod - v0.9.0",
+                "revision": "25ece59c495d525614f28971d41d5708a31bf1e3",
+                "repository": {
+                    "cloneUrl": "https://github.com/gitpod-io/gitpod.git",
+                    "host": "github.com",
+                    "name": "gitpod",
+                    "owner": "gitpod-io",
+                    "private": false
+                }
+            }
+        )
+    }
+
     @test public async testCommitsContext_01() {
         const result = await this.parser.handle({}, this.user, 'https://github.com/gitpod-io/gitpod-test-repo/commits/4test');
         expect(result).to.deep.include({

--- a/components/server/src/github/github-context-parser.ts
+++ b/components/server/src/github/github-context-parser.ts
@@ -40,6 +40,12 @@ export class GithubContextParser extends AbstractContextParser implements IConte
                     case 'commits': {
                         return await this.handleTreeContext({span}, user, host, owner, repoName, moreSegments.slice(1));
                     }
+                    case 'releases': {
+                        if (moreSegments.length > 1 && moreSegments[1] === "tag") {
+                            return await this.handleTreeContext({ span }, user, host, owner, repoName, moreSegments.slice(2));
+                        }
+                        break;
+                    }
                     case 'issues': {
                         const issueNr = parseInt(moreSegments[1], 10);
                         if (isNaN(issueNr))


### PR DESCRIPTION
Handle context URLs like https://github.com/gitpod-io/gitpod/releases/tag/v0.9.0.

Test it: https://corneliusludmann-context-parser-4584.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod/releases/tag/v0.9.0
Verify that the proper tag has been opened.

Fixes #4584