### PR TITLE
disable userfaultfd for all unprivileged users

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -208,6 +208,7 @@ spec:
               sysctl -w "net.ipv4.tcp_tw_reuse=1" &&
               sysctl -w fs.inotify.max_user_watches=1000000 &&
               sysctl -w "kernel.dmesg_restrict=1"
+              sysctl -w vm.unprivileged_userfaultfd=0
             ) && echo "done!" || echo "failed!"
       containers:
       - name: ws-daemon


### PR DESCRIPTION
The `userfaultfd` system call (and subsequent API) can be misused making it easier to exploit existing use-after-free (and similar) bugs that might otherwise only make a short window or race condition available.

Thus, we here disable it (on the host nodes) for unprivileged users through the global sysctl knob "vm.unprivileged_userfaultfd".

Fixes #5156 

Signed-off-by: Leo Di Donato <leodidonato@gmail.com>