### PR TITLE
[Analytics] Fixed wrong name in signup tracking

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -517,7 +517,7 @@ export class UserController {
             properties: {
                 "auth_provider": user.identities[0].authProviderId,
                 "email": User.getPrimaryEmail(user),
-                "name": User.getName(user),
+                "name": user.identities[0].authName,
                 "full_name": user.fullName,
                 "created_at": user.creationDate,
                 "unsubscribed": !user.allowsMarketingCommunication,


### PR DESCRIPTION
Fixes that fullName instead of name is passed to name attribute in analytics signup tracking call.

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe