### PR TITLE
[loadgen] Add benchmark for prod startup time

### DIFF
--- a/dev/loadgen/go.mod
+++ b/dev/loadgen/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace github.com/gitpod-io/gitpod/common-go => ../../components/common-go // leeway

--- a/dev/loadgen/go.sum
+++ b/dev/loadgen/go.sum
@@ -504,6 +504,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -522,4 +523,5 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/dev/loadgen/pkg/loadgen/generator.go
+++ b/dev/loadgen/pkg/loadgen/generator.go
@@ -156,6 +156,7 @@ func (f *FixedLoadGenerator) Close() error {
 type WorkspaceCfg struct {
 	CloneURL       string `json:"cloneURL"`
 	WorkspaceImage string `json:"workspaceImage"`
+	CloneTarget    string `json:"cloneTarget"`
 }
 
 type MultiWorkspaceGenerator struct {
@@ -183,7 +184,7 @@ func (f *MultiWorkspaceGenerator) Generate() (*StartWorkspaceSpec, error) {
 		Spec: &csapi.WorkspaceInitializer_Git{
 			Git: &csapi.GitInitializer{
 				CheckoutLocation: "",
-				CloneTaget:       "main",
+				CloneTaget:       repo.CloneTarget,
 				RemoteUri:        repo.CloneURL,
 				TargetMode:       csapi.CloneTargetMode_REMOTE_BRANCH,
 				Config: &csapi.GitConfig{

--- a/dev/loadgen/prod-benchmark.yaml
+++ b/dev/loadgen/prod-benchmark.yaml
@@ -1,0 +1,42 @@
+## start with
+##    loadgen benchmark prod-benchmark.yaml
+
+workspaces: 500
+ideImage: eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8c1466008dedabe79d82cbb91931a16f7ce7994c
+repos:
+  - cloneURL: https://github.com/gitpod-io/template-typescript-node/
+    # image: gitpod/workspace-mongodb
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:53489ee25aa4d1797edd10485d8ecc2fc7a7456ae37718399a54efb498f7236f
+  - cloneURL: https://github.com/gitpod-io/template-typescript-react
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
+  - cloneURL: https://github.com/gitpod-io/template-python-django/
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
+  - cloneURL: https://github.com/gitpod-io/template-python-flask
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
+  - cloneURL: https://github.com/gitpod-io/spring-petclinic/
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
+#  - cloneURL: https://github.com/gitpod-io/template-php-drupal-ddev
+    # image: (dockerfile)
+#    workspaceImage:
+#  - cloneURL: https://github.com/gitpod-io/template-php-laravel-mysql
+    # image: (dockerfile)
+    #workspaceImage:
+#  - cloneURL: https://github.com/gitpod-io/template-ruby-on-rails-postgres/
+    # image: (dockerfile)
+    #workspaceImage:
+  - cloneURL: https://github.com/gitpod-io/template-golang-cli/
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
+  - cloneURL: https://github.com/gitpod-io/template-rust-cli/
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
+  - cloneURL: https://github.com/gitpod-io/template-dotnet-core-cli-csharp/
+    # image: gitpod/workspace-dotnet
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:0b62a3c575c8f00b9130f8a6572d9b4fd935e06de4498cef4ec2db8507cd6159
+  - cloneURL: https://github.com/gitpod-io/template-sveltejs/
+    # image: gitpod/workspace-full:latest
+    workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84

--- a/dev/loadgen/prod-benchmark.yaml
+++ b/dev/loadgen/prod-benchmark.yaml
@@ -2,21 +2,26 @@
 ##    loadgen benchmark prod-benchmark.yaml
 
 workspaces: 500
-ideImage: eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8c1466008dedabe79d82cbb91931a16f7ce7994c
+ideImage: eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ff263e14024f00d0ed78386b4417dfa6bcd4ae2f
 repos:
   - cloneURL: https://github.com/gitpod-io/template-typescript-node/
+    cloneTarget: master
     # image: gitpod/workspace-mongodb
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:53489ee25aa4d1797edd10485d8ecc2fc7a7456ae37718399a54efb498f7236f
   - cloneURL: https://github.com/gitpod-io/template-typescript-react
+    cloneTarget: main
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
   - cloneURL: https://github.com/gitpod-io/template-python-django/
+    cloneTarget: master
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
   - cloneURL: https://github.com/gitpod-io/template-python-flask
+    cloneTarget: master
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
   - cloneURL: https://github.com/gitpod-io/spring-petclinic/
+    cloneTarget: main
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
 #  - cloneURL: https://github.com/gitpod-io/template-php-drupal-ddev
@@ -29,14 +34,18 @@ repos:
     # image: (dockerfile)
     #workspaceImage:
   - cloneURL: https://github.com/gitpod-io/template-golang-cli/
+    cloneTarget: master
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
   - cloneURL: https://github.com/gitpod-io/template-rust-cli/
+    cloneTarget: main
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84
   - cloneURL: https://github.com/gitpod-io/template-dotnet-core-cli-csharp/
+    cloneTarget: main
     # image: gitpod/workspace-dotnet
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:0b62a3c575c8f00b9130f8a6572d9b4fd935e06de4498cef4ec2db8507cd6159
   - cloneURL: https://github.com/gitpod-io/template-sveltejs/
+    cloneTarget: main
     # image: gitpod/workspace-full:latest
     workspaceImage: eu.gcr.io/gitpod-dev/workspace-images:63bf2cbae693a7ecf60a40fb1eadc90b83a99919a2a010019a336a81b0c54b84


### PR DESCRIPTION
This PR adds a `benchmark` command to loadgen that can start multiple different workspaces against a workspace cluster.

Thanks @meysholdt for the pairing session and for producing the scenario file.

/werft no-preview