### PR TITLE
[supervisor] fix firing unload event

### DIFF
--- a/components/supervisor/frontend/src/ide/gitpod-service-client.ts
+++ b/components/supervisor/frontend/src/ide/gitpod-service-client.ts
@@ -31,10 +31,6 @@ export async function create(): Promise<GitpodServiceClient> {
         rejectAuth = reject
     });
     async function auth(workspaceInstanceId: string): Promise<void> {
-        if (document.cookie.includes(`${workspaceInstanceId}_owner_`)) {
-            resolveAuth!();
-            return;
-        }
         try {
             const response = await fetch(wsUrl.asStart().asWorkspaceAuth(workspaceInstanceId).toString(), {
                 credentials: 'include'

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -161,7 +161,7 @@ const loadingIDE = new Promise(resolve => window.addEventListener('DOMContentLoa
         updateCurrentFrame();
         trackIDEStatusRenderedEvent();
     });
-    window.addEventListener('beforeunload', () => trackStatusRenderedEvent('window-unload'), { capture: true });
+    window.addEventListener('unload', () => trackStatusRenderedEvent('window-unload'), { capture: true });
     //#endregion
 
     //#region heart-beat


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

Uses `unload` window event instead of `beforeunload` to track closed windows. The latter is not always emitted.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/4199

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
