### PR TITLE
feat(contribute): add codetour extension

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -55,3 +55,4 @@ vscode:
     - stkb.rewrap
     - zxh404.vscode-proto3
     - matthewpi.caddyfile-support
+    - vsls-contrib.codetour


### PR DESCRIPTION
## Description

As part of making it easier for people to contribute to the gitpod-io/gitpod project this pull-request wires in [codetour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) and a couple of initial codebase walkthroughs as a proof-of-concept.

Requires at least VSCode v1.60. See https://github.com/gitpod-io/gitpod/issues/4978#issuecomment-921531749

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use codetour to make it easier to contribute to Gitpod.
```
