### PR TITLE
[ws-manager] Skip backups for image builds

### DIFF
--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -408,6 +408,18 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 			result.Phase = api.WorkspacePhase_STOPPED
 		}
 
+		// image builds are normal workspaces but with no backups.
+		if wso.IsWorkspaceHeadless() {
+			switch wsk8s.GetWorkspaceType(pod) {
+			case "imagebuild":
+				result.Conditions.FinalBackupComplete = api.WorkspaceConditionBool_FALSE
+			case "prebuild":
+				result.Conditions.FinalBackupComplete = api.WorkspaceConditionBool_FALSE
+			}
+			result.Phase = api.WorkspacePhase_STOPPED
+			return nil
+		}
+
 		if rawDisposalStatus, ok := pod.Annotations[disposalStatusAnnotation]; ok {
 			var ds workspaceDisposalStatus
 			err := json.Unmarshal([]byte(rawDisposalStatus), &ds)

--- a/components/ws-manager/pkg/manager/testdata/status_prebuildFail_STOPPED00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_prebuildFail_STOPPED00.golden
@@ -81,7 +81,6 @@
         "conditions": {
             "service_exists": 1,
             "snapshot": "workspaces/gray-lemming-0wlyvzy5/snapshot-1622467387276004249.tar@gitpod-user-a0dfe7e6-351b-4fd8-80c2-5ed45814f44a",
-            "final_backup_complete": 1,
             "deployed": 1
         },
         "runtime": {

--- a/components/ws-manager/pkg/manager/testdata/status_prebuildSuccess_STOPPED00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_prebuildSuccess_STOPPED00.golden
@@ -81,7 +81,6 @@
         "conditions": {
             "service_exists": 1,
             "snapshot": "workspaces/green-wombat-62dzneud/snapshot-1622206186881521445.tar@gitpod-user-d98c5b92-2066-4fce-bea6-1e08b58642ab",
-            "final_backup_complete": 1,
             "deployed": 1
         },
         "runtime": {


### PR DESCRIPTION
## Description

Workspace of type `imagebuild` and `prebuild` does not need backups.

## Release Notes
```release-note
NONE
```
