### PR TITLE
[ws-daemon] Refactoring to reduce log verbosity

### DIFF
--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -235,7 +235,7 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 		"source": source,
 		"dest":   dest,
 		"fstype": filesystem,
-	}).Info("handling mount syscall")
+	}).Debug("handling mount syscall")
 
 	if filesystem == "proc" || filesystem == "sysfs" {
 		// When a process wants to mount proc relative to `/proc/self` that path has no meaning outside of the processes' context.

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -228,8 +228,9 @@ func RunInitializer(ctx context.Context, destination string, initializer *csapi.
 		withDebug = "--debug"
 	}
 
-	rw := log.Writer(log.WithFields(opts.OWI))
+	rw := log.JSONWriter(log.WithFields(opts.OWI))
 	defer rw.Close()
+
 	cmd = exec.Command("runc", "--root", "state", withDebug, "--log-format", "json", "run", "gogogo")
 	cmd.Dir = tmpdir
 	cmd.Stdout = rw

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -667,7 +667,7 @@ func nsinsider(instanceID string, targetPid int, mod func(*exec.Cmd), opts ...ns
 		cmd.ExtraFiles = append(cmd.ExtraFiles, f)
 	}
 
-	rw := log.Writer(log.WithFields(log.OWI("", "", instanceID)))
+	rw := log.JSONWriter(log.WithFields(log.OWI("", "", instanceID)))
 	defer rw.Close()
 
 	cmd.Stdout = rw


### PR DESCRIPTION
## Description

`ws-daemon` executes `runc` and returns the output of the command execution (JSON) to the configured logger.
This is an issue because it doesn't respect the configured log level and also the output is messy (the output is nested in field `msg`). This PR also changes the log level of mount syscalls to debug.

The log appears only in `DEBUG` level or if the output of the commands is in `ERROR` level.

```
{"level":"debug","message":"nsexec[256524]: =\u003e nsexec container setup","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"openat2 not available, falling back to securejoin","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: ~\u003e nsexec stage-0","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: spawn stage-1","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: -\u003e stage-1 synchronisation loop","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-1[256528]: ~\u003e nsexec stage-1","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-1[256528]: unshare remaining namespace (except cgroupns)","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-1[256528]: spawn stage-2","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-1[256528]: request stage-0 to forward stage-2 pid (256531)","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-2[1]: ~\u003e nsexec stage-2","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: stage-1 requested pid to be forwarded","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: forward stage-1 (256528) and stage-2 (256531) pids to runc","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-1[256528]: signal completion to stage-0","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-1[256528]: \u003c~ nsexec stage-1","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: stage-1 complete","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: \u003c- stage-1 synchronisation loop","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: -\u003e stage-2 synchronisation loop","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: signalling stage-2 to run","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-2[1]: signal completion to stage-0","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-2[1]: \u003c= nsexec container setup","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-2[1]: booting up go runtime ...","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: stage-2 complete","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: \u003c- stage-2 synchronisation loop","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"nsexec-0[256524]: \u003c~ nsexec stage-0","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"child process in init()","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"init: closing the pipe to signal completion","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"sending signal to process urgent I/O condition","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
{"level":"debug","message":"sending signal to process urgent I/O condition","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:21Z"}
```

```
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"nsexec started","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"join mnt namespace: 5","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"chroot: 3","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"chcwd: 4","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"nsexec started","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"join pid namespace: 3","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"nsexec started","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"join mnt namespace: 6","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"chroot: 4","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"chcwd: 5","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
{"instanceId":"2eb915e5-d57c-4776-bab4-0ce2c257e767","level":"debug","message":"join pid namespace: 7","serviceContext":{"service":"ws-daemon","version":""},"severity":"DEBUG","time":"2021-09-11T21:41:26Z","userId":"","workspaceId":""}
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5561

## How to test
<!-- Provide steps to test this PR -->
- start a workspace
- check `ws-daemon` logs
- change `ws-daemon` log level running `kubectl port-forward <ws-daemon pod>` and 
   `curl localhost:60060/debug/logging -d '{"level":"info"}'`
- start a new workspace
- check there is no logs with `nsexec` content related to the new workspace
- 
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
