### PR TITLE
[runc-facade] Remove unpriv port sysctl

### DIFF
--- a/components/docker-up/runc-facade/main.go
+++ b/components/docker-up/runc-facade/main.go
@@ -60,6 +60,7 @@ func createAndRunc(runcPath string) error {
 	}
 
 	cfg.Process.OOMScoreAdj = &defaultOOMScoreAdj
+	delete(cfg.Linux.Sysctl, "net.ipv4.ip_unprivileged_port_start")
 
 	fc, err = json.Marshal(cfg)
 	if err != nil {

--- a/components/docker-up/runc-facade/main.go
+++ b/components/docker-up/runc-facade/main.go
@@ -61,6 +61,11 @@ func createAndRunc(runcPath string) error {
 
 	cfg.Process.OOMScoreAdj = &defaultOOMScoreAdj
 	delete(cfg.Linux.Sysctl, "net.ipv4.ip_unprivileged_port_start")
+	cfg.Process.Capabilities.Ambient = append(cfg.Process.Capabilities.Ambient, "CAP_NET_BIND_SERVICE")
+	cfg.Process.Capabilities.Bounding = append(cfg.Process.Capabilities.Bounding, "CAP_NET_BIND_SERVICE")
+	cfg.Process.Capabilities.Effective = append(cfg.Process.Capabilities.Effective, "CAP_NET_BIND_SERVICE")
+	cfg.Process.Capabilities.Inheritable = append(cfg.Process.Capabilities.Inheritable, "CAP_NET_BIND_SERVICE")
+	cfg.Process.Capabilities.Permitted = append(cfg.Process.Capabilities.Permitted, "CAP_NET_BIND_SERVICE")
 
 	fc, err = json.Marshal(cfg)
 	if err != nil {

--- a/components/docker-up/slirp-docker-proxy/main.go
+++ b/components/docker-up/slirp-docker-proxy/main.go
@@ -64,6 +64,15 @@ func xmain(f *os.File) error {
 		return errors.New("$DOCKERUP_SLIRP4NETNS_SOCKET needs to be set")
 	}
 
+	if *hostIP == "::" {
+		f := os.NewFile(3, "status")
+		f.Write([]byte("0\n"))
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, os.Interrupt)
+		<-ch
+		return nil
+	}
+
 	// We don't have CAP_NET_BIND_SERVICE outside the network namespace, hence cannot bind
 	// to ports < 1024. If we didn't fail here explicitly, slirp4netns would fail strangely.
 	if *hostPort < 1024 {


### PR DESCRIPTION
## Description
This change makes Docker 20.10 work in Gitpod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #3051

## How to test
```bash
sudo apt-get update
sudo apt-get install docker-ce
docker run --rm -it -p 5000:5000 alpine:latest
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[workspace] Support Docker 20.10
```
