### PR TITLE
Change default branch label colors for dark theme

### DIFF
--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -160,7 +160,7 @@ export default function () {
                             <div>
                                 <div className="text-base text-gray-900 dark:text-gray-50 font-medium mb-1">
                                     {branchName}
-                                    {branch.isDefault && (<span className="ml-2 self-center rounded-xl py-0.5 px-2 text-sm bg-blue-50 text-blue-400">DEFAULT</span>)}
+                                    {branch.isDefault && (<span className="ml-2 self-center rounded-xl py-0.5 px-2 text-sm bg-blue-50 text-blue-40 dark:bg-blue-500 dark:text-blue-100">DEFAULT</span>)}
                                 </div>
                             </div>
                         </ItemField>


### PR DESCRIPTION
## Description

This will add color support for dark theme for the default branch label, following the label specs used in https://github.com/gitpod-io/gitpod/pull/4607.

| BEFORE | AFTER |
|-|-|
| <img width="714" alt="label-before" src="https://user-images.githubusercontent.com/120486/132256247-ac660033-5dac-4417-9f56-4d925c97b197.png"> | <img width="714" alt="label-after" src="https://user-images.githubusercontent.com/120486/132256257-cab2d293-2e98-4a22-8e20-af0cb1327c24.png"> |

## How to test

1. Enable **Teams & Projects** by going to `/new`.
2. Add a project using GitLab provider since GitHub integration is not ready to use in preview environments.
3. Once you add a project, go to _Branches_ for that project. Make sure there's a default branch with at least one commit.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Change default branch label colors for dark theme
```
