### PR TITLE
[server, dashboard] Fix (offline) headless log access for non-owners

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1201,7 +1201,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
             throw new ResponseError(ErrorCodes.NOT_FOUND, `Workspace instance for ${instanceId} not found`);
         }
 
-        const urls = await this.headlessLogService.getHeadlessLogURLs(user.id, wsi);
+        const urls = await this.headlessLogService.getHeadlessLogURLs(user.id, wsi, ws.ownerId);
         if (!urls || (typeof urls.streams === "object" && Object.keys(urls.streams).length === 0)) {
             throw new ResponseError(ErrorCodes.NOT_FOUND, `Headless logs for ${instanceId} not found`);
         }

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -127,7 +127,7 @@ export class HeadlessLogController {
 
             try {
                 const taskId = params.taskId;
-                const downloadUrl = await this.headlessLogService.getHeadlessLogDownloadUrl(user.id, instance, taskId);
+                const downloadUrl = await this.headlessLogService.getHeadlessLogDownloadUrl(user.id, instance, workspace.ownerId, taskId);
                 res.send(downloadUrl);  // cmp. headless_log_download.go
             } catch (err) {
                 log.error(logCtx, "error retrieving headless log download URL", err);

--- a/components/server/src/workspace/headless-log-service.ts
+++ b/components/server/src/workspace/headless-log-service.ts
@@ -32,7 +32,7 @@ export class HeadlessLogService {
     @inject(Config) protected readonly config: Config;
     @inject(HeadlessLogServiceClient) protected readonly headlessLogClient: HeadlessLogServiceClient;
 
-    public async getHeadlessLogURLs(userId: string, wsi: WorkspaceInstance, maxTimeoutSecs: number = 30): Promise<HeadlessLogUrls | undefined> {
+    public async getHeadlessLogURLs(userId: string, wsi: WorkspaceInstance, ownerId: string, maxTimeoutSecs: number = 30): Promise<HeadlessLogUrls | undefined> {
         if (isSupervisorAvailableSoon(wsi)) {
             const aborted = new Deferred<boolean>();
             setTimeout(() => aborted.resolve(true), maxTimeoutSecs * 1000);
@@ -43,12 +43,12 @@ export class HeadlessLogService {
         }
 
         // we were unable to get a repsonse from supervisor - let's try content service next
-        return await this.contentServiceListLogs(userId, wsi);
+        return await this.contentServiceListLogs(userId, wsi, ownerId);
     }
 
-    protected async contentServiceListLogs(userId: string, wsi: WorkspaceInstance): Promise<HeadlessLogUrls | undefined> {
+    protected async contentServiceListLogs(userId: string, wsi: WorkspaceInstance, ownerId: string): Promise<HeadlessLogUrls | undefined> {
         const req = new ListLogsRequest();
-        req.setOwnerId(userId);
+        req.setOwnerId(ownerId);
         req.setWorkspaceId(wsi.workspaceId);
         req.setInstanceId(wsi.id);
         const response = await new Promise<ListLogsResponse>((resolve, reject) => {
@@ -124,14 +124,15 @@ export class HeadlessLogService {
      *
      * @param userId
      * @param wsi
+     * @param ownerId
      * @param taskId
      * @returns
      */
-    async getHeadlessLogDownloadUrl(userId: string, wsi: WorkspaceInstance, taskId: string): Promise<string | undefined> {
+    async getHeadlessLogDownloadUrl(userId: string, wsi: WorkspaceInstance, ownerId: string, taskId: string): Promise<string | undefined> {
         try {
             return await new Promise<string>((resolve, reject) => {
                 const req = new LogDownloadURLRequest();
-                req.setOwnerId(userId);
+                req.setOwnerId(ownerId);
                 req.setWorkspaceId(wsi.workspaceId);
                 req.setInstanceId(wsi.id);
                 req.setTaskId(taskId);


### PR DESCRIPTION
## Description
This contains two commits:
 - don't spam us with logs requests if something is obviously wrong: https://github.com/gitpod-io/gitpod/commit/54ea45d25c31607d3bbd256fc436ca89c9feca08
 - use proper userId when requesting prebuilds logs which have been triggered by a different user: https://github.com/gitpod-io/gitpod/commit/207bd07c1440f5a0d140e18dfcdf280c10a06142
![image](https://user-images.githubusercontent.com/32448529/132341210-339659aa-233c-429a-9355-dc10a8de6fff.png)


## Related Issue(s)
Fixes #5569.

## How to test
1. create two accounts A and B, in different containers/sessions. Get "T & P" permission in both
1. A: create a new team and project, select a repo with prebuids configured, trigger a prebuild and wait until it finishes
1. A: after the prebuild succeeded, access the logs and see that it works: :heavy_check_mark: 
1. A: invite B into the test team
1. B: access invite link
1. B: find the prebuild and access it's log: :heavy_check_mark: 

## Release Notes
```release-note
NONE
```
