### PR TITLE
[dropbear] patch to allow g+w and o+w to the user's homedir, ~/.ssh, and ~/.ssh/authorized_keys

### DIFF
--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -41,7 +41,7 @@ packages:
       commands:
         - ["curl", "-OL", "https://matt.ucc.asn.au/dropbear/dropbear-2020.81.tar.bz2"]
         - ["tar", "xjf", "dropbear-2020.81.tar.bz2"]
-        - ["sh", "-c", "cd dropbear-2020.81; ./configure --enable-static && sed -i '/clearenv();/d' svr-chansession.c && sed -i '/addnewvar(\"PATH\", DEFAULT_PATH);/d' svr-chansession.c && make"]
+        - ["sh", "-c", "cd dropbear-2020.81; ./configure --enable-static && sed -i '/clearenv();/d' svr-chansession.c && sed -i '/addnewvar(\"PATH\", DEFAULT_PATH);/d' svr-chansession.c && sed -i 's/filestat.st_mode & (S_IWGRP | S_IWOTH)/0/g' svr-authpubkey.c && make"]
         - ["mv", "dropbear-2020.81/dropbear", "dropbear"]
         - ["mv", "dropbear-2020.81/dropbearkey", "dropbearkey"]
         - ["rm", "-rf", "dropbear-2020.81*"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We are don't expect other users beside root and gitpod, so it should be fine to loosen permission constaints by dropbear.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix #5661

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace.
- In terminal: `chmod g+w /home/gitpod`
- In VS Code Web, select to open in VS Code Desktop. You should be able to connect.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
