### PR TITLE
[agent-smith]Fix crash when not provide blocklists

### DIFF
--- a/chart/templates/agent-smith-configmap.yaml
+++ b/chart/templates/agent-smith-configmap.yaml
@@ -19,7 +19,7 @@ metadata:
 data:
   config.json: |
     {
-      "blacklists": {
+      "blocklists": {
         "very": {
           "signatures": [
             {

--- a/components/ee/agent-smith/pkg/config/config.go
+++ b/components/ee/agent-smith/pkg/config/config.go
@@ -216,7 +216,7 @@ type Blocklists struct {
 
 func (b *Blocklists) Classifier() (classifier.ProcessClassifier, error) {
 	if b == nil {
-		return &classifier.CommandlineClassifier{}, nil
+		return classifier.NewCommandlineClassifier(nil, nil)
 	}
 
 	var err error


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[agent-smith]Fix crash when not provide blocklists
Since #6150 `blacklists` changed to `blocklist` but not modify in `values.yml`, agent-smith crash when start.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
