### PR TITLE
[werft] Don't hard-fail if observability ingress don't come up

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -173,7 +173,7 @@ function ensureIngressesReadiness(params: InstallMonitoringSatelliteParams) {
     }
 
     if (!prometheusIngressReady || !grafanaIngressReady) {
-        throw new Error('Timeout while waiting for ingresses readiness')
+        werft.log(sliceName, "Time out while waiting for ingress readiness")
     }
 }
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
As per title

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6216 

## How to test
<!-- Provide steps to test this PR -->
Spin up previews with observability multiple times until we break our ingresses (hit let's encrypt rate limit) and notice that the werft job doesn't fail

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
