### PR TITLE
[werft] Remove left-over installer build

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -151,9 +151,6 @@ export async function build(context, version) {
                 throw new Error(`'${version}' is not semver compliant and thus cannot used for Self-Hosted releases!`)
             }
 
-            werft.phase("publish", "publishing docker images...");
-            exec(`leeway run --werft=true install/installer:publish-as-latest -Dversion=${version} -DimageRepoBase=${imageRepo}`);
-
             werft.phase("publish", "publishing Helm chart...");
             publishHelmChart("gcr.io/gitpod-io/self-hosted", version);
 


### PR DESCRIPTION
Installers have been removed in #4687. This PR removes the installers build in the werft job.