### PR TITLE
[teams] Fix typo in 'Delete Team' button text

### DIFF
--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -54,7 +54,7 @@ export default function TeamSettings() {
         <PageWithSubMenu subMenu={settingsMenu} title='General' subtitle='Manage general team settings.'>
             <h3>Delete Team</h3>
             <p className="text-base text-gray-500 pb-4">Deleting this team will also remove all associated data with this team, including projects and workspaces. Deleted teams cannot be restored!</p>
-            <button className="danger secondary" onClick={() => setModal(true)}>Delete Account</button>
+            <button className="danger secondary" onClick={() => setModal(true)}>Delete Team</button>
         </PageWithSubMenu>
 
         <ConfirmationModal


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The button says `Delete Account`, but it should actually be `Delete Team`:

<img width="1437" alt="Screenshot 2021-10-05 at 09 30 46" src="https://user-images.githubusercontent.com/599268/135979669-3d0f2a8e-3cfb-4758-9b40-a5df919ae9fd.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/uncc