### PR TITLE
Rename teams to team plans

### DIFF
--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -428,7 +428,7 @@ function AllTeams() {
         <div className="flex flex-row">
             <div className="flex-grow ">
                 <h3 className="self-center">All Teams</h3>
-                <h2>Manage teams and team members.</h2>
+                <h2>Manage team plan and team members.</h2>
             </div>
             <div className="flex flex-end space-x-3">
                 {isChargebeeCustomer && (
@@ -459,9 +459,9 @@ function AllTeams() {
         {(getActiveSubs().length === 0 && !pendingPlanPurchase) && (
             <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
                 <div className="m-auto text-center">
-                    <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Teams</h3>
-                    <div className="text-gray-500 mb-6">Get started by creating a team<br /> and adding team members. <a href="https://www.gitpod.io/docs/teams/" target="_blank" rel="noopener" className="gp-link">Learn more</a></div>
-                    <button className="self-center" onClick={() => showCreateTeamModal()}>Create Team</button>
+                    <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Team Plans</h3>
+                    <div className="text-gray-500 mb-6">Get started by creating a team plan<br /> and adding team members. <a href="https://www.gitpod.io/docs/teams/" target="_blank" rel="noopener" className="gp-link">Learn more</a></div>
+                    <button className="self-center" onClick={() => showCreateTeamModal()}>Create Team Plan</button>
                 </div>
             </div>
         )}
@@ -526,7 +526,7 @@ function AllTeams() {
             <div className="flex flex-row">
                 <div className="flex-grow ">
                     <h3 className="self-center">All Teams</h3>
-                    <h2>Manage teams and team members.</h2>
+                    <h2>Manage team plans and team members.</h2>
                 </div>
             </div>
         )}
@@ -609,7 +609,7 @@ function AddMembersModal(props: {
     return (<Modal visible={true} onClose={props.onClose}>
         <h3 className="pb-2">Add Members</h3>
         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-            <p className="pb-4 text-gray-500 text-base">Add members to the team.</p>
+            <p className="pb-4 text-gray-500 text-base">Add members to the team plan.</p>
 
             <div className="flex flex-col space-y-2 pb-4">
                 <label htmlFor="quantity" className="font-medium">Members</label>
@@ -662,9 +662,9 @@ function NewTeamModal(props: {
     }
 
     return (<Modal visible={true} onClose={props.onClose}>
-        <h3 className="pb-2">New Team</h3>
+        <h3 className="pb-2">New Team Plan</h3>
         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-            <p className="pb-4 text-gray-500 text-base">Create a team and add team members.</p>
+            <p className="pb-4 text-gray-500 text-base">Create a team plan and add team members.</p>
 
             <div className="flex flex-col space-y-2">
                 <label htmlFor="type" className="font-medium">Team</label>

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -18,7 +18,7 @@ export default [
         link: ['/plans']
     },
     {
-        title: 'Teams',
+        title: 'Team Plans',
         link: ['/teams']
     },
     {


### PR DESCRIPTION
## Description

This will rename the current _Teams_ feature to _Team Plans_ to avoid confusion with the upcoming _Teams & Projects_ feature which will introduce a way to create a team and invite members. 🍵 

We've decided to proceed with this MVC (minimum viable change) instead of adding a deprecation notice in https://github.com/gitpod-io/gitpod/pull/5121. 🙀 

There's also a follow up PR to update the relevant docs section in https://github.com/gitpod-io/website/pull/1032.
> https://www.gitpod.io/docs/teams

See relevant discussion points[[1](https://www.notion.so/gitpod/Team-Meta-Sync-3cedd13aa1fb4a0380a7ff1b5c4de971#0698ada4491b4bb1bb593de277545c2e)][[2](https://www.notion.so/gitpod/Team-Meta-Sync-3cedd13aa1fb4a0380a7ff1b5c4de971#d0ad4cf1e16a4eb4b82902e5c752d50a)] (internal).

## How to test

1. Go to `/teams`
2. Create a team plan, manage team members.

## Release Notes
```release-note
NONE
```
