### PR TITLE
Use the member's userId in removal

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1559,7 +1559,6 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         const user = this.checkAndBlockUser("deleteTeam");
         await this.guardTeamOperation(teamId, "delete");
 
-        await this.teamDB.deleteTeam(teamId);
         const teamProjects = await this.projectsService.getTeamProjects(teamId);
         teamProjects.forEach(project => {
             this.deleteProject(project.id);
@@ -1567,8 +1566,10 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
 
         const teamMembers = await this.teamDB.findMembersByTeam(teamId);
         teamMembers.forEach(member => {
-            this.removeTeamMember(teamId, userId);
+            this.removeTeamMember(teamId, member.userId);
         })
+
+        await this.teamDB.deleteTeam(teamId);
 
         return this.analytics.track({
             userId: user.id,


### PR DESCRIPTION
## Description
This fixes the bug where when a team is deleted, a member is still able to access a team's soft-deleted resources.

## Related Issue(s)
Fixes #6016

## How to test
1. Create a team
2. Add an owner and a member
3. Delete the team via /settings
4. Access the URL of the old team's projects e.g. `staging-url/t/some-team/projects`

## Release Notes
```release-note
NONE
```
