### PR TITLE
[chart] Upgrade kube-rbac-proxy to v0.11.0

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -357,7 +357,7 @@ storage:
 
 {{- define "gitpod.kube-rbac-proxy" -}}
 - name: kube-rbac-proxy
-  image: quay.io/brancz/kube-rbac-proxy:v0.9.0
+  image: quay.io/brancz/kube-rbac-proxy:v0.11.0
   args:
   - --v=10
   - --logtostderr


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[chart] Upgrade kube-rbac-proxy to v0.11.0
```
