### PR TITLE
Truncate commit message on branches and prebuilds

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -179,8 +179,8 @@ export default function () {
                         </a>
                     </ItemField>
                     <ItemField className="flex items-center">
-                        <div>
-                            <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1">{shortCommitMessage(p.info.changeTitle)}</div>
+                        <div className="truncate">
+                            <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate">{shortCommitMessage(p.info.changeTitle)}</div>
                             <p>{p.info.changeAuthorAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={p.info.changeAuthorAvatar || ''} alt={p.info.changeAuthor} />}Authored {formatDate(p.info.changeDate)} · {p.info.changeHash?.substring(0, 8)}</p>
                         </div>
                     </ItemField>

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -230,8 +230,8 @@ export default function () {
                                 </div>
                             </ItemField>
                             <ItemField className="flex items-center">
-                                <div>
-                                    <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1">{shortCommitMessage(branch.changeTitle)}</div>
+                                <div className="truncate">
+                                    <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate">{shortCommitMessage(branch.changeTitle)}</div>
                                     <p>{avatar}Authored {formatDate(branch.changeDate)} · {branch.changeHash?.substring(0, 8)}</p>
                                 </div>
                             </ItemField>


### PR DESCRIPTION
## Description

This will truncate the commit message on branches and prebuilds.

## Related Issue(s)

Fix https://github.com/gitpod-io/gitpod/issues/5335

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2021-10-06 at 6 39 42 PM (2)" src="https://user-images.githubusercontent.com/120486/136237075-2f7d2e60-8a05-4ec6-a4a9-2a3e1b6e64b4.png"> | <img width="1440" alt="Screenshot 2021-10-06 at 6 39 55 PM (2)" src="https://user-images.githubusercontent.com/120486/136237081-e6694ebc-6003-4e37-ab3b-ababecd29d65.png"> |

## How to test

1. Add a project with a long commit message on the default branch
2. Trigger a prebuild for the default branch
3. Check out the branches and prebuilds pages for that project

## Release Notes

```release-note
Truncate commit message on branches and prebuilds
```
