### PR TITLE
[changelog] added PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+<!-- Describe your changes in detail -->
+
+## Related Issue(s)
+<!-- List the issue(s) this PR solves -->
+Fixes #
+
+## How to test
+<!-- Provide steps to test this PR -->
+
+## Release Notes
+<!--
+  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
+  Each line becomes a separate entry.
+  Format: [!<optional for breaking>] <description>
+  Example: !basic auth is no longer supported
+-->
+```release-note
+```


### PR DESCRIPTION
## Description
Adds a pull request template to the repo

## Related Issue(s)
First step of #4919

## How to test
Create a PR and note you're getting a template

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Creators of PRs now get a template with a _release-note_ section
```
