### PR TITLE
[projects] paginate listReposAccessibleToInstallation call

### DIFF
--- a/components/server/ee/src/github/github-app-support.ts
+++ b/components/server/ee/src/github/github-app-support.ts
@@ -42,7 +42,7 @@ export class GitHubAppSupport {
         const findInstallationForAccount = async (account: string) => {
             try {
                 return await appApi.apps.getUserInstallation({ username: account })
-            } catch (error) {
+            } catch (error: any) {
                 if (error instanceof RequestError) {
                     // ignore 404 - not found
                 } else {
@@ -53,8 +53,8 @@ export class GitHubAppSupport {
         const listReposForInstallation = async (installation: RestEndpointMethodTypes["apps"]["getUserInstallation"]["response"]) => {
             const sub = await probot.auth(installation.data.id);
             try {
-                const accessibleRepos = await sub.apps.listReposAccessibleToInstallation({ per_page: 100 });
-                return accessibleRepos.data.repositories.map(r => {
+                const accessibleRepos = (await sub.paginate(sub.rest.apps.listReposAccessibleToInstallation, { per_page: 100 }));
+                return accessibleRepos.repositories.map(r => {
                     return {
                         name: r.name,
                         cloneUrl: r.clone_url,
@@ -65,7 +65,7 @@ export class GitHubAppSupport {
                         installationUpdatedAt: installation.data.updated_at
                     };
                 });
-            } catch (error) {
+            } catch (error: any) {
                 if (error instanceof RequestError) {
                     // ignore 404 - not found
                 } else {


### PR DESCRIPTION


## Description
Fetch more repos per installation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5926

## How to test
Try to select repos for GH App installations on orgs with more than 100 repos. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Teams & Projects] Removes 100 repos limitation.
```
