### PR TITLE
Refactor GRPC TLS connection defaults

### DIFF
--- a/components/common-go/grpc/grpc.go
+++ b/components/common-go/grpc/grpc.go
@@ -5,6 +5,10 @@
 package grpc
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -14,6 +18,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/grpclog"
@@ -105,4 +110,112 @@ func SetupLogging() {
 		log.WithField("component", "grpc").WriterLevel(logrus.WarnLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.ErrorLevel),
 	))
+}
+
+// TLSConfigOption configures a TLSConfig
+type TLSConfigOption func(*tlsConfigOptions) error
+
+type tlsConfigOptions struct {
+	ClientAuth tls.ClientAuthType
+	ServerName string
+
+	RootCAs   bool
+	ClientCAs bool
+}
+
+// WithClientAuth configures a policy for TLS Client Authentication
+func WithClientAuth(authType tls.ClientAuthType) TLSConfigOption {
+	return func(ico *tlsConfigOptions) error {
+		ico.ClientAuth = authType
+		return nil
+	}
+}
+
+// WithServerName configures thge ServerName used to verify the hostname
+func WithServerName(serverName string) TLSConfigOption {
+	return func(ico *tlsConfigOptions) error {
+		ico.ServerName = serverName
+		return nil
+	}
+}
+
+func WithSetRootCAs(rootCAs bool) TLSConfigOption {
+	return func(ico *tlsConfigOptions) error {
+		ico.RootCAs = rootCAs
+		return nil
+	}
+}
+
+func WithSetClientCAs(clientCAs bool) TLSConfigOption {
+	return func(ico *tlsConfigOptions) error {
+		ico.ClientCAs = clientCAs
+		return nil
+	}
+}
+
+func ClientAuthTLSConfig(authority, certificate, privateKey string, opts ...TLSConfigOption) (*tls.Config, error) {
+	// Telepresence (used for debugging only) requires special paths to load files from
+	if root := os.Getenv("TELEPRESENCE_ROOT"); root != "" {
+		authority = filepath.Join(root, authority)
+		certificate = filepath.Join(root, certificate)
+		privateKey = filepath.Join(root, privateKey)
+	}
+
+	// Load certs
+	tlsCertificate, err := tls.LoadX509KeyPair(certificate, privateKey)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot load TLS certificate: %w", err)
+	}
+
+	// Create a certificate pool from the certificate authority
+	certPool := x509.NewCertPool()
+	ca, err := os.ReadFile(authority)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot not read ca certificate: %w", err)
+	}
+
+	if ok := certPool.AppendCertsFromPEM(ca); !ok {
+		return nil, xerrors.Errorf("failed to append ca certs")
+	}
+
+	options := tlsConfigOptions{}
+	for _, o := range opts {
+		err := o(&options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{tlsCertificate},
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		},
+		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
+		MinVersion:       tls.VersionTLS12,
+		MaxVersion:       tls.VersionTLS12,
+		NextProtos:       []string{"h2"},
+	}
+
+	tlsConfig.ServerName = options.ServerName
+
+	if options.ClientAuth != tls.NoClientCert {
+		log.WithField("clientAuth", options.ClientAuth).Info("enabling client authentication")
+		tlsConfig.ClientAuth = options.ClientAuth
+	}
+
+	if options.ClientCAs {
+		tlsConfig.ClientCAs = certPool
+	}
+
+	if options.RootCAs {
+		tlsConfig.RootCAs = certPool
+	}
+
+	return tlsConfig, nil
 }

--- a/components/ee/ws-scheduler/pkg/scaler/driver.go
+++ b/components/ee/ws-scheduler/pkg/scaler/driver.go
@@ -6,10 +6,6 @@ package scaler
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"os"
-	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -81,43 +77,16 @@ func NewWorkspaceManagerPrescaleDriver(config WorkspaceManagerPrescaleDriverConf
 
 	grpcOpts := common_grpc.DefaultClientOptions()
 	if config.WsManager.TLS != nil {
-		ca := config.WsManager.TLS.CA
-		crt := config.WsManager.TLS.Certificate
-		key := config.WsManager.TLS.PrivateKey
-
-		// Telepresence (used for debugging only) requires special paths to load files from
-		if root := os.Getenv("TELEPRESENCE_ROOT"); root != "" {
-			ca = filepath.Join(root, ca)
-			crt = filepath.Join(root, crt)
-			key = filepath.Join(root, key)
-		}
-
-		rootCA, err := os.ReadFile(ca)
-		if err != nil {
-			return nil, xerrors.Errorf("could not read ca certificate: %s", err)
-		}
-		certPool := x509.NewCertPool()
-		if ok := certPool.AppendCertsFromPEM(rootCA); !ok {
-			return nil, xerrors.Errorf("failed to append ca certs")
-		}
-
-		certificate, err := tls.LoadX509KeyPair(crt, key)
+		tlsConfig, err := common_grpc.ClientAuthTLSConfig(
+			config.WsManager.TLS.CA, config.WsManager.TLS.Certificate, config.WsManager.TLS.PrivateKey,
+			common_grpc.WithSetRootCAs(true),
+		)
 		if err != nil {
 			log.WithField("config", config.WsManager.TLS).Error("Cannot load ws-manager certs - this is a configuration issue.")
 			return nil, xerrors.Errorf("cannot load ws-manager certs: %w", err)
 		}
 
-		creds := credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{certificate},
-			RootCAs:      certPool,
-			MinVersion:   tls.VersionTLS12,
-		})
-		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(creds))
-		log.
-			WithField("ca", ca).
-			WithField("cert", crt).
-			WithField("key", key).
-			Debug("using TLS config to connect ws-manager")
+		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {
 		grpcOpts = append(grpcOpts, grpc.WithInsecure())
 	}

--- a/components/image-builder-api/go/config/config.go
+++ b/components/image-builder-api/go/config/config.go
@@ -6,12 +6,12 @@ package config
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	//wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
+
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io/ioutil"
+
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 )
 
 type PProf struct {
@@ -48,29 +48,17 @@ func (c *TLSConfig) ServerOption() (grpc.ServerOption, error) {
 		return nil, nil
 	}
 
-	// Load certs
-	certificate, err := tls.LoadX509KeyPair(c.Certificate, c.PrivateKey)
+	tlsConfig, err := common_grpc.ClientAuthTLSConfig(
+		c.Authority, c.Certificate, c.PrivateKey,
+		common_grpc.WithSetClientCAs(true),
+		common_grpc.WithClientAuth(tls.RequireAndVerifyClientCert),
+		common_grpc.WithServerName("ws-manager"),
+	)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot load TLS certificate: %w", err)
+		return nil, xerrors.Errorf("cannot load certs: %w", err)
 	}
 
-	// Create a certificate pool from the certificate authority
-	certPool := x509.NewCertPool()
-	ca, err := ioutil.ReadFile(c.Authority)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot not read ca certificate: %w", err)
-	}
-	if ok := certPool.AppendCertsFromPEM(ca); !ok {
-		return nil, xerrors.Errorf("failed to append ca certs")
-	}
-
-	creds := credentials.NewTLS(&tls.Config{
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		Certificates: []tls.Certificate{certificate},
-		ClientCAs:    certPool,
-	})
-
-	return grpc.Creds(creds), nil
+	return grpc.Creds(credentials.NewTLS(tlsConfig)), nil
 }
 
 // Configuration configures the orchestrator

--- a/components/image-builder/cmd/root.go
+++ b/components/image-builder/cmd/root.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	"github.com/gitpod-io/gitpod/image-builder/pkg/builder"
@@ -109,28 +109,15 @@ func (c *tlsConfig) ServerOption() (grpc.ServerOption, error) {
 		return nil, nil
 	}
 
-	// Load certs
-	certificate, err := tls.LoadX509KeyPair(c.Certificate, c.PrivateKey)
+	tlsConfig, err := common_grpc.ClientAuthTLSConfig(
+		c.Authority, c.Certificate, c.PrivateKey,
+		common_grpc.WithClientAuth(tls.RequireAndVerifyClientCert),
+		common_grpc.WithSetClientCAs(true),
+		common_grpc.WithServerName("ws-manager"),
+	)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot load TLS certificate: %w", err)
+		return nil, xerrors.Errorf("cannot load certs: %w", err)
 	}
 
-	// Create a certificate pool from the certificate authority
-	certPool := x509.NewCertPool()
-	ca, err := os.ReadFile(c.Authority)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot not read ca certificate: %w", err)
-	}
-	if ok := certPool.AppendCertsFromPEM(ca); !ok {
-		return nil, xerrors.Errorf("failed to append ca certs")
-	}
-
-	creds := credentials.NewTLS(&tls.Config{
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		Certificates: []tls.Certificate{certificate},
-		ClientCAs:    certPool,
-		MinVersion:   tls.VersionTLS12,
-	})
-
-	return grpc.Creds(creds), nil
+	return grpc.Creds(credentials.NewTLS(tlsConfig)), nil
 }

--- a/components/ws-daemon/pkg/config/config.go
+++ b/components/ws-daemon/pkg/config/config.go
@@ -6,13 +6,13 @@ package config
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"os"
 
-	"github.com/gitpod-io/gitpod/ws-daemon/pkg/daemon"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/daemon"
 )
 
 type Config struct {
@@ -42,28 +42,15 @@ func (c *TLS) ServerOption() (grpc.ServerOption, error) {
 		return nil, nil
 	}
 
-	// Load certs
-	certificate, err := tls.LoadX509KeyPair(c.Certificate, c.PrivateKey)
+	tlsConfig, err := common_grpc.ClientAuthTLSConfig(
+		c.Authority, c.Certificate, c.PrivateKey,
+		common_grpc.WithClientAuth(tls.RequireAndVerifyClientCert),
+		common_grpc.WithSetClientCAs(true),
+		common_grpc.WithServerName("ws-manager"),
+	)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot load TLS certificate: %w", err)
+		return nil, xerrors.Errorf("cannot load certs: %w", err)
 	}
 
-	// Create a certificate pool from the certificate authority
-	certPool := x509.NewCertPool()
-	ca, err := os.ReadFile(c.Authority)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot not read ca certificate: %w", err)
-	}
-	if ok := certPool.AppendCertsFromPEM(ca); !ok {
-		return nil, xerrors.Errorf("failed to append ca certs")
-	}
-
-	creds := credentials.NewTLS(&tls.Config{
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		Certificates: []tls.Certificate{certificate},
-		ClientCAs:    certPool,
-		MinVersion:   tls.VersionTLS12,
-	})
-
-	return grpc.Creds(creds), nil
+	return grpc.Creds(credentials.NewTLS(tlsConfig)), nil
 }

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -6,10 +6,7 @@ package proxy
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strconv"
 	"sync"
@@ -143,28 +140,17 @@ func (p *RemoteWorkspaceInfoProvider) Run() (err error) {
 	target := p.Config.WsManagerAddr
 	dialOption := grpc.WithInsecure()
 	if p.Config.TLS.CA != "" && p.Config.TLS.Cert != "" && p.Config.TLS.Key != "" {
-		log.
-			WithField("ca", p.Config.TLS.CA).
-			WithField("cert", p.Config.TLS.Cert).
-			WithField("key", p.Config.TLS.Key).
-			Debug("using TLS config to connect ws-manager")
-		certPool := x509.NewCertPool()
-		ca, err := ioutil.ReadFile(p.Config.TLS.CA)
+		tlsConfig, err := common_grpc.ClientAuthTLSConfig(
+			p.Config.TLS.CA, p.Config.TLS.Cert, p.Config.TLS.Key,
+			common_grpc.WithSetRootCAs(true),
+			common_grpc.WithServerName("ws-manager"),
+		)
 		if err != nil {
-			return err
+			log.WithField("config", p.Config.TLS).Error("Cannot load ws-manager certs - this is a configuration issue.")
+			return xerrors.Errorf("cannot load ws-manager certs: %w", err)
 		}
-		if !certPool.AppendCertsFromPEM(ca) {
-			return xerrors.Errorf("failed appending CA cert")
-		}
-		cert, err := tls.LoadX509KeyPair(p.Config.TLS.Cert, p.Config.TLS.Key)
-		if err != nil {
-			return err
-		}
-		creds := credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      certPool,
-		})
-		dialOption = grpc.WithTransportCredentials(creds)
+
+		dialOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 	conn, client, err := p.Dialer(target, dialOption)
 	if err != nil {


### PR DESCRIPTION
## Description

Refactor `TLSConfig` to be more strict. In particular, disable tls1.3.

**Changes:**
- CurvePreferences: tls.X25519, tls.CurveP256
- TLS versions (min/max) to tls.VersionTLS12
- Enable h2 setting	`NextProtos`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Refactor GRPC TLS connection defaults
```

xref: https://github.com/gitpod-io/gitpod/issues/5301