### PR TITLE
[chart] Set priorityClasssName for gitpod components

### DIFF
--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -32,6 +32,7 @@ spec:
         stage: {{ .Values.installation.stage }}
         gitpod.io/nodeService: registry-facade
     spec:
+      priorityClassName: system-node-critical
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
       serviceAccountName: registry-facade
       enableServiceLinks: false

--- a/chart/templates/resource-quotas.yaml
+++ b/chart/templates/resource-quotas.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+# https://kubernetes.io/docs/concepts/policy/resource-quotas/
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gitpod-resource-quota
+  namespace: {{ .Release.Namespace }}
+spec:
+  hard:
+    pods: 10k
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -82,6 +82,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
     spec:
+      priorityClassName: system-node-critical
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: server
       enableServiceLinks: false

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -38,11 +38,7 @@ spec:
         {{- end }}
     spec:
 {{ include "gitpod.workspaceAffinity" $this | indent 6 }}
-      # see https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/ for more
-      # details on this priority class.
-      # Pior to Kubernetes 1.17 critical pods can only be scheduled in kube-system: https://github.com/kubernetes/kubernetes/pull/76310
-      # Leaving this in here so that others might enable it and we don't forget about this when 1.17 comes around in GKE.
-      # priorityClassName: system-node-critical
+      priorityClassName: system-node-critical
       tolerations:
       - key: node.kubernetes.io/disk-pressure
         operator: "Exists"

--- a/chart/templates/ws-manager-bridge-deployment.yaml
+++ b/chart/templates/ws-manager-bridge-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
     spec:
+      priorityClassName: system-node-critical
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-manager-bridge
       enableServiceLinks: false

--- a/chart/templates/ws-manager-deployment.yaml
+++ b/chart/templates/ws-manager-deployment.yaml
@@ -37,6 +37,7 @@ spec:
       annotations:
         checksum/tlskey: {{ include (print $.Template.BasePath "/ws-daemon-tlssecret.yaml") $ | sha256sum }}
     spec:
+      priorityClassName: system-node-critical
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-manager
       securityContext:

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
     spec:
+      priorityClassName: system-node-critical
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-proxy
       securityContext:

--- a/chart/templates/ws-scheduler-deployment.yaml
+++ b/chart/templates/ws-scheduler-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
     spec:
+      priorityClassName: system-node-critical
 {{ include "gitpod.pod.affinity" $this | indent 6 }}
       serviceAccountName: ws-scheduler
       securityContext:


### PR DESCRIPTION
The important part of this change is not setting the class but prevent the pod from becoming permanently unavailable.

https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/

xref: #4931