### PR TITLE
Enable GRPC logging

### DIFF
--- a/components/common-go/grpc/grpc.go
+++ b/components/common-go/grpc/grpc.go
@@ -7,11 +7,14 @@ package grpc
 import (
 	"time"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"github.com/opentracing/opentracing-go"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -66,4 +69,12 @@ func ServerOptionsWithInterceptors(stream []grpc.StreamServerInterceptor, unary 
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(stream...)),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unary...)),
 	}
+}
+
+func SetupLogging() {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(
+		log.WithField("component", "grpc").WriterLevel(logrus.InfoLevel),
+		log.WithField("component", "grpc").WriterLevel(logrus.WarnLevel),
+		log.WithField("component", "grpc").WriterLevel(logrus.ErrorLevel),
+	))
 }

--- a/components/content-service/cmd/run.go
+++ b/components/content-service/cmd/run.go
@@ -33,6 +33,8 @@ var runCmd = &cobra.Command{
 		cfg := getConfig()
 		reg := prometheus.NewRegistry()
 
+		common_grpc.SetupLogging()
+
 		grpcMetrics := grpc_prometheus.NewServerMetrics()
 		grpcMetrics.EnableHandlingTimeHistogram()
 		reg.MustRegister(grpcMetrics)

--- a/components/image-builder-mk3/cmd/run.go
+++ b/components/image-builder-mk3/cmd/run.go
@@ -33,6 +33,8 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := getConfig()
 
+		common_grpc.SetupLogging()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		span, ctx := opentracing.StartSpanFromContext(ctx, "/cmd/Run")

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
 )
@@ -17,6 +18,7 @@ var runCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, true, true)
+		common_grpc.SetupLogging()
 		supervisor.Run()
 	},
 }

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/workspacekit/pkg/lift"
 	"github.com/gitpod-io/gitpod/workspacekit/pkg/seccomp"
@@ -58,6 +59,8 @@ var ring0Cmd = &cobra.Command{
 	Run: func(_ *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, true, true)
 		log := log.WithField("ring", 0)
+
+		common_grpc.SetupLogging()
 
 		exitCode := 1
 		defer handleExit(&exitCode)
@@ -177,6 +180,8 @@ var ring1Cmd = &cobra.Command{
 	Run: func(_cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, true, true)
 		log := log.WithField("ring", 1)
+
+		common_grpc.SetupLogging()
 
 		exitCode := 1
 		defer handleExit(&exitCode)
@@ -606,6 +611,8 @@ var ring2Cmd = &cobra.Command{
 	Run: func(_cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, true, true)
 		log := log.WithField("ring", 2)
+
+		common_grpc.SetupLogging()
 
 		exitCode := 1
 		defer handleExit(&exitCode)

--- a/components/ws-daemon/cmd/run.go
+++ b/components/ws-daemon/cmd/run.go
@@ -36,6 +36,8 @@ var runCmd = &cobra.Command{
 			log.WithError(err).Fatal("cannot create daemon")
 		}
 
+		common_grpc.SetupLogging()
+
 		grpcMetrics := grpc_prometheus.NewServerMetrics()
 		grpcMetrics.EnableHandlingTimeHistogram()
 		reg.MustRegister(grpcMetrics)

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -49,6 +49,8 @@ var runCmd = &cobra.Command{
 		}
 		log.Info("wsman configuration is valid")
 
+		common_grpc.SetupLogging()
+
 		ctrl.SetLogger(logrusr.NewLogger(log.Log))
 
 		opts := ctrl.Options{

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/proxy"
@@ -36,6 +37,8 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			log.WithError(err).WithField("filename", args[0]).Fatal("cannot load config")
 		}
+
+		common_grpc.SetupLogging()
 
 		const wsmanConnectionAttempts = 5
 		workspaceInfoProvider := proxy.NewRemoteWorkspaceInfoProvider(cfg.WorkspaceInfoProviderConfig)

--- a/dev/gpctl/cmd/root.go
+++ b/dev/gpctl/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/gpctl/pkg/prettyprint"
 	"github.com/gitpod-io/gitpod/gpctl/pkg/util"
@@ -28,6 +29,8 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	common_grpc.SetupLogging()
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
## Description

Configures GRPC logs to use `logrus`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Check any go component with grpc connections, like `ws-manager`and check it contains similar output to 
``` 
 130 ❯ k logs -f -c ws-manager ws-manager-86dd89c5c8-snfhb|grep grpc
{"component":"grpc","level":"info","message":"WARNING: 2021/09/11 16:33:18 [core] Adjusting keepalive ping interval to minimum period of 10s","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:18Z"}
{"component":"grpc","level":"warning","message":"WARNING: 2021/09/11 16:33:18 [core] Adjusting keepalive ping interval to minimum period of 10s","serviceContext":{"service":"ws-manager","version":""},"severity":"WARNING","time":"2021-09-11T16:33:18Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] parsed scheme: \"\"","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] scheme \"\" not registered, fallback to default scheme","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] ccResolverWrapper: sending update to cc: {[{10.96.0.90:10590  \u003cnil\u003e 0 \u003cnil\u003e}] \u003cnil\u003e \u003cnil\u003e}","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] ClientConn switching balancer to \"pick_first\"","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] Channel switches to new LB policy \"pick_first\"","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] Subchannel Connectivity change to CONNECTING","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] Subchannel picks a new address \"10.96.0.90:10590\" to connect","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] Channel Connectivity change to CONNECTING","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] Subchannel Connectivity change to READY","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:33 [core] Channel Connectivity change to READY","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-11T16:33:33Z"}
``` 

in case of errors
```
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:14 [core] Subchannel picks a new address \"ws-manager:8080\" to connect","serviceContext":{"service":"ws-proxy","version":""},"severity":"INFO","time":"2021-09-11T16:33:14Z"}
{"component":"grpc","level":"info","message":"WARNING: 2021/09/11 16:33:15 [core] grpc: addrConn.createTransport failed to connect to {ws-manager:8080 ws-manager:8080 \u003cnil\u003e 0 \u003cnil\u003e}. Err: connection error: desc = \"transport: Error while dialing dial tcp 10.100.11.2:8080: i/o timeout\". Reconnecting...","serviceContext":{"service":"ws-proxy","version":""},"severity":"INFO","time":"2021-09-11T16:33:15Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:15 [core] Subchannel Connectivity change to TRANSIENT_FAILURE","serviceContext":{"service":"ws-proxy","version":""},"severity":"INFO","time":"2021-09-11T16:33:15Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/11 16:33:15 [core] Channel Connectivity change to TRANSIENT_FAILURE","serviceContext":{"service":"ws-proxy","version":""},"severity":"INFO","time":"2021-09-11T16:33:15Z"}
{"component":"grpc","level":"warning","message":"WARNING: 2021/09/11 16:33:15 [core] grpc: addrConn.createTransport failed to connect to {ws-manager:8080 ws-manager:8080 \u003cnil\u003e 0 \u003cnil\u003e}. Err: connection error: desc = \"transport: Error while dialing dial tcp 10.100.11.2:8080: i/o timeout\". Reconnecting...","serviceContext":{"service":"ws-proxy","version":""},"severity":"WARNING","time":"2021-09-11T16:33:15Z"}
{"
```

## Release Notes
```release-note
NONE
```

Note: the default level `info` should be enabled temporarely.