### PR TITLE
[server] Set owner token cookie HttpOnly and Secure

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -216,8 +216,8 @@ export class UserController {
             const name = `_${cookiePrefix}_ws_${instanceID}_owner_`;
             res.cookie(name, token, {
                 path: "/",
-                httpOnly: false,
-                secure: false,
+                httpOnly: true,
+                secure: true,
                 maxAge: 1000 * 60 * 60 * 24 * 1,    // 1 day
                 sameSite: "lax",                    // default: true. "Lax" needed for cookie to work in the workspace domain.
                 domain: `.${this.env.hostUrl.url.host}`


### PR DESCRIPTION
Prior the owner token could be read by a VS Code extension or a website served from a port.
Granted, not a very useful thing to do especially in the latter case, because you're already in the workspace then.

fixes #4830