### PR TITLE
Pin default monitoring-satellite to `release-v0.2.0`

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -556,7 +556,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 
     async function installMonitoring() {
         const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
-        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "main";
+        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "release-v0.2.0";
         installMonitoringSatelliteParams.pathToKubeConfig = ""
         installMonitoringSatelliteParams.satelliteNamespace = namespace
         installMonitoringSatelliteParams.clusterName = namespace


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
I'll soon start making a lot of breaking changes to the `main` branch of gitpod-io/observability to make the codebase public.

I'd like to avoid breaking our monitoring-satellites in preview-environments in the process, so I'm pinning their target revision meanwhile.

The `release-v0.2.0` release was cut just a moment ago: https://github.com/gitpod-io/observability/releases/tag/v0.2.0

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

- [X] /werft with-observability