### PR TITLE
[teams] make Gitpod icon team-aware

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -208,11 +208,18 @@ export default function Menu() {
         )
     }
 
+    const gitpodIconUrl = () => {
+        if (team) {
+            return `/t/${team.slug}`;
+        }
+        return "/"
+    }
+
     return <>
         <header className={`lg:px-28 px-10 flex flex-col pt-4 space-y-4 ${isMinimalUI || !!prebuildId ? 'pb-4' : ''}`} data-analytics='{"button_type":"menu"}'>
             <div className="flex h-10">
                 <div className="flex justify-between items-center pr-3">
-                    <Link to="/">
+                    <Link to={gitpodIconUrl()}>
                         <img src={gitpodIcon} className="h-6" />
                     </Link>
                     {!isMinimalUI && <div className="ml-2 text-base">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```
