### PR TITLE
fix(server): cloning bitbucket branches named such as feature/JIRA-123-summary

### DIFF
--- a/components/server/src/bitbucket/README.md
+++ b/components/server/src/bitbucket/README.md
@@ -3,10 +3,10 @@
 To run the BitBucket integration tests via `npm test` the `GITPOD_TEST_TOKEN_BITBUCKET` environment variable needs to be defined:
 
 ```bash
-export GITPOD_TEST_TOKEN_BITBUCKET='{ value: "$token", scopes: [] }'
+export GITPOD_TEST_TOKEN_BITBUCKET='{ "username": "$username", "value": "$applicationPassword", "scopes": [] }'
 ```
 
-Replace `$token` with the integration test token.
+Replace `$username` / `$applicationPassword` with the integration test username and application password.
 
 ## Running a single test
 

--- a/components/server/src/bitbucket/README.md
+++ b/components/server/src/bitbucket/README.md
@@ -1,0 +1,10 @@
+# BitBucket Integration tests
+
+To run the BitBucket integration tests via `npm test` the `GITPOD_TEST_TOKEN_BITBUCKET` environment variable needs to be defined:
+
+```bash
+export GITPOD_TEST_TOKEN_BITBUCKET='{ value: "$token", scopes: [] }'
+```
+
+Replace `$token` with the integration test token.
+

--- a/components/server/src/bitbucket/README.md
+++ b/components/server/src/bitbucket/README.md
@@ -8,3 +8,20 @@ export GITPOD_TEST_TOKEN_BITBUCKET='{ value: "$token", scopes: [] }'
 
 Replace `$token` with the integration test token.
 
+## Running a single test
+
+Use `test.only` thus:
+
+```js
+test('Your cool test', function (done) {
+    //...
+}
+```
+
+becomes
+
+```js
+test.only('Your cool test', function (done) {
+    //...
+}
+```

--- a/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
@@ -61,7 +61,7 @@ class TestBitbucketContextParser {
     }
 
     @test public testCanHandleBitbucketRepo() {
-        expect(this.parser.canHandle(this.user, "https://bitbucket.org/gitpod/sample-repository/src/master/")).to.be.true;
+        expect(this.parser.canHandle(this.user, "https://bitbucket.org/gitpod/integration-tests/src/master/")).to.be.true;
     }
 
     @test public testCanNotHandleGitHubRepo() {
@@ -69,7 +69,7 @@ class TestBitbucketContextParser {
     }
 
     @test public async testShortContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests');
         expect(result).to.deep.include({
             "ref": "master",
             "refType": "branch",
@@ -79,17 +79,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - master"
+            "title": "gitpod/integration-tests - master"
         })
     }
 
     @test public async testSrcContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/master/');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/master/');
         expect(result).to.deep.include({
             "ref": "master",
             "refType": "branch",
@@ -99,17 +99,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - master"
+            "title": "gitpod/integration-tests - master"
         })
     }
 
     @test public async testSrcContext_02() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/8fcf6c869d0cdb570bb6f2f9aa5f8ed72c9d953a/?at=Gitpod%2Ftesttxt-created-online-with-bitbucket-1589277871983');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/8fcf6c869d0cdb570bb6f2f9aa5f8ed72c9d953a/?at=Gitpod%2Ftesttxt-created-online-with-bitbucket-1589277871983');
         expect(result).to.deep.include({
             "ref": "Gitpod/testtxt-created-online-with-bitbucket-1589277871983",
             "refType": "branch",
@@ -119,17 +119,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - Gitpod/testtxt-created-online-with-bitbucket-1589277871983"
+            "title": "gitpod/integration-tests - Gitpod/testtxt-created-online-with-bitbucket-1589277871983"
         })
     }
 
     @test public async testSrcContext_03() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/second-branch/');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/second-branch/');
         expect(result).to.deep.include({
             "ref": "second-branch",
             "refType": "branch",
@@ -139,17 +139,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - second-branch"
+            "title": "gitpod/integration-tests - second-branch"
         })
     }
 
     @test public async testCommitsContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/commits/branch/second-branch');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/commits/branch/second-branch');
         expect(result).to.deep.include({
             "ref": "second-branch",
             "refType": "branch",
@@ -159,17 +159,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - second-branch"
+            "title": "gitpod/integration-tests - second-branch"
         })
     }
 
     @test public async testBranchContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/branch/master/');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/branch/master/');
         expect(result).to.deep.include({
             "ref": "master",
             "refType": "branch",
@@ -179,17 +179,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - master"
+            "title": "gitpod/integration-tests - master"
         })
     }
 
     @test public async testBranchContext_02() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/branch/second-branch');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/branch/second-branch');
         expect(result).to.deep.include({
             "ref": "second-branch",
             "refType": "branch",
@@ -199,17 +199,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - second-branch"
+            "title": "gitpod/integration-tests - second-branch"
         })
     }
 
     @test public async testBranchContext_03() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/branch/feature/JIRA-123-summary');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/branch/feature/JIRA-123-summary');
         expect(result).to.deep.include({
             "ref": "feature/JIRA-123-summary",
             "refType": "branch",
@@ -219,17 +219,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - feature/JIRA-123-summary"
+            "title": "gitpod/integration-tests - feature/JIRA-123-summary"
         })
     }
 
     @test public async testCommitsContext_02() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/commits/tag/first-tag');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/commits/tag/first-tag');
         expect(result).to.deep.include({
             "ref": "first-tag",
             "refType": "tag",
@@ -239,17 +239,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - first-tag"
+            "title": "gitpod/integration-tests - first-tag"
         })
     }
 
     @test public async testSrcContext_04() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/first-tag/');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/first-tag/');
         expect(result).to.deep.include({
             "ref": "first-tag",
             "refType": "tag",
@@ -259,17 +259,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - first-tag"
+            "title": "gitpod/integration-tests - first-tag"
         })
     }
 
     @test public async testCommitsContext_03() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/commits/5a24a0c8a7b42c2e6418593d788e17cb987bda25');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/commits/5a24a0c8a7b42c2e6418593d788e17cb987bda25');
         expect(result).to.deep.include({
             "ref": "",
             "refType": "revision",
@@ -279,17 +279,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - 5a24a0c8a7b42c2e6418593d788e17cb987bda25"
+            "title": "gitpod/integration-tests - 5a24a0c8a7b42c2e6418593d788e17cb987bda25"
         })
     }
 
     @test public async testFileContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/master/README.md');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/master/README.md');
         expect(result).to.deep.include({
             "ref": "master",
             "refType": "branch",
@@ -299,17 +299,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - master:README.md"
+            "title": "gitpod/integration-tests - master:README.md"
         })
     }
 
     @test public async testFileContext_02() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/branch-with-dir/my-dir/test.txt');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/branch-with-dir/my-dir/test.txt');
         expect(result).to.deep.include({
             "ref": "branch-with-dir",
             "refType": "branch",
@@ -319,17 +319,17 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - branch-with-dir:my-dir/test.txt"
+            "title": "gitpod/integration-tests - branch-with-dir:my-dir/test.txt"
         })
     }
 
     @test public async testDirectoryContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/src/branch-with-dir/my-dir/');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/src/branch-with-dir/my-dir/');
         expect(result).to.deep.include({
             "ref": "branch-with-dir",
             "refType": "branch",
@@ -339,24 +339,24 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false
             },
-            "title": "gitpod/sample-repository - branch-with-dir:my-dir"
+            "title": "gitpod/integration-tests - branch-with-dir:my-dir"
         })
     }
 
     @test public async testPullRequestContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/pull-requests/1/readme-updated/diff');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/pull-requests/1/readme-updated/diff');
         expect(result).to.deep.include({
             "title": "Readme updated",
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false,
             },
@@ -368,8 +368,8 @@ class TestBitbucketContextParser {
                 "repository": {
                     "host": "bitbucket.org",
                     "owner": "gitpod",
-                    "name": "sample-repository",
-                    "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                    "name": "integration-tests",
+                    "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                     "defaultBranch": "master",
                     "private": false
                 },
@@ -380,22 +380,22 @@ class TestBitbucketContextParser {
     }
 
     @test public async testPullRequestContext_02() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/pull-requests/3/say-hello-to-gitpod/diff');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/pull-requests/3/say-hello-to-gitpod/diff');
         expect(result).to.deep.include({
             "title": "Say Hello to Gitpod",
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "corneliusltf",
-                "name": "sample-repository",
-                "cloneUrl": "https://bitbucket.org/corneliusltf/sample-repository.git",
+                "name": "integration-tests",
+                "cloneUrl": "https://bitbucket.org/corneliusltf/integration-tests.git",
                 "defaultBranch": "master",
                 "private": false,
                 "fork": {
                     "parent": {
-                        "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                        "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                         "defaultBranch": "master",
                         "host": "bitbucket.org",
-                        "name": "sample-repository",
+                        "name": "integration-tests",
                         "owner": "gitpod",
                         "private": false,
                     }
@@ -409,8 +409,8 @@ class TestBitbucketContextParser {
                 "repository": {
                     "host": "bitbucket.org",
                     "owner": "gitpod",
-                    "name": "sample-repository",
-                    "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                    "name": "integration-tests",
+                    "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                     "defaultBranch": "master",
                     "private": false
                 },
@@ -421,15 +421,15 @@ class TestBitbucketContextParser {
     }
 
     @test public async testIssueContext_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/issues/1/first-issue');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests/issues/1/first-issue');
         expect(result).to.deep.include(
             {
                 "title": "First issue",
                 "repository": {
                     "host": "bitbucket.org",
                     "owner": "gitpod",
-                    "name": "sample-repository",
-                    "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                    "name": "integration-tests",
+                    "cloneUrl": "https://bitbucket.org/gitpod/integration-tests.git",
                     "defaultBranch": "master",
                     "private": false
                 },
@@ -473,7 +473,7 @@ class TestBitbucketContextParser {
     }
 
     @test public async testFetchCommitHistory() {
-        const result = await this.parser.fetchCommitHistory({}, this.user, 'https://bitbucket.org/gitpod/sample-repository', 'dd0aef8097a7c521b8adfced795fcf96c9e598ef', 100);
+        const result = await this.parser.fetchCommitHistory({}, this.user, 'https://bitbucket.org/gitpod/integration-tests', 'dd0aef8097a7c521b8adfced795fcf96c9e598ef', 100);
         expect(result).to.deep.equal([
             'da2119f51b0e744cb6b36399f8433b477a4174ef',
         ])

--- a/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
@@ -214,7 +214,7 @@ class TestBitbucketContextParser {
             "ref": "feature/JIRA-123-summary",
             "refType": "branch",
             "path": "",
-            "revision": "5a24a0c8a7b42c2e6418593d788e17cb987bda25",
+            "revision": "bcf3a4b9329385b7a5f50a4490b79570da029cf3",
             "isFile": false,
             "repository": {
                 "host": "bitbucket.org",
@@ -386,8 +386,8 @@ class TestBitbucketContextParser {
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "corneliusltf",
-                "name": "integration-tests",
-                "cloneUrl": "https://bitbucket.org/corneliusltf/integration-tests.git",
+                "name": "sample-repository",
+                "cloneUrl": "https://bitbucket.org/corneliusltf/sample-repository.git",
                 "defaultBranch": "master",
                 "private": false,
                 "fork": {
@@ -443,18 +443,18 @@ class TestBitbucketContextParser {
     }
 
     @test public async testSrcContextForkedRepo_01() {
-        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/clu-sample-repo/src/master/');
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/integration-tests-forked-repository/src/master/');
         expect(result).to.deep.include({
             "ref": "master",
             "refType": "branch",
             "path": "",
-            "revision": "d932021835e4024136a4f608719720d414490c73",
+            "revision": "3f1c8403570427170bd3776cfb3aa24c688c2b29",
             "isFile": false,
             "repository": {
                 "host": "bitbucket.org",
                 "owner": "gitpod",
-                "name": "clu-sample-repo",
-                "cloneUrl": "https://bitbucket.org/gitpod/clu-sample-repo.git",
+                "name": "integration-tests-forked-repository",
+                "cloneUrl": "https://bitbucket.org/gitpod/integration-tests-forked-repository.git",
                 "defaultBranch": "master",
                 "private": false,
                 "fork": {
@@ -468,7 +468,7 @@ class TestBitbucketContextParser {
                     }
                 }
             },
-            "title": "gitpod/clu-sample-repo - master"
+            "title": "gitpod/integration-tests-forked-repository - master"
         })
     }
 

--- a/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.spec.ts
@@ -208,6 +208,26 @@ class TestBitbucketContextParser {
         })
     }
 
+    @test public async testBranchContext_03() {
+        const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/branch/feature/JIRA-123-summary');
+        expect(result).to.deep.include({
+            "ref": "feature/JIRA-123-summary",
+            "refType": "branch",
+            "path": "",
+            "revision": "5a24a0c8a7b42c2e6418593d788e17cb987bda25",
+            "isFile": false,
+            "repository": {
+                "host": "bitbucket.org",
+                "owner": "gitpod",
+                "name": "sample-repository",
+                "cloneUrl": "https://bitbucket.org/gitpod/sample-repository.git",
+                "defaultBranch": "master",
+                "private": false
+            },
+            "title": "gitpod/sample-repository - feature/JIRA-123-summary"
+        })
+    }
+
     @test public async testCommitsContext_02() {
         const result = await this.parser.handle({}, this.user, 'https://bitbucket.org/gitpod/sample-repository/commits/tag/first-tag');
         expect(result).to.deep.include({

--- a/components/server/src/bitbucket/bitbucket-context-parser.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.ts
@@ -58,8 +58,8 @@ export class BitbucketContextParser extends AbstractContextParser implements ICo
                     }
                     case "branch": {
                         const more: Partial<NavigatorContext> = {};
-                        const branch = moreSegments.length > 1 ? moreSegments[1] : "";
-                        more.ref = branch;
+                        const pathSegments = moreSegments.length > 1 ? moreSegments.slice(1) : [];
+                        more.ref = pathSegments.join("/");
                         more.refType = "branch";
                         return this.handleNavigatorContext(ctx, user, host, owner, repoName, more);
                     }

--- a/components/server/src/bitbucket/bitbucket-file-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-file-provider.spec.ts
@@ -61,14 +61,14 @@ class TestBitbucketFileProvider {
     }
 
     @test public async testGetFileContents() {
-        const result = await this.fileProvider.getFileContent({ repository: { owner: "gitpod", name: "sample-repository" }, revision: "5a24a0c" } as Commit, this.user, "README.md");
+        const result = await this.fileProvider.getFileContent({ repository: { owner: "gitpod", name: "integration-tests" }, revision: "5a24a0c" } as Commit, this.user, "README.md");
         expect(result).to.equal(`# README #
 
 This is the readme of the second branch.`);
     }
 
     @test public async testGetLastChangeRevision() {
-        const result = await this.fileProvider.getLastChangeRevision({ owner: "gitpod", name: "sample-repository" } as Repository, "second-branch", this.user, "README.md");
+        const result = await this.fileProvider.getLastChangeRevision({ owner: "gitpod", name: "integration-tests" } as Repository, "second-branch", this.user, "README.md");
         expect(result).to.equal("5a24a0c8a7b42c2e6418593d788e17cb987bda25");
     }
 }

--- a/components/server/src/bitbucket/bitbucket-language-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-language-provider.spec.ts
@@ -61,7 +61,7 @@ class TestBitbucketLanguageProvider {
     }
 
     @test public async testGetLanguages() {
-        const result = await this.languageProvider.getLanguages({ owner: "gitpod", name: "sample-repository" } as Repository, this.user);
+        const result = await this.languageProvider.getLanguages({ owner: "gitpod", name: "integration-tests" } as Repository, this.user);
         expect(result).to.deep.equal({ "markdown": 100.0 });
     }
 

--- a/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
@@ -61,14 +61,14 @@ class TestBitbucketRepositoryProvider {
     }
 
     @test public async testGetRepo() {
-        const result = await this.repoProvider.getRepo(this.user, "gitpod", "sample-repository");
+        const result = await this.repoProvider.getRepo(this.user, "gitpod", "integration-tests");
         expect(result).to.deep.include({
             host: "bitbucket.org",
             owner: "gitpod",
-            name: "sample-repository",
-            cloneUrl: "https://gitpod@bitbucket.org/gitpod/sample-repository.git",
-            description: "This is a sample repository.",
-            webUrl: "https://bitbucket.org/gitpod/sample-repository",
+            name: "integration-tests",
+            cloneUrl: "https://gitpod-test@bitbucket.org/gitpod/integration-tests.git",
+            description: "This is the repository used for integration tests.",
+            webUrl: "https://bitbucket.org/gitpod/integration-tests",
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/5364

# observations

Assuming `https://bitbucket.org/gitpod/integration-tests/branch/feature/JIRA-123-summary` as test input the logic did not account for n + 1 segments

```
[0] branch [1] feature [2] jira-123-summary
const branch = moreSegments.length > 1 ? moreSegments[1] : "";
[0] feature
more.ref = branch;
```

# cleanup

1. established `gitpod-test` user and adjusted tests to expect this username.
1. Sample-repository was renamed to integration-tests on our bitbucket account so the purpose is clearer
1. @corneliusludmann's forked repository was moved to gitpod/integration-tests-forked-repository

# testing

Here's the output from `npm run test`. You'll need to define the `GITPOD_TEST_TOKEN_BITBUCKET` using the recently created `gitpod-test` user. See the password safe for specifics.

```
export GITPOD_TEST_TOKEN_BITBUCKET='GITPOD_TEST_TOKEN_BITBUCKET={ "username": "gitpod-test", "value": "REDACTED", "scopes": [] }'
```

```
gitpod /workspace/gitpod/components/server $ npm run test
Debugger listening on ws://127.0.0.1:53197/9cf0b5b1-3a04-48f1-b1d9-6aeffe9e0c1a
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.

> @gitpod/server@0.0.0 test /workspace/gitpod/components/server
> mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'

Debugger listening on ws://127.0.0.1:53141/1720965b-7a95-4266-b11d-0e4e24b6946d
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Debugger listening on ws://127.0.0.1:53356/e380b5b5-25b9-4379-b459-3fc5f43efa7a
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Skipping suite TestGithubContextParser because env var 'GITPOD_TEST_TOKEN_GITHUB' is not set
Skipping suite TestGitlabContextParser because env var 'GITPOD_TEST_TOKEN_GITLAB' is not set


  EMailDomainServiceSpec
Loading TypeORM entities and migrations from /workspace/gitpod/components/gitpod-db/lib/typeorm
Using DB: localhost:23306/gitpod
    ✓ internal_check (5031ms)

  GitHub app
    ✓ should not run prebuilds without explicit configuration
    ✓ should not run prebuilds without tasks to execute
    ✓ should behave well with individual configuration

  TestResourceAccess
    ✓ areScopesSubsetOf
    ✓ scopedResourceGuardIsAllowedUnder
    ✓ tokenResourceGuardCanAccess
    ✓ scopedResourceGuardCanAccess
    ✓ workspaceEnvVarAccessGuardCanAccess

  TestBitbucketContextParser
    ✓ testCanHandleBitbucketRepo
    ✓ testCanNotHandleGitHubRepo
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testShortContext_01 (898ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testSrcContext_01 (1188ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testSrcContext_02 (856ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testSrcContext_03 (1245ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testCommitsContext_01 (813ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testBranchContext_01 (854ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testBranchContext_02 (805ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testBranchContext_03 (801ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testCommitsContext_02 (813ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testSrcContext_04 (1307ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testCommitsContext_03 (417ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testFileContext_01 (1643ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testFileContext_02 (1598ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testDirectoryContext_01 (1667ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testPullRequestContext_01 (1239ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testPullRequestContext_02 (1732ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testIssueContext_01 (1160ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testSrcContextForkedRepo_01 (1569ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testFetchCommitHistory (419ms)

  TestBitbucketFileProvider
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testGetFileContents (362ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testGetLastChangeRevision (376ms)

  TestBitbucketLanguageProvider
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testGetLanguages (387ms)
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
{ userId: 'somefox' } Could not get languages of Bitbucket repo.
    ✓ testGetLanguagesNonExistingRepo (328ms)

  TestBitbucketRepositoryProvider
 BITBUCKET CLOUD API LATEST UPDATES:  https://developer.atlassian.com/cloud/bitbucket 
    ✓ testGetRepo (414ms)

  TestConsensusLeaderQuorum
    - testSingleServer
    - testMultipleFixedServer
    - testMultipleServersLoss
    - testMultipleServersStableConsensus

  express-util
    isAllowedWebsocketDomain for dev-staging
      ✓ should return false for workspace-port locations
      ✓ should return true for workspace locations
      ✓ should return true for dashboard
    isAllowedWebsocketDomain for gitpod.io
      ✓ should return false for workspace-port locations
      ✓ should return true for workspace locations

  TestWsLayer
    ✓ testSimple
    ✓ doesNotCallNext
Error: Should be caught
    at Object.<anonymous> (/workspace/gitpod/components/server/src/express/ws-layer.spec.ts:32:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Module.m._compile (/workspace/gitpod/node_modules/ts-node/src/index.ts:435:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/workspace/gitpod/node_modules/ts-node/src/index.ts:438:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at /workspace/gitpod/node_modules/mocha/lib/mocha.js:250:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/workspace/gitpod/node_modules/mocha/lib/mocha.js:247:14)
    at Mocha.run (/workspace/gitpod/node_modules/mocha/lib/mocha.js:576:10)
    at Object.<anonymous> (/workspace/gitpod/node_modules/mocha/bin/_mocha:637:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 { ws: {}, req: {} }
    ✓ errorHandlingSimpleCalled
Error: Should be caught
    at Object.<anonymous> (/workspace/gitpod/components/server/src/express/ws-layer.spec.ts:32:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Module.m._compile (/workspace/gitpod/node_modules/ts-node/src/index.ts:435:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/workspace/gitpod/node_modules/ts-node/src/index.ts:438:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at /workspace/gitpod/node_modules/mocha/lib/mocha.js:250:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/workspace/gitpod/node_modules/mocha/lib/mocha.js:247:14)
    at Mocha.run (/workspace/gitpod/node_modules/mocha/lib/mocha.js:576:10)
    at Object.<anonymous> (/workspace/gitpod/node_modules/mocha/bin/_mocha:637:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 { ws: {}, req: {} }
    ✓ errorHandlingSimpleNotCalled
Error: Should be caught
    at Object.<anonymous> (/workspace/gitpod/components/server/src/express/ws-layer.spec.ts:32:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Module.m._compile (/workspace/gitpod/node_modules/ts-node/src/index.ts:435:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/workspace/gitpod/node_modules/ts-node/src/index.ts:438:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at /workspace/gitpod/node_modules/mocha/lib/mocha.js:250:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/workspace/gitpod/node_modules/mocha/lib/mocha.js:247:14)
    at Mocha.run (/workspace/gitpod/node_modules/mocha/lib/mocha.js:576:10)
    at Object.<anonymous> (/workspace/gitpod/node_modules/mocha/bin/_mocha:637:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 { ws: {}, req: {} }
    ✓ errorHandlingChained
Error: Should be caught
    at Object.<anonymous> (/workspace/gitpod/components/server/src/express/ws-layer.spec.ts:32:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Module.m._compile (/workspace/gitpod/node_modules/ts-node/src/index.ts:435:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/workspace/gitpod/node_modules/ts-node/src/index.ts:438:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at /workspace/gitpod/node_modules/mocha/lib/mocha.js:250:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/workspace/gitpod/node_modules/mocha/lib/mocha.js:247:14)
    at Mocha.run (/workspace/gitpod/node_modules/mocha/lib/mocha.js:576:10)
    at Object.<anonymous> (/workspace/gitpod/node_modules/mocha/bin/_mocha:637:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 { ws: {}, req: {} }
    ✓ errorHandlingRecover
Error: Should be caught
    at Object.<anonymous> (/workspace/gitpod/components/server/src/express/ws-layer.spec.ts:32:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Module.m._compile (/workspace/gitpod/node_modules/ts-node/src/index.ts:435:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Object.require.extensions.<computed> [as .ts] (/workspace/gitpod/node_modules/ts-node/src/index.ts:438:12)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at /workspace/gitpod/node_modules/mocha/lib/mocha.js:250:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/workspace/gitpod/node_modules/mocha/lib/mocha.js:247:14)
    at Mocha.run (/workspace/gitpod/node_modules/mocha/lib/mocha.js:576:10)
    at Object.<anonymous> (/workspace/gitpod/node_modules/mocha/bin/_mocha:637:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 { ws: {}, req: {} }
    ✓ errorHandlingDuringErrorHandlingAndRecover

  TestGithubContextParser
    - testErrorContext_01
    - testErrorContext_02
    - testErrorContext_03
    - testErrorContext_04
    - testTreeContext_01
    - testTreeContext_02
    - testTreeContext_03
    - testTreeContext_04
    - testTreeContext_05
    - testTreeContext_06
    - testTreeContext_07
    - testTreeContext_tag_01
    - testReleasesContext_tag_01
    - testCommitsContext_01
    - testCommitContext_01
    - testCommitContext_02_notExistingCommit
    - testCommitContext_02_invalidSha
    - testPullRequestContext_01
    - testPullRequestthroughIssueContext_04
    - testIssueContext_01
    - testIssuePageContext
    - testIssueThroughPullRequestContext
    - testBlobContext_01
    - testBlobContext_02
    - testBlobContextShort_01
    - testBlobContextShort_02
    - testFetchCommitHistory

  TestGitlabContextParser
    - testErrorContext_01
    - testTreeContext_01
    - testTreeContext_01_regression
    - testTreeContext_02
    - testTreeContext_03
    - testTreeContext_04
    - testTreeContext_tag_01
    - testCommitsContext_01
    - testCommitContext_01
    - testCommitContext_02_notExistingCommit
    - testPullRequestContext_01
    - testIssueContext_01
    - testTreeContextSubgroup_01
    - testTreeContextSubgroup_02
    - testTreeContextSubgroup_03
    - testTreeContextSubgroup_04
    - testTreeContextSubgroup_05
    - testTreeContextSubgroup_tag_01
    - testIssueContextSubgroup_01
    - testTreeContextBranchWithSlash
    - testTreeContextBranchWithSlash_NewURLwithDash
    - testTreeContextTagWithSlash
    - testTreeContextBranchWithSlashAndPathWithSpaces
    - testEmptyProject
    - testFetchCommitHistory

  TestAuthenticationGitHub
    - before
    - after
    - testAuthenticationOnRepositories

  PermissionSpec
    ✓ hasPermission_viewer
    ✓ hasPermission_dev

  TestEnvvarPrefixParser
    ✓ testFindPrefixGood
    ✓ testFindPrefixSomewhatOk
    ✓ testFindPrefixBad
    ✓ testHandleGood
    ✓ testHandleDuplicate
    ✓ testHandleBad


  55 passing (28s)
  59 pending

Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
```

# final thoughts

We should hook up `npm run test` for `components/server` into Gitpod's CI/CD so that this test path is validated in the future.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- fixed cloning bitbucket branches named such as feature/JIRA-123-summary
```
