### PR TITLE
[dashboard] fix handling of incomplete referrer

### DIFF
--- a/components/dashboard/src/FromReferrer.tsx
+++ b/components/dashboard/src/FromReferrer.tsx
@@ -8,7 +8,8 @@ import { Link } from "react-router-dom";
 
 export default function FromReferrer() {
     const contextUrl = document.referrer;
-    if (contextUrl && contextUrl !== '') {
+
+    if (contextUrl && contextUrl !== '' && new URL(contextUrl).pathname !== '/') {
         // Redirect to gitpod.io/#<contextUrl> to get the same experience as with direct call
         const url = new URL(window.location.toString());
         url.pathname = "/";
@@ -16,13 +17,17 @@ export default function FromReferrer() {
         window.location.href = url.toString();
         return <></>;
     }
+
     return <div className="lg:px-28 px-10 flex flex-col space-y-2">
         <div className="px-6 py-3 flex justify-between space-x-2 text-gray-400 h-96">
             <div className="flex flex-col items-center w-96 m-auto mt-40">
                 <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Referrer Found</h3>
                 <div className="text-center pb-6 text-gray-500">
-                    <p>It looks like you are trying to open a workspace, but the referrer URL is empty. This happens when the git hoster doesn't send the referrer header.
-                    <br/> Please prefix the repository URL with <pre>https://gitpod.io/#</pre> in order to start a workspace.  <a className="text-gray-400 learn-more hover:text-gray-600" href="https://www.gitpod.io/docs/getting-started/">Learn more</a></p>
+                    <p>
+                        It looks like you are trying to open a workspace, but the referrer URL is empty or has an incomplete path.
+                        This happens when the git hoster or browser doesn't send the referrer header.
+                        <br/> Please prefix the repository URL with <pre>https://gitpod.io/#</pre> in order to start a workspace. <a className="text-gray-400 learn-more hover:text-gray-600" href="https://www.gitpod.io/docs/getting-started/">Learn more</a>
+                    </p>
                 </div>
                 <span>
                     <Link to="/"><button className="secondary">Go to Dashboard</button></Link>


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4701

I investigated the issue and found that it is not possible to retrieve the referrer information from Safari, even though the information is available in the request header. 
Therefore what I did instead was fix the handling in FromReferrer.tsx, by showing the intended text when we don't have a complete referrer URL. 
I also adjusted the text a little bit - please let me know if the new text is acceptable.