### PR TITLE
Update bug report template to include workspace

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,6 +19,12 @@ body:
     description: Describe the steps to reproduce the issue
   validations:
     required: true
+- type: input
+  id: workspace
+  attributes:
+    label: Workspace Affected
+    description: Does this issue affect a specific workspace?
+    placeholder: e.g. kumquat-goose-831fpnxf
 - type: textarea
   id: expected-behavior
   attributes:


### PR DESCRIPTION
## Description

Given that we get quite a few requests where workspace name (ID) would help in advance, this will add an optional field in the bug report template to allow users to submit the affected workspace name (id) when possible or needed.

See also [relevant discusion](https://gitpod.slack.com/archives/C01KPEPLLRY/p1632747716042900) (internal).

## Release Notes

```release-note
NONE
```
