### PR TITLE
[chart] Remove deprecated field 'maxBackupSize' from _helpers.tpl

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -348,7 +348,6 @@ storage:
     secure: {{ $remoteStorageMinio.secure | default ($minio.enabled | default false) }}
     region: {{ $remoteStorageMinio.region | default "local" }}
     parallelUpload: {{ $remoteStorageMinio.parallelUpload | default "" }}
-    maxBackupSize: {{ $remoteStorageMinio.maxBackupSize | default "" }}
 {{- else }}
 {{ toYaml .remoteStorage | indent 2 }}
 {{- end -}}


### PR DESCRIPTION
Fixes `ws-daemon` crash loop back-off in dev staging:

```
    "error": "json: unknown field \"maxBackupSize\""
```