### PR TITLE
[server] Add support for typescript map

### DIFF
--- a/components/server/src/main.ts
+++ b/components/server/src/main.ts
@@ -4,6 +4,8 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import 'source-map-support/register';
+
 import { start } from "./init";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Container } from "inversify";


### PR DESCRIPTION
In case of errors, the stack trace reports the line of the compiled javascript file instead of the typescript one.
https://www.npmjs.com/package/source-map-support