### PR TITLE
[werft] fix let's encrypt cert expire issue

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -1,6 +1,38 @@
 import { exec } from './shell';
 import { sleep } from './util';
+import { readFileSync, writeFileSync } from 'fs';
 
+const deleteCA = `-----BEGIN CERTIFICATE-----
+MIIFYDCCBEigAwIBAgIQQAF3ITfU6UK47naqPGQKtzANBgkqhkiG9w0BAQsFADA/
+MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
+DkRTVCBSb290IENBIFgzMB4XDTIxMDEyMDE5MTQwM1oXDTI0MDkzMDE4MTQwM1ow
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwggIiMA0GCSqGSIb3DQEB
+AQUAA4ICDwAwggIKAoICAQCt6CRz9BQ385ueK1coHIe+3LffOJCMbjzmV6B493XC
+ov71am72AE8o295ohmxEk7axY/0UEmu/H9LqMZshftEzPLpI9d1537O4/xLxIZpL
+wYqGcWlKZmZsj348cL+tKSIG8+TA5oCu4kuPt5l+lAOf00eXfJlII1PoOK5PCm+D
+LtFJV4yAdLbaL9A4jXsDcCEbdfIwPPqPrt3aY6vrFk/CjhFLfs8L6P+1dy70sntK
+4EwSJQxwjQMpoOFTJOwT2e4ZvxCzSow/iaNhUd6shweU9GNx7C7ib1uYgeGJXDR5
+bHbvO5BieebbpJovJsXQEOEO3tkQjhb7t/eo98flAgeYjzYIlefiN5YNNnWe+w5y
+sR2bvAP5SQXYgd0FtCrWQemsAXaVCg/Y39W9Eh81LygXbNKYwagJZHduRze6zqxZ
+Xmidf3LWicUGQSk+WT7dJvUkyRGnWqNMQB9GoZm1pzpRboY7nn1ypxIFeFntPlF4
+FQsDj43QLwWyPntKHEtzBRL8xurgUBN8Q5N0s8p0544fAQjQMNRbcTa0B7rBMDBc
+SLeCO5imfWCKoqMpgsy6vYMEG6KDA0Gh1gXxG8K28Kh8hjtGqEgqiNx2mna/H2ql
+PRmP6zjzZN7IKw0KKP/32+IVQtQi0Cdd4Xn+GOdwiK1O5tmLOsbdJ1Fu/7xk9TND
+TwIDAQABo4IBRjCCAUIwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYw
+SwYIKwYBBQUHAQEEPzA9MDsGCCsGAQUFBzAChi9odHRwOi8vYXBwcy5pZGVudHJ1
+c3QuY29tL3Jvb3RzL2RzdHJvb3RjYXgzLnA3YzAfBgNVHSMEGDAWgBTEp7Gkeyxx
++tvhS5B1/8QVYIWJEDBUBgNVHSAETTBLMAgGBmeBDAECATA/BgsrBgEEAYLfEwEB
+ATAwMC4GCCsGAQUFBwIBFiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQu
+b3JnMDwGA1UdHwQ1MDMwMaAvoC2GK2h0dHA6Ly9jcmwuaWRlbnRydXN0LmNvbS9E
+U1RST09UQ0FYM0NSTC5jcmwwHQYDVR0OBBYEFHm0WeZ7tuXkAXOACIjIGlj26Ztu
+MA0GCSqGSIb3DQEBCwUAA4IBAQAKcwBslm7/DlLQrt2M51oGrS+o44+/yQoDFVDC
+5WxCu2+b9LRPwkSICHXM6webFGJueN7sJ7o5XPWioW5WlHAQU7G75K/QosMrAdSW
+9MUgNTP52GE24HGNtLi1qoJFlcDyqSMo59ahy2cI2qBDLKobkx/J3vWraV0T9VuG
+WCLKTVXkcGdtwlfFRjlBz4pYg1htmf5X6DYO8A4jqv2Il9DjXA6USbW1FzXSLr9O
+he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
+Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
+-----END CERTIFICATE-----`
 
 export class IssueCertificateParams {
     pathToTerraform: string
@@ -74,19 +106,29 @@ export async function issueCertficate(werft, params: IssueCertificateParams) {
 export async function installCertficate(werft, params: InstallCertificateParams) {
     let notReadyYet = true;
     werft.log('certificate', `copying certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`);
-    const cmd = `export KUBECONFIG=${params.pathToKubeConfig} && kubectl get secret ${params.certName} --namespace=${params.certNamespace} -o yaml \
+    const exportCert = `export KUBECONFIG=${params.pathToKubeConfig} && rm -f cert.yml tls.crt && kubectl get secret ${params.certName} --namespace=${params.certNamespace} -o yaml \
     | yq d - 'metadata.namespace' \
     | yq d - 'metadata.uid' \
     | yq d - 'metadata.resourceVersion' \
     | yq d - 'metadata.creationTimestamp' \
-    | sed 's/${params.certName}/${params.certSecretName}/g' \
+    | sed 's/${params.certName}/${params.certSecretName}/g' > cert.yml \
+    && yq r cert.yml data[tls.crt] | base64 -d > tls.crt`
+    
+    const importCert = `export KUBECONFIG=${params.pathToKubeConfig} && cat cert.yml \
+    | yq w - data.[tls.crt] $(cat tls.crt | base64 -w 0) \
     | kubectl apply --namespace=${params.destinationNamespace} -f -`
 
     for (let i = 0; i < 60 && notReadyYet; i++) {
-        const result = exec(cmd, { silent: true, dontCheckRc: true });
+        let result = exec(exportCert, { silent: true, dontCheckRc: true });
         if (result != undefined && result.code === 0) {
-            notReadyYet = false;
-            break;
+            let cert = readFileSync('tls.crt').toString()
+            cert = cert.replace(deleteCA, '')
+            writeFileSync('tls.crt', cert)
+            result = exec(importCert, { silent: true, dontCheckRc: true })
+            if (result != undefined && result.code === 0) {
+                notReadyYet = false;
+                break;
+            }
         }
         werft.log('certificate', `Could not copy "${params.certNamespace}/${params.certName}", will retry`);
         await sleep(5000);


### PR DESCRIPTION
## Description
Since Sept 30, let's encrypt `Cross Signing` root CA `DST Root CA X3` is expire, most browsers are working fine, but vscode doesn't
this PR delete expire rootCA section, hope it works


## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
exec `openssl s_client -connect pd-local-app-add-other-arch-support-fork.staging.gitpod-dev.com:443` 
and you can see 
![image](https://user-images.githubusercontent.com/8299500/136008375-fefa89ba-90ba-474d-b85a-13d669b8c8e3.png)

after delete ,there is not found `DST Root CA X3`
![image](https://user-images.githubusercontent.com/8299500/136008523-af4b65ba-cce5-4473-9752-c355375e1bbb.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
