### PR TITLE
Import GitLab projects

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -23,9 +23,9 @@ export default function NewProject() {
     const location = useLocation();
     const history = useHistory();
     const { teams } = useContext(TeamsContext);
-    const { user } = useContext(UserContext);
+    const { user, setUser } = useContext(UserContext);
 
-    const [provider, setProvider] = useState<string>("github.com");
+    const [provider, setProvider] = useState<string | undefined>();
     const [reposInAccounts, setReposInAccounts] = useState<ProviderRepository[]>([]);
     const [repoSearchFilter, setRepoSearchFilter] = useState<string>("");
     const [selectedAccount, setSelectedAccount] = useState<string | undefined>(undefined);
@@ -38,6 +38,16 @@ export default function NewProject() {
     const [loaded, setLoaded] = useState<boolean>(false);
 
     useEffect(() => {
+        if (user && provider === undefined) {
+            if (user.identities.find(i => i.authProviderId === "Public-GitLab")) {
+                setProvider("gitlab.com");
+            } else if (user.identities.find(i => i.authProviderId === "Public-GitHub")) {
+                setProvider("github.com");
+            }
+        }
+    }, [user]);
+
+    useEffect(() => {
         const params = new URLSearchParams(location.search);
         const teamParam = params.get("team");
         if (teamParam) {
@@ -45,16 +55,6 @@ export default function NewProject() {
             const team = teams?.find(t => t.slug === teamParam);
             setSelectedTeamOrUser(team);
         }
-
-        (async () => {
-            updateOrgsState();
-            const repos = await updateReposInAccounts();
-            const first = repos[0];
-            if (first) {
-                setSelectedAccount(first.account);
-            }
-            setLoaded(true);
-        })();
     }, []);
 
     useEffect(() => {
@@ -77,9 +77,27 @@ export default function NewProject() {
         setRepoSearchFilter("");
     }, [selectedAccount]);
 
+    useEffect(() => {
+        if (!provider) {
+            return;
+        }
+        (async () => {
+            updateOrgsState();
+            const repos = await updateReposInAccounts();
+            const first = repos[0];
+            if (first) {
+                setSelectedAccount(first.account);
+            }
+            setLoaded(true);
+        })();
+    }, [provider]);
+
     const isGitHub = () => provider === "github.com";
 
     const updateReposInAccounts = async (installationId?: string) => {
+        if (!provider) {
+            return [];
+        }
         try {
             const repos = await getGitpodService().server.getProviderRepositoriesForUser({ provider, hints: { installationId } });
             setReposInAccounts(repos);
@@ -96,7 +114,7 @@ export default function NewProject() {
     }
 
     const updateOrgsState = async () => {
-        if (isGitHub()) {
+        if (provider && isGitHub()) {
             try {
                 const ghToken = await getToken(provider);
                 setNoOrgs(ghToken?.scopes.includes("read:org") !== true);
@@ -130,6 +148,9 @@ export default function NewProject() {
     }
 
     const createProject = async (teamOrUser: Team | User, selectedRepo: string) => {
+        if (!provider) {
+            return;
+        }
         const repo = reposInAccounts.find(r => r.account === selectedAccount && r.name === selectedRepo);
         if (!repo) {
             console.error("No repo selected!")
@@ -156,7 +177,6 @@ export default function NewProject() {
         return splitted.shift() && splitted.join("/");
     }
 
-    const reposToRender = Array.from(reposInAccounts).filter(r => r.account === selectedAccount && r.name.includes(repoSearchFilter));
     const accounts = new Map<string, { avatarUrl: string }>();
     reposInAccounts.forEach(r => { if (!accounts.has(r.account)) accounts.set(r.account, { avatarUrl: r.accountAvatarUrl }) });
 
@@ -193,33 +213,40 @@ export default function NewProject() {
 
     const renderSelectRepository = () => {
 
+        const noReposAvailable = reposInAccounts.length === 0;
+        const filteredRepos = Array.from(reposInAccounts).filter(r => r.account === selectedAccount && r.name.includes(repoSearchFilter));
         const icon = selectedAccount && accounts.get(selectedAccount)?.avatarUrl;
 
-        const renderRepos = () => (<div className="mt-10 border rounded-t-xl border-gray-100 flex-col">
-            <div className="px-8 pt-8 flex flex-col space-y-2">
-                <ContextMenu classes="w-full left-0 cursor-pointer" menuEntries={getDropDownEntries(accounts)}>
-                    <div className="w-full">
-                        <img src={icon} className="rounded-full w-6 h-6 absolute top-1/4 left-4" />
-                        <input className="w-full px-12 cursor-pointer font-semibold" readOnly type="text" value={selectedAccount || ""}></input>
-                        <img src={CaretDown} title="Select Account" className="filter-grayscale absolute top-1/2 right-3" />
-                    </div>
-                </ContextMenu>
-                <div className="w-full relative ">
-                    <img src={search} title="Search" className="filter-grayscale absolute top-1/3 left-3" />
-                    <input className="w-96 pl-10 border-0" type="text" placeholder="Search Repositories" value={repoSearchFilter}
-                        onChange={(e) => setRepoSearchFilter(e.target.value)}></input>
+        const renderRepos = () => (<>
+            <div className={`mt-10 border rounded-xl border-gray-100 flex-col`}>
+                <div className="px-8 pt-8 flex flex-col space-y-2">
+                    <ContextMenu classes="w-full left-0 cursor-pointer" menuEntries={getDropDownEntries(accounts)}>
+                        <div className="w-full">
+                            {icon && (
+                                <img src={icon} className="rounded-full w-6 h-6 absolute top-1/4 left-4" />
+                            )}
+                            <input className="w-full px-12 cursor-pointer font-semibold" readOnly type="text" value={selectedAccount || ""}></input>
+                            <img src={CaretDown} title="Select Account" className="filter-grayscale absolute top-1/2 right-3" />
+                        </div>
+                    </ContextMenu>
+                    {filteredRepos.length > 0 && (
+                        <div className="w-full relative ">
+                            <img src={search} title="Search" className="filter-grayscale absolute top-1/3 left-3" />
+                            <input className="w-96 pl-10 border-0" type="text" placeholder="Search Repositories" value={repoSearchFilter}
+                                onChange={(e) => setRepoSearchFilter(e.target.value)}></input>
+                        </div>
+                    )}
                 </div>
-            </div>
-            <div className="p-6 flex-col">
-                {reposToRender.length > 0 && (
-                    <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
-                        {reposToRender.map(r => (
-                            <div key={`repo-${r.name}`} className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group" >
+                <div className="p-6 flex-col">
+                    {filteredRepos.length > 0 && (
+                        <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
+                            {filteredRepos.map((r, index) => (
+                                <div key={`repo-${index}-${r.account}-${r.name}`} className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group" >
 
-                                <div className="flex-grow">
-                                    <div className="text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap">{toSimpleName(r.name)}</div>
-                                    <p>Updated {moment(r.updatedAt).fromNow()}</p>
-                                </div>
+                                    <div className="flex-grow">
+                                        <div className="text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap">{toSimpleName(r.name)}</div>
+                                        <p>Updated {moment(r.updatedAt).fromNow()}</p>
+                                    </div>
                                     <div className="flex justify-end">
                                         <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100">
                                             {!r.inUse ? (
@@ -229,54 +256,73 @@ export default function NewProject() {
                                             )}
                                         </div>
                                     </div>
-                            </div>
-                        ))}
-                    </div>
-                )}
-                {reposToRender.length === 0 && (
-                    <p className="text-center ">not found</p>
-                )}
-            </div>
-
-            <div className="px-3 pt-3 bg-gray-100">
-                <div className="text-gray-500 text-center">
-                    Repository not found? <a href="javascript:void(0)" onClick={e => reconfigure()} className="text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600">Reconfigure</a>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    {!noReposAvailable && filteredRepos.length === 0 && (
+                        <p className="text-center">No Results</p>
+                    )}
+                    {loaded && noReposAvailable && isGitHub() && (<div>
+                        <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl">
+                            <img src={NoAccess} title="No Access" className="m-auto mb-4" />
+                            <h3 className="mb-2 text-gray-600 dark:text-gray-400">
+                                No Access
+                            </h3>
+                            <span className="dark:text-gray-500">
+                                Authorize GitHub (github.com) or select a different account.
+                            </span>
+                            <br />
+                            <button className="mt-6" onClick={() => reconfigure()}>Authorize</button>
+                        </div>
+                    </div>)}
                 </div>
-                {isGitHub() && noOrgs && (
-                    <div className="text-gray-500 mx-auto text-center">
-                        Missing organizations? <a href="javascript:void(0)" onClick={e => grantReadOrgPermissions()} className="text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600">Grant permissions</a>
-                    </div>
-                )}
-            </div>
-            <div className="h-3 border rounded-b-xl border-gray-100 bg-gray-100"></div>
-        </div>);
 
-        const renderEmptyState = () => (<div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
-            <div>
-                <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl">
-                    <img src={NoAccess} title="No Access" className="m-auto mb-4" />
-                    <h3 className="mb-2 text-gray-600 dark:text-gray-400">
-                        No Access
-                    </h3>
-                    <span className="dark:text-gray-500">
-                        Authorize GitHub (github.com) or select a different account.
-                    </span>
-                    <br/>
-                    <button className="mt-6" onClick={() => reconfigure()}>Authorize Provider</button>
+            </div>
+            {isGitHub() && (
+                    <div className="pt-3">
+                        <div className="text-gray-500 text-center w-96 mx-8">
+                            Repository not found? <a href="javascript:void(0)" onClick={e => reconfigure()} className="text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600">Reconfigure</a>
+                        </div>
+                        {isGitHub() && noOrgs && (
+                            <div className="text-gray-500 mx-auto text-center">
+                                Missing organizations? <a href="javascript:void(0)" onClick={e => grantReadOrgPermissions()} className="text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600">Grant permissions</a>
+                            </div>
+                        )}
+                    </div>
+            )}
+        </>
+        );
+
+        const renderEmptyState = () => (<div>
+            <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
+                <div>
+                    <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
+                        <h3 className="mb-2 text-gray-400 dark:text-gray-600 animate-pulse">
+                            Loading ...
+                        </h3>
+                    </div>
                 </div>
             </div>
         </div>)
 
-        const empty = reposInAccounts.length === 0;
-
-        const onGitProviderSeleted = (host: string) => {
+        const onGitProviderSeleted = async (host: string, updateUser?: boolean) => {
+            if (updateUser) {
+                setUser(await getGitpodService().server.getLoggedInUser());
+            }
             setShowGitProviders(false);
             setProvider(host);
         }
 
-        return (<>
-            {(loaded && empty) ? renderEmptyState() : (showGitProviders ? (<GitProviders onHostSelected={onGitProviderSeleted} />) : renderRepos())}
-        </>)
+        if (!loaded) {
+            return renderEmptyState();
+        }
+
+        if (showGitProviders) {
+            return (<GitProviders onHostSelected={onGitProviderSeleted} />);
+        }
+
+        return renderRepos();
     };
 
     const renderSelectTeam = () => {
@@ -322,7 +368,7 @@ export default function NewProject() {
 
     return (<div className="flex flex-col w-96 mt-24 mx-auto items-center">
         <h1>New Project</h1>
-        <p className="text-gray-500 text-center text-base">Select a git repository.</p>
+        <p className="text-gray-500 text-center text-base">Select a git repository on <strong>{provider}</strong>.</p>
 
         {!selectedRepo && renderSelectRepository()}
 
@@ -335,7 +381,7 @@ export default function NewProject() {
 }
 
 function GitProviders(props: {
-    onHostSelected: (host: string) => void
+    onHostSelected: (host: string, updateUser?: boolean) => void
 }) {
     const [authProviders, setAuthProviders] = useState<AuthProviderInfo[]>([]);
 
@@ -355,8 +401,8 @@ function GitProviders(props: {
         await openAuthorizeWindow({
             host: ap.host,
             scopes: ap.requirements?.default,
-            onSuccess: () => {
-                props.onHostSelected(ap.host);
+            onSuccess: async () => {
+                props.onHostSelected(ap.host, true);
             },
             onError: (error) => {
                 console.log(error);

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -16,12 +16,14 @@ import PrebuildLogs from "../components/PrebuildLogs";
 import { shortCommitMessage } from "./render-utils";
 
 export default function () {
-    const { teams } = useContext(TeamsContext);
     const location = useLocation();
+
+    const { teams } = useContext(TeamsContext);
+    const team = getCurrentTeam(location, teams);
+
     const match = useRouteMatch<{ team: string, project: string, prebuildId: string }>("/:team/:project/:prebuildId");
     const projectName = match?.params?.project;
     const prebuildId = match?.params?.prebuildId;
-    const team = getCurrentTeam(location, teams);
 
     const [ prebuild, setPrebuild ] = useState<PrebuildInfo | undefined>();
 
@@ -44,7 +46,7 @@ export default function () {
             });
             setPrebuild(prebuilds[0]);
         })();
-    }, [ teams, team ]);
+    }, [ teams ]);
 
     const renderTitle = () => {
         if (!prebuild) {

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -18,11 +18,13 @@ import { shortCommitMessage } from "./render-utils";
 
 export default function () {
     const history = useHistory();
-    const { teams } = useContext(TeamsContext);
     const location = useLocation();
+
+    const { teams } = useContext(TeamsContext);
+    const team = getCurrentTeam(location, teams);
+
     const match = useRouteMatch<{ team: string, resource: string }>("/:team/:resource");
     const projectName = match?.params?.resource;
-    const team = getCurrentTeam(location, teams);
 
     // @ts-ignore
     const [project, setProject] = useState<Project | undefined>();
@@ -55,7 +57,7 @@ export default function () {
                 }
             }
         })();
-    }, [ teams, team ]);
+    }, [ teams ]);
 
     const prebuildContextMenu = (p: PrebuildInfo) => {
         const running = p.status === "building";

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -18,11 +18,13 @@ import { shortCommitMessage } from "./render-utils";
 
 export default function () {
     const history = useHistory();
-    const { teams } = useContext(TeamsContext);
     const location = useLocation();
+
+    const { teams } = useContext(TeamsContext);
+    const team = getCurrentTeam(location, teams);
+
     const match = useRouteMatch<{ team: string, resource: string }>("/:team/:resource");
     const projectName = match?.params?.resource;
-    const team = getCurrentTeam(location, teams);
 
     const [project, setProject] = useState<Project | undefined>();
 
@@ -34,7 +36,7 @@ export default function () {
 
     useEffect(() => {
         updateProject();
-    }, [ teams, team ]);
+    }, [ teams ]);
 
     const updateProject = async () => {
         if (!teams || !projectName) {
@@ -87,7 +89,7 @@ export default function () {
             // TODO(at): this need to be revised once prebuild events are integrated
             return;
         }
-        if (!team || !project) {
+        if (!project) {
             return;
         }
         prebuildLoaders.add(branch.name);

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -32,7 +32,7 @@ export default function () {
 
     useEffect(() => {
         updateProjects();
-    }, [ teams, team ]);
+    }, [ teams ]);
 
     const updateProjects = async () => {
         if (!teams) {

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -53,6 +53,7 @@ import { BlockedUserFilter } from "../../src/auth/blocked-user-filter";
 import { EMailDomainService, EMailDomainServiceImpl } from "./auth/email-domain-service";
 import { UserDeletionServiceEE } from "./user/user-deletion-service";
 import { GitHubAppSupport } from "./github/github-app-support";
+import { GitLabAppSupport } from "./gitlab/gitlab-app-support";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -71,6 +72,7 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(GithubAppRules).toSelf().inSingletonScope();
     bind(PrebuildStatusMaintainer).toSelf().inSingletonScope();
     bind(GitLabApp).toSelf().inSingletonScope();
+    bind(GitLabAppSupport).toSelf().inSingletonScope();
     bind(BitbucketApp).toSelf().inSingletonScope();
 
     bind(LicenseEvaluator).toSelf().inSingletonScope();

--- a/components/server/ee/src/github/github-app-support.ts
+++ b/components/server/ee/src/github/github-app-support.ts
@@ -59,7 +59,7 @@ export class GitHubAppSupport {
                         name: r.name,
                         cloneUrl: r.clone_url,
                         account: r.owner.login,
-                        accountAvatarUrl: r.owner.avatar_url,
+                        accountAvatarUrl: r.owner?.avatar_url,
                         updatedAt: r.updated_at,
                         installationId: installation.data.id,
                         installationUpdatedAt: installation.data.updated_at

--- a/components/server/ee/src/gitlab/gitlab-app-support.ts
+++ b/components/server/ee/src/gitlab/gitlab-app-support.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { ProviderRepository, User } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { TokenProvider } from "../../../src/user/token-provider";
+import { UserDB } from "@gitpod/gitpod-db/lib";
+import { Gitlab } from "@gitbeaker/node";
+
+@injectable()
+export class GitLabAppSupport {
+
+    @inject(UserDB) protected readonly userDB: UserDB;
+    @inject(TokenProvider) protected readonly tokenProvider: TokenProvider;
+
+    async getProviderRepositoriesForUser(params: { user: User, provider: string, hints?: object }): Promise<ProviderRepository[]> {
+        const token = await this.tokenProvider.getTokenForHost(params.user, "gitlab.com");
+        const oauthToken = token.value;
+        const api = new Gitlab({ oauthToken });
+
+        const result: ProviderRepository[] = [];
+
+        // cf. https://docs.gitlab.com/ee/api/projects.html#list-all-projects
+        // we are listing only those projects with access level of maintainers.
+        // also cf. https://docs.gitlab.com/ee/api/members.html#valid-access-levels
+        //
+        const projectsWithAccess = await api.Projects.all({ min_access_level: "40", perPage: 100 });
+        for (const project of projectsWithAccess) {
+            const anyProject = project as any;
+            const fullPath = anyProject.path_with_namespace as string;
+            const cloneUrl = anyProject.http_url_to_repo as string;
+            const updatedAt = anyProject.last_activity_at as string;
+            const accountAvatarUrl = anyProject.owner?.avatar_url as string;
+
+            result.push({
+                name: project.name,
+                account: fullPath.split("/")[0],
+                cloneUrl,
+                updatedAt,
+                accountAvatarUrl,
+                // inUse: // todo(at) compute usage via ProjectHooks API
+            })
+        }
+
+        return result;
+    }
+
+}

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -352,8 +352,8 @@ export class GithubApp {
                 }
             }
         }
-
     }
+
     protected async findInstallationOwner(installationId: number): Promise<{user: User, project?: Project} | undefined> {
         // Legacy mode
         //

--- a/components/server/ee/src/prebuilds/gitlab-service.ts
+++ b/components/server/ee/src/prebuilds/gitlab-service.ts
@@ -13,6 +13,7 @@ import { GitLabApp } from "./gitlab-app";
 import { Env } from "../../../src/env";
 import { TokenService } from "../../../src/user/token-service";
 import { GitlabContextParser } from "../../../src/gitlab/gitlab-context-parser";
+import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 
 @injectable()
 export class GitlabService extends RepositoryService {
@@ -26,36 +27,43 @@ export class GitlabService extends RepositoryService {
 	@inject(GitlabContextParser) protected gitlabContextParser: GitlabContextParser;
 
     async canInstallAutomatedPrebuilds(user: User, cloneUrl: string): Promise<boolean> {
-        const { host } = await this.gitlabContextParser.parseURL(user, cloneUrl);
-        return host === this.config.host;
+        const { host, owner, repoName } = await this.gitlabContextParser.parseURL(user, cloneUrl);
+        if (host !== this.config.host) {
+            return false;
+        }
+        const api = await this.api.create(user);
+        const response = (await api.Projects.show(`${owner}/${repoName}`)) as unknown as GitLab.Project;
+        if (GitLab.ApiError.is(response)) {
+            throw response;
+        }
+        // one need to have at least the access level of a maintainer (40) in order to install webhooks on a project
+        // cf. https://docs.gitlab.com/ee/api/members.html#valid-access-levels
+        return GitLab.Permissions.hasMaintainerAccess(response);
     }
 
     async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {
         const api = await this.api.create(user);
         const { owner, repoName } = await this.gitlabContextParser.parseURL(user, cloneUrl);
-        const response = (await api.Projects.show(`${owner}/${repoName}`)) as unknown as GitLab.Project;
-        if (GitLab.ApiError.is(response)) {
-            throw response;
-        }
-        const hooks = (await api.ProjectHooks.all(response.id)) as unknown as GitLab.ProjectHook[];
+        const gitlabProjectId = `${owner}/${repoName}`;
+        const hooks = (await api.ProjectHooks.all(gitlabProjectId)) as unknown as GitLab.ProjectHook[];
         if (GitLab.ApiError.is(hooks)) {
             throw hooks;
         }
         let existingProps: any = {};
         for (const hook of hooks) {
             if (hook.url === this.getHookUrl()) {
-                console.log('Deleting existing hook');
+                log.info('Deleting existing hook');
                 existingProps = hook
-                await api.ProjectHooks.remove(response.id, hook.id);
+                await api.ProjectHooks.remove(gitlabProjectId, hook.id);
             }
         }
         const tokenEntry = await this.tokenService.createGitpodToken(user, GitlabService.PREBUILD_TOKEN_SCOPE, cloneUrl);
-        await api.ProjectHooks.add(response.id, this.getHookUrl(), <Partial<GitLab.ProjectHook>>{
+        await api.ProjectHooks.add(gitlabProjectId, this.getHookUrl(), <Partial<GitLab.ProjectHook>>{
             ...existingProps,
             push_events: true,
             token: user.id+'|'+tokenEntry.token.value
         });
-        console.log('Installed Webhook for ' + cloneUrl);
+        log.info('Installed Webhook for ' + cloneUrl, { cloneUrl, userId: user.id });
     }
 
     async canAccessHeadlessLogs(user: User, context: WorkspaceContext): Promise<boolean> {
@@ -67,7 +75,7 @@ export class GitlabService extends RepositoryService {
         try {
             // If we can "see" a project we are allowed to access it's headless logs
             const api = await this.api.create(user);
-            const response = (await api.Projects.show(`${owner}/${repoName}`)) as unknown as GitLab.Project;
+            const response = await api.Projects.show(`${owner}/${repoName}`);
             if (GitLab.ApiError.is(response)) {
                 return false;
             }

--- a/components/server/src/gitlab/api.ts
+++ b/components/server/src/gitlab/api.ts
@@ -204,7 +204,17 @@ export namespace GitLab {
         private_profile: boolean;
     }
     export interface Permissions {
-        project_access: {
+        project_access?: {
+            /**`
+             * 10 => Guest access
+             * 20 => Reporter access
+             * 30 => Developer access
+             * 40 => Maintainer access
+             * 50 => Owner accesss
+            `*/
+            access_level: number;
+        },
+        group_access?: {
             /**`
              * 10 => Guest access
              * 20 => Reporter access
@@ -217,7 +227,22 @@ export namespace GitLab {
     }
     export namespace Permissions {
         export function hasWriteAccess(repo: Project): boolean {
-            return repo.permissions.project_access.access_level >= 30;
+            if (repo.permissions.project_access) {
+                return repo.permissions.project_access.access_level >= 30;
+            }
+            if (repo.permissions.group_access) {
+                return repo.permissions.group_access.access_level >= 30;
+            }
+            return false;
+        }
+        export function hasMaintainerAccess(repo: Project): boolean {
+            if (repo.permissions.project_access) {
+                return repo.permissions.project_access.access_level >= 40;
+            }
+            if (repo.permissions.group_access) {
+                return repo.permissions.group_access.access_level >= 40;
+            }
+            return false;
         }
     }
     export interface Commit {
@@ -225,12 +250,15 @@ export namespace GitLab {
         short_id: string;
         title: string;
         message: string;
-        parent_ids: string[];
+        parent_ids: string[] | null;
+        author_name: string;
+        authored_date: string;
     }
     export interface Branch {
         commit: Commit;
         name: string;
         default: boolean;
+        web_url: string;
     }
     export interface Tag {
         name: string,

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -11,6 +11,8 @@ import { GitLabApi, GitLab } from "./api";
 import { RepositoryProvider } from '../repohost/repository-provider';
 import { parseRepoUrl } from '../repohost/repo-url';
 
+import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+
 @injectable()
 export class GitlabRepositoryProvider implements RepositoryProvider {
     @inject(GitLabApi) protected readonly gitlab: GitLabApi;
@@ -25,23 +27,71 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
         const cloneUrl = response.http_url_to_repo;
         const description = response.default_branch;
         const host = parseRepoUrl(cloneUrl)!.host;
-        const avatarUrl = response.owner.avatar_url || undefined;
+        const avatarUrl = response.owner?.avatar_url || undefined;
         const webUrl = response.web_url;
-        return { host, owner, name, cloneUrl, description, avatarUrl, webUrl };
+        const defaultBranch = response.default_branch
+        return { host, owner, name, cloneUrl, description, avatarUrl, webUrl, defaultBranch };
     }
 
     async getBranch(user: User, owner: string, repo: string, branch: string): Promise<Branch> {
-        // todo
-        throw new Error("not implemented");
+        const response = await this.gitlab.run<GitLab.Branch>(user, async g => {
+            return g.Branches.show(`${owner}/${repo}`, branch);
+        });
+        if (GitLab.ApiError.is(response)) {
+            throw response;
+        }
+        return {
+            htmlUrl: response.web_url,
+            name: response.name,
+            commit: {
+                sha: response.commit.id,
+                author: response.commit.author_name,
+                authorAvatarUrl: "", // TODO(at) fetch avatar URL
+                authorDate: response.commit.authored_date,
+                commitMessage: response.commit.message || "missing commit message",
+            }
+        };
     }
 
     async getBranches(user: User, owner: string, repo: string): Promise<Branch[]> {
-        // todo
-        return [];
+        const branches: Branch[] = [];
+        const response = await this.gitlab.run<GitLab.Branch[]>(user, async g => {
+            return g.Branches.all(`${owner}/${repo}`);
+        });
+        if (GitLab.ApiError.is(response)) {
+            throw response;
+        }
+        for (const b of response) {
+            branches.push({
+                htmlUrl: b.web_url,
+                name: b.name,
+                commit: {
+                    sha: b.commit.id,
+                    author: b.commit.author_name,
+                    authorDate: b.commit.authored_date,
+                    authorAvatarUrl: "", // TODO(at) fetch avatar URL
+                    commitMessage: b.commit.message || "missing commit message",
+                }
+            })
+        }
+        return branches;
     }
 
     async getCommitInfo(user: User, owner: string, repo: string, ref: string): Promise<CommitInfo | undefined> {
-        // todo
-        return undefined;
+        const response = await this.gitlab.run<GitLab.Commit>(user, async g => {
+            return g.Commits.show(`${owner}/${repo}`, ref);
+        });
+        if (GitLab.ApiError.is(response)) {
+            // throw response;
+            log.debug("Failed to fetch commit.", { response });
+            return undefined;
+        }
+        return {
+            sha: response.id,
+            author: response.author_name,
+            authorDate: response.authored_date,
+            commitMessage: response.message || "missing commit message",
+            authorAvatarUrl: "",
+        };
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,7 +4661,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react@*", "@types/react@17.0.0", "@types/react@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
@@ -14875,7 +14875,7 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.9.2:
+nan@2.14.1, nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.9.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
@@ -15446,6 +15446,13 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+oniguruma@7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.1.tgz#51775834f7819b6e31aa878706aa7f65ad16b07f"
+  integrity sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==
+  dependencies:
+    nan "^2.14.0"
 
 open@^7.0.2:
   version "7.4.2"
@@ -17585,7 +17592,7 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@^17.0.1:
+react-dom@17.0.1, react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
@@ -17714,7 +17721,7 @@ react-scripts@^4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react@^17.0.1:
+react@17.0.1, react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
@@ -20992,10 +20999,23 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
-vscode-jsonrpc@^5.0.0:
+vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
+
+vscode-languageserver-protocol@3.15.3:
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
+  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+  dependencies:
+    vscode-jsonrpc "^5.0.1"
+    vscode-languageserver-types "3.15.1"
+
+vscode-languageserver-types@3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
+  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
 vscode-uri@^1.0.1:
   version "1.0.8"


### PR DESCRIPTION
This PR enables importing of GitLab repositories as projects into Gitpod.

Your GitLab account needs to have at the access level of a maintainer in order to install webhooks for prebuilds. That's also a filter criteria for repositories to be choose from.

<img width="706" alt="Screen Shot 2021-08-09 at 17 06 51" src="https://user-images.githubusercontent.com/914497/128729075-05b2e135-fddf-402b-a9a4-ea4b26f1df09.png">

Closes https://github.com/gitpod-io/gitpod/issues/5278