### PR TITLE
feat(plans): upgrade Gitpodders Gitpod plan

### DIFF
--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -26,6 +26,7 @@ export interface AdminServer {
 
     adminGetAccountStatement(userId: string): Promise<AccountStatement>;
     adminSetProfessionalOpenSource(userId: string, shouldGetProfOSS: boolean): Promise<void>;
+    adminIsGitpodder(userId: string): Promise<boolean>;
     adminIsStudent(userId: string): Promise<boolean>;
     adminAddStudentEmailDomain(userId: string, domain: string): Promise<void>;
     adminGrantExtraHours(userId: string, extraHours: number): Promise<void>;

--- a/components/server/ee/src/auth/email-domain-service.spec.ts
+++ b/components/server/ee/src/auth/email-domain-service.spec.ts
@@ -32,6 +32,20 @@ export class EMailDomainServiceSpec {
         expect(await test("asd@hdm-stuttgart.de")).to.be.true;
         expect(await test("as@purdue.edu")).to.be.true;
     }
+
+    @test public async GitpodIoEmailAddress()
+    {
+        const svc = testContainer.get<EMailDomainService>(EMailDomainService);
+        const test = (emailOrDomain: string) => (svc as any).hasGitpodIoSuffix(emailOrDomain);
+
+        expect(await test("")).to.be.false;
+        expect(await test("hdm-stuttgart.de")).to.be.false;
+        expect(await test("asd@hdm-stuttgart.de")).to.be.false;
+
+        expect(await test("gitpod.io")).to.be.true;
+        expect(await test("asd@gitpod.io")).to.be.true;
+
+    }
 }
 
 module.exports = new EMailDomainServiceSpec();

--- a/components/server/ee/src/auth/email-domain-service.ts
+++ b/components/server/ee/src/auth/email-domain-service.ts
@@ -14,6 +14,7 @@ import { BlockedUserFilter } from "../../../src/auth/blocked-user-filter"
 export const EMailDomainService = Symbol('EMailDomainService');
 export interface EMailDomainService extends BlockedUserFilter {
     hasEducationalInstitutionSuffix(email: string): Promise<boolean>;
+    hasGitpodIoSuffix(email: string): Promise<boolean>;
 }
 
 @injectable()
@@ -46,6 +47,12 @@ export class EMailDomainServiceImpl implements EMailDomainService {
     protected async checkSwotJsForEducationalInstitutionSuffix(email: string): Promise<boolean> {
         const swotJs = await this.swotJsPromise;
         return !!swotJs.check(email);
+    }
+
+    protected async hasGitpodIoSuffix(email: string): Promise<boolean>
+    {
+        const { domain } = this.parseMail(email);
+        return domain === "gitpod.io";
     }
 
     protected parseMail(email: string): { user: string, domain: string } {

--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -54,6 +54,28 @@ export class EligibilityService {
     @inject(AccountStatementProvider) protected readonly accountStatementProvider: AccountStatementProvider;
 
     /**
+     * Whether the given user is recognized as a Gitpodder within Gitpod
+     * @param user
+     */
+    async isGitpodder(user: User | string): Promise<boolean> {
+        user = await this.getUser(user);
+
+        // check if any of the user's emails is from a known university
+        for (const identity of user.identities) {
+            if (!identity.primaryEmail) {
+                continue;
+            }
+
+            const emailSuffixMatches = await this.domainService.hasGitpodIoSuffix(identity.primaryEmail);
+            if (emailSuffixMatches) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Whether the given user is recognized as a student within Gitpod
      * @param user
      */

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1442,6 +1442,16 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
         }
     }
 
+    async adminIsGitpodder(userId: string): Promise<boolean> {
+        const user = this.checkAndBlockUser("adminIsGitpodder");
+        if (!this.authorizationService.hasPermission(user, Permission.ADMIN_USERS)) {
+            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, "not allowed");
+        }
+
+        return this.eligibilityService.isGitpodder(userId);
+    }
+
+
     async adminIsStudent(userId: string): Promise<boolean> {
         const user = this.checkAndBlockUser("adminIsStudent");
         if (!this.authorizationService.hasPermission(user, Permission.ADMIN_USERS)) {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -138,6 +138,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
 
         "adminAddStudentEmailDomain":  { group: "default", points: 1 },
         "adminGetAccountStatement":  { group: "default", points: 1 },
+        "adminIsGitpodder":  { group: "default", points: 1 },
         "adminIsStudent":  { group: "default", points: 1 },
         "adminSetProfessionalOpenSource":  { group: "default", points: 1 },
         "adminGrantExtraHours":  { group: "default", points: 1 },


### PR DESCRIPTION
## Description

Gitpod is growing and [this style of request](https://gitpod.slack.com/archives/C020VCB0U5A/p1630945637079700) keeps popping up to upgrade employees plans. In this pull-request I'm exploring a path forward to automatically upgrade employees to the highest plan.

## Design questions

Need input from others:

1. Automatically upgrade Gitpodder accounts to the max tier?
1. Do we need a way to toggle on/off the plan change to enable chargebee testing scenarios?

### Assumptions

1. The only way to get a `gitpod.io` email address is if a user on GitLab/GitHub/BitBucket has completed the email address verification flow on the platform.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```
