### PR TITLE
[ws-manager-bridge] Add status update metric

### DIFF
--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -15,6 +15,7 @@ export class PrometheusMetricsExporter {
     protected readonly timeToFirstUserActivityHistogram: prom.Histogram<string>;
     protected readonly clusterScore: prom.Gauge<string>;
     protected readonly clusterCordoned: prom.Gauge<string>;
+    protected readonly statusUpdatesTotal: prom.Counter<string>;
 
     constructor() {
         this.workspaceStartupTimeHistogram = new prom.Histogram({
@@ -38,6 +39,11 @@ export class PrometheusMetricsExporter {
             name: 'gitpod_ws_manager_bridge_cluster_cordoned',
             help: 'Cordoned status of the individual registered workspace cluster',
             labelNames: ["workspace_cluster"]
+        });
+        this.statusUpdatesTotal = new prom.Counter({
+            name: 'gitpod_ws_manager_bridge_status_updates_total',
+            help: 'Total workspace status updates received',
+            labelNames: ["workspace_cluster", "known_instance"]
         });
     }
 
@@ -68,6 +74,10 @@ export class PrometheusMetricsExporter {
             this.clusterCordoned.labels(cluster.name).set(cluster.state === 'cordoned' ? 1 : 0);
             this.clusterScore.labels(cluster.name).set(cluster.score);
         });
+    }
+
+    statusUpdateReceived(installation: string, knownInstance: boolean): void {
+        this.statusUpdatesTotal.labels(installation, knownInstance ? "true" : "false").inc();
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds a metric that counts the total status updates we've received from a workspace cluster.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5754

## How to test
1. Start a workspace
2. Check the ws-manager-bridge metrics and find `gitpod_ws_manager_bridge_status_updates_total`

Shoud look something like this:
![image](https://user-images.githubusercontent.com/3210701/133880612-1cda137a-b6b7-4a83-a2f5-6cfb46272ea8.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager-bridge] Introduce `gitpod_ws_manager_bridge_status_updates_total` metric to monitor workspace cluster stability
```
