### PR TITLE
[ws-daemon] Filter tasks log if the file does not exists

### DIFF
--- a/components/ws-daemon/pkg/resources/controller.go
+++ b/components/ws-daemon/pkg/resources/controller.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -284,7 +283,7 @@ func (gov *Controller) controlProcessPriorities() {
 	fn := filepath.Join(gov.CGroupBasePath, "pids", gov.CGroupPath, "tasks")
 	fc, err := os.ReadFile(fn)
 	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
+		if !errors.Is(err, os.ErrNotExist) {
 			gov.log.WithError(err).Warn("cannot read tasks file")
 		}
 		return


### PR DESCRIPTION
fix #4952 is not enough because the error is wrapped

Test:

- Open a workspace
- Check `ws-daemon` log and check there is no "cannot read tasks file" error