### PR TITLE
[dashboard] Remove duplicate status header in Prebuild page

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -13,7 +13,7 @@ import PrebuildLogs from "../components/PrebuildLogs";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
 import { ThemeContext } from "../theme-context";
-import { prebuildStatusIcon, prebuildStatusLabel, PrebuildInstanceStatus } from "./Prebuilds";
+import { PrebuildInstanceStatus } from "./Prebuilds";
 import { shortCommitMessage } from "./render-utils";
 
 export default function () {
@@ -62,15 +62,8 @@ export default function () {
         if (!prebuild) {
             return "";
         }
-        const statusIcon = prebuildStatusIcon(prebuild.status);
-        const status = prebuildStatusLabel(prebuild.status);
         const startedByAvatar = prebuild.info.startedByAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={prebuild.info.startedByAvatar || ''} alt={prebuild.info.startedBy} />;
         return (<div className="flex">
-            <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase">
-                <div className="inline-block align-text-bottom mr-2 w-4 h-4">{statusIcon}</div>
-                {status}
-            </div>
-            <p className="mx-2 my-auto">·</p>
             <div className="my-auto">
                 <p>{startedByAvatar}Triggered {moment(prebuild.info.startedAt).fromNow()}</p>
             </div>


### PR DESCRIPTION
Implements B from https://github.com/gitpod-io/gitpod/issues/5526

## Description
<!-- Describe your changes in detail -->

| BEFORE | AFTER |
| --- | --- |
| <img width="1438" alt="Screenshot 2021-09-17 at 09 59 09" src="https://user-images.githubusercontent.com/599268/133746884-f4431ec6-06f2-45f6-8295-9b5fa14a7129.png"> | <img width="1439" alt="Screenshot 2021-09-17 at 09 56 36" src="https://user-images.githubusercontent.com/599268/133746874-2bf2ce4e-8eda-48a9-97c6-953493283328.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5526

## How to test
<!-- Provide steps to test this PR -->

1. Trigger one or more prebuilds for a project
2. Open the prebuild page -- there should be only one status widget shown

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
