### PR TITLE
[code] Enable terminal localEcho by default

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 49fa70822b4f1bbb68f29dd3dc1008840ed7128c
+ENV GP_CODE_COMMIT 6765bd40bce2a8f7151d6e2ce318289e73bc5d8e
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/5715

## How to test
<!-- Provide steps to test this PR -->
1. Switch to latest VS Code.
2. Start a workspace.
3. Open a terminal and start typing fast, you should see that some characters have a dimmed color but then become normal

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
