### PR TITLE
[teams] Can create new team with deleted team name

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -33,7 +33,6 @@ export default function Menu() {
     const { user } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
-    const visibleTeams = teams?.filter(team => { return Boolean(!team.markedDeleted) });
 
     const match = useRouteMatch<{ segment1?: string, segment2?: string, segment3?: string }>("/(t/)?:segment1/:segment2?/:segment3?");
     const projectName = (() => {
@@ -192,7 +191,7 @@ export default function Menu() {
                             separator: true,
                             link: '/',
                         },
-                        ...(visibleTeams || []).map(t => ({
+                        ...(teams || []).map(t => ({
                             title: t.name,
                             customContent: <div className="w-full text-gray-400 flex flex-col">
                                 <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{t.name}</span>

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -76,7 +76,7 @@ export class TeamDBImpl implements TeamDB {
 
     public async findTeamById(teamId: string): Promise<Team | undefined> {
         const teamRepo = await this.getTeamRepo();
-        return teamRepo.findOne({ id: teamId, deleted: false });
+        return teamRepo.findOne({ id: teamId, deleted: false, markedDeleted: false});
     }
 
     public async findMembersByTeam(teamId: string): Promise<TeamMemberInfo[]> {
@@ -123,7 +123,7 @@ export class TeamDBImpl implements TeamDB {
             throw new Error('A team cannot have the same name as an existing user');
         }
         const teamRepo = await this.getTeamRepo();
-        const existingTeam = await teamRepo.findOne({ slug, deleted: false });
+        const existingTeam = await teamRepo.findOne({ slug, deleted: false, markedDeleted: false });
         if (!!existingTeam) {
             throw new Error('A team with this name already exists');
         }


### PR DESCRIPTION
## Description
We had users have problems that after deleting a team, they are unable to create a team with the same name.
This PR allows that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6211

## How to test
1. Create a team with any name
2. Delete the team
3. Create a team with the same name as the deleted one

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Deleted team's name can be reused.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
