### PR TITLE
[workspacekit] Check if process is already finished during termination

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -146,6 +146,11 @@ var ring0Cmd = &cobra.Command{
 				log.Warn("ring1 did not shut down in time - sending sigkill")
 				err = cmd.Process.Kill()
 				if err != nil {
+					if isProcessAlreadyFinished(err) {
+						err = nil
+						return
+					}
+
 					log.WithError(err).Error("cannot kill ring1")
 				}
 				return
@@ -847,4 +852,8 @@ func init() {
 
 	ring1Cmd.Flags().BoolVar(&ring1Opts.MappingEstablished, "mapping-established", false, "true if the UID/GID mapping has already been established")
 	ring2Cmd.Flags().StringVar(&ring2Opts.SupervisorPath, "supervisor-path", supervisorPath, "path to the supervisor binary (taken from $GITPOD_WORKSPACEKIT_SUPERVISOR_PATH, defaults to '$PWD/supervisor')")
+}
+
+func isProcessAlreadyFinished(err error) bool {
+	return strings.Contains(err.Error(), "os: process already finished")
 }


### PR DESCRIPTION
## Description

During workspace termination `ring1` process could be already terminated before the call to process.Kill()
This change ensures we do not return an invalid error.

```
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"os: process already finished","level":"error","message":"cannot kill ring1","ring":0,"serviceContext":{"service":"workspacekit","version":""},"severity":"ERROR","time":"2021-09-11T23:30:29Z"}
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
