### PR TITLE
Update header padding

### DIFF
--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -20,7 +20,7 @@ export default function Header(p: HeaderProps) {
         document.title = `${p.title} — Gitpod`;
     }, []);
     return <div className="lg:px-28 px-10 border-gray-200 dark:border-gray-800">
-        <div className="flex py-10">
+        <div className="flex pb-8 pt-6">
             <div className="">
                 {typeof p.title === "string" ? (<h1 className="tracking-tight">{p.title}</h1>) : p.title}
                 {typeof p.subtitle === "string" ? (<h2 className="tracking-wide">{p.subtitle}</h2>) : p.subtitle}


### PR DESCRIPTION
## Description

Follow up from https://github.com/gitpod-io/gitpod/pull/5555/files#r714938307.


## How to test
1. Go to any dashboard page
2. Header padding should feel better 😁 

| BEFORE | AFTER |
|-|-|
| <img width="398" alt="header-before" src="https://user-images.githubusercontent.com/120486/136851537-d9f56ce4-7da5-408c-9713-1bece26b2684.png"> | <img width="398" alt="header-after" src="https://user-images.githubusercontent.com/120486/136851543-ec3136a4-6e53-4b78-a038-9f60225ffbfb.png"> |

## Release Notes
```release-note
NONE
```