### PR TITLE
[observability] Improve documentantion regarding deployment to production

### DIFF
--- a/operations/observability/mixins/README.md
+++ b/operations/observability/mixins/README.md
@@ -12,6 +12,7 @@ Gitpod's mixin is based on the [Prometheus Monitoring Mixins project](https://gi
     * [Recording Rules](#Recording-Rules)
     * [Alerts](#Alerts)
     * [Rules and Alerts validation](#Rules-and-Alerts-validation)
+* [Deploying merged changes to production](#Deploying-merged-changes-to-production)
 * [Frequently asked Questions](#FAQ)
     * [Any recommendations when developing new dashboards?](#Any-recommendations-when-developing-new-dashboards)
     * [How is our mixin consumed?](#How-is-our-mixin-consumed)
@@ -267,6 +268,14 @@ You can use our Makefile to make sure the alerts and recording rules you've crea
 By running `make promtool-lint`, you'll generate a new file called `prometheus_alerts.yaml` with all teams' recording rules and alerts together, and also use the `promtool` binary to validate all of them.
 
 We also have this same validation running in our CI, to make sure we don't merge stuff that can break our monitoring system.
+
+## Deploying merged changes to production
+
+Alright, you got your changes merged, now what? The changes need to land on our [gitpod-io/observability](https://github.com/gitpod-io/observability) repository by updating the `vendor/` folder.
+
+The `vendor/` folder can be updated by triggering this [workflow](https://github.com/gitpod-io/observability/actions/workflows/dep-update.yaml). Yes, you just need to click the button and the workflow will open a new Pull Request with the updates.
+
+After all CI checks pass, it is safe to merge the Pull Request. It is now ArgoCD's duty to synchronize the monitoring-satellite applications across all clusters. If you want to check progress, you can do that through [ArgoCD UI](https://argo-cd.gitpod-io-dev.com/applications?labels=application%253Dmonitoring-satellite).
 
 ## FAQ
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Adds extra documentation regarding deploying merged changes to production.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6239 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
