### PR TITLE
[ws-daemon] Try stay alive long enough (<= 100s) until containerd is back online

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -264,6 +264,7 @@ spec:
             path: "/"
           initialDelaySeconds: 5
           periodSeconds: 10
+          failureThreshold: 10
         securityContext:
           privileged: true
           procMount: Default


### PR DESCRIPTION
We do this because we assume that ws-daemon holds volatile state which we need to keep to mitigate negative consequences. The state is hold in the session store:: https://github.com/gitpod-io/gitpod/blob/7ede7bad3382f09991dcf02f4975105c93f04176/components/ws-daemon/pkg/content/service.go#L44).