### PR TITLE
Add support link to the dashboard

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -138,8 +138,8 @@ export default function Menu() {
             link: 'https://www.gitpod.io/docs/',
         },
         {
-            title: 'Community',
-            link: 'https://community.gitpod.io/',
+            title: 'Support',
+            link: 'https://www.gitpod.io/support',
         }
     ];
 


### PR DESCRIPTION
### What does this PR do?

Replace the _Community_ link on the top right menu with a link to the new _Support_ page added in https://github.com/gitpod-io/website/pull/862.
> https://www.gitpod.io/support