### PR TITLE
[analytics] improve status_rendered events

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -77,7 +77,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         properties: {
           sessionId,
           instanceId: this.state.workspaceInstance?.id,
-          workspaceId: this.state?.workspace?.id,
+          workspaceId: this.props.workspaceId,
           type: this.state.workspace?.type,
           phase: newPhase
         },


### PR DESCRIPTION
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe

## Description
<!-- Describe your changes in detail -->

- report an initial ide state, we are missing sometimes ready state because it is already happened
- report when window is unloaded to detect the session end
- report stack trace of IDE failure error
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
 Related to #4199

## How to test
<!-- Provide steps to test this PR -->

- Start a new workspace, try to reload windows and stop the workspace eventually: https://ak-stuck-on-loading.staging.gitpod-dev.com/#github.com/akosyakov/parcel-demo
- Go to segment and inspect status_rendered events for staging untrusted source.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
