### PR TITLE
Fix kube-rbac-proxy configuration for ws-manager-bridge and proxy

### DIFF
--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -51,6 +51,7 @@ spec:
             - -c
             - "sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range='1024 65000'"
       containers:
+{{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       - name: proxy
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}

--- a/chart/templates/proxy-rolebinding.yaml
+++ b/chart/templates/proxy-rolebinding.yaml
@@ -17,3 +17,23 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Namespace }}-ns-psp:restricted-root-user
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-proxy-kube-rbac-proxy
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: proxy
+    kind: role-binding
+    stage: {{ .Values.installation.stage }}
+subjects:
+- kind: ServiceAccount
+  name: proxy
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name:  {{ .Release.Namespace }}-kube-rbac-proxy
+  apiGroup: rbac.authorization.k8s.io

--- a/chart/templates/ws-manager-bridge-rolebinding.yaml
+++ b/chart/templates/ws-manager-bridge-rolebinding.yaml
@@ -20,4 +20,29 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Namespace }}-ns-psp:unprivileged
   apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name:  {{ .Release.Namespace }}-kube-rbac-proxy
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-ws-manager-bridge-kube-rbac-proxy
+  labels:
+    app: {{ template "gitpod.fullname" . }}
+    component: ws-manager-bridge
+    kind: role-binding
+    stage: {{ .Values.installation.stage }}
+subjects:
+- kind: ServiceAccount
+  name: ws-manager-bridge
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name:  {{ .Release.Namespace }}-kube-rbac-proxy
+  apiGroup: rbac.authorization.k8s.io
+
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -430,6 +430,9 @@ components:
       https:
         expose: true
         containerPort: 443
+      metrics:
+        expose: false
+        containerPort: 9500
     loadBalancerIP: null
     serviceType: "LoadBalancer"
     serviceSessionAffinity: "None"

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -129,7 +129,9 @@
 :8003 {
 	respond /live 200
 	respond /ready 200
+}
 
+127.0.0.1:9500 {
 	metrics /metrics {
 		disable_openmetrics
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The ClusterRoleBinding is required for access to TokenReviews

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager-bridge] Add missing cluster role binding for tokenreviews
[proxy] Enable kube-rbac-proxy
```
