### PR TITLE
[ws-man-bridge] don't update stopped workspaces

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -214,12 +214,16 @@ export class WorkspaceManagerBridge implements Disposable {
                     instance.status.phase = "interrupted";
                     break;
                 case WorkspacePhase.STOPPING:
-                    instance.status.phase = "stopping";
-                    if (!instance.stoppingTime) {
-                        // The first time a workspace enters stopping we record that as it's stoppingTime time.
-                        // This way we don't take the time a workspace requires to stop into account when
-                        // computing the time a workspace instance was running.
-                        instance.stoppingTime = new Date().toISOString();
+                    if (instance.status.phase != 'stopped') {
+                        instance.status.phase = "stopping";
+                        if (!instance.stoppingTime) {
+                            // The first time a workspace enters stopping we record that as it's stoppingTime time.
+                            // This way we don't take the time a workspace requires to stop into account when
+                            // computing the time a workspace instance was running.
+                            instance.stoppingTime = new Date().toISOString();
+                        }
+                    } else {
+                        log.warn("Got a stopping event for an already stopped workspace.", instance);
                     }
                     break;
                 case WorkspacePhase.STOPPED:


### PR DESCRIPTION
`ws-manager-bridge` currently resets already stopped workspaces to stopping. This breaks the user experience as users cannot start a stopping workspace.

I don't believe this is only a race within a few seconds but have seen long stopped workspaces getting rest to 'stopping'. So this doesn't solve the root cause but just makes sure users are able to start their workspaces again.

Also https://github.com/gitpod-io/gitpod/pull/5223 is an attempt to solve the ordering of phases in a more holistic way. It doesn't seem to be complete yet, through.