### PR TITLE
[observability] Fix broken CI check

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -121,10 +121,16 @@ export function observabilityStaticChecks() {
 
 function jsonnetFmtCheck(): boolean {
     werft.log(sliceName, "Checking if jsonnet compiles and is well formated")
-    let success = exec('make lint', {slice: sliceName}).code == 0
+    let success = exec('make fmt && git diff --exit-code .', {slice: sliceName}).code == 0
 
     if (!success) {
-        werft.fail(sliceName, "Jsonnet linter failed. You can fix it by running 'cd operations/observability/mixins && make fmt'");
+        werft.fail(sliceName, "Jsonnet is badly formatted. You can fix it by running 'cd operations/observability/mixins && make fmt'");
+    }
+
+    success = exec('make lint', {slice: sliceName}).code == 0
+
+    if (!success) {
+        werft.fail(sliceName, "Jsonnet does not compile.");
     }
     return success
 }

--- a/operations/observability/mixins/workspace/rules/components/workspaces/rules.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/rules.libsonnet
@@ -15,8 +15,8 @@
               sum(gitpod_ws_manager_workspace_activity_total{active="false"}) / sum(gitpod_ws_manager_workspace_activity_total)
             |||,
           },
-        ]
-      }
+        ],
+      },
     ],
   },
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Previously to this PR, we tried to make CI to fail in case code under `operations/observability/mixins` was not well-formatted, but the Makefile step was returning exit code `0` anyways. This PR makes sure the CI fails in case of bad code formatting.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6237 

## How to test
<!-- Provide steps to test this PR -->
Compare results of CI between commits:
* 12c4668 - https://werft.gitpod-dev.com/job/gitpod-build-arthursens-observability-broken-6237.2
* f06433b - https://werft.gitpod-dev.com/job/gitpod-build-arthursens-observability-broken-6237.3

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```