### PR TITLE
[dashboard] Allow workspace renaming

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -7,13 +7,15 @@
 import { CommitContext, Workspace, WorkspaceInfo, WorkspaceInstance, WorkspaceInstanceConditions, WorkspaceInstancePhase } from '@gitpod/gitpod-protocol';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import moment from 'moment';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import ConfirmationModal from '../components/ConfirmationModal';
+import Modal from '../components/Modal';
 import { ContextMenuEntry } from '../components/ContextMenu';
 import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon } from '../components/ItemsList';
 import PendingChangesDropdown from '../components/PendingChangesDropdown';
 import Tooltip from '../components/Tooltip';
 import { WorkspaceModel } from './workspace-model';
+import { getGitpodService } from '../service/service';
 
 function getLabel(state: WorkspaceInstancePhase, conditions?: WorkspaceInstanceConditions) {
     if (conditions?.failed) {
@@ -30,10 +32,15 @@ interface Props {
 }
 
 export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
-    const [isModalVisible, setModalVisible] = useState(false);
+    const [isDeleteModalVisible, setDeleteModalVisible] = useState(false);
+    const [isRenameModalVisible, setRenameModalVisible] = useState(false);
+    const renameInputRef = useRef<HTMLInputElement>(null);
+    const [errorMessage, setErrorMessage] = useState('');
     const state: WorkspaceInstancePhase = desc.latestInstance?.status?.phase || 'stopped';
     const currentBranch = desc.latestInstance?.status.repo?.branch || Workspace.getBranchName(desc.workspace) || '<unknown>';
     const ws = desc.workspace;
+    const [workspaceDescription, setWsDescription] = useState(ws.description);
+
     const startUrl = new GitpodHostUrl(window.location.href).with({
         pathname: '/start/',
         hash: '#' + ws.id
@@ -45,7 +52,16 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         {
             title: 'Open',
             href: startUrl.toString()
-        }];
+        },
+        {
+            title: 'Rename',
+            href: "",
+            onClick: () => {
+                setRenameModalVisible(true);
+            }
+        },
+
+    ];
     if (state === 'running') {
         menuEntries.push({
             title: 'Stop',
@@ -78,12 +94,40 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                 title: 'Delete',
                 customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
                 onClick: () => {
-                    setModalVisible(true);
+                    setDeleteModalVisible(true);
                 }
             }
         );
     }
     const project = getProject(ws);
+
+    const updateWorkspaceDescription = async () => {
+        // Need this check because ref is called twice
+        // https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs
+        if (!renameInputRef.current) {
+            return;
+        }
+
+        try {
+            if (renameInputRef.current!.value.length === 0) {
+                setErrorMessage('Description must not be empty.');
+                return false;
+            }
+
+            if (renameInputRef.current!.value.length > 250) {
+                setErrorMessage('Description is too long for readability.');
+                return false;
+            }
+
+            setWsDescription(renameInputRef.current!.value);
+            await getGitpodService().server.setWorkspaceDescription(ws.id, renameInputRef.current!.value);
+            setErrorMessage('');
+            setRenameModalVisible(false);
+        } catch (error) {
+            console.error(error);
+            window.alert("Something went wrong. Please try renaming again.");
+        }
+    }
 
     return <Item className="whitespace-nowrap py-6 px-6">
         <ItemFieldIcon>
@@ -96,7 +140,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
             </Tooltip>
         </ItemField>
         <ItemField className="w-4/12 flex flex-col">
-            <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">{ws.description}</div>
+            <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">{workspaceDescription}</div>
             <a href={ws.contextURL}>
                 <div className="text-sm text-gray-400 dark:text-gray-500 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">{ws.contextURL}</div>
             </a>
@@ -111,7 +155,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
             </Tooltip>
         </ItemField>
         <ItemFieldContextMenu menuEntries={menuEntries} />
-        {isModalVisible && <ConfirmationModal
+        {isDeleteModalVisible && <ConfirmationModal
             title="Delete Workspace"
             areYouSureText="Are you sure you want to delete this workspace?"
             children={{
@@ -119,10 +163,29 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                 description: ws.description,
             }}
             buttonText="Delete Workspace"
-            visible={isModalVisible}
-            onClose={() => setModalVisible(false)}
+            visible={isDeleteModalVisible}
+            onClose={() => setDeleteModalVisible(false)}
             onConfirm={() => model.deleteWorkspace(ws.id)}
         />}
+        <Modal visible={isRenameModalVisible} onClose={() => setRenameModalVisible(false)} onEnter={() => { updateWorkspaceDescription(); return isRenameModalVisible }}>
+            <h3 className="mb-4">Rename Workspace Description</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 space-y-2">
+                {errorMessage.length > 0 ?
+                    <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">
+                        {errorMessage}
+                    </div>
+                    : null}
+                <input className="w-full truncate" type="text" defaultValue={workspaceDescription} ref={renameInputRef} />
+                <div className="mt-1">
+                    <p className="text-gray-500">Change the description to make it easier to go back to a workspace.</p>
+                    <p className="text-gray-500">Workspace URLs and endpoints will remain the same.</p>
+                </div>
+            </div>
+            <div className="flex justify-end mt-6">
+                <button className="secondary" onClick={() => setRenameModalVisible(false)}>Cancel</button>
+                <button className="ml-2" type="submit" onClick={updateWorkspaceDescription}>Rename</button>
+            </div>
+        </Modal>
     </Item>;
 }
 
@@ -134,7 +197,7 @@ export function getProject(ws: Workspace) {
     }
 }
 
-export function WorkspaceStatusIndicator({instance}: {instance?: WorkspaceInstance}) {
+export function WorkspaceStatusIndicator({ instance }: { instance?: WorkspaceInstance }) {
     const state: WorkspaceInstancePhase = instance?.status?.phase || 'stopped';
     const conditions = instance?.status?.conditions;
     let stateClassName = 'rounded-full w-3 h-3 text-sm align-middle';

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -110,7 +110,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
 
         try {
             if (renameInputRef.current!.value.length === 0) {
-                setErrorMessage('Description must not be empty.');
+                setErrorMessage('Description cannot not be empty.');
                 return false;
             }
 
@@ -183,7 +183,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
             </div>
             <div className="flex justify-end mt-6">
                 <button className="secondary" onClick={() => setRenameModalVisible(false)}>Cancel</button>
-                <button className="ml-2" type="submit" onClick={updateWorkspaceDescription}>Rename</button>
+                <button className="ml-2" type="submit" onClick={updateWorkspaceDescription}>Update Description</button>
             </div>
         </Modal>
     </Item>;


### PR DESCRIPTION
## Description
After a discussion with @corneliusludmann and @gtsiolis, instead of the initial proposal of allowing workspace ID renames, this PR allows the renaming of a workspace context description. 
The reason to go this way is because the the workspaceID affects at the very least the URL of the workspace, and therefore could introduce breaking changes.

## Related Issue(s)
Fixes #3946

## How to test
1. Go to list of workspaces in Dashboard.
2. Click on the options on the far right, choose Rename.
3. Give the workspace a different description.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allows renaming of workspace description.
```
<img width="259" alt="Screenshot 2021-09-14 at 15 00 03" src="https://user-images.githubusercontent.com/8015191/133271755-f76e4aad-4716-4ee7-8f8f-e7b2f112d319.png">
<img width="530" alt="Screenshot 2021-09-14 at 15 00 17" src="https://user-images.githubusercontent.com/8015191/133271773-7e31e7e4-3ae2-48cd-85c5-452cd64d7dd4.png">
<img width="1062" alt="Screenshot 2021-09-14 at 15 00 24" src="https://user-images.githubusercontent.com/8015191/133271792-54c2a820-ebb9-44c2-9c1b-3ee79480701b.png">
