### PR TITLE
Revert "(Partially) revert #6148"

### DIFF
--- a/components/common-go/grpc/grpc.go
+++ b/components/common-go/grpc/grpc.go
@@ -66,7 +66,7 @@ func DefaultClientOptions() []grpc.DialOption {
 			Backoff: bfConf,
 		}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                5 * time.Second,
+			Time:                10 * time.Second,
 			Timeout:             time.Second,
 			PermitWithoutStream: true,
 		}),
@@ -90,7 +90,7 @@ func ServerOptionsWithInterceptors(stream []grpc.StreamServerInterceptor, unary 
 	return []grpc.ServerOption{
 		// terminate the connection if the client pings more than once every 2 seconds
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             2 * time.Second,
+			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),
 		grpc.MaxRecvMsgSize(maxMsgSize),
@@ -106,7 +106,7 @@ func ServerOptionsWithInterceptors(stream []grpc.StreamServerInterceptor, unary 
 
 func SetupLogging() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(
-		log.WithField("component", "grpc").WriterLevel(logrus.InfoLevel),
+		log.WithField("component", "grpc").WriterLevel(logrus.DebugLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.WarnLevel),
 		log.WithField("component", "grpc").WriterLevel(logrus.ErrorLevel),
 	))


### PR DESCRIPTION
Reverts gitpod-io/gitpod#6170

The original partial revert is without consequence as gRPC has a minimum of 10 seconds here.
The actual fix for the underlying issue is https://github.com/gitpod-io/gitpod/pull/6166

```release-notes
NONE
```