### PR TITLE
[meta] Fix log format so it can be parsed again

### DIFF
--- a/components/gitpod-protocol/src/util/logging.ts
+++ b/components/gitpod-protocol/src/util/logging.ts
@@ -125,14 +125,8 @@ export namespace log {
 
         // set/unset log functions based on loglevel so we only have to evaluate once, not every call
         const noop = () => {};
-        const setLog = (logFunc: (calleViaConsole: boolean, args: any[]) => void, funcLvl: LogrusLogLevel): (() => void) => {
-            if (LogrusLogLevel.isGreatherOrEqual(funcLvl, logLevel)) {
-                return function (...args: any[]): void {
-                    logFunc(true, args);
-                };
-            } else {
-                return noop;
-            }
+        const setLog = (logFunc: DoLogFunction, funcLevel: LogrusLogLevel): DoLogFunction => {
+            return LogrusLogLevel.isGreatherOrEqual(funcLevel, logLevel) ? logFunc : noop;
         };
 
         errorLog = setLog(doErrorLog, "error");
@@ -155,6 +149,8 @@ export namespace log {
         version = versionArg;
     }
 }
+
+type DoLogFunction = (calledViaConsole: boolean, args: any[]) => void;
 
 let errorLog = doErrorLog;
 function doErrorLog(calledViaConsole: boolean, args: any[]): void {

--- a/components/server/src/debug-app.ts
+++ b/components/server/src/debug-app.ts
@@ -32,20 +32,24 @@ export class DebugApp {
 
     create(): express.Application {
         const app = express();
+
+        app.use(express.json());
+        app.use(express.urlencoded({ extended: true }));
+
         app.post('/debug/logging', (req, res) => {
-	        try {
-                const parsed = JSON.parse(req.body);
-                if (!SetLogLevelRequest.is(parsed)) {
+            try {
+                const levelRequest = req.body;
+                if (!SetLogLevelRequest.is(levelRequest)) {
                     res.status(400).end("not a SetLogLevelRequest");
                     return;
                 }
 
-                const newLogLevel = parsed.level;
+                const newLogLevel = levelRequest.level;
                 log.setLogLevel(newLogLevel);
                 log.info("set log level", { newLogLevel });
-	        } catch (err) {
-    		    res.status(500).end(err);
-	        }
+            } catch (err) {
+                res.status(500).end(err);
+            }
         });
         return app;
     }


### PR DESCRIPTION
## Description
Currently the log output looks like this:
```
{
    "component": "server",
    "serverity": "INFO",
    "time": ....
    "environment": "staging",
    "payload": [
      false,
      [
        "Request getHeadlessLog unsuccessful",
        {
          "args": [
            ....
          ],
          "method": "getHeadlessLog"
        }
      ]
    ],
    "component": "server",
    "region": "europe-west1",
    "loggedViaConsole": true
  }
```
where it should look likes this:
```
{
    "component": "server",
    "severity": "INFO",
    "time": "2021-09-28T08:55:39.089Z",
    "environment": "devstaging",
    "region": "europe-west1",
    "message": ...,
    "payload": {
        "id": "...",
        "domain": "",
        "level": 1,
        "validUntil": ...,
        "seats": 5
    },
    "loggedViaConsole": true
}
```

to be properly parsed by cloud console.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix log format for meta components
```
