### PR TITLE
[ws-daemon] Re-establish IWS on restart

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -439,6 +439,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         let flags = ""
         flags += ` --namespace ${namespace}`;
         flags += ` --set components.imageBuilder.hostDindData=/mnt/disks/ssd0/docker-${namespace}`;
+        flags += ` --set components.wsDaemon.hostWorkspaceArea=/mnt/disks/ssd0/workspaces-${namespace}`;
         flags += ` --set version=${version}`;
         flags += ` --set hostname=${domain}`;
         flags += ` --set devBranch=${destname}`;

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -754,9 +754,13 @@ func workspaceLifecycleHooks(cfg Config, kubernetesNamespace string, workspaceEx
 		return nil
 	}
 
+	// startIWS starts the in-workspace service for a workspace. This lifecycle hook is idempotent, hence can - and must -
+	// be called on initialization and ready. The on-ready hook exists only to support ws-daemon restarts.
+	startIWS := iws.ServeWorkspace(uidmapper, api.FSShiftMethod(cfg.UserNamespaces.FSShift))
+
 	return map[session.WorkspaceState][]session.WorkspaceLivecycleHook{
-		session.WorkspaceInitializing: {setupWorkspace, iws.ServeWorkspace(uidmapper, api.FSShiftMethod(cfg.UserNamespaces.FSShift))},
-		session.WorkspaceReady:        {setupWorkspace},
+		session.WorkspaceInitializing: {setupWorkspace, startIWS},
+		session.WorkspaceReady:        {setupWorkspace, startIWS},
 		session.WorkspaceDisposing:    {iws.StopServingWorkspace},
 	}
 }

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -78,6 +78,10 @@ var (
 // ServeWorkspace establishes the IWS server for a workspace
 func ServeWorkspace(uidmapper *Uidmapper, fsshift api.FSShiftMethod) func(ctx context.Context, ws *session.Workspace) error {
 	return func(ctx context.Context, ws *session.Workspace) (err error) {
+		if _, running := ws.NonPersistentAttrs[session.AttrWorkspaceServer]; running {
+			return nil
+		}
+
 		//nolint:ineffassign
 		span, ctx := opentracing.StartSpanFromContext(ctx, "iws.ServeWorkspace")
 		defer tracing.FinishSpan(span, &err)


### PR DESCRIPTION
fixes #5079 

ws-daemon provides an in-workspace service (IWS) to workspacekit. We use this IWS to establish the UID/GID mapping, mount proc and sysfs, prepare the rootfs and unmount it all on shutdown. If the IWS is not available, the workspace does not function well. Prior to this change, ws-daemon would not re-establish the IWS for already running workspaces due to a missing call in the lifecycle hooks.

### How to test
1. Start a workspace
2. Restart the ws-daemon on the node where the workspace is running
3. Run `docker run --rm -it alpine:latest` in the workspace. The container should just run and not complain about procfs.