### PR TITLE
[ws-manager-api] Change log level for ws-manager unavailable

### DIFF
--- a/components/ws-manager-api/typescript/src/promisified-client.ts
+++ b/components/ws-manager-api/typescript/src/promisified-client.ts
@@ -46,7 +46,7 @@ async function linearBackoffRetry<Res>(run: (attempt: number) => Promise<Res>, a
                 throw err;
             }
 
-            console.debug(`ws-manager unavailable - retrying in ${delayMS}ms`);
+            console.warn(`ws-manager unavailable - retrying in ${delayMS}ms`);
             await new Promise((retry, _) => setTimeout(retry, delayMS));
         }
 
@@ -55,7 +55,7 @@ async function linearBackoffRetry<Res>(run: (attempt: number) => Promise<Res>, a
         }
     }
 
-    console.debug(`ws-manager unavailable - no more attempts left`);
+    console.error(`ws-manager unavailable - no more attempts left`);
     throw error;
 }
 


### PR DESCRIPTION
## Description

We should not require enabling `debug` log level to get messages about `ws-manager` being unavailable

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
