### PR TITLE
[Teams & Projects] Minor UX improvements

### DIFF
--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -47,6 +47,7 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
     terminalRef.current = terminal;
     terminal.loadAddon(fitAddon);
     terminal.open(xTermParentRef.current);
+    terminal.write('Connecting to workspace logs...\r\n');
     props.logsEmitter.on('logs', logs => {
       if (terminal && logs) {
         terminal.write(logs);
@@ -74,7 +75,7 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
 
   useEffect(() => {
     if (terminalRef.current && props.errorMessage) {
-      terminalRef.current.write(`\n\u001b[38;5;196m${props.errorMessage}\u001b[0m`);
+      terminalRef.current.write(`\r\n\u001b[38;5;196m${props.errorMessage}\u001b[0m`);
     }
   }, [ terminalRef.current, props.errorMessage ]);
 

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -121,6 +121,16 @@ export default function () {
         return true;
     }
 
+    const prebuildSorter = (a: PrebuildWithStatus, b: PrebuildWithStatus) => {
+        if (a.info.startedAt < b.info.startedAt) {
+            return 1;
+        }
+        if (a.info.startedAt === b.info.startedAt) {
+            return 0;
+        }
+        return -1;
+    }
+
     const openPrebuild = (pb: PrebuildInfo) => {
         history.push(`/${!!team ? 't/'+team.slug : 'projects'}/${projectName}/${pb.id}`);
     }
@@ -164,7 +174,7 @@ export default function () {
                         <ItemFieldContextMenu />
                     </ItemField>
                 </Item>
-                {prebuilds.filter(filter).map((p, index) => <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">
+                {prebuilds.filter(filter).sort(prebuildSorter).map((p, index) => <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">
                     <ItemField className="flex items-center">
                         <div className="cursor-pointer" onClick={() => openPrebuild(p.info)}>
                             <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1">

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -15,6 +15,7 @@ import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
 import { prebuildStatusIcon, prebuildStatusLabel } from "./Prebuilds";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import { shortCommitMessage } from "./render-utils";
+import Spinner from "../icons/Spinner.svg";
 
 export default function () {
     const history = useHistory();
@@ -28,6 +29,7 @@ export default function () {
 
     const [project, setProject] = useState<Project | undefined>();
 
+    const [isLoadingBranches, setIsLoadingBranches] = useState<boolean>(false);
     const [branches, setBranches] = useState<Project.BranchDetails[]>([]);
     const [lastPrebuilds, setLastPrebuilds] = useState<Map<string, PrebuildWithStatus | undefined>>(new Map());
     const [prebuildLoaders] = useState<Set<string>>(new Set());
@@ -53,11 +55,18 @@ export default function () {
 
         setProject(project);
 
-        const details = await getGitpodService().server.getProjectOverview(project.id);
-        if (details) {
-            // default branch on top of the rest
-            const branches = details.branches.sort((a, b) => (b.isDefault as any) - (a.isDefault as any)) || [];
-            setBranches(branches);
+        setIsLoadingBranches(true);
+        try {
+            const details = await getGitpodService().server.getProjectOverview(project.id);
+            if (details) {
+                // default branch on top of the rest
+                const branches = details.branches.sort((a, b) => (b.isDefault as any) - (a.isDefault as any)) || [];
+                setBranches(branches);
+            }
+        } catch (error) {
+            console.error('Error getting project overview', error);
+        } finally {
+            setIsLoadingBranches(false);
         }
     }
 
@@ -146,6 +155,10 @@ export default function () {
                         <ItemFieldContextMenu />
                     </ItemField>
                 </Item>
+                {isLoadingBranches && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16">
+                    <img className="h-4 w-4 animate-spin" src={Spinner} />
+                    <span>Fetching repository branches...</span>
+                </div>}
                 {branches.filter(filter).slice(0, 10).map((branch, index) => {
 
                     const branchName = branch.name;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- [x] Shows `Fetching repository branches ...` with a spinner when loading branches:

<img width="1436" alt="Screenshot 2021-09-22 at 12 32 29" src="https://user-images.githubusercontent.com/599268/134328935-20aca9d1-53f4-4c05-9fd9-c40c62f4955e.png">

- [x] Shows `Connecting to workspace logs ...` when trying to show workspace logs:

<img width="1438" alt="Screenshot 2021-09-22 at 12 33 49" src="https://user-images.githubusercontent.com/599268/134328984-0e9b6349-9471-4648-bb18-5e64d692fd64.png">

- [x] Also sorts Prebuilds by `startedAt` time (descending order) in the Prebuilds page

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5772

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/uncc