### PR TITLE
[ws-manager-api] Partially revert the use of a deadline per grpc call

### DIFF
--- a/components/ws-manager-api/typescript/src/promisified-client.ts
+++ b/components/ws-manager-api/typescript/src/promisified-client.ts
@@ -219,7 +219,9 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
     }
 
     protected getDefaultUnaryOptions(): Partial<grpc.CallOptions> {
+        let deadline = new Date(new Date().getTime() + 30000);
         return {
+            deadline
         }
     }
 


### PR DESCRIPTION
## Description

Reverts the removal of the configuration of deadline per grpc calls and increases the time to 30s
(we know now that some requests can take more than 20s)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
