### PR TITLE
[ws-manager-bridge] Also copy status.conditions.headlessTaskFailed into WorkspaceInstanceConditions

### DIFF
--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -145,6 +145,9 @@ export interface WorkspaceInstanceConditions {
 
     // ISO8601 timestamp when the first user activity was registered in the frontend. Only set if the workspace is running.
     firstUserActivity?: string;
+
+    // headless_task_failed indicates that a headless workspace task failed
+    headlessTaskFailed?: string;
 }
 
 // AdmissionLevel describes who can access a workspace instance and its ports.

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -165,6 +165,7 @@ export class WorkspaceManagerBridge implements Disposable {
             instance.status.conditions.deployed = toBool(status.conditions.deployed);
             instance.status.conditions.timeout = status.conditions.timeout;
             instance.status.conditions.firstUserActivity = mapFirstUserActivity(rawStatus.getConditions()!.getFirstUserActivity());
+            instance.status.conditions.headlessTaskFailed = status.conditions.headlessTaskFailed;
             instance.status.message = status.message;
             instance.status.nodeName = instance.status.nodeName || status.runtime?.nodeName;
             instance.status.podName = instance.status.podName || status.runtime?.podName;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In the new Teams & Projects UI, we've introduced a Prebuild Status widget.

To determine a Prebuild's status, depending on the context of the page, the widget sometimes relies on:
1. A [prebuild.{state,error}](https://github.com/gitpod-io/gitpod/blob/afd2cb3a2a7da004412fd45742609daa16019105/components/gitpod-protocol/src/protocol.ts#L634-L645) (e.g. when listing Prebuilds for a Project/Branch)
2. A [instance.{phase,conditions}](https://github.com/gitpod-io/gitpod/blob/afd2cb3a2a7da004412fd45742609daa16019105/components/gitpod-protocol/src/workspace-instance.ts#L56-L87) (e.g. when showing the live logs of a Prebuild)

If an `init` task fails during a Prebuild, this creates a `status.conditions.headlessTaskFailed` error.
1. If there is such an error, it [gets copied into](https://github.com/gitpod-io/gitpod/blob/46feeac4c9d5ace28a9a565ca9d81b8a2f4e09d3/components/ws-manager-bridge/ee/src/bridge.ts#L81-L83) the `prebuild.error` -- so the first widget implementation can support & show this error state
2. However, it [does not currently get copied](https://github.com/gitpod-io/gitpod/blob/b031cf3296931f383c60c47bcb6fa53557861bd1/components/ws-manager-bridge/src/bridge.ts#L162-L167) into the `instance.conditions` -- so the second widget implementation is not aware of such errors, and cannot show them

Proposed solution:
- Copy `status.conditions.headlessTaskFailed` into the `instance.conditions` (so that the instance-based status widget can watch out for such errors)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
1. Trigger a prebuild with an init task like `- init: oops`
2. The prebuild workspace instance should have a `instance.conditions.headlessTaskFailed` when the above fails

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/uncc