### PR TITLE
Reword team creation header to meet current features

### DIFF
--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -32,7 +32,7 @@ export default function () {
 
     return <div className="flex flex-col w-96 mt-24 mx-auto items-center">
         <h1>New Team</h1>
-        <p className="text-gray-500 text-center text-base">Teams allow you to <strong>group multiple projects</strong>, <strong>collaborate with others</strong>, <strong>manage subscriptions</strong> with one centralized billing, and more. <a className="gp-link" href="https://www.gitpod.io/docs/teams/">Learn more</a></p>
+        <p className="text-gray-500 text-center text-base">Teams allow you to <strong>manage multiple projects</strong>, <strong>group workspaces</strong>, and <strong>collaborate with your team</strong>.</p>
         <form className="mt-16 w-full" onSubmit={createTeam}>
             <div className="border rounded-xl p-6 border-gray-100 dark:border-gray-800">
                 <h3 className="text-center text-xl mb-6">What's your team's name?</h3>


### PR DESCRIPTION
## Description

This will reword the creation header to meet current features.

Also, removed the docs link until WIP docs in https://github.com/gitpod-io/website/pull/842 get merged to avoid shipping this feature and link while the docs are missing.

## Related Issue(s)

Fix https://github.com/gitpod-io/gitpod/issues/5974

## How to test

Try creating a new team. See screenshots below.

| BEFORE  | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2021-10-01 at 2 12 18 PM (2)" src="https://user-images.githubusercontent.com/120486/135611305-168d9c8e-e3c3-4e1b-bd3c-98609d830d97.png"> | <img width="1440" alt="Screenshot 2021-10-01 at 2 29 23 PM (2)" src="https://user-images.githubusercontent.com/120486/135612773-f76942ec-5d67-4c28-a4d2-dcccf8d42dd1.png"> |

## Release Notes
```release-note
NONE
```
