### PR TITLE
[dashboard] Fix typo on Select Account page

### DIFF
--- a/components/dashboard/src/settings/SelectAccountModal.tsx
+++ b/components/dashboard/src/settings/SelectAccountModal.tsx
@@ -46,7 +46,7 @@ export function SelectAccountModal(props: SelectAccountPayload & {
         <p className="pb-2 text-gray-500 text-base">You are trying to authorize a provider that is already connected with another account on Gitpod.</p>
 
         <InfoBox className="mt-4 w-full mx-auto">
-            Disconnect a provider in one of you accounts, if you like to continue with the other account.
+            Disconnect a provider in one of your accounts, if you would like to continue with the other account.
         </InfoBox>
 
         <div className="mt-10 mb-6 flex-grow flex flex-row justify-around align-center">


### PR DESCRIPTION
A typo that I found when on the Select Account page. I did not create an issue since this was a quick fix.

<img width="592" alt="Screenshot 2021-08-24 at 10 58 42" src="https://user-images.githubusercontent.com/8015191/130635640-f667521b-67a3-477f-9343-ccd954ed4b82.png">