### PR TITLE
[bob] Add debug instructions

### DIFF
--- a/components/image-builder-bob/.vscode/launch.json
+++ b/components/image-builder-bob/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Attach",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"remotePath": "",
+			"port":2345,
+			"host":"127.0.0.1",
+			"showLog": true,
+			"trace": "log",
+			"logOutput": "rpc"
+		}
+	]
+}

--- a/components/image-builder-bob/README.md
+++ b/components/image-builder-bob/README.md
@@ -1,0 +1,38 @@
+## How to try locally
+
+Prerequisite: make sure you have buildkit in the path
+```bash
+cd /tmp
+curl -OL https://github.com/moby/buildkit/releases/download/v0.9.0/buildkit-v0.9.0.linux-amd64.tar.gz
+tar xzfv buildkit-v0.9.0.linux-amd64.tar.gz
+sudo mv bin/* /usr/bin
+```
+
+Set things up
+```bash
+# run a local registry
+docker run --rm -d -p 5000:5000 registry:latest
+
+# produce a test image
+mkdir -p /tmp/f
+cd /tmp/f
+echo <<EOF > Dockerfile
+FROM alpine:latest
+ENV foo=bar
+EOF
+docker build -t localhost:5000/source:latest .
+docker push localhost:5000/source:latest
+```
+
+Build and run
+```
+# build and install bob (do this after every change)
+cd /workspace/gitpod/components/image-builder-bob
+go install
+
+# run bob
+BOB_BASE_REF=localhost:5000/source:latest BOB_TARGET_REF=localhost:5000/target:83 sudo -E $(which bob) build
+
+# debug using delve
+BOB_BASE_REF=localhost:5000/source:latest BOB_TARGET_REF=localhost:5000/target:83 sudo -E $(which dlv) --listen=:2345 --headless=true --api-version=2 exec $(which bob) build
+```


### PR DESCRIPTION
## Description
Adds debugging instructions for image-builder-mk3's bob

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
