### PR TITLE
[server] Redirect without hitting sorry endpoint.

### DIFF
--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -356,11 +356,11 @@ export class GenericAuthProvider implements AuthProvider {
                 message = 'OAuth Error. Please try again.'; // this is a 5xx response from authorization service
             }
 
-            if (!UnconfirmedUserException.is(err)) {
-                // user did not accept ToS. Don't count this towards the error burn rate.
-                increaseLoginCounter("failed", this.host);
+            if (UnconfirmedUserException.is(err)) {
+                return this.sendCompletionRedirectWithError(response, { error: err.message });
             }
 
+            increaseLoginCounter("failed", this.host);
             log.error(context, `(${strategyName}) Redirect to /sorry from verify callback`, err, { ...defaultLogPayload, err });
             response.redirect(this.getSorryUrl(message));
             return;


### PR DESCRIPTION
Fixes #5183

## Description
When an unauthorized GitLab user logs into Gitpod, we used to handle that by redirecting to /sorry. However, GitLab doesn't clearly show this to the user, and the user doesn't know that they have an incomplete auth process. 
Now we redirect to the frontend and show the error message, so that the user will know that they should complete the auth process on GitLab.

<img width="571" alt="Screenshot 2021-09-07 at 10 41 24" src="https://user-images.githubusercontent.com/8015191/132315786-e921e6c2-26e5-4f29-88da-eee577011a23.png">

## Related Issue(s)
Fixes #5183

## How to test
Same as how @AlexTugarev described the reproduction steps [here](https://github.com/gitpod-io/gitpod/issues/5183#issuecomment-910213892):

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```
GitLab users who have not completed the auth process on GitLab will be notified with an error message. ([#5568](https://github.com/gitpod-io/gitpod/pull/5568))
```
