### PR TITLE
[database] Rename migration file name

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1626351957505-AddProjectIdToPrebuiltWorkspace.ts
+++ b/components/gitpod-db/src/typeorm/migration/1626351957505-AddProjectIdToPrebuiltWorkspace.ts
@@ -7,7 +7,7 @@
  import {MigrationInterface, QueryRunner} from "typeorm";
  import { tableExists, columnExists } from "./helper/helper";
 
-export class AddProjectIdToPrebuiltWorkspace1624962141719 implements MigrationInterface {
+export class AddProjectIdToPrebuiltWorkspace1626351957505 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
         if (await tableExists(queryRunner, "d_b_prebuilt_workspace")) {


### PR DESCRIPTION
Due to the incorrect order of migration and file name the db-sync operation was failing. This commit renames the file which should migrate later.