### PR TITLE
[observability] Alert for high CPU usage.

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -221,12 +221,12 @@ function installSetup() {
     exec('kubectl apply -f observability/monitoring-satellite/manifests/namespace.yaml', {silent: true})
     exec('kubectl apply -f observability/monitoring-satellite/manifests/podsecuritypolicy-restricted.yaml', {silent: true})
 
-    const crdExists = exec('kubectl get customresourcedefinitions.apiextensions.k8s.io alertmanagers.monitoring.coreos.com', {silent: true}).code == 0
+    const crdExists = exec('kubectl get customresourcedefinitions.apiextensions.k8s.io alertmanagers.monitoring.coreos.com', {silent: true, dontCheckRc: true}).code == 0
     if (crdExists) {
         werft.log(sliceName, "CRDs already exists, replacing CRDs'")
         exec('for yaml in $(find observability/monitoring-satellite/manifests/prometheus-operator/ -type f -name "*CustomResourceDefinition.yaml"); do cat $yaml | kubectl delete -f -; done', {slice: sliceName})
     }
-    exec('find observability/monitoring-satellite/manifests/prometheus-operator/ -type f -name "*CustomResourceDefinition.yaml" | kubectl create -f -', {slice: sliceName})
+    exec('for yaml in $(find observability/monitoring-satellite/manifests/prometheus-operator/ -type f -name "*CustomResourceDefinition.yaml"); do cat $yaml | kubectl create -f -; done', {slice: sliceName})
     // Making sure CRDs got installed
     exec('until kubectl get servicemonitors.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done', {silent: true})
 

--- a/operations/observability/mixins/workspace/rules/components/components.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/components.libsonnet
@@ -3,6 +3,8 @@
  * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
  */
 
+(import './nodes/alerts.libsonnet') +
+(import './nodes/rules.libsonnet') +
 (import './workspaces/alerts.libsonnet') +
 (import './workspaces/rules.libsonnet') +
 (import './ws-daemon/alerts.libsonnet') +

--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'gitpod-workspace-component-node-alerts',
+        rules: [
+          {
+            alert: 'GitpodWorkspaceNodeHighNormalizedLoadAverage',
+            labels: {
+              severity: 'warning',
+            },
+            'for': '10m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md',
+              summary: "Workspace node's normalized load average is higher than 10 for more than 10 minutes.",
+              description: 'Node {{ $labels.node }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.',
+            },
+            expr: 'nodepool:node_load1:normalized{nodepool=~".*workspace.*"} > 10',
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/operations/observability/mixins/workspace/rules/components/nodes/rules.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/rules.libsonnet
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusRules+:: {
+    groups+: [
+      {
+        name: 'gitpod-workspace-component-node-records',
+        rules: [
+          {
+            record: 'nodepool:node_load1:normalized',
+            expr:
+              |||
+                node_load1 * on(node) group_left(nodepool) kube_node_labels
+                /
+                count without (cpu) (
+                  count without (mode) (
+                    node_cpu_seconds_total * on(node) group_left(nodepool) kube_node_labels
+                  )
+                )
+              |||,
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds an alert for high load average. Calculation is done by normalizing 1 min load average over the number of CPU cores that a node has.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/runbooks/issues/289

## How to test
<!-- Provide steps to test this PR -->
Access [Grafana](https://grafana-as-node-cpu-alert.preview.gitpod-dev.com/d/gitpod-overview/gitpod-overview?orgId=1&refresh=30s) to check the normalized load average on the `Gitpod / Overview` dashboard.

Alert can be seen at [Prometheus](https://prometheus-as-node-cpu-alert.preview.gitpod-dev.com/alerts)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [X] /werft with-observability