### PR TITLE
[ws-manager] Log event trace log as INFO

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -458,7 +458,7 @@ func (m *Monitor) writeEventTraceLog(status *api.WorkspaceStatus, wso *workspace
 
 	if m.manager.Config.EventTraceLog == "-" {
 		//nolint:errcheck
-		log.WithField("evt", entry).Debug("event trace log")
+		log.WithField("evt", entry).Info("event trace log")
 		return
 	}
 


### PR DESCRIPTION
## Description
With upcoming changes in the default log level we want to ensure we retain the event trace log.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5549

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```
