### PR TITLE
[content-service] Do not log prebuild initialized logs in info level

### DIFF
--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -121,7 +121,7 @@ func (p *PrebuildInitializer) Run(ctx context.Context, mappings []archive.IDMapp
 		log.Debug("prebuild initializer Git operations complete")
 	}
 
-	log.Info("Initialized workspace with prebuilt snapshot")
+	log.Debug("Initialized workspace with prebuilt snapshot")
 	return
 }
 


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
