### PR TITLE
[openvsx-proxy] Prevent of tracking unexpected paths in status counter metric

### DIFF
--- a/components/openvsx-proxy/pkg/prometheus.go
+++ b/components/openvsx-proxy/pkg/prometheus.go
@@ -135,6 +135,14 @@ func (p *Prometheus) createMetrics() {
 	})
 }
 
+var expectedPaths = map[string]struct{}{
+	"/api/-/query":                   {},
+	"/vscode/asset":                  {},
+	"/vscode/gallery/extensionquery": {},
+	"/vscode/gallery/itemName":       {},
+	"/vscode/gallery/publishers":     {},
+}
+
 func (p *Prometheus) IncStatusCounter(r *http.Request, status string) {
 	path := r.URL.Path
 	if strings.HasPrefix(path, "/vscode/asset/") {
@@ -149,6 +157,11 @@ func (p *Prometheus) IncStatusCounter(r *http.Request, status string) {
 	// since path starts with a / the first segment is an emtpy string, therefore len > 4 and not len > 3
 	if s := strings.SplitN(path, "/", 5); len(s) > 4 {
 		path = strings.Join(s[:4], "/")
+	}
+	// don't track unexepected paths (e.g. requests from crawlers/bots)
+	if _, ok := expectedPaths[strings.TrimSuffix(path, "/")]; !ok || path != "/" {
+		log.WithField("path", path).Debug("unexpected path")
+		path = "(other)"
 	}
 	p.RequestsCounter.WithLabelValues(status, fmt.Sprintf("%s %s", r.Method, path)).Inc()
 }


### PR DESCRIPTION
e.g. requests from crawlers/bots

/cc @akosyakov 

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
