### PR TITLE
[server] remove prebuilt time limit

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1592203031938-Baseline.ts
+++ b/components/gitpod-db/src/typeorm/migration/1592203031938-Baseline.ts
@@ -6,7 +6,7 @@
 
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-import { BUILTIN_WORKSPACE_PROBE_USER_NAME } from "../../user-db";
+import { BUILTIN_WORKSPACE_PROBE_USER_ID } from "../../user-db";
 
 export class Baseline1592203031938 implements MigrationInterface {
 
@@ -81,7 +81,7 @@ export class Baseline1592203031938 implements MigrationInterface {
         {
             const exists = (await queryRunner.query(`SELECT COUNT(1) AS cnt FROM d_b_user WHERE id = 'builtin-user-workspace-probe-0000000'`))[0].cnt == 1;
             if (!exists) {
-                await queryRunner.query(`INSERT IGNORE INTO d_b_user (id, creationDate, avatarUrl, name, fullName) VALUES ('builtin-user-workspace-probe-0000000', '${new Date().toISOString()}', '', '${BUILTIN_WORKSPACE_PROBE_USER_NAME}', '')`)
+                await queryRunner.query(`INSERT IGNORE INTO d_b_user (id, creationDate, avatarUrl, name, fullName) VALUES ('${BUILTIN_WORKSPACE_PROBE_USER_ID}', '${new Date().toISOString()}', '', 'builtin-workspace-prober', '')`)
             }
         }
     }

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -11,7 +11,7 @@ import { DateInterval, ExtraAccessTokenFields, GrantIdentifier, OAuthClient, OAu
 import { inject, injectable, postConstruct } from "inversify";
 import { EntityManager, Repository } from "typeorm";
 import * as uuidv4 from 'uuid/v4';
-import { BUILTIN_WORKSPACE_PROBE_USER_NAME, MaybeUser, PartialUserUpdate, UserDB } from "../user-db";
+import { BUILTIN_WORKSPACE_PROBE_USER_ID, MaybeUser, PartialUserUpdate, UserDB } from "../user-db";
 import { DBGitpodToken } from "./entity/db-gitpod-token";
 import { DBIdentity } from "./entity/db-identity";
 import { DBTokenEntry } from "./entity/db-token-entry";
@@ -310,7 +310,7 @@ export class TypeORMUserDBImpl implements UserDB {
             WHERE markedDeleted != true`;
         if (excludeBuiltinUsers) {
             query = `${query}
-                AND name <> '${BUILTIN_WORKSPACE_PROBE_USER_NAME}'`
+                AND id <> '${BUILTIN_WORKSPACE_PROBE_USER_ID}'`
         }
         const res = await userRepo.query(query);
         const count = res[0].cnt;
@@ -354,7 +354,7 @@ export class TypeORMUserDBImpl implements UserDB {
             qBuilder.andWhere("user.creationDate < :maxCreationDate", { maxCreationDate: maxCreationDate.toISOString() });
         }
         if (excludeBuiltinUsers) {
-            qBuilder.andWhere("user.name <> :username", { username: BUILTIN_WORKSPACE_PROBE_USER_NAME })
+            qBuilder.andWhere("user.id <> :userId", { userId: BUILTIN_WORKSPACE_PROBE_USER_ID })
         }
         qBuilder.orderBy("user." + orderBy, orderDir);
         qBuilder.skip(offset).take(limit).select();

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -18,7 +18,7 @@ import { DBRepositoryWhiteList } from "./entity/db-repository-whitelist";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { DBPrebuiltWorkspace } from "./entity/db-prebuilt-workspace";
 import { DBPrebuiltWorkspaceUpdatable } from "./entity/db-prebuilt-workspace-updatable";
-import { BUILTIN_WORKSPACE_PROBE_USER_NAME } from "../user-db";
+import { BUILTIN_WORKSPACE_PROBE_USER_ID } from "../user-db";
 import { DBPrebuildInfo } from "./entity/db-prebuild-info-entry";
 
 type RawTo<T> = (instance: WorkspaceInstance, ws: Workspace) => T;
@@ -463,11 +463,9 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
                                     ws.softDeletedTime < NOW() - INTERVAL ? DAY
                                 OR  ws.softDeletedTime = ''
                             )
-                        AND ws.ownerId NOT IN (
-                            SELECT id from d_b_user WHERE name = ?
-                        )
+                        AND ws.ownerId <> ?
                     LIMIT ?;
-            `, [minSoftDeletedTimeInDays, BUILTIN_WORKSPACE_PROBE_USER_NAME, limit]);
+            `, [minSoftDeletedTimeInDays, BUILTIN_WORKSPACE_PROBE_USER_ID, limit]);
 
         return dbResults as WorkspaceOwnerAndSoftDeleted[];
     }
@@ -572,25 +570,6 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
             .orderBy('pws.creationTime', 'DESC')
             .innerJoinAndMapOne('pws.workspace', DBWorkspace, 'ws', "pws.buildWorkspaceId = ws.id and ws.contentDeletedTime = ''")
             .getOne();
-    }
-
-    public async getTotalPrebuildUseSeconds(forDays: number): Promise<number | undefined> {
-        const manager = await this.getManager();
-        const res = await manager.query(`
-            SELECT SUM(COALESCE(STR_TO_DATE(wsi.stoppedTime, "%Y-%m-%dT%H:%i:%s.%fZ") - STR_TO_DATE(wsi.startedTime, "%Y-%m-%dT%H:%i:%s.%fZ"))) AS tps FROM d_b_workspace_instance wsi
-            INNER JOIN d_b_prebuilt_workspace pws ON pws.buildWorkspaceId = wsi.workspaceId
-            INNER JOIN (
-	            SELECT ws.context->>'$.prebuildWorkspaceId' as sid FROM d_b_workspace ws
-                WHERE  ws.creationTime > NOW() - INTERVAL ? DAY
-                  AND  JSON_EXTRACT(ws.context, '$.prebuildWorkspaceId') IS NOT NULL
-            ) AS sns ON sns.sid = pws.id
-            WHERE wsi.startedTime IS NOT NULL
-        `, [forDays]);
-        if (!res || res.length < 1) {
-            return;
-        }
-
-        return res[0].tps;
     }
 
     public async findPrebuildByWorkspaceID(wsid: string): Promise<PrebuiltWorkspace | undefined> {

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -119,7 +119,7 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
 }
 export type PartialUserUpdate = Partial<Omit<User, "identities">> & Pick<User, "id">
 
-export const BUILTIN_WORKSPACE_PROBE_USER_NAME = "builtin-workspace-prober";
+export const BUILTIN_WORKSPACE_PROBE_USER_ID = "builtin-user-workspace-probe-0000000";
 
 export interface OwnerAndRepo {
     owner: string

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -95,7 +95,6 @@ export interface WorkspaceDB {
     findSnapshotsByWorkspaceId(workspaceId: string): Promise<Snapshot[]>;
     storeSnapshot(snapshot: Snapshot): Promise<Snapshot>;
 
-    getTotalPrebuildUseSeconds(forDays: number): Promise<number | undefined>;
     storePrebuiltWorkspace(pws: PrebuiltWorkspace): Promise<PrebuiltWorkspace>;
     findPrebuiltWorkspaceByCommit(cloneURL: string, commit: string): Promise<PrebuiltWorkspace | undefined>;
     findPrebuildsWithWorkpace(cloneURL: string): Promise<PrebuildWithWorkspace[]>;

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -218,27 +218,6 @@ func (e *Evaluator) HasEnoughSeats(seats int) bool {
 	return e.lic.Seats == 0 || seats <= e.lic.Seats
 }
 
-// CanUsePrebuild returns true if the use a prebuild is permissible under the license,
-// given the total prebuild time used already.
-func (e *Evaluator) CanUsePrebuild(totalPrebuildTimeSpent time.Duration) bool {
-	if !e.Enabled(FeaturePrebuild) {
-		// prebuilds aren't even enabled - time spent doesn't matter
-		return false
-	}
-
-	pbt := e.lic.Level.allowance().PrebuildTime
-	if pbt == 0 {
-		// allowed prebuild time == 0 means the prebuild time is not limited
-		return true
-	}
-	if totalPrebuildTimeSpent <= pbt {
-		// not all time is spent yet
-		return true
-	}
-
-	return false
-}
-
 // Inspect returns the license information this evaluator holds.
 // This function is intended for transparency/debugging purposes only and must
 // never be used to determine feature eligibility under a license. All code making

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -151,30 +151,6 @@ func TestFeatures(t *testing.T) {
 	}
 }
 
-func TestCanUsePrebuild(t *testing.T) {
-	validate := func(usedTime time.Duration, expectation bool) func(t *testing.T, eval *Evaluator) {
-		return func(t *testing.T, eval *Evaluator) {
-			act := eval.CanUsePrebuild(usedTime)
-			if expectation != act {
-				t.Errorf("CanUsePrebuild returned unexpected value: expected %v, got %v", expectation, act)
-			}
-		}
-	}
-
-	enterpriseLic := &LicensePayload{Domain: domain, ID: someID, Level: LevelEnterprise, Seats: 0, ValidUntil: time.Now().Add(6 * time.Hour)}
-	tests := []licenseTest{
-		{Name: "default license ok", License: nil, Validate: validate(0*time.Hour, true)},
-		{Name: "default license not ok", License: nil, Validate: validate(250*time.Hour, false)},
-		{Name: "enterprise license a", License: enterpriseLic, Validate: validate(1*time.Hour, true)},
-		{Name: "enterprise license b", License: enterpriseLic, Validate: validate(500*time.Hour, true)},
-		{Name: "enterprise license c", License: enterpriseLic, Validate: validate(-1*time.Hour, true)},
-		{Name: "broken license", License: &LicensePayload{Level: LevelEnterprise}, Validate: validate(0*time.Hour, false)},
-	}
-	for _, test := range tests {
-		test.Run(t)
-	}
-}
-
 func TestEvalutorKeys(t *testing.T) {
 	tests := []struct {
 		Name       string

--- a/components/licensor/typescript/ee/main.go
+++ b/components/licensor/typescript/ee/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"C"
 	"encoding/json"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -61,18 +60,6 @@ func HasEnoughSeats(id int, seats int) (permitted, ok bool) {
 	}
 
 	return e.HasEnoughSeats(seats), true
-}
-
-// CanUsePrebuild returns true if the use a prebuild is permissible under the license,
-// given the total prebuild time used already.
-//export CanUsePrebuild
-func CanUsePrebuild(id int, totalSecondsUsed int64) (permitted, ok bool) {
-	e, ok := instances[id]
-	if !ok {
-		return
-	}
-
-	return e.CanUsePrebuild(time.Duration(totalSecondsUsed) * time.Second), true
 }
 
 // Inspect returns the license information this evaluator holds.

--- a/components/licensor/typescript/ee/src/index.ts
+++ b/components/licensor/typescript/ee/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject, postConstruct } from 'inversify';
-import { init, Instance, dispose, isEnabled, hasEnoughSeats, canUsePrebuild, inspect, validate } from "./nativemodule";
+import { init, Instance, dispose, isEnabled, hasEnoughSeats, inspect, validate } from "./nativemodule";
 import { Feature, LicensePayload } from './api';
 
 export const LicenseKeySource = Symbol("LicenseKeySource");
@@ -55,10 +55,6 @@ export class LicenseEvaluator {
 
     public hasEnoughSeats(seats: number): boolean {
         return hasEnoughSeats(this.instanceID, seats);
-    }
-
-    public canUsePrebuild(totalPrebuildSecondsSpent: number): boolean {
-        return canUsePrebuild(this.instanceID, totalPrebuildSecondsSpent);
     }
 
     public inspect(): LicensePayload {

--- a/components/licensor/typescript/ee/src/module.cc
+++ b/components/licensor/typescript/ee/src/module.cc
@@ -165,41 +165,6 @@ void HasEnoughSeatsM(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(Boolean::New(isolate, r.r0));
 }
 
-void CanUsePrebuildM(const FunctionCallbackInfo<Value> &args) {
-    Isolate *isolate = args.GetIsolate();
-    Local<Context> context = isolate->GetCurrentContext();
-
-    if (args.Length() < 2) {
-        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "wrong number of arguments")));
-        return;
-    }
-    if (!args[0]->IsNumber() || args[0]->IsUndefined()) {
-        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "argument 0 must be a number")));
-        return;
-    }
-    if (!args[1]->IsNumber() || args[1]->IsUndefined()) {
-        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "argument 1 must be a number")));
-        return;
-    }
-
-    double rid = args[0]->NumberValue(context).FromMaybe(0);
-    int id = static_cast<int>(rid);
-    double rsec = args[1]->NumberValue(context).FromMaybe(-1);
-    GoInt64 sec = static_cast<GoInt64>(rsec);
-    if (sec < 0) {
-        isolate->ThrowException(Exception::Error(String::NewFromUtf8(isolate, "cannot convert total prebuild time used")));
-    }
-
-    CanUsePrebuild_return r = CanUsePrebuild(id, sec);
-    if (!r.r1) {
-        isolate->ThrowException(Exception::Error(String::NewFromUtf8(isolate, "invalid instance ID")));
-        return;
-    }
-
-    // return the value
-    args.GetReturnValue().Set(Boolean::New(isolate, r.r0));
-}
-
 void InspectM(const FunctionCallbackInfo<Value> &args) {
     Isolate *isolate = args.GetIsolate();
     Local<Context> context = isolate->GetCurrentContext();
@@ -250,7 +215,6 @@ void initModule(Local<Object> exports) {
     NODE_SET_METHOD(exports, "validate", ValidateM);
     NODE_SET_METHOD(exports, "isEnabled", EnabledM);
     NODE_SET_METHOD(exports, "hasEnoughSeats", HasEnoughSeatsM);
-    NODE_SET_METHOD(exports, "canUsePrebuild", CanUsePrebuildM);
     NODE_SET_METHOD(exports, "inspect", InspectM);
     NODE_SET_METHOD(exports, "dispose", DisposeM);
 }

--- a/components/licensor/typescript/ee/src/nativemodule.d.ts
+++ b/components/licensor/typescript/ee/src/nativemodule.d.ts
@@ -11,6 +11,5 @@ export function init(key: string, domain: string): Instance;
 export function validate(id: Instance): { msg: string, valid: boolean };
 export function isEnabled(id: Instance, feature: Feature): boolean;
 export function hasEnoughSeats(id: Instance, seats: int): boolean;
-export function canUsePrebuild(id: Instance, totalPrebuildTimeSpent: number): boolean;
 export function inspect(id: Instance): string;
 export function dispose(id: Instance);

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -192,11 +192,6 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
         this.requireEELicense(Feature.FeaturePrebuild);
         const span = TraceContext.startSpan("createForPrebuiltWorkspace", ctx);
 
-        const fallback = await this.fallbackIfOutPrebuildTime(ctx, user, context, normalizedContextURL);
-        if (!!fallback) {
-            return fallback;
-        }
-
         try {
             const buildWorkspaceID = context.prebuiltWorkspace.buildWorkspaceId;
             const buildWorkspace = await this.db.trace({span}).findById(buildWorkspaceID);
@@ -239,17 +234,6 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
         } finally {
             span.finish();
         }
-    }
-
-    protected async fallbackIfOutPrebuildTime(ctx: TraceContext, user: User, context: PrebuiltWorkspaceContext, normalizedContextURL: string): Promise<Workspace | undefined> {
-        const prebuildTime = await this.db.trace({}).getTotalPrebuildUseSeconds(30);
-        if (!this.licenseEvaluator.canUsePrebuild(prebuildTime || 0)) {
-            // TODO: find a way to signal the out-of-prebuild-time situation
-            log.warn({}, "cannot use prebuild because enterprise license prevents it", {prebuildTime});
-            return this.createForContext(ctx, user, context.originalContext, normalizedContextURL);
-        }
-
-        return;
     }
 
 }

--- a/components/server/ee/src/workspace/workspace-health-monitoring.ts
+++ b/components/server/ee/src/workspace/workspace-health-monitoring.ts
@@ -10,7 +10,7 @@ import { WorkspaceInstance, WorkspaceProbeContext, RunningWorkspaceInfo } from "
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { URL } from "url";
 import { WorkspaceFactory } from "../../../src/workspace/workspace-factory";
-import { UserDB, BUILTIN_WORKSPACE_PROBE_USER_NAME, WorkspaceDB, TracedWorkspaceDB, DBWithTracing, TracedUserDB } from "@gitpod/gitpod-db/lib";
+import { UserDB, BUILTIN_WORKSPACE_PROBE_USER_ID, WorkspaceDB, TracedWorkspaceDB, DBWithTracing, TracedUserDB } from "@gitpod/gitpod-db/lib";
 import { WorkspaceStarter } from "../../../src/workspace/workspace-starter";
 import fetch from "node-fetch";
 import { Config } from "../../../src/config";
@@ -37,7 +37,7 @@ export class WorkspaceHealthMonitoring {
         const span = TraceContext.startSpan("startWorkspaceProbe", ctx);
 
         try {
-            const user = await this.userDB.trace({span}).findUserByName(BUILTIN_WORKSPACE_PROBE_USER_NAME);
+            const user = await this.userDB.trace({span}).findUserById(BUILTIN_WORKSPACE_PROBE_USER_ID);
             if (!user) {
                 throw new Error("cannot find workspace probe user. DB not set up properly?")
             }


### PR DESCRIPTION
## Description
Removes the unnecessary check of prebuild times. The query is logged to take around 7 secs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
