### PR TITLE
[dashboard] don't show 'new project' button

### DIFF
--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -152,11 +152,7 @@ export default function () {
                                 onClick: () => { if (workspaceModel) workspaceModel.limit = 200; }
                             }]} />
                         </div>
-                        {
-                            projects.length === 0
-                            ? <button onClick={onNewProject} className="ml-2">New Project</button>
-                            : <button onClick={showStartWSModal} className="ml-2">New Workspace</button>
-                        }
+                        <button onClick={showStartWSModal} className="ml-2">New Workspace</button>
                     </div>
                     <ItemsList className="lg:px-28 px-10">
                         <div className="border-t border-gray-200 dark:border-gray-800"></div>


### PR DESCRIPTION
## Description
There is never a case where we want to show "New Project" on the top right of the list, because in this situation there are already workspaces and hence we know who to start more of them.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5915

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
