### PR TITLE
[supervisor] Be more robust against a too aggressive reaper

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -186,7 +186,7 @@ func (c *Client) GitWithOutput(ctx context.Context, subcommand string, args ...s
 
 	res, err := cmd.CombinedOutput()
 	if err != nil {
-		if err.Error() == "wait: no child processes" || err.Error() == "waitid: no child processes" {
+		if strings.Contains(err.Error(), "no child process") {
 			return res, nil
 		}
 

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -281,6 +281,9 @@ func (tm *tasksManager) Run(ctx context.Context, wg *sync.WaitGroup, successChan
 				} else {
 					t.successChan <- taskFailed(state.String())
 				}
+			} else if err != nil && strings.Contains(err.Error(), "no child process") {
+				// our own reaper broke Go's child process handling
+				t.successChan <- taskSuccessful
 			} else {
 				msg := "cannot wait for task"
 				if err != nil {


### PR DESCRIPTION
## Description
The child process reaper in supervisor is too aggressive at times, especially during shutdown. This occasionally breaks headless workspaces, e.g. image builds. This PR makes the error reporting a bit more informative and does not report `waitid` failures for headless tasks.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
/approve no-issue

## How to test
```bash
cd test
go test -v -run TestBaseImageBuild ./... -count 1
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```
