### PR TITLE
[prebuild-logs] ignore other instances

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -35,7 +35,11 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
           setWorkspaceInstance(info.latestInstance);
         }
         disposables.push(getGitpodService().registerClient({
-          onInstanceUpdate: setWorkspaceInstance,
+          onInstanceUpdate: (instance) => {
+            if (props.workspaceId === instance.workspaceId) {
+              setWorkspaceInstance(instance);
+            }
+          },
           onWorkspaceImageBuildLogs: (info: WorkspaceImageBuild.StateInfo, content?: WorkspaceImageBuild.LogContent) => {
             if (!content) {
               return;


### PR DESCRIPTION

## Description
Prebuild logs should not react on instance updates of other workspaces. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Ref #5888

## How to test
<!-- Provide steps to test this PR -->
See https://github.com/gitpod-io/gitpod/issues/5888#issuecomment-936076775

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
