### PR TITLE
[supervisor] Add carret return to prebuild terminal message

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -459,7 +459,7 @@ func (tm *tasksManager) watch(task *task, terminal *terminal.Term) {
 					if elapsedInMinutes != "1" {
 						duration += "s"
 					}
-					duration += "\n"
+					duration += "\r\n"
 				}
 				data := string(buf[:n])
 				fileWriter.Write(buf[:n])
@@ -467,7 +467,7 @@ func (tm *tasksManager) watch(task *task, terminal *terminal.Term) {
 					tm.reporter.write(data, task, terminal)
 				}
 
-				endMessage := "\n🤙 This task ran as a workspace prebuild\n" + duration + "\n"
+				endMessage := "\r\n🤙 This task ran as a workspace prebuild\r\n" + duration + "\r\n"
 				fileWriter.WriteString(endMessage)
 				break
 			}
@@ -496,7 +496,7 @@ func importParentLogAndGetDuration(fn string, out io.Writer) time.Duration {
 	}
 	defer file.Close()
 
-	defer out.Write([]byte("♻️ Re-running task as an incremental workspace prebuild\n\n"))
+	defer out.Write([]byte("♻️ Re-running task as an incremental workspace prebuild\r\n\r\n"))
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {


### PR DESCRIPTION
## Description

This fixes line endings for certain terminal emulators, like Gitpod's logs viewer, which currently shows things like this:

<img width="1438" alt="Screenshot 2021-09-29 at 09 37 48" src="https://user-images.githubusercontent.com/599268/135225050-c55b40a3-4968-4c37-a760-28eb17c2102f.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
