### PR TITLE
[dev] build job: move from name-based to label-based node selector

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -1,8 +1,15 @@
 # debug using `werft run github -f -s .werft/build.js -j .werft/build.yaml -a debug=true`
 pod:
   serviceAccount: werft
-  nodeSelector:
-    cloud.google.com/gke-nodepool: builds
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: dev/workload
+            operator: In
+            values:
+            - "builds"
   volumes:
   - name: monitoring-satellite-preview-token
     secret:

--- a/.werft/changelog.yaml
+++ b/.werft/changelog.yaml
@@ -2,8 +2,15 @@
 # this werft job is periodically run every night
 pod:
   serviceAccount: werft
-  nodeSelector:
-    cloud.google.com/gke-nodepool: builds
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: dev/workload
+            operator: In
+            values:
+            - "builds"
   containers:
   - name: build
     image: eu.gcr.io/gitpod-core-dev/dev/changelog:0.0.24


### PR DESCRIPTION
## Description
Instead of tying us to one single NodePool (which hurts us during platform changes, like mirgations) reference multiple pools with a label

## Related Issue(s)
none

## How to test
- check https://werft.gitpod-dev.com/job/gitpod-build-gpl-dev-build-node-selector.2/logs and see that is was executed flawlessly

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
