### PR TITLE
[.gitpod.yml] Remove agent smith BPF dev env task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,11 +36,10 @@ ports:
   - port: 1234
     onOpen: ignore
 tasks:
-  - name: Prepare Agent Smith BPF dev environment
-    command: leeway run components/ee/agent-smith:qemu
   - name: Java
     init: leeway exec --package components/supervisor-api/java:lib -- ./gradlew jar
-  - before: scripts/branch-namespace.sh
+  - name: TypeScript
+    before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build
   - name: Go
     init: leeway exec --filter-type go -v -- go mod verify


### PR DESCRIPTION
## Description
Removes the agent smith BPF dev env task from `.gitpod.yml` file ([internal discussion](https://gitpod.slack.com/archives/C01KGM9AW4W/p1633952583010000)).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Meta
/werft no-preview
/cc @jankeromnes 