### PR TITLE
Update team plans page header

### DIFF
--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -427,7 +427,7 @@ function AllTeams() {
     const renderTeams = () => (<React.Fragment>
         <div className="flex flex-row">
             <div className="flex-grow ">
-                <h3 className="self-center">All Teams</h3>
+                <h3 className="self-center">All Team Plans</h3>
                 <h2>Manage team plans and team members.</h2>
             </div>
             <div className="flex flex-end space-x-3">


### PR DESCRIPTION
## Description

Follow up from https://github.com/gitpod-io/gitpod/pull/6011. 

## How to test

1. Go to `/teams`
2. See the new page header (All Team Plans)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```