### PR TITLE
[dashboard] Adjust Prebuild and Project Configurator pages to spec

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -68,47 +68,47 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
       case "unknown":
         break;
 
-        // Preparing means that we haven't actually started the workspace instance just yet, but rather
-        // are still preparing for launch. This means we're building the Docker image for the workspace.
-        case "preparing":
-          getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
-          break;
+      // Preparing means that we haven't actually started the workspace instance just yet, but rather
+      // are still preparing for launch. This means we're building the Docker image for the workspace.
+      case "preparing":
+        getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
+        break;
 
-        // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
-        // some space within the cluster. If for example the cluster needs to scale up to accomodate the
-        // workspace, the workspace will be in Pending state until that happened.
-        case "pending":
-          break;
+      // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
+      // some space within the cluster. If for example the cluster needs to scale up to accomodate the
+      // workspace, the workspace will be in Pending state until that happened.
+      case "pending":
+        break;
 
-        // Creating means the workspace is currently being created. That includes downloading the images required
-        // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
-        // network speed, image size and cache states.
-        case "creating":
-          break;
+      // Creating means the workspace is currently being created. That includes downloading the images required
+      // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
+      // network speed, image size and cache states.
+      case "creating":
+        break;
 
-        // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
-        // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
-        case "initializing":
-          break;
+      // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
+      // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
+      case "initializing":
+        break;
 
-        // Running means the workspace is able to actively perform work, either by serving a user through Theia,
-        // or as a headless workspace.
-        case "running":
-          break;
+      // Running means the workspace is able to actively perform work, either by serving a user through Theia,
+      // or as a headless workspace.
+      case "running":
+        break;
 
-        // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
-        // When in this state, we expect it to become running or stopping anytime soon.
-        case "interrupted":
-          break;
+      // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
+      // When in this state, we expect it to become running or stopping anytime soon.
+      case "interrupted":
+        break;
 
-        // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
-        case "stopping":
-          break;
+      // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
+      case "stopping":
+        break;
 
-        // Stopped means the workspace ended regularly because it was shut down.
-        case "stopped":
-          getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
-          break;
+      // Stopped means the workspace ended regularly because it was shut down.
+      case "stopped":
+        getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
+        break;
     }
     if (workspaceInstance?.status.conditions.failed) {
       setError(new Error(workspaceInstance.status.conditions.failed));

--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -14,12 +14,10 @@ import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
 import Header from "../components/Header";
 import Spinner from "../icons/Spinner.svg";
 import SpinnerDark from "../icons/SpinnerDark.svg";
-import StatusDone from "../icons/StatusDone.svg";
-import StatusPaused from "../icons/StatusPaused.svg";
-import StatusRunning from "../icons/StatusRunning.svg";
 import PrebuildLogsEmpty from "../images/prebuild-logs-empty.svg";
 import PrebuildLogsEmptyDark from "../images/prebuild-logs-empty-dark.svg";
 import { ThemeContext } from "../theme-context";
+import { PrebuildInstanceStatus } from "./Prebuilds";
 
 const MonacoEditor = React.lazy(() => import('../components/MonacoEditor'));
 
@@ -70,7 +68,7 @@ export default function () {
   const [ isDetecting, setIsDetecting ] = useState<boolean>(true);
   const [ prebuildWasTriggered, setPrebuildWasTriggered ] = useState<boolean>(false);
   const [ startPrebuildResult, setStartPrebuildResult ] = useState<StartPrebuildResult | undefined>();
-  const [ prebuildPhase, setPrebuildPhase ] = useState<string | undefined>();
+  const [ prebuildInstance, setPrebuildInstance ] = useState<WorkspaceInstance | undefined>();
   const { isDark } = useContext(ThemeContext);
 
   useEffect(() => {
@@ -144,7 +142,7 @@ export default function () {
   }
 
   const onInstanceUpdate = (instance: WorkspaceInstance) => {
-    setPrebuildPhase(instance.status.phase);
+    setPrebuildInstance(instance);
   }
 
   useEffect(() => { document.title = 'Configure Project — Gitpod' }, []);
@@ -179,7 +177,7 @@ export default function () {
             </div>
         }</div>
         <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
-          {prebuildWasTriggered && <PrebuildStatus prebuildPhase={prebuildPhase} isDark={isDark} />}
+          {prebuildWasTriggered && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} isDark={isDark} />}
           <div className="flex-grow" />
           <button className="secondary">New Workspace</button>
           <button disabled={isDetecting} onClick={buildProject}>Run Prebuild</button>
@@ -196,51 +194,4 @@ function EditorMessage(props: { heading: string, message: string, type: 'success
   </div>;
 }
 
-function PrebuildStatus(props: { prebuildPhase?: string, isDark?: boolean }) {
-  let status = <></>;
-  let details = <></>;
-  switch (props.prebuildPhase) {
-    case undefined: // Fall through
-    case 'unknown':
-      status = <div className="flex space-x-1 items-center text-yellow-600">
-        <img className="h-4 w-4" src={StatusPaused} />
-        <span>PENDING</span>
-      </div>;
-      details = <div className="flex space-x-1 items-center text-gray-400">
-        <img className="h-4 w-4 animate-spin" src={props.isDark ? SpinnerDark : Spinner} />
-        <span>Prebuild in progress ...</span>
-      </div>;
-      break;
-    case 'preparing': // Fall through
-    case 'pending': // Fall through
-    case 'creating': // Fall through
-    case 'initializing': // Fall  through
-    case 'running': // Fall through
-    case 'interrupted':
-      status = <div className="flex space-x-1 items-center text-blue-600">
-        <img className="h-4 w-4" src={StatusRunning} />
-        <span>RUNNING</span>
-      </div>;
-      details = <div className="flex space-x-1 items-center text-gray-400">
-        <img className="h-4 w-4 animate-spin" src={props.isDark ? SpinnerDark : Spinner} />
-        <span>Prebuild in progress ...</span>
-      </div>;
-      break;
-    case 'stopping': // Fall through
-    case 'stopped':
-      status = <div className="flex space-x-1 items-center text-green-600">
-        <img className="h-4 w-4" src={StatusDone} />
-        <span>READY</span>
-      </div>;
-      // TODO(janx): Calculate actual duration from prebuild instance.
-      details = <div className="flex space-x-1 items-center text-gray-400">
-        <img className="h-4 w-4 filter-grayscale" src={StatusRunning} />
-        <span>00:34</span>
-      </div>;
-      break;
-  }
-  return <div className="flex flex-col space-y-1 justify-center text-sm font-semibold">
-    <div>{status}</div>
-    <div>{details}</div>
-  </div>;
-}
+

--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -166,7 +166,7 @@ export default function () {
         </Suspense>
         {isDetecting && <div className="absolute h-full w-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center space-x-2">
           <img className="h-5 w-5 animate-spin" src={isDark ? SpinnerDark : Spinner} />
-          <span className="font-semibold text-gray-400">Detecting project type ...</span>
+          <span className="font-semibold text-gray-400">Detecting project configuration ...</span>
         </div>}
       </div>
       <div className="flex-1 h-96 rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-700 flex flex-col">

--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -131,7 +131,9 @@ export default function () {
     }
     try {
       setPrebuildWasTriggered(true);
-      await getGitpodService().server.setProjectConfiguration(project.id, gitpodYml);
+      if (!isEditorDisabled) {
+        await getGitpodService().server.setProjectConfiguration(project.id, gitpodYml);
+      }
       const result = await getGitpodService().server.createWorkspace({
         contextUrl: `prebuild/${project.cloneUrl}`,
         mode: CreateWorkspaceMode.ForceNew,
@@ -182,7 +184,7 @@ export default function () {
           {prebuildWasTriggered && <PrebuildStatus prebuildPhase={prebuildPhase} isDark={isDark} />}
           <div className="flex-grow" />
           <button className="secondary">New Workspace</button>
-          <button disabled={isEditorDisabled} onClick={buildProject}>Run Prebuild</button>
+          <button disabled={isDetecting} onClick={buildProject}>Run Prebuild</button>
         </div>
       </div>
     </div>

--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -170,17 +170,19 @@ export default function () {
       <div className="flex-1 h-96 rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-700 flex flex-col">
         <div className="flex-grow flex">{startPrebuildResult
           ? <PrebuildLogs workspaceId={startPrebuildResult.wsid} onInstanceUpdate={onInstanceUpdate} />
-          : <div className="flex-grow flex flex-col items-center justify-center">
+          : (!prebuildWasTriggered && <div className="flex-grow flex flex-col items-center justify-center">
               <img className="w-14" role="presentation" src={isDark ? PrebuildLogsEmptyDark : PrebuildLogsEmpty} />
               <h3 className="text-center text-lg text-gray-500 dark:text-gray-50 mt-4">No Recent Prebuild</h3>
               <p className="text-center text-base text-gray-500 dark:text-gray-400 mt-2 w-64">Edit the project configuration on the left to get started. <a className="gp-link" href="https://www.gitpod.io/docs/config-gitpod-file/">Learn more</a></p>
-            </div>
+            </div>)
         }</div>
         <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
           {prebuildWasTriggered && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} isDark={isDark} />}
           <div className="flex-grow" />
-          <button className="secondary">New Workspace</button>
-          <button disabled={isDetecting} onClick={buildProject}>Run Prebuild</button>
+          {(prebuildInstance?.status.phase === "stopped" && !prebuildInstance?.status.conditions.failed)
+              ? <a className="my-auto" href={`/#${project?.cloneUrl}`}><button className="secondary">New Workspace</button></a>
+              : <button disabled={true} className="secondary">New Workspace</button>}
+          <button disabled={isDetecting || (prebuildWasTriggered && prebuildInstance?.status.phase !== "stopped")} onClick={buildProject}>Run Prebuild</button>
         </div>
       </div>
     </div>

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -385,7 +385,7 @@ export default function NewProject() {
 
     return (<div className="flex flex-col w-96 mt-24 mx-auto items-center">
         <h1>New Project</h1>
-        <p className="text-gray-500 text-center text-base">Select a git repository on <strong>{provider}</strong>.</p>
+        <p className="text-gray-500 text-center text-base">Select a git repository on <strong>{provider}</strong>. (<a className="gp-link cursor-pointer" onClick={() => setShowGitProviders(true)}>change</a>)</p>
 
         {!selectedRepo && renderSelectRepository()}
 

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -10,7 +10,7 @@ import { useContext, useEffect, useState } from "react";
 import { useLocation, useRouteMatch } from "react-router";
 import Header from "../components/Header";
 import PrebuildLogs from "../components/PrebuildLogs";
-import { getGitpodService } from "../service/service";
+import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
 import { ThemeContext } from "../theme-context";
 import { prebuildStatusIcon, prebuildStatusLabel, PrebuildInstanceStatus } from "./Prebuilds";
@@ -97,8 +97,9 @@ export default function () {
                 <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
                     {prebuildInstance && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} isDark={isDark} />}
                     <div className="flex-grow" />
-                    <button className="secondary">New Workspace</button>
-                    <button>Run Prebuild</button>
+                    {prebuildInstance?.status.phase === "stopped"
+                        ? <a className="my-auto" href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}><button>New Workspace</button></a>
+                        : <button disabled={true}>New Workspace</button>}
                 </div>
             </div>
         </div>

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -5,14 +5,15 @@
  */
 
 import moment from "moment";
-import { PrebuildWithStatus } from "@gitpod/gitpod-protocol";
+import { PrebuildWithStatus, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { useContext, useEffect, useState } from "react";
 import { useLocation, useRouteMatch } from "react-router";
 import Header from "../components/Header";
+import PrebuildLogs from "../components/PrebuildLogs";
 import { getGitpodService } from "../service/service";
 import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
-import { prebuildStatusIcon, prebuildStatusLabel } from "./Prebuilds";
-import PrebuildLogs from "../components/PrebuildLogs";
+import { ThemeContext } from "../theme-context";
+import { prebuildStatusIcon, prebuildStatusLabel, PrebuildInstanceStatus } from "./Prebuilds";
 import { shortCommitMessage } from "./render-utils";
 
 export default function () {
@@ -26,6 +27,8 @@ export default function () {
     const prebuildId = match?.params?.prebuildId;
 
     const [ prebuild, setPrebuild ] = useState<PrebuildWithStatus | undefined>();
+    const [ prebuildInstance, setPrebuildInstance ] = useState<WorkspaceInstance | undefined>();
+    const { isDark } = useContext(ThemeContext);
 
     useEffect(() => {
         if (!teams || !projectName || !prebuildId) {
@@ -78,13 +81,25 @@ export default function () {
         </div>)
     };
 
+    const onInstanceUpdate = (instance: WorkspaceInstance) => {
+        setPrebuildInstance(instance);
+    }
+
     useEffect(() => { document.title = 'Prebuild — Gitpod' }, []);
 
     return <>
         <Header title={renderTitle()} subtitle={renderSubtitle()} />
         <div className="lg:px-28 px-10 mt-8">
-            <div className="h-96 rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
-                <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId}/>
+            <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
+                <div className="h-96 flex">
+                    <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId} onInstanceUpdate={onInstanceUpdate} />
+                </div>
+                <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
+                    {prebuildInstance && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} isDark={isDark} />}
+                    <div className="flex-grow" />
+                    <button className="secondary">New Workspace</button>
+                    <button>Run Prebuild</button>
+                </div>
             </div>
         </div>
     </>;

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -27,7 +27,6 @@ export default function () {
     const projectName = match?.params?.resource;
 
     const [project, setProject] = useState<Project | undefined>();
-    const [defaultBranch, setDefaultBranch] = useState<string | undefined>();
 
     const [searchFilter, setSearchFilter] = useState<string | undefined>();
     const [statusFilter, setStatusFilter] = useState<PrebuiltWorkspaceState | undefined>();
@@ -66,11 +65,6 @@ export default function () {
             const newProject = projectName && projects.find(p => p.name === projectName);
             if (newProject) {
                 setProject(newProject);
-
-                const details = await getGitpodService().server.getProjectOverview(newProject.id);
-                if (details?.branches) {
-                    setDefaultBranch(details.branches.find(b => b.isDefault)?.name);
-                }
             }
         })();
     }, [teams]);
@@ -124,7 +118,7 @@ export default function () {
         history.push(`/${!!team ? team.slug : 'projects'}/${projectName}/${pb.id}`);
     }
 
-    const triggerPrebuild = (branchName: string) => {
+    const triggerPrebuild = (branchName: string | null) => {
         if (project) {
             getGitpodService().server.triggerPrebuild(project.id, branchName);
         }
@@ -148,7 +142,7 @@ export default function () {
                 <div className="py-3 pl-3">
                     <DropDown prefix="Prebuild Status: " contextMenuWidth="w-32" entries={statusFilterEntries()} />
                 </div>
-                <button disabled={!defaultBranch} onClick={() => { defaultBranch && triggerPrebuild(defaultBranch) }} className="ml-2">Trigger Prebuild</button>
+                <button disabled={!project} onClick={() => triggerPrebuild(null)} className="ml-2">Trigger Prebuild</button>
             </div>
             <ItemsList className="mt-2">
                 <Item header={true} className="grid grid-cols-3">

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -64,10 +64,6 @@ export default function () {
     const branchContextMenu = (branch: Project.BranchDetails) => {
         const entries: ContextMenuEntry[] = [];
         entries.push({
-            title: "New Workspace",
-            onClick: () => onNewWorkspace(branch)
-        });
-        entries.push({
             title: "Rerun Prebuild",
             onClick: () => triggerPrebuild(branch),
         });
@@ -107,10 +103,6 @@ export default function () {
             return false;
         }
         return true;
-    }
-
-    const onNewWorkspace = (branch: Project.BranchDetails) => {
-        window.location.href = gitpodHostUrl.withContext(`${branch.url}`).toString();
     }
 
     const triggerPrebuild = (branch: Project.BranchDetails) => {

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -13,7 +13,7 @@ import {
 } from './protocol';
 import {
     Team, TeamMemberInfo,
-    TeamMembershipInvite, Project, TeamMemberRole, PrebuildWithStatus
+    TeamMembershipInvite, Project, TeamMemberRole, PrebuildWithStatus, StartPrebuildResult
 } from './teams-projects-protocol';
 import { JsonRpcProxy, JsonRpcServer } from './messaging/proxy-factory';
 import { Disposable, CancellationTokenSource } from 'vscode-jsonrpc';
@@ -132,7 +132,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getUserProjects(): Promise<Project[]>;
     getProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
     findPrebuilds(params: FindPrebuildsParams): Promise<PrebuildWithStatus[]>;
-    triggerPrebuild(projectId: string, branchName: string | null): Promise<void>;
+    triggerPrebuild(projectId: string, branchName: string | null): Promise<StartPrebuildResult>;
     setProjectConfiguration(projectId: string, configString: string): Promise<void>;
     fetchProjectRepositoryConfiguration(projectId: string): Promise<string | undefined>;
     guessProjectConfiguration(projectId: string): Promise<string | undefined>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -132,7 +132,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getUserProjects(): Promise<Project[]>;
     getProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
     findPrebuilds(params: FindPrebuildsParams): Promise<PrebuildWithStatus[]>;
-    triggerPrebuild(projectId: string, branch: string): Promise<void>;
+    triggerPrebuild(projectId: string, branchName: string | null): Promise<void>;
     setProjectConfiguration(projectId: string, configString: string): Promise<void>;
     fetchProjectRepositoryConfiguration(projectId: string): Promise<string | undefined>;
     guessProjectConfiguration(projectId: string): Promise<string | undefined>;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -90,6 +90,12 @@ export namespace PrebuildInfo {
     }
 }
 
+export interface StartPrebuildResult {
+    wsid: string;
+    done: boolean;
+    didFinish?: boolean;
+}
+
 export interface Team {
     id: string;
     name: string;

--- a/components/server/ee/src/prebuilds/bitbucket-app.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-app.ts
@@ -7,10 +7,9 @@
 import * as express from 'express';
 import { postConstruct, injectable, inject } from 'inversify';
 import { UserDB } from '@gitpod/gitpod-db/lib';
-import { User } from '@gitpod/gitpod-protocol';
+import { User, StartPrebuildResult } from '@gitpod/gitpod-protocol';
 import { PrebuildManager } from '../prebuilds/prebuild-manager';
 import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
-import { StartPrebuildResult } from './prebuild-manager';
 import { TokenService } from '../../../src/user/token-service';
 
 @injectable()

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -13,11 +13,11 @@ import { Config } from '../../../src/config';
 import { AppInstallationDB, TracedWorkspaceDB, DBWithTracing, UserDB, WorkspaceDB, ProjectDB, TeamDB } from '@gitpod/gitpod-db/lib';
 import * as express from 'express';
 import { log, LogContext } from '@gitpod/gitpod-protocol/lib/util/logging';
-import { WorkspaceConfig, User, Project } from '@gitpod/gitpod-protocol';
+import { WorkspaceConfig, User, Project, StartPrebuildResult } from '@gitpod/gitpod-protocol';
 import { MessageBusIntegration } from '../../../src/workspace/messagebus-integration';
 import { GithubAppRules } from './github-app-rules';
 import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
-import { PrebuildManager, StartPrebuildResult } from './prebuild-manager';
+import { PrebuildManager } from './prebuild-manager';
 import { PrebuildStatusMaintainer } from './prebuilt-status-maintainer';
 import { Options, ApplicationFunctionOptions } from 'probot/lib/types';
 

--- a/components/server/ee/src/prebuilds/gitlab-app.ts
+++ b/components/server/ee/src/prebuilds/gitlab-app.ts
@@ -7,10 +7,9 @@
 import * as express from 'express';
 import { postConstruct, injectable, inject } from 'inversify';
 import { ProjectDB, TeamDB, UserDB } from '@gitpod/gitpod-db/lib';
-import { Project, User } from '@gitpod/gitpod-protocol';
+import { Project, User, StartPrebuildResult } from '@gitpod/gitpod-protocol';
 import { PrebuildManager } from '../prebuilds/prebuild-manager';
 import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
-import { StartPrebuildResult } from './prebuild-manager';
 import { TokenService } from '../../../src/user/token-service';
 import { HostContextProvider } from '../../../src/auth/host-context-provider';
 import { GitlabService } from './gitlab-service';

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -5,7 +5,7 @@
  */
 
 import { DBWithTracing, TracedWorkspaceDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
-import { CommitContext, Project, StartPrebuildContext, User, WorkspaceConfig, WorkspaceInstance } from '@gitpod/gitpod-protocol';
+import { CommitContext, Project, StartPrebuildContext, StartPrebuildResult, User, WorkspaceConfig, WorkspaceInstance } from '@gitpod/gitpod-protocol';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
 import { inject, injectable } from 'inversify';
@@ -30,12 +30,6 @@ export interface StartPrebuildParams {
     commit: string;
     project?: Project;
 }
-export interface StartPrebuildResult {
-    wsid: string;
-    done: boolean;
-    didFinish?: boolean;
-}
-
 
 @injectable()
 export class PrebuildManager {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1508,7 +1508,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
         return repositories;
     }
 
-    async triggerPrebuild(projectId: string, branchName: string): Promise<void> {
+    async triggerPrebuild(projectId: string, branchName: string | null): Promise<void> {
         const user = this.checkAndBlockUser("triggerPrebuild");
 
         const project = await this.projectsService.getProject(projectId);
@@ -1520,7 +1520,9 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
         const span = opentracing.globalTracer().startSpan("triggerPrebuild");
         span.setTag("userId", user.id);
 
-        const branchDetails = await this.projectsService.getBranchDetails(user, project, branchName);
+        const branchDetails = (!!branchName
+            ? await this.projectsService.getBranchDetails(user, project, branchName)
+            : (await this.projectsService.getBranchDetails(user, project)).filter(b => b.isDefault));
         if (branchDetails.length !== 1) {
             log.debug({ userId: user.id }, 'Cannot find branch details.', { project, branchName });
         }
@@ -1533,7 +1535,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
             cloneURL: project.cloneUrl,
             commit: context.revision,
             user,
-            branch: branchName,
+            branch: branchDetails[0].name,
             project
         });
     }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1525,6 +1525,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
             : (await this.projectsService.getBranchDetails(user, project)).filter(b => b.isDefault));
         if (branchDetails.length !== 1) {
             log.debug({ userId: user.id }, 'Cannot find branch details.', { project, branchName });
+            throw new ResponseError(ErrorCodes.NOT_FOUND, `Could not find ${!branchName ? 'a default branch' : `branch '${branchName}'`} in repository ${project.cloneUrl}`);
         }
         const contextURL = branchDetails[0].url;
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -7,7 +7,7 @@
 import { BlobServiceClient } from "@gitpod/content-service/lib/blobs_grpc_pb";
 import { DownloadUrlRequest, DownloadUrlResponse, UploadUrlRequest, UploadUrlResponse } from '@gitpod/content-service/lib/blobs_pb';
 import { AppInstallationDB, UserDB, UserMessageViewsDB, WorkspaceDB, DBWithTracing, TracedWorkspaceDB, DBGitpodToken, DBUser, UserStorageResourcesDB, TeamDB } from '@gitpod/gitpod-db/lib';
-import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, Project, ProviderRepository, TeamMemberRole, WithDefaultConfig, FindPrebuildsParams, PrebuildWithStatus } from '@gitpod/gitpod-protocol';
+import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, Project, ProviderRepository, TeamMemberRole, WithDefaultConfig, FindPrebuildsParams, PrebuildWithStatus, StartPrebuildResult } from '@gitpod/gitpod-protocol';
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { AdminBlockUserRequest, AdminGetListRequest, AdminGetListResult, AdminGetWorkspacesRequest, AdminModifyPermanentWorkspaceFeatureFlagRequest, AdminModifyRoleOrPermissionRequest, WorkspaceAndInstance } from '@gitpod/gitpod-protocol/lib/admin-protocol';
 import { GetLicenseInfoResult, LicenseFeature, LicenseValidationResult } from '@gitpod/gitpod-protocol/lib/license-protocol';
@@ -1544,9 +1544,9 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         return this.projectsService.getProjectOverview(user, project);
     }
 
-    public async triggerPrebuild(projectId: string, branchName: string | null): Promise<void> {
+    public async triggerPrebuild(projectId: string, branchName: string | null): Promise<StartPrebuildResult> {
         this.checkAndBlockUser("triggerPrebuild");
-        // implemented in EE
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Triggering Prebuilds is implemented in Gitpod's Enterprise Edition`);
     }
 
     public async setProjectConfiguration(projectId: string, configString: string): Promise<void> {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1544,7 +1544,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         return this.projectsService.getProjectOverview(user, project);
     }
 
-    public async triggerPrebuild(projectId: string, branch: string): Promise<void> {
+    public async triggerPrebuild(projectId: string, branchName: string | null): Promise<void> {
         this.checkAndBlockUser("triggerPrebuild");
         // implemented in EE
     }


### PR DESCRIPTION
Aligns the Prebuild & Project Configurator pages with the specs to fix https://github.com/gitpod-io/gitpod/issues/4423

TODO:

- [x] Show detailed Prebuild status and runtime below the logs in the Prebuild and Configurator pages
- [x] Refactor `server.triggerPrebuild` to make `branchName` optional (picks the default branch and makes e.g. the Prebuilds page load faster) and return information about the triggered Prebuild (so that we can get the logs after triggering in the Configurator)
- [x] Refactor the Configurator to use `server.triggerPrebuild` instead of the "manual" prebuild prefix (thus keeping the prebuild/project association)
- [x] Enable `Run Prebuild` button for Git-based configurations in the Configurator
- [x] Fix the `Run Prebuild` and `New Workspace` buttons for the Prebuild & Configurator pages, fixes #5392 and fixes #5501

Drive-by fixes:

- [x] Rename `Detecting project type ...` loading screen to `Detecting project configuration ...` to be more truthful
- [x] Add more discoverable 'change' link when adding projects from GitLab/GitHub

/uncc