### PR TITLE
[workspace]: update logs

### DIFF
--- a/chart/templates/ws-manager-bridge-configmap.yaml
+++ b/chart/templates/ws-manager-bridge-configmap.yaml
@@ -27,8 +27,8 @@ data:
         },
         "timeouts": {
           "metaInstanceCheckIntervalSeconds": 60,
-          "preparingPhaseSeconds": 7200,
-          "stoppingPhaseSeconds": 7200,
+          "preparingPhaseSeconds": 3600,
+          "stoppingPhaseSeconds": 3600,
           "unknownPhaseSeconds": 600
         },
         "staticBridges": {{ index (include "ws-manager-list" (dict "root" . "gp" $.Values "comp" .Values.components.server) | fromYaml) "manager" | default list | toJson }}


### PR DESCRIPTION
To help with #5254. In the dev environment, this picks up the instances that need stopping. Have improved the logging to further investigate why it's not picking up the instances to stop.

Have reduced the times to kill instances to 1 hour (from 2) after talking with @svenefftinge 