### PR TITLE
[proxy] Enable Caddy metrics

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -129,6 +129,10 @@
 :8003 {
 	respond /live 200
 	respond /ready 200
+
+	metrics /metrics {
+		disable_openmetrics
+	}
 }
 
 # always redirect to HTTPS


### PR DESCRIPTION
## Description

This PR enables the metrics endpoint on port `8003` in order to be consumed in Prometheus.

~~@ArthurSens Could you test it with the preview environment?~~ Done.

@aledbf Could you review this?

## Related Issue(s)
See also:
- https://github.com/gitpod-io/ops/pull/9
- https://github.com/gitpod-io/observability/issues/265


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/no-cc