### PR TITLE
[gitpod-protocol] Adjust typescript GRPC options

### DIFF
--- a/components/gitpod-protocol/src/util/grpc.ts
+++ b/components/gitpod-protocol/src/util/grpc.ts
@@ -5,9 +5,9 @@
  */
 
  export const defaultGRPCOptions = {
-    "grpc.keepalive_timeout_ms": 1000,
-    "grpc.keepalive_time_ms": 5000,
-    "grpc.http2.min_time_between_pings_ms": 1000,
+    "grpc.keepalive_timeout_ms": 10000,
+    "grpc.keepalive_time_ms": 60000,
+    "grpc.http2.min_time_between_pings_ms": 10000,
     "grpc.keepalive_permit_without_calls": 1,
     "grpc-node.max_session_memory": 50,
     "grpc.max_reconnect_backoff_ms": 5000,


### PR DESCRIPTION
## Description

After https://github.com/gitpod-io/gitpod/pull/6148 we need to adjust the typescript side of GRPC settings to avoid errors related to frequent pings

```
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","serviceContext":{"service":"ws-manager-bridge","version":"<ts-not-set>"},"component":"ws-manager-bridge","severity":"ERROR","time":"2021-10-11T23:35:42.397Z","environment":"devstaging","message":"Connection to dns:///ws-manager:8080 at 10.100.8.159:8080 rejected by server because of excess pings. Increasing ping interval to 10000 ms","loggedViaConsole":true}
```

## How to test
<!-- Provide steps to test this PR -->

Check `ws-manager-bridge` log. There should not be any reference to `rejected by server because of excess pings`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gitpod-protocol] Adjust typescript GRPC options
```
