### PR TITLE
[server / inferrer] prefetch configuration files

### DIFF
--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -201,7 +201,7 @@ export class ProjectsService {
             cache[path] = content;
             return await content;
         }
-        // eagerly fetch for all files that the inferrer usualyl asks for.
+        // eagerly fetch for all files that the inferrer usually asks for.
         this.requestedPaths.forEach(path => !(path in cache) && readFile(path));
         const config: WorkspaceConfig = await new ConfigInferrer().getConfig({
             config: {},

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -186,19 +186,23 @@ export class ProjectsService {
         return configString;
     }
 
+    // a static cache used to prefetch inferrer related files in parallel in advance
+    private requestedPaths = new Set<string>();
+
     async guessProjectConfiguration(ctx: TraceContext, user: User, projectId: string): Promise<string | undefined> {
         const { fileProvider, commitContext } = await this.getRepositoryFileProviderAndCommitContext(ctx, user, projectId);
-        const cache: { [path: string]: string } = {};
+        const cache: { [path: string]: Promise<string | undefined> } = {};
         const readFile = async (path: string) => {
             if (path in cache) {
-                return cache[path];
+                return await cache[path];
             }
-            const content = await fileProvider.getFileContent(commitContext, user, path);
-            if (content) {
-                cache[path] = content;
-            }
-            return content;
+            this.requestedPaths.add(path);
+            const content = fileProvider.getFileContent(commitContext, user, path);
+            cache[path] = content;
+            return await content;
         }
+        // eagerly fetch for all files that the inferrer usualyl asks for.
+        this.requestedPaths.forEach(path => !(path in cache) && readFile(path));
         const config: WorkspaceConfig = await new ConfigInferrer().getConfig({
             config: {},
             read: readFile,


### PR DESCRIPTION
Prefetch configuration files in parallel and in advanced based on a static cache.

Context: The inferred logic is based on a conditional tree, that asks about configuration files sequentially one by one. Requesting all those files in parallel should speed up the process.

fixes #5527 