### PR TITLE
[ops] meta: Add "version" graph

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/server.json
+++ b/operations/observability/mixins/meta/dashboards/components/server.json
@@ -49,7 +49,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1633704520775,
+  "iteration": 1634205960963,
   "links": [],
   "panels": [
     {
@@ -774,13 +774,95 @@
       "type": "timeseries"
     },
     {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 63,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum (gitpod_version_info{}) by (cluster, gitpod_version)",
+          "interval": "",
+          "legendFormat": "{{ cluster }}: {{ gitpod_version }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Version",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 34
       },
       "id": 50,
       "panels": [
@@ -1035,7 +1117,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 16,
       "panels": [],
@@ -1098,7 +1180,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 28
+        "y": 36
       },
       "id": 55,
       "options": {
@@ -1137,7 +1219,7 @@
         "h": 7,
         "w": 7,
         "x": 10,
-        "y": 28
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 2,
@@ -1232,7 +1314,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 28
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1335,7 +1417,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 6,
@@ -1428,7 +1510,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 8,
@@ -1520,7 +1602,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 42
+        "y": 50
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1618,7 +1700,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 42
+        "y": 50
       },
       "hiddenSeries": false,
       "id": 38,
@@ -1718,7 +1800,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 42
+        "y": 50
       },
       "hiddenSeries": false,
       "id": 40,
@@ -1819,7 +1901,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 49
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 32,
@@ -1913,7 +1995,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 49
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 34,
@@ -2020,7 +2102,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 49
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 36,
@@ -2121,7 +2203,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 66
       },
       "id": 22,
       "panels": [
@@ -2698,5 +2780,5 @@
   "timezone": "utc",
   "title": "Gitpod / Component / server",
   "uid": "server",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a simple graph for "version" as reported from `server`:
![image](https://user-images.githubusercontent.com/32448529/137309217-8800978d-fe8e-4882-a39f-d764c50f5442.png)

Note that `cluster` is not set in devstaging, but is in prod/staging, thus the label is a tad off. Cmp. prod:
![image](https://user-images.githubusercontent.com/32448529/137309531-9aa7a0d0-a2bd-4e22-9748-5194ae28db92.png)


Query: `sum (gitpod_version_info{}) by (cluster, gitpod_version)`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/observability/issues/270.

## How to test
<!-- Provide steps to test this PR -->
- open workspace: https://gitpod.io/#github.com/gitpod-io/gitpod/pull/6206
- `kubectl port-forward grafana-7f74f4ddfd-g7rcl 3000`
- navigate to `/d/server/gitpod-component-server?orgId=1&refresh=30s` on said port

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [ ] /werft with-observability
- [x] /werft with-clean-slate-deployment