### PR TITLE
[code] speed up fetch git repo

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir gp-code \
     && cd gp-code \
     && git init \
     && git remote add origin https://github.com/gitpod-io/vscode \
-    && git fetch origin $GP_CODE_COMMIT \
+    && git fetch origin $GP_CODE_COMMIT --depth=1 \
     && git reset --hard FETCH_HEAD
 WORKDIR /gp-code
 RUN yarn --frozen-lockfile --network-timeout 180000


### PR DESCRIPTION
## Description
use `git fetch origin $GP_CODE_COMMIT --depth=1` to speed up fetch git repo and reduce network traffic

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```
