### PR TITLE
[build] Don't deploy monitoring-satelite by default

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -395,7 +395,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         werft.fail('deploy', err);
     } finally {
         // produce the result independently of Helm succeding, so that in case Helm fails we still have the URL.
-        exec(`werft log result -d "dev installation" -c github url ${url}/workspaces/`);
+        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces/`);
     }
 
     werft.log(`observability`, "Installing monitoring-satellite...")


### PR DESCRIPTION
## Description
This PR fixes an issue introduced in #5694 whereby we'd deploy monitoring-satellite always.

## How to test
We should have deployed the preview-env without monitoring satellite. 
Add a comment `/werft run with-observability` and you should get monitoring satellite as well.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
