### PR TITLE
[server] Don't re-set owner cookie

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -170,6 +170,18 @@ export class UserController {
                 return;
             }
 
+            let cookiePrefix: string = this.config.hostUrl.url.host;
+            cookiePrefix = cookiePrefix.replace(/^https?/, '');
+            [" ", "-", "."].forEach(c => cookiePrefix = cookiePrefix.split(c).join("_"));
+            const name = `_${cookiePrefix}_ws_${instanceID}_owner_`;
+
+            if (!!req.cookies[name]) {
+                // cookie is already set - do nothing. This prevents server from drowning in load
+                // if the dashboard is ill-behaved.
+                res.sendStatus(200);
+                return;
+            }
+
             const [workspace, instance] = await Promise.all([
                 this.workspaceDB.findByInstanceId(instanceID),
                 this.workspaceDB.findInstanceById(instanceID)
@@ -207,11 +219,6 @@ export class UserController {
                 return;
             }
 
-            let cookiePrefix: string = this.config.hostUrl.url.host;
-            cookiePrefix = cookiePrefix.replace(/^https?/, '');
-            [" ", "-", "."].forEach(c => cookiePrefix = cookiePrefix.split(c).join("_"));
-
-            const name = `_${cookiePrefix}_ws_${instanceID}_owner_`;
             res.cookie(name, token, {
                 path: "/",
                 httpOnly: true,


### PR DESCRIPTION
## Description
When starting a workspace we're installing the "owner cookie" which is used for ws-proxy's authentication mechanism. The dashboard will ask many times for this cookie. To ease load on the server, we'll only properly process the request when the cookie isn't set yet.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5718

## How to test
Modify server to produce a log message when this happens. Start a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
