### PR TITLE
[analytics] include instance id in status_rendered track call

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -71,7 +71,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     if (newPhase !== oldPhase) {
       getGitpodService().server.trackEvent({
         event: "status_rendered",
-        properties: { workspaceId: this.state?.workspaceInstance?.workspaceId, "phase": newPhase },
+        properties: {
+          workspaceId: this.state?.workspaceInstance?.workspaceId,
+          instanceId: this.state?.workspaceInstance?.id,
+          phase: newPhase
+        },
       });
     }
 


### PR DESCRIPTION
Including the instance ID here will allow us to analyze the life cycles of instances. At the moment, we cannot differentiate between different instances of the same workspace.

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe