### PR TITLE
[ws-daemon] Reduce messages log level

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -123,7 +123,7 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		log.WithError(err).Warn("error while updating submodules - continuing")
 	}
 
-	log.WithField("stage", "init").WithField("location", ws.Location).Info("Git operations complete")
+	log.WithField("stage", "init").WithField("location", ws.Location).Debug("Git operations complete")
 	return
 }
 

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -149,7 +149,7 @@ func (s *WorkspaceService) InitWorkspace(ctx context.Context, req *api.InitWorks
 	owi := log.OWI(req.Metadata.Owner, req.Metadata.MetaId, req.Id)
 	tracing.ApplyOWI(span, owi)
 	log := log.WithFields(owi)
-	log.Info("InitWorkspace called")
+	log.Debug("InitWorkspace called")
 
 	var (
 		wsloc string

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -97,7 +97,7 @@ func ServeWorkspace(uidmapper *Uidmapper, fsshift api.FSShiftMethod) func(ctx co
 			return xerrors.Errorf("cannot start in-workspace-helper server: %w", err)
 		}
 
-		log.WithFields(ws.OWI()).Info("established IWS server")
+		log.WithFields(ws.OWI()).Debug("established IWS server")
 		ws.NonPersistentAttrs[session.AttrWorkspaceServer] = helper.Stop
 
 		return nil
@@ -121,7 +121,7 @@ func StopServingWorkspace(ctx context.Context, ws *session.Workspace) (err error
 	}
 
 	stopFn()
-	log.WithFields(ws.OWI()).Info("stopped IWS server")
+	log.WithFields(ws.OWI()).Debug("stopped IWS server")
 	return nil
 }
 

--- a/components/ws-daemon/pkg/resources/dispatch.go
+++ b/components/ws-daemon/pkg/resources/dispatch.go
@@ -113,7 +113,7 @@ func (d *DispatchListener) WorkspaceAdded(ctx context.Context, ws *dispatch.Work
 
 	d.governer[ws.ContainerID] = g
 	go g.Start(ctx)
-	log.Info("started new resource governer")
+	log.Debug("started new resource governer")
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Continue cleanup of log messages and levels.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/approve no-issue