### PR TITLE
[ops] Add alert GitpodMetaMessagebusTotalQueues

### DIFF
--- a/operations/observability/mixins/meta/rules/components/components.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/components.libsonnet
@@ -5,4 +5,5 @@
 
 (import './nodes/alerts.libsonnet') +
 (import './nodes/rules.libsonnet') +
-(import './server/alerts.libsonnet')
+(import './server/alerts.libsonnet') +
+(import './messagebus/alerts.libsonnet')

--- a/operations/observability/mixins/meta/rules/components/messagebus/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/messagebus/alerts.libsonnet
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'gitpod-component-meta-messagebus-alerts',
+        rules: [
+          {
+            alert: 'GitpodMetaMessagebusTotalQueues',
+            labels: {
+              severity: 'critical',
+            },
+            'for': '2m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodMetaMessagebusTotalQueues.md',
+              summary: 'A messagebus has too many queues in total.',
+              description: 'messagebus {{ $labels.pod }} is reporting {{ printf "%.2f" $value }} queues in total.',
+            },
+            expr: 'sum by (instance) (rabbitmq_queues) > 10000',
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Description
Adds an alert called `GitpodMetaMessagebusTotalQueues` with a threshold of 10.000 / instance (currently we see max. 4.000 / instance).



Alert in prometheus:
![image](https://user-images.githubusercontent.com/32448529/137311241-aae5fb9f-0d67-4a60-a6cb-c9316e6914da.png)

Query in prometheus:
![image](https://user-images.githubusercontent.com/32448529/137311485-36460fcc-9383-453b-a6d4-e6bb738320a9.png)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5955 

Runbook PR: https://github.com/gitpod-io/observability/pull/290 (already merged)

## How to test
<!-- Provide steps to test this PR -->
- workspace: https://gitpod.io/#github.com/gitpod-io/gitpod/pull/6178
- `kubectl port-forward prometheus-k8s-0 9090`
- go to said port , path `/alerts`
- find alert `GitpodMetaMessagebusTotalQueues` at the top

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


 - [x] /werft with-observability
 - [ ] /werft with-clean-slate-deployment