### PR TITLE
[prow] Add labels to OWNERS files

### DIFF
--- a/components/blobserve/OWNERS
+++ b/components/blobserve/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/common-go/OWNERS
+++ b/components/common-go/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/content-service-api/OWNERS
+++ b/components/content-service-api/OWNERS
@@ -7,4 +7,4 @@ options:
 
 approvers:
   - csweichel
-  - corneliusludmann
+  - geropl

--- a/components/content-service/OWNERS
+++ b/components/content-service/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/dashboard/OWNERS
+++ b/components/dashboard/OWNERS
@@ -4,4 +4,6 @@ options:
 
 approvers:
   - engineering-meta
-  - gtsiolis
+
+labels:
+  - "team: meta"

--- a/components/docker-up/OWNERS
+++ b/components/docker-up/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/ee/agent-smith/OWNERS
+++ b/components/ee/agent-smith/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/ee/db-sync/OWNERS
+++ b/components/ee/db-sync/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/ee/kedge/OWNERS
+++ b/components/ee/kedge/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/ee/payment-endpoint/OWNERS
+++ b/components/ee/payment-endpoint/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/ee/ws-scheduler/OWNERS
+++ b/components/ee/ws-scheduler/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/gitpod-cli/OWNERS
+++ b/components/gitpod-cli/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/gitpod-db/OWNERS
+++ b/components/gitpod-db/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/gitpod-protocol/OWNERS
+++ b/components/gitpod-protocol/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/gitpod-protocol/java/OWNERS
+++ b/components/gitpod-protocol/java/OWNERS
@@ -3,3 +3,6 @@ options:
 
 approvers:
   - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/components/ide/OWNERS
+++ b/components/ide/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/components/image-builder/OWNERS
+++ b/components/image-builder/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/licensor/OWNERS
+++ b/components/licensor/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/local-app/OWNERS
+++ b/components/local-app/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/components/openvsx-proxy/OWNERS
+++ b/components/openvsx-proxy/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/components/proxy/OWNERS
+++ b/components/proxy/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/registry-facade/OWNERS
+++ b/components/registry-facade/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/server/OWNERS
+++ b/components/server/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/service-waiter/OWNERS
+++ b/components/service-waiter/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/supervisor/OWNERS
+++ b/components/supervisor/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/components/workspacekit/OWNERS
+++ b/components/workspacekit/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/ws-daemon-api/OWNERS
+++ b/components/ws-daemon-api/OWNERS
@@ -7,4 +7,4 @@ options:
 
 approvers:
   - csweichel
-  - fntlnz
+  - aledbf

--- a/components/ws-daemon/OWNERS
+++ b/components/ws-daemon/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/ws-manager-bridge/OWNERS
+++ b/components/ws-manager-bridge/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-meta
+
+labels:
+  - "team: meta"

--- a/components/ws-manager/OWNERS
+++ b/components/ws-manager/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/ws-proxy/OWNERS
+++ b/components/ws-proxy/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/dev/gpctl/OWNERS
+++ b/dev/gpctl/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/dev/loadgen/OWNERS
+++ b/dev/loadgen/OWNERS
@@ -4,3 +4,6 @@ options:
 
 approvers:
   - engineering-workspace
+
+labels:
+  - "team: workspace"


### PR DESCRIPTION
## Description
This PR adds `labels` section to the OWNERS files, which in conjunction with the [`owners-labels` prow plugin](https://github.com/gitpod-io/gitbot/commit/8f81ac10d547b9b46c6a4d2114799ac312da1bf0) automatically adds labels to PRs based on the files that were modified.

## How to test
Open a PR in gitpod-test-repo, e.g. [this one](https://github.com/gitpod-io/gitpod-test-repo/pull/202) and notice that prow added a label.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
