### PR TITLE
chore: capitalize proper noun Git in dashboard components

### DIFF
--- a/components/dashboard/src/FromReferrer.tsx
+++ b/components/dashboard/src/FromReferrer.tsx
@@ -25,7 +25,7 @@ export default function FromReferrer() {
                 <div className="text-center pb-6 text-gray-500">
                     <p>
                         It looks like you are trying to open a workspace, but the referrer URL is empty or has an incomplete path.
-                        This happens when the git hoster or browser doesn't send the referrer header.
+                        This happens when the Git hoster or browser doesn't send the referrer header.
                         <br/> Please prefix the repository URL with <pre>https://gitpod.io/#</pre> in order to start a workspace. <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">Learn more</a>
                     </p>
                 </div>

--- a/components/dashboard/src/Setup.tsx
+++ b/components/dashboard/src/Setup.tsx
@@ -34,14 +34,14 @@ export default function Setup() {
         })();
     }
 
-    const headerText = "Configure a git integration with a GitLab or GitHub instance."
+    const headerText = "Configure a Git integration with a GitLab or GitHub instance."
 
     return <div>
         {!showModal && (
             <Modal visible={true} onClose={() => { }} closeable={false}>
                 <h3 className="pb-2">Welcome to Gitpod 🎉</h3>
                 <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                    <p className="pb-4 text-gray-500 text-base">To start using Gitpod, you will need to set up a git integration.</p>
+                    <p className="pb-4 text-gray-500 text-base">To start using Gitpod, you will need to set up a Git integration.</p>
 
                     <div className="flex">
                         <span className="text-gray-500">

--- a/components/dashboard/src/prebuilds/InstallGitHubApp.tsx
+++ b/components/dashboard/src/prebuilds/InstallGitHubApp.tsx
@@ -66,7 +66,7 @@ export default function InstallGitHubApp() {
                 <div className="flex flex-col items-center m-auto max-w-lg mt-40">
                     <h3 className="text-center pb-3 text-gray-500">Install GitHub App</h3>
                     <div className="text-center pb-6 text-gray-500">You are about to install the GitHub app for Gitpod.</div>
-                    <InfoBox>This action will also allow Gitpod to access private repositories. You can edit git provider permissions later in user settings.</InfoBox>
+                    <InfoBox>This action will also allow Gitpod to access private repositories. You can edit Git provider permissions later in user settings.</InfoBox>
                     <div className="mt-6">
                         <button className="secondary">Cancel</button>
                         <button className="ml-2" onClick={() => registerApp(installationId, setModal)}>Install App</button>

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -385,7 +385,7 @@ export default function NewProject() {
 
     return (<div className="flex flex-col w-96 mt-24 mx-auto items-center">
         <h1>New Project</h1>
-        <p className="text-gray-500 text-center text-base">Select a git repository on <strong>{provider}</strong>. (<a className="gp-link cursor-pointer" onClick={() => setShowGitProviders(true)}>change</a>)</p>
+        <p className="text-gray-500 text-center text-base">Select a Git repository on <strong>{provider}</strong>. (<a className="gp-link cursor-pointer" onClick={() => setShowGitProviders(true)}>change</a>)</p>
 
         {!selectedRepo && renderSelectRepository()}
 

--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -45,9 +45,9 @@ export default function Account() {
             <input className="w-full" type="text" onChange={e => setTypedEmail(e.target.value)}></input>
         </ConfirmationModal>
 
-        <PageWithSubMenu subMenu={settingsMenu}  title='Account' subtitle='Manage account and git configuration.'>
+        <PageWithSubMenu subMenu={settingsMenu}  title='Account' subtitle='Manage account and Git configuration.'>
             <h3>Profile</h3>
-            <p className="text-base text-gray-500 pb-4 max-w-2xl">The following information will be used to set up git configuration. You can override git author name and email per project by using the default environment variables <CodeText>GIT_AUTHOR_NAME</CodeText> and <CodeText>GIT_COMMITTER_EMAIL</CodeText>.</p>
+            <p className="text-base text-gray-500 pb-4 max-w-2xl">The following information will be used to set up Git configuration. You can override Git author name and email per project by using the default environment variables <CodeText>GIT_AUTHOR_NAME</CodeText> and <CodeText>GIT_COMMITTER_EMAIL</CodeText>.</p>
             <div className="flex flex-col lg:flex-row">
                 <div>
                     <div className="mt-4">

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -25,7 +25,7 @@ import settingsMenu from "./settings-menu";
 export default function Integrations() {
 
     return (<div>
-        <PageWithSubMenu subMenu={settingsMenu} title='Integrations' subtitle='Manage permissions for git providers and integrations.'>
+        <PageWithSubMenu subMenu={settingsMenu} title='Integrations' subtitle='Manage permissions for Git providers and integrations.'>
             <GitProviders />
             <div className="h-12"></div>
             <GitIntegrations />
@@ -280,7 +280,7 @@ function GitProviders() {
         )}
 
         <h3>Git Providers</h3>
-        <h2>Manage permissions for git providers.</h2>
+        <h2>Manage permissions for Git providers.</h2>
         <ItemsList className="pt-6">
             {authProviders && authProviders.map(ap => (
                 <Item key={"ap-" + ap.authProviderId} className="h-16">
@@ -360,7 +360,7 @@ function GitIntegrations() {
         {modal?.mode === "delete" && (
             <ConfirmationModal
                 title="Remove Integration"
-                areYouSureText="Are you sure you want to remove the following git integration?"
+                areYouSureText="Are you sure you want to remove the following Git integration?"
                 children={{
                     name: modal.provider.type,
                     description: modal.provider.host,
@@ -375,7 +375,7 @@ function GitIntegrations() {
         <div className="flex items-start sm:justify-between mb-2">
             <div>
                 <h3>Git Integrations</h3>
-                <h2 className="text-gray-500">Manage git integrations for GitLab or GitHub self-hosted instances.</h2>
+                <h2 className="text-gray-500">Manage Git integrations for GitLab or GitHub self-hosted instances.</h2>
             </div>
             {providers.length !== 0
                 ?
@@ -625,7 +625,7 @@ export function GitIntegrationModal(props: ({
                 <AlertBox>You need to activate this integration.</AlertBox>
             )}
             <div className="flex flex-col">
-                <span className="text-gray-500">{props.headerText || "Configure a git integration with a GitLab or GitHub self-hosted instance."}</span>
+                <span className="text-gray-500">{props.headerText || "Configure a Git integration with a GitLab or GitHub self-hosted instance."}</span>
             </div>
 
             <div className="overscroll-contain max-h-96 overflow-y-auto pr-2">

--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -59,12 +59,12 @@ export function StartWorkspaceModal(p: StartWorkspaceModalProps) {
                         <div className="flex flex-col pt-10 items-center px-2">
                             <h3 className="mb-2 text-gray-500 dark:text-gray-400">No Recent Projects</h3>
                             <p className="text-center">Projects you use frequently will show up here.</p>
-                            <p className="text-center">Prefix a git repository URL with gitpod.io/# or start with an example.</p>
+                            <p className="text-center">Prefix a Git repository URL with gitpod.io/# or start with an example.</p>
                             <button onClick={() => setSelection('Examples')} className="font-medium mt-8">Select Example</button>
                         </div> :
                         <div className="flex flex-col pt-10 items-center px-2">
                             <h3 className="mb-2 text-gray-500 dark:text-gray-400">No Example Projects</h3>
-                            <p className="text-center">Sorry there seem to be no example projects, that work with your current git provider.</p>
+                            <p className="text-center">Sorry there seem to be no example projects, that work with your current Git provider.</p>
                         </div>)
                 }
             </div>

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -193,7 +193,7 @@ export default function () {
                             </>
                             :<>
                                 <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Workspaces</h3>
-                                <div className="text-center pb-6 text-gray-500">Prefix any git repository URL with gitpod.io/# or create a new workspace for a recently used project. <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">Learn more</a></div>
+                                <div className="text-center pb-6 text-gray-500">Prefix any Git repository URL with gitpod.io/# or create a new workspace for a recently used project. <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">Learn more</a></div>
                                 <span>
                                     <button onClick={showStartWSModal}>New Workspace</button>
                                 </span>


### PR DESCRIPTION
## Description

- Capitalize proper noun Git in dashboard components

## Related Issue(s)

Driveby PR, not closing any issue with this.

## How to test

1. Review changes in the PR for correct spelling/capitalization.
1. Find way to preview dashboard components on a dev server.
1. Find way to run the tests, to confirm I'm not breaking any Jest snapshots or other test files.

This is my first contribution to the Gitpod program itself.
I did not find any developer documentation on how to run a dev server which shows me the components, so I can verify my changes myself.

Also please review/edit my Release Notes below, I hope this is the correct format.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
capitalize proper noun Git in dashboard components
```