### PR TITLE
[ws-manger] Add dependency on dependsOn key for ws-manager

### DIFF
--- a/chart/templates/ws-manager-deployment.yaml
+++ b/chart/templates/ws-manager-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         kind: pod
         stage: {{ .Values.installation.stage }}
       annotations:
+{{ include "gitpod.pod.dependsOn" $this | indent 8 }}
         checksum/tlskey: {{ include (print $.Template.BasePath "/ws-daemon-tlssecret.yaml") $ | sha256sum }}
     spec:
       priorityClassName: system-node-critical


### PR DESCRIPTION
The ws-manger pods should restart if there is a corresponding change in the ws-manager config map. The dependency on the CM was already added but the section to include it in the ws-manger pod spec was missing.