### PR TITLE
surface errors that occur in local-app ResolveSSHConnection

### DIFF
--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -398,9 +398,9 @@ func summarizeErrors(errs []error) error {
 	case 1:
 		return errs[0]
 	}
-	messages := make([]string, len(errs), len(errs))
-	for i := range errs {
-		messages[i] = errs[i].Error()
+	messages := []string{}
+	for _, e := range errs {
+		messages = append(messages, e.Error())
 	}
 	return xerrors.Errorf("multiple errors: %s", strings.Join(messages, ", "))
 }

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -256,12 +256,14 @@ func (b *Bastion) FullUpdate() {
 func (b *Bastion) Update(workspaceID string) (*Workspace, error) {
 	ws, err := b.Client.GetWorkspace(b.ctx, workspaceID)
 	if err != nil {
-		logrus.WithError(err).WithField("WorkspaceID", workspaceID).Error("cannot get workspace")
-		return nil, xerrors.Errorf("cannot get workspace: %w", err)
+		err = xerrors.Errorf("cannot get workspace: %w", err)
+		logrus.WithError(err).WithField("WorkspaceID", workspaceID).Error("cannot update workspace")
+		return nil, err
 	}
 	if ws.LatestInstance == nil {
-		logrus.WithError(err).WithField("WorkspaceID", workspaceID).Error("cannot get workspace last known instance")
-		return nil, xerrors.Errorf("cannot get workspace last known instance: %w", err)
+		err := xerrors.Errorf("cannot get workspace last known instance")
+		logrus.WithError(err).WithField("WorkspaceID", workspaceID).Error("cannot update workspace")
+		return nil, err
 	}
 	done := make(chan *Workspace)
 	errChan := make(chan error)

--- a/components/local-app/pkg/bastion/bastion_test.go
+++ b/components/local-app/pkg/bastion/bastion_test.go
@@ -1,0 +1,53 @@
+package bastion
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSummarrizeErrors(t *testing.T) {
+	type testCase struct {
+		label    string
+		errs     []error
+		expected error
+	}
+
+	tests := []testCase{
+		{
+			label:    "no errors",
+			errs:     nil,
+			expected: nil,
+		},
+		{
+			label:    "1 error",
+			errs:     []error{errors.New("one")},
+			expected: errors.New("one"),
+		},
+		{
+			label:    "2 error",
+			errs:     []error{errors.New("one"), errors.New("two")},
+			expected: errors.New("multiple errors: one, two"),
+		},
+		{
+			label:    "3 error",
+			errs:     []error{errors.New("one"), errors.New("two"), errors.New("three")},
+			expected: errors.New("multiple errors: one, two, three"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.label, func(t *testing.T) {
+			actual := summarizeErrors(tc.errs)
+			if tc.expected == nil || actual == nil {
+				if actual != tc.expected {
+					t.Errorf("expected: %v, intead got: %v", tc.expected, actual)
+				}
+				return
+			}
+			if actual.Error() != tc.expected.Error() {
+				t.Errorf("expected: %v, intead got: %v", tc.expected, actual)
+			}
+		})
+	}
+
+}

--- a/components/local-app/pkg/bastion/bastion_test.go
+++ b/components/local-app/pkg/bastion/bastion_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
 package bastion
 
 import (

--- a/components/local-app/pkg/bastion/service.go
+++ b/components/local-app/pkg/bastion/service.go
@@ -66,12 +66,12 @@ func (s *LocalAppService) AutoTunnel(ctx context.Context, req *api.AutoTunnelReq
 }
 
 func (s *LocalAppService) ResolveSSHConnection(ctx context.Context, req *api.ResolveSSHConnectionRequest) (*api.ResolveSSHConnectionResponse, error) {
-	ws := s.b.Update(req.WorkspaceId)
+	ws, err := s.b.Update(req.WorkspaceId)
+	if err != nil {
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
 	if ws == nil || ws.InstanceID != req.InstanceId {
 		return nil, status.Error(codes.NotFound, "workspace not found")
-	}
-	if ws.localSSHListener == nil {
-		return nil, status.Error(codes.NotFound, "workspace ssh tunnel not configured")
 	}
 	return &api.ResolveSSHConnectionResponse{
 		Host:       ws.WorkspaceID,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When handling a workspace update in the local-app, there are several possible things that can go wrong. This change is mostly cosmetic, and should not change behavior for the user, but should surface a more precise error if for instance: local-app cannot connect to the supervisor, or fails to open ssh tunnel.

Additionally, if multiple errors are encountered, a summary will be surfaced in the ResolveSSHConnection grpc response, and to the user.

## Related Issue(s)
related to https://github.com/gitpod-io/gitpod/issues/5767

## How to test
<!-- Provide steps to test this PR -->
- exercise local-companion app both standalone and from vscode
- observe error log
- if possible attempt to reproduce #5767, and hopefully observe a more detailed error

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NA
