### PR TITLE
chore(docker) Align Alpine versions

### DIFF
--- a/components/ee/kedge/leeway.Dockerfile
+++ b/components/ee/kedge/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Gitpod Enterprise Source Code License,
 # See License.enterprise.txt in the project root folder.
 
-FROM alpine:latest
+FROM alpine:3.14
 
 RUN apk add --no-cache git bash ca-certificates
 COPY components-ee-kedge--app/kedge /app/


### PR DESCRIPTION
## Description

Most leeway Dockerfiles use Alpine 3.14. There are two cases were this isn't the case. `kedge` uses `latest` and `theia` uses `3.13`. We should lint for `latest` and disallow its use as it has a variable definition. There are minor differences between 3.13 and 3.14 this is just a chore, parameterizing this in the future to change in one place might be useful.

## How to test

I used leeway to build the docker images and checked that they ran. Other tests would likely be useful. 

## Release Notes

```release-note
NONE
```