### PR TITLE
[workspace]: add force-stop check on stopping workspaces

### DIFF
--- a/chart/templates/ws-manager-bridge-configmap.yaml
+++ b/chart/templates/ws-manager-bridge-configmap.yaml
@@ -28,6 +28,7 @@ data:
         "timeouts": {
           "metaInstanceCheckIntervalSeconds": 60,
           "preparingPhaseSeconds": 7200,
+          "stoppingPhaseSeconds": 7200,
           "unknownPhaseSeconds": 600
         },
         "staticBridges": {{ index (include "ws-manager-list" (dict "root" . "gp" $.Values "comp" .Values.components.server) | fromYaml) "manager" | default list | toJson }}

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -327,9 +327,13 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         ).map(wsinfo => wsinfo.latestInstance);
     }
 
-    public async findRunningInstancesWithWorkspaces(installation?: string, userId?: string): Promise<RunningWorkspaceInfo[]> {
+    public async findRunningInstancesWithWorkspaces(installation?: string, userId?: string, includeStopping: boolean = false): Promise<RunningWorkspaceInfo[]> {
         const params: any = {};
-        const conditions = ["wsi.phasePersisted != 'stopped'", "wsi.phasePersisted != 'stopping'", "wsi.deleted != TRUE"];
+        const conditions = ["wsi.phasePersisted != 'stopped'", "wsi.deleted != TRUE"];
+        if (!includeStopping) {
+            // This excludes instances in a 'stopping' phase
+            conditions.push("wsi.phasePersisted != 'stopping'");
+        }
         if (installation) {
             params.region = installation;
             conditions.push("wsi.region = :region");

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -86,7 +86,7 @@ export interface WorkspaceDB {
     findAllWorkspaceInstances(offset: number, limit: number, orderBy: keyof WorkspaceInstance, orderDir: "ASC" | "DESC", ownerId?: string, minCreationTime?: Date, maxCreationTime?: Date, onlyRunning?: boolean, type?: WorkspaceType): Promise<{ total: number, rows: WorkspaceInstance[] }>;
 
     findRegularRunningInstances(userId?: string): Promise<WorkspaceInstance[]>;
-    findRunningInstancesWithWorkspaces(installation?: string, userId?: string): Promise<RunningWorkspaceInfo[]>;
+    findRunningInstancesWithWorkspaces(installation?: string, userId?: string, includeStopping?: boolean): Promise<RunningWorkspaceInfo[]>;
 
     isWhitelisted(repositoryUrl : string): Promise<boolean>;
     getFeaturedRepositories(): Promise<Partial<WhitelistedRepository>[]>;

--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -33,6 +33,7 @@ export interface Configuration {
     timeouts: {
         metaInstanceCheckIntervalSeconds: number;
         preparingPhaseSeconds: number;
+        stoppingPhaseSeconds: number;
         unknownPhaseSeconds: number;
     }
 }


### PR DESCRIPTION
> Further work on #5055 

Since #4910 stopped counting "stopping" workspaces for billing purposes,
any workspace caught in a "stopping" phase would never be force-stopped.
This adds a conditional "excludeStopping" boolean (defaulting to `true`)
to the DB implementation and the meta-instance-controller simply includes
that phase in the search.

It was discovered that ~200 workspaces were caught in this phase (90%
prebuilds) so this phase is necessary to force-stop.