### PR TITLE
Upgrade grpc-js library

### DIFF
--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.6",
+    "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.17.3",
     "inversify": "^5.0.1",
     "node-pre-gyp": "^0.13.0",

--- a/components/image-builder-api/typescript/package.json
+++ b/components/image-builder-api/typescript/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "^1.3.6",
+    "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.17.3",
     "inversify": "^5.0.1",
     "opentracing": "^0.14.4"

--- a/components/supervisor-api/typescript-grpc/package.json
+++ b/components/supervisor-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.6",
+    "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.17.3"
   },
   "devDependencies": {

--- a/components/ws-daemon-api/typescript/package.json
+++ b/components/ws-daemon-api/typescript/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
-    "@grpc/grpc-js": "^1.3.6",
+    "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.17.3",
     "inversify": "^5.0.1",
     "node-pre-gyp": "^0.13.0",

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "^1.3.6",
+    "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.17.3",
     "inversify": "^5.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-bridge-api/typescript/package.json
+++ b/components/ws-manager-bridge-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.6",
+    "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.17.3",
     "inversify": "^5.0.1",
     "node-pre-gyp": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,10 +3038,10 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@grpc/grpc-js@^1.3.6":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.6.tgz#6e2d17610c2c8df0f6ceab0e1968f563df74b173"
-  integrity sha512-v7+LQFbqZKmd/Tvf5/j1Xlbq6jXL/4d+gUtm2TNX4QiEC3ELWADmGr2dGlUyLl6aKTuYfsN72vAsO5zmavYkEg==
+"@grpc/grpc-js@^1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.7.tgz#58b687aff93b743aafde237fd2ee9a3259d7f2d8"
+  integrity sha512-CKQVuwuSPh40tgOkR7c0ZisxYRiN05PcKPW72mQL5y++qd7CwBRoaJZvU5xfXnCJDFBmS3qZGQ71Frx6Ofo2XA==
   dependencies:
     "@types/node" ">=12.12.47"
 


### PR DESCRIPTION
A recent bug fix was made to grpc-js library [1.3.7 release](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.3.7) which fixes issue of connection closure. This can potentially fix https://github.com/gitpod-io/gitpod/issues/5414