### PR TITLE
[ws-daemon] Always remove temp backup file

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -464,9 +464,7 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 		}
 		defer func() {
 			tmpf.Close()
-			if err != nil {
-				os.Remove(tmpf.Name())
-			}
+			os.Remove(tmpf.Name())
 		}()
 
 		var opts []archive.TarOption


### PR DESCRIPTION
This PR makes ws-daemon always remove the temporary backup archive, also in case of an error. The original intent of not deleting the file when an error occurred was to leave a way of workspace content recovery in this case. In practise this 
- behaviour has lead to more failure because of disks filling up, and
- it's utterly impractical as a means of recovery at scale.

fixes #4939
