### PR TITLE
[ws-daemon] Reduce log level of CPU limit messages

### DIFF
--- a/components/ws-daemon/pkg/resources/controller.go
+++ b/components/ws-daemon/pkg/resources/controller.go
@@ -247,11 +247,11 @@ func (gov *Controller) SetFixedCPULimit(jiffiesPerSec int64) {
 	gov.mu.Lock()
 	defer gov.mu.Unlock()
 
+	gov.cpuLimiterOverride = nil
+
 	if jiffiesPerSec > 0 {
 		gov.cpuLimiterOverride = FixedLimiter(jiffiesPerSec)
-		gov.log.WithField("limit", jiffiesPerSec).Info("set fixed CPU limit for workspace")
-	} else {
-		gov.cpuLimiterOverride = nil
+		gov.log.WithField("limit", jiffiesPerSec).Debug("set fixed CPU limit for workspace")
 	}
 }
 


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
