### PR TITLE
Fix node-root path for new nodepool of core-dev

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -161,6 +161,9 @@ components:
     resources:
       cpu: 1m
       memory: 1Mi
+    nodeRoots:
+      - /var/lib
+      - /run/containerd/io.containerd.runtime.v2.task/k8s.io
 
   wsScheduler:
     scaler:


### PR DESCRIPTION
The nodepool 4 got upgraded to kuberntes version 1.19 which has a different path of node rooot. This PR fixes it