### PR TITLE
vscode desktop on windows

### DIFF
--- a/components/local-app/main.go
+++ b/components/local-app/main.go
@@ -93,7 +93,10 @@ func main() {
 				},
 			},
 			&cli.BoolFlag{
-				Name:  "verbose",
+				Name: "verbose",
+				EnvVars: []string{
+					"GITPOD_LCA_VERBOSE",
+				},
 				Value: false,
 			},
 		},

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -328,7 +328,7 @@ func (b *Bastion) handleUpdate(ur *WorkspaceUpdateRequest) {
 			var err error
 			ws.supervisorClient, err = grpc.Dial(ws.supervisorListener.LocalAddr, grpc.WithInsecure())
 			if err != nil {
-				logrus.WithError(err).WithField("workspace", ws.WorkspaceID).Print("error connecting to supervisor")
+				logrus.WithError(err).WithField("workspace", ws.WorkspaceID).Error("error connecting to supervisor")
 			} else {
 				go func() {
 					<-ws.ctx.Done()


### PR DESCRIPTION
#### What it does

fix https://github.com/gitpod-io/gitpod/issues/5437: It is a set of small changes to the local app to track down issues on windows.

The underlying issue was that `tmp` npm module tracks all temp files by default and delete them on process exit. On windows it will lock files and prevent starting the local app or opening a new window. I reconfigured the library that it does not keep and immediately release the file descriptor. Plus added a way to use the user download local app, enable verbose logging and cancel the window opening if it hangs. The real fix was done here: https://github.com/gitpod-io/vscode/commit/1f703052161666d580969a8618f5a840dc9463c0 and already published to the marketplace.

#### How to test

There is no really anything to test in prev env. You can try to use Windows machine in the production to open VS Code Desktop from latest VS Code Web. Or just merge it 😉 