### PR TITLE
[dashboard] sort projects by activity

### DIFF
--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -73,6 +73,10 @@ export default function () {
         return true;
     }
 
+    function hasNewerPrebuild(p0: Project, p1: Project): number {
+        return moment(lastPrebuilds.get(p1.id)?.info?.startedAt || '1970-01-01').diff(moment(lastPrebuilds.get(p0.id)?.info?.startedAt || '1970-01-01'));
+    }
+
     const teamOrUserSlug = !!team ? 't/'+team.slug : 'projects';
 
     return <>
@@ -105,7 +109,7 @@ export default function () {
                     <button className="ml-2" onClick={() => onNewProject()}>New Project</button>
                 </div>
                 <div className="mt-4 grid grid-cols-3 gap-4">
-                    {projects.filter(filter).map(p => (<div key={`project-${p.id}`} className="h-52">
+                    {projects.filter(filter).sort(hasNewerPrebuild).map(p => (<div key={`project-${p.id}`} className="h-52">
                         <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
                             <div className="h-32 p-6">
                                 <div className="flex text-xl font-semibold text-gray-700 dark:text-gray-200 font-medium">


### PR DESCRIPTION
## Description
Project list is now sorted by most recent pre-build

## Related Issue(s)
Fixes #6062

## How to test
1) Create a project with a pre-build
2) in the same team, create a project without a pre-build -> project should appear after the first one in the projects list
3) go to configuration and start a prebuild -> project should move before the first one in the projects list

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Projects in the dashboard are now sorted by most recent pre-build
```
