### PR TITLE
[local-app] Handle reconnecting websocket cancel

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -241,7 +241,7 @@ func ConnectToServer(endpoint string, opts ConnectToServerOpts) (*APIoverJSONRPC
 	}
 	ws := NewReconnectingWebsocket(endpoint, reqHeader, opts.Log)
 	ws.ReconnectionHandler = opts.ReconnectionHandler
-	go ws.Dial()
+	go ws.Dial(context.Background())
 
 	var res APIoverJSONRPC
 	res.log = opts.Log

--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -123,12 +123,7 @@ func (rc *ReconnectingWebsocket) ReadObject(v interface{}) error {
 }
 
 // Dial creates a new client connection.
-func (rc *ReconnectingWebsocket) Dial() {
-	rc.DialContext(context.Background())
-}
-
-// DialContext creates a new client connection with a context
-func (rc *ReconnectingWebsocket) DialContext(ctx context.Context) {
+func (rc *ReconnectingWebsocket) Dial(ctx context.Context) {
 	var conn *WebsocketConnection
 	defer func() {
 		if conn == nil {
@@ -164,7 +159,7 @@ func (rc *ReconnectingWebsocket) connect(ctx context.Context) *WebsocketConnecti
 		// Gorilla websocket does not check if context is valid when dialing so we do it prior
 		select {
 		case <-ctx.Done():
-			rc.log.WithField("url", rc.url).Info("context done...closing")
+			rc.log.WithField("url", rc.url).Debug("context done...closing")
 			rc.Close()
 			return nil
 		default:

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -442,7 +442,7 @@ func (b *Bastion) connectTunnelClient(ctx context.Context, ws *Workspace) error 
 	h := make(http.Header)
 	h.Set("x-gitpod-owner-token", ws.OwnerToken)
 	webSocket := gitpod.NewReconnectingWebsocket(tunnelURL, h, logrus.WithField("workspace", ws.WorkspaceID))
-	go webSocket.Dial()
+	go webSocket.DialContext(ctx)
 	go func() {
 		var (
 			client *TunnelClient

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -442,7 +442,7 @@ func (b *Bastion) connectTunnelClient(ctx context.Context, ws *Workspace) error 
 	h := make(http.Header)
 	h.Set("x-gitpod-owner-token", ws.OwnerToken)
 	webSocket := gitpod.NewReconnectingWebsocket(tunnelURL, h, logrus.WithField("workspace", ws.WorkspaceID))
-	go webSocket.DialContext(ctx)
+	go webSocket.Dial(ctx)
 	go func() {
 		var (
 			client *TunnelClient


### PR DESCRIPTION
Fixes #4858

Pass in context to allow cancel to be handled and not stay in reconnection attempt loop.