### PR TITLE
[ws-daemon] Remove use of intemediate buffer during tar creation

### DIFF
--- a/components/ws-daemon/pkg/content/archive.go
+++ b/components/ws-daemon/pkg/content/archive.go
@@ -6,7 +6,6 @@ package content
 
 import (
 	"archive/tar"
-	"bufio"
 	"context"
 	"io"
 	"os"
@@ -82,10 +81,8 @@ func BuildTarbal(ctx context.Context, src string, dst string, fullWorkspaceBacku
 	}
 
 	defer fout.Close()
-	fbout := bufio.NewWriter(fout)
-	defer fbout.Flush()
 
-	targetOut := newLimitWriter(fbout, cfg.MaxSizeBytes)
+	targetOut := newLimitWriter(fout, cfg.MaxSizeBytes)
 	defer func(e *error) {
 		if targetOut.DidMaxOut() {
 			*e = ErrMaxSizeExceeded
@@ -96,7 +93,7 @@ func BuildTarbal(ctx context.Context, src string, dst string, fullWorkspaceBacku
 	if err != nil {
 		return cleanCorruptedTarballAndReturnError(dst, xerrors.Errorf("cannot write tar file: %w", err))
 	}
-	if err = fbout.Flush(); err != nil {
+	if err = fout.Sync(); err != nil {
 		return cleanCorruptedTarballAndReturnError(dst, xerrors.Errorf("cannot flush tar out stream: %w", err))
 	}
 


### PR DESCRIPTION
## How to test
- start a workspace
- open a terminal and run `dd if=/dev/urandom of=14GB.bin bs=64M count=16 iflag=fullblock`
- stop workspace
- observe ws-daemon memory

Repeat in a namespace without this change

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


**Before:**`ws-daemon-qtvcr   476m         2671Mi`
**After:** `ws-daemon-64svr   430m         98Mi`
