### PR TITLE
[server] Trigger restart on deployment if config changed

### DIFF
--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -72,6 +72,8 @@ spec:
         component: server
         kind: pod
         stage: {{ .Values.installation.stage }}
+      annotations:
+{{ include "gitpod.pod.dependsOn" $this | indent 8 }}
     spec:
       priorityClassName: system-node-critical
 {{ include "gitpod.pod.affinity" $this | indent 6 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -288,7 +288,8 @@ components:
 
   server:
     name: "server"
-    dependsOn: []
+    dependsOn:
+    - "server-configmap.yaml"
     resources:
       cpu: "200m"
     githubApp:


### PR DESCRIPTION
## Description
ATM `server` does not restart because it does no longer depend on `VERSION`, and not yet depends on it's config.

## Related Issue(s)
Fixes #5584

## How to test
1. branch from this branch, wait for the deployment
2. re-trigger the previous build (`werft job run previous`) which changes the `version` (branch.0 -> branch.1) and should trigger a re-start of server

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
NONE
```
