### PR TITLE
[db] Create index ind_buildWorkspaceId on d_b_prebuild_workspace_info

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1632903852031-IndexBuildWorkspaceId.ts
+++ b/components/gitpod-db/src/typeorm/migration/1632903852031-IndexBuildWorkspaceId.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { indexExists } from "./helper/helper";
+
+const INDEX_NAME = "ind_buildWorkspaceId";
+const TABLE_NAME = "d_b_prebuilt_workspace";
+
+export class IndexBuildWorkspaceId1632903852031 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        if (!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE_NAME} (buildWorkspaceId)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`DROP INDEX ${INDEX_NAME} ON ${TABLE_NAME}`);
+    }
+
+}


### PR DESCRIPTION
## Description
We were lagging an index on column `d_b_prebuild_workspace.buildWorkspaceId`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5906.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[db] add missing index `d_b_prebuild_workspace.buildWorkspaceId`
```
