### PR TITLE
Mention username who added project in a team

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -315,15 +315,17 @@ export default function NewProject() {
                                 <div key={`repo-${index}-${r.account}-${r.name}`} className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group" >
 
                                     <div className="flex-grow">
-                                        <div className="text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap">{toSimpleName(r.name)}</div>
+                                        <div className={"text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap" + (r.inUse ? " text-gray-400 dark:text-gray-500" : "text-gray-700")}>{toSimpleName(r.name)}</div>
                                         <p>Updated {moment(r.updatedAt).fromNow()}</p>
                                     </div>
                                     <div className="flex justify-end">
-                                        <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100">
+                                        <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100 items-center mr-2 text-right">
                                             {!r.inUse ? (
                                                 <button className="primary" onClick={() => setSelectedRepo(r)}>Select</button>
                                             ) : (
-                                                <p className="my-auto">already taken</p>
+                                                <p className="text-gray-500 font-medium">
+                                                    @{r.inUse.userName} already<br/>added this repo
+                                                </p>
                                             )}
                                         </div>
                                     </div>

--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -10,7 +10,7 @@ export const ProjectDB = Symbol('ProjectDB');
 export interface ProjectDB {
     findProjectById(projectId: string): Promise<Project | undefined>;
     findProjectByCloneUrl(cloneUrl: string): Promise<Project | undefined>;
-    findProjectsByCloneUrls(cloneUrls: string[]): Promise<Project[]>;
+    findProjectsByCloneUrls(cloneUrls: string[]): Promise<(Project & { teamOwners?: string[] })[]>;
     findTeamProjects(teamId: string): Promise<Project[]>;
     findUserProjects(userId: string): Promise<Project[]>;
     storeProject(project: Project): Promise<Project>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -271,7 +271,7 @@ export interface ProviderRepository {
     installationId?: number;
     installationUpdatedAt?: string;
 
-    inUse?: boolean;
+    inUse?: { userName: string };
 }
 
 export interface ClientHeaderFields {

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -37,7 +37,7 @@ export class ProjectsService {
         return this.projectDB.findUserProjects(userId);
     }
 
-    async getProjectsByCloneUrls(cloneUrls: string[]): Promise<Project[]> {
+    async getProjectsByCloneUrls(cloneUrls: string[]): Promise<(Project & { teamOwners?: string[] })[]> {
         return this.projectDB.findProjectsByCloneUrls(cloneUrls);
     }
 


### PR DESCRIPTION
### What does this PR do?

This is using the existing structure for indicating already imported projects instead of the tooltip shown in the issue description, see https://github.com/gitpod-io/gitpod/issues/5119.

1. Change the repository name color when it's not available to import.
2. Add a placeholder for inserting the user who already added a project.

Fix https://github.com/gitpod-io/gitpod/issues/5119.

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2021-08-10 at 12 39 36 AM" src="https://user-images.githubusercontent.com/120486/128778039-cff8cf78-4414-4ddf-b547-fbe8b03a54c6.png"> | <img width="1440" alt="Screenshot 2021-08-10 at 12 24 46 AM" src="https://user-images.githubusercontent.com/120486/128777182-8ef25322-ff6e-4ac6-ae39-981b4d4727a5.png"> |