### PR TITLE
[ws-manager] Add validation of grpc connections in the pool

### DIFF
--- a/components/ws-manager/pkg/manager/integration_test.go
+++ b/components/ws-manager/pkg/manager/integration_test.go
@@ -344,7 +344,7 @@ func (test *SingleWorkspaceIntegrationTest) Run(t *testing.T) {
 		test.MockWsdaemon(t, s)
 		ctx := test.WsdaemonConnectionContext()
 		return connectToMockWsdaemon(ctx, s)
-	})
+	}, func(checkAddress string) bool { return false })
 
 	monitor, err := manager.CreateMonitor()
 	if err != nil {

--- a/components/ws-manager/pkg/manager/internal/grpcpool/pool.go
+++ b/components/ws-manager/pkg/manager/internal/grpcpool/pool.go
@@ -7,6 +7,7 @@ package grpcpool
 import (
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
@@ -27,14 +28,27 @@ type Pool struct {
 	factory     Factory
 	closed      bool
 	mu          sync.RWMutex
+
+	checkFn ConnectionValidationFunc
 }
 
+type ConnectionValidationFunc func(hostIP string) (valid bool)
+
 // New creates a new connection pool
-func New(factory Factory) *Pool {
-	return &Pool{
+func New(factory Factory, checkFn ConnectionValidationFunc) *Pool {
+	pool := &Pool{
 		connections: make(map[string]*grpc.ClientConn),
 		factory:     factory,
+		checkFn:     checkFn,
 	}
+
+	go func() {
+		for range time.Tick(5 * time.Minute) {
+			pool.ValidateConnections()
+		}
+	}()
+
+	return pool
 }
 
 // Get will return a client connection to the host. If no connection exists yet, the factory
@@ -97,4 +111,28 @@ func (p *Pool) Close() error {
 	}
 
 	return nil
+}
+
+// ValidateConnections check if existing connections in the pool
+// are using valid addresses and remove them from the pool if not.
+func (p *Pool) ValidateConnections() {
+	p.mu.RLock()
+	addresses := make([]string, 0, len(p.connections))
+	for address := range p.connections {
+		addresses = append(addresses, address)
+	}
+	p.mu.RUnlock()
+
+	for _, address := range addresses {
+		found := p.checkFn(address)
+		if !found {
+			continue
+		}
+
+		p.mu.Lock()
+		conn := p.connections[address]
+		conn.Close()
+		delete(p.connections, address)
+		p.mu.Unlock()
+	}
 }


### PR DESCRIPTION
## Description

Existing connections in the grpc pool could not be valid anymore. In the logs is possible to find errors like:
"transport: Error while dialing dial tcp 10.12.9.78:8080: i/o timeout". Reconnecting..."

Internal link https://cloudlogging.app.goo.gl/tbxez3C2b1L2Dpkj9

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5763

## How to test
<!-- Provide steps to test this PR -->

- delete `ws-daemon` pod
- wait until next validation window (five minutes)
- check `ws-manager` log contains a `SHUTDOWN` output

```
{"component":"grpc","level":"info","message":"INFO: 2021/09/18 14:38:38 [core] Subchannel Connectivity change to TRANSIENT_FAILURE","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-18T14:38:38Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/18 14:38:38 [core] Channel Connectivity change to TRANSIENT_FAILURE","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-18T14:38:38Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/18 14:38:39 [core] Channel Connectivity change to SHUTDOWN","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-18T14:38:39Z"}
{"component":"grpc","level":"info","message":"INFO: 2021/09/18 14:38:39 [core] Subchannel Connectivity change to SHUTDOWN","serviceContext":{"service":"ws-manager","version":""},"severity":"INFO","time":"2021-09-18T14:38:39Z"}
``` 
 
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
