### PR TITLE
[projects] limit number of prebuilts

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -239,6 +239,8 @@ export interface FindPrebuildsParams {
     branch?: string;
     latest?: boolean;
     prebuildId?: string;
+    // default: 30
+    limit?: number;
 }
 export interface GetProviderRepositoriesParams {
     provider: string;

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -159,7 +159,10 @@ export class ProjectsService {
                 prebuilds.push(pbws);
             }
         } else {
-            const limit = params.latest ? 1 : undefined;
+            let limit = params.limit !== undefined ? params.limit : 30;
+            if (params.latest) {
+                limit = 1;
+            }
             let branch = params.branch;
             prebuilds = await this.workspaceDb.trace({}).findPrebuiltWorkspacesByProject(project.id, branch, limit);
         }


### PR DESCRIPTION
this PR limits the number of prebuilds to be shown on the Prebuidls page.

closes https://github.com/gitpod-io/gitpod/issues/5185