### PR TITLE
[supervisor] Remove misleading error message

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1142,7 +1143,7 @@ func socketActivationForDocker(ctx context.Context, wg *sync.WaitGroup, term *te
 		})
 		return err
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		log.WithError(err).Error("cannot provide Docker activation socket")
 	}
 }


### PR DESCRIPTION
During the workspace disposal process, we see a message error triggered by closing the context.

```
...
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"context canceled","level":"error","message":"cannot provide Docker activation socket","serviceContext":{"service":"supervisor","version":""},"severity":"ERROR","time":"2021-08-18T11:46:37Z"}
```

xref: #5240 