### PR TITLE
[dashboard] Don't list deleted user projects

### DIFF
--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -57,7 +57,7 @@ export class ProjectDBImpl implements ProjectDB {
 
     public async findUserProjects(userId: string): Promise<Project[]> {
         const repo = await this.getRepo();
-        return repo.find({ userId });
+        return repo.find({ userId, markedDeleted: false });
     }
 
     public async storeProject(project: Project): Promise<Project> {
@@ -67,7 +67,7 @@ export class ProjectDBImpl implements ProjectDB {
 
     public async setProjectConfiguration(projectId: string, config: ProjectConfig): Promise<void> {
         const repo = await this.getRepo();
-        const project = await repo.findOne({ id: projectId, deleted: false });
+        const project = await repo.findOne({ id: projectId, markedDeleted: false });
         if (!project) {
             throw new Error('A project with this ID could not be found');
         }


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/5063

Fun fact: Deleting user projects actually worked as expected, but the observed symptoms were caused by two different problems:
- The `findUserProjects` method returned all projects, even those marked as deleted (whereas the `findTeamProjects` method correctly returned only non-deleted projects)
- When listing a deleted user project, the page also tried to fetch its prebuilds, which failed with the error reported in the issue

This PR fixes both problems. ✅ 