### PR TITLE
[gpctl] Improve image builds

### DIFF
--- a/dev/gpctl/cmd/imagebuilds-build.go
+++ b/dev/gpctl/cmd/imagebuilds-build.go
@@ -83,6 +83,7 @@ var imagebuildsBuildCmd = &cobra.Command{
 		br, err := client.Build(ctx, &builder.BuildRequest{
 			Source:       &source,
 			ForceRebuild: forceRebuild,
+			Auth:         &builder.BuildRegistryAuth{Mode: &builder.BuildRegistryAuth_Total{Total: &builder.BuildRegistryAuthTotal{AllowAll: true}}},
 		})
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Choose a free port when doing the port-forwarding to image builder. This allows the parallel build of images.
Also add "AuthFor: all" to allow building from any registry the image builder has access to.

/approve no-issue