### PR TITLE
Send error response to frontend

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1015,7 +1015,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
                     }).request((error: any, result: any) => {
                         if (error) {
                             log.error(logContext, 'Checkout page error', error);
-                            reject(error);
+                            throw new ResponseError(ErrorCodes.PAYMENT_ERROR, `${error.api_error_code}: ${error.message}`);
                         } else {
                             log.debug(logContext, 'Checkout page initiated');
                             resolve(result.hosted_page);


### PR DESCRIPTION
[WIP]

## Description
A user was blocked from checking out due to an error sent by Chargebee to our server, and never knew why they could not complete the checkout process. This change sends an error message to the frontend to be shown to the user, so they are aware of what is happening.

## Related Issue(s)
Fixes #5737

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
User sees an error when Chargebee rejects checkout attempt.
```
