### PR TITLE
[gp-cli] Add `gp stop` command

### DIFF
--- a/components/gitpod-cli/cmd/stop-workspace.go
+++ b/components/gitpod-cli/cmd/stop-workspace.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/spf13/cobra"
+)
+
+// stopWorkspaceCmd represents the stopWorkspaceCmd command
+var stopWorkspaceCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop current workspace",
+	Args:  cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			fail(err.Error())
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:stopWorkspace",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+		err = client.StopWorkspace(ctx, wsInfo.WorkspaceId)
+		if err != nil {
+			fail(err.Error())
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(stopWorkspaceCmd)
+}

--- a/components/gitpod-cli/pkg/gitpod/server.go
+++ b/components/gitpod-cli/pkg/gitpod/server.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"context"
+	"os"
+
+	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
+	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/xerrors"
+	"google.golang.org/grpc"
+)
+
+func GetWSInfo(ctx context.Context) (*supervisor.WorkspaceInfoResponse, error) {
+	supervisorAddr := os.Getenv("SUPERVISOR_ADDR")
+	if supervisorAddr == "" {
+		supervisorAddr = "localhost:22999"
+	}
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	if err != nil {
+		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
+	}
+	defer supervisorConn.Close()
+	wsinfo, err := supervisor.NewInfoServiceClient(supervisorConn).WorkspaceInfo(ctx, &supervisor.WorkspaceInfoRequest{})
+	if err != nil {
+		return nil, xerrors.Errorf("failed getting workspace info from supervisor: %w", err)
+	}
+	return wsinfo, nil
+}
+
+func ConnectToServer(ctx context.Context, wsInfo *supervisor.WorkspaceInfoResponse, scope []string) (*serverapi.APIoverJSONRPC, error) {
+	supervisorAddr := os.Getenv("SUPERVISOR_ADDR")
+	if supervisorAddr == "" {
+		supervisorAddr = "localhost:22999"
+	}
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	if err != nil {
+		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
+	}
+	defer supervisorConn.Close()
+	clientToken, err := supervisor.NewTokenServiceClient(supervisorConn).GetToken(ctx, &supervisor.GetTokenRequest{
+		Host:  wsInfo.GitpodApi.Host,
+		Kind:  "gitpod",
+		Scope: scope,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed getting token from supervisor: %w", err)
+	}
+	client, err := serverapi.ConnectToServer(wsInfo.GitpodApi.Endpoint, serverapi.ConnectToServerOpts{
+		Token:   clientToken.Token,
+		Context: ctx,
+		Log:     log.NewEntry(log.StandardLogger()),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed connecting to server: %w", err)
+	}
+	return client, nil
+}


### PR DESCRIPTION
## Description
Add `gp stop` command

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5195

## How to test
<!-- Provide steps to test this PR -->
Run workspace
exec `gp stop`
see workspace is terminating
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
