### PR TITLE
[ws-manager] Remove error message if pod no longer exists

### DIFF
--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -171,7 +171,11 @@ func (m *Manager) modifyFinalizer(ctx context.Context, workspaceID string, final
 
 		pod, err := m.findWorkspacePod(ctx, workspaceID)
 		if err != nil {
-			return xerrors.Errorf("cannot find workspace %s: %w", workspaceID, err)
+			if isKubernetesObjNotFoundError(err) {
+				return nil
+			}
+
+			return xerrors.Errorf("unexpected error searching workspace %s: %w", workspaceID, err)
 		}
 		if pod == nil {
 			return xerrors.Errorf("workspace %s does not exist", workspaceID)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

If the pod no longer exists and we want to remove the finalizer that's not really an error.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5563

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
