### PR TITLE
[gitpod-db] Don't count stopping instances as running

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -326,7 +326,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
 
     public async findRunningInstancesWithWorkspaces(installation?: string, userId?: string): Promise<RunningWorkspaceInfo[]> {
         const params: any = {};
-        const conditions = ["wsi.phasePersisted != 'stopped'", "wsi.deleted != TRUE"];
+        const conditions = ["wsi.phasePersisted != 'stopped'", "wsi.phasePersisted != 'stopping'", "wsi.deleted != TRUE"];
         if (installation) {
             params.region = installation;
             conditions.push("wsi.region = :region");


### PR DESCRIPTION
With this PR we no longer count `stopping` workspaces as running.

I've gone through the callers of `findRegularRunningInstances` and `findRunningInstancesWithWorkspaces`, and have not found a place where that change would adversely affect the behaviour with one minor exception:

In tthe cluster service the check if the cluster is empty using `findRegularRunningInstances`. Prior we would not consider the cluster empty if there were still stopping instances, now `stopping` instances no longer prevent cluster de-registration. This does not mean the workspaces would loose their backup, but the data in the database must become inconsistent. We should **never** even deregister a non-empty cluster to begin with. All things considered, I figured the additional variance/complexity of introducing something like `includeStoppingWorkspaces` just for this one case was unjustified.

fixes #4906