### PR TITLE
Add option to disable kube-health-monitor

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -158,6 +158,7 @@ components:
 
   wsDaemon:
     hostWorkspaceArea: /mnt/disks/ssd0/workspaces
+    disableKubeHealthMonitor: true
     volumes:
     - name: gcloud-tmp
       hostPath:

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -105,6 +105,36 @@ spec:
 {{- if (or $comp.userNamespaces.shiftfsModuleLoader.enabled $comp.userNamespaces.seccompProfileInstaller.enabled) }}
       initContainers:
 {{- end }}
+{{- if $comp.disableKubeHealthMonitor }}
+      - name: disable-kube-health-monitor
+        # 20.4 is Ubuntu Focal, which we run on GKE atm
+        image: ubuntu:20.04
+        securityContext:
+          privileged: true
+          procMount: Default
+        # use nsenter to run code on the node
+        command:
+          - /usr/bin/nsenter
+          - -t
+          - "1"
+          - -a
+          - /bin/bash
+          - -c
+        args:
+          - |
+            exec {BASH_XTRACEFD}>&1 # this causes 'set -x' to write to stdout insted of stderr
+            set -euExo pipefail
+            systemctl status kube-container-runtime-monitor.service || true
+            if [ "$(systemctl is-active kube-container-runtime-monitor.service)" == "active" ]
+            then
+                echo "kube-container-runtime-monitor.service is active"
+                systemctl stop kube-container-runtime-monitor.service
+                systemctl disable kube-container-runtime-monitor.service
+                systemctl status kube-container-runtime-monitor.service || true
+            else
+                echo "kube-container-runtime-monitor.service is not active, not doing anything"
+            fi
+{{- end }}
 {{- if $comp.setupSSDRaid }}
       - name: raid-local-disks
         image: scylladb/raid-setup:0.1


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/5265

Add an option to our helm chart to disable kube-health-monitor. 

Dev-Loop:
* run `docker run --rm --privileged --pid=host  ubuntu /usr/bin/nsenter -t "1" -a bash -c "$(cat stop.sh)"` on a node with `stop.sh` being the bash snippet from this PR.

Testing
* Look at the [logs on core-dev](https://console.cloud.google.com/logs/query;query=%22disable-kube-health-monitor%22;timeRange=PT15M;cursorTimestamp=2021-08-19T10:53:20Z?project=gitpod-core-dev)

- [x] /werft with-clean-slate-deployment