### PR TITLE
[teams] don't show error if already in team

### DIFF
--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -24,7 +24,21 @@ export default function() {
                 if (!inviteId) {
                     throw new Error('This invite URL is incorrect.');
                 }
-                const team = await getGitpodService().server.joinTeam(inviteId);
+
+                let team;
+                try {
+                    team = await getGitpodService().server.joinTeam(inviteId);
+                } catch (error) {
+                    const message: string | undefined = error && typeof error.message === "string" && error.message;
+                    const regExp = /You are already a member of this team. \((.*)\)/;
+                    const match = message && regExp.exec(message);
+                    if (match && match[1]) {
+                        const slug = match[1];
+                        history.push(`/t/${slug}/members`);
+                        return;
+                    }
+                    throw error;
+                }
                 const teams = await getGitpodService().server.getTeams();
                 setTeams(teams);
 
@@ -44,5 +58,5 @@ export default function() {
 
     useEffect(() => { document.title = 'Joining Team — Gitpod' }, []);
 
-    return <div className="mt-16 text-center text-gitpod-red">{String(joinError)}</div>
+    return joinError ? <div className="mt-16 text-center text-gitpod-red">{String(joinError)}</div> : <></>;
 }

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -154,7 +154,7 @@ export class TeamDBImpl implements TeamDB {
         const membershipRepo = await this.getMembershipRepo();
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
         if (!!membership) {
-            throw new Error('You are already a member of this team');
+            throw new Error(`You are already a member of this team. (${team.slug})`);
         }
         await membershipRepo.save({
             id: uuidv4(),


### PR DESCRIPTION
## Description
Directly redirect to the team if following an invitation link but already part of the team.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5925

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
