### PR TITLE
[code] Add open dashboard menu option to home menu

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -393,7 +393,7 @@ components:
       imageName: "ide/theia"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-f723f543352e43a884239c93bdd441fdf1dd4788"
+      stableVersion: "commit-59f277ba0a7795afe2cc4ca4509c718cd4013f29"
     supervisor:
       imageName: "supervisor"
     dockerUp:

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 6d71890eae337a06260fb41896b443e290af751e
+ENV GP_CODE_COMMIT b667bcb6376c418cc5782072b134a49290b83495
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
**What it does**
fixes #4195

Changes in Gitpod Code: https://github.com/gitpod-io/vscode/commit/b667bcb6376c418cc5782072b134a49290b83495

**How to test**
- Start a workspace: https://jp-add-open-dashboard-home-4195.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-typescript-node
- Open Home menu and observe that `Gitpod: Open Dashboard` is present, click on it and it should open the dashboard