### PR TITLE
[server] Allow team members (and everyone in legacy mode) to access prebuilds

### DIFF
--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -32,7 +32,7 @@ interface BearerAuthError extends Error {
     code: typeof bearerAuthCode
 }
 export function isBearerAuthError(error: Error): error is BearerAuthError {
-    return 'code' in error && error['code'] === bearerAuthCode;
+    return 'code' in error && (error as any)['code'] === bearerAuthCode;
 }
 function createBearerAuthError(message: string): BearerAuthError {
     return Object.assign(new Error(message), { code: bearerAuthCode } as { code: typeof bearerAuthCode });

--- a/components/server/src/websocket-connection-manager.ts
+++ b/components/server/src/websocket-connection-manager.ts
@@ -15,7 +15,7 @@ import { ErrorCodes as RPCErrorCodes, MessageConnection, ResponseError } from "v
 import { AllAccessFunctionGuard, FunctionAccessGuard, WithFunctionAccessGuard } from "./auth/function-access";
 import { HostContextProvider } from "./auth/host-context-provider";
 import { RateLimiter, RateLimiterConfig, UserRateLimiter } from "./auth/rate-limiter";
-import { CompositeResourceAccessGuard, OwnerResourceGuard, ResourceAccessGuard, SharedWorkspaceAccessGuard, WithResourceAccessGuard, WorkspaceLogAccessGuard } from "./auth/resource-access";
+import { CompositeResourceAccessGuard, OwnerResourceGuard, ResourceAccessGuard, SharedWorkspaceAccessGuard, TeamMemberResourceGuard, WithResourceAccessGuard, WorkspaceLogAccessGuard } from "./auth/resource-access";
 import { increaseApiCallCounter, increaseApiConnectionClosedCounter, increaseApiConnectionCounter, increaseApiCallUserCounter } from "./prometheus-metrics";
 import { GitpodServerImpl } from "./workspace/gitpod-server-impl";
 
@@ -70,6 +70,7 @@ export class WebsocketConnectionManager<C extends GitpodClient, S extends Gitpod
         } else if (!!user) {
             resourceGuard = new CompositeResourceAccessGuard([
                 new OwnerResourceGuard(user.id),
+                new TeamMemberResourceGuard(user.id),
                 new SharedWorkspaceAccessGuard(),
                 new WorkspaceLogAccessGuard(user, this.hostContextProvider),
             ]);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1679,6 +1679,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         this.checkUser("resolvePlugins")
 
         const workspace = await this.internalGetWorkspace(workspaceId, this.workspaceDb.trace({}));
+        await this.guardAccess({ kind: "workspace", subject: workspace }, "get");
         const result = await this.pluginService.resolvePlugins(workspace.ownerId, params);
         return result.resolved;
     };

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -416,7 +416,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         try {
             const workspace = await this.internalGetWorkspace(id, this.workspaceDb.trace({ span }));
             const latestInstancePromise = this.workspaceDb.trace({}).findCurrentInstance(id);
-            let teamMembers = await this.getTeamMembersByProject(workspace.projectId);
+            const teamMembers = await this.getTeamMembersByProject(workspace.projectId);
             await this.guardAccess({ kind: "workspace", subject: workspace, teamMembers }, "get");
             const latestInstance = await latestInstancePromise;
             if (!!latestInstance) {


### PR DESCRIPTION
This PR relaxes resource-access so that team members can access prebuild workspaces and workspaceinstances. 
It also replaces the old access guard for headless logs that would use the git access in favor of user/team based check.
caveat: Old prebuilds that don't have a project associated, yet, are accessible from everyone ([see](https://github.com/gitpod-io/gitpod/pull/5433/files#diff-b4ab99413da84ca8b9ecc7d07a462a1eb0a7bc086cbb90b90d5b59c2b170eb44R178)).


fixes https://github.com/gitpod-io/gitpod/issues/5344