### PR TITLE
[observability] Add OpenVSX registry down alert

### DIFF
--- a/operations/observability/mixins/IDE/rules/components/components.libsonnet
+++ b/operations/observability/mixins/IDE/rules/components/components.libsonnet
@@ -3,14 +3,9 @@
  * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
  */
 
-// When implementing the first alerts and recording rules, please follow the same folder structure used by other teams' mixins
-// Ping @ArthurSens if necessary
-{
-  prometheusAlerts+:: {
-    groups+: [],
-    // IDE team doesn have any alerts yet
-  },
+(import './openvsx-proxy/alerts.libsonnet')
 
+{
   prometheusRules+:: {
     groups+: [],
     // IDE team doesn have any recording rules yet

--- a/operations/observability/mixins/IDE/rules/components/openvsx-proxy/alerts.libsonnet
+++ b/operations/observability/mixins/IDE/rules/components/openvsx-proxy/alerts.libsonnet
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'gitpod-component-openvsx-proxy-alerts',
+        rules: [
+          {
+            alert: 'GitpodOpenVsxProxyServesFromCache',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodOpenVsxProxyServesFromCache.md',
+              summary: 'OpenVSX serves from backup cache.',
+              description: 'In the past 10 minutes, the OpenVSX proxy served more than 10 % of all requests from our cache most likely because the OpenVSX registry was not reachable.',
+            },
+            expr: |||
+              (sum(rate(gitpod_openvsx_proxy_backup_cache_serve_total[10m])) / sum(rate(gitpod_openvsx_proxy_duration_overall_seconds_count[10m])) > 0.1
+            |||,
+          },
+          {
+            alert: 'GitpodOpenVsxProxyConnectionErrors',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodOpenVsxProxyConnectionErrors.md',
+              summary: 'OpenVSX proxy has connection errors.',
+              description: 'In the past 10 minutes, more than 10 % of the requests to the OpenVSX proxy had connectivity errors.',
+            },
+            expr: |||
+              sum(rate(gitpod_openvsx_proxy_requests_total{status="error"}[10m])) / sum(rate(gitpod_openvsx_proxy_requests_total[10m])) > 0.1
+            |||,
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
@@ -18,7 +18,7 @@
             },
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/WebsocketConnectionsNotClosing.md',
-              summary: 'Open websocket connections are not closing for the last 10 minutes and accumulating.'
+              summary: 'Open websocket connections are not closing for the last 10 minutes and accumulating.',
             },
           },
         ],


### PR DESCRIPTION
## Description
Adds an alert when the OpenVSX registry is not reachable.

See also runbook PR: https://github.com/gitpod-io/observability/pull/292

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

