### PR TITLE
[content-service] Don't filter blobs during clone

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -272,7 +272,9 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 		args = append(args, strings.TrimSpace(key)+"="+strings.TrimSpace(value))
 	}
 
-	args = append(args, "--filter=blob:none")
+	// TODO(cw): re-introduce this when we have a better story for repo forking
+	// args = append(args, "--filter=blob:none")
+
 	args = append(args, ".")
 
 	return c.Git(ctx, "clone", args...)


### PR DESCRIPTION
We recently introduced `--filter blob:none` during Git clone operations. While this brought considerable performance improvements it's also been detrimental to user experience. We'll remove this behaviour until we've found a good way to provide sensible UX with this change.