### PR TITLE
[ws-daemon] Use unique container names for init

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -226,6 +226,11 @@ func (s *WorkspaceService) InitWorkspace(ctx context.Context, req *api.InitWorks
 				{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},
 				{ContainerID: 1, HostID: 100000, Size: 65534},
 			},
+			OWI: OWI{
+				Owner:       req.Metadata.Owner,
+				WorkspaceID: req.Metadata.MetaId,
+				InstanceID:  req.Id,
+			},
 		}
 
 		err = RunInitializer(ctx, workspace.Location, req.Initializer, remoteContent, opts)


### PR DESCRIPTION
## Description
This PR makes ws-daemon use unique names when starting the content init container. It also fixes the logging issue where the content-init logs would not be associated with the workspace they were caused by.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5790

## How to test
1. Run `kubectl exec -it  -c ws-daemon <ws-daemon-pod> -- watch ls /sys/fs/cgroup/cpuset`
2. Start a workspace
3. Observe a short-lived cgroup named `init-ws-<instanceID>`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-daemon] Improved the stability of concurrent content initialisation
```
