### PR TITLE
Install monitoring-satellite from main branch by default

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -552,7 +552,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 
     async function installMonitoring() {
         const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
-        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "release-v0.2.0";
+        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "main";
         installMonitoringSatelliteParams.pathToKubeConfig = ""
         installMonitoringSatelliteParams.satelliteNamespace = namespace
         installMonitoringSatelliteParams.clusterName = namespace


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We've successfully migrated our observability repository to a public one. The branch `release-v0.2.0` do not exist anymore, so we need to switch back to `main`

```release-note
NONE
```
