### PR TITLE
[code] show open in desktop notificaiton

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 9255ed132288a5b3591e4f8ce79fdb83f3fc6f9c
+ENV GP_CODE_COMMIT 49fa70822b4f1bbb68f29dd3dc1008840ed7128c
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

Show the notification to open in VS Code Desktop on page load.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5732

## How to test
<!-- Provide steps to test this PR -->

- Switch to latest VS Code.
- Start a workspace.
- You should see a notification, press it, you should open in VS Code Desktop.
- Reload the page, select don't show again, then reload again and test that there is notification anymore.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
