### PR TITLE
[database]: allow configuring of db username with DB_USERNAME envvar

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -208,6 +208,8 @@ env:
 {{- $gp := .gp -}}
 - name: DB_HOST
   value: "{{ $gp.db.host }}"
+- name: DB_USERNAME
+  value: "{{ $gp.db.username }}"
 - name: DB_PORT
   value: "{{ $gp.db.port }}"
 - name: DB_PASSWORD

--- a/chart/templates/db-migrations-job.yaml
+++ b/chart/templates/db-migrations-job.yaml
@@ -43,6 +43,8 @@ spec:
       - name: db-migrations
         image: "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" .Values "comp" $.Values.components.dbMigrations) }}"
         env:
+        - name: "DB_USERNAME"
+          value: "{{ $.Values.db.username }}"
         - name: "DB_PASSWORD"
           value: "{{ $.Values.db.password }}"
         - name: "DB_PORT"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -62,6 +62,7 @@ workspaceSizing:
 db:
   host: db
   port: 3306
+  username: gitpod
   password: test
 
 defaults:

--- a/components/gitpod-db/src/config.ts
+++ b/components/gitpod-db/src/config.ts
@@ -16,7 +16,7 @@ export class Config {
         const dbSetup = {
             host: process.env.DB_HOST || 'localhost',
             port: getEnvVarParsed('DB_PORT', Number.parseInt, '23306'),
-            username: 'gitpod',
+            username: process.env.DB_USERNAME || 'gitpod',
             password: process.env.DB_PASSWORD || 'test',
             database: process.env.DB_NAME || 'gitpod'
         };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, the DB usernames are all hard-coded to `gitpod`. This prevents usage with certain DB instances that cannot use that notation (eg, Azure which enforces usernames to be `<username>@<hostname>`). This allows configuration of the DB username with an envvar.

`DB_USERNAME` is used as it's already supported by the `database-waiter` component.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5508 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Enable setting of DB username with DB_USERNAME envvar
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
https://github.com/gitpod-io/website/issues/1065
