### PR TITLE
[ws-manager-bridge] Properly provide cluster metrics

### DIFF
--- a/components/ws-manager-bridge/tsconfig.json
+++ b/components/ws-manager-bridge/tsconfig.json
@@ -5,6 +5,7 @@
         "outDir": "dist",
         "lib": [
             "es6",
+            "es2017",
             "esnext.asynciterable"
         ],
         "strict": true,
@@ -15,7 +16,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es2017",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
## Description
This PR fixes the `cluster_score` and `cluster_cordoned` metrics in ws-manager-bridge.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5866

## How to test
```bash
kubectl port-forward ws-manager-bridge-... 9500
curl localhost:9500/metrics
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
