### PR TITLE
[server] Fix admin stop workspace

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -644,7 +644,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
         const span = opentracing.globalTracer().startSpan("adminForceStopWorkspace");
         const workspace = await this.workspaceDb.trace({ span }).findById(id);
         if (workspace) {
-            await this.internalStopWorkspace({ span }, workspace, StopWorkspacePolicy.IMMEDIATELY);
+            await this.internalStopWorkspace({ span }, workspace, StopWorkspacePolicy.IMMEDIATELY, true);
         }
     }
 

--- a/test/pkg/integration/user.go
+++ b/test/pkg/integration/user.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package integration
+
+import (
+	"github.com/google/uuid"
+)
+
+func CreateUser(it *Test, username string, admin bool) (userId string, err error) {
+	userUUID, err := uuid.NewRandom()
+	if err != nil {
+		return
+	}
+	userId = userUUID.String()
+
+	rolesOrPermissions := "[]"
+	if admin {
+		rolesOrPermissions = `["admin"]`
+	}
+
+	db := it.API().DB()
+	_, err = db.Exec("INSERT INTO d_b_user (id, creationDate, name, rolesOrPermissions) VALUES (?, NOW(), ?, ?)",
+		userId,
+		username,
+		rolesOrPermissions,
+	)
+	return
+}
+
+func DeleteUser(it *Test, userId string) (err error) {
+	db := it.API().DB()
+	_, err = db.Exec("DELETE FROM d_b_user WHERE id = ?", userId)
+	return
+}
+
+func IsUserBlocked(it *Test, userId string) (blocked bool, err error) {
+	db := it.API().DB()
+	rows, err := db.Query("SELECT blocked FROM d_b_user WHERE id = ?", userId)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		it.t.Fatal("no rows selected - should not happen")
+	}
+
+	err = rows.Scan(&blocked)
+	return
+}

--- a/test/tests/admin/blockuser_test.go
+++ b/test/tests/admin/blockuser_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package admin
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+)
+
+func TestAdminBlockUser(t *testing.T) {
+	it, ctx := integration.NewTest(t, 5*time.Minute)
+	defer it.Done()
+
+	rand.Seed(time.Now().UnixNano())
+	randN := rand.Intn(1000)
+
+	adminUsername := fmt.Sprintf("admin%d", randN)
+	adminUserId, err := integration.CreateUser(it, adminUsername, true)
+	if err != nil {
+		t.Fatalf("cannot create user: %q", err)
+	}
+	defer func() {
+		err := integration.DeleteUser(it, adminUserId)
+		if err != nil {
+			t.Fatalf("error deleting user %q", err)
+		}
+	}()
+	t.Logf("user '%s' with ID %s created", adminUsername, adminUserId)
+
+	username := fmt.Sprintf("johndoe%d", randN)
+	userId, err := integration.CreateUser(it, username, false)
+	if err != nil {
+		t.Fatalf("cannot create user: %q", err)
+	}
+	defer func() {
+		err := integration.DeleteUser(it, userId)
+		if err != nil {
+			t.Fatalf("error deleting user %q", err)
+		}
+	}()
+	t.Logf("user '%s' with ID %s created", username, userId)
+
+	serverOpts := []integration.GitpodServerOpt{integration.WithGitpodUser(adminUsername)}
+	server := it.API().GitpodServer(serverOpts...)
+	err = server.AdminBlockUser(ctx, &protocol.AdminBlockUserRequest{UserID: userId, IsBlocked: true})
+	if err != nil {
+		t.Fatalf("cannot perform AdminBlockUser: %q", err)
+	}
+
+	blocked, err := integration.IsUserBlocked(it, userId)
+	if err != nil {
+		t.Fatalf("error checking if user is blocked: %q", err)
+	}
+
+	if !blocked {
+		t.Fatalf("expected user '%s' with ID %s is blocked, but is not", username, userId)
+	}
+}


### PR DESCRIPTION
This PR fixes the admin stop workspace feature and adds a simple integration test for blocking users. Checking if stopping of workspaces works as well [is currently not possible](https://gitpod.slack.com/archives/C01KGM9AW4W/p1630920777145600) with an integration test. However, this change at least brings the first step for such a test.

Fixes #5377

## How to test
- Login with a second user (e.g. in incognito mode of your browser)
- Start a workspace with the second user
- Go to the admin portal with the first user and stop this workspace
- Start again a workspace for the second user
- Go to the admin portal with the first user and block the second user
- All workspaces of the second user should stop immediately
