### PR TITLE
Add What's New entry for teams and projects

### DIFF
--- a/components/dashboard/src/whatsnew/WhatsNew-2021-08.tsx
+++ b/components/dashboard/src/whatsnew/WhatsNew-2021-08.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User } from "@gitpod/gitpod-protocol";
+import { WhatsNewEntry } from "./WhatsNew";
+import { switchToVSCodeAction } from "./WhatsNew-2021-04";
+import PillLabel from "../components/PillLabel";
+
+export const WhatsNewEntry202108: WhatsNewEntry = {
+    children: (user: User, setUser: React.Dispatch<User>) => {
+
+        return <>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 pt-6 pb-4">
+                <p className="pb-2 text-gray-900 dark:text-gray-100 text-base font-medium">Teams & Projects <PillLabel>New Feature</PillLabel></p>
+                <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">Hey! We're introducing <strong>Teams & Projects</strong> to surface <strong>Prebuilds</strong> in the dashboard. All existing teams will be migrated over the upcoming weeks. No action is required on your side. 🎉</p>
+                <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">You can create as many teams as you need and import repositories as projects from the top navigation. 💡</p>
+                <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">We welcome any input on this first iteration in <a href="/new" className="learn-more">the feedback issue</a>. 📝</p>
+            </div>
+        </>;
+    },
+    newsKey: 'August-2021',
+    maxUserCreationDate: '2021-08-17',
+    actionAfterSeen: switchToVSCodeAction,
+};

--- a/components/dashboard/src/whatsnew/WhatsNew-2021-08.tsx
+++ b/components/dashboard/src/whatsnew/WhatsNew-2021-08.tsx
@@ -17,7 +17,7 @@ export const WhatsNewEntry202108: WhatsNewEntry = {
                 <p className="pb-2 text-gray-900 dark:text-gray-100 text-base font-medium">Teams & Projects <PillLabel>New Feature</PillLabel></p>
                 <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">Hey! We're introducing <strong>Teams & Projects</strong> to surface <strong>Prebuilds</strong> in the dashboard. All existing teams will be migrated over the upcoming weeks. No action is required on your side. 🎉</p>
                 <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">You can create as many teams as you need and import repositories as projects from the top navigation. 💡</p>
-                <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">We welcome any input on this first iteration in <a href="/new" className="learn-more">the feedback issue</a>. 📝</p>
+                <p className="pb-2 text-gray-500 dark:text-gray-400 text-sm">We welcome any input on this first iteration in <a href="https://github.com/gitpod-io/gitpod/issues/5095" className="learn-more">the feedback issue</a>. 📝</p>
             </div>
         </>;
     },

--- a/components/dashboard/src/whatsnew/WhatsNew.tsx
+++ b/components/dashboard/src/whatsnew/WhatsNew.tsx
@@ -8,6 +8,7 @@ import { User } from "@gitpod/gitpod-protocol";
 import Modal from "../components/Modal";
 import { WhatsNewEntry202104 } from "./WhatsNew-2021-04";
 import { WhatsNewEntry202106 } from "./WhatsNew-2021-06";
+import { WhatsNewEntry202108 } from "./WhatsNew-2021-08";
 import { UserContext } from "../user-context";
 import { useContext, useState } from "react";
 import { getGitpodService } from "../service/service";
@@ -15,6 +16,7 @@ import { getGitpodService } from "../service/service";
 const allEntries: WhatsNewEntry[] = [
     WhatsNewEntry202106,
     WhatsNewEntry202104,
+    WhatsNewEntry202108
 ]
 
 export const shouldSeeWhatsNew = (user: User, news: { newsKey: string, maxUserCreationDate: string }[] = allEntries) => {


### PR DESCRIPTION
This will add an entry in the **What's New** modal for the upcoming **Teams & Projects** feature.

Fix https://github.com/gitpod-io/gitpod/issues/5114.

First time adding an entry after the refactoring in https://github.com/gitpod-io/gitpod/pull/4607. ⚠️ 

| What's New entry for Teams & Projects |
|-|
| <img width="1440" alt="Screenshot 2021-08-09 at 11 07 40 PM" src="https://user-images.githubusercontent.com/120486/128768104-372f1cb1-b369-4582-a9fe-789fc3dae9e3.png"> |