### PR TITLE
upgrade typescript compiler target to es6

### DIFF
--- a/components/content-service-api/typescript/tsconfig.json
+++ b/components/content-service-api/typescript/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/dashboard/tsconfig.json
+++ b/components/dashboard/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",

--- a/components/ee/db-sync/tsconfig.json
+++ b/components/ee/db-sync/tsconfig.json
@@ -9,7 +9,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "lib": [
             "es6",

--- a/components/gitpod-db/tsconfig.json
+++ b/components/gitpod-db/tsconfig.json
@@ -9,7 +9,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "lib": [
             "es6",

--- a/components/gitpod-messagebus/tsconfig.json
+++ b/components/gitpod-messagebus/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/gitpod-protocol/tsconfig.json
+++ b/components/gitpod-protocol/tsconfig.json
@@ -9,7 +9,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "lib": [
             "es6",

--- a/components/image-builder-api/typescript/tsconfig.json
+++ b/components/image-builder-api/typescript/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/licensor/typescript/tsconfig.json
+++ b/components/licensor/typescript/tsconfig.json
@@ -16,7 +16,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/local-app-api/typescript-grpcweb/tsconfig.json
+++ b/components/local-app-api/typescript-grpcweb/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6"
         ],

--- a/components/supervisor-api/typescript-grpc/tsconfig.json
+++ b/components/supervisor-api/typescript-grpc/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/supervisor-api/typescript-grpcweb/tsconfig.json
+++ b/components/supervisor-api/typescript-grpcweb/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/supervisor/frontend/tsconfig.json
+++ b/components/supervisor/frontend/tsconfig.json
@@ -3,7 +3,7 @@
     "rootDir": "src",
     "outDir": "lib",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "es6",
       "dom"

--- a/components/ws-daemon-api/typescript/tsconfig.json
+++ b/components/ws-daemon-api/typescript/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/ws-manager-api/typescript/tsconfig.json
+++ b/components/ws-manager-api/typescript/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,

--- a/components/ws-manager-bridge-api/typescript/tsconfig.json
+++ b/components/ws-manager-bridge-api/typescript/tsconfig.json
@@ -15,7 +15,7 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
## Description
upgrade typescript compiler target to es6
it can reduce compile cost and boost performance a little

![image](https://user-images.githubusercontent.com/8299500/136202635-1da851dd-647a-43b8-b32d-4a7c809598bb.png)
and fix this problem from dashboard (515720ad8210f6718d6fb3c41509e0bd93fd669a)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
