### PR TITLE
Include workspace click events for /workspaces

### DIFF
--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from "react";
 import Modal from "../components/Modal";
 import TabMenuItem from "../components/TabMenuItem";
+import { getGitpodService } from "../service/service";
 
 export interface WsStartEntry {
     title: string
@@ -28,9 +29,18 @@ export function StartWorkspaceModal(p: StartWorkspaceModalProps) {
     const computeSelection = () => p.selected || (p.recent.length > 0 ? 'Recent' : 'Examples');
     const [selection, setSelection] = useState(computeSelection());
     useEffect(() => { !p.visible && setSelection(computeSelection()) }, [p.visible, p.recent, p.selected]);
+    const trackWorkspaceClick = (startUrl: string) => {
+        getGitpodService().server.trackEvent({
+            event:"workspace_new_clicked",
+            properties:{
+                context: selection,
+                contextUrl: startUrl.split("#")[1]
+            }
+        });
+    }
 
     const list = (selection === 'Recent' ? p.recent : p.examples).map((e, i) =>
-        <a key={`item-${i}-${e.title}`} href={e.startUrl} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-4 my-1">
+        <a key={`item-${i}-${e.title}`} href={e.startUrl} onClick={() => trackWorkspaceClick(e.startUrl)} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-4 my-1">
             <div className="w-full">
                 <p className="text-base text-gray-800 dark:text-gray-200 font-semibold">{e.title}</p>
                 <p>{e.description}</p>

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -14,6 +14,7 @@ import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon } from '../compone
 import PendingChangesDropdown from '../components/PendingChangesDropdown';
 import Tooltip from '../components/Tooltip';
 import { WorkspaceModel } from './workspace-model';
+import { getGitpodService } from "../service/service";
 
 function getLabel(state: WorkspaceInstancePhase, conditions?: WorkspaceInstanceConditions) {
     if (conditions?.failed) {
@@ -41,10 +42,21 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
     const downloadURL = new GitpodHostUrl(window.location.href).with({
         pathname: `/workspace-download/get/${ws.id}`
     }).toString();
+    const trackWorkspaceClick = (context:string) => {
+        getGitpodService().server.trackEvent({
+            event:"workspace_open_clicked",
+            properties:{
+                workspaceId: ws.id,
+                context: context,
+                state: state
+            }
+        });
+    }
     const menuEntries: ContextMenuEntry[] = [
         {
             title: 'Open',
-            href: startUrl.toString()
+            href: startUrl.toString(),
+            onClick: () => trackWorkspaceClick("button")
         }];
     if (state === 'running') {
         menuEntries.push({
@@ -90,7 +102,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
             <WorkspaceStatusIndicator instance={desc?.latestInstance} />
         </ItemFieldIcon>
         <ItemField className="w-3/12 flex flex-col">
-            <a href={startUrl.toString()}><div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">{ws.id}</div></a>
+            <a href={startUrl.toString()} onClick= {() => trackWorkspaceClick("link")}><div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">{ws.id}</div></a>
             <a href={project ? 'https://' + project : undefined}><div className="text-sm overflow-ellipsis truncate text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400">{project || 'Unknown'}</div></a>
         </ItemField>
         <ItemField className="w-4/12 flex flex-col">


### PR DESCRIPTION
Include events for the click that caused a workspace start from the dashboard in order to understand user behaviour better.

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe