### PR TITLE
[dashboard] Redirect "/chat" to "https://www.gitpod.io/chat"

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -113,6 +113,10 @@ function App() {
         window.location.href = `https://www.gitpod.io`;
         return <div></div>;
     }
+    if (window.location.pathname === '/chat') {
+        window.location.href = `https://www.gitpod.io/chat`;
+        return <div></div>;
+    }
 
     if (loading) {
         return (<Loading />);


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/5452

### How to test

https://jx-chat.staging.gitpod-dev.com/chat