### PR TITLE
[db] Sync and GC d_b_team_membership_invite

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -227,6 +227,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: '_lastModified',
         },
         {
+            name: 'd_b_team_membership_invite',
+            primaryKeys: ['id'],
+            deletionColumn: 'deleted',
+            timeColumn: '_lastModified',
+        },
+        {
             name: 'd_b_project',
             primaryKeys: ['id'],
             deletionColumn: 'deleted',

--- a/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
+++ b/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
@@ -46,6 +46,7 @@ const tables: TableWithDeletion[] = [
     { deletionColumn: "deleted", name: "d_b_code_sync_resource" },
     { deletionColumn: "deleted", name: "d_b_team" },
     { deletionColumn: "deleted", name: "d_b_team_membership" },
+    { deletionColumn: "deleted", name: "d_b_team_membership_invite" },
     { deletionColumn: "deleted", name: "d_b_project" },
     { deletionColumn: "deleted", name: "d_b_prebuild_info" },
 ];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add `d_b_team_membership_invite` to db-sync and GC lists.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5965

## How to test
<!-- Provide steps to test this PR -->

1. Create team in EU
2. Try invite link from US

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[teams] Fix joining teams from different DB region
```
