### PR TITLE
[analytics] Propagate allows onboarding to Segment

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -512,6 +512,7 @@ export class UserController {
                 "name": user.identities[0].authName,
                 "full_name": user.fullName,
                 "created_at": user.creationDate,
+                "unsubscribed_onboarding": !user.additionalData?.emailNotificationSettings?.allowsOnboardingMail,
                 "unsubscribed_changelog": !user.additionalData?.emailNotificationSettings?.allowsChangelogMail,
                 "unsubscribed_devx": !user.additionalData?.emailNotificationSettings?.allowsDevXMail,
                 "blocked": user.blocked


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
the onboarding campaign preference is sent along with the signup analytics call
## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
1. go to the debugger of the untrusted staging source in segment
2. sign up to gitpod with a new user in the preview environment
3. ensure that the signup event is properly forwarded to segment, including the `unsubsribed_onboarding` property

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe