### PR TITLE
[observability] Update runbooks' URL

### DIFF
--- a/operations/observability/mixins/cross-teams/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/cross-teams/rules/components/nodes/alerts.libsonnet
@@ -16,7 +16,7 @@
             },
             'for': '10m',
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodNodeRunningOutOfEphemeralStorage.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodNodeRunningOutOfEphemeralStorage.md',
               summary: 'Node almost out of ephemeral storage',
               description: 'Node {{ $labels.node }} is reporting {{ printf "%.2f" $value }}% ephemeral storage left under {{ $labels.mountpoint }}.',
             },

--- a/operations/observability/mixins/meta/rules/components/messagebus/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/messagebus/alerts.libsonnet
@@ -16,7 +16,7 @@
             },
             'for': '2m',
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodMetaMessagebusTotalQueues.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodMetaMessagebusTotalQueues.md',
               summary: 'A messagebus has too many queues in total.',
               description: 'messagebus {{ $labels.pod }} is reporting {{ printf "%.2f" $value }} queues in total.',
             },

--- a/operations/observability/mixins/meta/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/nodes/alerts.libsonnet
@@ -15,7 +15,7 @@
               severity: 'warning',
             },
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodMetaNodeOOMKills.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodMetaNodeOOMKills.md',
               summary: 'A meta node is reporting OOM kills.',
               description: 'Meta node {{ $labels.instance }} is reporting {{ printf "%.2f" $value }} Out Of Memory kills in the last 10 minutes.',
             },
@@ -28,7 +28,7 @@
             },
             'for': '10m',
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodMetaNodeCPUSaturation.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodMetaNodeCPUSaturation.md',
               summary: 'High CPU Saturation of a meta node.',
               description: 'Meta node {{ $labels.instance }} is reporting {{ printf "%.2f" $value }}% CPU usage for more than 10 minutes.',
             },

--- a/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
@@ -17,7 +17,7 @@
               severity: 'critical',
             },
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/WebsocketConnectionsNotClosing.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebsocketConnectionsNotClosing.md',
               summary: 'Open websocket connections are not closing for the last 10 minutes and accumulating.'
             },
           },

--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -16,7 +16,7 @@
             },
             'for': '1h',
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWorkspaceStuckOnStarting.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStarting.md',
               summary: '5 or more workspaces are stuck on starting',
               description: '{{ printf "%.2f" $value }} regular workspaces are stuck on starting for more than 1 hour. Current status: "{{ $labels.reason }}"',
             },
@@ -33,7 +33,7 @@
             },
             'for': '1h',
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md',
               summary: '5 or more workspaces are stuck on stopping',
               description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 1 hour.',
             },

--- a/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
@@ -15,7 +15,7 @@
               severity: 'critical',
             },
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWsDaemonCrashLooping.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonCrashLooping.md',
               summary: 'Ws-daemon is crashlooping.',
               description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.',
             },

--- a/operations/observability/mixins/workspace/rules/components/ws-manager/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/ws-manager/alerts.libsonnet
@@ -15,7 +15,7 @@
               severity: 'critical',
             },
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWsManagerCrashLooping.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsManagerCrashLooping.md',
               summary: 'Ws-manager is crashlooping.',
               description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.',
             },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that our 'observability' code is public, all our runbooks were moved to a new(actually it's the same old, but renamed). This requires us to update all our runbook URL in the alerts.

See also: https://github.com/gitpod-io/runbooks/issues/291#issuecomment-946807932


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
