### PR TITLE
[agent-smith] Extend signatures to be also checked against strings inside executables

### DIFF
--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -30,7 +30,7 @@ pod:
 
       werft log phase prepare
       gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
-      gcloud container clusters get-credentials dev --zone europe-west1-b --project gitpod-core-dev
+      gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev
 
       export NAMESPACE="{{ .Annotations.namespace }}"
       sudo chown -R gitpod:gitpod /workspace

--- a/components/ee/agent-smith/cmd/signature-elfdump.go
+++ b/components/ee/agent-smith/cmd/signature-elfdump.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"debug/elf"
 	"fmt"
 	"log"
 	"os"
@@ -25,12 +26,23 @@ var signatureElfdumpCmd = &cobra.Command{
 		}
 		defer f.Close()
 
-		syms, err := signature.ExtractELFSymbols(f)
+		executable, err := elf.NewFile(f)
+		if err != nil {
+			log.Fatalf("cannot anaylze ELF file: %v", err)
+			return
+		}
+
+		syms, err := signature.ExtractELFSymbols(executable)
 		if err != nil {
 			log.Fatal(err)
 		}
-
 		fmt.Println(strings.Join(syms, "\n"))
+
+		strs, err := signature.ExtractELFStrings(executable)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("strings:\n%s", strs)
 	},
 }
 

--- a/components/ee/agent-smith/pkg/agent/agent.go
+++ b/components/ee/agent-smith/pkg/agent/agent.go
@@ -710,12 +710,14 @@ func (agent *Smith) handleExecveEvent(execve Execve) func() (*InfringingWorkspac
 		if len(res) == 0 {
 			fd, err := os.Open(filepath.Join("/proc", strconv.Itoa(execve.TID), "exe"))
 			if err != nil {
+				e := log.WithField("tid", execve.TID).WithField("filename", execve.Filename)
 				if os.IsNotExist(err) || strings.Contains(err.Error(), "no such process") {
 					// This happens often enough to be too spammy in the logs. Thus we use a metric instead.
 					// If agent-smith does not work as intended, this metric can be indicative of the reason.
 					agent.metrics.signatureCheckMiss.Inc()
+					e.Debug("cannot find")
 				} else {
-					log.WithError(err).WithField("path", execve.Filename).Warn("cannot open executable to check signatures")
+					e.WithError(err).WithField("path", execve.Filename).Warn("cannot open executable to check signatures")
 				}
 
 				return nil, nil


### PR DESCRIPTION
Blocked by: https://github.com/gitpod-io/gitpod/issues/5237

So far we check signatures against symbols only. It was only a matter of time until someone started using binaries which symbols stripped, especially since we went open source. :slightly_smiling_face:

This PR extends the signatures matching to section `.rodata` which is commonly filled with static strings, which are easy/cheaply/precisely to match against a set of common strings only found in miner executables.
