### PR TITLE
[teams] use owner's GitLab account by default

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -76,8 +76,13 @@ export default function NewProject() {
         if (reposInAccounts.length === 0) {
             setSelectedAccount(undefined);
         } else {
-            const mostRecent = reposInAccounts.reduce((prev, current) => (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current);
-            setSelectedAccount(mostRecent.account);
+            const first = reposInAccounts[0];
+            if (!!first.installationUpdatedAt) {
+                const mostRecent = reposInAccounts.reduce((prev, current) => (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current);
+                setSelectedAccount(mostRecent.account);
+            } else {
+                setSelectedAccount(first.account);
+            }
         }
 
     }, [reposInAccounts]);


### PR DESCRIPTION
## Description
When creating a new project from gitlab.com one's personal account should be preselected.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5331

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
