### PR TITLE
[gitlab] Accept '#' sign in branches / context URLs

### DIFF
--- a/components/server/src/gitlab/gitlab-context-parser.spec.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.spec.ts
@@ -528,6 +528,66 @@ class TestGitlabContextParser {
         })
     }
 
+    @test public async testTreeContextBranchWithHashSign01() {
+        const result = await this.parser.handle({}, this.user, 'https://gitlab.com/gp-test-group/gp-test-project/-/tree/feature/%23123-issue');
+        expect(result).to.deep.include({
+            "ref": "feature/#123-issue",
+            "refType": "branch",
+            "path": "",
+            "revision": "8b389233c0a3a55a5cd75f89d2c96761420bf2c8",
+            "isFile": false,
+            "repository": {
+                "host": "gitlab.com",
+                "owner": "gp-test-group",
+                "name": "gp-test-project",
+                "cloneUrl": "https://gitlab.com/gp-test-group/gp-test-project.git",
+                "defaultBranch": "master",
+                "private": false
+            },
+            "title": "gp-test-group/gp-test-project - feature/#123-issue"
+        })
+    }
+
+    @test public async testTreeContextBranchWithHashSign02() {
+        const result = await this.parser.handle({}, this.user, 'https://gitlab.com/gp-test-group/gp-test-project/-/tree/issue-%23123');
+        expect(result).to.deep.include({
+            "ref": "issue-#123",
+            "refType": "branch",
+            "path": "",
+            "revision": "8b389233c0a3a55a5cd75f89d2c96761420bf2c8",
+            "isFile": false,
+            "repository": {
+                "host": "gitlab.com",
+                "owner": "gp-test-group",
+                "name": "gp-test-project",
+                "cloneUrl": "https://gitlab.com/gp-test-group/gp-test-project.git",
+                "defaultBranch": "master",
+                "private": false
+            },
+            "title": "gp-test-group/gp-test-project - issue-#123"
+        })
+    }
+
+    @test public async testTreeContextBranchWithAndSign() {
+        const result = await this.parser.handle({}, this.user, 'https://gitlab.com/gp-test-group/gp-test-project/-/tree/another&amp;branch');
+        expect(result).to.deep.include({
+            "ref": "another&amp;branch",
+            "refType": "branch",
+            "path": "",
+            "revision": "8b389233c0a3a55a5cd75f89d2c96761420bf2c8",
+            "isFile": false,
+            "repository": {
+                "host": "gitlab.com",
+                "owner": "gp-test-group",
+                "name": "gp-test-project",
+                "cloneUrl": "https://gitlab.com/gp-test-group/gp-test-project.git",
+                "defaultBranch": "master",
+                "private": false
+            },
+            "title": "gp-test-group/gp-test-project - another&amp;branch"
+        })
+    }
+
     @test public async testEmptyProject() {
         const result = await this.parser.handle({}, this.user, 'https://gitlab.com/gp-test-group/gp-test-empty-project');
         expect(result).to.deep.include({

--- a/components/server/src/gitlab/gitlab-context-parser.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.ts
@@ -72,7 +72,9 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
     public async parseURL(user: User, contextUrl: string): Promise<URLParts> {
         var { host, owner, repoName, moreSegments, searchParams } = await super.parseURL(user, contextUrl);
         // TODO: we remove the /-/ in the path in the next line as quick fix for #3809 -- improve this in the long term
-        const segments = [owner, repoName, ...moreSegments.filter(s => s !== '-')];
+        const segments = [owner, repoName, ...moreSegments.filter(s => s !== '-')]
+            // Replace URL encoded '#' sign. Don't use decodeURI() because GitLab seems to be inconsistent in what needs to be decoded and what not.
+            .map(x => x.replace(/%23/g, '#'));
         var moreSegmentsStart: number = 2;
         /*
             We cannot deduce the namespace (aka `owner`) and project name (aka `repoName`) from the URI with certainty.


### PR DESCRIPTION
Allow to open GitLab branches with `#` sign (encoded as `%23`).

Test with: https://clu-workspace-creation-5129.staging.gitpod-dev.com/#https://gitlab.com/gp-test-group/gp-test-project/-/tree/issue-%23123

Fixes #5129