### PR TITLE
[server] Add workspace ID in trace span WorkspaceStarter.startWorkspace

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -180,6 +180,7 @@ export class WorkspaceStarter {
             }
 
             // start that thing
+            log.info('starting instance', {instanceId: instance.id});
             const resp = (await manager.startWorkspace({ span }, startRequest)).toObject();
             span.log({ "resp": resp });
 
@@ -211,8 +212,7 @@ export class WorkspaceStarter {
             if (rethrow) {
                 throw err;
             } else {
-                // we "swallow" this error as the promise of this function might not be awaited to - and even so,
-                // we've already handled the error properly.
+                log.error("error starting instance", err, { instanceId: instance.id});
             }
 
             return { instanceID: instance.id };

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -55,6 +55,7 @@ export class WorkspaceStarter {
 
     public async startWorkspace(ctx: TraceContext, workspace: Workspace, user: User, userEnvVars?: UserEnvVar[], options?: StartWorkspaceOptions): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("WorkspaceStarter.startWorkspace", ctx);
+        span.setTag("workspaceId", workspace.id);
 
         options = options || {};
         try {


### PR DESCRIPTION
## Description

The span `WorkspaceStarter.startWorkspace` does not contains details about the workspace

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5653

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
