### PR TITLE
support self-host http gitlab integrations

### DIFF
--- a/chart/templates/server-configmap.yaml
+++ b/chart/templates/server-configmap.yaml
@@ -38,6 +38,7 @@ data:
         "definitelyGpDisabled": {{ $comp.definitelyGpDisabled }},
         "workspaceGarbageCollection": {{ $comp.garbageCollection | toJson }},
         "enableLocalApp": {{ $comp.enableLocalApp }},
+        "enableHttpGitlabProvider": {{ $comp.enableHttpGitlabProvider }},
         "authProviderConfigs": {{ .Values.authProviders | toJson }},
         "disableDynamicAuthProviderLogin": {{ $comp.disableDynamicAuthProviderLogin }},
         "brandingConfig": {{ .Values.branding | toJson }},

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -346,6 +346,7 @@ components:
       contentChunkLimit: 1000
     definitelyGpDisabled: "false"
     enableLocalApp: false
+    enableHttpGitlabProvider: false
     disableDynamicAuthProviderLogin: false
     maxEnvvarPerUserCount: 4048
     maxConcurrentPrebuildsPerRef: 10

--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -148,7 +148,7 @@ func parseHostFromStdin() string {
 
 func parseProcessTree() (repoUrl string, gitCommand string) {
 	gitCommandRegExp := regexp.MustCompile(`git(,\d+\s+|\s+)(push|clone|fetch|pull|diff)`)
-	repoUrlRegExp := regexp.MustCompile(`\sorigin\s*(https:[^\s]*)\s`)
+	repoUrlRegExp := regexp.MustCompile(`\sorigin\s*(https?:[^\s]*)\s`)
 	pid := os.Getpid()
 	for {
 		cmdLine := readProc(pid, "cmdline")

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1554,6 +1554,7 @@ type OAuth2Config struct {
 	ScopeSeparator      string            `json:"scopeSeparator,omitempty"`
 	SettingsURL         string            `json:"settingsUrl,omitempty"`
 	TokenURL            string            `json:"tokenUrl,omitempty"`
+	Protocol            string            `json:"protocol,omitempty"`
 }
 
 // AuthProviderEntry is the AuthProviderEntry message type

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1145,6 +1145,7 @@ export interface OAuth2Config {
     readonly tokenUrl: string;
     readonly scope?: string;
     readonly scopeSeparator?: string;
+    readonly protocol?: string;
 
     readonly settingsUrl?: string;
     readonly authorizationParams?: { [key: string]: string }

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -83,6 +83,7 @@ export interface ConfigSerialized {
 
     enableLocalApp: boolean;
 
+    enableHttpGitlabProvider: boolean;
     authProviderConfigs: AuthProviderParams[];
     builtinAuthProvidersConfigured: boolean;
     disableDynamicAuthProviderLogin: boolean;

--- a/components/server/src/gitlab/api.ts
+++ b/components/server/src/gitlab/api.ts
@@ -15,11 +15,13 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { GitLabScope } from "./scopes";
 import { AuthProviderParams } from "../auth/auth-provider";
 import { GitLabTokenHelper } from "./gitlab-token-helper";
+import { Config } from "../config";
 
 @injectable()
 export class GitLabApi {
 
     @inject(AuthProviderParams) readonly config: AuthProviderParams;
+    @inject(Config) readonly globalConfig: Config;
     @inject(GitLabTokenHelper) protected readonly tokenHelper: GitLabTokenHelper;
 
     async create(userOrToken: User | string) {
@@ -30,8 +32,12 @@ export class GitLabApi {
             const gitlabToken = await this.tokenHelper.getTokenWithScopes(userOrToken, GitLabScope.Requirements.DEFAULT);
             oauthToken = gitlabToken.value;
         }
+        let host = `https://${this.config.host}`
+        if (this.globalConfig.enableHttpGitlabProvider === true && this.config.oauth.protocol === "http") {
+            host = `http://${this.config.host}`
+        }
         return GitLab.create({
-            host: `https://${this.config.host}`,
+            host,
             oauthToken
         });
     }

--- a/components/server/src/gitlab/gitlab-auth-provider.ts
+++ b/components/server/src/gitlab/gitlab-auth-provider.ts
@@ -36,7 +36,12 @@ export class GitLabAuthProvider extends GenericAuthProvider {
      */
     protected get oauthConfig() {
         const oauth = this.params.oauth!;
-        const defaultUrls = oauthUrls(this.params.host);
+        let protocol = "https"
+        if (this.config.enableHttpGitlabProvider === true && oauth.protocol === "http") {
+            protocol = "http"
+        }
+
+        const defaultUrls = oauthUrls(this.params.host, protocol);
         const scopeSeparator = " ";
         return <typeof oauth>{
             ...oauth,
@@ -53,6 +58,9 @@ export class GitLabAuthProvider extends GenericAuthProvider {
     }
 
     protected get baseURL() {
+        if (this.config.enableHttpGitlabProvider === true && this.params.oauth?.protocol === "http") {
+            return `http://${this.params.host}`;
+        }
         return `https://${this.params.host}`;
     }
 

--- a/components/server/src/gitlab/gitlab-urls.ts
+++ b/components/server/src/gitlab/gitlab-urls.ts
@@ -5,10 +5,10 @@
  */
 
 
-export function oauthUrls(host: string) {
+export function oauthUrls(host: string, protocol: string = "https") {
     return {
-        authorizationUrl: `https://${host}/oauth/authorize`,
-        tokenUrl: `https://${host}/oauth/token`,
-        settingsUrl: `https://${host}/-/profile/applications`,
+        authorizationUrl: `${protocol}://${host}/oauth/authorize`,
+        tokenUrl: `${protocol}://${host}/oauth/token`,
+        settingsUrl: `${protocol}://${host}/-/profile/applications`,
     }
 }

--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -32,7 +32,7 @@ export abstract class AbstractContextParser implements IContextParser {
         if (url.startsWith(`${this.host}/`)) {
             url = `https://${url}`;
         }
-        if (url.startsWith(`https://${this.host}/`)) {
+        if (url.startsWith(`https://${this.host}/`) || url.startsWith(`http://${this.host}/`) ) {
             return url;
         }
         return undefined;

--- a/components/server/src/workspace/git-token-scope-guesser.ts
+++ b/components/server/src/workspace/git-token-scope-guesser.ts
@@ -45,7 +45,7 @@ export class GitTokenScopeGuesser {
      * @param repoUrl e.g. https://gitlab.domain.com/group/subgroup1/subgroug2/project-repo.git
      */
     protected parseRepoFull(repoUrl: string | undefined): string | undefined {
-        if (repoUrl && repoUrl.startsWith("https://") && repoUrl.endsWith(".git")) {
+        if (repoUrl && (repoUrl.startsWith("https://") || repoUrl.startsWith("http://")) && repoUrl.endsWith(".git")) {
             const parts = repoUrl.substr("https://".length).split("/").splice(1); // without host parts
             if (parts.length >= 2) {
                 parts[parts.length - 1] = parts[parts.length - 1].slice(0, -1 * ".git".length);


### PR DESCRIPTION
## Description
In many case, self-host gitlab is deploy in a private network, it might don't support https
in current gitpod version event you config `authProviders.oauth.authorizationUrl` and `authProviders.oauth.tokenUrl` in  `values.yml` it still doesn't support
```yaml
authProviders: 
  - id: "http self host gitlab"
    host: "test.com"
    type: "GitLab"
    oauth:
      clientId: "xxx"
      clientSecret: "xxxx"
      callBackUrl: "https://gitpod.test.com/auth/test.com/callback"
      settingsUrl: "http://test.com/-/profile/applications"
      authorizationUrl: "http://test.com/oauth/authorize"
      tokenUrl: "http://test.com/oauth/token"
```

this PR only resolve self-host gitpod, it need cluster admin config `authProviders.oauth.tokenUrl` to a http url in `value.yml`,
the SaaS gitpod just can add callBackUrl, other url is auto generate.

hope this pr can help some http self-host gitlab user.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
add a http gitlab self-host auth provider to value.yaml and test every function like login, start workspace, git pull, git push and so on

## Release Notes
```release-note
NONE
```
