### PR TITLE
open task terminal in correct workspace location

### DIFF
--- a/components/supervisor/pkg/terminal/terminal_test.go
+++ b/components/supervisor/pkg/terminal/terminal_test.go
@@ -313,3 +313,70 @@ func TestConcurrent(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWorkDirProvider(t *testing.T) {
+	mux := NewMux()
+	defer mux.Close()
+
+	terminalService := NewMuxTerminalService(mux)
+
+	type AssertWorkDirTest struct {
+		expectedWorkDir string
+		providedWorkDir string
+	}
+	assertWorkDir := func(arg *AssertWorkDirTest) {
+		term, err := terminalService.Open(context.Background(), &api.OpenTerminalRequest{
+			Workdir: arg.providedWorkDir,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(arg.expectedWorkDir, term.Terminal.CurrentWorkdir); diff != "" {
+			t.Errorf("unexpected output (-want +got):\n%s", diff)
+		}
+		_, err = terminalService.Shutdown(context.Background(), &api.ShutdownTerminalRequest{
+			Alias: term.Terminal.Alias,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	staticWorkDir, err := os.MkdirTemp("", "staticworkdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(staticWorkDir)
+
+	terminalService.DefaultWorkdir = staticWorkDir
+	assertWorkDir(&AssertWorkDirTest{
+		expectedWorkDir: staticWorkDir,
+	})
+
+	dynamicWorkDir := ""
+	terminalService.DefaultWorkdirProvider = func() string {
+		return dynamicWorkDir
+	}
+	assertWorkDir(&AssertWorkDirTest{
+		expectedWorkDir: staticWorkDir,
+	})
+
+	dynamicWorkDir, err = os.MkdirTemp("", "dynamicworkdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dynamicWorkDir)
+	assertWorkDir(&AssertWorkDirTest{
+		expectedWorkDir: dynamicWorkDir,
+	})
+
+	providedWorkDir, err := os.MkdirTemp("", "providedworkdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(providedWorkDir)
+	assertWorkDir(&AssertWorkDirTest{
+		providedWorkDir: providedWorkDir,
+		expectedWorkDir: providedWorkDir,
+	})
+}


### PR DESCRIPTION
#### What it does

- fix #4935

#### How to test

- Without workspace location: https://akosyakov-terminal-does-not-open-4935.staging.gitpod-dev.com#https://github.com/akosyakov/parcel-demo
  - In this case we fall back to checkoutLocation.
- Workspace location as file: https://akosyakov-terminal-does-not-open-4935.staging.gitpod-dev.com#https://github.com/gitpod-io/gitpod
  - In this case we fall back to checkoutLocation too.
- Workspace location as dir: https://akosyakov-terminal-does-not-open-4935.staging.gitpod-dev.com#https://github.com/redwoodjs/redwood
  - In this case workspaceLocation should be used but only for task terminals, regular terminals (new created by VS Code) not under our control