### PR TITLE
[ws-manager] Adjust probe InitialDelaySeconds value

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -457,10 +457,11 @@ func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) 
 			// We make the readiness probe more difficult to fail than the liveness probe.
 			// This way, if the workspace really has a problem it will be shut down by Kubernetes rather than end up in
 			// some undefined state.
-			FailureThreshold: 600,
-			PeriodSeconds:    1,
-			SuccessThreshold: 1,
-			TimeoutSeconds:   1,
+			FailureThreshold:    600,
+			PeriodSeconds:       1,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      1,
+			InitialDelaySeconds: 2,
 		}
 	)
 

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -163,6 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -157,6 +157,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -160,6 +160,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -149,6 +149,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -163,6 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -163,6 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -167,6 +167,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -167,6 +167,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -163,6 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -159,6 +159,7 @@
                                 "echo"
                             ]
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -163,6 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -163,6 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -164,6 +164,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -159,6 +159,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
+                        "initialDelaySeconds": 2,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,


### PR DESCRIPTION
We know that it takes at least five seconds. Do not log four errors (at least) per workspace.

Internal link https://cloudlogging.app.goo.gl/B64q9nYtXMBBHZiMA