### PR TITLE
Support per-workspace filesystem quota on `/workspace`

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -159,7 +159,7 @@ spec:
             # If the disk has already been created, sleep indefinitely
             if [ -b "${RAID_DEVICE}" ] && [ -d "${RAID_DIR}" ]; then
                 echo "raid array already created!"
-                mount -o noatime "${RAID_DEVICE}" "${RAID_DIR}" || true
+                mount -o noatime,prjquota "${RAID_DEVICE}" "${RAID_DIR}" || true
                 exit 0
             fi
             # Discover how many disks there are
@@ -200,7 +200,7 @@ spec:
             mkfs.xfs "${RAID_DEVICE}"
             # Mount the raid array in a predefined location
             mkdir -p "${RAID_DIR}"
-            mount -o noatime "${RAID_DEVICE}" "${RAID_DIR}"
+            mount -o noatime,prjquota "${RAID_DEVICE}" "${RAID_DIR}"
             ls -l /dev/md*
             cat /proc/mdstat
 {{- end }}

--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -379,6 +379,8 @@ func InitializeWorkspace(ctx context.Context, location string, remoteStorage sto
 
 	src = csapi.WorkspaceInitFromOther
 
+	// Note: it's important that CleanSlate does not remove the location itself, but merely its content.
+	//       If the location were removed that might break the filesystem quota we have put in place prior.
 	if cfg.CleanSlate {
 		// 1. Clean out the workspace directory
 		if _, err := os.Stat(location); os.IsNotExist(err) {

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -14,7 +14,7 @@ RUN apk upgrade \
   && rm -rf /var/cache/apk/*
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
-RUN apk add --no-cache git bash openssh-client lz4 e2fsprogs coreutils tar strace
+RUN apk add --no-cache git bash openssh-client lz4 e2fsprogs coreutils tar strace xfsprogs-extra
 COPY --from=dl /dl/runc.amd64 /usr/bin/runc
 
 # Add gitpod user for operations (e.g. checkout because of the post-checkout hook!)

--- a/components/ws-daemon/pkg/content/hooks.go
+++ b/components/ws-daemon/pkg/content/hooks.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package content
+
+import (
+	"context"
+	"os"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
+	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
+	"github.com/gitpod-io/gitpod/ws-daemon/api"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/internal/session"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/iws"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/quota"
+	"golang.org/x/xerrors"
+)
+
+// workspaceLifecycleHooks configures the lifecycle hooks for all workspaces
+func workspaceLifecycleHooks(cfg Config, kubernetesNamespace string, workspaceExistenceCheck WorkspaceExistenceCheck, uidmapper *iws.Uidmapper, xfs *quota.XFS) map[session.WorkspaceState][]session.WorkspaceLivecycleHook {
+	// startIWS starts the in-workspace service for a workspace. This lifecycle hook is idempotent, hence can - and must -
+	// be called on initialization and ready. The on-ready hook exists only to support ws-daemon restarts.
+	startIWS := iws.ServeWorkspace(uidmapper, api.FSShiftMethod(cfg.UserNamespaces.FSShift))
+
+	return map[session.WorkspaceState][]session.WorkspaceLivecycleHook{
+		session.WorkspaceInitializing: {
+			hookSetupRemoteStorage(cfg),
+			hookSetupWorkspaceLocation,
+			hookInstallQuota(xfs, cfg.WorkspaceSizeLimit),
+			startIWS,
+		},
+		session.WorkspaceReady: {
+			hookSetupRemoteStorage(cfg),
+			hookInstallQuota(xfs, cfg.WorkspaceSizeLimit),
+			startIWS,
+		},
+		session.WorkspaceDisposed: {
+			iws.StopServingWorkspace,
+			hookRemoveQuota(xfs),
+		},
+	}
+}
+
+// hookSetupRemoteStorage configures the remote storage for a workspace
+func hookSetupRemoteStorage(cfg Config) session.WorkspaceLivecycleHook {
+	return func(ctx context.Context, ws *session.Workspace) error {
+		if _, ok := ws.NonPersistentAttrs[session.AttrRemoteStorage]; !ws.RemoteStorageDisabled && !ok {
+			remoteStorage, err := storage.NewDirectAccess(&cfg.Storage)
+			if err != nil {
+				return xerrors.Errorf("cannot use configured storage: %w", err)
+			}
+
+			err = remoteStorage.Init(ctx, ws.Owner, ws.WorkspaceID, ws.InstanceID)
+			if err != nil {
+				return xerrors.Errorf("cannot use configured storage: %w", err)
+			}
+
+			err = remoteStorage.EnsureExists(ctx)
+			if err != nil {
+				return xerrors.Errorf("cannot use configured storage: %w", err)
+			}
+
+			ws.NonPersistentAttrs[session.AttrRemoteStorage] = remoteStorage
+		}
+
+		return nil
+	}
+}
+
+// hookSetupWorkspaceLocation recreates the workspace location
+func hookSetupWorkspaceLocation(ctx context.Context, ws *session.Workspace) error {
+	location := ws.Location
+
+	// 1. Clean out the workspace directory
+	if _, err := os.Stat(location); os.IsNotExist(err) {
+		// in the very unlikely event that the workspace Pod did not mount (and thus create) the workspace directory, create it
+		err = os.Mkdir(location, 0755)
+		if os.IsExist(err) {
+			log.WithError(err).WithField("location", location).Debug("ran into non-atomic workspace location existence check")
+		} else if err != nil {
+			return xerrors.Errorf("cannot create workspace: %w", err)
+		}
+	}
+
+	// Chown the workspace directory
+	err := os.Chown(location, initializer.GitpodUID, initializer.GitpodGID)
+	if err != nil {
+		return xerrors.Errorf("cannot create workspace: %w", err)
+	}
+	return nil
+}
+
+// hookInstallQuota enforces filesystem quota on the workspace location (if the filesystem supports it)
+func hookInstallQuota(xfs *quota.XFS, size quota.Size) session.WorkspaceLivecycleHook {
+	return func(ctx context.Context, ws *session.Workspace) error {
+		if xfs == nil {
+			return nil
+		}
+		if size == 0 {
+			return nil
+		}
+
+		if ws.XFSProjectID != 0 {
+			xfs.RegisterProject(ws.XFSProjectID)
+			return nil
+		}
+
+		prj, err := xfs.SetQuota(ws.Location, size)
+		if err != nil {
+			log.WithFields(ws.OWI()).WithError(err).Warn("cannot enforce workspace size limit")
+		}
+		ws.XFSProjectID = int(prj)
+
+		return nil
+	}
+}
+
+// hookRemoveQuota removes the filesystem quota, freeing up resources if need be
+func hookRemoveQuota(xfs *quota.XFS) session.WorkspaceLivecycleHook {
+	return func(ctx context.Context, ws *session.Workspace) error {
+		if xfs == nil {
+			return nil
+		}
+
+		if xfs == nil {
+			return nil
+		}
+		if ws.XFSProjectID == 0 {
+			return nil
+		}
+
+		return xfs.RemoveQuota(ws.XFSProjectID)
+	}
+}

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -315,9 +315,9 @@ func RunInitializerChild() (err error) {
 
 	initSource, err := wsinit.InitializeWorkspace(ctx, "/dst", rs,
 		wsinit.WithInitializer(initializer),
-		wsinit.WithCleanSlate,
 		wsinit.WithMappings(initmsg.IDMappings),
 		wsinit.WithChown(initmsg.UID, initmsg.GID),
+		wsinit.WithCleanSlate,
 	)
 	if err != nil {
 		return err

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/internal/session"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/iws"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/quota"
 )
 
 // WorkspaceService implements the InitService and WorkspaceService
@@ -65,8 +66,13 @@ func NewWorkspaceService(ctx context.Context, cfg Config, kubernetesNamespace st
 		return nil, xerrors.Errorf("cannot create working area: %w", err)
 	}
 
+	xfs, err := quota.NewXFS(cfg.WorkingArea)
+	if err != nil {
+		return nil, err
+	}
+
 	// read all session json files
-	store, err := session.NewStore(ctx, cfg.WorkingArea, workspaceLifecycleHooks(cfg, kubernetesNamespace, wec, uidmapper))
+	store, err := session.NewStore(ctx, cfg.WorkingArea, workspaceLifecycleHooks(cfg, kubernetesNamespace, wec, uidmapper, xfs))
 	if err != nil {
 		return nil, xerrors.Errorf("cannot create session store: %w", err)
 	}
@@ -794,39 +800,4 @@ func (c *cannotCancelContext) Err() error {
 
 func (c *cannotCancelContext) Value(key interface{}) interface{} {
 	return c.Delegate.Value(key)
-}
-
-func workspaceLifecycleHooks(cfg Config, kubernetesNamespace string, workspaceExistenceCheck WorkspaceExistenceCheck, uidmapper *iws.Uidmapper) map[session.WorkspaceState][]session.WorkspaceLivecycleHook {
-	var setupWorkspace session.WorkspaceLivecycleHook = func(ctx context.Context, ws *session.Workspace) error {
-		if _, ok := ws.NonPersistentAttrs[session.AttrRemoteStorage]; !ws.RemoteStorageDisabled && !ok {
-			remoteStorage, err := storage.NewDirectAccess(&cfg.Storage)
-			if err != nil {
-				return xerrors.Errorf("cannot use configured storage: %w", err)
-			}
-
-			err = remoteStorage.Init(ctx, ws.Owner, ws.WorkspaceID, ws.InstanceID)
-			if err != nil {
-				return xerrors.Errorf("cannot use configured storage: %w", err)
-			}
-
-			err = remoteStorage.EnsureExists(ctx)
-			if err != nil {
-				return xerrors.Errorf("cannot use configured storage: %w", err)
-			}
-
-			ws.NonPersistentAttrs[session.AttrRemoteStorage] = remoteStorage
-		}
-
-		return nil
-	}
-
-	// startIWS starts the in-workspace service for a workspace. This lifecycle hook is idempotent, hence can - and must -
-	// be called on initialization and ready. The on-ready hook exists only to support ws-daemon restarts.
-	startIWS := iws.ServeWorkspace(uidmapper, api.FSShiftMethod(cfg.UserNamespaces.FSShift))
-
-	return map[session.WorkspaceState][]session.WorkspaceLivecycleHook{
-		session.WorkspaceInitializing: {setupWorkspace, startIWS},
-		session.WorkspaceReady:        {setupWorkspace, startIWS},
-		session.WorkspaceDisposed:     {iws.StopServingWorkspace},
-	}
 }

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -69,6 +69,8 @@ type Workspace struct {
 
 	RemoteStorageDisabled bool `json:"remoteStorageDisabled,omitempty"`
 
+	XFSProjectID int `json:"xfsProjectID"`
+
 	NonPersistentAttrs map[string]interface{} `json:"-"`
 
 	store              *Store

--- a/components/ws-daemon/pkg/quota/xfs.go
+++ b/components/ws-daemon/pkg/quota/xfs.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package quota
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type xfsQuotaExec func(dir, command string) (output string, err error)
+
+func defaultXfsQuotaExec(dir, command string) (output string, err error) {
+	out, err := exec.Command("xfs_quota", "-x", "-c", command, dir).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("xfs_quota error: %s: %v", string(out), err)
+	}
+	return string(out), nil
+}
+
+const (
+	prjidLow = 1000
+	prjidHi  = 10000
+)
+
+type XFS struct {
+	Dir string
+
+	exec xfsQuotaExec
+
+	projectIDs map[int]struct{}
+	mu         sync.Mutex
+}
+
+func NewXFS(path string) (*XFS, error) {
+	res := &XFS{
+		Dir:        path,
+		projectIDs: make(map[int]struct{}),
+		exec:       defaultXfsQuotaExec,
+	}
+
+	// Note: if the underlying filesystem does not support XFS project quota,
+	//       getUsedProjectIDs will fail, hence the NewXFS call will fail.
+	prjIDs, err := res.getUsedProjectIDs()
+	if err != nil {
+		return nil, err
+	}
+	for _, prjID := range prjIDs {
+		res.projectIDs[prjID] = struct{}{}
+	}
+
+	return res, nil
+}
+
+// getUsedProjectIDs lists all project IDs used on the filesystem
+func (xfs *XFS) getUsedProjectIDs() ([]int, error) {
+	out, err := xfs.exec(xfs.Dir, "report -N")
+	if err != nil {
+		return nil, err
+	}
+
+	var res []int
+	for _, l := range strings.Split(out, "\n") {
+		fields := strings.Fields(l)
+		if len(fields) < 2 {
+			continue
+		}
+
+		prjID, err := strconv.Atoi(strings.TrimPrefix(fields[0], "#"))
+		if err != nil {
+			continue
+		}
+
+		used, err := strconv.Atoi(strings.TrimSpace(fields[1]))
+		if err != nil || used == 0 {
+			continue
+		}
+
+		res = append(res, prjID)
+	}
+	return res, nil
+}
+
+// SetQuota sets the quota for a path
+func (xfs *XFS) SetQuota(path string, quota Size) (projectID int, err error) {
+	xfs.mu.Lock()
+	var (
+		prjID = prjidLow
+		found bool
+	)
+	for ; prjID < prjidHi; prjID++ {
+		_, exists := xfs.projectIDs[prjID]
+		if !exists {
+			found = true
+			xfs.projectIDs[prjID] = struct{}{}
+			break
+		}
+	}
+	xfs.mu.Unlock()
+	if !found {
+		return 0, fmt.Errorf("no free projectID found")
+	}
+
+	defer func() {
+		if err != nil {
+			xfs.mu.Lock()
+			delete(xfs.projectIDs, prjID)
+			xfs.mu.Unlock()
+		}
+	}()
+
+	_, err = xfs.exec(xfs.Dir, fmt.Sprintf("project -s -d 1 -p %s %d", path, prjID))
+	if err != nil {
+		return 0, err
+	}
+	_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bsoft=%d bhard=%d %d", quota, quota, prjID))
+	if err != nil {
+		return 0, err
+	}
+	return prjID, nil
+}
+
+// RegisterProject tells this implementation that a projectID is already in use
+func (xfs *XFS) RegisterProject(prjID int) {
+	xfs.mu.Lock()
+	defer xfs.mu.Unlock()
+
+	xfs.projectIDs[prjID] = struct{}{}
+}
+
+// RemoveQuota removes the limitation for a project/path and frees the projectID
+func (xfs *XFS) RemoveQuota(projectID int) error {
+	_, err := xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bsoft=0 bhard=0 %d", projectID))
+	if err != nil {
+		return err
+	}
+	xfs.mu.Lock()
+	delete(xfs.projectIDs, projectID)
+	xfs.mu.Unlock()
+	return nil
+}
+
+// GetProjectUseCount returns the number of projectIDs in use
+func (xfs *XFS) GetProjectUseCount() int {
+	xfs.mu.Lock()
+	defer xfs.mu.Unlock()
+
+	return len(xfs.projectIDs)
+}

--- a/components/ws-daemon/pkg/quota/xfs_test.go
+++ b/components/ws-daemon/pkg/quota/xfs_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package quota
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetUsedProjectIDs(t *testing.T) {
+	type Expectation struct {
+		ProjectIDs []int
+		Error      string
+	}
+	tests := []struct {
+		Name        string
+		Input       string
+		InputErr    error
+		Expectation Expectation
+	}{
+		{
+			Name:  "no projects",
+			Input: "",
+		},
+		{
+			Name:  "single project",
+			Input: "#0              4      0      0  00 [------]",
+			Expectation: Expectation{
+				ProjectIDs: []int{0},
+			},
+		},
+		{
+			Name:  "multiple projects none used",
+			Input: "#0              0      0      0  00 [------]\n#100            0     5M     5M  00 [------]\n#200            0    10M    10M  00 [------]",
+		},
+		{
+			Name:  "multiple projects in use",
+			Input: "#0              0      0      0  00 [------]\n#100            4     5M     5M  00 [------]\n#200            1    10M    10M  00 [------]",
+			Expectation: Expectation{
+				ProjectIDs: []int{100, 200},
+			},
+		},
+		{
+			Name:     "exec failure",
+			InputErr: fmt.Errorf("exec failed"),
+			Expectation: Expectation{
+				Error: "exec failed",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			xfs := &XFS{
+				exec: func(dir, command string) (output string, err error) {
+					return test.Input, test.InputErr
+				},
+			}
+
+			var (
+				act Expectation
+				err error
+			)
+			act.ProjectIDs, err = xfs.getUsedProjectIDs()
+			if err != nil {
+				act.Error = err.Error()
+			}
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected getUsedProjectIDs (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetQuota(t *testing.T) {
+	type Expectation struct {
+		ProjectID  int
+		ProjectIDs []int
+		Execs      []string
+		Error      string
+	}
+	tests := []struct {
+		Name        string
+		Size        Size
+		ExecErr     func(cmd string) error
+		ProjectIDs  []int
+		Expectation Expectation
+	}{
+		{
+			Name: "happpy path",
+			Size: 100 * Kilobyte,
+			Expectation: Expectation{
+				ProjectID:  1000,
+				ProjectIDs: []int{1000},
+				Execs: []string{
+					"project -s -d 1 -p /foo 1000",
+					"limit -p bsoft=102400 bhard=102400 1000",
+				},
+			},
+		},
+		{
+			Name:       "with other prj",
+			Size:       100 * Kilobyte,
+			ProjectIDs: []int{1000},
+			Expectation: Expectation{
+				ProjectID:  1001,
+				ProjectIDs: []int{1000, 1001},
+				Execs: []string{
+					"project -s -d 1 -p /foo 1001",
+					"limit -p bsoft=102400 bhard=102400 1001",
+				},
+			},
+		},
+		{
+			Name: "prj creation failure",
+			Size: 100 * Kilobyte,
+			ExecErr: func(cmd string) error {
+				if strings.Contains(cmd, "project") {
+					return fmt.Errorf("failed to create project")
+				}
+				return nil
+			},
+			Expectation: Expectation{
+				ProjectID: 0,
+				Execs: []string{
+					"project -s -d 1 -p /foo 1000",
+				},
+				Error: "failed to create project",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var (
+				act Expectation
+				err error
+			)
+			xfs := &XFS{
+				exec: func(dir, command string) (output string, err error) {
+					act.Execs = append(act.Execs, command)
+					if test.ExecErr != nil {
+						return "", test.ExecErr(command)
+					}
+
+					return "", nil
+				},
+				projectIDs: make(map[int]struct{}),
+				Dir:        "/",
+			}
+			for _, prjid := range test.ProjectIDs {
+				xfs.projectIDs[prjid] = struct{}{}
+			}
+
+			act.ProjectID, err = xfs.SetQuota("/foo", test.Size)
+			if err != nil {
+				act.Error = err.Error()
+			}
+			for p := range xfs.projectIDs {
+				act.ProjectIDs = append(act.ProjectIDs, p)
+			}
+			sort.Ints(act.ProjectIDs)
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected SetQuota (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR implements XFS based filesystem quota for each workspace in their resp. `/workspace` directory.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #4938

## How to test
1. Open a workspace
2. Run `df -h` and you should see a limit of `50gb` on `/workspace`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[workspaces] Add support filesystem quota on /workspace
```

## Caveats
- Before this PR can be merged we should drop the `nodepool 4` commit. @wulfthimm can you confirm?
- For this to work the workspace content filesystem must be XFS and mounted with `prjquota`. In core-dev this means we need to deploy this ws-daemon first on a nodepool so that the `raid-local-disks` container can mount the XFS filesystem with `prjquota`