### PR TITLE
fix parisng of tasks env vars in go

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1827,14 +1827,14 @@ type ResolvePluginsParams struct {
 
 // TaskConfig is the TaskConfig message type
 type TaskConfig struct {
-	Before   string            `json:"before,omitempty"`
-	Command  string            `json:"command,omitempty"`
-	Env      map[string]string `json:"env,omitempty"`
-	Init     string            `json:"init,omitempty"`
-	Name     string            `json:"name,omitempty"`
-	OpenIn   string            `json:"openIn,omitempty"`
-	OpenMode string            `json:"openMode,omitempty"`
-	Prebuild string            `json:"prebuild,omitempty"`
+	Before   string                 `json:"before,omitempty"`
+	Command  string                 `json:"command,omitempty"`
+	Env      map[string]interface{} `json:"env,omitempty"`
+	Init     string                 `json:"init,omitempty"`
+	Name     string                 `json:"name,omitempty"`
+	OpenIn   string                 `json:"openIn,omitempty"`
+	OpenMode string                 `json:"openMode,omitempty"`
+	Prebuild string                 `json:"prebuild,omitempty"`
 }
 
 // VSCodeConfig is the VSCodeConfig message type

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -705,7 +705,7 @@ export interface TaskConfig {
     init?: string;
     prebuild?: string;
     command?: string;
-    env?: { [env: string]: string };
+    env?: { [env: string]: any };
     openIn?: 'bottom' | 'main' | 'left' | 'right';
     openMode?: 'split-top' | 'split-left' | 'split-right' | 'split-bottom' | 'tab-before' | 'tab-after';
 }

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -224,14 +224,14 @@ type WorkspaceGitpodToken struct {
 
 // TaskConfig defines gitpod task shape
 type TaskConfig struct {
-	Name     *string            `json:"name,omitempty"`
-	Before   *string            `json:"before,omitempty"`
-	Init     *string            `json:"init,omitempty"`
-	Prebuild *string            `json:"prebuild,omitempty"`
-	Command  *string            `json:"command,omitempty"`
-	Env      *map[string]string `json:"env,omitempty"`
-	OpenIn   *string            `json:"openIn,omitempty"`
-	OpenMode *string            `json:"openMode,omitempty"`
+	Name     *string                 `json:"name,omitempty"`
+	Before   *string                 `json:"before,omitempty"`
+	Init     *string                 `json:"init,omitempty"`
+	Prebuild *string                 `json:"prebuild,omitempty"`
+	Command  *string                 `json:"command,omitempty"`
+	Env      *map[string]interface{} `json:"env,omitempty"`
+	OpenIn   *string                 `json:"openIn,omitempty"`
+	OpenMode *string                 `json:"openMode,omitempty"`
 }
 
 // Validate validates this configuration

--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -24,6 +24,11 @@ import (
 var skipCommand = "echo \"skip\""
 var failCommand = "exit 1"
 
+var testEnv = &map[string]interface{}{
+	"object": map[string]interface{}{"baz": 3},
+}
+var testEnvCommand = `test $object == "{\"baz\":3}"`
+
 func TestTaskManager(t *testing.T) {
 	log.Log.Logger.SetLevel(logrus.FatalLevel)
 	tests := []struct {
@@ -97,6 +102,17 @@ func TestTaskManager(t *testing.T) {
 			ExpectedReporter: testHeadlessTaskProgressReporter{
 				Done:    true,
 				Success: false,
+			},
+		},
+		{
+			Desc:        "env var parsing",
+			Headless:    true,
+			Source:      csapi.WorkspaceInitFromOther,
+			GitpodTasks: &[]TaskConfig{{Init: &testEnvCommand, Env: testEnv}},
+
+			ExpectedReporter: testHeadlessTaskProgressReporter{
+				Done:    true,
+				Success: true,
 			},
 		},
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Our gitpod protocol schema allows any as a type for env vars of tasks. This PR adjusts typings to respect it in the code.
We considered also to make the scheme more strict, but it will be a breaking change, and there is no apparent downside of any value given that clients expect that the value be serialized/deserialized as JSON. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix #5699

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace on the repo which is using not string env var for tasks: https://akosyakov-gitpod-yml-tasks-not-5699.staging.gitpod-dev.com/#https://github.com/akosyakov/sir-lancebot/blob/eca8bcebf7c47de7fa661009df583fe79b95334e/.gitpod.yml#L5
- Check that the task terminal is running and env var is set: `printenv PIP_USER` should be `false`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix parsing of tasks' env vars.
```
