### PR TITLE
[supervisor] Increase sendHeartBeat to 30s plus a random additional wait

### DIFF
--- a/components/supervisor/frontend/src/ide/heart-beat.ts
+++ b/components/supervisor/frontend/src/ide/heart-beat.ts
@@ -30,9 +30,11 @@ export function schedule(instanceId: string): void {
         sendHeartBeat(true);
     }, { once: true });
 
-    let activityInterval = 10000;
+    let activityInterval = 30000;
     intervalHandle = setInterval(() => {
-        if (lastActivity + activityInterval < new Date().getTime()) {
+        // add an additional random value between 5 and 15 seconds
+        const randomInterval = Math.floor(Math.random() * (15000 - 5000 + 1)) + 5000;
+        if (lastActivity + activityInterval + randomInterval < new Date().getTime()) {
             // no activity, no heartbeat
             return;
         }


### PR DESCRIPTION
## Description

The current `sendHeartBeat` value is low

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

![Screenshot from 2021-09-08 09-08-52](https://user-images.githubusercontent.com/161571/132678899-1510f85e-ffd8-4fb2-94df-75c7422f0807.png)
