### PR TITLE
[server] Introduce /debug/logging

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -183,7 +183,13 @@ env:
 - name: GITPOD_INSTALLATION_SHORTNAME
   value: {{ template "gitpod.installation.shortname" . }}
 - name: LOG_LEVEL
-  value: {{ $gp.log.level | default "debug" | lower | quote }}
+  value: {{ template "gitpod.loglevel" }}
+{{- end -}}
+
+{{- define "gitpod.loglevel" -}}
+{{- $ := .root -}}
+{{- $gp := .gp -}}
+{{ $gp.log.level | default "debug" | lower | quote }}
 {{- end -}}
 
 {{- define "gitpod.container.analyticsEnv" -}}

--- a/chart/templates/server-configmap.yaml
+++ b/chart/templates/server-configmap.yaml
@@ -23,6 +23,7 @@ data:
 {{- if .Values.devBranch }}
         "devBranch": "{{ .Values.devBranch }}",
 {{- end }}
+        "logLevel": {{ template "gitpod.loglevel" }},
         "license": "{{ .Values.license }}",
         "workspaceHeartbeat": {{ $comp.workspaceHeartbeat | toJson }},
         "workspaceDefaults": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -299,7 +299,6 @@ components:
     githubApp:
       enabled: false
       authProviderId: "Public-GitHub"
-      logLevel: "trace"
     blockNewUsers:
       enabled: false
       passlist: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -326,9 +326,12 @@ components:
       metrics:
         expose: true
         containerPort: 9500
-      debug:
+      debugNode:
         expose: false
         containerPort: 9229
+      debug:
+        expose: false
+        containerPort: 6060
     serviceSessionAffinity: None
     serverContainer:
       volumeMounts: null

--- a/components/ee/db-sync/src/main.ts
+++ b/components/ee/db-sync/src/main.ts
@@ -7,11 +7,11 @@
 require("reflect-metadata")
 
 import { ArgumentParser } from "argparse";
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { log, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { ICommand } from "./commands";
 import { Container } from "inversify";
 import { productionContainerModule } from "./container-module";
-log.enableJSONLogging('db-sync', undefined);
+log.enableJSONLogging('db-sync', undefined, LogrusLogLevel.getFromEnv());
 
 const parser = new ArgumentParser({
     version: "0.1.5",

--- a/components/ee/payment-endpoint/src/main.ts
+++ b/components/ee/payment-endpoint/src/main.ts
@@ -11,10 +11,10 @@ import { Container } from 'inversify';
 import { Server } from "./server";
 import { productionContainerModule } from './container-module';
 
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { log, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { dbContainerModule } from '@gitpod/gitpod-db/lib/container-module';
 
-log.enableJSONLogging('payment-endpoint', undefined);
+log.enableJSONLogging('payment-endpoint', undefined, LogrusLogLevel.getFromEnv());
 
 const init = async () => {
     const container = new Container();

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -12,7 +12,7 @@ import { injectable, inject } from 'inversify';
 import { Config } from '../../../src/config';
 import { AppInstallationDB, TracedWorkspaceDB, DBWithTracing, UserDB, WorkspaceDB, ProjectDB, TeamDB } from '@gitpod/gitpod-db/lib';
 import * as express from 'express';
-import { log, LogContext } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { log, LogContext, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { WorkspaceConfig, User, Project, StartPrebuildResult } from '@gitpod/gitpod-protocol';
 import { MessageBusIntegration } from '../../../src/workspace/messagebus-integration';
 import { GithubAppRules } from './github-app-rules';
@@ -56,7 +56,7 @@ export class GithubApp {
                     appId: config.githubApp.appId,
                     privateKey: GithubApp.loadPrivateKey(config.githubApp.certPath),
                     secret: config.githubApp.webhookSecret,
-                    logLevel: config.githubApp.logLevel as Options["logLevel"],
+                    logLevel: GithubApp.mapToGitHubLogLevel(config.logLevel),
                     baseUrl: config.githubApp.baseUrl,
                 })
             });
@@ -402,6 +402,17 @@ export namespace GithubApp {
             if (key) {
                 return key.toString();
             }
+        }
+    }
+
+    export function mapToGitHubLogLevel(logLevel: LogrusLogLevel): Options["logLevel"] {
+        switch (logLevel) {
+            case "warning":
+                return "warn";
+            case "panic":
+                return "fatal";
+            default:
+                return logLevel;
         }
     }
 }

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -13,7 +13,7 @@ import { RateLimiterConfig } from './auth/rate-limiter';
 import { CodeSyncConfig } from './code-sync/code-sync-service';
 import { ChargebeeProviderOptions, readOptionsFromFile } from "@gitpod/gitpod-payment-endpoint/lib/chargebee";
 import * as fs from 'fs';
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { log, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { filePathTelepresenceAware, KubeStage, translateLegacyStagename } from '@gitpod/gitpod-protocol/lib/env';
 import { BrandingParser } from './branding-parser';
 
@@ -51,6 +51,7 @@ export interface ConfigSerialized {
     stage: string;
     devBranch?: string;
     insecureNoDomain: boolean;
+    logLevel: LogrusLogLevel;
 
     license?: string;
 
@@ -74,7 +75,6 @@ export interface ConfigSerialized {
         authProviderId: string;
         certPath: string;
         marketplaceName: string;
-        logLevel?: string;
     };
 
     definitelyGpDisabled: boolean;

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -83,6 +83,7 @@ import { defaultGRPCOptions } from '@gitpod/gitpod-protocol/lib/util/grpc';
 import { IDEConfigService } from './ide-config';
 import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
 import { IClientCallMetrics } from '@gitpod/content-service/lib/client-call-metrics';
+import { DebugApp } from './debug-app';
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -103,6 +104,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(SessionHandlerProvider).toSelf().inSingletonScope();
     bind(Server).toSelf().inSingletonScope();
+    bind(DebugApp).toSelf().inSingletonScope();
 
     bind(GitpodFileParser).toSelf().inSingletonScope();
 

--- a/components/server/src/debug-app.ts
+++ b/components/server/src/debug-app.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as http from 'http';
+import * as express from 'express';
+import { injectable, postConstruct } from "inversify";
+import { log, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
+
+
+export interface SetLogLevelRequest {
+    level: LogrusLogLevel,
+}
+export namespace SetLogLevelRequest {
+    export function is(o: any): o is SetLogLevelRequest {
+        return typeof o === 'object'
+            && 'level' in o;
+    }
+}
+
+@injectable()
+export class DebugApp {
+    protected _app: express.Application;
+    protected httpServer: http.Server | undefined = undefined;
+
+    @postConstruct()
+    public ctor() {
+        this._app = this.create();
+    }
+
+    create(): express.Application {
+        const app = express();
+        app.post('/debug/logging', (req, res) => {
+	        try {
+                const parsed = JSON.parse(req.body);
+                if (!SetLogLevelRequest.is(parsed)) {
+                    res.status(400).end("not a SetLogLevelRequest");
+                    return;
+                }
+
+                const newLogLevel = parsed.level;
+                log.setLogLevel(newLogLevel);
+                log.info("set log level", { newLogLevel });
+	        } catch (err) {
+    		    res.status(500).end(err);
+	        }
+        });
+        return app;
+    }
+
+    public start(port: number) {
+        this.httpServer = this._app.listen(port, 'localhost', () => {
+            log.info(`debug server listening on port: ${port}`);
+        });
+    }
+
+    public async stop() {
+        const server = this.httpServer;
+        if (!server) {
+            return;
+        }
+        return new Promise<void>((resolve) => server.close((err: any) => {
+            if (err) {
+                log.warn(`error while closing http server`, { err });
+            }
+            this.httpServer = undefined;
+            resolve();
+        }));
+    }
+
+    public get app(): express.Application {
+        return this._app;
+    }
+}

--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -59,13 +59,13 @@ if (typeof (Symbol as any).asyncIterator === 'undefined') {
 import * as express from 'express';
 import { Container } from 'inversify';
 import { Server } from "./server"
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { log, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { TracingManager } from '@gitpod/gitpod-protocol/lib/util/tracing';
 if (process.env.NODE_ENV === 'development') {
     require('longjohn');
 }
 
-log.enableJSONLogging('server', process.env.VERSION);
+log.enableJSONLogging('server', process.env.VERSION, LogrusLogLevel.getFromEnv());
 
 export async function start(container: Container) {
     const tracing = container.get(TracingManager);

--- a/components/ws-manager-bridge/src/main.ts
+++ b/components/ws-manager-bridge/src/main.ts
@@ -7,7 +7,7 @@
 import { Container } from 'inversify';
 import * as express from 'express';
 import * as prometheusClient from 'prom-client';
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { log, LogrusLogLevel } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { MessageBusIntegration } from './messagebus-integration';
 import { TypeORM } from '@gitpod/gitpod-db/lib/typeorm/typeorm';
 import { TracingManager } from '@gitpod/gitpod-protocol/lib/util/tracing';
@@ -15,7 +15,7 @@ import { ClusterServiceServer } from './cluster-service-server';
 import { BridgeController } from './bridge-controller';
 import { MetaInstanceController } from './meta-instance-controller';
 
-log.enableJSONLogging('ws-manager-bridge', undefined);
+log.enableJSONLogging('ws-manager-bridge', undefined, LogrusLogLevel.getFromEnv());
 
 export const start = async (container: Container) => {
     try {


### PR DESCRIPTION
## Description

Introduces an endpoint for changing log levels at runtime, similar to the one introduced [here](https://github.com/gitpod-io/gitpod/pull/4433).

Currently this is server-only. `DebugApp` can and should easily be moved to a `common-ts` package, but did not want to make this part of this PR.

## Related Issue(s)
Context: #5551 

## How to test
1. kubectl port-forward deployment server 6060
2. `curl localhost:6060/debug/logging -d '{"level":"info"}'`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
runtime configurable log-level for `server`
```
