### PR TITLE
[server] add vscode(-insiders) ouath2 clients

### DIFF
--- a/components/gitpod-db/package.json
+++ b/components/gitpod-db/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@jmondi/oauth2-server": "^1.1.0",
+    "@jmondi/oauth2-server": "^2.2.2",
     "mysql": "^2.18.1",
     "reflect-metadata": "^0.1.13",
     "the-big-username-blacklist": "^1.5.2",

--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
@@ -33,7 +33,7 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
         return (await this.getEntityManager()).getRepository<DBOAuthAuthCodeEntry>(DBOAuthAuthCodeEntry);
     }
 
-    public async getByIdentifier(authCodeCode: string): Promise<OAuthAuthCode> {
+    public async getByIdentifier(authCodeCode: string): Promise<DBOAuthAuthCodeEntry> {
         const authCodeRepo = await this.getOauthAuthCodeRepo();
         let authCodes = await authCodeRepo.find({ code: authCodeCode });
         authCodes = authCodes.filter((te) => new Date(te.expiresAt).getTime() > Date.now());
@@ -54,7 +54,7 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
             scopes: scopes,
         };
     }
-    public async persist(authCode: OAuthAuthCode): Promise<void> {
+    public async persist(authCode: DBOAuthAuthCodeEntry): Promise<void> {
         const authCodeRepo = await this.getOauthAuthCodeRepo();
         authCodeRepo.save(authCode);
     }

--- a/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { OAuthAuthCode, OAuthClient, OAuthScope } from "@jmondi/oauth2-server";
+import { CodeChallengeMethod, OAuthAuthCode, OAuthClient, OAuthScope } from "@jmondi/oauth2-server";
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 import { Transformer } from "../transformer";
 import { DBUser } from "./db-user";
@@ -38,7 +38,7 @@ export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
         type: "varchar",
         length: 10,
     })
-    codeChallengeMethod: string;
+    codeChallengeMethod: CodeChallengeMethod
 
     @Column({
         type: "timestamp",

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -486,7 +486,7 @@ export class TypeORMUserDBImpl implements UserDB {
         } else {
             var user: MaybeUser;
             if (accessToken.user) {
-                user = await this.findUserById(accessToken.user.id);
+                user = await this.findUserById(accessToken.user.id.toString());
             }
             dbToken = {
                 tokenHash,

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -210,7 +210,7 @@ https://{$GITPOD_DOMAIN} {
 	@codesync path /code-sync*
 	handle @codesync {
 		gitpod.cors_origin {
-			base_domain {$GITPOD_DOMAIN}
+			any_domain true
 		}
 
 		import compression

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -39,7 +39,7 @@
     "@gitpod/ws-manager": "0.1.5",
     "@google-cloud/storage": "^5.6.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
-    "@jmondi/oauth2-server": "^1.1.0",
+    "@jmondi/oauth2-server": "^2.2.2",
     "@octokit/rest": "18.6.1",
     "@probot/get-private-key": "^1.1.1",
     "amqplib": "^0.8.0",

--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -57,10 +57,30 @@ const jetBrainsGateway: OAuthClient = {
     ],
 };
 
+function createVSCodeClient(protocol: "vscode" | "vscode-insiders"): OAuthClient {
+    return {
+        id: protocol + "-" + "gitpod",
+        name: `VS Code${protocol === "vscode-insiders" ? " Insiders" : ""}: Gitpod extension`,
+        redirectUris: [protocol + "://gitpod.gitpod-desktop/complete-gitpod-auth"],
+        allowedGrants: ["authorization_code"],
+        scopes: [
+            { name: "function:getGitpodTokenScopes" },
+            { name: "function:getLoggedInUser" },
+            { name: "function:accessCodeSyncStorage" },
+            { name: "resource:default" },
+        ],
+    };
+}
+
+const vscode = createVSCodeClient("vscode");
+const vscodeInsiders = createVSCodeClient("vscode-insiders");
+
 export const inMemoryDatabase: InMemory = {
     clients: {
         [localClient.id]: localClient,
         [jetBrainsGateway.id]: jetBrainsGateway,
+        [vscode.id]: vscode,
+        [vscodeInsiders.id]: vscodeInsiders,
     },
     tokens: {},
     scopes: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,10 +1727,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@jmondi/oauth2-server@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@jmondi/oauth2-server/-/oauth2-server-1.1.1.tgz#cb2530c17e2c7db3cc632bb68ec0f38a54c7ae1c"
-  integrity sha512-my3776n6TDsJQJ+nONG52VNgTQ7veH9lo4kb/AAWt9Rko6VBuMxOb/KxcYdkDrpOznJ036+tVveuhY7zSJjGYg==
+"@jmondi/oauth2-server@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@jmondi/oauth2-server/-/oauth2-server-2.2.2.tgz#e99b6edcd068c1a58423e2e8e94eeb0acb048b39"
+  integrity sha512-U9038EvDQJwc6SUxGjNfP1nhcyIzUuo4MLDBjWEp4ieuoyMYFBlMtmUbXcIEvvlwWQSXneUm7+TcTBcNHKrE8w==
   dependencies:
     jsonwebtoken "^8.5.1"
     ms "^2.1.3"


### PR DESCRIPTION
## Description
It adds 2 new oauth2 clients for Gitpod Server: VS Code Desktop and VS Code Desktop Insiders.

## Related Issue(s)
#3733

## How to test
<!-- Provide steps to test this PR -->

Check that the local app is still working.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
