### PR TITLE
[werft] replaced ws-nodepools and enabled raid0 on ws-nodepools

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -424,8 +424,8 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         flags += ` --set components.registryFacade.ports.registry.servicePort=${registryNodePortMeta}`;
 
         const nodeAffinityValues = [
-            "values.nodeAffinities_0.yaml",
-            "values.nodeAffinities_1.yaml"
+            "values.nodeAffinities_2.yaml",
+            "values.nodeAffinities_3.yaml",
         ]
 
         if (k3sWsCluster) {
@@ -477,8 +477,8 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
     function addDeploymentFlags() {
         let flags = ""
         flags += ` --namespace ${namespace}`;
-        flags += ` --set components.imageBuilder.hostDindData=/mnt/disks/ssd0/docker-${namespace}`;
-        flags += ` --set components.wsDaemon.hostWorkspaceArea=/mnt/disks/ssd0/workspaces-${namespace}`;
+        flags += ` --set components.imageBuilder.hostDindData=/mnt/disks/raid0/docker-${namespace}`;
+        flags += ` --set components.wsDaemon.hostWorkspaceArea=/mnt/disks/raid0/workspaces-${namespace}`;
         flags += ` --set version=${version}`;
         flags += ` --set hostname=${domain}`;
         flags += ` --set devBranch=${destname}`;

--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -152,7 +152,7 @@ components:
       memory: 350Mi
 
   wsDaemon:
-    hostWorkspaceArea: /mnt/disks/ssd0/workspaces
+    setupSSDRaid: true
     disableKubeHealthMonitor: true
     volumes:
     - name: gcloud-tmp

--- a/.werft/values.nodeAffinities_2.yaml
+++ b/.werft/values.nodeAffinities_2.yaml
@@ -14,7 +14,7 @@ components:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
           - matchExpressions:
-            - key: gitpod.io/workspace_1
+            - key: gitpod.io/workspace_2
               operator: Exists
 
   registryFacade:
@@ -23,13 +23,13 @@ components:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
           - matchExpressions:
-            - key: gitpod.io/workspace_1
+            - key: gitpod.io/workspace_2
               operator: Exists
 
 
   workspace:
     affinity:
-      default: gitpod.io/workspace_1
+      default: gitpod.io/workspace_2
 
 # Sub-Charts
 

--- a/.werft/values.nodeAffinities_3.yaml
+++ b/.werft/values.nodeAffinities_3.yaml
@@ -14,7 +14,7 @@ components:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
           - matchExpressions:
-            - key: gitpod.io/workspace_0
+            - key: gitpod.io/workspace_3
               operator: Exists
 
   registryFacade:
@@ -23,13 +23,13 @@ components:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
           - matchExpressions:
-            - key: gitpod.io/workspace_0
+            - key: gitpod.io/workspace_3
               operator: Exists
 
 
   workspace:
     affinity:
-      default: gitpod.io/workspace_0
+      default: gitpod.io/workspace_3
 
 # Sub-Charts
 


### PR DESCRIPTION
## Description
New nodepools have been added with 4 local ssds that are combined in a raid0 by this PR.
This does only work with one Gitpod installtion as ws-daemon would create evertime a new raid0 volume.
## How to test
Create a new branch and check if Gitpod is installed properly using a raid0.

## Release Notes
```release-notes
NONE
```