### PR TITLE
[ws-daemon] Properly handle mark unmount

### DIFF
--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -48,9 +48,14 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 	}
 	cgCustomizer := &CgroupCustomizer{}
 	cgCustomizer.WithCgroupBasePath(config.Resources.CGroupsBasePath)
+	markUnmountFallback, err := NewMarkUnmountFallback(reg)
+	if err != nil {
+		return nil, err
+	}
 	dsptch, err := dispatch.NewDispatch(containerRuntime, clientset, config.Runtime.KubernetesNamespace, nodename,
 		resources.NewDispatchListener(&config.Resources, reg),
 		cgCustomizer,
+		markUnmountFallback,
 	)
 	if err != nil {
 		return nil, err

--- a/components/ws-daemon/pkg/daemon/markunmount.go
+++ b/components/ws-daemon/pkg/daemon/markunmount.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package daemon
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/dispatch"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// propagationGracePeriod is the time we allow on top of a container's deletionGracePeriod
+	// to make sure the changes propagate on the data plane.
+	propagationGracePeriod = 10 * time.Second
+)
+
+// NewMarkUnmountFallback produces a new MarkUnmountFallback. reg can be nil
+func NewMarkUnmountFallback(reg prometheus.Registerer) (*MarkUnmountFallback, error) {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "markunmountfallback_active_total",
+		Help: "counts how often the mark unmount fallback was active",
+	}, []string{"successful"})
+	if reg != nil {
+		err := reg.Register(counter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &MarkUnmountFallback{
+		activityCounter: counter,
+	}, nil
+}
+
+// MarkUnmountFallback works around the mount propagation of the ring1 FS mark mount.
+// When ws-daemon restarts runc propagates all rootfs mounts to ws-daemon's mount namespace.
+// This prevents proper unmounting of the mark mount, hence the rootfs of the workspace container.
+//
+// To work around this issue we wait pod.terminationGracePeriod + propagationGracePeriod and,
+// after which we attempt to unmount the mark mount.
+//
+// Some clusters might run an older version of containerd, for which we build this workaround.
+type MarkUnmountFallback struct {
+	mu      sync.Mutex
+	handled map[string]struct{}
+
+	activityCounter *prometheus.CounterVec
+}
+
+// WorkspaceAdded does nothing but implemented the dispatch.Listener interface
+func (c *MarkUnmountFallback) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspace) error {
+	return nil
+}
+
+// WorkspaceUpdated gets called when a workspace pod is updated. For containers being deleted, we'll check
+// if they're still running after their terminationGracePeriod and if Kubernetes still knows about them.
+func (c *MarkUnmountFallback) WorkspaceUpdated(ctx context.Context, ws *dispatch.Workspace) error {
+	if ws.Pod.DeletionTimestamp == nil {
+		return nil
+	}
+
+	err := func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if c.handled == nil {
+			c.handled = make(map[string]struct{})
+		}
+		if _, exists := c.handled[ws.InstanceID]; exists {
+			return nil
+		}
+		c.handled[ws.InstanceID] = struct{}{}
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
+
+	var gracePeriod int64
+	if ws.Pod.DeletionGracePeriodSeconds != nil {
+		gracePeriod = *ws.Pod.DeletionGracePeriodSeconds
+	} else {
+		gracePeriod = 30
+	}
+	ttl := time.Duration(gracePeriod)*time.Second + propagationGracePeriod
+
+	go func() {
+		time.Sleep(ttl)
+
+		dsp := dispatch.GetFromContext(ctx)
+		if !dsp.WorkspaceExistsOnNode(ws.InstanceID) {
+			// container is already gone - all is well
+			return
+		}
+
+		err := unmountMark(ws.InstanceID)
+		if err != nil {
+			log.WithFields(ws.OWI()).WithError(err).Error("cannot unmount mark mount from within ws-daemon")
+			c.activityCounter.WithLabelValues("false").Inc()
+		} else {
+			c.activityCounter.WithLabelValues("true").Inc()
+		}
+
+		// We expect the container to be gone now. Don't keep its referenec in memory.
+		c.mu.Lock()
+		delete(c.handled, ws.InstanceID)
+		c.mu.Unlock()
+	}()
+
+	return nil
+}
+
+// if the mark mount still exists in /proc/mounts it means we failed to unmount it and
+// we cannot remove the content. As a side effect the pod will stay in Terminating state
+func unmountMark(instanceID string) error {
+	mounts, err := ioutil.ReadFile("/proc/mounts")
+	if err != nil {
+		return xerrors.Errorf("cannot read /proc/mounts: %w", err)
+	}
+
+	dir := content.ServiceDirName(instanceID)
+	path := fromPartialMount(filepath.Join(dir, "mark"), mounts)
+	// empty path means no mount found
+	if len(path) == 0 {
+		return nil
+	}
+
+	// in some scenarios we need to wait for the unmount
+	var errorFn = func(err error) bool {
+		return strings.Contains(err.Error(), "device or resource busy")
+	}
+
+	var eg errgroup.Group
+	for _, p := range path {
+		// add p as closure so that we can use it inside the Go routine.
+		p := p
+		eg.Go(func() error {
+			return retry.OnError(wait.Backoff{
+				Steps:    5,
+				Duration: 1 * time.Second,
+				Factor:   5.0,
+				Jitter:   0.1,
+			}, errorFn, func() error {
+				return unix.Unmount(p, 0)
+			})
+		})
+	}
+	return eg.Wait()
+}
+
+func fromPartialMount(path string, info []byte) (res []string) {
+	scanner := bufio.NewScanner(bytes.NewReader(info))
+	for scanner.Scan() {
+		mount := strings.Split(scanner.Text(), " ")
+		if len(mount) < 2 {
+			continue
+		}
+
+		if strings.Contains(mount[1], path) {
+			res = append(res, mount[1])
+		}
+	}
+
+	return res
+}

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -363,22 +363,9 @@ func actOnPodEvent(ctx context.Context, m actingManager, status *api.WorkspaceSt
 		_, gone := wso.Pod.Annotations[wsk8s.ContainerIsGoneAnnotation]
 
 		if terminated || gone {
-			// workaround for https://github.com/containerd/containerd/pull/4214 which can prevent pod status
-			// propagation. ws-daemon observes the pods and propagates this state out-of-band via the annotation.
+			// We start finalizing the workspace content only after the container is gone. This way we ensure there's
+			// no process modifying the workspace content as we create the backup.
 			go m.finalizeWorkspaceContent(ctx, wso)
-		} else {
-			// add an additional wait time on top of a deletionGracePeriod
-			// to make sure the changes propagate on the data plane.
-			var gracePeriod int64 = 30
-			if wso.Pod.DeletionGracePeriodSeconds != nil {
-				gracePeriod = *wso.Pod.DeletionGracePeriodSeconds
-			}
-			ttl := time.Duration(gracePeriod) * time.Second * 2
-
-			go func() {
-				time.Sleep(ttl)
-				m.finalizeWorkspaceContent(ctx, wso)
-			}()
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR moves the mark unmount fallback back to ws-daemon. Prior to this change we'd try and finalise workspace content even before the pod was stopped. During content finalisation we'd try and unmount the mark mount that might have been propagated to ws-daemon during a restart. If that happened, the pod would never actually stop - hence we'd try to finalise even if the pod was not stopped yet.

This change pushes all this mark mount business back into ws-dameon using the `dispatch` mechanism. If a pod lingers around for longer than its termination grace period, we'll try and unmount the mark mount, eventually causing the pod to stop.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5689

## How to test
1. Start a workspace
2. Restart ws-daemon
3. Stop the workspace
4. The workspace should have stopped just fine and the `gitpod_ws_daemon_markunmountfallback_active_total` metric on ws-daemon should have incremented by one.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[workspace] Make the workspace stopping mechanism more deterministic
```
