### PR TITLE
[dashboard] Fix alignment of pending changes widget in workspaces list

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -101,7 +101,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         </ItemField>
         <ItemField className="w-2/12 flex flex-col">
             <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">{currentBranch}</div>
-            <PendingChangesDropdown workspaceInstance={desc.latestInstance} />
+            <div className="mr-auto"><PendingChangesDropdown workspaceInstance={desc.latestInstance} /></div>
         </ItemField>
         <ItemField className="w-2/12 flex">
             <Tooltip content={`Created ${moment(desc.workspace.creationTime).fromNow()}`}>


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4670

Now looks like this:

<img width="1157" alt="Screenshot 2021-07-29 at 14 34 29" src="https://user-images.githubusercontent.com/599268/127492581-49973fc6-4980-4cf5-b359-01b83c83f33a.png">
