### PR TITLE
[dashboard] Add invite members button on projects page

### DIFF
--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -79,6 +79,7 @@ export default function () {
                             onClick: () => { /* TODO */ }
                         }]} />
                     </div>
+                    <Link to="./members"><button className="ml-2 secondary">Invite Members</button></Link>
                     <button className="ml-2" onClick={() => onNewProject()}>New Project</button>
                 </div>
                 <div className="mt-4 grid grid-cols-3 gap-4">


### PR DESCRIPTION
This will add a button to invite members on the projects page that links to the _Members_ page.

| BEFORE | AFTER |
|-|-|
| <img width="1315" alt="Screenshot 2021-07-19 at 3 23 52 PM" src="https://user-images.githubusercontent.com/120486/126159709-5c7af877-d4c1-43ef-9c5c-72c72b7a7171.png"> | <img width="1315" alt="Screenshot 2021-07-19 at 3 23 48 PM" src="https://user-images.githubusercontent.com/120486/126159714-9656da6d-eaf6-4b61-9f9c-ad9e9451a1e6.png"> | 