### PR TITLE
[ws-daemon] Don't remove the backup tar before uploading it

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -412,10 +412,7 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 		if err != nil {
 			return
 		}
-		defer func() {
-			tmpf.Close()
-			os.Remove(tmpf.Name())
-		}()
+		defer tmpf.Close()
 
 		var opts []archive.TarOption
 		opts = append(opts, archive.TarbalMaxSize(int64(s.config.WorkspaceSizeLimit)))
@@ -460,9 +457,8 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 		return xerrors.Errorf("cannot create archive: %w", err)
 	}
 	defer func() {
-		if err == nil && tmpf != nil {
-			// we only remove the layer archive when there was no error during
-			// upload, just as some sort of safety net.
+		if tmpf != nil {
+			// always remove the archive file to not fill up the node needlessly
 			os.Remove(tmpf.Name())
 		}
 	}()


### PR DESCRIPTION
fixes #4991 

This was not actually a status bug, but much worse: a bug that prevented all backups from succeeding. We got a bit too eager with cleaning up the backup archive and removed it before the upload would actually happen.


### How to test
1. Start and stop a workspace
2. Start a workspace and let it timeout (not really different to the previous case, but that's what the original issue claims is the problem)