### PR TITLE
(Partially) revert #6148

### DIFF
--- a/components/common-go/grpc/grpc.go
+++ b/components/common-go/grpc/grpc.go
@@ -101,7 +101,7 @@ func ServerOptionsWithInterceptors(stream []grpc.StreamServerInterceptor, unary 
 
 func SetupLogging() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(
-		log.WithField("component", "grpc").WriterLevel(logrus.InfoLevel),
+		log.WithField("component", "grpc").WriterLevel(logrus.DebugLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.WarnLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.ErrorLevel),
 	))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes https://console.cloud.google.com/logs/query;query=error_group%2528%22CISRmNnx2fnk5wE%22%2529%0AlogName:%22stderr%22%0Aresource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22stag-meta-eu01%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.container_name%3D%22ws-manager-bridge%22;timeRange=2021-10-12T07:31:53.386Z%2F2021-10-12T08:31:53.386Z;cursorTimestamp=2021-10-12T07:54:47.218Z?project=gitpod-staging:
```
Connection to dns:35.189.223.37:8080 at 35.189.223.37:8080 rejected by server because of excess pings. Increasing ping interval to 10000 ms
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- `kubectl -n staging-gpl-revert-6148 logs ws-manager-bridge-7d9c7bddc6-gv9m7 ws-manager-bridge -f` does not show any reconnection issues anymore

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
