### PR TITLE
[Teams] Fix Teams menu rendering even when there are backend errors

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -77,8 +77,11 @@ export default function Menu() {
         (async () => {
             const members: Record<string, TeamMemberInfo[]> = {};
             await Promise.all(teams.map(async (team) => {
-                const infos = await getGitpodService().server.getTeamMembers(team.id);
-                members[team.id] = infos;
+                try {
+                    members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
+                } catch (error) {
+                    console.error('Could not get members of team', team, error);
+                }
             }));
             setTeamMembers(members);
         })();
@@ -108,8 +111,8 @@ export default function Menu() {
             ];
         }
         // Team menu
-        if (team && teamMembers && teamMembers[team.id]) {
-            const currentUserInTeam = teamMembers[team.id].find(m => m.userId === user?.id);
+        if (team) {
+            const currentUserInTeam = (teamMembers[team.id] || []).find(m => m.userId === user?.id);
 
             const teamSettingsList = [
                 {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In https://github.com/gitpod-io/gitpod/issues/6035 and https://github.com/gitpod-io/gitpod/issues/6037 we noticed that:

- [x] When a user account gets deleted, their team memberships remain active, causing errors for all other team members (now fixed in this PR ✅)

- [x] When getting the members of one of your teams fail, the Team menu rendering is broken (all members count stay as `...`, and the tabs menu is not the Team menu but the User menu) (also fixed in this PR ✅)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6035
Fixes https://github.com/gitpod-io/gitpod/issues/6037

## How to test
<!-- Provide steps to test this PR -->

1. Create two users, and add them to a Team
2. Delete one of the user accounts (without manually removing them from the Team)
3. The other user should still have a functional Teams dropdown menu, showing the Team with only 1 member (themselves)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Teams] Fix Teams menu rendering even when there are backend errors
```

/uncc