### PR TITLE
[workspacekit] Discover bind mount paths

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -5,8 +5,13 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -243,14 +248,30 @@ var ring1Cmd = &cobra.Command{
 			log.WithField("fsshift", fsshift).Fatal("unknown FS shift method")
 		}
 
-		mnts = append(mnts,
-			mnte{Target: "/sys", Flags: unix.MS_BIND | unix.MS_REC},
-			mnte{Target: "/dev", Flags: unix.MS_BIND | unix.MS_REC},
-			mnte{Target: "/etc/hosts", Flags: unix.MS_BIND | unix.MS_REC},
-			mnte{Target: "/etc/hostname", Flags: unix.MS_BIND | unix.MS_REC},
-			mnte{Target: "/etc/resolv.conf", Flags: unix.MS_BIND | unix.MS_REC},
-			mnte{Target: "/tmp", Source: "tmpfs", FSType: "tmpfs"},
-		)
+		procMounts, err := ioutil.ReadFile("/proc/mounts")
+		if err != nil {
+			log.WithError(err).Fatal("cannot read /proc/mounts")
+		}
+
+		candidates, err := findBindMountCandidates(bytes.NewReader(procMounts), os.Readlink)
+		if err != nil {
+			log.WithError(err).Fatal("cannot detect mount candidates")
+		}
+		for _, c := range candidates {
+			mnts = append(mnts, mnte{Target: c, Flags: unix.MS_BIND | unix.MS_REC})
+		}
+		mnts = append(mnts, mnte{Target: "/tmp", Source: "tmpfs", FSType: "tmpfs"})
+
+		if adds := os.Getenv("GITPOD_WORKSPACEKIT_BIND_MOUNTS"); adds != "" {
+			var additionalMounts []string
+			err = json.Unmarshal([]byte(adds), &additionalMounts)
+			if err != nil {
+				log.WithError(err).Fatal("cannot unmarshal GITPOD_WORKSPACEKIT_BIND_MOUNTS")
+			}
+			for _, c := range additionalMounts {
+				mnts = append(mnts, mnte{Target: c, Flags: unix.MS_BIND | unix.MS_REC})
+			}
+		}
 
 		// FWB workspaces do not require mounting /workspace
 		// if that is done, the backup will not contain any change in the directory
@@ -443,6 +464,77 @@ var ring1Cmd = &cobra.Command{
 		}
 		exitCode = 0 // once we get here everythings good
 	},
+}
+
+var (
+	knownMountCandidatePaths = []string{
+		"/workspace",
+		"/sys",
+		"/dev",
+		"/etc/hosts",
+		"/etc/hostname",
+		"/etc/resolv.conf",
+	}
+)
+
+// findBindMountCandidates attempts to find bind mount candidates in the ring0 mount namespace.
+// It does that by either checking for knownMountCandidatePaths, or after rejecting based on filesystems (e.g. cgroup or proc),
+// checking if in the root of the mountpoint there's a `..data` symlink pointing to a file starting with `..`.
+// That's how configMaps and secrets behave in Kubernetes.
+//
+// Note/Caveat: configMap or secret volumes with a subPath do not behave as described above and will not be recognised by this function.
+//              in those cases you'll want to use GITPOD_WORKSPACEKIT_BIND_MOUNTS to explicitely list those paths.
+func findBindMountCandidates(procMounts io.Reader, readlink func(path string) (dest string, err error)) (mounts []string, err error) {
+	scanner := bufio.NewScanner(procMounts)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 {
+			continue
+		}
+
+		// accept known paths
+		var (
+			path   = fields[1]
+			accept bool
+		)
+		for _, p := range knownMountCandidatePaths {
+			if p == path {
+				accept = true
+				break
+			}
+		}
+		if accept {
+			mounts = append(mounts, path)
+			continue
+		}
+
+		// reject known filesystems
+		var (
+			fs     = fields[0]
+			reject bool
+		)
+		switch fs {
+		case "cgroup", "devpts", "mqueue", "shm", "proc", "sysfs":
+			reject = true
+		}
+		if reject {
+			continue
+		}
+
+		// test remaining candidates if they're a Kubernetes configMap or secret
+		ln, err := readlink(filepath.Join(path, "..data"))
+		if err != nil {
+			log.WithField("path", path).Debug("not bind-mounting because this doesn't look like a configMap")
+			continue
+		}
+		if !strings.HasPrefix(ln, "..") {
+			log.WithField("path", path).WithField("ln", ln).Debug("not bind-mounting because this doesn't look like a configMap")
+			continue
+		}
+
+		mounts = append(mounts, path)
+	}
+	return mounts, scanner.Err()
 }
 
 func receiveSeccmpFd(conn *net.UnixConn) (libseccomp.ScmpFd, error) {

--- a/components/workspacekit/cmd/rings_test.go
+++ b/components/workspacekit/cmd/rings_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindBindMountCandidates(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Mounts      string
+		Readlink    func(path string) (dest string, err error)
+		Expectation []string
+	}{
+		{
+			Name:     "no configmap",
+			Mounts:   "overlay / overlay rw,relatime,lowerdir=1714/fs:1713/fs:1712/fs:1711/fs:1710/fs:1709/fs:1708/fs:1707/fs:1706/fs:1705/fs:1704/fs:1703/fs:1702/fs:1701/fs:791/fs:257/fs:256/fs:255/fs:254/fs:253/fs:252/fs:251/fs:250/fs:249/fs:248/fs:247/fs:246/fs:245/fs:244/fs:243/fs:242/fs:241/fs:240/fs:239/fs:235/fs:234/fs:233/fs:232/fs:231/fs:230/fs:229/fs:228/fs:227/fs:226/fs:225/fs:224/fs:223/fs:222/fs:221/fs:220/fs:219/fs:215/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1715/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1715/work,xino=off 0 0\nproc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\ntmpfs /dev tmpfs rw,nosuid,size=65536k,mode=755 0 0\ndevpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666 0 0\nmqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0\nsysfs /sys sysfs ro,nosuid,nodev,noexec,relatime 0 0\ntmpfs /sys/fs/cgroup tmpfs rw,nosuid,nodev,noexec,relatime,mode=755 0 0\ncgroup /sys/fs/cgroup/systemd cgroup ro,nosuid,nodev,noexec,relatime,xattr,name=systemd 0 0\ncgroup /sys/fs/cgroup/rdma cgroup ro,nosuid,nodev,noexec,relatime,rdma 0 0\ncgroup /sys/fs/cgroup/cpu,cpuacct cgroup ro,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\ncgroup /sys/fs/cgroup/pids cgroup ro,nosuid,nodev,noexec,relatime,pids 0 0\ncgroup /sys/fs/cgroup/blkio cgroup ro,nosuid,nodev,noexec,relatime,blkio 0 0\ncgroup /sys/fs/cgroup/freezer cgroup ro,nosuid,nodev,noexec,relatime,freezer 0 0\ncgroup /sys/fs/cgroup/net_cls,net_prio cgroup ro,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0\ncgroup /sys/fs/cgroup/memory cgroup ro,nosuid,nodev,noexec,relatime,memory 0 0\ncgroup /sys/fs/cgroup/devices cgroup ro,nosuid,nodev,noexec,relatime,devices 0 0\ncgroup /sys/fs/cgroup/perf_event cgroup ro,nosuid,nodev,noexec,relatime,perf_event 0 0\ncgroup /sys/fs/cgroup/hugetlb cgroup ro,nosuid,nodev,noexec,relatime,hugetlb 0 0\ncgroup /sys/fs/cgroup/cpuset cgroup ro,nosuid,nodev,noexec,relatime,cpuset 0 0\n/dev/sdb /workspace ext4 rw,relatime,discard 0 0\n/dev/sdb /.workspace ext4 rw,relatime,discard 0 0\n/dev/sda1 /etc/hosts ext4 rw,relatime 0 0\n/dev/sda1 /dev/termination-log ext4 rw,relatime 0 0\n/dev/sda1 /etc/hostname ext4 rw,relatime 0 0\n/dev/sda1 /etc/resolv.conf ext4 rw,relatime 0 0\nshm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k 0 0\nproc /proc/bus proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/fs proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/irq proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/sys proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/sysrq-trigger proc ro,nosuid,nodev,noexec,relatime 0 0\ntmpfs /proc/acpi tmpfs ro,relatime 0 0\ntmpfs /proc/kcore tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/keys tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/timer_list tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/sched_debug tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/scsi tmpfs ro,relatime 0 0\ntmpfs /sys/firmware tmpfs ro,relatime 0 0",
+			Readlink: func(path string) (dest string, err error) { return "", os.ErrNotExist },
+			Expectation: []string{
+				"/dev",
+				"/sys",
+				"/workspace",
+				"/etc/hosts",
+				"/etc/hostname",
+				"/etc/resolv.conf",
+			},
+		},
+		{
+			Name:     "without /workspace",
+			Mounts:   "overlay / overlay rw,relatime,lowerdir=1714/fs:1713/fs:1712/fs:1711/fs:1710/fs:1709/fs:1708/fs:1707/fs:1706/fs:1705/fs:1704/fs:1703/fs:1702/fs:1701/fs:791/fs:257/fs:256/fs:255/fs:254/fs:253/fs:252/fs:251/fs:250/fs:249/fs:248/fs:247/fs:246/fs:245/fs:244/fs:243/fs:242/fs:241/fs:240/fs:239/fs:235/fs:234/fs:233/fs:232/fs:231/fs:230/fs:229/fs:228/fs:227/fs:226/fs:225/fs:224/fs:223/fs:222/fs:221/fs:220/fs:219/fs:215/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1715/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1715/work,xino=off 0 0\nproc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\ntmpfs /dev tmpfs rw,nosuid,size=65536k,mode=755 0 0\ndevpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666 0 0\nmqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0\nsysfs /sys sysfs ro,nosuid,nodev,noexec,relatime 0 0\ntmpfs /sys/fs/cgroup tmpfs rw,nosuid,nodev,noexec,relatime,mode=755 0 0\ncgroup /sys/fs/cgroup/systemd cgroup ro,nosuid,nodev,noexec,relatime,xattr,name=systemd 0 0\ncgroup /sys/fs/cgroup/rdma cgroup ro,nosuid,nodev,noexec,relatime,rdma 0 0\ncgroup /sys/fs/cgroup/cpu,cpuacct cgroup ro,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\ncgroup /sys/fs/cgroup/pids cgroup ro,nosuid,nodev,noexec,relatime,pids 0 0\ncgroup /sys/fs/cgroup/blkio cgroup ro,nosuid,nodev,noexec,relatime,blkio 0 0\ncgroup /sys/fs/cgroup/freezer cgroup ro,nosuid,nodev,noexec,relatime,freezer 0 0\ncgroup /sys/fs/cgroup/net_cls,net_prio cgroup ro,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0\ncgroup /sys/fs/cgroup/memory cgroup ro,nosuid,nodev,noexec,relatime,memory 0 0\ncgroup /sys/fs/cgroup/devices cgroup ro,nosuid,nodev,noexec,relatime,devices 0 0\ncgroup /sys/fs/cgroup/perf_event cgroup ro,nosuid,nodev,noexec,relatime,perf_event 0 0\ncgroup /sys/fs/cgroup/hugetlb cgroup ro,nosuid,nodev,noexec,relatime,hugetlb 0 0\ncgroup /sys/fs/cgroup/cpuset cgroup ro,nosuid,nodev,noexec,relatime,cpuset 0 0\n/dev/sdb /.workspace ext4 rw,relatime,discard 0 0\n/dev/sda1 /etc/hosts ext4 rw,relatime 0 0\n/dev/sda1 /dev/termination-log ext4 rw,relatime 0 0\n/dev/sda1 /etc/hostname ext4 rw,relatime 0 0\n/dev/sda1 /etc/resolv.conf ext4 rw,relatime 0 0\nshm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k 0 0\nproc /proc/bus proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/fs proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/irq proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/sys proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/sysrq-trigger proc ro,nosuid,nodev,noexec,relatime 0 0\ntmpfs /proc/acpi tmpfs ro,relatime 0 0\ntmpfs /proc/kcore tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/keys tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/timer_list tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/sched_debug tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/scsi tmpfs ro,relatime 0 0\ntmpfs /sys/firmware tmpfs ro,relatime 0 0",
+			Readlink: func(path string) (dest string, err error) { return "", os.ErrNotExist },
+			Expectation: []string{
+				"/dev",
+				"/sys",
+				"/etc/hosts",
+				"/etc/hostname",
+				"/etc/resolv.conf",
+			},
+		},
+		{
+			Name:   "with configmap",
+			Mounts: "overlay / overlay rw,relatime,lowerdir=1714/fs:1713/fs:1712/fs:1711/fs:1710/fs:1709/fs:1708/fs:1707/fs:1706/fs:1705/fs:1704/fs:1703/fs:1702/fs:1701/fs:791/fs:257/fs:256/fs:255/fs:254/fs:253/fs:252/fs:251/fs:250/fs:249/fs:248/fs:247/fs:246/fs:245/fs:244/fs:243/fs:242/fs:241/fs:240/fs:239/fs:235/fs:234/fs:233/fs:232/fs:231/fs:230/fs:229/fs:228/fs:227/fs:226/fs:225/fs:224/fs:223/fs:222/fs:221/fs:220/fs:219/fs:215/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1715/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1715/work,xino=off 0 0\nproc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\ntmpfs /dev tmpfs rw,nosuid,size=65536k,mode=755 0 0\ndevpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666 0 0\nmqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0\nsysfs /sys sysfs ro,nosuid,nodev,noexec,relatime 0 0\ntmpfs /sys/fs/cgroup tmpfs rw,nosuid,nodev,noexec,relatime,mode=755 0 0\ncgroup /sys/fs/cgroup/systemd cgroup ro,nosuid,nodev,noexec,relatime,xattr,name=systemd 0 0\ncgroup /sys/fs/cgroup/rdma cgroup ro,nosuid,nodev,noexec,relatime,rdma 0 0\ncgroup /sys/fs/cgroup/cpu,cpuacct cgroup ro,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\ncgroup /sys/fs/cgroup/pids cgroup ro,nosuid,nodev,noexec,relatime,pids 0 0\ncgroup /sys/fs/cgroup/blkio cgroup ro,nosuid,nodev,noexec,relatime,blkio 0 0\ncgroup /sys/fs/cgroup/freezer cgroup ro,nosuid,nodev,noexec,relatime,freezer 0 0\ncgroup /sys/fs/cgroup/net_cls,net_prio cgroup ro,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0\ncgroup /sys/fs/cgroup/memory cgroup ro,nosuid,nodev,noexec,relatime,memory 0 0\ncgroup /sys/fs/cgroup/devices cgroup ro,nosuid,nodev,noexec,relatime,devices 0 0\ncgroup /sys/fs/cgroup/perf_event cgroup ro,nosuid,nodev,noexec,relatime,perf_event 0 0\ncgroup /sys/fs/cgroup/hugetlb cgroup ro,nosuid,nodev,noexec,relatime,hugetlb 0 0\ncgroup /sys/fs/cgroup/cpuset cgroup ro,nosuid,nodev,noexec,relatime,cpuset 0 0\n/dev/sdb /workspace ext4 rw,relatime,discard 0 0\n/dev/sdb /.workspace ext4 rw,relatime,discard 0 0\n/dev/sda1 /etc/hosts ext4 rw,relatime 0 0\n/dev/sda1 /dev/termination-log ext4 rw,relatime 0 0\n/dev/sda1 /etc/hostname ext4 rw,relatime 0 0\n/dev/sda1 /etc/resolv.conf ext4 rw,relatime 0 0\nshm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k 0 0\nproc /proc/bus proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/fs proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/irq proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/sys proc ro,nosuid,nodev,noexec,relatime 0 0\nproc /proc/sysrq-trigger proc ro,nosuid,nodev,noexec,relatime 0 0\ntmpfs /proc/acpi tmpfs ro,relatime 0 0\ntmpfs /proc/kcore tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/keys tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/timer_list tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/sched_debug tmpfs rw,nosuid,size=65536k,mode=755 0 0\ntmpfs /proc/scsi tmpfs ro,relatime 0 0\ntmpfs /sys/firmware tmpfs ro,relatime 0 0\ntmpfs /custom-certs tmpfs ro,relatime 0 0",
+			Readlink: func(path string) (dest string, err error) {
+				if strings.HasPrefix(path, "/custom-certs") {
+					return "..2021_07_22_14_41_17.266694288", nil
+				}
+				return "", os.ErrNotExist
+			},
+			Expectation: []string{
+				"/dev",
+				"/sys",
+				"/workspace",
+				"/etc/hosts",
+				"/etc/hostname",
+				"/etc/resolv.conf",
+				"/custom-certs",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			act, err := findBindMountCandidates(bytes.NewReader([]byte(test.Mounts)), test.Readlink)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected findBindMountCandidates() (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -7,6 +7,7 @@ replace github.com/seccomp/libseccomp-golang => github.com/kinvolk/libseccomp-go
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon/api v0.0.0-00010101000000-000000000000
+	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/moby/sys/mountinfo v0.4.0
 	github.com/rootless-containers/rootlesskit v0.11.1
 	github.com/seccomp/libseccomp-golang v0.9.1


### PR DESCRIPTION
Prior to this PR the paths we'd bind mount into ring1 were hardcoded in workspacekit. This PR makes workspacekit "auto-discover" such paths using a "configMap/secret heuristic" (see [here](https://github.com/gitpod-io/gitpod/blob/0f03e89ad265ebbd2e79f0fa024e6bb120450062/components/workspacekit/cmd/rings.go#L488-L526)).

In addition, bind mount paths can be explicitly specified using the `GITPOD_WORKSPACEKIT_BIND_MOUNTS` environment variable, which expects a JSON array of paths.