### PR TITLE
Fix proxy deployment manifest duplicated keys

### DIFF
--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -86,9 +86,6 @@ spec:
             secretKeyRef:
               name: server-proxy-apikey
               key: apikey
-{{ include "gitpod.container.defaultEnv" (dict "root" . "gp" $.Values "comp" $wsProxy "noVersion" true) | indent 8 }}
-        securityContext:
-          privileged: false
       volumes:
       - name: vhosts
         configMap:


### PR DESCRIPTION
This removes duplicated keys (`env` and `securityContext`) from the proxy deployment manifest.