### PR TITLE
[server] Allow re-triggering failed Prebuilds

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -82,27 +82,28 @@ function ContextMenu(props: ContextMenuProps) {
             </div>
             {expanded ?
                 <div className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${props.classes || 'w-48 right-0'}`} data-analytics='{"button_type":"context_menu"}'>
-                    {props.menuEntries.map((e, index) => {
-                        const clickable = e.href || e.onClick || e.link;
-                        const entry = <div className={`px-4 flex py-3 ${clickable ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : ''} ${e.active ? 'bg-gray-50 dark:bg-gray-800' : ''} ${index === 0 ? 'rounded-t-lg' : ''} ${index === props.menuEntries.length - 1 ? 'rounded-b-lg' : ''} text-sm leading-1 ${e.customFontStyle || font} ${e.separator ? ' border-b border-gray-200 dark:border-gray-800' : ''}`} title={e.title}>
-                            {e.customContent || <><div className="truncate w-52">{e.title}</div><div className="flex-1"></div>{e.active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}</>}
-                        </div>
-                        const key = `entry-${menuId}-${index}-${e.title}`;
-                        if (e.link) {
-                            return <Link key={key} to={e.link} onClick={e.onClick}>
-                                {entry}
-                            </Link>;
-                        } else if (e.href) {
-                            return <a key={key} href={e.href} onClick={e.onClick}>
-                                {entry}
-                            </a>;
-                        } else {
-                            return <div key={key} onClick={e.onClick}>
-                                {entry}
+                    {props.menuEntries.length === 0
+                        ? <p className="px-4 py-3">No actions available</p>
+                        : props.menuEntries.map((e, index) => {
+                            const clickable = e.href || e.onClick || e.link;
+                            const entry = <div className={`px-4 flex py-3 ${clickable ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : ''} ${e.active ? 'bg-gray-50 dark:bg-gray-800' : ''} ${index === 0 ? 'rounded-t-lg' : ''} ${index === props.menuEntries.length - 1 ? 'rounded-b-lg' : ''} text-sm leading-1 ${e.customFontStyle || font} ${e.separator ? ' border-b border-gray-200 dark:border-gray-800' : ''}`} title={e.title}>
+                                {e.customContent || <><div className="truncate w-52">{e.title}</div><div className="flex-1"></div>{e.active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}</>}
                             </div>
-                        }
-
-                    })}
+                            const key = `entry-${menuId}-${index}-${e.title}`;
+                            if (e.link) {
+                                return <Link key={key} to={e.link} onClick={e.onClick}>
+                                    {entry}
+                                </Link>;
+                            } else if (e.href) {
+                                return <a key={key} href={e.href} onClick={e.onClick}>
+                                    {entry}
+                                </a>;
+                            } else {
+                                return <div key={key} onClick={e.onClick}>
+                                    {entry}
+                                </div>
+                            }
+                        })}
                 </div>
                 :
                 null

--- a/components/dashboard/src/components/ItemsList.tsx
+++ b/components/dashboard/src/components/ItemsList.tsx
@@ -46,10 +46,10 @@ export function ItemFieldIcon(props: {
 }
 
 export function ItemFieldContextMenu(props: {
-    menuEntries?: ContextMenuEntry[];
+    menuEntries: ContextMenuEntry[];
     className?: string;
 }) {
     return <div className={`flex self-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer w-8 ${props.className || ""}`}>
-        {!props.menuEntries ? null : <ContextMenu menuEntries={props.menuEntries} />}
+        <ContextMenu menuEntries={props.menuEntries} />
     </div>;
 }

--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -110,6 +110,9 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
         getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
         break;
     }
+    if (workspaceInstance?.status.conditions.headlessTaskFailed) {
+      setError(new Error(workspaceInstance.status.conditions.headlessTaskFailed));
+    }
     if (workspaceInstance?.status.conditions.failed) {
       setError(new Error(workspaceInstance.status.conditions.failed));
     }

--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -75,7 +75,7 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
 
   useEffect(() => {
     if (terminalRef.current && props.errorMessage) {
-      terminalRef.current.write(`\r\n\u001b[38;5;196m${props.errorMessage}\u001b[0m`);
+      terminalRef.current.write(`\r\n\u001b[38;5;196m${props.errorMessage}\u001b[0m\r\n`);
     }
   }, [ terminalRef.current, props.errorMessage ]);
 

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -171,7 +171,6 @@ export default function () {
                     </ItemField>
                     <ItemField>
                         <span>Branch</span>
-                        <ItemFieldContextMenu />
                     </ItemField>
                 </Item>
                 {prebuilds.filter(filter).sort(prebuildSorter).map((p, index) => <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -5,9 +5,9 @@
  */
 
 import moment from "moment";
-import { PrebuildInfo, PrebuildWithStatus, PrebuiltWorkspaceState, Project, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { PrebuildWithStatus, PrebuiltWorkspaceState, Project, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { useContext, useEffect, useState } from "react";
-import { useHistory, useLocation, useRouteMatch } from "react-router";
+import { useLocation, useRouteMatch } from "react-router";
 import Header from "../components/Header";
 import DropDown, { DropDownEntry } from "../components/DropDown";
 import { ItemsList, Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
@@ -22,7 +22,6 @@ import { ContextMenuEntry } from "../components/ContextMenu";
 import { shortCommitMessage } from "./render-utils";
 
 export default function () {
-    const history = useHistory();
     const location = useLocation();
 
     const { teams } = useContext(TeamsContext);
@@ -45,7 +44,7 @@ export default function () {
         const registration = getGitpodService().registerClient({
             onPrebuildUpdate: (update: PrebuildWithStatus) => {
                 if (update.info.projectId === project.id) {
-                    setPrebuilds(prev => [update, ...prev.filter(p => p.info.id !== update.info.id)])
+                    setPrebuilds(prev => [update, ...prev.filter(p => p.info.id !== update.info.id)]);
                 }
             }
         });
@@ -77,18 +76,17 @@ export default function () {
     }, [teams]);
 
     const prebuildContextMenu = (p: PrebuildWithStatus) => {
-        const running = p.status === "building";
+        const isFailed = p.status === "aborted" || p.status === "timeout" || !!p.error;
+        const isRunning = p.status === "building";
         const entries: ContextMenuEntry[] = [];
-        entries.push({
-            title: "View Prebuild",
-            onClick: () => openPrebuild(p.info)
-        });
-        entries.push({
-            title: "Trigger Prebuild",
-            onClick: () => triggerPrebuild(p.info.branch),
-            separator: running
-        });
-        if (running) {
+        if (isFailed) {
+            entries.push({
+                title: `Rerun Prebuild (${p.info.branch})`,
+                onClick: () => triggerPrebuild(p.info.branch),
+                separator: isRunning
+            });
+        }
+        if (isRunning) {
             entries.push({
                 title: "Cancel Prebuild",
                 customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
@@ -131,10 +129,6 @@ export default function () {
         return -1;
     }
 
-    const openPrebuild = (pb: PrebuildInfo) => {
-        history.push(`/${!!team ? 't/'+team.slug : 'projects'}/${projectName}/${pb.id}`);
-    }
-
     const triggerPrebuild = (branchName: string | null) => {
         if (project) {
             getGitpodService().server.triggerPrebuild(project.id, branchName);
@@ -159,7 +153,8 @@ export default function () {
                 <div className="py-3 pl-3">
                     <DropDown prefix="Prebuild Status: " contextMenuWidth="w-32" entries={statusFilterEntries()} />
                 </div>
-                <button disabled={!project} onClick={() => triggerPrebuild(null)} className="ml-2">Trigger Prebuild</button>
+                {(!!project && prebuilds.length === 0) &&
+                    <button onClick={() => triggerPrebuild(null)} className="ml-2">Run Prebuild</button>}
             </div>
             <ItemsList className="mt-2">
                 <Item header={true} className="grid grid-cols-3">
@@ -175,13 +170,13 @@ export default function () {
                 </Item>
                 {prebuilds.filter(filter).sort(prebuildSorter).map((p, index) => <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">
                     <ItemField className="flex items-center">
-                        <div className="cursor-pointer" onClick={() => openPrebuild(p.info)}>
+                        <a href={`/${!!team ? 't/'+team.slug : 'projects'}/${projectName}/${p.info.id}`} className="cursor-pointer">
                             <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1">
-                                <div className="inline-block align-text-bottom mr-2 w-4 h-4">{prebuildStatusIcon(p.status)}</div>
-                                {prebuildStatusLabel(p.status)}
+                                <div className="inline-block align-text-bottom mr-2 w-4 h-4">{prebuildStatusIcon(p)}</div>
+                                {prebuildStatusLabel(p)}
                             </div>
                             <p>{p.info.startedByAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={p.info.startedByAvatar || ''} alt={p.info.startedBy} />}Triggered {formatDate(p.info.startedAt)}</p>
-                        </div>
+                        </a>
                     </ItemField>
                     <ItemField className="flex items-center">
                         <div>
@@ -203,41 +198,39 @@ export default function () {
     </>;
 }
 
-export function prebuildStatusLabel(status: PrebuiltWorkspaceState | undefined) {
-    switch (status) {
-        case "aborted":
+export function prebuildStatusLabel(prebuild?: PrebuildWithStatus) {
+    if (prebuild?.error) {
+        return (<span className="font-medium text-red-500 uppercase">failed</span>);
+    }
+    switch (prebuild?.status) {
+        case undefined: // Fall through
+        case "queued":
+            return (<span className="font-medium text-orange-500 uppercase">pending</span>);
+        case "building":
+            return (<span className="font-medium text-blue-500 uppercase">running</span>);
+        case "aborted": // Fall through
+        case "timeout":
             return (<span className="font-medium text-red-500 uppercase">failed</span>);
         case "available":
             return (<span className="font-medium text-green-500 uppercase">ready</span>);
-        case "building":
-            return (<span className="font-medium text-blue-500 uppercase">running</span>);
-        case "queued":
-            return (<span className="font-medium text-orange-500 uppercase">pending</span>);
-        default:
-            break;
     }
 }
 
-export function prebuildStatusIcon(status: PrebuiltWorkspaceState | undefined) {
-    switch (status) {
-        case "aborted":
-            return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L6.58579 8L5.29289 9.29289C4.90237 9.68342 4.90237 10.3166 5.29289 10.7071C5.68342 11.0976 6.31658 11.0976 6.70711 10.7071L8 9.41421L9.29289 10.7071C9.68342 11.0976 10.3166 11.0976 10.7071 10.7071C11.0976 10.3166 11.0976 9.68342 10.7071 9.29289L9.41421 8L10.7071 6.70711C11.0976 6.31658 11.0976 5.68342 10.7071 5.29289C10.3166 4.90237 9.68342 4.90237 9.29289 5.29289L8 6.58579L6.70711 5.29289Z" fill="#F87171" />
-            </svg>)
-        case "available":
-            return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM11.7071 6.70711C12.0976 6.31658 12.0976 5.68342 11.7071 5.29289C11.3166 4.90237 10.6834 4.90237 10.2929 5.29289L7 8.58578L5.7071 7.29289C5.31658 6.90237 4.68342 6.90237 4.29289 7.29289C3.90237 7.68342 3.90237 8.31658 4.29289 8.70711L6.29289 10.7071C6.68342 11.0976 7.31658 11.0976 7.7071 10.7071L11.7071 6.70711Z" fill="#84CC16" />
-            </svg>);
-        case "building":
-            return (<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M8.99609 16C13.4144 16 16.9961 12.4183 16.9961 8C16.9961 3.58172 13.4144 0 8.99609 0C4.57781 0 0.996094 3.58172 0.996094 8C0.996094 12.4183 4.57781 16 8.99609 16ZM9.99609 4C9.99609 3.44772 9.54837 3 8.99609 3C8.4438 3 7.99609 3.44772 7.99609 4V8C7.99609 8.26522 8.10144 8.51957 8.28898 8.70711L11.1174 11.5355C11.5079 11.9261 12.1411 11.9261 12.5316 11.5355C12.9221 11.145 12.9221 10.5118 12.5316 10.1213L9.99609 7.58579V4Z" fill="#60A5FA" />
-            </svg>);
+export function prebuildStatusIcon(prebuild?: PrebuildWithStatus) {
+    if (prebuild?.error) {
+        return <img className="h-4 w-4" src={StatusFailed} />;
+    }
+    switch (prebuild?.status) {
+        case undefined: // Fall through
         case "queued":
-            return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM5 6C5 5.44772 5.44772 5 6 5C6.55228 5 7 5.44772 7 6V10C7 10.5523 6.55228 11 6 11C5.44772 11 5 10.5523 5 10V6ZM10 5C9.44771 5 9 5.44772 9 6V10C9 10.5523 9.44771 11 10 11C10.5523 11 11 10.5523 11 10V6C11 5.44772 10.5523 5 10 5Z" fill="#FBBF24" />
-            </svg>);
-        default:
-            break;
+            return <img className="h-4 w-4" src={StatusPaused} />;
+        case "building":
+            return <img className="h-4 w-4" src={StatusRunning} />;
+        case "aborted": // Fall through
+        case "timeout":
+            return <img className="h-4 w-4" src={StatusFailed} />;
+        case "available":
+            return <img className="h-4 w-4" src={StatusDone} />;
     }
 }
 
@@ -285,7 +278,7 @@ export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInst
                 </div>;
             break;
     }
-    if (props.prebuildInstance?.status.conditions.failed) {
+    if (props.prebuildInstance?.status.conditions.failed || props.prebuildInstance?.status.conditions.headlessTaskFailed) {
         status = <div className="flex space-x-1 items-center text-gitpod-red">
             <img className="h-4 w-4" src={StatusFailed} />
             <span>FAILED</span>

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -262,7 +262,8 @@ export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInst
         case 'creating': // Fall through
         case 'initializing': // Fall  through
         case 'running': // Fall through
-        case 'interrupted':
+        case 'interrupted': // Fall through
+        case 'stopping':
             status = <div className="flex space-x-1 items-center text-blue-600">
                 <img className="h-4 w-4" src={StatusRunning} />
                 <span>RUNNING</span>
@@ -272,7 +273,6 @@ export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInst
                 <span>Prebuild in progress ...</span>
                 </div>;
             break;
-        case 'stopping': // Fall through
         case 'stopped':
             status = <div className="flex space-x-1 items-center text-green-600">
                 <img className="h-4 w-4" src={StatusDone} />

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -203,7 +203,6 @@ export default function () {
                         </ItemField>
                         <ItemField>
                             <span>Prebuild</span>
-                            <ItemFieldContextMenu />
                         </ItemField>
                     </Item>
                     {isLoadingBranches && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16">

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -13,7 +13,6 @@ import { ItemsList, Item, ItemField, ItemFieldContextMenu } from "../components/
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
 import { prebuildStatusIcon, prebuildStatusLabel } from "./Prebuilds";
-import { ContextMenuEntry } from "../components/ContextMenu";
 import { shortCommitMessage, toRemoteURL } from "./render-utils";
 import Spinner from "../icons/Spinner.svg";
 import NoAccess from "../icons/NoAccess.svg";
@@ -120,15 +119,6 @@ export default function () {
         });
     };
 
-    const branchContextMenu = (branch: Project.BranchDetails) => {
-        const entries: ContextMenuEntry[] = [];
-        entries.push({
-            title: "Rerun Prebuild",
-            onClick: () => triggerPrebuild(branch),
-        });
-        return entries;
-    }
-
     const lastPrebuild = (branch: Project.BranchDetails) => {
         const lastPrebuild = lastPrebuilds.get(branch.name);
         if (!lastPrebuild) {
@@ -211,18 +201,17 @@ export default function () {
                     </div>}
                     {branches.filter(filter).slice(0, 10).map((branch, index) => {
 
-                        const branchName = branch.name;
                         const prebuild = lastPrebuild(branch); // this might lazily trigger fetching of prebuild details
 
                         const avatar = branch.changeAuthorAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={branch.changeAuthorAvatar || ''} alt={branch.changeAuthor} />;
-                        const statusIcon = prebuildStatusIcon(prebuild?.status);
-                        const status = prebuildStatusLabel(prebuild?.status);
+                        const statusIcon = prebuildStatusIcon(prebuild);
+                        const status = prebuildStatusLabel(prebuild);
 
-                        return <Item key={`branch-${index}-${branchName}`} className="grid grid-cols-3 group">
+                        return <Item key={`branch-${index}-${branch.name}`} className="grid grid-cols-3 group">
                             <ItemField className="flex items-center">
                                 <div>
                                     <a href={branch.url}><div className="text-base text-gray-600 hover:text-gray-800 dark:text-gray-50 dark:hover:text-gray-200 font-medium mb-1">
-                                        {branchName}
+                                        {branch.name}
                                         {branch.isDefault && (<span className="ml-2 self-center rounded-xl py-0.5 px-2 text-sm bg-blue-50 text-blue-40 dark:bg-blue-500 dark:text-blue-100">DEFAULT</span>)}
                                     </div></a>
                                 </div>
@@ -241,7 +230,12 @@ export default function () {
                                 <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
                                     <button className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}>New Workspace</button>
                                 </a>
-                                <ItemFieldContextMenu className="py-0.5" menuEntries={branchContextMenu(branch)} />
+                                <ItemFieldContextMenu className="py-0.5" menuEntries={(!prebuild || prebuild.status === 'aborted' || prebuild.status === 'timeout' || !!prebuild.error)
+                                    ? [{
+                                        title: `${prebuild ? 'Rerun' : 'Run'} Prebuild (${branch.name})`,
+                                        onClick: () => triggerPrebuild(branch),
+                                    }]
+                                    : []} />
                             </ItemField>
                         </Item>
                     }

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -14,13 +14,10 @@ import { useContext, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
 import { ThemeContext } from "../theme-context";
-import { PrebuildWithStatus, PrebuiltWorkspaceState, Project } from "@gitpod/gitpod-protocol";
+import { PrebuildWithStatus, Project } from "@gitpod/gitpod-protocol";
 import { toRemoteURL } from "./render-utils";
 import ContextMenu from "../components/ContextMenu";
-import StatusDone from "../icons/StatusDone.svg";
-import StatusPaused from "../icons/StatusPaused.svg";
-import StatusRunning from "../icons/StatusRunning.svg";
-import StatusFailed from "../icons/StatusFailed.svg";
+import { prebuildStatusIcon } from "./Prebuilds";
 
 export default function () {
     const location = useLocation();
@@ -77,21 +74,6 @@ export default function () {
     }
 
     const teamOrUserSlug = !!team ? 't/'+team.slug : 'projects';
-
-    const getPrebuildStatusIcon = (status: PrebuiltWorkspaceState) => {
-        switch (status) {
-            case undefined: // Fall through
-            case "queued":
-                return StatusPaused;
-            case "building":
-                return StatusRunning;
-            case "aborted": // Fall through
-            case "timeout":
-                return StatusFailed;
-            case "available":
-                return StatusDone;
-        }
-    }
 
     return <>
         <Header title="Projects" subtitle="Manage recently added projects." />
@@ -160,11 +142,11 @@ export default function () {
                         <div className="h-10 px-4 border rounded-b-xl dark:border-gray-800 bg-gray-100 border-gray-100 dark:bg-gray-800">
                             {lastPrebuilds.get(p.id)
                                 ? (<div className="flex flex-row h-full text-sm justify-between">
-                                    <Link to={`/${teamOrUserSlug}/${p.name}/${lastPrebuilds.get(p.id)?.info?.id}`} className="flex my-auto group space-x-2">
-                                        <img className="h-4 w-4 my-auto" src={getPrebuildStatusIcon(lastPrebuilds.get(p.id)!.status)} />
-                                        <div className="my-auto font-semibold text-gray-500 dark:text-gray-400 truncate w-24" title={lastPrebuilds.get(p.id)?.info?.branch}>{lastPrebuilds.get(p.id)?.info?.branch}</div>
-                                        <span className="mx-1 my-auto text-gray-400 dark:text-gray-600">·</span>
-                                        <div className="my-auto text-gray-400 dark:text-gray-500 flex-grow hover:text-gray-800 dark:hover:text-gray-300">{moment(lastPrebuilds.get(p.id)?.info?.startedAt, "YYYYMMDD").fromNow()}</div>
+                                    <Link to={`/${teamOrUserSlug}/${p.name}/${lastPrebuilds.get(p.id)?.info?.id}`} className="flex my-auto items-center group space-x-2">
+                                        {prebuildStatusIcon(lastPrebuilds.get(p.id))}
+                                        <div className="font-semibold text-gray-500 dark:text-gray-400 truncate w-24" title={lastPrebuilds.get(p.id)?.info?.branch}>{lastPrebuilds.get(p.id)?.info?.branch}</div>
+                                        <span className="mx-1 text-gray-400 dark:text-gray-600">·</span>
+                                        <div className="text-gray-400 dark:text-gray-500 flex-grow hover:text-gray-800 dark:hover:text-gray-300">{moment(lastPrebuilds.get(p.id)?.info?.startedAt, "YYYYMMDD").fromNow()}</div>
                                     </Link>
                                     <Link to={`/${teamOrUserSlug}/${p.name}/prebuilds`} className="my-auto group">
                                         <div className="flex my-auto text-gray-400 flex-grow text-right group-hover:text-gray-600 dark:hover:text-gray-300">View All &rarr;</div>

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -216,7 +216,6 @@ export default function EnvVars() {
                 <Item header={true}>
                     <ItemField className="w-5/12">Name</ItemField>
                     <ItemField className="w-5/12">Scope</ItemField>
-                    <ItemFieldContextMenu />
                 </Item>
                 {envVars.map(variable => {
                     return <Item className="whitespace-nowrap">

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -151,7 +151,6 @@ export default function() {
                     </ItemField>
                     <ItemField className="flex items-center">
                         <span className="flex-grow">Role</span>
-                        <ItemFieldContextMenu />
                     </ItemField>
                 </Item>
                 {filteredMembers.length === 0
@@ -190,7 +189,7 @@ export default function() {
                                         customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
                                         onClick: () => removeTeamMember(m.userId)
                                     }]
-                                    : undefined)} />
+                                    : [])} />
                         </ItemField>
                     </Item>)}
             </ItemsList>

--- a/components/ee/db-sync/src/tests/basic-replication.spec.db.ts
+++ b/components/ee/db-sync/src/tests/basic-replication.spec.db.ts
@@ -64,7 +64,8 @@ describe('Basic unidirectional replication', () => {
         ]);
     })
 
-    it('Should replicate with a start date', async () => {
+    it('Should replicate with a start date', async function () {
+        this.timeout(10000);
         await query(source, `INSERT INTO names VALUES ("9fa18735-c43b-4651-81c5-ddfbdee1035c", "Foo", "1970-01-01 00:00:01.001", 0)`)
         await query(source, `INSERT INTO names VALUES ("9fa18735-c43b-4651-81c5-ddfbdee1035d", "Bar", "1980-01-01 00:00:01.001", 0)`)
 

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -567,6 +567,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         return await repo.save(pws as DBPrebuiltWorkspace);
     }
 
+    // Find the (last triggered) prebuild for a given commit
     public async findPrebuiltWorkspaceByCommit(cloneURL: string, commit: string): Promise<PrebuiltWorkspace | undefined> {
         if (!commit || !cloneURL) {
             return undefined;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -57,6 +57,7 @@ export namespace Project {
 export interface PrebuildWithStatus {
     info: PrebuildInfo;
     status: PrebuiltWorkspaceState;
+    error?: string;
 }
 
 export interface PrebuildInfo {

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -93,7 +93,6 @@ export namespace PrebuildInfo {
 export interface StartPrebuildResult {
     wsid: string;
     done: boolean;
-    didFinish?: boolean;
 }
 
 export interface Team {

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -67,7 +67,10 @@ export class PrebuildManager {
         try {
             const existingPB = await this.workspaceDB.trace({ span }).findPrebuiltWorkspaceByCommit(cloneURL, commit);
             if (!!existingPB) {
-                return { wsid: existingPB.buildWorkspaceId, done: true, didFinish: existingPB.state === 'available' };
+                // If the prebuild is failed, we want to retrigger it.
+                if (existingPB.state !== 'aborted' && existingPB.state !== 'timeout' && !existingPB.error) {
+                    return { wsid: existingPB.buildWorkspaceId, done: true };
+                }
             }
 
             const contextParser = this.getContextParserFor(contextURL);

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -694,6 +694,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
 
             const logCtx: LogContext = { userId: user.id };
             const cloneUrl = context.repository.cloneUrl;
+            // Note: findPrebuiltWorkspaceByCommit always returns the last triggered prebuild (so, if you re-trigger a prebuild, the newer one will always be used here)
             const prebuiltWorkspace = await this.workspaceDb.trace({ span }).findPrebuiltWorkspaceByCommit(cloneUrl, context.revision);
             const logPayload = { mode, cloneUrl, commit: context.revision, prebuiltWorkspace };
             log.debug(logCtx, "Looking for prebuilt workspace: ", logPayload);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- [x] Make it possible to re-trigger failed or timed out Prebuilds (for the same commit)
- [x] Only show the option to re-trigger Prebuilds in the UI when it's actually possible, and provide immediate visual feedback upon (re-)triggering
- [x] Drive-by fix: Show "stopping" prebuild instances as still "running" and not yet "ready" (see [community](https://community.gitpod.io/t/prebuild-not-working/5102/9?u=jan))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5771
Fixes https://github.com/gitpod-io/gitpod/issues/5374

## How to test
<!-- Provide steps to test this PR -->

See https://github.com/gitpod-io/gitpod/pull/5836#issuecomment-929979502

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make it possible to re-trigger failed or timed out Prebuilds
```

/uncc