### PR TITLE
add GIT_AUTHOR_EMAIL

### DIFF
--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -47,7 +47,7 @@ export default function Account() {
 
         <PageWithSubMenu subMenu={settingsMenu}  title='Account' subtitle='Manage account and Git configuration.'>
             <h3>Profile</h3>
-            <p className="text-base text-gray-500 pb-4 max-w-2xl">The following information will be used to set up Git configuration. You can override Git author name and email per project by using the default environment variables <CodeText>GIT_AUTHOR_NAME</CodeText> and <CodeText>GIT_COMMITTER_EMAIL</CodeText>.</p>
+            <p className="text-base text-gray-500 pb-4 max-w-2xl">The following information will be used to set up Git configuration. You can override Git author name and email per project by using the default environment variables <CodeText>GIT_AUTHOR_NAME</CodeText>, <CodeText>GIT_COMMITTER_NAME</CodeText>, <CodeText>GIT_AUTHOR_EMAIL</CodeText> and <CodeText>GIT_COMMITTER_EMAIL</CodeText>.</p>
             <div className="flex flex-col lg:flex-row">
                 <div>
                     <div className="mt-4">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`GIT_AUTHOR_EMAIL` also needs to be set, otherwise only the committer email is changed but the author email remains the same
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6028

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
add `GIT_AUTHOR_EMAIL` to the environment variables mentioned in account settings
```
