### PR TITLE
changed nodeAffinity for preview environments

### DIFF
--- a/.werft/jaeger.yaml
+++ b/.werft/jaeger.yaml
@@ -33,11 +33,9 @@ spec:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
-          - matchExpressions:
-              - key: dev/workload
-                operator: In
-                values:
-                  - workload
+        - matchExpressions:
+          - key: workload/meta
+            operator: Exists
   strategy: allInOne
   storage:
     options:

--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -10,15 +10,7 @@ certificatesSecret:
   secretName: proxy-config-certificates
 version: not-set
 imagePullPolicy: Always
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: gitpod.io/workload_meta
-          operator: In
-          values:
-          - "true"
+
 authProviders: []
 tracing:
   endoint: http://jaeger-collector:14268/api/traces
@@ -78,8 +70,6 @@ components:
     # configure GCP registry
     pullSecret:
       secretName: gcp-sa-registry-auth
-    affinity:
-      default: "gitpod.io/workload_workspace"
     templates:
       default:
         spec:
@@ -217,16 +207,6 @@ minio:
   serviceAccount:
     name: ws-daemon
     create: false
-  # make sure the pod ends up where it's supposed to stay
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: dev/workload
-            operator: In
-            values:
-            - "workload"
   resources:
     requests:
       # in preview envs, we want deployments to push scale-up early
@@ -235,15 +215,6 @@ minio:
 mysql:
   primary:
     # make sure the pod ends up where it's supposed to stay
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: dev/workload
-              operator: In
-              values:
-              - "workload"
     resources:
       requests:
         # in preview envs, we want deployments to push scale-up early
@@ -258,15 +229,6 @@ rabbitmq:
     username: override-me
     password: override-me
   # make sure the pod ends up where it's supposed to stay
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: dev/workload
-            operator: In
-            values:
-            - "workload"
   resources:
     requests:
       # in preview envs, we want deployments to push scale-up early

--- a/.werft/values.k3sWsCluster.yaml
+++ b/.werft/values.k3sWsCluster.yaml
@@ -10,15 +10,6 @@ certificatesSecret:
   secretName: proxy-config-certificates
 version: not-set
 imagePullPolicy: Always
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: gitpod.io/workload_services
-          operator: In
-          values:
-          - "true"
 authProviders: []
 tracing:
   endoint: http://jaeger-collector:14268/api/traces

--- a/.werft/values.nodeAffinities_0.yaml
+++ b/.werft/values.nodeAffinities_0.yaml
@@ -1,0 +1,62 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: workload/meta
+          operator: Exists
+
+components:
+
+  wsDaemon:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gitpod.io/workspace_0
+              operator: Exists
+
+  registryFacade:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gitpod.io/workspace_0
+              operator: Exists
+
+
+  workspace:
+    affinity:
+      default: gitpod.io/workspace_0
+
+# Sub-Charts
+
+rabbitmq:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: workload/meta
+            operator: Exists
+
+mysql:
+  primary:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: workload/meta
+              operator: Exists
+
+minio:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: workload/meta
+            operator: Exists

--- a/.werft/values.nodeAffinities_1.yaml
+++ b/.werft/values.nodeAffinities_1.yaml
@@ -1,0 +1,62 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: workload/meta
+          operator: Exists
+
+components:
+
+  wsDaemon:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gitpod.io/workspace_1
+              operator: Exists
+
+  registryFacade:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gitpod.io/workspace_1
+              operator: Exists
+
+
+  workspace:
+    affinity:
+      default: gitpod.io/workspace_1
+
+# Sub-Charts
+
+rabbitmq:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: workload/meta
+            operator: Exists
+
+mysql:
+  primary:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: workload/meta
+              operator: Exists
+
+minio:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: workload/meta
+            operator: Exists


### PR DESCRIPTION
This PR should move the preview environments to new clusters which are split into meta and workspace nodepools. This should reduce the overload the current workload nodepool. All nodeaffinities have been moved to a sepeate file. This will be used later to add new nodepools. There will be a file for every set of nodepools and a file will be choosen randomly.