### PR TITLE
changed clustername in wipe-devstaging

### DIFF
--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -30,7 +30,7 @@ pod:
 
       werft log phase prepare
       gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
-      gcloud container clusters get-credentials dev --zone europe-west1-b --project gitpod-core-dev
+      gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev
 
       export NAMESPACE="{{ .Annotations.namespace }}"
       sudo chown -R gitpod:gitpod /workspace


### PR DESCRIPTION
sweeper is not able to wipe namespaces because it connects to the wrong cluster