### PR TITLE
[supervisor] reduce noise when terminating child processes

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1078,7 +1078,7 @@ func terminateProcess(pid int, privileged bool) {
 	}
 
 	if err != nil {
-		log.WithError(err).WithField("pid", pid).Warn("cannot terminate child process")
+		log.WithError(err).WithField("pid", pid).Debug("child process is already terminated")
 		return
 	}
 


### PR DESCRIPTION
## Description
Supervisor shouldn't warn when unable to kill child processes. They are already terminated then. 

## Related Issue(s)
Fixes #5562

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```
