### PR TITLE
Add support for `deployDisabled` config in OpenVSX proxy helm templates

### DIFF
--- a/chart/templates/openvsx-proxy-configmap.yaml
+++ b/chart/templates/openvsx-proxy-configmap.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{ if not .Values.components.openVsxProxy.disabled -}}
+{{ if and (not .Values.components.openVsxProxy.disabled) (not .Values.components.openVsxProxy.deployDisabled) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/templates/openvsx-proxy-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/openvsx-proxy-deny-all-allow-explicit-networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ if .Values.installNetworkPolicies -}}
-{{ if not .Values.components.openVsxProxy.disabled -}}
+{{ if and (not .Values.components.openVsxProxy.disabled) (not .Values.components.openVsxProxy.deployDisabled) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/openvsx-proxy-rolebinding.yaml
+++ b/chart/templates/openvsx-proxy-rolebinding.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{ if not .Values.components.openVsxProxy.disabled -}}
+{{ if and (not .Values.components.openVsxProxy.disabled) (not .Values.components.openVsxProxy.deployDisabled) -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -22,7 +22,7 @@ roleRef:
 
 ---
 
-{{ if not .Values.components.openVsxProxy.disabled -}}
+{{ if and (not .Values.components.openVsxProxy.disabled) (not .Values.components.openVsxProxy.deployDisabled) -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/chart/templates/openvsx-proxy-service.yaml
+++ b/chart/templates/openvsx-proxy-service.yaml
@@ -1,4 +1,6 @@
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if and (not .Values.components.openVsxProxy.disabled) (not .Values.components.openVsxProxy.deployDisabled) -}}
 {{ template "gitpod.service.default" dict "root" . "gp" .Values "comp" .Values.components.openVsxProxy }}
+{{ end }}

--- a/chart/templates/openvsx-proxy-serviceaccount.yaml
+++ b/chart/templates/openvsx-proxy-serviceaccount.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{ if not .Values.components.openVsxProxy.disabled -}}
+{{ if and (not .Values.components.openVsxProxy.disabled) (not .Values.components.openVsxProxy.deployDisabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/templates/openvsx-proxy-statefulset.yaml
+++ b/chart/templates/openvsx-proxy-statefulset.yaml
@@ -3,7 +3,7 @@
 
 {{ $comp := .Values.components.openVsxProxy -}}
 {{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
-{{- if not $comp.disabled -}}
+{{- if and (not $comp.disabled) (not $comp.deployDisabled) -}}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
This change enables to deploy the OpenVSX component independently of the other meta components.

When we set `openVsxProxy.disabled=false` and `openVsxProxy.deployDisabled=true` in the `values.yaml` file it prepares everything for the OpenVSX proxy in other components (`server` and `blobserve`) but does not deploys the OpenVSX proxy itself.

/cc @akosyakov 




```release-note
NONE
```
