### PR TITLE
[dashboard] Disallow team names that might conflict with dashboard URLs

### DIFF
--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -38,7 +38,7 @@ export default function () {
                 <h3 className="text-center text-xl mb-6">What's your team's name?</h3>
                 <h4>Team Name</h4>
                 <input className={`w-full${!!creationError ? ' error' : ''}`} type="text" onChange={event => name = event.target.value} />
-                {!!creationError && <p className="text-gitpod-red">{creationError.message}</p>}
+                {!!creationError && <p className="text-gitpod-red">{creationError.message.replace(/Request \w+ failed with message: /, '')}</p>}
             </div>
             <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-2">
                 <button type="submit">Create Team</button>

--- a/components/gitpod-db/package.json
+++ b/components/gitpod-db/package.json
@@ -25,6 +25,7 @@
     "@jmondi/oauth2-server": "^1.1.0",
     "mysql": "^2.15.0",
     "reflect-metadata": "^0.1.10",
+    "the-big-username-blacklist": "^1.5.2",
     "typeorm": "0.1.20",
     "uuid": "^3.1.0"
   },

--- a/components/gitpod-db/src/the-big-username-blocklist.d.ts
+++ b/components/gitpod-db/src/the-big-username-blocklist.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+// Source: https://github.com/marteinn/The-Big-Username-Blacklist-JS/blob/master/src/index.js
+declare module 'the-big-username-blacklist' {
+    export function validate (username: string): boolean;
+    export var list: string[];
+}

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -4,6 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { list as blocklist } from "the-big-username-blacklist";
 import { Team, TeamMemberInfo, TeamMemberRole, TeamMembershipInvite, User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from "inversify";
 import { TypeORM } from "./typeorm";
@@ -14,6 +15,40 @@ import { DBTeam } from "./entity/db-team";
 import { DBTeamMembership } from "./entity/db-team-membership";
 import { DBUser } from "./entity/db-user";
 import { DBTeamMembershipInvite } from "./entity/db-team-membership-invite";
+
+const FORBIDDEN_SLUGS = [
+    'access-control',
+    'account',
+    'admin',
+    'blocked',
+    'branches',
+    'from-referrer',
+    'install-github-app',
+    'integrations',
+    'issues',
+    'login',
+    'merge-requests',
+    'new',
+    'notifications',
+    'oauth-approval',
+    'plans',
+    'prebuilds',
+    'preferences',
+    'projects',
+    'pull-requests',
+    'settings',
+    'setup',
+    'snapshots',
+    'sorry',
+    'start',
+    'subscription',
+    'teams',
+    'upgrade-subscription',
+    'usage',
+    'variables',
+    'workspaces',
+    ...(blocklist),
+].sort((a, b) => b > a ? -1 : 1);
 
 @injectable()
 export class TeamDBImpl implements TeamDB {
@@ -79,6 +114,14 @@ export class TeamDBImpl implements TeamDB {
             throw new Error('Please choose a team name containing only letters, numbers, -, _, \', or spaces.');
         }
         const slug = name.toLocaleLowerCase().replace(/[ ']/g, '-');
+        if (FORBIDDEN_SLUGS.indexOf(slug) !== -1) {
+            throw new Error('Creating a team with this name is not allowed');
+        }
+        const userRepo = await this.getUserRepo();
+        const existingUsers = await userRepo.query('SELECT COUNT(id) AS count FROM d_b_user WHERE fullName LIKE ? OR name LIKE ?', [ name, slug ]);
+        if (existingUsers[0].count > 0) {
+            throw new Error('A team cannot have the same name as an existing user');
+        }
         const teamRepo = await this.getTeamRepo();
         const existingTeam = await teamRepo.findOne({ slug, deleted: false });
         if (!!existingTeam) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20066,6 +20066,11 @@ text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+the-big-username-blacklist@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/the-big-username-blacklist/-/the-big-username-blacklist-1.5.2.tgz#0a4e88fe636e39552c9306b72e7722c99b6eece6"
+  integrity sha512-bKRIZbu3AoDhEkjNcErodWLpR18vZQQqg9DEab/zELgGw++M1x0KBeTGdoEPHPw0ghmx1jf/B6kZKuwDDPhGBQ==
+
 thenify-all@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4469

### How to test

1. Try to create a team called:
    - "workspaces" (or any other dashboard page)
    - "root" (or any other [suspicious name](https://github.com/marteinn/The-Big-Username-Blocklist/blob/main/list_raw.txt))
    - the same as your user