### PR TITLE
[ws-daemon] Currectly use limit writer

### DIFF
--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -44,9 +44,7 @@ type GCPConfig struct {
 	Project         string `json:"projectId"`
 	ParallelUpload  int    `json:"parallelUpload"`
 
-	// The maximum size a workspace can have before backup is disabled. 0 disables these checks.
-	MaximumBackupSize  int64 `json:"maximumBackupSize"`
-	MaximumBackupCount int   `json:"maximumBackupCount"`
+	MaximumBackupCount int `json:"maximumBackupCount"`
 }
 
 var validateExistsInFilesystem = validation.By(func(o interface{}) error {
@@ -365,11 +363,6 @@ func (rs *DirectGCPStorage) Upload(ctx context.Context, source string, name stri
 	}
 	totalSize = stat.Size()
 	span.SetTag("totalSize", totalSize)
-
-	if rs.GCPConfig.MaximumBackupSize > 0 && totalSize > rs.GCPConfig.MaximumBackupSize {
-		err = xerrors.Errorf("Workspace is too big and cannot be uploaded. Workspace size is %d bytes, max size is %d bytes", totalSize, rs.GCPConfig.MaximumBackupSize)
-		return
-	}
 
 	uploadSpan := opentracing.StartSpan("remote-upload", opentracing.ChildOf(span.Context()))
 	uploadSpan.SetTag("bucket", rs.bucketName())

--- a/components/content-service/pkg/storage/minio.go
+++ b/components/content-service/pkg/storage/minio.go
@@ -34,7 +34,6 @@ type MinIOConfig struct {
 
 	Region         string `json:"region"`
 	ParallelUpload uint   `json:"parallelUpload,omitempty"`
-	MaxBackupSize  int64  `json:"maxBackupSize,omitempty"`
 }
 
 // Validate checks if the GCloud storage MinIOconfig is valid

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -468,6 +468,7 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 		}()
 
 		var opts []archive.TarOption
+		opts = append(opts, archive.TarbalMaxSize(int64(s.config.WorkspaceSizeLimit)))
 		if !sess.FullWorkspaceBackup {
 			mappings := []archive.IDMapping{
 				{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},


### PR DESCRIPTION
This PR enables the use of the `limitWriter` in ws-daemon. While previously existing, it was not used (anymore?). In the same vein, I've removed the storage-specific maximum backup configuration. Instead, we're now using a single size to determine how large a workspace can be: https://github.com/gitpod-io/gitpod/blob/40f913c1a2415156a34bbaaee41adced3d207f2c/components/ws-daemon/pkg/content/config.go#L32

/cc @meysholdt
this has potentially config breaking changes

fixes #4961