### PR TITLE
Add node affinity to monitoring-satellite

### DIFF
--- a/.werft/util/observability.ts
+++ b/.werft/util/observability.ts
@@ -30,6 +30,7 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
     --ext-str node_exporter_port="${params.nodeExporterPort}" \
     --ext-str prometheus_dns_name="prometheus-${params.previewDomain}" \
     --ext-str grafana_dns_name="grafana-${params.previewDomain}" \
+    --ext-str node_affinity_label="gitpod.io/workload_services" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/gitpod/pull/5745 took a little longer than I expected to get merged. In the mean time I introduced a new external variable to monitoring satellite.

When rendering jsonnet code while not passing all external-variables, it fails with error:
```
RUNTIME ERROR: field does not exist: extvar 'node_affinity_label'
```

As @laushinka tried to deploy the stack for the first time after #5745, it failed 😬 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft withMonitoringSatellite