### PR TITLE
[proxy] Fix CORS for /headless-log-download

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -415,7 +415,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
             flags += ` --set components.server.wsmanSkipSelf=true`
         }
         if (storage === "gcp") {
-            exec("kubectl get secret gcp-sa-cloud-storage-dev-sync-key -n werft -o yaml | yq d - metadata | yq w - metadata.name remote-storage-gcloud | kubectl apply -f -");
+            exec("kubectl get secret gcp-sa-gitpod-dev-deployer -n werft -o yaml | yq d - metadata | yq w - metadata.name remote-storage-gcloud | kubectl apply -f -");
             flags += ` -f ../.werft/values.dev.gcp-storage.yaml`;
         }
 
@@ -443,8 +443,8 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         flags += ` --set components.registryFacade.ports.registry.servicePort=${registryNodePortK3sWs}`;
         flags += ` --set components.wsProxy.loadBalancerIP=${wsProxyIP}`;
         if (storage === "gcp") {
-            // notice below that we are not using the k3s cluster to get the gcp-sa-cloud-storage-dev-sync-key. As it is present in the dev cluster only
-            exec("kubectl get secret gcp-sa-cloud-storage-dev-sync-key -n werft -o yaml | yq d - metadata | yq w - metadata.name remote-storage-gcloud > remote-storage-gcloud.yaml");
+            // notice below that we are not using the k3s cluster to get the gcp-sa-gitpod-dev-deployer. As it is present in the dev cluster only
+            exec("kubectl get secret gcp-sa-gitpod-dev-deployer -n werft -o yaml | yq d - metadata | yq w - metadata.name remote-storage-gcloud > remote-storage-gcloud.yaml");
             // After storing the yaml we apply it to the k3s cluster
             exec(`export KUBECONFIG=${pathToKubeConfig} && kubectl apply -f remote-storage-gcloud.yaml`)
             flags += ` -f ../.werft/values.dev.gcp-storage.yaml`;

--- a/.werft/values.dev.gcp-storage.yaml
+++ b/.werft/values.dev.gcp-storage.yaml
@@ -6,10 +6,8 @@ components:
         enabled: true
         maxLength: 2
       gcloud:
-        credentialsFileUpload: true
-        credentialsFile: /credentials/gitpod-dev-syncd-key.json
-        secretName: remote-storage-gcloud
-        projectId: gitpod-dev
+        credentialsFile: /credentials/service-account.json
+        projectId: gitpod-core-dev
         region: europe-west1
         parallelUpload: 6
     volumes:

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -2,6 +2,7 @@
 	# disable automatic SSL certificate generation
 	auto_https off
 	# disable admin API server
+	# admin localhost:2019
 	admin off
 
 	# set default SNI for old clients
@@ -13,7 +14,7 @@
 	# https://caddyserver.com/docs/caddyfile/directives#directive-order
 	order gitpod.cors_origin            before header
 	order gitpod.workspace_download     before redir
-	order gitpod.headless_log_download  before redir
+	order gitpod.headless_log_download	before rewrite
 	order gitpod.sec_websocket_key      before header
 	order http_cache                    before reverse_proxy
 	order gitpod.body_intercept         before redir
@@ -154,23 +155,21 @@ https://{$GITPOD_DOMAIN} {
 			service http://server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 		}
 
+		# redirect works here because we "navigate" to this URL, which makes the browser handle this as primary request, and not fuff around with CORS at all
 		redir {http.gitpod.workspace_download_url} 303
 	}
 
 	@headless_log_download path /headless-log-download*
 	handle @headless_log_download {
-		import google_storage_headers
-
 		header {
-			# The browser needs to see the correct content type to trigger the download.
+			# Alltough logs are plain text "text/html" works for reliably for streaming
 			content-type "text/html; charset=utf-8"
 		}
 
+		# Perform lookup to server and actual reverse_proxy in one go because caddy's `reverse_proxy` is not powerful enough
 		gitpod.headless_log_download {
 			service http://server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000
 		}
-
-		redir {http.gitpod.headless_log_download_url} 303
 	}
 
 	@backend_wss {

--- a/components/proxy/plugins/headlesslogdownload/headless_log_download.go
+++ b/components/proxy/plugins/headlesslogdownload/headless_log_download.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	headlessLogDownloadModule = "gitpod.headless_log_download"
-	redirectURLVariable       = "http." + headlessLogDownloadModule + "_url"
 )
 
 func init() {
@@ -41,19 +40,19 @@ func (HeadlessLogDownload) CaddyModule() caddy.ModuleInfo {
 
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 func (m HeadlessLogDownload) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
-	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
-
 	query := r.URL.RawQuery
 	if query != "" {
 		query = "?" + query
 	}
 
-	// server has an endpoint on the same path that returns the
-	url := fmt.Sprintf("%v%v%v", m.Service, r.URL.Path, query)
+	// server has an endpoint on the same path that returns the upstream endpoint for the actual download
+	origReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
+	u := fmt.Sprintf("%v%v%v", m.Service, origReq.URL.Path, query)
 	client := http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
-		return fmt.Errorf("Server Error: cannot download headless log")
+		caddy.Log().Sugar().Errorf("cannot resolve headless log URL %v: %w", u, err)
+		return fmt.Errorf("server error: cannot resolve headless log URL")
 	}
 
 	// pass browser headers
@@ -64,12 +63,10 @@ func (m HeadlessLogDownload) ServeHTTP(w http.ResponseWriter, r *http.Request, n
 		}
 	}
 
-	// override content-type
-	req.Header.Set("Content-Type", "*/*")
-
+	// query server and parse response
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Server Error: cannot download headless log")
+		return fmt.Errorf("server error: cannot resolve headless log URL")
 	}
 	defer resp.Body.Close()
 
@@ -77,11 +74,31 @@ func (m HeadlessLogDownload) ServeHTTP(w http.ResponseWriter, r *http.Request, n
 		return fmt.Errorf("Bad Request: /headless-log-download/get returned with code %v", resp.StatusCode)
 	}
 
-	redirectURL, err := io.ReadAll(resp.Body)
+	upstreamURLBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("Server error: cannot obtain headless log redirect URL")
+		return fmt.Errorf("server error: cannot obtain headless log redirect URL")
 	}
-	repl.Set(redirectURLVariable, string(redirectURL))
+	upstreamURL := string(upstreamURLBytes)
+
+	// perform the upstream request here
+	resp, err = http.Get(upstreamURL)
+	if err != nil {
+		caddy.Log().Sugar().Errorf("error starting download of prebuild log for %v: %v", upstreamURL, err)
+		return caddyhttp.Error(http.StatusInternalServerError, fmt.Errorf("unexpected error downloading prebuild log"))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		caddy.Log().Sugar().Errorf("invalid status code downloading prebuild log for %v: %v", upstreamURL, resp.StatusCode)
+		return caddyhttp.Error(http.StatusInternalServerError, fmt.Errorf("unexpected error downloading prebuild log"))
+	}
+
+	brw := newNoBufferResponseWriter(w)
+	_, err = io.Copy(brw, resp.Body)
+	if err != nil {
+		caddy.Log().Sugar().Errorf("error proxying prebuild log download for %v: %v", upstreamURL, err)
+		return caddyhttp.Error(http.StatusInternalServerError, fmt.Errorf("unexpected error downloading prebuild log"))
+	}
 
 	return next.ServeHTTP(w, r)
 }
@@ -130,3 +147,28 @@ var (
 	_ caddyhttp.MiddlewareHandler = (*HeadlessLogDownload)(nil)
 	_ caddyfile.Unmarshaler       = (*HeadlessLogDownload)(nil)
 )
+
+// noBufferWriter ResponseWriter that allow an HTTP handler to flush buffered data to the client.
+type noBufferWriter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+}
+
+func newNoBufferResponseWriter(w http.ResponseWriter) *noBufferWriter {
+	writer := &noBufferWriter{
+		w: w,
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		writer.flusher = flusher
+	}
+	return writer
+}
+
+func (n *noBufferWriter) Write(p []byte) (written int, err error) {
+	written, err = n.w.Write(p)
+	if n.flusher != nil {
+		n.flusher.Flush()
+	}
+
+	return
+}


### PR DESCRIPTION
## Description
Fix the CORS issue around downloading workspace logs that surfaced with "Teams&Projects".

Thx @aledbf for the hint and solution with in-plugin proxy! :slightly_smiling_face: 

## Related Issue(s)
Fixes #5576

## How to test
 1. create an [account](https://gpl-5576-cors-redir.staging.gitpod-dev.com/workspaces), unblock yourself and get role `teams-and-projects`
 1. create a project with working prebuilds (for instance: choose "Gitlab" as provider, choose "gitpod-team" and then "rails")
 1. go to "branches" and hit "..." -> "rerun prebuild"
 1. go to "prebuilds" and wait until the prebuild is "ready"
 1. hit "..." -> "view prebuild" and notice how the log is shown

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

- [x] /werft storage=gcp
