### PR TITLE
[ws-daemon] log reduced severity

### DIFF
--- a/components/ws-daemon/pkg/dispatch/dispatch.go
+++ b/components/ws-daemon/pkg/dispatch/dispatch.go
@@ -277,7 +277,7 @@ func (d *Dispatch) handlePodDeleted(pod *corev1.Pod) {
 
 	state, ok := d.ctxs[instanceID]
 	if !ok {
-		log.WithFields(wsk8s.GetOWIFromObject(&pod.ObjectMeta)).Error("received pod deletion for a workspace, but have not seen it before. Ignoring update.")
+		log.WithFields(wsk8s.GetOWIFromObject(&pod.ObjectMeta)).Debug("received pod deletion for a workspace, but have not seen it before. Probably another node. Ignoring update.")
 		return
 	}
 	if state.Cancel != nil {


### PR DESCRIPTION
Seems like when a workspace stops all ws-daemons get a notification when only one knows that workspaces.
The rest is [logging on error level](https://cloudlogging.app.goo.gl/N26SsTqu7vncPMq96). 


fixes https://github.com/gitpod-io/gitpod/issues/5341