### PR TITLE
fix(.github): security policy item gets automatically created when SECURITY.md exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Community
     url: https://community.gitpod.io
     about: Please ask and answer usage questions here.
-  - name: Security
-    url: https://www.gitpod.io/security
-    about: Please report security vulnerabilities here.


### PR DESCRIPTION
Since the repository already contains a SECURITY.md file there's no need to specify a link to an external page (which is referred to by the SECURITY.md file).

The issue menu will automatically show an item like the following one.

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/120051/127275426-22b08dfc-b0c3-4c6f-9b84-ac9fbf1ef423.png">

Clicking on it will bring the user to this GitHub page (Security tab > Security policy):

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/120051/127275540-9c6e3c54-3f36-44eb-9405-0aca545d5681.png">

Putting this in

/hold

because I first wanna discuss it with the team internally.

Fixes #4979 

