### PR TITLE
Enable VS Code Desktop for stable VS Code Web

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -394,7 +394,7 @@ components:
       imageName: "ide/theia"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-59f277ba0a7795afe2cc4ca4509c718cd4013f29"
+      stableVersion: "commit-2f069ca3b646ab8099c05f7efd181004c08e95cb"
     supervisor:
       imageName: "supervisor"
     dockerUp:

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT b667bcb6376c418cc5782072b134a49290b83495
+ENV GP_CODE_COMMIT 26bf7356a65baf730233257f41d77ebbf7e977f3
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \

--- a/components/server/src/oauth-server/oauth-controller.ts
+++ b/components/server/src/oauth-server/oauth-controller.ts
@@ -51,7 +51,7 @@ export class OAuthController {
 
             // Let the local app know they rejected the approval
             const rt = req.query.redirect_uri;
-            if (!rt || !rt.startsWith("http://localhost:")) {
+            if (!rt || !rt.startsWith("http://127.0.0.1:")) {
                 log.error(`/oauth/authorize: invalid returnTo URL: "${rt}"`)
                 res.sendStatus(400);
                 return false;


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

## Description
<!-- Describe your changes in detail -->

- It enables VS Code Desktop in stable VS Code Web.
- It also fixes the issue in the server see https://github.com/gitpod-io/gitpod/pull/5599#issuecomment-915809527
- and adds auth timeout of 30secs to avoid hanging the local app if auth process failed because of server issues or a user simply closing the auth page

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace and use F1 -> Open VS Code: https://ak-stable-code-desktop.staging.gitpod-dev.com/#github.com/akosyakov/parcel-demo
- Check that VS Code Desktop was opened.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
VS Code Desktop support
```
