### PR TITLE
[gitpod-db] Fix invalid table name in query

### DIFF
--- a/components/gitpod-db/src/periodic-deleter.ts
+++ b/components/gitpod-db/src/periodic-deleter.ts
@@ -46,7 +46,7 @@ export class PeriodicDbDeleter {
     }
     protected async collectRowsToBeDeleted(table: TableDescription): Promise<{ table: string, deletions: string[] }> {
         try {
-            await this.query(`SELECT COUNT(1) FROM ${table}`);
+            await this.query(`SELECT COUNT(1) FROM ${table.name}`);
         } catch (err) {
             // table does not exist - we're done here
             return { table: table.name, deletions: [] };


### PR DESCRIPTION
Debugging another issue I found this error:
```json
{
	"component": "server",
	"severity": "INFO",
	"time": "2021-08-06T22:42:09.778Z",
	"environment": "production",
	"region": "us-west-2",
	"message": "query failed: ",
	"payload": "SELECT COUNT(1) FROM [object Object]",
	"loggedViaConsole": true
}
``` 