### PR TITLE
Provide better feedback when gitpod.yml is invalid

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -42,7 +42,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
     this.createWorkspace();
   }
 
-  async createWorkspace(mode = CreateWorkspaceMode.SelectIfRunning) {
+  async createWorkspace(mode = CreateWorkspaceMode.SelectIfRunning, forceDefaultConfig = false) {
     // Invalidate any previous result.
     this.setState({ result: undefined, stillParsing: true });
 
@@ -52,7 +52,8 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
     try {
       const result = await getGitpodService().server.createWorkspace({
         contextUrl: this.props.contextUrl,
-        mode
+        mode,
+        forceDefaultConfig
       });
       if (result.workspaceURL) {
         window.location.href = result.workspaceURL;
@@ -113,6 +114,11 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
         case ErrorCodes.CONTEXT_PARSE_ERROR:
           statusMessage = <div className="text-center">
             <p className="text-base mt-2">Learn more about <a className="text-blue" href="https://www.gitpod.io/docs/context-urls/">supported context URLs</a></p>
+          </div>;
+          break;
+        case ErrorCodes.INVALID_GITPOD_YML:
+          statusMessage = <div className="mt-2 flex flex-col space-y-8">
+            <button className="" onClick={() => { this.createWorkspace(CreateWorkspaceMode.Default, true) }}>Continue with default configuration</button>
           </div>;
           break;
         case ErrorCodes.NOT_AUTHENTICATED:

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -292,6 +292,7 @@ export namespace GitpodServer {
     export interface CreateWorkspaceOptions {
         contextUrl: string;
         mode?: CreateWorkspaceMode;
+        forceDefaultConfig?: boolean;
     }
     export interface StartWorkspaceOptions {
         forceDefaultImage: boolean;

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -34,6 +34,9 @@ export namespace ErrorCodes {
     // 460 Context Parse Error (custom status code)
     export const CONTEXT_PARSE_ERROR = 460;
 
+    // 461 Invalid gitpod yml
+    export const INVALID_GITPOD_YML = 461;
+
     // 450 Payment error
     export const PAYMENT_ERROR = 450;
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -802,6 +802,29 @@ export namespace WithPrebuild {
     }
 }
 
+/**
+ * WithDefaultConfig contexts disable the download of the gitpod.yml from the repository
+ * and fall back to the built-in configuration.
+ */
+export interface WithDefaultConfig {
+    withDefaultConfig: true;
+}
+
+export namespace WithDefaultConfig {
+    export function is(context: any): context is WithDefaultConfig {
+        return context
+            && 'withDefaultConfig' in context
+            && context.withDefaultConfig;
+    }
+
+    export function mark(ctx: WorkspaceContext): WorkspaceContext & WithDefaultConfig {
+        return {
+            ...ctx,
+            withDefaultConfig: true
+        }
+    }
+}
+
 export interface SnapshotContext extends WorkspaceContext, WithSnapshot {
     snapshotId: string;
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -7,7 +7,7 @@
 import { BlobServiceClient } from "@gitpod/content-service/lib/blobs_grpc_pb";
 import { DownloadUrlRequest, DownloadUrlResponse, UploadUrlRequest, UploadUrlResponse } from '@gitpod/content-service/lib/blobs_pb';
 import { AppInstallationDB, UserDB, UserMessageViewsDB, WorkspaceDB, DBWithTracing, TracedWorkspaceDB, DBGitpodToken, DBUser, UserStorageResourcesDB, ProjectDB, TeamDB } from '@gitpod/gitpod-db/lib';
-import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, ProjectInfo, Project, ProviderRepository, PrebuildInfo, TeamMemberRole } from '@gitpod/gitpod-protocol';
+import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, ProjectInfo, Project, ProviderRepository, PrebuildInfo, TeamMemberRole, WithDefaultConfig } from '@gitpod/gitpod-protocol';
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { AdminBlockUserRequest, AdminGetListRequest, AdminGetListResult, AdminGetWorkspacesRequest, AdminModifyPermanentWorkspaceFeatureFlagRequest, AdminModifyRoleOrPermissionRequest, WorkspaceAndInstance } from '@gitpod/gitpod-protocol/lib/admin-protocol';
 import { GetLicenseInfoResult, LicenseFeature, LicenseValidationResult } from '@gitpod/gitpod-protocol/lib/license-protocol';
@@ -807,6 +807,11 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
                 this.mayStartWorkspace({ span }, user, runningInstancesPromise),
                 this.mayOpenContext(user, context)
             ]);
+
+            // if we're forced to use the default config, mark the context as such
+            if (!!options.forceDefaultConfig) {
+                context = WithDefaultConfig.mark(context);
+            }
 
             // if this is an explicit prebuild, check if the user wants to install an app.
             if (StartPrebuildContext.is(context) && CommitContext.is(context.actual) && context.actual.repository.cloneUrl) {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -49,6 +49,7 @@ import { WorkspaceFactory } from './workspace-factory';
 import { WorkspaceStarter } from './workspace-starter';
 import { HeadlessLogUrls } from "@gitpod/gitpod-protocol/lib/headless-workspace-log";
 import { HeadlessLogService } from "./headless-log-service";
+import { InvalidGitpodYMLError } from "./config-provider";
 
 @injectable()
 export class GitpodServerImpl<Client extends GitpodClient, Server extends GitpodServer> implements GitpodServer, Disposable {
@@ -863,6 +864,9 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
             }
             if (UnauthorizedError.is(error)) {
                 throw new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "Unauthorized", error.data);
+            }
+            if (InvalidGitpodYMLError.is(error)) {
+                throw new ResponseError(ErrorCodes.INVALID_GITPOD_YML, error.message);
             }
 
             TraceContext.logError({ span }, error);


### PR DESCRIPTION
fixes #4828

This PR adds a proper failure mode for invalid gitpod.yml configuration. Instead of silently falling back to the default config, it surfaces the error and offers the choice to start with the default config.

### How to test
1. https://csweichel-provide-better-feedback-4828.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod-test-repo/tree/broken-gitpod-config