### PR TITLE
Handle reconnecting websocket cancel

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -241,7 +241,7 @@ func ConnectToServer(endpoint string, opts ConnectToServerOpts) (*APIoverJSONRPC
 	}
 	ws := NewReconnectingWebsocket(endpoint, reqHeader, opts.Log)
 	ws.ReconnectionHandler = opts.ReconnectionHandler
-	go ws.Dial()
+	go ws.Dial(opts.Context)
 
 	var res APIoverJSONRPC
 	res.log = opts.Log

--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -123,7 +123,7 @@ func (rc *ReconnectingWebsocket) ReadObject(v interface{}) error {
 }
 
 // Dial creates a new client connection.
-func (rc *ReconnectingWebsocket) Dial() {
+func (rc *ReconnectingWebsocket) Dial(ctx context.Context) {
 	var conn *WebsocketConnection
 	defer func() {
 		if conn == nil {
@@ -133,7 +133,7 @@ func (rc *ReconnectingWebsocket) Dial() {
 		conn.Close()
 	}()
 
-	conn = rc.connect()
+	conn = rc.connect(ctx)
 
 	for {
 		select {
@@ -145,7 +145,7 @@ func (rc *ReconnectingWebsocket) Dial() {
 			conn.Close()
 
 			time.Sleep(1 * time.Second)
-			conn = rc.connect()
+			conn = rc.connect(ctx)
 			if conn != nil && rc.ReconnectionHandler != nil {
 				go rc.ReconnectionHandler()
 			}
@@ -153,11 +153,20 @@ func (rc *ReconnectingWebsocket) Dial() {
 	}
 }
 
-func (rc *ReconnectingWebsocket) connect() *WebsocketConnection {
+func (rc *ReconnectingWebsocket) connect(ctx context.Context) *WebsocketConnection {
 	delay := rc.minReconnectionDelay
 	for {
+		// Gorilla websocket does not check if context is valid when dialing so we do it prior
+		select {
+		case <-ctx.Done():
+			rc.log.WithField("url", rc.url).Debug("context done...closing")
+			rc.Close()
+			return nil
+		default:
+		}
+
 		dialer := websocket.Dialer{HandshakeTimeout: rc.handshakeTimeout}
-		conn, _, err := dialer.Dial(rc.url, rc.reqHeader)
+		conn, _, err := dialer.DialContext(ctx, rc.url, rc.reqHeader)
 		if err == nil {
 			rc.log.WithField("url", rc.url).Debug("connection was successfully established")
 			ws, err := NewWebsocketConnection(context.Background(), conn, func(staleErr error) {

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -442,7 +442,7 @@ func (b *Bastion) connectTunnelClient(ctx context.Context, ws *Workspace) error 
 	h := make(http.Header)
 	h.Set("x-gitpod-owner-token", ws.OwnerToken)
 	webSocket := gitpod.NewReconnectingWebsocket(tunnelURL, h, logrus.WithField("workspace", ws.WorkspaceID))
-	go webSocket.Dial()
+	go webSocket.Dial(ctx)
 	go func() {
 		var (
 			client *TunnelClient


### PR DESCRIPTION
Fixes #4858

Pass in context to allow cancel to be handled and not stay in reconnection attempt loop.