### PR TITLE
[ws-proxy] Change log level if no owner cookie is present

### DIFF
--- a/components/ws-proxy/pkg/proxy/auth.go
+++ b/components/ws-proxy/pkg/proxy/auth.go
@@ -83,7 +83,7 @@ func WorkspaceAuthHandler(domain string, info WorkspaceInfoProvider) mux.Middlew
 				cn := fmt.Sprintf("%s%s_owner_", cookiePrefix, ws.InstanceID)
 				c, err := req.Cookie(cn)
 				if err != nil {
-					log.WithField("cookieName", cn).Warn("no owner cookie present")
+					log.WithField("cookieName", cn).Debug("no owner cookie present")
 					resp.WriteHeader(http.StatusUnauthorized)
 					return
 				}


### PR DESCRIPTION
## Description

Using log level `warn` makes this log too verbose, and there is nothing actionable we can do about it.

If this situation should be noticed, it must be converted to a metric?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
