### PR TITLE
[code] upgrade to VS Code 1.60.2

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh |
     && npm install -g yarn node-gyp
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV GP_CODE_COMMIT 6765bd40bce2a8f7151d6e2ce318289e73bc5d8e
+ENV GP_CODE_COMMIT 8aa7f43919a48f5d5dc3e8eb997d0919977de32a
 RUN mkdir gp-code \
     && cd gp-code \
     && git init \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Upgrade to VS Code 1.60.2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5734

## How to test
<!-- Provide steps to test this PR -->

- Switch to latest VS Code in settings.
- Start a workspace.
- Test following:
  - terminals are preserved and resized properly between window reloads
  - extension host process: check language smartness and debugging
  - extension management (installing/uninstalling)
    - install VIM extension to test web extensions
  - that user data are sync across workspaces as well as on workspace restart, especially for extensions
    - extensions from .gitpod.yml are not installed as sync
    - extensions installed as sync are actually sync in new workspaces
  - settings should not contain any mentions of MS telemetry
  - websockets and workers are properly proxied
    - diff editor should be operatable
    - trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old websockets are closed and new opened of the same amount
  - workspace specific commands should work, i.e. F1 → type Gitpod prefix
  - that a PR view is preloaded on the PR url
  - test gp open and preview
  - test open in VS Code Desktop, check gp open and preview in task/user terminals

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
