### PR TITLE
Fixes #4831 - replace regex with env var set by chart helper

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -182,6 +182,8 @@ env:
   value: "https://{{ $gp.hostname }}"
 - name: GITPOD_REGION
   value: {{ $gp.installation.region | quote }}
+- name: GITPOD_WS_DNS_LABEL
+  value: "ws-{{ $gp.installation.cluster }}"
 - name: GITPOD_INSTALLATION_LONGNAME
   value: {{ template "gitpod.installation.longname" . }}
 - name: GITPOD_INSTALLATION_SHORTNAME

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -255,7 +255,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 	}
 
 	# foreign content origin should be decoupled from the workspace (port) origin but the workspace (port) prefix should be the path root for routing
-	@foreign_content header_regexp host Host ^(.*)(foreign).ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	@foreign_content header_regexp host Host ^(.*)(foreign).{$GITPOD_WS_DNS_LABEL}.{$GITPOD_DOMAIN}
 	handle @foreign_content {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 			import workspace_transport


### PR DESCRIPTION
Hi Gitpod team,

This should fix #4831 and the [Caddy] proxy component. [I tested the matcher here.](https://regex101.com/r/WHpXML/1)

The subdomain we need to match on in Caddy for foreign content must include the cluster used at the time of the Gitpod installation. For example, [given this comment](https://github.com/gitpod-io/gitpod/blob/main/components/ws-manager/pkg/manager/config.go#L82), **eu11**  would be the cluster in workspace host **ws-eu11.gitpod.io**.

## Questions
1. Do we expect any foreign requests to not start with **ws**? 
     _I assume no, all requests will include a subdomain starting with **ws**._
2. Do we expect any foreign requests to have a subdomain that is just **ws**, without a cluster reference like `-us13`? 
     _I assume no, all foreign requests for a workspace will include `ws-<cluster>`._

If the answer to either question is yes, we might want to change the `Caddyfile` to `ws(-{$GITPOD_WS_DNS_LABEL})?`, and `_helper.tpl` to `value: "{{ $gp.installation.cluster }}"`.

## Domains other than gitpod.io

[In this recording, at 7:43](https://www.loom.com/share/e9f4c09a8eef40589a4d4fdb10c57f9c), I see foreign content references for workspace host `ws-dev` on Gitpod domain `gitpod-dev.com`. In that example, I assume `dev` is the cluster being used - so we should be good for lower environments too, I hope?

## Supporting info

The workspace I used for this issue and PR was `https://lime-bovid-yd8e9ly2.ws-us13.gitpod.io/`. It took me a while to figure out how `ws-us13` was being built. [I started by building this diagram](https://viewer.diagrams.net/?highlight=0000ff&edit=_blank&layers=1&nav=1&title=gitpod.startworkspace.drawio#R5Vtbc9o4FP41zLQPYXzHPIZc2t1NLxN2m82jbMlGjbGoLALk16%2BEZXyRoaTYKLvbyTS2LB9L3zn6zkXKwL6arz9QsJh9IhAlA8uA64F9PbAs07Gsgfgx4CZv8Q0zb4gphrJT2TDFL0g2GrJ1iSHKah0ZIQnDi3pjSNIUhazWBiglq3q3iCT1ry5AjJSGaQgStfUBQzaTs3CNsv0jwvGs%2BLJpyCdzUHSWDdkMQLKqNNk3A%2FuKEsLyq%2Fn6CiUCvAKX%2FL3bPU93A6MoZce8kFkfAu8H%2BHZNXl4%2BGRd%2FRt9e7i%2FMcS7mGSRLOWM5WrYpIKBkmUIkpBgDe7KaYYamCxCKpyuudN42Y%2FOE35n8UopDlKH13oGau%2Blzu0Fkjhjd8C7yBVsCJi3GLrBelfiPC%2FOYVbD3CuiB1Hm8E13Cwi8kMq9ByXvzKJlHgsRR6gskBaNrkM0CAijUDpZjNmxKRcu0Wk2qL7BUA0KQE4%2B8JZTNSExSkNyUrZM6amWfO0IWEqvviLGNZFGwZKSOJEeLbv6u3jwKYUO3uL1eS%2BH53Ube5WMVAzyMP58PWdIQHZi4nDcDNEbsQD%2BnXZ8UJYDh5%2Fo4OteOpZjylA%2BYPRD6lAkzHbJsPbC8hE9gElB%2BFYuru%2FFIVWqScE%2BFzmPkXt3IR0caud%2BXkdsKjDFmCwIvFpQwEpJEOy%2BY3hvjBcvVwQsRSdkVSQjdftG%2BvTX4v27XvXPkurdGJy787auXlIJNpcOC4JRlFclfRUNpB9a4bgeW0YilGv1d92B%2FfpGPoDSE3VROsI22KESSUM1kvB9LEVROwlyllwK%2BOHjHh8h%2F%2BLeNytX7snvBYw8oyEj4xNUkpfPRBsXDKu1198lCKmfXtEu5U5TCTATjKMt4pC4unzHg%2F%2F8%2B%2FfKZ%2F7r%2FKt60hkZlqvkY%2Fo2zpejHEmUsf7F8nNV8l1jQz2L5bsWsiubfYE3efwEMtqRpVkNiVQGBBN9Fvrh9H6dhsoQ4jauI%2FEWTvUC0UPQdCHjqW6NVkOA45dchhxvxKUyEr8I8t7yUD%2BYYwpzBUYZfQLCVJ4hX8hUX7k4G7vVPKbrFCcqEWAod7NLQKnkfcEF7XaYxtAontal98HUMrVCqN64LNRoSSBRlgpIaDrYDXnX2hSkZos94G%2B21BHuu42mN9poJoPZoz3S0pjSVLOaxlsT0ntJ4R4Y2pq0zpzFdxcxVJ3h%2BXuuev8w9qaMUf2EM7Xrsdhp99c9PaolOEBMHXnf21AiaPe3Zk62lqnKG7Mm0j%2BQYe4%2FGzsQxezP%2B3GIv8HyRtLtTx9XrTpuVAE%2B%2FPx0pYE7uvzxMb%2B4VoPi0WR2RjFHyhAqrTEkqUIxwkjSajqfyNhXUl04HWvD9uhYsR9WC06IEqy8lFIKrSri8%2BuPm83UPSqD5hDTrYGTUdTBuofVd8HkeJaj12Gy5EMF5Rk70glVtcO6OosgKQ0V1%2FAn0Ao9TVB9%2B09HuN9XQUCnUNgn7XUzEiItS0XvtwUiTwB1fN6pqua6RVwoIFUc4sltKwBrzStfS7QjbAHm7ieW%2BaBCtMauI43ePxZf4dSlM3PSx7yajiZ9HkFqzVEsNejgHrTctBHQFINycyDsN%2Bocu8qHTRv%2B%2BFdheR%2FTvNPm%2FZe%2F%2BzLtOaoopqQoG2om9gdZorBstWz3psCsac8AOJDljWa%2B%2B47PQSvJNZ%2BkfG4L0R%2FJ6q4evPBBxhpTfPjblz6Pjc%2B%2BYOlYjTPAP75g2%2BxeHFXrdMbXVesQqu5AORTOtNb2A23LM7cxeQOW1j2TFGyDZ7pyyGRa%2FOFBMbKAxkQAM3IksRopq7q2C6ulJcYKiE3PiV2%2Bd%2FXqwvDuCWM2VHVdVYm%2B5clEd6eyo4j70mkWLLpZEo%2FLgtaRwtt%2ByJCy3N7ekJnGcQeYgBfEbKMC7zT1A7ZUEW43fQ5JGOG5Pdn1baxjkOY0wSHuu66ir9ay57tsLg%2FwjwyD71INjp9m9r9o9RYDtKfK4ovM2E%2FDGepeAY7%2B5JbAvDMF5ECJij2wZQDIHWJwYgoghOsfpNkaJREFYdipP%2B%2FQSmHSxZSIWULG2zS60%2BcsetDdtqiG4OMmV4TlOgNBVlGyVC7KtfmqnrIfDfA2VLf9TNY5awsqu1Mhvy79ByhOv8i%2B57Jt%2FAA%3D%3D) to help me understand how the Dashboard starts a workspace. 

Once I figured out how workspaces were being started, I was able to find related code for creating workspaces, and that's where I found the answer for workspace hosts, and them including the cluster used at the time of the Gitpod installation.