### PR TITLE
[ws-daemon] remove failed backups

### DIFF
--- a/components/ws-daemon/pkg/content/archive.go
+++ b/components/ws-daemon/pkg/content/archive.go
@@ -82,6 +82,11 @@ func BuildTarbal(ctx context.Context, src string, dst string, fullWorkspaceBacku
 		return xerrors.Errorf("cannot open archive for writing: %w", err)
 	}
 	defer fout.Close()
+	defer func(e *error) {
+		if e != nil {
+			os.Remove(dst)
+		}
+	}(&err)
 	fbout := bufio.NewWriter(fout)
 	defer fbout.Flush()
 

--- a/components/ws-daemon/pkg/content/archive_test.go
+++ b/components/ws-daemon/pkg/content/archive_test.go
@@ -89,6 +89,13 @@ func TestBuildTarbalMaxSize(t *testing.T) {
 		err = BuildTarbal(context.Background(), wd, tgt.Name(), false, carchive.TarbalMaxSize(test.MaxSize))
 		if (err == nil && test.Err != nil) || (err != nil && test.Err == nil) || (err != nil && test.Err != nil && err.Error() != test.Err.Error()) {
 			t.Errorf("%s: unexpected error: expected \"%v\", actual \"%v\"", test.Name, test.Err, err)
+		} else {
+
+			_, doesNotExistErr := os.Stat(tgt.Name())
+			doesNotExist := doesNotExistErr != nil && os.IsNotExist(doesNotExistErr)
+			if err != nil && !doesNotExist {
+				t.Errorf("The file should be deleted when buildTarbal failed.")
+			}
 		}
 	}
 


### PR DESCRIPTION
When a backup failed (mostly due to hitting the size limit)
the tar file hangs around on the node without clean up.

fixes https://github.com/gitpod-io/gitpod/issues/5324