### PR TITLE
[Projects] Fix prebuild association

### DIFF
--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -12,7 +12,6 @@ export interface ProjectDB {
     findProjectByCloneUrl(cloneUrl: string): Promise<Project | undefined>;
     findProjectsByCloneUrls(cloneUrls: string[]): Promise<Project[]>;
     findProjectByTeamAndName(teamId: string, projectName: string): Promise<Project | undefined>;
-    findProjectByInstallationId(installationId: string): Promise<Project | undefined>;
     findTeamProjects(teamId: string): Promise<Project[]>;
     findUserProjects(userId: string): Promise<Project[]>;
     storeProject(project: Project): Promise<Project>;

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -50,11 +50,6 @@ export class ProjectDBImpl implements ProjectDB {
         return projects.find(p => p.name === projectName);
     }
 
-    public async findProjectByInstallationId(appInstallationId: string): Promise<Project | undefined> {
-        const repo = await this.getRepo();
-        return repo.findOne({ appInstallationId, markedDeleted: false });
-    }
-
     public async findTeamProjects(teamId: string): Promise<Project[]> {
         const repo = await this.getRepo();
         return repo.find({ teamId, markedDeleted: false });


### PR DESCRIPTION
This fixes a serious bug in the association of projects to prebuilds which are triggered on push events. Replacing all `findProjectByInstallationId` by `findProjectByCloneUrl`, because an installation can be used to create multiple projects this cannot be unambiguous. 