### PR TITLE
[t&p] add workspaces to teams

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -265,6 +265,9 @@ function App() {
                         if (resourceOrPrebuild === "configure") {
                             return <ConfigureProject />;
                         }
+                        if (resourceOrPrebuild === "workspaces") {
+                            return <Workspaces />;
+                        }
                         if (resourceOrPrebuild === "prebuilds") {
                             return <Prebuilds />;
                         }
@@ -276,20 +279,27 @@ function App() {
                     <Route exact path="/teams/new" component={NewTeam} />
                     <Route exact path="/teams/join" component={JoinTeam} />
                 </Route>
-                {(teams || []).map(team => <Route key={`route-for-team-${team.slug}`} path={`/t/${team.slug}`}>
+                {(teams || []).map(team =>
+                <Route path={`/t/${team.slug}`} key={team.slug}>
                     <Route exact path={`/t/${team.slug}`}>
-                        <Redirect to={`/t/${team.slug}/projects`} />
+                        <Redirect to={`/t/${team.slug}/workspaces`} />
                     </Route>
                     <Route exact path={`/t/${team.slug}/:maybeProject/:resourceOrPrebuild?`} render={(props) => {
                         const { maybeProject, resourceOrPrebuild } = props.match.params;
                         if (maybeProject === "projects") {
                             return <Projects />;
                         }
+                        if (maybeProject === "workspaces") {
+                            return <Workspaces />;
+                        }
                         if (maybeProject === "members") {
                             return <Members />;
                         }
                         if (resourceOrPrebuild === "configure") {
                             return <ConfigureProject />;
+                        }
+                        if (resourceOrPrebuild === "workspaces") {
+                            return <Workspaces />;
                         }
                         if (resourceOrPrebuild === "prebuilds") {
                             return <Prebuilds />;

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -43,7 +43,7 @@ export default function Menu() {
     })();
     const prebuildId = (() => {
         const resource = projectName && match?.params?.segment3;
-        if (resource !== "prebuilds" && resource !== "settings" && resource !== "configure") {
+        if (resource !== "workspaces" && resource !== "prebuilds" && resource !== "settings" && resource !== "configure") {
             return resource;
         }
     })();
@@ -94,6 +94,10 @@ export default function Menu() {
                     link: `${teamOrUserSlug}/${projectName}`
                 },
                 {
+                    title: 'Workspaces',
+                    link: `${teamOrUserSlug}/${projectName}/workspaces`
+                },
+                {
                     title: 'Prebuilds',
                     link: `${teamOrUserSlug}/${projectName}/prebuilds`
                 },
@@ -109,7 +113,11 @@ export default function Menu() {
                 {
                     title: 'Projects',
                     link: `/t/${team.slug}/projects`,
-                    alternatives: [`/${team.slug}`]
+                },
+                {
+                    title: 'Workspaces',
+                    link: `/t/${team.slug}/workspaces`,
+                    alternatives: [`/t/${team.slug}`]
                 },
                 {
                     title: 'Members',

--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -20,7 +20,7 @@ export default function Header(p: HeaderProps) {
         document.title = `${p.title} — Gitpod`;
     }, []);
     return <div className="lg:px-28 px-10 border-gray-200 dark:border-gray-800">
-        <div className="flex pb-8 pt-6">
+        <div className="flex py-10">
             <div className="">
                 {typeof p.title === "string" ? (<h1 className="tracking-tight">{p.title}</h1>) : p.title}
                 {typeof p.subtitle === "string" ? (<h2 className="tracking-wide">{p.subtitle}</h2>) : p.subtitle}

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -59,7 +59,7 @@
     }
 
     a.gp-link {
-        @apply underline underline-thickness-thin underline-offset-small text-gray-400 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-500;
+        @apply text-blue-500 hover:text-blue-600  dark:text-blue-400 dark:hover:text-blue-500;
     }
 
     input[type=text], input[type=search], input[type=password], select {

--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -43,7 +43,7 @@ export function StartWorkspaceModal(p: StartWorkspaceModalProps) {
         <div className="border-t border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 pt-2">
             <div className="flex">
                 <TabMenuItem name='Recent' selected={selection === 'Recent'} onClick={() => setSelection('Recent')} />
-                <TabMenuItem name='Examples' selected={selection === 'Examples'} onClick={() => setSelection('Examples')} />
+                {p.examples.length>0 && <TabMenuItem name='Examples' selected={selection === 'Examples'} onClick={() => setSelection('Examples')} />}
             </div>
         </div>
         <div className="border-t border-gray-200 dark:border-gray-800 -mx-6 px-6 py-2">

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -4,16 +4,19 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import React from "react";
-import { WhitelistedRepository, Workspace, WorkspaceInfo } from "@gitpod/gitpod-protocol";
+import { useContext, useEffect, useState } from "react";
+import { Project, WhitelistedRepository, Workspace, WorkspaceInfo } from "@gitpod/gitpod-protocol";
 import Header from "../components/Header";
 import DropDown from "../components/DropDown";
-import exclamation from "../images/exclamation.svg";
 import { WorkspaceModel } from "./workspace-model";
 import { WorkspaceEntry } from "./WorkspaceEntry";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
-import {StartWorkspaceModal, WsStartEntry} from "./StartWorkspaceModal";
-import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon, ItemsList } from "../components/ItemsList";
+import { StartWorkspaceModal, WsStartEntry } from "./StartWorkspaceModal";
+import { Item, ItemField, ItemsList } from "../components/ItemsList";
+import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
+import { useLocation, useRouteMatch } from "react-router";
+import { toRemoteURL } from "../projects/render-utils";
+import { useHistory } from "react-router-dom";
 
 export interface WorkspacesProps {
 }
@@ -24,144 +27,75 @@ export interface WorkspacesState {
     repos: WhitelistedRepository[];
 }
 
-export default class Workspaces extends React.Component<WorkspacesProps, WorkspacesState> {
+export default function () {
+    const location = useLocation();
+    const history = useHistory();
 
-    protected workspaceModel: WorkspaceModel | undefined;
+    const { teams } = useContext(TeamsContext);
+    const team = getCurrentTeam(location, teams);
+    const match = useRouteMatch<{ team: string, resource: string }>("/(t/)?:team/:resource");
+    const projectName = match?.params?.resource !== 'workspaces' ? match?.params?.resource : undefined;
+    const [projects, setProjects] = useState<Project[]>([]);
+    const [activeWorkspaces, setActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
+    const [inactiveWorkspaces, setInactiveWorkspaces] = useState<WorkspaceInfo[]>([]);
+    const [repos, setRepos] = useState<WhitelistedRepository[]>([]);
+    const [isTemplateModelOpen, setIsTemplateModelOpen] = useState<boolean>(false);
+    const [workspaceModel, setWorkspaceModel] = useState<WorkspaceModel>();
 
-    constructor(props: WorkspacesProps) {
-        super(props);
-        this.state = {
-            workspaces: [],
-            isTemplateModelOpen: false,
-            repos: [],
-        };
+    const newProjectUrl = !!team ? `/new?team=${team.slug}` : '/new';
+    const onNewProject = () => {
+        history.push(newProjectUrl);
     }
 
-    async componentDidMount() {
-        this.workspaceModel = new WorkspaceModel(this.setWorkspaces);
-        const repos = await getGitpodService().server.getFeaturedRepositories();
-        this.setState({
-            repos
-        });
-    }
+    useEffect(() => {
+        // only show example repos on the global user context
+        if (!team && !projectName) {
+            getGitpodService().server.getFeaturedRepositories().then(setRepos);
+        }
+        (async () => {
+            const projects = (!!team
+                ? await getGitpodService().server.getTeamProjects(team.id)
+                : await getGitpodService().server.getUserProjects());
 
-    protected setWorkspaces = (workspaces: WorkspaceInfo[]) => {
-        this.setState({
-            workspaces
-        });
-    }
-
-    protected showStartWSModal = () => this.setState({
-        isTemplateModelOpen: true
-    });
-
-    protected hideStartWSModal = () => this.setState({
-        isTemplateModelOpen: false
-    });
-
-    render() {
-        const wsModel = this.workspaceModel;
-        const onActive = () => wsModel!.active = true;
-        const onAll = () => wsModel!.active = false;
-        return <>
-            <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
-
-            <div className="lg:px-28 px-10 pt-8 flex">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"/></svg>
-                    </div>
-                    <input type="search" placeholder="Search Workspaces" onChange={(v) => { if (wsModel) wsModel.setSearch(v.target.value) }} />
-                </div>
-                <div className="flex-1" />
-                <div className="py-3">
-                    <DropDown prefix="Filter: " contextMenuWidth="w-32" activeEntry={wsModel?.active ? 'Active' : 'All'} entries={[{
-                        title: 'Active',
-                        onClick: onActive
-                    }, {
-                        title: 'All',
-                        onClick: onAll
-                    }]} />
-                </div>
-                <div className="py-3 pl-3">
-                    <DropDown prefix="Limit: " contextMenuWidth="w-32" activeEntry={wsModel ? wsModel?.limit+'' : undefined} entries={[{
-                        title: '50',
-                        onClick: () => { if (wsModel) wsModel.limit = 50; }
-                    }, {
-                        title: '100',
-                        onClick: () => { if (wsModel) wsModel.limit = 100; }
-                    }, {
-                        title: '200',
-                        onClick: () => { if (wsModel) wsModel.limit = 200; }
-                    }]} />
-                </div>
-                {wsModel && this.state?.workspaces.length > 0 ?
-                 <button onClick={this.showStartWSModal} className="ml-2">New Workspace</button>
-                 : null
+            let project: Project | undefined = undefined;
+            if (projectName) {
+                project = projects.find(p => p.name === projectName);
+                if (project) {
+                    setProjects([project]);
                 }
-            </div>
-            {wsModel && (
-                this.state?.workspaces.length > 0 || wsModel.searchTerm ?
-                    <ItemsList className="lg:px-28 px-10">
-                        <Item header={true} className="px-6">
-                            <ItemFieldIcon />
-                            <ItemField className="w-3/12">Name</ItemField>
-                            <ItemField className="w-4/12">Context</ItemField>
-                            <ItemField className="w-2/12">Pending Changes</ItemField>
-                            <ItemField className="w-2/12">Last Start</ItemField>
-                            <ItemFieldContextMenu />
-                        </Item>
-                        {
-                            wsModel.active || wsModel.searchTerm ? null :
-                                <Item className="w-full bg-gitpod-kumquat-light py-6 px-6">
-                                    <ItemFieldIcon>
-                                        <img src={exclamation} alt="Exclamation Mark" className="m-auto" />
-                                    </ItemFieldIcon>
-                                    <ItemField className=" flex flex-col">
-                                        <div className="text-gitpod-red font-semibold">Garbage Collection</div>
-                                        <p className="text-gray-500">Unpinned workspaces that have been stopped for more than 14 days will be automatically deleted. <a className="gp-link" href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection">Learn more</a></p>
-                                    </ItemField>
-                                </Item>
-                        }
-                        {
-                            this.state?.workspaces.map(e => {
-                                return <WorkspaceEntry key={e.workspace.id} desc={e} model={wsModel} stopWorkspace={wsId => getGitpodService().server.stopWorkspace(wsId)}/>
-                            })
-                        }
-                    </ItemsList>
-                    :
-                    <div className="lg:px-28 px-10 flex flex-col space-y-2">
-                        <div className="px-6 py-3 flex justify-between space-x-2 text-gray-400 border-t border-gray-200 dark:border-gray-800 h-96">
-                            <div className="flex flex-col items-center w-96 m-auto">
-                                <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Active Workspaces</h3>
-                                <div className="text-center pb-6 text-gray-500">Prefix any git repository URL with gitpod.io/# or create a new workspace for a recently used project. <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">Learn more</a></div>
-                                <span>
-                                    <button onClick={this.showStartWSModal}>New Workspace</button>
-                                    {wsModel.getAllFetchedWorkspaces().size > 0 ? <button className="secondary ml-2" onClick={onAll}>View All Workspaces</button>:null}
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-            )}
-            <StartWorkspaceModal
-                onClose={this.hideStartWSModal}
-                visible={!!this.state?.isTemplateModelOpen}
-                examples={this.state?.repos && this.state.repos.map(r => ({
-                    title: r.name,
-                    description: r.description || r.url,
-                    startUrl:  gitpodHostUrl.withContext(r.url).toString()
-                }))}
-                recent={wsModel && this.state?.workspaces ?
-                    this.getRecentSuggestions()
-                : []} />
-        </>;
-    }
+            } else {
+                setProjects(projects);
+            }
+            let workspaceModel;
+            if (!!project) {
+                workspaceModel = new WorkspaceModel(setActiveWorkspaces, setInactiveWorkspaces, Promise.resolve([project.id]), false);
+            } else if (!!team) {
+                workspaceModel = new WorkspaceModel(setActiveWorkspaces, setInactiveWorkspaces, getGitpodService().server.getTeamProjects(team?.id).then(projects => projects.map(p => p.id)), false);
+            } else {
+                workspaceModel = new WorkspaceModel(setActiveWorkspaces, setInactiveWorkspaces, getGitpodService().server.getUserProjects().then(projects => projects.map(p => p.id)), true);
+            }
+            setWorkspaceModel(workspaceModel);
+        })();
+    }, [teams, location]);
 
-    protected getRecentSuggestions(): WsStartEntry[] {
-        if (this.workspaceModel) {
-            const all = this.workspaceModel.getAllFetchedWorkspaces();
+    const showStartWSModal = () => setIsTemplateModelOpen(true);
+    const hideStartWSModal = () => setIsTemplateModelOpen(false);
+
+    const getRecentSuggestions: () => WsStartEntry[] = () => {
+        if (projectName || team) {
+            return projects.map(p => {
+                const remoteUrl = toRemoteURL(p.cloneUrl);
+                return {
+                    title: (team ? team.name + '/' : '') + p.name,
+                    description: remoteUrl,
+                    startUrl: gitpodHostUrl.withContext(remoteUrl).toString()
+                };
+            });
+        }
+        if (workspaceModel) {
+            const all = workspaceModel.getAllFetchedWorkspaces();
             if (all && all.size > 0) {
-                const index = new Map<string, WsStartEntry & {lastUse: string}>();
+                const index = new Map<string, WsStartEntry & { lastUse: string }>();
                 for (const ws of Array.from(all.values())) {
                     const repoUrl = Workspace.getFullRepositoryUrl(ws.workspace);
                     if (repoUrl) {
@@ -183,10 +117,106 @@ export default class Workspaces extends React.Component<WorkspacesProps, Workspa
                     }
                 }
                 const list = Array.from(index.values());
-                list.sort((a,b) => b.lastUse.localeCompare(a.lastUse));
+                list.sort((a, b) => b.lastUse.localeCompare(a.lastUse));
                 return list;
             }
         }
         return [];
     }
+
+    return <>
+        <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
+
+        {workspaceModel?.initialized && (
+            activeWorkspaces.length > 0 || inactiveWorkspaces.length > 0 || workspaceModel.searchTerm ?
+                <>
+                    <div className="lg:px-28 px-10 py-2 flex">
+                        <div className="flex">
+                            <div className="py-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" /></svg>
+                            </div>
+                            <input type="search" className="text-sm" placeholder="Search Workspaces" onChange={(v) => { if (workspaceModel) workspaceModel.setSearch(v.target.value) }} />
+                        </div>
+                        <div className="flex-1" />
+                        <div className="py-3">
+                        </div>
+                        <div className="py-3 pl-3">
+                            <DropDown prefix="Limit: " contextMenuWidth="w-32" activeEntry={workspaceModel ? workspaceModel?.limit + '' : undefined} entries={[{
+                                title: '50',
+                                onClick: () => { if (workspaceModel) workspaceModel.limit = 50; }
+                            }, {
+                                title: '100',
+                                onClick: () => { if (workspaceModel) workspaceModel.limit = 100; }
+                            }, {
+                                title: '200',
+                                onClick: () => { if (workspaceModel) workspaceModel.limit = 200; }
+                            }]} />
+                        </div>
+                        {
+                            projects.length === 0
+                            ? <button onClick={onNewProject} className="ml-2">New Project</button>
+                            : <button onClick={showStartWSModal} className="ml-2">New Workspace</button>
+                        }
+                    </div>
+                    <ItemsList className="lg:px-28 px-10">
+                        <div className="border-t border-gray-200 dark:border-gray-800"></div>
+                        {
+                            activeWorkspaces.map(e => {
+                                return <WorkspaceEntry key={e.workspace.id} desc={e} model={workspaceModel} stopWorkspace={wsId => getGitpodService().server.stopWorkspace(wsId)} />
+                            })
+                        }
+                        {
+                            activeWorkspaces.length > 0 && <div className="py-6"></div>
+                        }
+                        {
+                            inactiveWorkspaces.length === 0 ? null :
+                                <Item className="w-full bg-gray-50 py-3 px-3 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-800">
+                                    <ItemField className=" flex flex-col">
+                                        <div className="text-gray-400 text-sm text-center">Unpinned workspaces that have been inactive for more than 14 days will be automatically deleted. <a className="gp-link" href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection">Learn more</a></div>
+                                    </ItemField>
+                                </Item>
+                        }
+                        {
+                            inactiveWorkspaces.map(e => {
+                                return <WorkspaceEntry key={e.workspace.id} desc={e} model={workspaceModel} stopWorkspace={wsId => getGitpodService().server.stopWorkspace(wsId)} />
+                            })
+                        }
+                    </ItemsList>
+                </>
+                :
+                <div className="lg:px-28 px-10 flex flex-col space-y-2">
+                    <div className="px-6 py-3 flex justify-between space-x-2 text-gray-400 border-t border-gray-200 dark:border-gray-800 h-96">
+                        <div className="flex flex-col items-center w-96 m-auto">
+                            {!!team && projects.length === 0
+                            ?<>
+                                <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Projects</h3>
+                                <div className="text-center pb-6 text-gray-500">This team doesn't have any projects, yet.</div>
+                                <span>
+                                    <button onClick={onNewProject}>New Project</button>
+                                </span>
+                            </>
+                            :<>
+                                <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Workspaces</h3>
+                                <div className="text-center pb-6 text-gray-500">Prefix any git repository URL with gitpod.io/# or create a new workspace for a recently used project. <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">Learn more</a></div>
+                                <span>
+                                    <button onClick={showStartWSModal}>New Workspace</button>
+                                </span>
+                            </>}
+                        </div>
+                    </div>
+                </div>
+        )}
+        <StartWorkspaceModal
+            onClose={hideStartWSModal}
+            visible={!!isTemplateModelOpen}
+            examples={repos && repos.map(r => ({
+                title: r.name,
+                description: r.description || r.url,
+                startUrl: gitpodHostUrl.withContext(r.url).toString()
+            }))}
+            recent={workspaceModel && activeWorkspaces ?
+                getRecentSuggestions()
+                : []} />
+    </>;
+
 }

--- a/components/gitpod-db/package.json
+++ b/components/gitpod-db/package.json
@@ -8,6 +8,7 @@
     "build:clean": "yarn clean && yarn build",
     "rebuild": "yarn build:clean",
     "build:watch": "watch 'yarn build' .",
+    "test": "leeway build components/gitpod-db:dbtest",
     "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
     "db-test": "r(){ . $(leeway run components/gitpod-db:db-test-env); yarn db-test-run; };r",
     "db-test-run": "mocha --opts mocha.opts '**/*.spec.db.ts' --exclude './node_modules/**'",

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -13,7 +13,8 @@ export type MaybeWorkspaceInstance = WorkspaceInstance | undefined;
 
 export interface FindWorkspacesOptions {
     userId: string
-    projectId?: string
+    projectId?: string | string[]
+    includeWithoutProject?: boolean;
     limit?: number
     searchString?: string
     includeHeadless?: boolean

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -313,7 +313,8 @@ export namespace GitpodServer {
         limit?: number;
         searchString?: string;
         pinnedOnly?: boolean;
-        projectId?: string;
+        projectId?: string | string[];
+        includeWithoutProject?: boolean;
     }
     export interface GetAccountStatementOptions {
         date?: string;


### PR DESCRIPTION
This PR adds a workspaces tab to teams and projects, showing only the relevant workspaces. 
Also under the individual account no workspaces that are created in the context of teams are shown anymore.
This PR also removes active and inactive filter and instead shows both at once. Finally, a few layout things have been aligned based on the design from @gtsiolis.

fixes #4921

# How to test

login, create team(s) and create projects below. Now start workspaces for different projects and also non-project contexts.
Verify that the workspaces are shown properly.

```release-note
NONE
``` 