### PR TITLE
[bridge] Set stoppedTime while workspace is stopping

### DIFF
--- a/components/ee/payment-endpoint/src/accounting/account-service-impl.ts
+++ b/components/ee/payment-endpoint/src/accounting/account-service-impl.ts
@@ -261,7 +261,7 @@ export class AccountServiceImpl implements AccountService {
             .map<OpenDebit>(s => {
                 const wsi = s.instance;
                 const sessionStartDate = oldest(wsi.startedTime!, startDate);
-                const sessionEndDate = earliest(wsi.stoppedTime || endDate, endDate);
+                const sessionEndDate = earliest(wsi.stoppingTime || wsi.stoppedTime || endDate, endDate);
                 return {
                     userId,
                     amount: -durationInHours(sessionEndDate, wsi.startedTime!),

--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -40,6 +40,20 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
     })
     deployedTime?: string;
 
+    /**
+     * StoppingTime is the time the workspace first entered the STOPPING phase, i.e.
+     * began to shut down on the cluster.
+     */
+    @Column({
+        default: '',
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED
+    })
+    stoppingTime?: string;
+
+    /**
+     * StoppedTime is the time the workspace entered the STOPPED phase, i.e.
+     * was actually stopped on the cluster.
+     */
     @Column({
         default: '',
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED

--- a/components/gitpod-db/src/typeorm/migration/1626350762001-WorkspaceInstanceStoppingTime.ts
+++ b/components/gitpod-db/src/typeorm/migration/1626350762001-WorkspaceInstanceStoppingTime.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { columnExists, tableExists } from "./helper/helper";
+
+export class WorkspaceInstanceStoppingTime1626350762001 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        if (await tableExists(queryRunner, "d_b_workspace_instance")) {
+            if (!(await columnExists(queryRunner, "d_b_workspace_instance", "stoppingTime"))) {
+                await queryRunner.query("ALTER TABLE d_b_workspace_instance ADD COLUMN stoppingTime varchar(255) NOT NULL DEFAULT ''");
+            }
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -48,6 +48,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
         creationTime: this.timeBefore,
         startedTime: undefined,
         deployedTime: undefined,
+        stoppingTime: undefined,
         stoppedTime: undefined,
         status: {
             phase: "preparing",
@@ -68,6 +69,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
         creationTime: this.timeAfter,
         startedTime: undefined,
         deployedTime: undefined,
+        stoppingTime: undefined,
         stoppedTime: undefined,
         status: {
             phase: "running",
@@ -102,6 +104,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
         creationTime: this.timeBefore,
         startedTime: undefined,
         deployedTime: undefined,
+        stoppingTime: undefined,
         stoppedTime: undefined,
         status: {
             phase: "preparing",

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -32,7 +32,7 @@ export interface WorkspacePortsAuthData {
     workspace: WorkspaceAuthData;
 }
 
-export type WorkspaceInstanceSession = Pick<WorkspaceInstance, "id" | "startedTime" | "stoppedTime">;
+export type WorkspaceInstanceSession = Pick<WorkspaceInstance, "id" | "startedTime"| "stoppingTime" | "stoppedTime">;
 export type WorkspaceSessionData = Pick<Workspace, "id" | "contextURL" | "context" | "type">;
 export interface WorkspaceInstanceSessionWithWorkspace {
     instance: WorkspaceInstanceSession;

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -23,6 +23,9 @@ export interface WorkspaceInstance {
     // The time an instance has switched phase to 'Running'
     startedTime?: string;
 
+    // The time an instance has switched phase to 'Stopping' */
+    stoppingTime?: string;
+
     // The time an instance has switched phase to 'Stopped' */
     stoppedTime?: string;
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -222,6 +222,7 @@ export class WorkspaceStarter {
             // We may have never actually started the workspace which means that ws-manager-bridge never set a workspace status.
             // We have to set that status ourselves.
             instance.status.phase = 'stopped';
+            instance.stoppingTime = new Date().toISOString();
             instance.stoppedTime = new Date().toISOString();
 
             instance.status.conditions.failed = err.toString();

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -227,11 +227,13 @@ export class WorkspaceManagerBridge implements Disposable {
                     }
                     break;
                 case WorkspacePhase.STOPPED:
+                    const now = new Date().toISOString();
+                    instance.stoppedTime = now;
                     instance.status.phase = "stopped";
                     if (!instance.stoppingTime) {
                         // It's possible we've never seen a stopping update, hence have not set the `stoppingTime`
                         // yet. Just for this case we need to set it now.
-                        instance.stoppingTime = new Date().toISOString();
+                        instance.stoppingTime = now;
                     }
                     lifecycleHandler = () => this.onInstanceStopped({span}, userId, instance);
                     break;


### PR DESCRIPTION
there's no need to include the time our workspaces take to stop into account when computing workspace runtime (which is accounting relevant).

fixes #4818 