### PR TITLE
[local-app] add other arch support

### DIFF
--- a/components/dashboard/conf/Caddyfile
+++ b/components/dashboard/conf/Caddyfile
@@ -12,6 +12,13 @@
 		path /static/* /favicon* /manifest.json
 	}
 
+    rewrite /static/bin/gitpod-local-companion-linux /static/bin/gitpod-local-companion-linux-amd64
+    rewrite /static/bin/gitpod-local-companion-darwin /static/bin/gitpod-local-companion-darwin-amd64
+    rewrite /static/bin/gitpod-local-companion-windows.exe /static/bin/gitpod-local-companion-windows-amd64.exe
+    rewrite /static/bin/gitpod-local-companion-linux.gz /static/bin/gitpod-local-companion-linux-amd64.gz
+    rewrite /static/bin/gitpod-local-companion-darwin.gz /static/bin/gitpod-local-companion-darwin-amd64.gz
+    rewrite /static/bin/gitpod-local-companion-windows.exe.gz /static/bin/gitpod-local-companion-windows-amd64.exe.gz
+
 	@bin_asset {
 		file
 		path /static/bin/*

--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -16,14 +16,18 @@ RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '
 RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.png' -o -name '*.svg' -o -name '*.map' -o -name '*.json' \) \
   -exec /bin/sh -c 'brotli -v -q 11 -o "$1.br" "$1"' /bin/sh {} \;
 
-COPY components-local-app--app/components-local-app--app-linux/local-app /www/static/bin/gitpod-local-companion-linux
-COPY components-local-app--app/components-local-app--app-darwin/local-app /www/static/bin/gitpod-local-companion-darwin
-COPY components-local-app--app/components-local-app--app-windows/local-app.exe /www/static/bin/gitpod-local-companion-windows.exe
+COPY components-local-app--app/components-local-app--app-linux-amd64/local-app /www/static/bin/gitpod-local-companion-linux-amd64
+COPY components-local-app--app/components-local-app--app-darwin-amd64/local-app /www/static/bin/gitpod-local-companion-darwin-amd64
+COPY components-local-app--app/components-local-app--app-windows-amd64/local-app.exe /www/static/bin/gitpod-local-companion-windows-amd64.exe
+COPY components-local-app--app/components-local-app--app-linux-arm64/local-app /www/static/bin/gitpod-local-companion-linux-arm64
+COPY components-local-app--app/components-local-app--app-darwin-arm64/local-app /www/static/bin/gitpod-local-companion-darwin-arm64
+COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe /www/static/bin/gitpod-local-companion-windows-arm64.exe
+COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe /www/static/bin/gitpod-local-companion-windows-386.exe
 
 COPY components-gitpod-protocol--gitpod-schema/gitpod-schema.json /www/static/schemas/gitpod-schema.json
 
-RUN for PLATFORM in linux darwin windows.exe;do \
-  gzip -v -f -9 -k "/www/static/bin/gitpod-local-companion-$PLATFORM"; \
+RUN for FILE in `ls /www/static/bin/gitpod-local-companion*`;do \
+  gzip -v -f -9 -k "$FILE"; \
 done
 
 FROM caddy/caddy:2.4.0-alpine

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -4,10 +4,14 @@ packages:
     config:
       commands: [["echo"]]
     deps:
-      - :app-linux
-      - :app-darwin
-      - :app-windows
-  - name: app-linux
+      - :app-linux-amd64
+      - :app-linux-arm64
+      - :app-darwin-amd64
+      - :app-darwin-arm64
+      - :app-windows-386
+      - :app-windows-amd64
+      - :app-windows-arm64
+  - name: app-linux-amd64
     type: go
     srcs:
       - go.mod
@@ -21,11 +25,31 @@ packages:
     env:
       - CGO_ENABLED=0
       - GOOS=linux
+      - GOARCH=amd64
     prep:
       - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
-  - name: app-darwin
+  - name: app-linux-arm64
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=linux
+      - GOARCH=arm64
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: app-darwin-amd64
     type: go
     srcs:
       - go.mod
@@ -39,11 +63,31 @@ packages:
     env:
       - CGO_ENABLED=0
       - GOOS=darwin
+      - GOARCH=amd64
     prep:
       - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
-  - name: app-windows
+  - name: app-darwin-arm64
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=darwin
+      - GOARCH=arm64
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: app-windows-amd64
     type: go
     srcs:
       - go.mod
@@ -57,6 +101,45 @@ packages:
     env:
       - CGO_ENABLED=0
       - GOOS=windows
+      - GOARCH=amd64
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: app-windows-386
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=windows
+      - GOARCH=386
+    prep:
+      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
+    config:
+      packaging: app
+  - name: app-windows-arm64
+    type: go
+    srcs:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+    deps:
+      - :version
+      - components/supervisor-api/go:lib
+      - components/gitpod-protocol/go:lib
+      - components/local-app-api/go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=windows
+      - GOARCH=arm64
     prep:
       - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:

--- a/components/local-app/leeway.Dockerfile
+++ b/components/local-app/leeway.Dockerfile
@@ -5,8 +5,17 @@
 FROM alpine:3.14
 
 WORKDIR /app
-COPY components-local-app--app/components-local-app--app-linux/local-app local-app-linux
-COPY components-local-app--app/components-local-app--app-darwin/local-app local-app-darwin
-COPY components-local-app--app/components-local-app--app-windows/local-app.exe local-app-windows.exe
+COPY components-local-app--app/components-local-app--app-linux-amd64/local-app local-app-linux
+COPY components-local-app--app/components-local-app--app-darwin-amd64/local-app local-app-darwin
+COPY components-local-app--app/components-local-app--app-windows-amd64/local-app.exe local-app-windows.exe
+
+COPY components-local-app--app/components-local-app--app-linux-amd64/local-app local-app-linux-amd64
+COPY components-local-app--app/components-local-app--app-darwin-amd64/local-app local-app-darwin-amd64
+COPY components-local-app--app/components-local-app--app-windows-amd64/local-app.exe local-app-windows-amd64.exe
+
+COPY components-local-app--app/components-local-app--app-linux-arm64/local-app local-app-linux-arm64
+COPY components-local-app--app/components-local-app--app-darwin-arm64/local-app local-app-darwin-arm64
+COPY components-local-app--app/components-local-app--app-windows-arm64/local-app.exe local-app-windows-arm64.exe
+COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe local-app-windows-386.exe
 
 CMD ["/bin/sh", "-c", "cp /app/* /out"]

--- a/components/local-app/pkg/auth/auth_test.go
+++ b/components/local-app/pkg/auth/auth_test.go
@@ -2,8 +2,8 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-//go:build linux
-// +build linux
+//go:build linux && amd64
+// +build linux,amd64
 
 package auth
 


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

## Description
Add windows-386(win32), windows-arm64, darwin-arm64, linux-arm64 support for local-app
next step is update gitpod.io website document and vscode extension

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #5872 and #5320 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
NONE
```
