### PR TITLE
Laushinka/allow users to delete 5066

### DIFF
--- a/components/dashboard/README.md
+++ b/components/dashboard/README.md
@@ -29,3 +29,6 @@ const GitIntegration = React.lazy(() => import('./settings/GitIntegration'));
 ```
 
 Global state is passed through `React.Context`.
+
+After creating a new component, run the following to update the license header:
+`leeway run components:update-license-header`

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -34,6 +34,7 @@ const CreateWorkspace = React.lazy(() => import(/* webpackPrefetch: true */ './s
 const NewTeam = React.lazy(() => import(/* webpackPrefetch: true */ './teams/NewTeam'));
 const JoinTeam = React.lazy(() => import(/* webpackPrefetch: true */ './teams/JoinTeam'));
 const Members = React.lazy(() => import(/* webpackPrefetch: true */ './teams/Members'));
+const TeamSettings = React.lazy(() => import(/* webpackPrefetch: true */ './teams/TeamSettings'));
 const NewProject = React.lazy(() => import(/* webpackPrefetch: true */ './projects/NewProject'));
 const ConfigureProject = React.lazy(() => import(/* webpackPrefetch: true */ './projects/ConfigureProject'));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ './projects/Projects'));
@@ -280,33 +281,36 @@ function App() {
                     <Route exact path="/teams/join" component={JoinTeam} />
                 </Route>
                 {(teams || []).map(team =>
-                <Route path={`/t/${team.slug}`} key={team.slug}>
-                    <Route exact path={`/t/${team.slug}`}>
-                        <Redirect to={`/t/${team.slug}/workspaces`} />
-                    </Route>
-                    <Route exact path={`/t/${team.slug}/:maybeProject/:resourceOrPrebuild?`} render={(props) => {
-                        const { maybeProject, resourceOrPrebuild } = props.match.params;
-                        if (maybeProject === "projects") {
-                            return <Projects />;
-                        }
-                        if (maybeProject === "workspaces") {
-                            return <Workspaces />;
-                        }
-                        if (maybeProject === "members") {
-                            return <Members />;
-                        }
-                        if (resourceOrPrebuild === "configure") {
-                            return <ConfigureProject />;
-                        }
-                        if (resourceOrPrebuild === "workspaces") {
-                            return <Workspaces />;
-                        }
-                        if (resourceOrPrebuild === "prebuilds") {
-                            return <Prebuilds />;
-                        }
-                        return resourceOrPrebuild ? <Prebuild /> : <Project />;
-                    }} />
-                </Route>)}
+                    <Route path={`/t/${team.slug}`} key={team.slug}>
+                        <Route exact path={`/t/${team.slug}`}>
+                            <Redirect to={`/t/${team.slug}/workspaces`} />
+                        </Route>
+                        <Route exact path={`/t/${team.slug}/:maybeProject/:resourceOrPrebuild?`} render={(props) => {
+                            const { maybeProject, resourceOrPrebuild } = props.match.params;
+                            if (maybeProject === "projects") {
+                                return <Projects />;
+                            }
+                            if (maybeProject === "workspaces") {
+                                return <Workspaces />;
+                            }
+                            if (maybeProject === "members") {
+                                return <Members />;
+                            }
+                            if (maybeProject === "settings") {
+                                return <TeamSettings />;
+                            }
+                            if (resourceOrPrebuild === "configure") {
+                                return <ConfigureProject />;
+                            }
+                            if (resourceOrPrebuild === "workspaces") {
+                                return <Workspaces />;
+                            }
+                            if (resourceOrPrebuild === "prebuilds") {
+                                return <Prebuilds />;
+                            }
+                            return resourceOrPrebuild ? <Prebuild /> : <Project />;
+                        }} />
+                    </Route>)}
                 <Route path="*" render={
                     (_match) => {
 

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -4,6 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import AlertBox from "./AlertBox";
 import Modal from "./Modal";
 
 export default function ConfirmationModal(props: {
@@ -13,27 +14,32 @@ export default function ConfirmationModal(props: {
     buttonText?: string,
     buttonDisabled?: boolean,
     visible?: boolean,
+    warningText?: string,
     onClose: () => void,
     onConfirm: () => void,
 }) {
 
-    const c: React.ReactChild[] = [
-        <p className="mt-1 mb-2 text-base text-gray-500">{props.areYouSureText || "Are you sure?"}</p>,
+    const child: React.ReactChild[] = [
+        <p className="mt-3 mb-3 text-base text-gray-500">{props.areYouSureText || "Are you sure?"}</p>,
     ]
+
+    if (props.warningText) {
+        child.unshift(<AlertBox>{props.warningText}</AlertBox>);
+    }
 
     const isEntity = (x: any): x is Entity => typeof x === "object" && "name" in x;
     if (props.children) {
         if (isEntity(props.children)) {
-            c.push(
+            child.push(
                 <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
                     <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.name}</p>
                     {props.children.description && <p className="text-gray-500">{props.children.description}</p>}
                 </div>
             )
         } else if (Array.isArray(props.children)) {
-            c.push(...props.children);
+            child.push(...props.children);
         } else {
-            c.push(props.children);
+            child.push(props.children);
         }
     }
 
@@ -52,7 +58,7 @@ export default function ConfirmationModal(props: {
             onClose={props.onClose}
             onEnter={() => { props.onConfirm(); return true; }}
         >
-            {c}
+            {child}
         </Modal>
     );
 }

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import { Redirect, useLocation } from "react-router";
+import ConfirmationModal from "../components/ConfirmationModal";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { getGitpodService, gitpodHostUrl } from "../service/service";
+import { UserContext } from "../user-context";
+import { getCurrentTeam, TeamsContext } from "./teams-context";
+
+export default function TeamSettings() {
+    const [modal, setModal] = useState(false);
+    const [teamSlug, setTeamSlug] = useState('');
+    const [isUserOwner, setIsUserOwner] = useState(true);
+    const { teams } = useContext(TeamsContext);
+    const { user } = useContext(UserContext);
+    const location = useLocation();
+    const team = getCurrentTeam(location, teams);
+
+    const close = () => setModal(false);
+
+    useEffect(() => {
+        (async () => {
+            if (!team) return;
+            const members = await getGitpodService().server.getTeamMembers(team.id);
+            const currentUserInTeam = members.find(member => member.userId === user?.id);
+            setIsUserOwner(currentUserInTeam?.role === 'owner');
+        })();
+    }, []);
+
+    if (!isUserOwner) {
+        return <Redirect to="/" />
+    };
+    const deleteTeam = async () => {
+        if (!team || !user) {
+            return
+        }
+        await getGitpodService().server.deleteTeam(team.id, user.id);
+        document.location.href = gitpodHostUrl.asDashboard().toString();
+    };
+
+    const settingsMenu = [
+        {
+            title: 'General',
+            link: [`/t/${team?.slug}/settings`]
+        }
+    ]
+
+    return <>
+        <PageWithSubMenu subMenu={settingsMenu} title='General' subtitle='Manage general team settings.'>
+            <h3>Delete Team</h3>
+            <p className="text-base text-gray-500 pb-4">Deleting this team will also remove all associated data with this team, including projects and workspaces. Deleted teams cannot be restored!</p>
+            <button className="danger secondary" onClick={() => setModal(true)}>Delete Account</button>
+        </PageWithSubMenu>
+
+        <ConfirmationModal
+            title="Delete Team"
+            areYouSureText="You are about to permanently delete this team including all associated data with this team."
+            buttonText="Delete Team"
+            buttonDisabled={teamSlug !== team!.slug}
+            visible={modal}
+            warningText="Warning: This action cannot be reversed."
+            onClose={close}
+            onConfirm={deleteTeam}
+        >
+            <ol className="text-gray-500 text-m list-outside list-decimal">
+                <li className="ml-5">All <b>projects</b> added in this team will be deleted and cannot be restored afterwards.</li>
+                <li className="ml-5">All <b>workspaces</b> opened for projects within this team will be deleted for all team members and cannot be restored afterwards.</li>
+                <li className="ml-5">All <b>members</b> of this team will lose access to this team, associated projects and workspaces.</li>
+            </ol>
+            <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">Type your team's URL slug to confirm</p>
+            <input className="w-full" type="text" onChange={e => setTeamSlug(e.target.value)}></input>
+        </ConfirmationModal>
+    </>
+}

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -18,4 +18,5 @@ export interface TeamDB {
     findTeamMembershipInviteById(inviteId: string): Promise<TeamMembershipInvite>;
     findGenericInviteByTeamId(teamId: string): Promise<TeamMembershipInvite | undefined>;
     resetGenericInvite(teamId: string): Promise<TeamMembershipInvite>;
+    deleteTeam(teamId: string): Promise<void>;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-team.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team.ts
@@ -22,6 +22,9 @@ export class DBTeam {
   @Column("varchar")
   creationTime: string;
 
+  @Column()
+  markedDeleted?: boolean;
+
   // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
   @Column()
   deleted: boolean;

--- a/components/gitpod-db/src/typeorm/migration/1632908105486-AddSoftDeletedToTeam.ts
+++ b/components/gitpod-db/src/typeorm/migration/1632908105486-AddSoftDeletedToTeam.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class AddMarkedDeletedToTeam1632908105486 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        if (!(await columnExists(queryRunner, "d_b_team", "markedDeleted"))) {
+            await queryRunner.query("ALTER TABLE d_b_team ADD COLUMN `markedDeleted` tinyint(4) NOT NULL DEFAULT '0'");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -145,6 +145,15 @@ export class TeamDBImpl implements TeamDB {
         return team;
     }
 
+    public async deleteTeam(teamId: string): Promise<void> {
+        const teamRepo = await this.getTeamRepo();
+        const team = await this.findTeamById(teamId);
+        if (team) {
+            team.markedDeleted = true;
+            await teamRepo.save(team);
+        }
+    }
+
     public async addMemberToTeam(userId: string, teamId: string): Promise<void> {
         const teamRepo = await this.getTeamRepo();
         const team = await teamRepo.findOneById(teamId);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -123,6 +123,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     removeTeamMember(teamId: string, userId: string): Promise<void>;
     getGenericInvite(teamId: string): Promise<TeamMembershipInvite>;
     resetGenericInvite(inviteId: string): Promise<TeamMembershipInvite>;
+    deleteTeam(teamId: string, userId: string): Promise<void>;
 
     // Projects
     getProviderRepositoriesForUser(params: GetProviderRepositoriesParams): Promise<ProviderRepository[]>;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -101,6 +101,7 @@ export interface Team {
     name: string;
     slug: string;
     creationTime: string;
+    markedDeleted?: boolean;
     /** This is a flag that triggers the HARD DELETION of this entity */
     deleted?: boolean;
 }

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -88,6 +88,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "removeTeamMember": { group: "default", points: 1 },
         "getGenericInvite": { group: "default", points: 1 },
         "resetGenericInvite": { group: "default", points: 1 },
+        "deleteTeam": { group: "default", points: 1 },
         "getProviderRepositoriesForUser":  { group: "default", points: 1 },
         "createProject":  { group: "default", points: 1 },
         "getTeamProjects": { group: "default", points: 1 },


### PR DESCRIPTION
## Description
1. A new settings page for teams.
2. Allows team deletion on the settings page.
3. When a team is deleted, projects are also deleted.

## Related Issue(s)
Fixes #5066

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Teams get a dedicated settings page where for now deletion can be done. 
```


<img width="503" alt="Screenshot 2021-09-30 at 19 08 24" src="https://user-images.githubusercontent.com/8015191/135500295-186977b6-167b-4885-a8c5-60baffad2be3.png">
<img width="267" alt="Screenshot 2021-09-30 at 19 09 33" src="https://user-images.githubusercontent.com/8015191/135500308-a53f09ca-abe0-47d9-914c-65fbe0725af5.png">
