### PR TITLE
[t&p] enable teams and projects ui

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -55,7 +55,6 @@ export default function Menu() {
     }
 
     const userFullName = user?.fullName || user?.name || '...';
-    const showTeamsUI = user?.rolesOrPermissions?.includes('teams-and-projects');
     const team = getCurrentTeam(location, teams);
 
     {
@@ -71,7 +70,7 @@ export default function Menu() {
 
     const [ teamMembers, setTeamMembers ] = useState<Record<string, TeamMemberInfo[]>>({});
     useEffect(() => {
-        if (!showTeamsUI || !teams) {
+        if (!teams) {
             return;
         }
         (async () => {
@@ -127,10 +126,10 @@ export default function Menu() {
         }
         // User menu
         return [
-            ...(showTeamsUI ? [{
+            {
                 title: 'Projects',
                 link: '/projects'
-            }] : []),
+            },
             {
                 title: 'Workspaces',
                 link: '/workspaces',
@@ -239,17 +238,7 @@ export default function Menu() {
                         <img src={gitpodIcon} className="h-6" />
                     </Link>
                     {!isMinimalUI && <div className="ml-2 text-base">
-                        {showTeamsUI
-                            ? renderTeamMenu()
-                            : <nav className="flex-1">
-                                <ul className="flex flex-1 items-center justify-between text-base text-gray-700 space-x-2">
-                                    <li className="flex-1"></li>
-                                    {leftMenu.map(entry => <li key={entry.title}>
-                                        <PillMenuItem name={entry.title} selected={isSelected(entry, location)} link={entry.link}/>
-                                    </li>)}
-                                </ul>
-                            </nav>
-                        }
+                        {renderTeamMenu()}
                     </div>}
                 </div>
                 <div className="flex flex-1 items-center w-auto" id="menu">
@@ -283,10 +272,10 @@ export default function Menu() {
                     </div>
                 </div>
             </div>
-            {!isMinimalUI && showTeamsUI && !prebuildId && <div className="flex">
+            {!isMinimalUI && !prebuildId && <div className="flex">
                 {leftMenu.map((entry: Entry) => <TabMenuItem key={entry.title} name={entry.title} selected={isSelected(entry, location)} link={entry.link}/>)}
             </div>}
         </header>
-        {showTeamsUI && <Separator />}
+        <Separator />
     </>;
 }

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -46,14 +46,6 @@ export default function NewProject() {
                 setProvider("github.com");
             }
         }
-        if (user) {
-            if (!user?.rolesOrPermissions?.includes('teams-and-projects')) {
-                (async () => {
-                    setUser(await getGitpodService().server.getLoggedInUser());
-                })();
-
-            }
-        }
     }, [user]);
 
     useEffect(() => {
@@ -93,13 +85,6 @@ export default function NewProject() {
         (async () => {
             updateOrgsState();
             const repos = await updateReposInAccounts();
-
-            { // automatically enable T&P
-                if (!user?.rolesOrPermissions?.includes('teams-and-projects')) {
-                    setUser(await getGitpodService().server.getLoggedInUser());
-                }
-            }
-
             const first = repos[0];
             if (first) {
                 setSelectedAccount(first.account);

--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -22,7 +22,7 @@ const u1: User = {
             "primaryEmail": "tester@gitpod.io",
         }
     ],
-    rolesOrPermissions: ["teams-and-projects"],
+    rolesOrPermissions: [],
     additionalData: {
         whatsNewSeen: {
             "April-2021": "true",

--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -7,12 +7,10 @@
 import { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { getGitpodService } from "../service/service";
-import { UserContext } from "../user-context";
 import { TeamsContext } from "./teams-context";
 
 export default function() {
     const { setTeams } = useContext(TeamsContext);
-    const { user, setUser } = useContext(UserContext);
     const history = useHistory();
 
     const [ joinError, setJoinError ] = useState<Error>();
@@ -27,12 +25,6 @@ export default function() {
                 const team = await getGitpodService().server.joinTeam(inviteId);
                 const teams = await getGitpodService().server.getTeams();
                 setTeams(teams);
-
-                { // automatically enable T&P
-                    if (!user?.rolesOrPermissions?.includes('teams-and-projects')) {
-                        setUser(await getGitpodService().server.getLoggedInUser());
-                    }
-                }
 
                 history.push(`/t/${team.slug}/members`);
             } catch (error) {

--- a/components/gitpod-protocol/src/permission.ts
+++ b/components/gitpod-protocol/src/permission.ts
@@ -16,7 +16,6 @@ export const Permissions = {
     "admin-api": undefined,
     "ide-settings": undefined,
     "new-workspace-cluster": undefined,
-    "teams-and-projects": undefined,
 };
 export type PermissionName = keyof (typeof Permissions);
 export const Roles = {"devops": undefined, "viewer": undefined, "admin": undefined };

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1503,8 +1503,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
         const cloneUrlsInUse = new Set(projects.map(p => p.cloneUrl));
         repositories.forEach(r => { r.inUse = cloneUrlsInUse.has(r.cloneUrl) });
 
-        await this.ensureTeamsEnabled();
-
         return repositories;
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1442,8 +1442,6 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         await this.teamDB.addMemberToTeam(user.id, invite.teamId);
         const team = await this.teamDB.findTeamById(invite.teamId);
 
-        await this.ensureTeamsEnabled();
-
         this.analytics.track({
             userId: user.id,
             event: "team_joined",
@@ -1453,16 +1451,6 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
             }
         })
         return team!;
-    }
-
-    protected async ensureTeamsEnabled() {
-        if (this.user && !this.user?.rolesOrPermissions?.includes('teams-and-projects')) {
-            this.user.rolesOrPermissions = [...(this.user.rolesOrPermissions || []), 'teams-and-projects'];
-            await this.userDB.updateUserPartial({
-                id: this.user.id,
-                rolesOrPermissions: this.user.rolesOrPermissions
-            })
-        }
     }
 
     public async setTeamMemberRole(teamId: string, userId: string, role: TeamMemberRole): Promise<void> {


### PR DESCRIPTION
## Description
Enabled the teams & projects UI for all users.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5953

## How to test
Go to the dashboard and verify that your can create teams and projects.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow creation of projects with visibility of prebuilds
Allow creation of teams used to collaborate on projects
```
