### PR TITLE
[dashboard/code] Produce timing data for workspace startup

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -65,6 +65,24 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     this.toDispose.dispose();
   }
 
+  componentDidUpdate(prevPros: StartWorkspaceProps, prevState: StartWorkspaceState) {
+    const newPhase = this.state?.workspaceInstance?.status.phase;
+    const oldPhase = prevState.workspaceInstance?.status.phase;
+    if (newPhase !== oldPhase) {
+      getGitpodService().server.trackEvent({
+        event: "status_rendered",
+        properties: { workspaceId: this.state?.workspaceInstance?.workspaceId, "phase": newPhase },
+      });
+    }
+
+    if (!!this.state.error && this.state.error !== prevState.error) {
+      getGitpodService().server.trackEvent({
+        event: "error_rendered",
+        properties: { workspaceId: this.state?.workspaceInstance?.workspaceId, "error": this.state.error },
+      });
+    }
+  }
+
   async startWorkspace(restart = false, forceDefaultImage = false) {
     const state = this.state;
     if (state) {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -691,6 +691,7 @@ export class WorkspaceStarter {
             "function:getEnvVars",
             "function:setEnvVar",
             "function:deleteEnvVar",
+            "function:trackEvent",
 
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "workspace", subjectID: workspace.id, operations: ["get", "update"]}),
             "resource:"+ScopedResourceGuard.marshalResourceScope({kind: "workspaceInstance", subjectID: instance.id, operations: ["get", "update", "delete"]}),

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -137,6 +137,15 @@ const loadingIDE = new Promise(resolve => window.addEventListener('DOMContentLoa
     ideService.onDidChange(() => {
         updateLoadingState();
         updateCurrentFrame();
+
+        window.gitpod.service.server.trackEvent({
+            event: "status_rendered",
+            properties: {
+                workspaceId: gitpodServiceClient.info.latestInstance?.workspaceId,
+                phase: `ide-${ideService.state}`,
+                error: ideService.failureCause?.message,
+            },
+        });
     });
     //#endregion
 


### PR DESCRIPTION
This PR produces analytics events from the frontend to track the speed and reliability of workspace starts. E.g.

```
{"payload":{"userId":"1c23ee48-4c56-4684-831e-cca71711a36b","event":"workspace-started","properties":{"workspaceId":"brown-leopon-tndxsxj3","instanceId":"7ed1f664-8af1-4ea0-8f4a-10178f925a79","contextURL":"https://github.com/gitpod-io/template-typescript-node","usesPrebuild":false}},"component":"server","severity":"DEBUG","time":"2021-07-22T09:30:16.571Z","environment":"devstaging","region":"europe-west1","message":"analytics track"}
{"payload":{"userId":"1c23ee48-4c56-4684-831e-cca71711a36b","event":"status_rendered","properties":{"workspaceId":"brown-leopon-tndxsxj3","phase":"creating"}},"component":"server","severity":"DEBUG","time":"2021-07-22T09:30:17.901Z","environment":"devstaging","region":"europe-west1","message":"analytics track"}
{"payload":{"userId":"1c23ee48-4c56-4684-831e-cca71711a36b","event":"status_rendered","properties":{"workspaceId":"brown-leopon-tndxsxj3","phase":"initializing"}},"component":"server","severity":"DEBUG","time":"2021-07-22T09:30:29.593Z","environment":"devstaging","region":"europe-west1","message":"analytics track"}
{"payload":{"userId":"1c23ee48-4c56-4684-831e-cca71711a36b","event":"status_rendered","properties":{"workspaceId":"brown-leopon-tndxsxj3","phase":"running"}},"component":"server","severity":"DEBUG","time":"2021-07-22T09:30:40.577Z","environment":"devstaging","region":"europe-west1","message":"analytics track"}
{"payload":{"userId":"1c23ee48-4c56-4684-831e-cca71711a36b","event":"status_rendered","properties":{"workspaceId":"brown-leopon-tndxsxj3","phase":"vsc_opened"}},"component":"server","severity":"DEBUG","time":"2021-07-22T09:30:45.054Z","environment":"devstaging","region":"europe-west1","message":"analytics track"}
```

Corresponding code PR: https://github.com/gitpod-io/vscode/pull/21
@akosyakov what's the usual path here? Merge the PR in vscode and then update the commit in this one?


Caveat: we'll possibly receive multiple `vsc_opened` events, namely whenever the user opens the IDE, e.g. reloads the window or opens another one.

fixes #4863 

/werft analytics=log

