### PR TITLE
[ws-manager] Stop workspaces timing out during backup

### DIFF
--- a/chart/templates/ws-manager-configmap.yaml
+++ b/chart/templates/ws-manager-configmap.yaml
@@ -83,7 +83,7 @@ data:
                 "initialization": "30m",
                 "regularWorkspace": "30m",
                 "startup": "60m",
-                "contentFinalization": "15m",
+                "contentFinalization": "60m",
                 "stopping": "60m",
                 "interrupted": "5m"
             },


### PR DESCRIPTION
Prior to this change workspaces that timed out during backup would never actually stop. Also, the `contentFinalization` timeout was not used during backup.

### How to test
1. Start a workspace
2. Change the `contentFinalization` timeout in `ws-manager-config` to `1s` (quicker testing)
3. Restart ws-manager
4. Once the workspace is running remove ws-daemon (e.g. edit the daemonSet's `affinity`)
5. Stop the workspace

You should see the workspace actually stopping, e.g.
![image](https://user-images.githubusercontent.com/3210701/126914465-accda18c-4236-4ced-a8a1-59de92505bfe.png)


fixes #4937

Note: this change will affect prod configuration, as we're now using the correct timeout for content finalization/backup (15m instead of 1h).
/cc @meysholdt 