### PR TITLE
[ws-daemon] Don't accept config with unknown fields

### DIFF
--- a/.werft/values.dev.gcp-storage.yaml
+++ b/.werft/values.dev.gcp-storage.yaml
@@ -11,7 +11,6 @@ components:
         secretName: remote-storage-gcloud
         projectId: gitpod-dev
         region: europe-west1
-        tmpdir: /mnt/sync-tmp
         parallelUpload: 6
     volumes:
       - name: gcloud-creds

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -349,7 +349,6 @@ storage:
     region: {{ $remoteStorageMinio.region | default "local" }}
     parallelUpload: {{ $remoteStorageMinio.parallelUpload | default "" }}
     maxBackupSize: {{ $remoteStorageMinio.maxBackupSize | default "" }}
-    tmpdir: {{ $remoteStorageMinio.tmpdir | default "/tmp" }}
 {{- else }}
 {{ toYaml .remoteStorage | indent 2 }}
 {{- end -}}

--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -26,6 +26,7 @@ daemon:
     {{- if (and $comp.workspaceSizeLimit (not (eq $comp.workspaceSizeLimit ""))) }}
     workspaceSizeLimit: {{ ($comp.workspaceSizeLimit | default "0g") | quote }}
     {{- end }}
+    tempDir: {{ $comp.backupTempDir | default "/tmp" }}
 {{ include "gitpod.remoteStorage.config" (dict "root" . "remoteStorage" .Values.components.contentService.remoteStorage) | indent 4 }}
     backup:
       timeout: "5m"
@@ -61,8 +62,9 @@ daemon:
         - name: {{ (printf "reg.%s" (.Values.components.registryFacade.hostname | default .Values.hostname)) | quote }}
           addr: 127.0.0.1
   disk:
-    path: "/mnt/wsdaemon-workingarea"
-    minBytesAvail: 21474836480
+    locations:
+    - path: "/mnt/wsdaemon-workingarea"
+      minBytesAvail: 21474836480
 service:
   address: ":{{ $comp.servicePort }}"
   tls:

--- a/components/ws-daemon/cmd/root.go
+++ b/components/ws-daemon/cmd/root.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -54,15 +55,15 @@ func Execute() {
 func getConfig() *config {
 	ctnt, err := os.ReadFile(configFile)
 	if err != nil {
-		log.WithError(xerrors.Errorf("cannot read config: %w", err)).Error("cannot read configuration. Maybe missing --config?")
-		os.Exit(1)
+		log.WithError(err).Fatal("cannot read configuration. Maybe missing --config?")
 	}
 
 	var cfg config
-	err = json.Unmarshal(ctnt, &cfg)
+	dec := json.NewDecoder(bytes.NewReader(ctnt))
+	dec.DisallowUnknownFields()
+	err = dec.Decode(&cfg)
 	if err != nil {
-		log.WithError(err).Error("cannot read configuration. Maybe missing --config?")
-		os.Exit(1)
+		log.WithError(err).Fatal("cannot decode configuration. Maybe missing --config?")
 	}
 
 	return &cfg

--- a/components/ws-daemon/example-config.json
+++ b/components/ws-daemon/example-config.json
@@ -4,6 +4,7 @@
         "workingArea": "/tmp/wsdaemon",
         "backupPeriod": "30m",
         "workspaceSizeLimit": "20g",
+        "tempDir": "/tmp",
         "storage": {
             "kind": "minio",
             "stage": "dev",
@@ -13,14 +14,12 @@
                 "project": "gitpod-dev",
                 "parallelUpload": 4,
                 "maximumBackupSize": 32212254720,
-                "maximumBackupCount": 20,
-                "tmpdir": "/tmp/gcloud"
+                "maximumBackupCount": 20
             },
             "minio": {
                 "endpoint": "127.0.0.1:9000",
                 "accessKeyID": "C1GL0KSOR9ERG1R5GW92",
-                "secretAccessKey": "CNmBGC9T5u7UC3xQfd+MVrVnfAVRkS0X2N3+B0RS",
-                "tmpdir": "/tmp/upload"
+                "secretAccessKey": "CNmBGC9T5u7UC3xQfd+MVrVnfAVRkS0X2N3+B0RS"
             }
         }
     },

--- a/components/ws-daemon/pkg/content/config.go
+++ b/components/ws-daemon/pkg/content/config.go
@@ -42,7 +42,7 @@ type Config struct {
 
 		// Attempts configures how many backup attempts we will make.
 		// Detaults to 3
-		Attempts int `json:"backupAttempts"`
+		Attempts int `json:"attempts"`
 
 		// Period is the time between regular workspace backups
 		Period util.Duration `json:"period"`

--- a/components/ws-manager/cmd/root.go
+++ b/components/ws-manager/cmd/root.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -74,15 +75,15 @@ func init() {
 func getConfig() *config {
 	ctnt, err := os.ReadFile(cfgFile)
 	if err != nil {
-		log.WithError(err).Error("cannot read configuration. Maybe missing --config?")
-		os.Exit(1)
+		log.WithError(err).Fatal("cannot read configuration. Maybe missing --config?")
 	}
 
 	var cfg config
-	err = json.Unmarshal(ctnt, &cfg)
+	dec := json.NewDecoder(bytes.NewReader(ctnt))
+	dec.DisallowUnknownFields()
+	err = dec.Decode(&cfg)
 	if err != nil {
-		log.WithError(err).Error("cannot read configuration. Maybe missing --config?")
-		os.Exit(1)
+		log.WithError(err).Fatal("cannot decode configuration. Maybe missing --config?")
 	}
 
 	return &cfg

--- a/install/gcp-terraform/modules/storage/templates/values.tpl
+++ b/install/gcp-terraform/modules/storage/templates/values.tpl
@@ -15,7 +15,6 @@ components:
         projectId: ${project}
         region: ${region}
         credentialsFile: /credentials/key.json
-        tmpdir: /mnt/sync-tmp
         parallelUpload: 6
 
   wsDaemon:
@@ -23,6 +22,7 @@ components:
     hostWorkspaceArea: /var/gitpod/workspaces
     servicePort: 8080
     workspaceSizeLimit: ""
+    backupTempDir: /mnt/sync-tmp
     containerRuntime:
       runtime: containerd
       containerd:


### PR DESCRIPTION
This PR makes ws-daemon and ws-manager fail on startup if the config file contains unknown fields. Such fields are often indicative of misconfiguration.

Note: this will most certainly impact prod config.

fixes #4940

/cc @meysholdt 