### PR TITLE
[projects] Enable New Workspace button when config is Git-based

### DIFF
--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -178,7 +178,7 @@ export default function () {
         <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
           {prebuildWasTriggered && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} />}
           <div className="flex-grow" />
-          {(prebuildInstance?.status.phase === "stopped" && !prebuildInstance?.status.conditions.failed)
+          {((!isDetecting && isEditorDisabled) || (prebuildInstance?.status.phase === "stopped" && !prebuildInstance?.status.conditions.failed))
               ? <a className="my-auto" href={`/#${project?.cloneUrl}`}><button className="secondary">New Workspace</button></a>
               : <button disabled={true} className="secondary">New Workspace</button>}
           <button disabled={isDetecting || (prebuildWasTriggered && prebuildInstance?.status.phase !== "stopped")} onClick={buildProject}>Run Prebuild</button>


### PR DESCRIPTION
Enables New Workspace button according to https://github.com/gitpod-io/gitpod/pull/5654#discussion_r710922579

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5591

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
