### PR TITLE
[ws-manager-api] Remove hardcoded grpc call deadline

### DIFF
--- a/components/ws-manager-api/typescript/src/promisified-client.ts
+++ b/components/ws-manager-api/typescript/src/promisified-client.ts
@@ -219,11 +219,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
     }
 
     protected getDefaultUnaryOptions(): Partial<grpc.CallOptions> {
-        /* the node grpc client does not support dial timeouts, hence we need to time out the operation as a whole.
-         */
-        let deadline = new Date(new Date().getTime() + 10000);
         return {
-            deadline
         }
     }
 


### PR DESCRIPTION
Remove deadline now that we have reconnections and keepalive settings enabled

fixes https://github.com/gitpod-io/gitpod/issues/5414