### PR TITLE
[helm] Introduce optional deploy of ide config map

### DIFF
--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -11,7 +11,7 @@
 {{ template "gitpod.comp.imageRepo" . }}:{{ $comp.stableVersion }}
 {{- end -}}
 
-{{- if $comp.serverIdeConfigDeploy }}
+{{- if $comp.serverIdeConfigDeploy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -11,6 +11,7 @@
 {{ template "gitpod.comp.imageRepo" . }}:{{ $comp.stableVersion }}
 {{- end -}}
 
+{{- if $comp.serverIdeConfigDeploy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -27,3 +28,4 @@ data:
         "ideImageRepo": "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) }}",
         "ideImageAliases": {{ (dict "code-latest" (include "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage)) "code" (include "stable-image-full" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage))) | toJson }}
     }
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -304,7 +304,8 @@ components:
       enabled: false
       passlist: []
     runDbDeleter: true
-    serverIdeConfigDeploy: true
+    serverIdeConfigDeploy:
+      enabled: true
     storage: {}
     wsman: []
     defaultBaseImageRegistryWhitelist: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -304,6 +304,7 @@ components:
       enabled: false
       passlist: []
     runDbDeleter: true
+    serverIdeConfigDeploy: true
     storage: {}
     wsman: []
     defaultBaseImageRegistryWhitelist: []


### PR DESCRIPTION
## Description
Allow optional deployment of server-ide-config configmap with gitpod installation.
This would allow us to decouple deployment of said resource with gitpod installation allowing us to have more control on the version of vscode we want to use.

## Related Issue(s)
https://github.com/gitpod-io/ops/issues/26

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```