### PR TITLE
Fixed element style for TailwindCSS configs with { important: false }

### DIFF
--- a/components/dashboard/src/components/DropDown.tsx
+++ b/components/dashboard/src/components/DropDown.tsx
@@ -20,7 +20,7 @@ export interface DropDownEntry {
 }
 
 function Arrow(props: {up: boolean}) {
-    return <span className="mx-2 border-gray-400 dark:border-gray-600 group-hover:border-gray-600 dark:group-hover:border-gray-400" style={{ margin: 2, padding: 3, border: 'solid black', borderWidth: '0 2px 2px 0', display: 'inline-block', transform: `rotate(${props.up ? '-135deg' : '45deg'})`}}></span>
+    return <span className="mx-2 border-gray-400 dark:border-gray-600 group-hover:border-gray-600 dark:group-hover:border-gray-400" style={{ marginTop: 2, marginBottom: 2, padding: 3, borderWidth: '0 2px 2px 0', display: 'inline-block', transform: `rotate(${props.up ? '-135deg' : '45deg'})`}}></span>
 }
 
 function DropDown(props: DropDownProps) {


### PR DESCRIPTION
## Description

This PR removes superfluous element style from DropBox arrows.

As a user of Gitpod Self-Hosted I want to apply my company style (located in external css files). By default, TailwindCSS's utilities overwrite all overlapping element styles with the config setting `{ important: true }`. However, sometimes it is important to be able to overwrite specific styles for branding purposes.

Especially the Gitpod(!) element styles fixed by this PR are currently overwritten by TailwindCSS. This makes them superfluous and blocks users which switch the TailwindCSS config to `{ important: false }`.

## Related Issue(s)

## How to test

Open https://gitpod.io in production. It will look like this:

![arrow-prod](https://user-images.githubusercontent.com/743833/137336829-793ab667-d8d0-470e-b2a4-877f52d56b02.png)

Open the `main` branch in Gitpod and change `tailwind.config.json`:

```diff
- important: true
+ important: false
```

The dashboard/workspaces will look broken, like this:

![arrow-broken](https://user-images.githubusercontent.com/743833/137337330-b9cf18ca-dff9-4cb4-abe6-daca96f343c5.png)

Open this PR in Gitpod and change `tailwind.config.json`:

```diff
- important: true
+ important: false
```

The dashboard/workspaces UI is fixed now:

![arrow-fixed](https://user-images.githubusercontent.com/743833/137337606-25f02531-85aa-4e5b-ae61-44fe8dcd1d9f.png)

Change it back to:

```diff
- important: false
+ important: true
```

The dashboard/workspaces UI will still look the same:

![arrow-fixed](https://user-images.githubusercontent.com/743833/137337606-25f02531-85aa-4e5b-ae61-44fe8dcd1d9f.png)

## Release Notes

```release-note
NONE
```

## Documentation
