### PR TITLE
[dashboard] Fix Teams & Projects top-level menu UX

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -6,7 +6,7 @@
 
 import { User, TeamMemberInfo } from "@gitpod/gitpod-protocol";
 import { useContext, useEffect, useState } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useLocation, useRouteMatch } from "react-router";
 import { Location } from "history";
 import gitpodIcon from './icons/gitpod.svg';
@@ -32,7 +32,6 @@ interface Entry {
 export default function Menu() {
     const { user } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
-    const history = useHistory();
     const location = useLocation();
 
     const match = useRouteMatch<{ segment1?: string, segment2?: string, segment3?: string }>("/:segment1/:segment2?/:segment3?");
@@ -147,12 +146,12 @@ export default function Menu() {
     const renderTeamMenu = () => {
         return (
             <div className="flex p-1 pl-3 ">
-                <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1">
+                { projectName && <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1">
                     <Link to={team ? `/${team.slug}/projects` : "/workspaces"}>
                         <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">{team?.name || userFullName}</span>
                     </Link>
-                </div>
-                <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 py-1">
+                </div> }
+                <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800">
                     <ContextMenu classes="w-64 left-0" menuEntries={[
                         {
                             title: userFullName,
@@ -161,7 +160,7 @@ export default function Menu() {
                                 <span className="">Personal Account</span>
                             </div>,
                             separator: true,
-                            onClick: () => history.push("/"),
+                            link: '/',
                         },
                         ...(teams || []).map(t => ({
                             title: t.name,
@@ -173,7 +172,7 @@ export default function Menu() {
                                 }</span>
                             </div>,
                             separator: true,
-                            onClick: () => history.push(`/${t.slug}`),
+                            link: `/${t.slug}`,
                         })).sort((a, b) => a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1),
                         {
                             title: 'Create a new team',
@@ -181,11 +180,12 @@ export default function Menu() {
                                 <span className="flex-1 font-semibold">New Team</span>
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5"><path fill="currentColor" fill-rule="evenodd" d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z" clip-rule="evenodd" /></svg>
                             </div>,
-                            onClick: () => history.push("/teams/new"),
+                            link: '/teams/new',
                         }
                     ]}>
-                        <div className="flex h-full px-2 py-1.5">
-                            <img className="filter-grayscale m-auto" src={CaretUpDown} />
+                        <div className="flex h-full px-2 py-1 space-x-3.5">
+                            { !projectName && <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">{team?.name || userFullName}</span>}
+                            <img className="filter-grayscale" style={{marginTop: 5, marginBottom: 5}} src={CaretUpDown} />
                         </div>
                     </ContextMenu>
                 </div>

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -159,6 +159,7 @@ export default function Menu() {
                                 <span className="text-gray-800 dark:text-gray-100 text-base font-semibold">{userFullName}</span>
                                 <span className="">Personal Account</span>
                             </div>,
+                            active: !team,
                             separator: true,
                             link: '/',
                         },
@@ -171,6 +172,7 @@ export default function Menu() {
                                     : '...'
                                 }</span>
                             </div>,
+                            active: team && team.id === t.id,
                             separator: true,
                             link: `/${t.slug}`,
                         })).sort((a, b) => a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1),

--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -84,7 +84,7 @@ function ContextMenu(props: ContextMenuProps) {
                 <div className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${props.classes || 'w-48 right-0'}`}>
                     {props.menuEntries.map((e, index) => {
                         const clickable = e.href || e.onClick || e.link;
-                        const entry = <div className={`px-4 flex py-3 ${clickable ? 'hover:bg-gray-200 dark:hover:bg-gray-800' : ''} text-sm leading-1 ${e.customFontStyle || font} ${e.separator ? ' border-b border-gray-200 dark:border-gray-800' : ''}`} title={e.title}>
+                        const entry = <div className={`px-4 flex py-3 ${clickable ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : ''} ${e.active ? 'bg-gray-50 dark:bg-gray-800' : ''} ${index === 0 ? 'rounded-t-lg' : ''} ${index === props.menuEntries.length - 1 ? 'rounded-b-lg' : ''} text-sm leading-1 ${e.customFontStyle || font} ${e.separator ? ' border-b border-gray-200 dark:border-gray-800' : ''}`} title={e.title}>
                             {e.customContent || <><div className="truncate w-52">{e.title}</div><div className="flex-1"></div>{e.active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}</>}
                         </div>
                         const key = `entry-${menuId}-${index}-${e.title}`;


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4622

<table><tr><th>BEFORE</th><th>AFTER</th></tr>
<tr><td>Dropdown is always split</td><td>Dropdown is only split on sub-pages</td></tr>
<tr><td>
<img width="534" alt="Screenshot 2021-08-05 at 17 52 11" src="https://user-images.githubusercontent.com/599268/128381478-2d1c4aad-4afc-4014-bf47-2efa1c047c58.png">
</td><td>
<img width="542" alt="Screenshot 2021-08-05 at 17 58 20" src="https://user-images.githubusercontent.com/599268/128382321-59d63bc7-bf51-4612-be3b-3ea0b5e3ae9c.png">
</td></tr><tr><td>
<img width="534" alt="Screenshot 2021-08-05 at 17 45 12" src="https://user-images.githubusercontent.com/599268/128381475-37328505-ee36-4612-87d6-6ec6a997c777.png">
</td><td>
<img width="535" alt="Screenshot 2021-08-05 at 17 52 01" src="https://user-images.githubusercontent.com/599268/128381476-0b35098b-24be-41ef-9be8-b6a9e644120e.png">
</td></tr></table>

@gtsiolis What do you think about this change? Is it a good trade-off? (Nicer on root pages, but still allows breadcrumb navigation when there are breadcrumbs.)

EDIT: Now also fixes https://github.com/gitpod-io/gitpod/issues/5072 and fixes https://github.com/gitpod-io/gitpod/issues/5073