### PR TITLE
[code] apply installation options for extensions from vsix

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT a0bc2b8ba2e0f65b94505223c8364ec9cc1b18be
+ENV GP_CODE_COMMIT 10009f5b3c471180d58f54c47f137654fd180de8
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

#### What it does

- fix #5405: It's a regression in VS Code, the extension installation was refactored and the installation option are not applied anymore fro extension from VSIX files.

Change in Gitpod Code: https://github.com/gitpod-io/vscode/commit/10009f5b3c471180d58f54c47f137654fd180de8

#### How to test

- Switch to latest VS Code: https://akosyakov-code-worspaces-extensions-5405.staging.gitpod-dev.com/preferences
- Start a workspace: https://akosyakov-code-worspaces-extensions-5405.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod
- Wait till all extensions from .gitpod.yml are installed and check that they are not synced.