### PR TITLE
[ws-manager] Restart pod on config change

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -389,6 +389,8 @@ components:
 
   wsManager:
     name: "ws-manager"
+    dependsOn:
+    - "ws-manager-configmap.yaml"
     resources:
       cpu: 100m
       memory: 32Mi


### PR DESCRIPTION
With this change `ws-manager` restarts whenever the content of it's ConfigMap changes.

Currently we often see config mismatches leading to broken deployments of preview environments. This change will fix this.

Adding platform to make sure this is ok for prod deployments as well.