### PR TITLE
[projects] clear team selection

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -58,10 +58,10 @@ export default function Menu() {
     const showTeamsUI = user?.rolesOrPermissions?.includes('teams-and-projects');
     const team = getCurrentTeam(location, teams);
 
-    if (team) {
+    {
         // updating last team selection
         try {
-            localStorage.setItem('team-selection', team.slug);
+            localStorage.setItem('team-selection', team ? team.slug : "");
         } catch {
         }
     }


### PR DESCRIPTION
Followup to https://github.com/gitpod-io/gitpod/pull/5854

In this change we clear the team selection whenever a non-team page is loaded.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
