### PR TITLE
Close stale PRs more agressively

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -45,6 +45,8 @@ limitPerRun: 30
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
 pulls:
+  daysUntilStale: 10
+  daysUntilClose: 5
   markComment: >
     This pull request has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
In order to reduce concurrent WIP and the total number of open PRs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
