### PR TITLE
Add 5 second interval automatic page reload to default 404 page for unserved ports.

### DIFF
--- a/components/ws-proxy/public/port-not-found.html
+++ b/components/ws-proxy/public/port-not-found.html
@@ -127,6 +127,7 @@
     document.getElementById('refresh').addEventListener('click', function () {
       window.location.reload(true);
     });
+    window.setInterval('window.location.reload(true);', 5000);
   </script>
 </body>
 


### PR DESCRIPTION
## Description
Add 5 second interval automatic page reload to default 404 page for unserved ports.

## Why
Thought this was an easy addition of a beneficial feature, also saw it mentioned here: https://community.gitpod.io/t/auto-reload-of-port-not-available/5187

## How to test
Try opening an unserved port from a running workspace and the page should automatically reload every 5 seconds until the port is served.

## Release Notes
```release-notes
Add automatic five second page reload to the "port not found" page
```