### PR TITLE
fix: select Running Workspace doesn't work

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -169,7 +169,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
           <p className="mt-1 mb-2 text-base">You already have running workspaces with the same context. You can open an existing one or open a new workspace.</p>
           <>
             {result?.existingWorkspaces?.map(w =>
-              <a href={w.latestInstance?.ideUrl} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-3 my-1">
+              <a href={w.latestInstance?.ideUrl || gitpodHostUrl.with({ pathname: '/start/', hash: '#' + w.latestInstance?.workspaceId }).toString()} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-3 my-1">
                 <div className="w-full">
                   <p className="text-base text-black dark:text-gray-100 font-bold">{w.workspace.id}</p>
                   <p className="truncate" title={w.workspace.contextURL}>{w.workspace.contextURL}</p>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes Select Running Workspace doesn't work
This happens when "Running workspace" not provide `ideUrl`, such as in building image.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6119

## How to test
<!-- Provide steps to test this PR -->
Run a `need build image workspace` then run another workspace with same context url.
select a running workspace, it should go to  workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
