### PR TITLE
patch dropbear to produce proper env vars

### DIFF
--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -143,7 +143,7 @@ func (rc *ReconnectingWebsocket) ReadObject(v interface{}) error {
 }
 
 // Dial creates a new client connection.
-func (rc *ReconnectingWebsocket) Dial(ctx context.Context) {
+func (rc *ReconnectingWebsocket) Dial(ctx context.Context) error {
 	var conn *WebsocketConnection
 	defer func() {
 		if conn == nil {
@@ -158,7 +158,7 @@ func (rc *ReconnectingWebsocket) Dial(ctx context.Context) {
 	for {
 		select {
 		case <-rc.closedCh:
-			return
+			return rc.closeErr
 		case connCh := <-rc.connCh:
 			connCh <- conn
 		case <-rc.errCh:

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -41,7 +41,7 @@ packages:
       commands:
         - ["curl", "-OL", "https://matt.ucc.asn.au/dropbear/dropbear-2020.81.tar.bz2"]
         - ["tar", "xjf", "dropbear-2020.81.tar.bz2"]
-        - ["sh", "-c", "cd dropbear-2020.81; ./configure --enable-static&& sed -i '/clearenv();/d' svr-chansession.c && make"]
+        - ["sh", "-c", "cd dropbear-2020.81; ./configure --enable-static && sed -i '/clearenv();/d' svr-chansession.c && sed -i '/addnewvar(\"PATH\", DEFAULT_PATH);/d' svr-chansession.c && make"]
         - ["mv", "dropbear-2020.81/dropbear", "dropbear"]
         - ["mv", "dropbear-2020.81/dropbearkey", "dropbearkey"]
         - ["rm", "-rf", "dropbear-2020.81*"]

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -944,8 +944,10 @@ func startSSHServer(ctx context.Context, cfg *Config, wg *sync.WaitGroup) {
 		log.WithError(err).WithField("out", string(out)).Error("cannot create hostkey file")
 		return
 	}
+	_ = os.Chown(hostkeyFN.Name(), gitpodUID, gitpodGID)
 
 	cmd := exec.Command(dropbear, "-F", "-E", "-w", "-s", "-p", fmt.Sprintf(":%d", cfg.SSHPort), "-r", hostkeyFN.Name())
+	cmd = runAsGitpodUser(cmd)
 	cmd.Env = buildChildProcEnv(cfg, nil)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

#### What it does 

fix #5348: It patches dropbear to avoid resetting inherited PATH env variable.

#### How to test

- Switch to latest VS Code: https://dropbear-as-gitpod-user.staging.gitpod-dev.com/preferences
##### Testing user terminals
- Start a workspace in gitpod-io/vscode: https://dropbear-as-gitpod-user.staging.gitpod-dev.com/#github.com/gitpod-io/vscode
- Open in VS Code Desktop: `File` -> `Open in VS Code`
- Create a new terminal in VS Code Desktop SSH session and check that you can run `yarn` in it.
##### Testing VS Code extensions
- Start a workspace in gitpod-io/gitpod: https://dropbear-as-gitpod-user.staging.gitpod-dev.com/#github.com/gitpod-io/gitpod
- Open in VS Code Desktop: `File` -> `Open in VS Code`
- Open some go file and check that language smartness is available
##### Testing recovery on failed server conneciton
- Do previous steps and don't stop the gitpod local companion in the activity manager!
- Add `/werft run` comment to this PR to recreate envs.
- Try to test again. You should be able to open VS Code Desktop and go via the authorization again.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```