### PR TITLE
[dashboard/server] Fix "start-workspace-cycle" on image builder errors

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -92,7 +92,7 @@ export async function build(context, version) {
     const workspaceFeatureFlags = (buildConfig["ws-feature-flags"] || "").split(",").map(e => e.trim())
     const dynamicCPULimits = "dynamic-cpu-limits" in buildConfig;
     const withInstaller = "with-installer" in buildConfig || mainBuild;
-    const noPreview = "no-preview" in buildConfig || publishRelease;
+    const noPreview = ("no-preview" in buildConfig && buildConfig["no-preview"] !== "false") || publishRelease;
     const storage = buildConfig["storage"] || "";
     const withIntegrationTests = "with-integration-tests" in buildConfig;
     const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -330,19 +330,32 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
   const logsEmitter = new EventEmitter();
   const service = getGitpodService();
   let pollTimeout: NodeJS.Timeout | undefined;
+  let prebuildDoneTriggered: boolean = false;
 
   useEffect(() => {
+    const checkIsPrebuildDone = async (): Promise<boolean> => {
+      if (prebuildDoneTriggered) {
+        console.debug("prebuild done already triggered, doing nothing");
+        return true;
+      }
+
+      const done = await service.server.isPrebuildDone(props.runningPrebuild.prebuildID);
+      if (done) {
+        // note: this treats "done" as "available" which is not equivalent.
+        // This works because the backend ignores prebuilds which are not "available", and happily starts a workspace as if there was no prebuild at all.
+        prebuildDoneTriggered = true;
+        props.onPrebuildSucceeded();
+        return true;
+      }
+      return false;
+    };
     const pollIsPrebuildDone = async () => {
       clearTimeout(pollTimeout!);
-      const available = await service.server.isPrebuildDone(props.runningPrebuild.prebuildID);
-      if (available) {
-        props.onPrebuildSucceeded();
-        return;
-      }
+      await checkIsPrebuildDone();
       pollTimeout = setTimeout(pollIsPrebuildDone, 10000);
     };
 
-    const disposables = watchHeadlessLogs(service.server, props.runningPrebuild.instanceID, (chunk) => logsEmitter.emit('logs', chunk), pollIsPrebuildDone);
+    const disposables = watchHeadlessLogs(service.server, props.runningPrebuild.instanceID, (chunk) => logsEmitter.emit('logs', chunk), checkIsPrebuildDone);
     return function cleanup() {
       clearTimeout(pollTimeout!);
       disposables.dispose();

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -346,7 +346,7 @@ function HeadlessWorkspaceView(props: { instanceId: string }) {
 
   useEffect(() => {
     const service = getGitpodService();
-    const disposables = watchHeadlessLogs(service.server, props.instanceId, (chunk) => logsEmitter.emit('logs', chunk), () => {});
+    const disposables = watchHeadlessLogs(service.server, props.instanceId, (chunk) => logsEmitter.emit('logs', chunk), async () => { return false; });
     return function cleanup() {
       disposables.dispose();
     };


### PR DESCRIPTION
Fixes #4856.

I pushed https://github.com/gitpod-io/gitpod/pull/4875/commits/bf44fa1d6653fe1c8b2254caa4fd2bf3a6256193 should serve as reproducer for #4856.

### Test

 1. Go to https://gpl-4856-prebuild-cycle.staging.gitpod-dev.com/workspaces/
 1. Open dev console
 1. Start a prebuild suing `/#prebuild/` which triggers a fresh image-build that takes longer than 1 minute
 2. Note how you see _exactly one_ line of `/start: started workspace instance: ` after ~1 minute
 1. Note how you get stuck on the prebuild page :confused: (cmp. https://github.com/gitpod-io/gitpod/issues/4856#issuecomment-883144199)