### PR TITLE
[gitpod-api] guard against unsupported notifications

### DIFF
--- a/components/gitpod-protocol/src/messaging/proxy-factory.ts
+++ b/components/gitpod-protocol/src/messaging/proxy-factory.ts
@@ -158,7 +158,9 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
      * methods calls.
      */
     protected onNotification(method: string, ...args: any[]): void {
-        this.target[method](...args);
+        if (this.target[method]) {
+            this.target[method](...args);
+        }
     }
 
     /**

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 332c5fa4288eddcb44f999fa5a7661e5d87f6d74
+ENV GP_CODE_COMMIT 9255ed132288a5b3591e4f8ce79fdb83f3fc6f9c
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adding new notifications from Gitpod server to clients is not backward compatible change. We used to have a guard which will allow client ignore such notifications but removed it to support proxies: https://github.com/gitpod-io/gitpod/commit/4c2fab7a93e6d9589d6b14fdfd9cfa1a878e9454#diff-b8847df09095afd1fed8277f763df0e828b40f2e071d73f3bbc4ed8c131903f9 Since `in` operator did not return any properties for proxies.

This PR reintroduces the guard but directly in handling of a concrete notification.

Changes in Gitpod Code: https://github.com/gitpod-io/openvscode-server/commit/9255ed132288a5b3591e4f8ce79fdb83f3fc6f9c

TODO:
- [ ] don't forget to publish new desktop version after PR is approved

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5717

## How to test
<!-- Provide steps to test this PR -->

Enable latest VS Code: https://ak-gp-api-notif-guard.staging.gitpod-dev.com/preferences
Start a workspace to verify that proxying still works: https://ak-gp-api-notif-guard.staging.gitpod-dev.com/#github.com/akosyakov/parcel-demo

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
