### PR TITLE
Align invite members button on the team page

### DIFF
--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -102,7 +102,7 @@ export default function () {
                             onClick: () => { /* TODO */ }
                         }]} />
                     </div>
-                    <Link to="./members"><button className="ml-2 secondary">Invite Members</button></Link>
+                    <Link to="./members" className="flex"><button className="ml-2 secondary">Invite Members</button></Link>
                     <button className="ml-2" onClick={() => onNewProject()}>New Project</button>
                 </div>
                 <div className="mt-4 grid grid-cols-3 gap-4">


### PR DESCRIPTION
Fix https://github.com/gitpod-io/gitpod/issues/5092.

| BEFORE | AFTER |
|-|-|
| <img width="412" alt="button-before" src="https://user-images.githubusercontent.com/120486/128508597-ee2c809a-2a8f-4dc8-9714-dffa5c9233c7.png"> | <img width="412" alt="button-after" src="https://user-images.githubusercontent.com/120486/128508599-8c5dbf65-7551-4b87-a93f-ad1f973f3b48.png"> |