### PR TITLE
[common-go] Adjust log level and ping keepalive interval

### DIFF
--- a/components/common-go/grpc/grpc.go
+++ b/components/common-go/grpc/grpc.go
@@ -61,7 +61,7 @@ func DefaultClientOptions() []grpc.DialOption {
 			Backoff: bfConf,
 		}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                5 * time.Second,
+			Time:                10 * time.Second,
 			Timeout:             time.Second,
 			PermitWithoutStream: true,
 		}),
@@ -85,7 +85,7 @@ func ServerOptionsWithInterceptors(stream []grpc.StreamServerInterceptor, unary 
 	return []grpc.ServerOption{
 		// terminate the connection if the client pings more than once every 2 seconds
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             2 * time.Second,
+			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),
 		grpc.MaxRecvMsgSize(maxMsgSize),
@@ -101,7 +101,7 @@ func ServerOptionsWithInterceptors(stream []grpc.StreamServerInterceptor, unary 
 
 func SetupLogging() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(
-		log.WithField("component", "grpc").WriterLevel(logrus.InfoLevel),
+		log.WithField("component", "grpc").WriterLevel(logrus.DebugLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.WarnLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.ErrorLevel),
 	))


### PR DESCRIPTION
## Description

Switch from info level to debug. The goal of this change is to reduce the verbosity of GRPC logs (mostly related to the setup of connections). Also, change the default ping interval to 10s (valid min value)

From grpc docs `// If set below 10s, a minimum value of 10s will be used instead.`

## Release Notes
```release-note
NONE
```
