### PR TITLE
[content-service] Improve CPU utilization for initial git clone command

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -272,7 +272,7 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 		args = append(args, strings.TrimSpace(key)+"="+strings.TrimSpace(value))
 	}
 
-	args = append(args, "--filter=blob:none")
+	args = append(args, "--filter=tree:0")
 	args = append(args, ".")
 
 	return c.Git(ctx, "clone", args...)


### PR DESCRIPTION
Before this change, we need to test the impact and side effects

/hold