### PR TITLE
[installer] Misc improvements

### DIFF
--- a/installer/cmd/init.go
+++ b/installer/cmd/init.go
@@ -7,9 +7,8 @@ package cmd
 import (
 	"fmt"
 
-	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config"
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
 )
 
 // initCmd represents the init command
@@ -23,8 +22,11 @@ be saved to a repository.`,
 	Example: `  # Save config to config.yaml.
   gitpod-installer init > config.yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var cfg config.Config
-		fc, err := yaml.Marshal(cfg)
+		cfg, err := config.NewDefaultConfig()
+		if err != nil {
+			panic(err)
+		}
+		fc, err := config.Marshal(config.CurrentVersion, cfg)
 		if err != nil {
 			panic(err)
 		}

--- a/installer/example-config.yaml
+++ b/installer/example-config.yaml
@@ -1,53 +1,28 @@
-analytics: null
-authProviders: null
+apiVersion: v1
 blockNewUsers:
   enabled: false
-  passlist: null
 certificate:
   kind: ""
   name: ""
 containerRegistry:
-  external: null
-  inCluster: null
+  inCluster: true
 database:
-  cloudSQL: null
-  rds: null
+  inCluster: true
 domain: "gitpod.io"
 imagePullSecrets: null
-installNetworkPolicies: false
 kind: Full
-messageBus: { }
 metadata:
   region: "eu-west1"
 objectStorage:
-  cloudStorage:
-    certificate:
-      name: "gcp-sa"
-  s3: null
+  inCluster: true
 observability:
-  logLevel: ""
-  tracing: null
-repository: "eu.gcr.io/gitpod-core-dev/build/"
+  logLevel: info
+repository: eu.gcr.io/gitpod-core-dev/build
 workspace:
   resources:
-    DynamicLimits:
-      CPU: null
-    Limits:
-      CPU: ""
-      EphemeralStorage: ""
-      Memory: ""
-      Storage: ""
-    Requests:
-      CPU: ""
-      EphemeralStorage: ""
-      Memory: ""
-      Storage: ""
+    requests:
+      cpu: "1"
+      memory: 2Gi
   runtime:
-    containerdRuntimeDir: ""
-    fsShiftMethod: "fuse"
-  templates:
-    default: null
-    ghost: null
-    image_build: null
-    prebuild: null
-    regular: null
+    containerdRuntimeDir: /run/containerd/io.containerd.runtime.v2.task/k8s.io
+    fsShiftMethod: fuse

--- a/installer/go.mod
+++ b/installer/go.mod
@@ -3,7 +3,6 @@ module github.com/gitpod-io/gitpod/installer
 go 1.17
 
 require (
-	github.com/Masterminds/goutils v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/gitpod-io/gitpod/agent-smith v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/blobserve v0.0.0-00010101000000-000000000000
@@ -17,7 +16,6 @@ require (
 	github.com/gitpod-io/gitpod/ws-proxy v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-scheduler v0.0.0-00010101000000-000000000000
 	github.com/google/go-cmp v0.5.6
-	github.com/hexops/valast v1.4.0
 	github.com/jetstack/cert-manager v1.5.3
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
@@ -108,9 +106,9 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.2 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/shirou/gopsutil v2.20.9+incompatible // indirect
-	github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -140,7 +138,6 @@ require (
 	k8s.io/client-go v0.22.0 // indirect
 	k8s.io/component-helpers v0.22.0 // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect
-	mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )
 

--- a/installer/go.sum
+++ b/installer/go.sum
@@ -67,7 +67,6 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgR
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -657,12 +656,6 @@ github.com/hashicorp/vault/api v1.1.1/go.mod h1:29UXcn/1cLOPHQNMWA7bCz2By4PSd0VK
 github.com/hashicorp/vault/sdk v0.1.14-0.20200519221530-14615acda45f/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/vault/sdk v0.2.1/go.mod h1:WfUiO1vYzfBkz1TmoE4ZGU7HD0T0Cl/rZwaxjBkgN4U=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/hexops/autogold v0.8.1 h1:wvyd/bAJ+Dy+DcE09BoLk6r4Fa5R5W+O+GUzmR985WM=
-github.com/hexops/autogold v0.8.1/go.mod h1:97HLDXyG23akzAoRYJh/2OBs3kd80eHyKPvZw0S5ZBY=
-github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/hexops/valast v1.4.0 h1:sFzyxPDP0riFQUzSBXTCCrAbbIndHPWMndxuEjXdZlc=
-github.com/hexops/valast v1.4.0/go.mod h1:uVjKZ0smVuYlgCSPz9NRi5A04sl7lp6GtFWsROKDgEs=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -1013,8 +1006,6 @@ github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shirou/gopsutil v2.20.9+incompatible h1:msXs2frUV+O/JLva9EDLpuJ84PrFsdCTCQex8PUdtkQ=
 github.com/shirou/gopsutil v2.20.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 h1:llrF3Fs4018ePo4+G/HV/uQUqEI1HMDjCeOf2V6puPc=
-github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -1526,7 +1517,6 @@ golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
@@ -1781,8 +1771,6 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e h1:ldQh+neBabomh7+89dTpiFAB8tGdfVmuIzAHbvtl+9I=
 k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=
-mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44 h1:7f9MST3yT/rcobqRRclyjMvnDyjkkjg+EAzBjZ+TLdg=
-mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/letsencrypt v0.0.3/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -8,16 +8,16 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
-	v1 "k8s.io/api/apps/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/docker/distribution/reference"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
 
@@ -289,9 +289,9 @@ var (
 	}
 )
 
-var DeploymentStrategy = v1.DeploymentStrategy{
-	Type: v1.RollingUpdateDeploymentStrategyType,
-	RollingUpdate: &v1.RollingUpdateDeployment{
+var DeploymentStrategy = appsv1.DeploymentStrategy{
+	Type: appsv1.RollingUpdateDeploymentStrategyType,
+	RollingUpdate: &appsv1.RollingUpdateDeployment{
 		MaxSurge:       &intstr.IntOrString{IntVal: 1},
 		MaxUnavailable: &intstr.IntOrString{IntVal: 0},
 	},

--- a/installer/pkg/common/render_test.go
+++ b/installer/pkg/common/render_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
-	"github.com/google/go-cmp/cmp"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/agent-smith/configmap.go
+++ b/installer/pkg/components/agent-smith/configmap.go
@@ -8,16 +8,18 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/agent-smith/pkg/agent"
 	"github.com/gitpod-io/gitpod/agent-smith/pkg/config"
 	"github.com/gitpod-io/gitpod/agent-smith/pkg/signature"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/agent-smith/daemonset.go
+++ b/installer/pkg/components/agent-smith/daemonset.go
@@ -6,7 +6,9 @@ package agentsmith
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	"github.com/hexops/valast"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/installer/pkg/components/agent-smith/daemonset.go
+++ b/installer/pkg/components/agent-smith/daemonset.go
@@ -7,8 +7,6 @@ package agentsmith
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
-	"github.com/hexops/valast"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -70,7 +68,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						),
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: pointer.Bool(true),
-							ProcMount:  valast.Addr(corev1.DefaultProcMount).(*corev1.ProcMountType),
+							ProcMount:  func() *corev1.ProcMountType { r := corev1.DefaultProcMount; return &r }(),
 						},
 					}, *common.KubeRBACProxyContainer()},
 					Volumes: []corev1.Volume{{

--- a/installer/pkg/components/agent-smith/networkpolicy.go
+++ b/installer/pkg/components/agent-smith/networkpolicy.go
@@ -6,6 +6,7 @@ package agentsmith
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/agent-smith/role.go
+++ b/installer/pkg/components/agent-smith/role.go
@@ -6,7 +6,9 @@ package agentsmith
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/agent-smith/rolebinding.go
+++ b/installer/pkg/components/agent-smith/rolebinding.go
@@ -6,7 +6,9 @@ package agentsmith
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/blobserve/configmap.go
+++ b/installer/pkg/components/blobserve/configmap.go
@@ -7,14 +7,16 @@ package blobserve
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/blobserve/pkg/blobserve"
 	"github.com/gitpod-io/gitpod/blobserve/pkg/config"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/blobserve/deployment.go
+++ b/installer/pkg/components/blobserve/deployment.go
@@ -6,7 +6,8 @@ package blobserve
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,14 +29,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"Component": Component},
 				},

--- a/installer/pkg/components/blobserve/networkpolicy.go
+++ b/installer/pkg/components/blobserve/networkpolicy.go
@@ -7,6 +7,7 @@ package blobserve
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ws-proxy"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/blobserve/networkpolicy.go
+++ b/installer/pkg/components/blobserve/networkpolicy.go
@@ -15,10 +15,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/blobserve/rolebinding.go
+++ b/installer/pkg/components/blobserve/rolebinding.go
@@ -6,7 +6,9 @@ package blobserve
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/content-service/configmap.go
+++ b/installer/pkg/components/content-service/configmap.go
@@ -7,9 +7,11 @@ package content_service
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/content-service/api/config"
 	apiconfig "github.com/gitpod-io/gitpod/content-service/api/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/content-service/deployment.go
+++ b/installer/pkg/components/content-service/deployment.go
@@ -6,6 +6,7 @@ package content_service
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/installer/pkg/components/content-service/networkpolicy.go
+++ b/installer/pkg/components/content-service/networkpolicy.go
@@ -13,10 +13,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/content-service/networkpolicy.go
+++ b/installer/pkg/components/content-service/networkpolicy.go
@@ -6,6 +6,7 @@ package content_service
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/content-service/rolebinding.go
+++ b/installer/pkg/components/content-service/rolebinding.go
@@ -6,7 +6,9 @@ package content_service
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/dashboard/deployment.go
+++ b/installer/pkg/components/dashboard/deployment.go
@@ -6,7 +6,8 @@ package dashboard
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,14 +20,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"Component": Component},
 				},

--- a/installer/pkg/components/dashboard/networkpolicy.go
+++ b/installer/pkg/components/dashboard/networkpolicy.go
@@ -17,10 +17,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{
@@ -34,10 +30,12 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 			PodSelector: metav1.LabelSelector{MatchLabels: labels},
 			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: ContainerPort},
-				}},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: common.TCPProtocol,
+						Port:     &intstr.IntOrString{IntVal: ContainerPort},
+					},
+				},
 				From: []networkingv1.NetworkPolicyPeer{{
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": proxy.Component,

--- a/installer/pkg/components/dashboard/networkpolicy.go
+++ b/installer/pkg/components/dashboard/networkpolicy.go
@@ -6,8 +6,10 @@ package dashboard
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/dashboard/rolebinding.go
+++ b/installer/pkg/components/dashboard/rolebinding.go
@@ -6,7 +6,9 @@ package dashboard
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/gitpod/configmap.go
+++ b/installer/pkg/components/gitpod/configmap.go
@@ -7,8 +7,10 @@ package gitpod
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/image-builder-mk3/clusterrole.go
+++ b/installer/pkg/components/image-builder-mk3/clusterrole.go
@@ -6,7 +6,9 @@ package image_builder_mk3
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/image-builder-mk3/configmap.go
+++ b/installer/pkg/components/image-builder-mk3/configmap.go
@@ -7,15 +7,17 @@ package image_builder_mk3
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/image-builder/api/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/installer/pkg/components/image-builder-mk3/deployment.go
@@ -8,9 +8,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,14 +55,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		}},
 	}
 
-	return []runtime.Object{&v1.Deployment{
+	return []runtime.Object{&appsv1.Deployment{
 		TypeMeta: common.TypeMetaDeployment,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Component,
 			Namespace: ctx.Namespace,
 			Labels:    labels,
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"Component": Component},
 			},

--- a/installer/pkg/components/image-builder-mk3/networkpolicy.go
+++ b/installer/pkg/components/image-builder-mk3/networkpolicy.go
@@ -6,7 +6,7 @@ package image_builder_mk3
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +32,7 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": server.Component,
+						"component": Component,
 					}},
 				}},
 			}},

--- a/installer/pkg/components/image-builder-mk3/networkpolicy.go
+++ b/installer/pkg/components/image-builder-mk3/networkpolicy.go
@@ -13,10 +13,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/image-builder-mk3/rolebinding.go
+++ b/installer/pkg/components/image-builder-mk3/rolebinding.go
@@ -6,7 +6,9 @@ package image_builder_mk3
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/image-builder-mk3/secret.go
+++ b/installer/pkg/components/image-builder-mk3/secret.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/google/uuid"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,7 @@ import (
 )
 
 func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
-	id, err := uuid.NewRandom()
+	key, err := common.RandomString(32)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +28,7 @@ func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Labels:    common.DefaultLabels(Component),
 		},
 		Data: map[string][]byte{
-			"keyfile": []byte(id.String()),
+			"keyfile": []byte(key),
 		},
 	}}, nil
 }

--- a/installer/pkg/components/image-builder-mk3/secret.go
+++ b/installer/pkg/components/image-builder-mk3/secret.go
@@ -6,20 +6,22 @@ package image_builder_mk3
 
 import (
 	"fmt"
-	util "github.com/Masterminds/goutils"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	v1 "k8s.io/api/core/v1"
+	"github.com/google/uuid"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
-	keyfile, err := util.CryptoRandomAlphaNumeric(32)
+	id, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}
 
-	return []runtime.Object{&v1.Secret{
+	return []runtime.Object{&corev1.Secret{
 		TypeMeta: common.TypeMetaSecret,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-authkey", Component),
@@ -27,7 +29,7 @@ func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Labels:    common.DefaultLabels(Component),
 		},
 		Data: map[string][]byte{
-			"keyfile": []byte(keyfile),
+			"keyfile": []byte(id.String()),
 		},
 	}}, nil
 }

--- a/installer/pkg/components/proxy/configmap.go
+++ b/installer/pkg/components/proxy/configmap.go
@@ -9,13 +9,15 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
-	util "github.com/Masterminds/goutils"
+	"text/template"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	util "github.com/Masterminds/goutils"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"text/template"
 )
 
 //go:embed templates/configmap/vhost.docker-registry.tpl

--- a/installer/pkg/components/proxy/configmap.go
+++ b/installer/pkg/components/proxy/configmap.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
-	util "github.com/Masterminds/goutils"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,13 +89,13 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	// todo(sje) make conditional
 	// todo(sje): allow value to be set via config
-	username, err := util.CryptoRandomAlphaNumeric(20)
+	username, err := common.RandomString(20)
 	if err != nil {
 		return nil, err
 	}
 
 	// todo(sje): allow value to be set via config
-	password, err := util.CryptoRandomAlphaNumeric(20)
+	password, err := common.RandomString(20)
 	if err != nil {
 		return nil, err
 	}

--- a/installer/pkg/components/proxy/deployment.go
+++ b/installer/pkg/components/proxy/deployment.go
@@ -6,8 +6,10 @@ package proxy
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,14 +55,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}}
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"Component": Component},
 				},

--- a/installer/pkg/components/proxy/networkpolicy.go
+++ b/installer/pkg/components/proxy/networkpolicy.go
@@ -16,10 +16,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/proxy/networkpolicy.go
+++ b/installer/pkg/components/proxy/networkpolicy.go
@@ -6,7 +6,9 @@ package proxy
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/proxy/rolebinding.go
+++ b/installer/pkg/components/proxy/rolebinding.go
@@ -6,7 +6,9 @@ package proxy
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/registry-facade/clusterrole.go
+++ b/installer/pkg/components/registry-facade/clusterrole.go
@@ -6,7 +6,9 @@ package registryfacade
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/registry-facade/configmap.go
+++ b/installer/pkg/components/registry-facade/configmap.go
@@ -7,29 +7,31 @@ package registryfacade
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	"github.com/gitpod-io/gitpod/registry-facade/api/config"
+	regfac "github.com/gitpod-io/gitpod/registry-facade/api/config"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	var tls config.TLS
+	var tls regfac.TLS
 	if ctx.Config.Certificate.Name != "" {
-		tls = config.TLS{
+		tls = regfac.TLS{
 			Certificate: "/mnt/certificates/tls.crt",
 			PrivateKey:  "/mnt/certificates/tls.key",
 		}
 	}
 
-	rfcfg := config.ServiceConfig{
-		Registry: config.Config{
+	rfcfg := regfac.ServiceConfig{
+		Registry: regfac.Config{
 			Port: ContainerPort,
-			RemoteSpecProvider: &config.RSProvider{
+			RemoteSpecProvider: &regfac.RSProvider{
 				Addr: fmt.Sprintf("dns:///ws-manager:%d", wsmanager.RPCPort),
-				TLS: &config.TLS{
+				TLS: &regfac.TLS{
 					Authority:   "/ws-manager-client-tls-certs/ca.crt",
 					Certificate: "/ws-manager-client-tls-certs/tls.crt",
 					PrivateKey:  "/ws-manager-client-tls-certs/tls.key",
@@ -39,7 +41,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Store:       "/mnt/cache/registry",
 			RequireAuth: false,
 			// todo(sje): figure out these values
-			StaticLayer: []config.StaticLayerCfg{{
+			StaticLayer: []regfac.StaticLayerCfg{{
 				Ref:  common.ImageName(ctx.Config.Repository, Component, "todo"),
 				Type: "image",
 			}, {

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -7,6 +7,7 @@ package registryfacade
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/installer/pkg/components/registry-facade/networkpolicy.go
+++ b/installer/pkg/components/registry-facade/networkpolicy.go
@@ -6,6 +6,7 @@ package registryfacade
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/registry-facade/networkpolicy.go
+++ b/installer/pkg/components/registry-facade/networkpolicy.go
@@ -13,10 +13,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/registry-facade/podsecuritypolicy.go
+++ b/installer/pkg/components/registry-facade/podsecuritypolicy.go
@@ -6,6 +6,7 @@ package registryfacade
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/registry-facade/rolebinding.go
+++ b/installer/pkg/components/registry-facade/rolebinding.go
@@ -6,7 +6,9 @@ package registryfacade
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/server/configmap.go
+++ b/installer/pkg/components/server/configmap.go
@@ -11,14 +11,13 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
 
-	util "github.com/Masterminds/goutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	jwtSecret, err := util.CryptoRandomAlphaNumeric(20)
+	jwtSecret, err := common.RandomString(20)
 	if err != nil {
 		return nil, err
 	}

--- a/installer/pkg/components/server/configmap.go
+++ b/installer/pkg/components/server/configmap.go
@@ -7,9 +7,11 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	util "github.com/Masterminds/goutils"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
+
+	util "github.com/Masterminds/goutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/server/deployment.go
+++ b/installer/pkg/components/server/deployment.go
@@ -81,7 +81,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							},
 						}},
-						InitContainers: []corev1.Container{*common.DatabaseWaiterContainer(), *common.MsgBusWaiterContainer()},
+						InitContainers: []corev1.Container{*common.DatabaseWaiterContainer(), *common.MessageBusWaiterContainer()},
 						Containers: []corev1.Container{{
 							Name:            Component,
 							Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Server.Version),

--- a/installer/pkg/components/server/deployment.go
+++ b/installer/pkg/components/server/deployment.go
@@ -8,10 +8,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,14 +32,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	wsmanCfgManager := base64.StdEncoding.EncodeToString(fc)
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"Component": Component},
 				},

--- a/installer/pkg/components/server/ide-configmap.go
+++ b/installer/pkg/components/server/ide-configmap.go
@@ -7,8 +7,10 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/server/networkpolicy.go
+++ b/installer/pkg/components/server/networkpolicy.go
@@ -6,6 +6,7 @@ package server
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/server/networkpolicy.go
+++ b/installer/pkg/components/server/networkpolicy.go
@@ -14,10 +14,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/server/role.go
+++ b/installer/pkg/components/server/role.go
@@ -6,6 +6,7 @@ package server
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/server/rolebinding.go
+++ b/installer/pkg/components/server/rolebinding.go
@@ -6,7 +6,9 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-daemon/clusterrole.go
+++ b/installer/pkg/components/ws-daemon/clusterrole.go
@@ -6,7 +6,9 @@ package wsdaemon
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -7,7 +7,6 @@ package wsdaemon
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
-	"github.com/hexops/valast"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +48,7 @@ fi
 `},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: pointer.Bool(true),
-				ProcMount:  valast.Addr(corev1.ProcMountType("Default")).(*corev1.ProcMountType),
+				ProcMount:  func() *corev1.ProcMountType { r := corev1.DefaultProcMount; return &r }(),
 			},
 		},
 		{
@@ -127,7 +126,7 @@ sysctl -w vm.unprivileged_userfaultfd=0
 							Name: "working-area",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/mnt/disks/ssd0/workspaces",
-								Type: valast.Addr(corev1.HostPathType("DirectoryOrCreate")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectoryOrCreate; return &r }(),
 							}},
 						},
 						{
@@ -144,49 +143,49 @@ sysctl -w vm.unprivileged_userfaultfd=0
 							Name: "containerd-socket",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/run/containerd/containerd.sock",
-								Type: valast.Addr(corev1.HostPathType("Socket")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathSocket; return &r }(),
 							}},
 						},
 						{
 							Name: "node-fs0",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/var/lib",
-								Type: valast.Addr(corev1.HostPathType("Directory")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectory; return &r }(),
 							}},
 						},
 						{
 							Name: "node-fs1",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/run/containerd/io.containerd.runtime.v2.task/k8s.io",
-								Type: valast.Addr(corev1.HostPathType("Directory")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectory; return &r }(),
 							}},
 						},
 						{
 							Name: "node-mounts",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/proc/mounts",
-								Type: valast.Addr(corev1.HostPathType("File")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathFile; return &r }(),
 							}},
 						},
 						{
 							Name: "node-cgroups",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/sys/fs/cgroup",
-								Type: valast.Addr(corev1.HostPathType("Directory")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectory; return &r }(),
 							}},
 						},
 						{
 							Name: "node-hosts",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/etc/hosts",
-								Type: valast.Addr(corev1.HostPathType("File")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathFile; return &r }(),
 							}},
 						},
 						{
 							Name: "node-linux-src",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/usr/src",
-								Type: valast.Addr(corev1.HostPathType("Directory")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectory; return &r }(),
 							}},
 						},
 						{
@@ -197,7 +196,7 @@ sysctl -w vm.unprivileged_userfaultfd=0
 							Name: "gcloud-tmp",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 								Path: "/mnt/disks/ssd0/sync-tmp",
-								Type: valast.Addr(corev1.HostPathType("DirectoryOrCreate")).(*corev1.HostPathType),
+								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectoryOrCreate; return &r }(),
 							}},
 						},
 					},
@@ -229,7 +228,7 @@ sysctl -w vm.unprivileged_userfaultfd=0
 								{
 									Name:             "working-area",
 									MountPath:        "/mnt/workingarea",
-									MountPropagation: valast.Addr(corev1.MountPropagationMode("Bidirectional")).(*corev1.MountPropagationMode),
+									MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationBidirectional; return &r }(),
 								},
 								{
 									Name:      "config",
@@ -251,12 +250,12 @@ sysctl -w vm.unprivileged_userfaultfd=0
 									Name:             "node-mounts",
 									ReadOnly:         true,
 									MountPath:        "/mnt/mounts",
-									MountPropagation: valast.Addr(corev1.MountPropagationMode("HostToContainer")).(*corev1.MountPropagationMode),
+									MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationHostToContainer; return &r }(),
 								},
 								{
 									Name:             "node-cgroups",
 									MountPath:        "/mnt/node-cgroups",
-									MountPropagation: valast.Addr(corev1.MountPropagationMode("HostToContainer")).(*corev1.MountPropagationMode),
+									MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationHostToContainer; return &r }(),
 								},
 								{
 									Name:      "node-hosts",
@@ -291,7 +290,6 @@ sysctl -w vm.unprivileged_userfaultfd=0
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(true),
-								ProcMount:  valast.Addr(corev1.DefaultProcMount).(*corev1.ProcMountType),
 							},
 						},
 						*common.KubeRBACProxyContainer(),

--- a/installer/pkg/components/ws-daemon/networkpolicy.go
+++ b/installer/pkg/components/ws-daemon/networkpolicy.go
@@ -6,6 +6,7 @@ package wsdaemon
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-daemon/rolebinding.go
+++ b/installer/pkg/components/ws-daemon/rolebinding.go
@@ -6,7 +6,9 @@ package wsdaemon
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-daemon/tlssecret.go
+++ b/installer/pkg/components/ws-daemon/tlssecret.go
@@ -6,6 +6,7 @@ package wsdaemon
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -7,7 +7,9 @@ package wsmanagerbridge
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -73,7 +73,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							},
 						}, pullSecretVolume},
-						InitContainers: []corev1.Container{*common.DatabaseWaiterContainer(), *common.MsgBusWaiterContainer()},
+						InitContainers: []corev1.Container{*common.DatabaseWaiterContainer(), *common.MessageBusWaiterContainer()},
 						Containers: []corev1.Container{{
 							Name:            Component,
 							Args:            []string{"run", "-v", "/mnt/config/config.json"},

--- a/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -7,7 +7,8 @@ package wsmanagerbridge
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,14 +30,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"Component": Component},
 				},

--- a/installer/pkg/components/ws-manager-bridge/objects.go
+++ b/installer/pkg/components/ws-manager-bridge/objects.go
@@ -6,6 +6,7 @@ package wsmanagerbridge
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 )

--- a/installer/pkg/components/ws-manager-bridge/rolebinding.go
+++ b/installer/pkg/components/ws-manager-bridge/rolebinding.go
@@ -6,7 +6,9 @@ package wsmanagerbridge
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-manager/configmap.go
+++ b/installer/pkg/components/ws-manager/configmap.go
@@ -7,15 +7,17 @@ package wsmanager
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/ws-manager/api/config"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/ws-manager/deployment.go
+++ b/installer/pkg/components/ws-manager/deployment.go
@@ -7,7 +7,8 @@ package wsmanager
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
-	"k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,14 +20,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"Component": Component,

--- a/installer/pkg/components/ws-manager/networkpolicy.go
+++ b/installer/pkg/components/ws-manager/networkpolicy.go
@@ -6,6 +6,7 @@ package wsmanager
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-manager/networkpolicy.go
+++ b/installer/pkg/components/ws-manager/networkpolicy.go
@@ -14,10 +14,6 @@ import (
 
 // todo(sje): establish how to pass in config with cw
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{

--- a/installer/pkg/components/ws-manager/role.go
+++ b/installer/pkg/components/ws-manager/role.go
@@ -6,6 +6,7 @@ package wsmanager
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-manager/role.go
+++ b/installer/pkg/components/ws-manager/role.go
@@ -13,10 +13,6 @@ import (
 )
 
 func role(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{

--- a/installer/pkg/components/ws-manager/rolebinding.go
+++ b/installer/pkg/components/ws-manager/rolebinding.go
@@ -6,7 +6,9 @@ package wsmanager
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-manager/tlssecret.go
+++ b/installer/pkg/components/ws-manager/tlssecret.go
@@ -6,12 +6,14 @@ package wsmanager
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/ws-manager/unpriviledged-rolebinding.go
+++ b/installer/pkg/components/ws-manager/unpriviledged-rolebinding.go
@@ -6,7 +6,9 @@ package wsmanager
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-proxy/configmap.go
+++ b/installer/pkg/components/ws-proxy/configmap.go
@@ -7,15 +7,17 @@ package wsproxy
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/config"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/proxy"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/ws-proxy/deployment.go
+++ b/installer/pkg/components/ws-proxy/deployment.go
@@ -6,8 +6,10 @@ package wsproxy
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,14 +40,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	return []runtime.Object{
-		&v1.Deployment{
+		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
 			},
-			Spec: v1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"Component": Component},
 				},

--- a/installer/pkg/components/ws-proxy/networkpolicy.go
+++ b/installer/pkg/components/ws-proxy/networkpolicy.go
@@ -6,6 +6,7 @@ package wsproxy
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-proxy/networkpolicy.go
+++ b/installer/pkg/components/ws-proxy/networkpolicy.go
@@ -14,14 +14,7 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
-
-	// todo(sje): do we need this wsManagerProxy port?
-	var wsManagerProxy networkingv1.NetworkPolicyPort
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{
 		TypeMeta: common.TypeMetaNetworkPolicy,
@@ -34,13 +27,15 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 			PodSelector: metav1.LabelSelector{MatchLabels: labels},
 			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: HTTPProxyPort},
-				}, {
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: HTTPSProxyPort},
-				}, wsManagerProxy},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: common.TCPProtocol,
+						Port:     &intstr.IntOrString{IntVal: HTTPProxyPort},
+					}, {
+						Protocol: common.TCPProtocol,
+						Port:     &intstr.IntOrString{IntVal: HTTPSProxyPort},
+					},
+				},
 			}},
 		},
 	}}, nil

--- a/installer/pkg/components/ws-proxy/rolebinding.go
+++ b/installer/pkg/components/ws-proxy/rolebinding.go
@@ -6,7 +6,9 @@ package wsproxy
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-scheduler/clusterrole.go
+++ b/installer/pkg/components/ws-scheduler/clusterrole.go
@@ -6,7 +6,9 @@ package wsscheduler
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-scheduler/clusterrolebinding.go
+++ b/installer/pkg/components/ws-scheduler/clusterrolebinding.go
@@ -6,7 +6,9 @@ package wsscheduler
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-scheduler/configmap.go
+++ b/installer/pkg/components/ws-scheduler/configmap.go
@@ -7,9 +7,11 @@ package wsscheduler
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scheduler"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/components/ws-scheduler/deployment.go
+++ b/installer/pkg/components/ws-scheduler/deployment.go
@@ -6,8 +6,10 @@ package wsscheduler
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,14 +20,14 @@ import (
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
-	return []runtime.Object{&v1.Deployment{
+	return []runtime.Object{&appsv1.Deployment{
 		TypeMeta: common.TypeMetaDeployment,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Component,
 			Namespace: ctx.Namespace,
 			Labels:    labels,
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"Component": Component},
 			},

--- a/installer/pkg/components/ws-scheduler/networkpolicy.go
+++ b/installer/pkg/components/ws-scheduler/networkpolicy.go
@@ -13,10 +13,6 @@ import (
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	if !ctx.Config.InstallNetworkPolicies {
-		return nil, nil
-	}
-
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{&networkingv1.NetworkPolicy{

--- a/installer/pkg/components/ws-scheduler/networkpolicy.go
+++ b/installer/pkg/components/ws-scheduler/networkpolicy.go
@@ -6,6 +6,7 @@ package wsscheduler
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/installer/pkg/config/v1/load.go
+++ b/installer/pkg/config/v1/load.go
@@ -51,7 +51,7 @@ func LoadMock() *Config {
 		},
 		Workspace: Workspace{
 			Runtime: WorkspaceRuntime{
-				FSShiftMethod: FSShiftFuseFS,
+				FSShiftMethod:        FSShiftFuseFS,
 				ContainerDRuntimeDir: "/run/containerd/io.containerd.runtime.v2.task/k8s.io",
 			},
 		},


### PR DESCRIPTION
## Description
This PR makes various improvements to the installer:
- clean up the import statements and group them by "stdlib", "gitopd-io", "rest of the world"
- remove dependencies to mastermind/goutils and valast
- introduce versioned config loading, including defaults
- simplify the config surface and introduce `omitempty` where appropriate


## How to test
```bash
cd installer

go run main.go init

go run main.go render --config example-config.json
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
