### PR TITLE
[openvsx-proxy] Fix status counter metric

### DIFF
--- a/components/openvsx-proxy/pkg/prometheus.go
+++ b/components/openvsx-proxy/pkg/prometheus.go
@@ -159,7 +159,7 @@ func (p *Prometheus) IncStatusCounter(r *http.Request, status string) {
 		path = strings.Join(s[:4], "/")
 	}
 	// don't track unexepected paths (e.g. requests from crawlers/bots)
-	if _, ok := expectedPaths[strings.TrimSuffix(path, "/")]; !ok || path != "/" {
+	if _, ok := expectedPaths[strings.TrimSuffix(path, "/")]; !ok {
 		log.WithField("path", path).Debug("unexpected path")
 		path = "(other)"
 	}


### PR DESCRIPTION
/cc @akosyakov 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
