### PR TITLE
Update right menu style

### DIFF
--- a/components/dashboard/src/components/PillMenuItem.tsx
+++ b/components/dashboard/src/components/PillMenuItem.tsx
@@ -12,7 +12,7 @@ export default function PillMenuItem(p: {
     link?: string,
     onClick?: (event: React.MouseEvent) => void
 }) {
-    const classes = 'flex block text-sm font-medium dark:text-gray-200 px-3 px-0 py-1.5 rounded-md transition ease-in-out ' +
+    const classes = 'flex block font-medium dark:text-gray-200 px-2 py-1 rounded-lg transition ease-in-out ' +
         (p.selected
             ? 'bg-gray-200 dark:bg-gray-700'
             : 'text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800');


### PR DESCRIPTION
This will resolve some inconsistencies on the font size used across the top level navigation menus.

Resolve the outstanding points in https://github.com/gitpod-io/gitpod/issues/4471.

| BEFORE | AFTER |
|-|-|
| <img width="1094" alt="menu-before" src="https://user-images.githubusercontent.com/120486/128370028-771bc64a-2c5b-4000-8b11-1c044f362633.png"> |  <img width="1094" alt="menu-after" src="https://user-images.githubusercontent.com/120486/128370103-dd88209f-1c06-46bb-b203-ac8d36a7d8a7.png"> |