### PR TITLE
[local-app] gracefully handle invalid token

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -174,6 +174,14 @@ export class TypeORMUserDBImpl implements UserDB {
         return { user: token.user, token };
     }
 
+    public async findGitpodTokensOfUser(userId: string, tokenHash: string): Promise<GitpodToken | undefined> {
+        const repo = await this.getGitpodTokenRepo()
+        const qBuilder = repo.createQueryBuilder('gitpodToken')
+            .leftJoinAndSelect("gitpodToken.user", "user");
+        qBuilder.where('user.id = :userId AND gitpodToken.tokenHash = :tokenHash', { userId, tokenHash });
+        return qBuilder.getOne();
+    }
+
     public async findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]> {
         const repo = await this.getGitpodTokenRepo()
         const qBuilder = repo.createQueryBuilder('gitpodToken')

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -111,6 +111,7 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
     findUserByName(name: string): Promise<User | undefined>;
 
     findUserByGitpodToken(tokenHash: string, tokenType?: GitpodTokenType): Promise<{ user: User, token: GitpodToken } | undefined>;
+    findGitpodTokensOfUser(userId: string, tokenHash: string): Promise<GitpodToken | undefined>;
     findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]>;
     storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void>;
     deleteGitpodToken(tokenHash: string): Promise<void>;

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -33,6 +33,7 @@ type APIInterface interface {
 	DeleteOwnAuthProvider(ctx context.Context, params *DeleteOwnAuthProviderParams) (err error)
 	GetBranding(ctx context.Context) (res *Branding, err error)
 	GetConfiguration(ctx context.Context) (res *Configuration, err error)
+	GetGitpodTokenScopes(ctx context.Context, tokenHash string) (res []string, err error)
 	GetToken(ctx context.Context, query *GetTokenSearchOptions) (res *Token, err error)
 	GetPortAuthenticationToken(ctx context.Context, workspaceID string) (res *Token, err error)
 	DeleteAccount(ctx context.Context) (err error)
@@ -106,6 +107,8 @@ const (
 	FunctionGetBranding FunctionName = "getBranding"
 	// FunctionGetConfiguration is the name of the getConfiguration function
 	FunctionGetConfiguration FunctionName = "getConfiguration"
+	// FunctionGetGitpodTokenScopes is the name of the GetGitpodTokenScopes function
+	FunctionGetGitpodTokenScopes FunctionName = "getGitpodTokenScopes"
 	// FunctionGetToken is the name of the getToken function
 	FunctionGetToken FunctionName = "getToken"
 	// FunctionGetPortAuthenticationToken is the name of the getPortAuthenticationToken function
@@ -495,6 +498,26 @@ func (gp *APIoverJSONRPC) GetConfiguration(ctx context.Context) (res *Configurat
 		return
 	}
 	res = &result
+
+	return
+}
+
+// GetGitpodTokenScopes calls getGitpodTokenScopes on the server
+func (gp *APIoverJSONRPC) GetGitpodTokenScopes(ctx context.Context, tokenHash string) (res []string, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	var _params []interface{}
+
+	_params = append(_params, tokenHash)
+
+	var result []string
+	err = gp.C.Call(ctx, "getGitpodTokenScopes", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
 
 	return
 }

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -405,6 +405,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetSnapshots(ctx, workspaceID interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshots", reflect.TypeOf((*MockAPIInterface)(nil).GetSnapshots), ctx, workspaceID)
 }
 
+// GetGitpodTokenScopes indicates an expected call of GetGitpodTokenScopes.
+func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokenScopes(ctx, tokenHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitpodTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GetGitpodTokenScopes), ctx, tokenHash)
+}
+
+// GetGitpodTokenScopes mocks base method.
+func (m *MockAPIInterface) GetGitpodTokenScopes(ctx context.Context, tokenHash string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGitpodTokenScopes", ctx, tokenHash)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // GetToken mocks base method.
 func (m *MockAPIInterface) GetToken(ctx context.Context, query *GetTokenSearchOptions) (*Token, error) {
 	m.ctrl.T.Helper()

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -55,6 +55,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getBranding(): Promise<Branding>;
     getConfiguration(): Promise<Configuration>;
     getToken(query: GitpodServer.GetTokenSearchOptions): Promise<Token | undefined>;
+    getGitpodTokenScopes(tokenHash: string): Promise<string[]>;
     /**
      * @deprecated
      */

--- a/components/local-app/go.mod
+++ b/components/local-app/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/gitpod-io/gitpod/gitpod-protocol v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/local-app/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
+	github.com/golang/mock v1.6.0 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/improbable-eng/grpc-web v0.14.0
 	github.com/kevinburke/ssh_config v1.1.0
@@ -30,7 +32,6 @@ require (
 	github.com/danieljoos/wincred v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/godbus/dbus/v5 v5.0.3 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 // indirect

--- a/components/local-app/go.sum
+++ b/components/local-app/go.sum
@@ -292,6 +292,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/components/local-app/pkg/auth/auth_test.go
+++ b/components/local-app/pkg/auth/auth_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+//go:build linux
+// +build linux
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"testing"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestValidateToken(t *testing.T) {
+	tkn := "foo"
+	hash := sha256.Sum256([]byte(tkn))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	unauthorizedErr := &gitpod.ErrBadHandshake{
+		Resp: &http.Response{
+			StatusCode: 401,
+		},
+	}
+
+	forbiddenErr := errors.New("jsonrpc2: code 403 message: getGitpodTokenScopes")
+
+	tests := []struct {
+		Desc        string
+		Scopes      []string
+		ScopesErr   error
+		Expectation error
+	}{
+		{
+			Desc:        "invalid: unauthorized",
+			ScopesErr:   unauthorizedErr,
+			Expectation: &ErrInvalidGitpodToken{unauthorizedErr},
+		},
+		{
+			Desc:        "invalid: forbidden",
+			ScopesErr:   forbiddenErr,
+			Expectation: &ErrInvalidGitpodToken{forbiddenErr},
+		},
+		{
+			Desc:        "invalid: missing scopes",
+			Scopes:      []string{"function:getWorkspace"},
+			Expectation: &ErrInvalidGitpodToken{errors.New("function:getGitpodTokenScopes scope is missing in [function:getWorkspace]")},
+		},
+		{
+			Desc:   "valid",
+			Scopes: authScopes,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			gitpodAPI := gitpod.NewMockAPIInterface(ctrl)
+			gitpodAPI.EXPECT().GetGitpodTokenScopes(context.Background(), tokenHash).Times(1).Return(test.Scopes, test.ScopesErr)
+
+			var expectation string
+			if test.Expectation != nil {
+				expectation = test.Expectation.Error()
+			}
+
+			var actual string
+			err := ValidateToken(gitpodAPI, tkn)
+			if err != nil {
+				actual = err.Error()
+			}
+
+			if diff := cmp.Diff(expectation, actual); diff != "" {
+				t.Errorf("unexpected output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -255,7 +255,8 @@ func (b *Bastion) FullUpdate() {
 func (b *Bastion) Update(workspaceID string) *Workspace {
 	ws, err := b.Client.GetWorkspace(b.ctx, workspaceID)
 	if err != nil {
-		logrus.WithError(err).WithField("WorkspaceID", workspaceID).Warn("cannot get workspace")
+		logrus.WithError(err).WithField("WorkspaceID", workspaceID).Error("cannot get workspace")
+		return nil
 	}
 	if ws.LatestInstance == nil {
 		return nil

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -10,8 +10,6 @@ import * as crypto from 'crypto';
 import * as express from 'express';
 import { IncomingHttpHeaders } from 'http';
 import { inject, injectable } from 'inversify';
-import * as websocket from 'ws';
-import { WsNextFunction, WsRequestHandler } from '../express/ws-handler';
 import { AllAccessFunctionGuard, ExplicitFunctionAccessGuard, WithFunctionAccessGuard } from './function-access';
 import { TokenResourceGuard, WithResourceAccessGuard } from './resource-access';
 
@@ -33,7 +31,7 @@ const bearerAuthCode = 'BearerAuth';
 interface BearerAuthError extends Error {
     code: typeof bearerAuthCode
 }
-function isBearerAuthError(error: Error): error is BearerAuthError {
+export function isBearerAuthError(error: Error): error is BearerAuthError {
     return 'code' in error && error['code'] === bearerAuthCode;
 }
 function createBearerAuthError(message: string): BearerAuthError {
@@ -47,7 +45,7 @@ export class BearerAuth {
     get restHandler(): express.RequestHandler {
         return async (req, res, next) => {
             try {
-                await this.doAuth(req);
+                await this.auth(req);
             } catch (e) {
                 if (isBearerAuthError(e)) {
                     res.status(401).send(e.message);
@@ -62,7 +60,7 @@ export class BearerAuth {
     get restHandlerOptionally(): express.RequestHandler {
         return async (req, res, next) => {
             try {
-                await this.doAuth(req);
+                await this.auth(req);
             } catch (e) {
                 // don't error the request, we just have not bearer authentication token
             }
@@ -70,14 +68,7 @@ export class BearerAuth {
         }
     }
 
-    public get websocketHandler(): WsRequestHandler {
-        return async (ws: websocket, req: express.Request, next: WsNextFunction): Promise<void> => {
-            await this.doAuth(req);
-            return next();
-        }
-    }
-
-    private async doAuth(req: express.Request): Promise<void> {
+    async auth(req: express.Request): Promise<void> {
         const token = getBearerToken(req.headers)
         if (!token) {
             throw createBearerAuthError('missing Bearer token');

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -46,6 +46,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "deleteOwnAuthProvider": { group: "default", points: 1 },
         "getBranding": { group: "default", points: 1 },
         "getConfiguration": { group: "default", points: 1 },
+        "getGitpodTokenScopes": { group: "default", points: 1 },
         "getToken": { group: "default", points: 1 },
         "getPortAuthenticationToken": { group: "default", points: 1 },
         "deleteAccount": { group: "default", points: 1 },

--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -5,7 +5,6 @@
  */
 
 import { OAuthClient, OAuthScope, OAuthToken } from "@jmondi/oauth2-server";
-import { ScopedResourceGuard } from "../auth/resource-access";
 
 /**
 * Currently (2021-05-15) we only support 1 client and a fixed set of scopes so hard-coding here is acceptable.
@@ -19,11 +18,11 @@ export interface InMemory {
 
 // Scopes
 const scopes: OAuthScope[] = [
+  { name: "function:getGitpodTokenScopes" },
   { name: "function:getWorkspace" },
   { name: "function:getWorkspaces" },
   { name: "function:listenForWorkspaceInstanceUpdates" },
-  { name: "resource:" + ScopedResourceGuard.marshalResourceScope({ kind: "workspace", subjectID: "*", operations: ["get"] }) },
-  { name: "resource:" + ScopedResourceGuard.marshalResourceScope({ kind: "workspaceInstance", subjectID: "*", operations: ["get"] }) }
+  { name: "resource:default" }
 ];
 
 // Clients

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -691,6 +691,7 @@ export class WorkspaceStarter {
             "function:storeLayout",
             "function:stopWorkspace",
             "function:getToken",
+            "function:getGitpodTokenScopes",
             "function:getContentBlobUploadUrl",
             "function:getContentBlobDownloadUrl",
             "function:accessCodeSyncStorage",


### PR DESCRIPTION
#### What it does

- fix #5368 by allowing the local app to validate the current token scopes against expected scopes. And if they don't match then invalidate the token and run auth flow again.

I had to move bearer auth into verify callback to return a proper error code during web socket handshake, instead of failing after web socket is established. It allows clients to analyse the bad hahdshake request for unauthorised access.

#### How to test

- Start a workspace: https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com/#github.com/akosyakov/parcel-demo
- Start the local app:
```
# mac
curl -OL https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com/static/bin/gitpod-local-companion-darwin
chmod +x ./gitpod-local-companion-darwin
GITPOD_HOST=https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com ./gitpod-local-companion-darwin --log-level=debug

# linux
# curl -OL https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com/static/bin/gitpod-local-companion-linux
chmod +x ./gitpod-local-companion-linux
GITPOD_HOST=https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com ./gitpod-local-companion-linux --log-level=debug

# windows
# curl -OL https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com/static/bin/gitpod-local-companion-windows.exe
GITPOD_HOST=https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com ./gitpod-local-companion-windows.exe --log-level=debug
```
- check that you went through the auth flow and output looks fine
- restart the app, checks that you don't need to go through the auth flow this time
- go and corrupt the token for https://akosyakov-local-app-is-crashing-5368.staging.gitpod-dev.com in keychain access
- restart the app, you should see the error that token is invalid and go through the auth flow again
- now corrupt tokens in the DB: `update d_b_gitpod_token set scopes = "";`
- restart the app, you should see the error that token is invalid and go through the auth flow again