### PR TITLE
[workspacekit] Update libseccomp and fuse-overlayfs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-deve.7
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-libsecov.2
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -43,7 +43,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-deve.7
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-libsecov.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-deve.7
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-libsecov.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-deve.7
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-libsecov.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/workspacekit/BUILD.yaml
+++ b/components/workspacekit/BUILD.yaml
@@ -19,7 +19,7 @@ packages:
     type: generic
     config:
       commands:
-        - ["sh", "-c", "curl -o fuse-overlayfs -L https://github.com/containers/fuse-overlayfs/releases/download/v1.4.0/fuse-overlayfs-x86_64 && chmod +x fuse-overlayfs"]
+        - ["sh", "-c", "curl -o fuse-overlayfs -L https://github.com/containers/fuse-overlayfs/releases/download/v1.7.1/fuse-overlayfs-x86_64 && chmod +x fuse-overlayfs"]
   - name: lib
     type: go
     srcs:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -108,11 +108,11 @@ RUN curl -fsSL https://packagecloud.io/datawireio/telepresence/gpgkey | apt-key 
 RUN curl -fsSL -o /usr/bin/toxiproxy https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy-cli-linux-amd64 \
     && chmod +x /usr/bin/toxiproxy
 
-### libseccomp > 2.5.0
+### libseccomp > 2.5.2
 RUN install-packages gperf \
     && cd $(mktemp -d) \
-    && curl -fsSL https://github.com/seccomp/libseccomp/releases/download/v2.5.1/libseccomp-2.5.1.tar.gz | tar xz \
-    && cd libseccomp-2.5.1 && ./configure && make && make install
+    && curl -fsSL https://github.com/seccomp/libseccomp/releases/download/v2.5.2/libseccomp-2.5.2.tar.gz | tar xz \
+    && cd libseccomp-2.5.2 && ./configure && make && make install
 
 USER gitpod
 


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[workspacekit] Update fuse-overlayfs to v1.7.1
[workspacekit] Update libseccomp to v2.5.2
```
