### PR TITLE
Fix proxy prometheus configuration and remove ws-manager-bridge role

### DIFF
--- a/chart/templates/proxy-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/proxy-deny-all-allow-explicit-networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
   # Allow prometheus scraping from proxy /metrics endpoint
   - ports:
     - protocol: TCP
-      port: 9145
+      port: 9500
     from:
     - namespaceSelector:
         matchLabels:

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -51,7 +51,33 @@ spec:
             - -c
             - "sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range='1024 65000'"
       containers:
-{{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
+      # TODO: remove once Caddy can listen only in localhost
+      - name: kube-rbac-proxy
+        args:
+        - --v=10
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9545/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9500
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       - name: proxy
         image: {{ template "gitpod.comp.imageFull" $this }}
 {{ include "gitpod.container.imagePullPolicy" $this | indent 8 }}

--- a/chart/templates/proxy-serviceaccount.yaml
+++ b/chart/templates/proxy-serviceaccount.yaml
@@ -10,4 +10,3 @@ metadata:
     component: proxy
     kind: service-account
     stage: {{ .Values.installation.stage }}
-automountServiceAccountToken: false

--- a/chart/templates/ws-manager-bridge-rolebinding.yaml
+++ b/chart/templates/ws-manager-bridge-rolebinding.yaml
@@ -20,10 +20,6 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Namespace }}-ns-psp:unprivileged
   apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: ClusterRole
-  name:  {{ .Release.Namespace }}-kube-rbac-proxy
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -131,7 +131,7 @@
 	respond /ready 200
 }
 
-127.0.0.1:9500 {
+localhost:9500 {
 	metrics /metrics {
 		disable_openmetrics
 	}

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -131,7 +131,8 @@
 	respond /ready 200
 }
 
-localhost:9500 {
+# TODO: refactor once we can listen only in localhost
+:9545 {
 	metrics /metrics {
 		disable_openmetrics
 	}


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager-bridge] Remove duplicated roleRef in helm chart
[proxy] Configure prometheus metrics endpoint
```
