### PR TITLE
[ws-daemon] Refactor unmount

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -355,12 +355,13 @@ func (m *Monitor) actOnPodEvent(ctx context.Context, status *api.WorkspaceStatus
 				break
 			}
 		}
-		if _, gone := wso.Pod.Annotations[wsk8s.ContainerIsGoneAnnotation]; !terminated && gone {
+		if _, gone := wso.Pod.Annotations[wsk8s.ContainerIsGoneAnnotation]; gone {
 			// workaround for https://github.com/containerd/containerd/pull/4214 which can prevent pod status
 			// propagation. ws-daemon observes the pods and propagates this state out-of-band via the annotation.
-			terminated = true
-		}
-		if terminated {
+			if !terminated {
+				go m.finalizeWorkspaceContent(ctx, wso)
+			}
+		} else {
 			go m.finalizeWorkspaceContent(ctx, wso)
 		}
 	}


### PR DESCRIPTION
**Issue:**
- ws-daemon restarts side effect is workspaces (pods) in indefinitely Terminating state.

**Changes:**
- Ensure pending connections are closed on exit.
- move Teardown from ring0 to ring1 (too late for IWS socket).
- ensure `finalizeWorkspaceContent` runs without Containerd4214 workaround.
- preserve manual backup feature (using `gitpod.io/containerIsGone` annotation).
- ensure `mark` is not mounted before trying to remove workspace content on disk to allow the pod termination.

**Scenarios:**

1.
- start workspace
- wait until finish loading
- change a file
- stop workspace
- check the workspace is terminated and a backup is created
- workspace pod should be removed
- open workspace and check the change is present

2.
- start workspace
- close window
- wait until timeout
- check the workspace is terminated and a backup is created
- workspace pod should be removed
- open workspace and check the change is present

3.
- start workspace
- kill ws-daemon pod in the same node
- stop the workspace (it will stay closing...)
- check the workspace is terminated and a backup is created
- workspace pod should be removed
- open workspace and check the change is present

4.
- start workspace
- kill ws-daemon pod in the same node
- close window
- wait until timeout
- check the workspace is terminated and a backup is created
- workspace pod should be removed
- open workspace and check the change is present

5.
- start workspace
- wait until finish loading
- start a container `docker run alpine` (to trigger the socket activation)
- stop workspace
- check the workspace is terminated and a backup is created
- workspace pod should be removed
- open workspace and check the change is present

6.
- start workspace
- wait until finish loading
- run `workspacekit lift bash` (to use lift socket)
- stop workspace
- check the workspace is terminated and a backup is created
- workspace pod should be removed
- open workspace and check the change is present

- [x] /werft with-clean-slate-deployment
