### PR TITLE
Add Gitpod version and score info metrics

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -101,3 +101,14 @@ export function increaseMessagebusTopicReads(topic: string) {
         topic,
     })
 }
+
+const gitpodVersionInfo = new prometheusClient.Gauge({
+    name: 'gitpod_version_info',
+    help: "Gitpod's version",
+    labelNames: ["gitpod_version"],
+    registers: [prometheusClient.register]
+});
+
+export function setGitpodVersion(gitpod_version: string){
+    gitpodVersionInfo.set({gitpod_version}, 1)
+}

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -36,7 +36,7 @@ import { GitpodClient, GitpodServer } from '@gitpod/gitpod-protocol';
 import { BearerAuth, isBearerAuthError } from './auth/bearer-authenticator';
 import { HostContextProvider } from './auth/host-context-provider';
 import { CodeSyncService } from './code-sync/code-sync-service';
-import { increaseHttpRequestCounter, observeHttpRequestDuration } from './prometheus-metrics';
+import { increaseHttpRequestCounter, observeHttpRequestDuration, setGitpodVersion } from './prometheus-metrics';
 import { OAuthController } from './oauth-server/oauth-controller';
 import { HeadlessLogController, HEADLESS_LOGS_PATH_PREFIX, HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from './workspace/headless-log-controller';
 import { NewsletterSubscriptionController } from './user/newsletter-subscription-controller';
@@ -84,6 +84,8 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
         // print config
         log.info("config", { config: JSON.stringify(this.config, undefined, 2) });
 
+        // Set version info metric
+        setGitpodVersion(this.config.version)
         // metrics
         app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
             const startTime = Date.now();


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
When ready, this PR will add two metrics that will be shown in `Gitpod / Overview` dashboard.
1. Gitpod's version, exposed by server.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
Hit the metrics endpoint of server  and look for the metric:
1. `gitpod_version_info`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```
