### PR TITLE
[observability] Add gRPC client call and additional functional metrics

### DIFF
--- a/chart/templates/ws-manager-bridge-deployment.yaml
+++ b/chart/templates/ws-manager-bridge-deployment.yaml
@@ -43,6 +43,7 @@ spec:
 {{ include "gitpod.databaseWaiter.container" $this | indent 6 }}
 {{ include "gitpod.msgbusWaiter.container" $this | indent 6 }}
       containers:
+{{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       - name: ws-manager-bridge
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.resources" $this | indent 8 }}

--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -65,6 +65,6 @@ data:
         },
         "pprofAddr": ":6060",
         "readinessProbeAddr": ":60088",
-        "prometheusAddr": ":60095"
+        "prometheusAddr": "localhost:9500"
     }
 {{- end -}}

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -54,6 +54,7 @@ spec:
 {{- end }}
       enableServiceLinks: false
       containers:
+{{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       - name: ws-proxy
         image: {{ template "gitpod.comp.imageFull" $this }}
         args: ["run", "-v", "/config/config.json"]

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-test/deep v1.0.5
 	github.com/google/go-cmp v0.5.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect

--- a/components/common-go/go.sum
+++ b/components/common-go/go.sum
@@ -103,6 +103,8 @@ github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97Dwqy
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/components/content-service-api/typescript/src/client-call-metrics.ts
+++ b/components/content-service-api/typescript/src/client-call-metrics.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as grpc from "@grpc/grpc-js";
+import { Status } from "@grpc/grpc-js/build/src/constants";
+
+type GrpcMethodType = 'unary' | 'client_stream' | 'server_stream' | 'bidi_stream';
+export interface IGrpcCallMetricsLabels {
+	service: string,
+	method: string,
+	type: GrpcMethodType,
+	code?: string
+}
+
+export const IClientCallMetrics = Symbol("IClientCallMetrics");
+
+export interface IClientCallMetrics {
+    called(labels: IGrpcCallMetricsLabels) : void;
+}
+
+export function getGrpcMethodType(requestStream: boolean, responseStream: boolean): GrpcMethodType {
+    if (requestStream) {
+        if (responseStream) {
+            return 'bidi_stream';
+        } else {
+            return 'client_stream';
+        }
+    } else {
+        if (responseStream) {
+            return 'server_stream';
+        } else {
+            return 'unary';
+        }
+    }
+}
+
+export function createClientCallMetricsInterceptor(metrics: IClientCallMetrics): grpc.Interceptor {
+    return (options, nextCall): grpc.InterceptingCall => {
+        const requester = new grpc.RequesterBuilder()
+            .withStart((metadata, listener, next) => {
+                const newListener = new grpc.ListenerBuilder().withOnReceiveStatus((status, next) => {
+                    try {
+                        const methodDef = options.method_definition;
+                        const method = methodDef.path.substring(methodDef.path.lastIndexOf('/') + 1);
+                        const service = methodDef.path.substring(0, methodDef.path.length - method.length);
+                        metrics.called({
+                            service,
+                            method,
+                            type: getGrpcMethodType(options.method_definition.requestStream, options.method_definition.responseStream),
+                            code: Status[status.code]
+                        });
+                    } finally {
+                        next(status);
+                    }
+                }).build()
+                next(metadata, newListener);
+            }).build();
+        return new grpc.InterceptingCall(nextCall(options), requester);
+    };
+}

--- a/components/ee/ws-scheduler/cmd/run.go
+++ b/components/ee/ws-scheduler/cmd/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
@@ -40,6 +41,27 @@ var runCmd = &cobra.Command{
 		}
 		log.Info("connected to Kubernetes")
 
+		reg := prometheus.NewRegistry()
+		if config.Prometheus.Addr != "" {
+			prometheus.WrapRegistererWithPrefix("gitpod_ws_scheduler_", reg).MustRegister(schedMetrics.AllMetrics...)
+			reg.MustRegister(common_grpc.ClientMetrics())
+
+			handler := http.NewServeMux()
+			handler.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+
+			go func() {
+				err := http.ListenAndServe(config.Prometheus.Addr, handler)
+				if err != nil {
+					log.WithError(err).Error("Prometheus metrics server failed")
+				}
+			}()
+			log.WithField("addr", config.Prometheus.Addr).Info("started Prometheus metrics server")
+		}
+
+		if config.PProf.Addr != "" {
+			go pprof.Serve(config.PProf.Addr)
+		}
+
 		scheduler, err := sched.NewScheduler(config.Scheduler, clientSet)
 		if err != nil {
 			log.WithError(err).Fatal("cannot create scheduler")
@@ -59,8 +81,6 @@ var runCmd = &cobra.Command{
 			log.Info("ws-scheduler shut down")
 		}()
 
-		reg := prometheus.NewRegistry()
-
 		if config.Scaler.Enabled {
 			controller, err := scaler.NewController(config.Scaler.Controller)
 			if err != nil {
@@ -78,25 +98,6 @@ var runCmd = &cobra.Command{
 			go driver.Run()
 			defer driver.Stop()
 			log.WithField("controller", config.Scaler.Controller.Kind).Info("started scaler")
-		}
-
-		if config.Prometheus.Addr != "" {
-			prometheus.WrapRegistererWithPrefix("gitpod_ws_scheduler_", reg).MustRegister(schedMetrics.AllMetrics...)
-
-			handler := http.NewServeMux()
-			handler.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-
-			go func() {
-				err := http.ListenAndServe(config.Prometheus.Addr, handler)
-				if err != nil {
-					log.WithError(err).Error("Prometheus metrics server failed")
-				}
-			}()
-			log.WithField("addr", config.Prometheus.Addr).Info("started Prometheus metrics server")
-		}
-
-		if config.PProf.Addr != "" {
-			go pprof.Serve(config.PProf.Addr)
 		}
 
 		log.Info("🗓️ ws-scheduler is up and running. Stop with SIGINT or CTRL+C")

--- a/components/ee/ws-scheduler/go.mod
+++ b/components/ee/ws-scheduler/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/content-service/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
-	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible
+	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
@@ -19,8 +19,8 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.39.1
 	google.golang.org/protobuf v1.27.1
-	k8s.io/api v0.22.0
-	k8s.io/apimachinery v0.22.0
+	k8s.io/api v0.22.1
+	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.0
 	k8s.io/component-helpers v0.22.0
 )
@@ -37,6 +37,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect

--- a/components/ee/ws-scheduler/go.sum
+++ b/components/ee/ws-scheduler/go.sum
@@ -112,8 +112,8 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-ozzo/ozzo-validation v3.5.0+incompatible h1:sUy/in/P6askYr16XJgTKq/0SZhiWsdg4WZGaLsGQkM=
-github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -184,6 +184,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/components/gitpod-protocol/src/messaging/client-call-metrics.ts
+++ b/components/gitpod-protocol/src/messaging/client-call-metrics.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { injectable } from 'inversify';
+import * as prometheusClient from 'prom-client';
+
+type GrpcMethodType = 'unary' | 'client_stream' | 'server_stream' | 'bidi_stream';
+export interface IGrpcCallMetricsLabels {
+	service: string,
+	method: string,
+	type: GrpcMethodType,
+	code?: string
+}
+
+export interface IClientCallMetrics {
+    called(labels: IGrpcCallMetricsLabels) : void;
+}
+
+@injectable()
+export class PrometheusClientCallMetrics implements IClientCallMetrics {
+
+	readonly counter: prometheusClient.Counter;
+
+	constructor() {
+		this.counter = new prometheusClient.Counter({
+			name: 'grpc_client_calls_total',
+			help: 'Total amount of gRPC client calls',
+			labelNames: ['grpc_service', 'grpc_method', 'grpc_type', 'grpc_code'],
+			registers: [prometheusClient.register]
+		});
+	}
+
+	called(labels: IGrpcCallMetricsLabels): void {
+		if (labels.code) {
+			this.counter.inc({
+				grpc_service: labels.service,
+				grpc_method: labels.method,
+				grpc_type: labels.type,
+				grpc_code: labels.code,
+			});
+		} else {
+			this.counter.inc({
+				grpc_service: labels.service,
+				grpc_method: labels.method,
+				grpc_type: labels.type
+			});
+		}
+	}
+}

--- a/components/image-builder-mk3/go.mod
+++ b/components/image-builder-mk3/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/components/image-builder-mk3/go.sum
+++ b/components/image-builder-mk3/go.sum
@@ -409,6 +409,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/components/image-builder-mk3/pkg/orchestrator/metrics.go
+++ b/components/image-builder-mk3/pkg/orchestrator/metrics.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package orchestrator
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// RegisterMetrics registers the metrics of this builder
+func (o *Orchestrator) RegisterMetrics(reg prometheus.Registerer) error {
+	err := reg.Register(o.metrics.imageBuildsDoneTotal)
+	if err != nil {
+		return err
+	}
+	err = reg.Register(o.metrics.imageBuildsStartedTotal)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+const (
+	metricsNamespace = "gitpod"
+	metricsSubsystem = "image_builder"
+)
+
+type metrics struct {
+	imageBuildsDoneTotal    *prometheus.CounterVec
+	imageBuildsStartedTotal prometheus.Counter
+}
+
+func newMetrics() *metrics {
+	return &metrics{
+		imageBuildsDoneTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "builds_done_total",
+		}, []string{"success"}),
+		imageBuildsStartedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "builds_started_total",
+		}),
+	}
+}
+
+func (m *metrics) BuildDone(success bool) {
+	m.imageBuildsDoneTotal.WithLabelValues(strconv.FormatBool(success)).Inc()
+}
+
+func (m *metrics) BuildStarted() {
+	m.imageBuildsStartedTotal.Inc()
+}

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -175,6 +175,7 @@ func NewOrchestratingBuilder(cfg Configuration) (res *Orchestrator, err error) {
 		logListener:    make(map[string]map[logListener]struct{}),
 		censorship:     make(map[string][]string),
 		builderAuthKey: builderAuthKey,
+		metrics:        newMetrics(),
 	}
 	o.monitor = newBuildMonitor(o, o.wsman)
 
@@ -197,6 +198,8 @@ type Orchestrator struct {
 	mu             sync.RWMutex
 
 	monitor *buildMonitor
+
+	metrics *metrics
 
 	protocol.UnimplementedImageBuilderServer
 }

--- a/components/registry-facade/cmd/run.go
+++ b/components/registry-facade/cmd/run.go
@@ -20,10 +20,12 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/gitpod-io/gitpod/registry-facade/pkg/registry"
@@ -41,6 +43,34 @@ var runCmd = &cobra.Command{
 		cfg, err := getConfig(configPath)
 		if err != nil {
 			log.WithError(err).WithField("filename", configPath).Fatal("cannot load config")
+		}
+
+		promreg := prometheus.NewRegistry()
+		gpreg := prometheus.WrapRegistererWithPrefix("gitpod_registry_facade_", promreg)
+		rtt, err := registry.NewMeasuringRegistryRoundTripper(newDefaultTransport(), prometheus.WrapRegistererWithPrefix("downstream_", gpreg))
+		if err != nil {
+			log.WithError(err).Fatal("cannot register metrics")
+		}
+		if cfg.PrometheusAddr != "" {
+			promreg.MustRegister(
+				collectors.NewGoCollector(),
+				collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+				common_grpc.ClientMetrics(),
+			)
+
+			handler := http.NewServeMux()
+			handler.Handle("/metrics", promhttp.HandlerFor(promreg, promhttp.HandlerOpts{}))
+
+			go func() {
+				err := http.ListenAndServe(cfg.PrometheusAddr, handler)
+				if err != nil {
+					log.WithError(err).Error("Prometheus metrics server failed")
+				}
+			}()
+			log.WithField("addr", cfg.PrometheusAddr).Info("started Prometheus metrics server")
+		}
+		if cfg.PProfAddr != "" {
+			go pprof.Serve(cfg.PProfAddr)
 		}
 
 		var dockerCfg *configfile.ConfigFile
@@ -61,13 +91,6 @@ var runCmd = &cobra.Command{
 				log.WithError(err).Fatal("cannot read docker config")
 			}
 			log.WithField("fn", authCfg).Info("using authentication for backing registries")
-		}
-
-		promreg := prometheus.NewRegistry()
-		gpreg := prometheus.WrapRegistererWithPrefix("gitpod_registry_facade_", promreg)
-		rtt, err := registry.NewMeasuringRegistryRoundTripper(newDefaultTransport(), prometheus.WrapRegistererWithPrefix("downstream_", gpreg))
-		if err != nil {
-			log.WithError(err).Fatal("cannot registry metrics")
 		}
 
 		resolverProvider := func() remotes.Resolver {
@@ -94,27 +117,6 @@ var runCmd = &cobra.Command{
 			defer close(registryDoneChan)
 			reg.MustServe()
 		}()
-
-		if cfg.PProfAddr != "" {
-			go pprof.Serve(cfg.PProfAddr)
-		}
-		if cfg.PrometheusAddr != "" {
-			promreg.MustRegister(
-				prometheus.NewGoCollector(),
-				prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-			)
-
-			handler := http.NewServeMux()
-			handler.Handle("/metrics", promhttp.HandlerFor(promreg, promhttp.HandlerOpts{}))
-
-			go func() {
-				err := http.ListenAndServe(cfg.PrometheusAddr, handler)
-				if err != nil {
-					log.WithError(err).Error("Prometheus metrics server failed")
-				}
-			}()
-			log.WithField("addr", cfg.PrometheusAddr).Info("started Prometheus metrics server")
-		}
 
 		log.Info("🏪 registry facade is up and running")
 		sigChan := make(chan os.Signal, 1)

--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/go-test/deep v1.0.5 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/klauspost/compress v1.11.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/components/registry-facade/go.sum
+++ b/components/registry-facade/go.sum
@@ -383,6 +383,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/components/ws-manager-bridge/BUILD.yaml
+++ b/components/ws-manager-bridge/BUILD.yaml
@@ -5,6 +5,7 @@ packages:
       - "**/*.ts"
       - package.json
     deps:
+      - components/content-service-api/typescript:lib
       - components/gitpod-db:lib
       - components/gitpod-messagebus:lib
       - components/gitpod-protocol:lib

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -17,12 +17,14 @@ import { TracingManager } from '@gitpod/gitpod-protocol/lib/util/tracing';
 import { PrometheusMetricsExporter } from './prometheus-metrics-exporter';
 import { BridgeController, WorkspaceManagerClientProviderConfigSource } from './bridge-controller';
 import { filePathTelepresenceAware } from '@gitpod/gitpod-protocol/lib/env';
-import { WorkspaceManagerClientProvider } from '@gitpod/ws-manager/lib/client-provider';
+import { WorkspaceManagerClientProvider, IWorkspaceManagerClientCallMetrics } from '@gitpod/ws-manager/lib/client-provider';
 import { WorkspaceManagerClientProviderCompositeSource, WorkspaceManagerClientProviderDBSource, WorkspaceManagerClientProviderSource } from '@gitpod/ws-manager/lib/client-provider-source';
 import { ClusterService, ClusterServiceServer } from './cluster-service-server';
 import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
 import { newAnalyticsWriterFromEnv } from '@gitpod/gitpod-protocol/lib/util/analytics';
 import { MetaInstanceController } from './meta-instance-controller';
+import { IClientCallMetrics } from '@gitpod/content-service/lib/client-call-metrics';
+import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
 
 export const containerModule = new ContainerModule(bind => {
 
@@ -33,6 +35,10 @@ export const containerModule = new ContainerModule(bind => {
     bind(BridgeController).toSelf().inSingletonScope();
 
     bind(MetaInstanceController).toSelf().inSingletonScope();
+
+    bind(PrometheusClientCallMetrics).toSelf().inSingletonScope();
+    bind(IClientCallMetrics).to(PrometheusClientCallMetrics).inSingletonScope();
+    bind(IWorkspaceManagerClientCallMetrics).toService(IClientCallMetrics);
 
     bind(WorkspaceManagerClientProvider).toSelf().inSingletonScope();
     bind(WorkspaceManagerClientProviderCompositeSource).toSelf().inSingletonScope();

--- a/components/ws-manager-bridge/src/main.ts
+++ b/components/ws-manager-bridge/src/main.ts
@@ -34,8 +34,8 @@ export const start = async (container: Container) => {
             res.send(prometheusClient.register.metrics().toString());
         });
         const metricsPort = 9500;
-        const metricsHttpServer = metricsApp.listen(metricsPort, () => {
-            log.info(`prometheus metrics server running on: ${metricsPort}`);
+        const metricsHttpServer = metricsApp.listen(metricsPort, 'localhost', () => {
+            log.info(`prometheus metrics server running on: localhost:${metricsPort}`);
         });
 
         const bridgeController = container.get<BridgeController>(BridgeController);

--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -7,11 +7,14 @@
 import * as prom from 'prom-client';
 import { injectable } from "inversify";
 import { WorkspaceInstance } from '@gitpod/gitpod-protocol';
+import { WorkspaceClusterWoTLS } from '@gitpod/gitpod-protocol/src/workspace-cluster';
 
 @injectable()
 export class PrometheusMetricsExporter {
     protected readonly workspaceStartupTimeHistogram: prom.Histogram;
     protected readonly timeToFirstUserActivityHistogram: prom.Histogram;
+    protected readonly clusterScore: prom.Gauge;
+    protected readonly clusterCordoned: prom.Gauge;
 
     constructor() {
         this.workspaceStartupTimeHistogram = new prom.Histogram({
@@ -25,6 +28,16 @@ export class PrometheusMetricsExporter {
             help: 'The time between a workspace is running and first user activity',
             labelNames: ['region'],
             buckets: prom.exponentialBuckets(2, 2, 10),
+        });
+        this.clusterScore = new prom.Gauge({
+            name: 'gitpod_ws_manager_bridge_cluster_score',
+            help: 'Score of the individual registered workspace cluster',
+            labelNames: ["workspace_cluster"]
+        });
+        this.clusterCordoned = new prom.Gauge({
+            name: 'gitpod_ws_manager_bridge_cluster_cordoned',
+            help: 'Cordoned status of the individual registered workspace cluster',
+            labelNames: ["workspace_cluster"]
         });
     }
 
@@ -46,4 +59,15 @@ export class PrometheusMetricsExporter {
             region: instance.region,
         }, timeToFirstUserActivity);
     }
+
+    updateClusterMetrics(clusters: WorkspaceClusterWoTLS[]): void {
+        this.clusterScore.reset();
+        this.clusterCordoned.reset();
+
+        clusters.forEach(cluster => {
+            this.clusterCordoned.labels(cluster.name).set(cluster.state === 'cordoned' ? 1 : 0);
+            this.clusterScore.labels(cluster.name).set(cluster.score);
+        });
+    }
 }
+

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -64,6 +64,10 @@ var runCmd = &cobra.Command{
 
 		if cfg.Prometheus.Addr != "" {
 			opts.MetricsBindAddress = cfg.Prometheus.Addr
+			err := metrics.Registry.Register(common_grpc.ClientMetrics())
+			if err != nil {
+				log.WithError(err).Error("Prometheus metrics incomplete")
+			}
 		}
 
 		mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), opts)
@@ -103,7 +107,7 @@ var runCmd = &cobra.Command{
 		defer mgmt.Close()
 
 		if cfg.Prometheus.Addr != "" {
-			err := mgmt.RegisterMetrics(metrics.Registry)
+			err = mgmt.RegisterMetrics(metrics.Registry)
 			if err != nil {
 				log.WithError(err).Error("Prometheus metrics incomplete")
 			}

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -1171,6 +1171,7 @@ func (m *Manager) connectToWorkspaceDaemon(ctx context.Context, wso workspaceObj
 // newWssyncConnectionFactory creates a new wsdaemon connection factory based on the wsmanager configuration
 func newWssyncConnectionFactory(managerConfig config.Configuration) (grpcpool.Factory, error) {
 	cfg := managerConfig.WorkspaceDaemon
+	// TODO(cw): add client-side gRPC metrics
 	grpcOpts := common_grpc.DefaultClientOptions()
 	if cfg.TLS.Authority != "" || cfg.TLS.Certificate != "" && cfg.TLS.PrivateKey != "" {
 		ca := cfg.TLS.Authority

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -8,13 +8,11 @@ require (
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.6
-	github.com/google/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
-	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.39.1
 )
@@ -27,6 +25,7 @@ require (
 	github.com/gitpod-io/gitpod/content-service/api v0.0.0-00010101000000-000000000000 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -43,6 +42,7 @@ require (
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -114,8 +114,6 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252 h1:tAkooHvRrtO8kFB6YOPTpLQok3Hfv1DNDXdNqgi29Ao=
-github.com/google/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252/go.mod h1:DavVbd41y+b7ukKDmlnPR4nGYmkWXR6vHUkjQNiHPBs=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -128,6 +126,7 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -19,7 +19,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.39.1
 	google.golang.org/protobuf v1.27.1
-	k8s.io/apimachinery v0.22.0
+	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.0.0
 )
 
@@ -56,7 +56,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.22.0 // indirect
+	k8s.io/api v0.22.1 // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect
 	k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -17,8 +17,8 @@ require (
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.39.1
-	k8s.io/api v0.22.0
-	k8s.io/apimachinery v0.22.0
+	k8s.io/api v0.22.1
+	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.0
 )
 
@@ -33,7 +33,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
-	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible // indirect
+	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -309,6 +309,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible h1:sUy/in/P6askYr16XJgTKq/0SZhiWsdg4WZGaLsGQkM=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=


### PR DESCRIPTION
## Description
Adds client call metrics to gRPC calls form TS and Go, and makes the server -> image-builder connection use the default gRPC unary options. The lack of the latter probably was the cause of the recent image-builder related outage.

Also adds cluster registration metrics to ws-manager-bridge, and image-build counts to image-builder-mk3

Thanks @JanKoehnlein for figuring out the nitty gritty of the grpc-js interceptor business.

## Related Issue(s)
Fixes #5706, #5707

## How to test
1. start a workspace to produce some data all the way 'round
2. look at the metric endpoints of `server`, `image-builder-mk3`, `ws-manager-bridge`, `ws-manager`, `ws-proxy`, `ws-scheduler`. You should see `grpc_client_calls_total` metrics on all those services.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Add gRPC client call metrics
[ws-manager-bridge] Add gRPC client call and cluster registration metrics
[image-builder-mk3] Add image-build metrics
```
