### PR TITLE
[bridge] Fix removal of "has-permission" admission constraint

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -175,10 +175,17 @@ export class ClusterService implements IClusterServiceServer {
                                 if (v.type !== c.type) {
                                     return true;
                                 }
-                                if (v.type === "has-permission" && v.permission === (c as AdmissionConstraintHasRole).permission) {
-                                    return true;
+
+                                switch (v.type) {
+                                    case "has-feature-preview":
+                                        return false;
+                                    case "has-permission":
+                                        if (v.permission === (c as AdmissionConstraintHasRole).permission) {
+                                            return false;
+                                        }
+                                        break;
                                 }
-                                return false;
+                                return true;
                             })
                         }
                     }


### PR DESCRIPTION
Fixes #4272.

### Test
 1. Start a workspace on this branch
 2. execute the following script
```
cd dev/gpctl
go build -v .
./gpctl clusters get-tls-config
./gpctl clusters --name ws-dev register --hint-govern --tls-path=./wsman-tls --url ws-manager:8080
./gpctl clusters list
./gpctl clusters update admission-constraint --name ws-dev add has-permission="test"
./gpctl clusters list
./gpctl clusters update admission-constraint --name ws-dev remove has-permission="test"
./gpctl clusters list
```