### PR TITLE
[preview-env] Deploy monitoring-satellite alongside preview environments

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -10,6 +10,7 @@ import * as util from 'util';
 import { sleep } from './util/util';
 import * as gpctl from './util/gpctl';
 import { createHash } from "crypto";
+import { InstallMonitoringSatelliteParams, installMonitoringSatellite } from './util/observability';
 
 const readDir = util.promisify(fs.readdir)
 
@@ -228,12 +229,14 @@ export async function build(context, version) {
     const destname = version.split(".")[0];
     const namespace = `staging-${destname}`;
     const domain = `${destname}.staging.gitpod-dev.com`;
+    const monitoringDomain = `${destname}.preview.gitpod-dev.com`;
     const url = `https://${domain}`;
     const deploymentConfig = {
         version,
         destname,
         namespace,
         domain,
+        monitoringDomain,
         url,
         analytics,
         cleanSlateDeployment,
@@ -251,6 +254,7 @@ interface DeploymentConfig {
     destname: string;
     namespace: string;
     domain: string;
+    monitoringDomain: string,
     url: string;
     k3sWsCluster?: boolean;
     analytics?: string;
@@ -265,10 +269,11 @@ interface DeploymentConfig {
  */
 export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceFeatureFlags: string[], dynamicCPULimits, storage) {
     werft.phase("deploy", "deploying to dev");
-    const { version, destname, namespace, domain, url, k3sWsCluster } = deploymentConfig;
-    const [wsdaemonPortMeta, registryNodePortMeta] = findFreeHostPorts("", [
+    const { version, destname, namespace, domain, monitoringDomain, url, k3sWsCluster } = deploymentConfig;
+    const [wsdaemonPortMeta, registryNodePortMeta, nodeExporterPort] = findFreeHostPorts("", [
         { start: 10000, end: 11000 },
         { start: 30000, end: 31000 },
+        { start: 31001, end: 32000 },
     ], 'hostports');
     const [wsdaemonPortK3sWs, registryNodePortK3sWs] = !k3sWsCluster ? [0, 0] : findFreeHostPorts(getK3sWsKubeConfigPath(), [
         { start: 10000, end: 11000 },
@@ -330,8 +335,18 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
             await issueK3sWsCerts(k3sWsProxyIP);
             await installWsCertificates();
         }
-
         werft.done('certificate');
+
+        werft.log(`observability`, "Installing monitoring-satellite...")
+        if (context.Annotations.withMonitoringSatellite != null) {
+            await installMonitoring();
+            exec(`werft log result -d "Monitoring Satellite - Grafana" -c github-check-Grafana url https://grafana-${monitoringDomain}/dashboards`);
+            exec(`werft log result -d "Monitoring Satellite - Prometheus" -c github-check-Prometheus url https://prometheus-${monitoringDomain}/graph`);
+        } else {
+            exec(`echo '"withMonitoringSatellite" annotation not set, skipping...'`, {slice: `observability`})
+            exec(`echo 'To deploy monitoring-satellite, please add "/werft withMonitoringSatellite" to your PR description.'`, {slice: `observability`})
+        }
+        werft.done('observability');
 
         werft.done('prep');
     } catch (err) {
@@ -533,6 +548,21 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         await installCertficate(werft, wsInstallCertParams);
     }
 
+    async function installMonitoring() {
+        const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
+        if(context.Annotations.withMonitoringSatellite == "") {
+            installMonitoringSatelliteParams.branch = 'main'
+        } else {
+            installMonitoringSatelliteParams.branch = context.Annotations.withMonitoringSatellite
+        }
+        installMonitoringSatelliteParams.pathToKubeConfig = ""
+        installMonitoringSatelliteParams.satelliteNamespace = namespace
+        installMonitoringSatelliteParams.clusterName = namespace
+        installMonitoringSatelliteParams.nodeExporterPort = nodeExporterPort
+        installMonitoringSatelliteParams.previewDomain = monitoringDomain
+        await installMonitoringSatellite(installMonitoringSatelliteParams);
+    }
+
 
     async function issueMetaCerts() {
         let additionalSubdomains: string[] = ["", "*.", "*.ws-dev."]
@@ -668,3 +698,4 @@ async function publishHelmChart(imageRepoBase, version) {
         exec(cmd, { slice: 'publish-charts' });
     });
 }
+

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -4,6 +4,9 @@ pod:
   nodeSelector:
     cloud.google.com/gke-nodepool: builds
   volumes:
+  - name: monitoring-satellite-preview-token
+    secret:
+      secretName: monitoring-satellite-preview-token
   - name: gcp-sa
     secret:
       secretName: gcp-sa-gitpod-dev-deployer
@@ -47,6 +50,8 @@ pod:
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:
+    - name: monitoring-satellite-preview-token
+      mountPath: /mnt/secrets/monitoring-satellite-preview-token
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa
       readOnly: true

--- a/.werft/util/observability.ts
+++ b/.werft/util/observability.ts
@@ -1,0 +1,87 @@
+import { werft, exec } from './shell';
+
+/**
+ * Monitoring satellite deployment bits
+ */
+ export class InstallMonitoringSatelliteParams {
+    pathToKubeConfig: string
+    satelliteNamespace: string
+    clusterName: string
+    nodeExporterPort: number
+    branch: string
+    previewDomain: string
+}
+
+const sliceName = 'observability';
+
+export async function installMonitoringSatellite(params: InstallMonitoringSatelliteParams) {
+    werft.log(sliceName, `Cloning observability repository - Branch: ${params.branch}`)
+    exec(`git clone --branch ${params.branch} https://roboquat:$(cat /mnt/secrets/monitoring-satellite-preview-token/token)@github.com/gitpod-io/observability.git`, {silent: true})
+    werft.log(sliceName, 'installing jsonnet utility tools')
+    exec('cd observability && make setup-workspace', {silent: true})
+    werft.log(sliceName, 'rendering YAML files')
+
+    let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
+    --ext-str is_preview="true" \
+    --ext-str alerting_enabled="false" \
+    --ext-str remote_write_enabled="false" \
+    --ext-str namespace="${params.satelliteNamespace}" \
+    --ext-str cluster_name="${params.satelliteNamespace}" \
+    --ext-str node_exporter_port="${params.nodeExporterPort}" \
+    --ext-str prometheus_dns_name="prometheus-${params.previewDomain}" \
+    --ext-str grafana_dns_name="grafana-${params.previewDomain}" \
+    monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
+    find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
+
+    exec(jsonnetRenderCmd, {silent: true})
+    // The correct kubectl context should already be configured prior to this step
+    ensureCorrectInstallationOrder()
+}
+
+async function ensureCorrectInstallationOrder(){
+    // Adds a label to the namespace metadata.
+    // This label is used by ServiceMonitor's namespaceSelector, so Prometheus
+    // only scrape metrics from its own namespace.
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/namespace.yaml', {silent: true})
+
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/podsecuritypolicy-restricted.yaml', {silent: true})
+    werft.log(sliceName, 'installing prometheus-operator')
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/prometheus-operator/', {silent: true})
+    exec('kubectl rollout status deployment prometheus-operator', {slice: sliceName})
+
+    deployPrometheus()
+    deployGrafana()
+    deployNodeExporter()
+    deployKubeStateMetrics()
+    deployGitpodServiceMonitors()
+}
+
+async function deployPrometheus() {
+    werft.log(sliceName, 'installing prometheus')
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/prometheus/', {silent: true})
+    exec('sleep 5 && kubectl rollout status statefulset prometheus-k8s', {slice: sliceName})
+}
+
+async function deployGrafana() {
+    werft.log(sliceName, 'installing grafana')
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/grafana/', {silent: true})
+    // We need to fix https://github.com/gitpod-io/observability/issues/258 first
+    exec('kubectl rollout status deployment grafana', {slice: sliceName})
+}
+
+async function deployNodeExporter() {
+    werft.log(sliceName, 'installing node-exporter')
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/node-exporter/', {silent: true})
+    exec('kubectl rollout status daemonset node-exporter', {slice: sliceName})
+}
+
+async function deployKubeStateMetrics() {
+    werft.log(sliceName, 'installing kube-state-metrics')
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/kube-state-metrics/', {silent: true})
+    exec('kubectl rollout status deployment kube-state-metrics', {slice: sliceName})
+}
+
+async function deployGitpodServiceMonitors() {
+    werft.log(sliceName, 'installing gitpod ServiceMonitor resources')
+    exec('kubectl apply -f observability/monitoring-satellite/manifests/gitpod/', {silent: true})
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds monitoring-satellite(with a few modifications) to preview environments. List of modifications:
* Alertmanager disabled. (Alerts are still in place and can be seen in Prometheus, they are just not routed anywhere)
* Remote-write disabled.
* All dashboards removed except for gitpod's own mixin.

To deploy monitoring-satellite to your preview you should:
* Add `/werft withMonitoringSatellite` to deploy from the main branch of https://github.com/gitpod-io/observability
* Add `/werft withMonitoringSatellite=<your-custom-branch>` to deploy a different branch from https://github.com/gitpod-io/observability

_PS: Not adding `/werft withMonitoringSatellite` to the PR description will prevent werft from deploying monitoring-satellite_

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5694

## How to test
<!-- Provide steps to test this PR -->
Run the werft build job and look at the results

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Known issues
* Deploying the stack multiple times makes us reach Certmanager rate limit. We cannot generate more than 5 certificates in less than 168h for the same DNS

/werft withMonitoringSatellite=arthursens/make-the-stack-compatible-262