### PR TITLE
[server] logging hygiene

### DIFF
--- a/components/gitpod-protocol/src/messaging/node/connection.ts
+++ b/components/gitpod-protocol/src/messaging/node/connection.ts
@@ -65,13 +65,13 @@ export function toIWebSocket(webSocket: ws) {
         send: content => {
             if (webSocket.readyState !== ws.OPEN) {
                 if (sendsAfterOpen++ > 3) {
-                    log.error(`Repeated try to send on closed web socket (readyState was ${webSocket.readyState})`, { ws });
+                    //log.debug(`Repeated try to send on closed web socket (readyState was ${webSocket.readyState})`, { ws });
                 }
                 return;
             }
             webSocket.send(content, err => {
                 if (err) {
-                    log.error('Error in ws.send()', err, { ws });
+                    log.error('error in ws.send()', err, { ws });
                 }
             })
         },

--- a/components/gitpod-protocol/src/util/logging.ts
+++ b/components/gitpod-protocol/src/util/logging.ts
@@ -128,6 +128,10 @@ export namespace log {
         console.info = infoConsoleLog;
         console.debug = debugConsoleLog;
     }
+
+    export function setVersion(versionArg: string) {
+        version = versionArg;
+    }
 }
 
 function errorLog(calledViaConsole: boolean, args: any[]): void {

--- a/components/server/ee/src/graphql/graphql-controller.ts
+++ b/components/server/ee/src/graphql/graphql-controller.ts
@@ -30,6 +30,10 @@ export class GraphQLController {
         const schema = makeExecutableSchema({
             typeDefs,
             resolvers,
+            // silence noisy warnings
+            resolverValidationOptions :{
+                requireResolversForResolveType: false,
+            },
         });
         return graphqlHTTP(async (request) => {
             const ctx = request as any as Context;

--- a/components/server/ee/src/monitoring-endpoint-ee.ts
+++ b/components/server/ee/src/monitoring-endpoint-ee.ts
@@ -36,7 +36,7 @@ export class MonitoringEndpointsAppEE extends WorkspaceHealthMonitoring {
                     res.status(200).send(result);
                 }
             } catch (err) {
-                log.error("failed to check workspace health", err);
+                log.debug("failed to check workspace health", err);
                 res.status(500).send(err);
             }
         });

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -64,6 +64,7 @@ export class GithubApp {
                 cert: config.githubApp.certPath,
                 secret: config.githubApp.webhookSecret
             });
+
             this.server.load(this.buildApp.bind(this));
         }
     }

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -51,10 +51,10 @@ export class BearerAuth {
                     res.status(401).send(e.message);
                     return;
                 }
-                throw e;
+                return next(e);
             }
             return next();
-        }
+        };
     }
 
     get restHandlerOptionally(): express.RequestHandler {
@@ -65,7 +65,7 @@ export class BearerAuth {
                 // don't error the request, we just have not bearer authentication token
             }
             return next();
-        }
+        };
     }
 
     async auth(req: express.Request): Promise<void> {

--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { status } from '@grpc/grpc-js';
+import { status, ServiceError } from '@grpc/grpc-js';
 import fetch from "node-fetch";
 import { User } from '@gitpod/gitpod-protocol/lib/protocol';
 import bodyParser = require('body-parser');
@@ -255,8 +255,12 @@ export class CodeSyncService {
                 const request = new DeleteRequest();
                 request.setOwnerId(userId);
                 request.setExact(oldObject);
-                this.blobs.delete(request, (err: any) => {
+                this.blobs.delete(request, (err: ServiceError | null) => {
                     if (err) {
+                        if (err.code === status.NOT_FOUND) {
+                            // we're good here
+                            return;
+                        }
                         log.error({ userId }, 'code sync: failed to delete', err, { object: oldObject });
                     }
                 });

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -80,6 +80,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
     protected monHttpServer?: http.Server;
 
     public async init(app: express.Application) {
+        log.setVersion(this.config.version);
         log.info('server initializing...');
 
         // print config

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -209,11 +209,11 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
             userId: this.user.id,
         };
         if (methodName) {
+            let payload = { api: true };
             if (logPayload) {
-                log.debug(userContext, methodName, logPayload);
-            } else {
-                log.debug(userContext, methodName);
+                payload = { ...logPayload, ...payload };
             }
+            log.debug(userContext, methodName, payload);
         }
         return this.user;
     }
@@ -225,11 +225,11 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
                 ...ctx,
                 userId: user.id,
             };
+            let payload = { api: true };
             if (logPayload) {
-                log.debug(userContext, `${methodName || 'checkAndBlockUser'}: blocked`, logPayload);
-            } else {
-                log.debug(userContext, `${methodName || 'checkAndBlockUser'}: blocked`);
+                payload = { ...logPayload, ...payload };
             }
+            log.debug(userContext, `${methodName || 'checkAndBlockUser'}: blocked`, payload);
             throw new ResponseError(ErrorCodes.USER_BLOCKED, "You've been blocked.");
         }
         return user;

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -96,7 +96,7 @@ export class HeadlessLogController {
 
                 res.end();
             } catch (err) {
-                log.error(logCtx, "error streaming headless logs", err);
+                log.debug(logCtx, "error streaming headless logs", err);
 
                 res.write(`\n${HEADLESS_LOG_STREAM_STATUS_CODE}: 500`);
                 res.end();

--- a/components/server/src/workspace/headless-log-service.ts
+++ b/components/server/src/workspace/headless-log-service.ts
@@ -145,7 +145,7 @@ export class HeadlessLogService {
                 });
             });
         } catch (err) {
-            log.error({ userId, workspaceId: wsi.workspaceId, instanceId: wsi.id }, "an error occurred retrieving a headless log download URL", err, { taskId });
+            log.debug({ userId, workspaceId: wsi.workspaceId, instanceId: wsi.id }, "an error occurred retrieving a headless log download URL", err, { taskId });
             return undefined;
         }
     }


### PR DESCRIPTION
## Description
This is basically logging hygiene for `server`, without the claiming to be comprehensive.
I tackled some well-known suspects, but also the top-error emitters (judging by Google Cloud Error Reporting).

## Related Issue(s)
Context: #5551 

## How to test
1. see that the preview deployment still works.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
