### PR TITLE
[ws-daemon] Set priority to system-node-critical

### DIFF
--- a/chart/templates/resource-quota.yaml
+++ b/chart/templates/resource-quota.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gitpod-resource-quota
+  namespace: {{ .Release.Namespace }}
+spec:
+  hard:
+    pods: 10
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gitpod-operator-resource-quota
+  namespace: {{ .Release.Namespace }}
+spec:
+  hard:
+    pods: 10
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-cluster-critical

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -103,6 +103,7 @@ spec:
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}
       enableServiceLinks: false
+      priorityClassName: system-node-critical
 {{- if (or $comp.userNamespaces.shiftfsModuleLoader.enabled $comp.userNamespaces.seccompProfileInstaller.enabled) }}
       initContainers:
 {{- end }}


### PR DESCRIPTION
This PR adds priority classes that help prevent eviction of critical services.

fixes #4933