### PR TITLE
Laushinka/rate limit 6108

### DIFF
--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -34,7 +34,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         default: {
             points: 60000, // 1,000 calls per user per second
             durationsSec: 60,
-        },
+        }
     }
     const defaultFunctions: FunctionsConfig = {
         "getLoggedInUser": { group: "default", points: 1 },

--- a/operations/observability/mixins/meta/dashboards/components/server.json
+++ b/operations/observability/mixins/meta/dashboards/components/server.json
@@ -49,7 +49,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1633610554136,
+  "iteration": 1633704520775,
   "links": [],
   "panels": [
     {
@@ -575,7 +575,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 18
       },
@@ -612,8 +612,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 18
       },
       "hiddenSeries": false,
@@ -691,6 +691,87 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(gitpod_server_api_calls_user_total{cluster=~\"$cluster\", method=~\"ts.*\"}[5m])) by (cluster, method) * 60",
+          "interval": "",
+          "legendFormat": "{{cluster}} {{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Team slot method calls",
+      "type": "timeseries"
     },
     {
       "collapsed": true,
@@ -2617,5 +2698,5 @@
   "timezone": "utc",
   "title": "Gitpod / Component / server",
   "uid": "server",
-  "version": 1
+  "version": 3
 }


### PR DESCRIPTION
## Description
Creates a Grafana panel for the above-mentioned methods.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6108

## How to test
For the Grafana panel:
1. Go to https://grafana-laushinka-rate-limit-6108.preview.gitpod-dev.com/d/server/gitpod-component-server
2. Expand "Server Metrics" and find the panel "Team slot method calls"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

<img width="575" alt="Screenshot 2021-10-11 at 11 35 46" src="https://user-images.githubusercontent.com/8015191/136768181-74fa3496-51cb-4212-be56-7e8659e4a16d.png">

- [x] /werft with-payment
- [x] /werft with-clean-slate-deployment