### PR TITLE
Properly update jb dependencies

### DIFF
--- a/.werft/util/observability.ts
+++ b/.werft/util/observability.ts
@@ -27,15 +27,13 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
     werft.log(sliceName, `Updating Gitpod's mixin in monitoring-satellite's jsonnetfile.json to latest commit SHA: ${currentCommit}`);
 
     let jsonnetFile = JSON.parse(fs.readFileSync(`${pwd}/observability/jsonnetfile.json`, 'utf8'));
-    let gitSource = ""
     jsonnetFile.dependencies.forEach(dep => {
         if(dep.name == 'gitpod') {
             dep.version = currentCommit
-            gitSource = dep.source.git.remote
         }
     });
     fs.writeFileSync(`${pwd}/observability/jsonnetfile.json`, JSON.stringify(jsonnetFile));
-    exec(`cd observability && jb update ${gitSource}`, {slice: sliceName})
+    exec(`cd observability && jb update`, {slice: sliceName})
 
     let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
     --ext-str is_preview="true" \


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Grafana in preview environments is not showing changes made to mixins.

That is because the jsonnet-bundler command that updates the dependencies inside the werft job is wrong.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/cc @laushinka 