### PR TITLE
[chart] Fix default log level

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -183,13 +183,13 @@ env:
 - name: GITPOD_INSTALLATION_SHORTNAME
   value: {{ template "gitpod.installation.shortname" . }}
 - name: LOG_LEVEL
-  value: {{ template "gitpod.loglevel" }}
+  value: {{ template "gitpod.loglevel" . }}
 {{- end -}}
 
 {{- define "gitpod.loglevel" -}}
 {{- $ := .root -}}
 {{- $gp := .gp -}}
-{{ $gp.log.level | default "debug" | lower | quote }}
+{{ $gp.log.level | default "info" | lower | quote }}
 {{- end -}}
 
 {{- define "gitpod.container.analyticsEnv" -}}

--- a/chart/templates/agent-smith-daemonset.yaml
+++ b/chart/templates/agent-smith-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
 {{- if $comp.volumeMounts }}
 {{ toYaml $comp.volumeMounts | indent 8 }}
 {{- end }}
-        args: ["run", "-v", "--config", "/config/config.json"]
+        args: ["run", "--config", "/config/config.json"]
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}

--- a/chart/templates/blobserve-deployment.yaml
+++ b/chart/templates/blobserve-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
       - name: blobserve
         image: {{ template "gitpod.comp.imageFull" $this }}
-        args: ["run", "-v", "/mnt/config/config.json"]
+        args: ["run", "/mnt/config/config.json"]
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}
         securityContext:

--- a/chart/templates/content-service-deployment.yaml
+++ b/chart/templates/content-service-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: content-service
         image: {{ template "gitpod.comp.imageFull" $this }}
-        args: ["run", "-v", "--config", "/config/config.json"]
+        args: ["run", "--config", "/config/config.json"]
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}
         ports:

--- a/chart/templates/image-builder-deployment.yaml
+++ b/chart/templates/image-builder-deployment.yaml
@@ -91,7 +91,6 @@ spec:
         image: {{ template "gitpod.comp.imageFull" $this }}
         args:
         - "run"
-        - "-v"
         - "--config"
         - "/config/image-builder.json"
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}

--- a/chart/templates/image-builder-mk3-deployment.yaml
+++ b/chart/templates/image-builder-mk3-deployment.yaml
@@ -72,7 +72,6 @@ spec:
         image: {{ template "gitpod.comp.imageFull" $this }}
         args:
         - "run"
-        - "-v"
         - "--config"
         - "/config/image-builder.json"
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}

--- a/chart/templates/kedge-deployment.yaml
+++ b/chart/templates/kedge-deployment.yaml
@@ -44,7 +44,6 @@ spec:
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
         args:
-        - "-v"
         - "--config"
         - "/config/config.json"
         - "run"

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
       - name: registry-facade
         image: {{ template "gitpod.comp.imageFull" $this }}
-        args: ["run", "-v", "/mnt/config/config.json"]
+        args: ["run", "/mnt/config/config.json"]
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}
         ports:

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -269,7 +269,7 @@ spec:
 {{- if $comp.volumeMounts }}
 {{ toYaml $comp.volumeMounts | indent 8 }}
 {{- end }}
-        args: ["run", "-v", "--config", "/config/config.json"]
+        args: ["run", "--config", "/config/config.json"]
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}

--- a/chart/templates/ws-manager-deployment.yaml
+++ b/chart/templates/ws-manager-deployment.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       - name: ws-manager
-        args: ["run", "-v", "--config", "/config/config.json"]
+        args: ["run", "--config", "/config/config.json"]
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -57,7 +57,7 @@ spec:
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       - name: ws-proxy
         image: {{ template "gitpod.comp.imageFull" $this }}
-        args: ["run", "-v", "/config/config.json"]
+        args: ["run", "/config/config.json"]
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}
 {{ include "gitpod.container.ports" $this | indent 8 }}

--- a/chart/templates/ws-scheduler-deployment.yaml
+++ b/chart/templates/ws-scheduler-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       enableServiceLinks: false
       containers:
       - name: scheduler
-        args: ["run", "-v", "--config", "/config/config.json"]
+        args: ["run", "--config", "/config/config.json"]
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}
 {{ include "gitpod.container.resources" $this | indent 8 }}

--- a/components/blobserve/cmd/root.go
+++ b/components/blobserve/cmd/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 	Short: "This service provides static assets from OCI images",
 	Args:  cobra.MinimumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 
 		// configure containerd log with gitpod-io configuration
 		containerd_log.WithLogger(context.Background(), log.Log)
@@ -52,7 +52,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 }
 
 // Config configures this servuce

--- a/components/blobserve/cmd/run.go
+++ b/components/blobserve/cmd/run.go
@@ -24,6 +24,7 @@ import (
 )
 
 var jsonLog bool
+var verbose bool
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{

--- a/components/common-go/log/log.go
+++ b/components/common-go/log/log.go
@@ -54,14 +54,17 @@ func init() {
 
 func logLevelFromEnv() {
 	level := os.Getenv("LOG_LEVEL")
-	if level == "" {
-		return
+	if len(level) == 0 {
+		level = "info"
 	}
 
 	newLevel, err := logrus.ParseLevel(level)
-	if err == nil {
-		Log.Logger.SetLevel(newLevel)
+	if err != nil {
+		Log.WithError(err).Errorf("cannot change log level to '%v'", level)
+		return
 	}
+
+	Log.Logger.SetLevel(newLevel)
 }
 
 // Init initializes/configures the application-wide logger

--- a/components/content-service/cmd/root.go
+++ b/components/content-service/cmd/root.go
@@ -28,13 +28,15 @@ var (
 	Version = ""
 )
 
+var jsonLog bool
 var verbose bool
 var configFile string
+
 var rootCmd = &cobra.Command{
 	Use:   "content-service",
 	Short: "Content service",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, verbose, verbose)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -69,6 +71,7 @@ func getConfig() *serviceConfig {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file")
 }

--- a/components/ee/agent-smith/cmd/root.go
+++ b/components/ee/agent-smith/cmd/root.go
@@ -27,6 +27,7 @@ var (
 
 var cfgFile string
 var jsonLog bool
+var verbose bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -34,7 +35,7 @@ var rootCmd = &cobra.Command{
 	Short: "Moves through workspace pods and finds bad players",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		os.Args = []string{""}
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 
 		// Disable golog, Googles logging framwork for misanthropic
 		err := goflag.Set("stderrthreshold", "5")
@@ -56,7 +57,8 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 }
 
 func getConfig() (*config, error) {

--- a/components/ee/kedge/cmd/root.go
+++ b/components/ee/kedge/cmd/root.go
@@ -26,13 +26,14 @@ var (
 
 var cfgFile string
 var jsonLog bool
+var verbose bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "kedge",
 	Short: "Remote kubernetes service discovery and replication",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -47,8 +48,9 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "confg.json", "config file")
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
 	rootCmd.PersistentFlags().String("kubeconfig", "", "kubernetes client config file")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 }
 
 func getConfig() (*config, error) {

--- a/components/ee/ws-scheduler/cmd/root.go
+++ b/components/ee/ws-scheduler/cmd/root.go
@@ -31,13 +31,14 @@ var (
 var cfgFile string
 var kubeconfig string
 var jsonLog bool
+var verbose bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "ws-scheduler",
 	Short: "ws-scheduler schedules workspace pods to nodes",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -57,7 +58,8 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kedgei.yaml)")
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file to use (defaults to in-cluster config)")
 }

--- a/components/image-builder-bob/cmd/root.go
+++ b/components/image-builder-bob/cmd/root.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 
 // Execute runs the root command
 func Execute() {
-	log.Init("bob", "", false, false)
+	log.Init("bob", "", true, false)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/components/image-builder-mk3/cmd/root.go
+++ b/components/image-builder-mk3/cmd/root.go
@@ -30,13 +30,14 @@ var (
 	Version = ""
 )
 
+var jsonLog bool
 var verbose bool
 var configFile string
 var rootCmd = &cobra.Command{
 	Use:   "image-builder-mk3",
 	Short: "Workspace image-builder service",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, verbose && !isatty.IsTerminal(os.Stdout.Fd()), verbose)
+		log.Init(ServiceName, Version, jsonLog && !isatty.IsTerminal(os.Stdout.Fd()), verbose)
 	},
 }
 
@@ -71,6 +72,7 @@ func getConfig() *config {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file")
 }

--- a/components/image-builder/cmd/root.go
+++ b/components/image-builder/cmd/root.go
@@ -29,13 +29,15 @@ var (
 	Version = ""
 )
 
+var jsonLog bool
 var verbose bool
 var configFile string
+
 var rootCmd = &cobra.Command{
 	Use:   "image-builder",
 	Short: "Workspace image-builder service",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, verbose && !isatty.IsTerminal(os.Stdout.Fd()), verbose)
+		log.Init(ServiceName, Version, jsonLog && !isatty.IsTerminal(os.Stdout.Fd()), verbose)
 	},
 }
 
@@ -70,6 +72,7 @@ func getConfig() *config {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file")
 }

--- a/components/registry-facade/cmd/root.go
+++ b/components/registry-facade/cmd/root.go
@@ -29,7 +29,7 @@ var rootCmd = &cobra.Command{
 	Short: "This service acts as image registry augmenting images with workspace content and Theia",
 	Args:  cobra.MinimumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -47,7 +47,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 }
 
 // Config configures this servuce

--- a/components/registry-facade/cmd/run.go
+++ b/components/registry-facade/cmd/run.go
@@ -32,6 +32,7 @@ import (
 )
 
 var jsonLog bool
+var verbose bool
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{

--- a/components/service-waiter/cmd/root.go
+++ b/components/service-waiter/cmd/root.go
@@ -25,13 +25,14 @@ var (
 
 var cfgFile string
 var jsonLog bool
+var verbose bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "service-waiter",
 	Short: "service-waiter waits until a service becomes available",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -48,7 +49,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.service-waiter.yaml)")
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 
 	defaultTimeout := os.Getenv("SERVICE_WAITER_TIMEOUT")
 	if defaultTimeout == "" {

--- a/components/supervisor/cmd/ghost.go
+++ b/components/supervisor/cmd/ghost.go
@@ -19,7 +19,7 @@ var ghostCmd = &cobra.Command{
 	Short: "starts the supervisor",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, true)
+		log.Init(ServiceName, Version, true, false)
 		log.Info("running as ghost - waiting for SIGTERM")
 
 		sigChan := make(chan os.Signal, 1)

--- a/components/supervisor/cmd/root.go
+++ b/components/supervisor/cmd/root.go
@@ -30,7 +30,7 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	log.Init(ServiceName, Version, false, true)
+	log.Init(ServiceName, Version, true, false)
 	log.Log.Logger.AddHook(fatalTerminationLogHook{})
 
 	if err := rootCmd.Execute(); err != nil {

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -17,7 +17,7 @@ var runCmd = &cobra.Command{
 	Short: "starts the supervisor",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, true)
+		log.Init(ServiceName, Version, true, false)
 		common_grpc.SetupLogging()
 		supervisor.Run()
 	},

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -57,7 +57,7 @@ var ring0Cmd = &cobra.Command{
 	Use:   "ring0",
 	Short: "starts ring0 - enter here",
 	Run: func(_ *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, true)
+		log.Init(ServiceName, Version, true, false)
 		log := log.WithField("ring", 0)
 
 		common_grpc.SetupLogging()
@@ -183,7 +183,7 @@ var ring1Cmd = &cobra.Command{
 	Use:   "ring1",
 	Short: "starts ring1",
 	Run: func(_cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, true)
+		log.Init(ServiceName, Version, true, false)
 		log := log.WithField("ring", 1)
 
 		common_grpc.SetupLogging()
@@ -614,7 +614,7 @@ var ring2Cmd = &cobra.Command{
 	Short: "starts ring2",
 	Args:  cobra.ExactArgs(1),
 	Run: func(_cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, true)
+		log.Init(ServiceName, Version, true, false)
 		log := log.WithField("ring", 2)
 
 		common_grpc.SetupLogging()

--- a/components/workspacekit/cmd/root.go
+++ b/components/workspacekit/cmd/root.go
@@ -29,7 +29,7 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	log.Init(ServiceName, Version, false, true)
+	log.Init(ServiceName, Version, true, false)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/components/ws-daemon/cmd/content-initializer/main.go
+++ b/components/ws-daemon/cmd/content-initializer/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	log.Init("content-initializer", "", true, true)
+	log.Init("content-initializer", "", true, false)
 	tracing.Init("content-initializer")
 
 	err := content.RunInitializerChild()

--- a/components/ws-daemon/cmd/root.go
+++ b/components/ws-daemon/cmd/root.go
@@ -31,11 +31,13 @@ var (
 
 var verbose bool
 var configFile string
+var jsonLog bool
+
 var rootCmd = &cobra.Command{
 	Use:   "ws-daemond",
 	Short: "Workspace initialization and synchronization daemon",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, verbose, verbose)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -70,6 +72,7 @@ func getConfig() *config {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file")
 }

--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -262,7 +262,7 @@ func main() {
 		},
 	}
 
-	log.Init("nsinsider", "", true, true)
+	log.Init("nsinsider", "", true, false)
 	err := app.Run(os.Args)
 	if err != nil {
 		log.WithField("instanceId", os.Getenv("GITPOD_INSTANCE_ID")).WithField("args", os.Args).Fatal(err)

--- a/components/ws-manager/cmd/root.go
+++ b/components/ws-manager/cmd/root.go
@@ -29,13 +29,14 @@ var (
 var cfgFile string
 var kubeconfig string
 var jsonLog bool
+var verbose bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "ws-manager",
 	Short: "ws-manager starts/stops/controls workspace deployments in Kubernetes",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -65,7 +66,8 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kedgei.yaml)")
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file to use (defaults to in-cluster config)")
 }

--- a/components/ws-proxy/cmd/root.go
+++ b/components/ws-proxy/cmd/root.go
@@ -30,7 +30,7 @@ var rootCmd = &cobra.Command{
 	Short: "This acts as reverse-proxy for all workspace-bound requests",
 	Args:  cobra.MinimumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -48,7 +48,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 }
 
 // Config configures this servuce

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -23,6 +23,7 @@ import (
 )
 
 var jsonLog bool
+var verbose bool
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{

--- a/dev/charts/poolkeeper/templates/deployment.yaml
+++ b/dev/charts/poolkeeper/templates/deployment.yaml
@@ -32,7 +32,6 @@ spec:
           - --config
           - /config/config.json
           - run
-          - -v
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/dev/poolkeeper/cmd/root.go
+++ b/dev/poolkeeper/cmd/root.go
@@ -30,13 +30,14 @@ var (
 var cfgFile string
 var kubeconfig string
 var jsonLog bool
+var verbose bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "poolkeeper",
 	Short: "poolkeeper",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, jsonLog, jsonLog)
+		log.Init(ServiceName, Version, jsonLog, verbose)
 	},
 }
 
@@ -56,7 +57,8 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
-	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "v", false, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose JSON logging")
 
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file to use (defaults to in-cluster config)")
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The invocation to the template was missing the context (`.`)

Also introduces two different flags for cli binaries, one for `verbose` logs and a different one to set `json-log` output format.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[chart] Fix default log level template
[chart] Do not enable verbose log level by default in containers

```