### PR TITLE
[dev] mysql: add explicit resource request

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -507,6 +507,9 @@ mysql:
       # OFF is the default as documented [here](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp) (we also see this in GCP), but not for this chart.
     - name: MYSQL_EXTRA_FLAGS
       value: --explicit-defaults-for-timestamp=OFF
+    resources:
+      requests:
+        memory: 128Mi
   auth:
     existingSecret: db-password
   serviceAccount:
@@ -515,10 +518,6 @@ mysql:
   initdbScriptsConfigMap: db-init-scripts
   volumePermissions:
     enabled: true
-  resources:
-    requests:
-      cpu: 200m
-      memory: 250Mi
 
 rabbitmq:
   enabled: true


### PR DESCRIPTION
YAML fact you never wanted to know, fact #120323: In the bitnami mysql chart, [resources](https://github.com/bitnami/charts/blob/0a9d4c7fb9096443393b05ee2a0c7572df9e5ba2/bitnami/mysql/values.yaml#L273-L286) belongs under [primary](https://github.com/bitnami/charts/blob/master/bitnami/mysql/values.yaml#L146).