### PR TITLE
[chart] Allow to add cert to registry facade

### DIFF
--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -71,6 +71,11 @@ spec:
         - name: https-certificates
           mountPath: "/mnt/certificates"
         {{- end }}
+        {{- range $idx, $sec := $comp.registryCerts }}
+        - mountPath: /etc/ssl/certs/{{ $sec.name }}.pem
+          name: docker-tls-certs-{{ $idx }}
+          subPath: tls.cert
+        {{- end }}
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       volumes:
       - name: cache
@@ -90,6 +95,11 @@ spec:
       - name: https-certificates
         secret:
           secretName: {{ .Values.certificatesSecret.secretName }}
+      {{- end }}
+      {{- range $idx, $sec := $comp.registryCerts }}
+      - name: docker-tls-certs-{{ $idx }}
+        secret:
+          secretName: {{ $sec.secret }}
       {{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -274,6 +274,7 @@ components:
     svcLabels:
       feature: registry
     serviceType: "ClusterIP"
+    registryCerts: []
 
   # enabled cronjob to restart the proxy deployment
   restarter:


### PR DESCRIPTION
`components.imageBuilder.registry.bypassProxy` will make registry facade unable to request registry


## Raw error
```
Head "https://registry.default.svc.cluster.local/v2/workspace-images/manifests/hash": x509: certificate signed by unknown authority
failed to do request
github.com/containerd/containerd/remotes/docker.(*request).do
	github.com/containerd/containerd@v1.5.2/remotes/docker/resolver.go:544
github.com/containerd/containerd/remotes/docker.(*request).doWithRetries
	github.com/containerd/containerd@v1.5.2/remotes/docker/resolver.go:551
github.com/containerd/containerd/remotes/docker.(*dockerResolver).Resolve
	github.com/containerd/containerd@v1.5.2/remotes/docker/resolver.go:280
github.com/gitpod-io/gitpod/registry-facade/pkg/registry.(*manifestHandler).getManifest.func1
	github.com/gitpod-io/gitpod/registry-facade/pkg/registry/manifest.go:137
github.com/gitpod-io/gitpod/registry-facade/pkg/registry.(*manifestHandler).getManifest
	github.com/gitpod-io/gitpod/registry-facade/pkg/registry/manifest.go:234
net/http.HandlerFunc.ServeHTTP
	net/http/server.go:2069
github.com/gorilla/handlers.MethodHandler.ServeHTTP
	github.com/gorilla/handlers@v1.4.2/handlers.go:30
github.com/gitpod-io/gitpod/registry-facade/pkg/registry.(*Registry).handleManifest.func3
	github.com/gitpod-io/gitpod/registry-facade/pkg/registry/manifest.go:77
net/http.HandlerFunc.ServeHTTP
	net/http/server.go:2069
github.com/gitpod-io/gitpod/registry-facade/pkg/registry.dispatcher.func1
	github.com/gitpod-io/gitpod/registry-facade/pkg/registry/registry.go:377
net/http.HandlerFunc.ServeHTTP
	net/http/server.go:2069
github.com/gorilla/mux.(*Router).ServeHTTP
	github.com/gorilla/mux@v1.8.0/mux.go:210
net/http.(*ServeMux).ServeHTTP
	net/http/server.go:2448
net/http.serverHandler.ServeHTTP
	net/http/server.go:2887
net/http.(*conn).serve
	net/http/server.go:1952
runtime.goexit
	runtime/asm_amd64.s:1371
```