### PR TITLE
[changelog] updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## October 2021
+- [Teams] Fix Teams menu rendering even when there are backend errors ([#6041](https://github.com/gitpod-io/gitpod/pull/6041)) - [@jankeromnes](https://github.com/jankeromnes)
+- Fixed incorrectly defined types in the installer components ([#6020](https://github.com/gitpod-io/gitpod/pull/6020)) - [@MrSimonEmms](https://github.com/MrSimonEmms)
+- improve websocket reconnection handling in the frontend ([#6006](https://github.com/gitpod-io/gitpod/pull/6006)) - [@geropl](https://github.com/geropl)
 - Teams get a dedicated settings page where for now deletion can be done. ([#5966](https://github.com/gitpod-io/gitpod/pull/5966)) - [@laushinka](https://github.com/laushinka)
 - [db] add missing index `ind_dbsync` to table `d_b_code_sync_resource` ([#6005](https://github.com/gitpod-io/gitpod/pull/6005)) - [@geropl](https://github.com/geropl)
 - Make it possible to re-trigger failed or timed out Prebuilds ([#5836](https://github.com/gitpod-io/gitpod/pull/5836)) - [@jankeromnes](https://github.com/jankeromnes)


### PR DESCRIPTION
Updated the changelog from recent PR descriptions

```release-note
NONE
```
- [x] /werft no-preview
- [x] /werft no-test