### PR TITLE
[server] Free private repos

### DIFF
--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -44,7 +44,6 @@ export default function () {
     const [ availableCoupons, setAvailableCoupons ] = useState<PlanCoupon[]>();
     const [ appliedCoupons, setAppliedCoupons ] = useState<PlanCoupon[]>();
     const [ gitHubUpgradeUrls, setGitHubUpgradeUrls ] = useState<GithubUpgradeURL[]>();
-    const [ privateRepoTrialEndDate, setPrivateRepoTrialEndDate ] = useState<string>();
 
     const [ teamClaimModal, setTeamClaimModal ] = useState<TeamClaimModal | undefined>(undefined);
 
@@ -63,16 +62,13 @@ export default function () {
             }),
             server.getAvailableCoupons().then(v => () => setAvailableCoupons(v)),
             server.getAppliedCoupons().then(v => () => setAppliedCoupons(v)),
-            server.getGithubUpgradeUrls().then(v => () => setGitHubUpgradeUrls(v)),
-            server.getPrivateRepoTrialEndDate().then(v => () => setPrivateRepoTrialEndDate(v)),
+            server.getGithubUpgradeUrls().then(v => () => setGitHubUpgradeUrls(v))
         ]).then(setters => setters.forEach(s => s()));
 
         return function cleanup() {
             clearTimeout(pollAccountStatementTimeout!);
         }
     }, []);
-
-    console.log('privateRepoTrialEndDate', privateRepoTrialEndDate);
 
     const activeSubscriptions = (accountStatement?.subscriptions || []).filter(s => Subscription.isActive(s, new Date().toISOString()));
     const freeSubscription =
@@ -335,7 +331,7 @@ export default function () {
 
     // Plan card: Free a.k.a. Open Source (or Professional Open Source)
     const openSourceFeatures = <>
-        <p className="truncate" title="Public Repositories">✓ Public Repositories</p>
+        <p className="truncate" title="Public Repositories">✓ Public &amp; Private Repositories</p>
         <p className="truncate" title="4 Parallel Workspaces">✓ 4 Parallel Workspaces</p>
         <p className="truncate" title="30 min Timeout">✓ 30 min Timeout</p>
     </>;
@@ -359,7 +355,6 @@ export default function () {
     // Plan card: Personal
     const personalFeatures = <>
         <p className="truncate" title={'Everything in ' + freePlan.name}>← Everything in {freePlan.name}</p>
-        <p className="truncate" title="Private Repositories">✓ Private Repositories</p>
     </>;
     if (currentPlan.chargebeeId === personalPlan.chargebeeId) {
         const bottomLabel = ('pendingSince' in currentPlan) ? <p className="text-green-600 animate-pulse">Upgrade in progress</p> : undefined;
@@ -434,7 +429,7 @@ export default function () {
             {showPaymentUI && <div className="w-full text-center">
                 <p className="text-xl text-gray-500">You are currently using the <span className="font-bold">{Plans.getById(assignedTs?.planId)?.name || currentPlan.name}</span> plan.</p>
                 {!assignedTs && (
-                    <p className="text-base w-96 m-auto">Upgrade your plan to get access to private repositories or more parallel workspaces.</p>
+                    <p className="text-base w-96 m-auto">Upgrade your plan to get more hours and more parallel workspaces.</p>
                 )}
                 <Tooltip content={`Current billing cycle: ${guessCurrentBillingCycle(currentPlan, accountStatement).map(d => d.toLocaleDateString()).join(' - ')}`}>
                     <p className="mt-2 font-semibold text-gray-500">Remaining hours: {typeof(accountStatement?.remainingHours) === 'number'

--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -201,28 +201,14 @@ export class EligibilityService {
 
     /**
      * Whether the given user may open a workspace on the given context.
-     * A user may open private repos if they either:
-     *  - not started their free "private repo trial" yet
-     *  - is has been no longer than 30 days since they started their "private repo trial"
-     *  - has a paid subscription
-     *  - has assigned team subscription
+     * A user may open private repos always.
+     * We previously limited private repo access to subscribed users.
      * @param user
      * @param context
      * @param date The date for which we want to know whether the user is allowed to set a timeout (depends on active subscription)
      */
     async mayOpenContext(user: User, context: WorkspaceContext, date: Date): Promise<boolean> {
-        if (!this.env.enablePayment) {
-            return true;
-        }
-
-        if (!this.isPrivateRepoContext(context)) {
-            return true;
-        }
-        const mayOpenPrivateRepo = await this.mayOpenPrivateRepo(user, date)
-        this.ensureFreePrivateRepoTrialStarted(user, date.toISOString())
-            .catch((err) => log.error(err));
-
-        return mayOpenPrivateRepo;
+        return true;
     }
 
     /**


### PR DESCRIPTION
We traditionally limited our freemium subscription to public repositories, but figured this would hinder adoption. In the end we really want people to experience Gitpod on their own projects. The upcoming pricing model would have removed this barrier, but it makes sense to release this already now.

I did not remove all the code around privateRepo and trial, yet. As I didn't want to break things accidentally. We will get to cleaning this soon, when we implement the new pricing model.
