### PR TITLE
[content-service] Start snapshots from-other

### DIFF
--- a/components/content-service/pkg/initializer/snapshot.go
+++ b/components/content-service/pkg/initializer/snapshot.go
@@ -30,7 +30,7 @@ func (s *SnapshotInitializer) Run(ctx context.Context, mappings []archive.IDMapp
 	span.SetTag("snapshot", s.Snapshot)
 	defer tracing.FinishSpan(span, &err)
 
-	src = csapi.WorkspaceInitFromOther
+	src = csapi.WorkspaceInitFromBackup
 
 	ok, err := s.Storage.DownloadSnapshot(ctx, s.Location, s.Snapshot, mappings)
 	if err != nil {


### PR DESCRIPTION
to make the tasks behave like a workspace restart.

This change makes snapshots behave as [documented](https://www.gitpod.io/docs/config-start-tasks#start-a-snapshot).

fixes #4894 

## How to test
1. Open https://csweichel-init-command-beeing-run-4894.staging.gitpod-dev.com#snapshot/3c239bd3-d3ff-4399-9ffe-e419ac99858a
2. `cat /workspace/.gitpod/ready` should be `from-backup`