### PR TITLE
[server] Update node.js to v14

### DIFF
--- a/components/server/leeway.Dockerfile
+++ b/components/server/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM node:12.22.6-slim as builder
+FROM node:14-slim as builder
 
 RUN apt-get update && apt-get install -y build-essential python
 
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN /installer/install.sh
 
 
-FROM node:12.22.6-slim
+FROM node:14-slim
 
 # Using ssh-keygen for RSA keypair generation
 RUN apt-get update && apt-get install -yq \


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Update node.js to v14
```
