### PR TITLE
[supervisor] Do not emit a warning creating symlinks

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -358,7 +358,7 @@ func symlinkBinaries(cfg *Config) {
 			to   = filepath.Join("/usr/bin", v)
 		)
 		err = os.Symlink(from, to)
-		if err != nil {
+		if err != nil && !os.IsExist(err) {
 			log.WithError(err).WithField("from", from).WithField("to", to).Warn("cannot create symlink")
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Do not emit a warning creating symlinks to target files that already exist

Example: `error: "symlink /.supervisor/gitpod-cli /usr/bin/gp: file exists"`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
