### PR TITLE
[supervisor] Add desktop IDE frontend support

### DIFF
--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -13,8 +13,9 @@ export enum StartPhase {
   Creating = 2,
   Starting = 3,
   Running = 4,
-  Stopping = 5,
-  Stopped = 6,
+  IdeReady = 5,
+  Stopping = 6,
+  Stopped = 7,
 };
 
 function getPhaseTitle(phase?: StartPhase, error?: StartWorkspaceError) {
@@ -32,6 +33,8 @@ function getPhaseTitle(phase?: StartPhase, error?: StartWorkspaceError) {
       return "Starting";
     case StartPhase.Running:
       return "Starting";
+    case StartPhase.IdeReady:
+      return "Your Workspace is Ready!";
     case StartPhase.Stopping:
       return "Stopping";
     case StartPhase.Stopped:
@@ -84,9 +87,9 @@ export function StartPage(props: StartPageProps) {
   return <div className="w-screen h-screen align-middle">
     <div className="flex flex-col mx-auto items-center text-center h-screen">
       <div className="h-1/3"></div>
-      <img src={gitpodIcon} alt="Gitpod's logo" className={`h-16 flex-shrink-0 ${(error || phase === StartPhase.Stopped) ? '' : 'animate-bounce'}`} />
+      <img src={gitpodIcon} alt="Gitpod's logo" className={`h-16 flex-shrink-0 ${(error || phase === StartPhase.Stopped || phase === StartPhase.IdeReady) ? '' : 'animate-bounce'}`} />
       <h3 className="mt-8 text-xl">{title}</h3>
-      {typeof(phase) === 'number' && phase < StartPhase.Stopping && <ProgressBar phase={phase} error={!!error} />}
+      {typeof(phase) === 'number' && phase < StartPhase.IdeReady && <ProgressBar phase={phase} error={!!error} />}
       {error && <StartError error={error} />}
       {props.children}
     </div>

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -27,6 +27,10 @@ export interface StartWorkspaceState {
   workspace?: Workspace;
   hasImageBuildLogs?: boolean;
   error?: StartWorkspaceError;
+  desktopIde?: {
+    link: string
+    label: string
+  }
 }
 
 export default class StartWorkspace extends React.Component<StartWorkspaceProps, StartWorkspaceState> {
@@ -45,6 +49,10 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
           if (event.data.state.ideFrontendFailureCause) {
             const error = { message: event.data.state.ideFrontendFailureCause };
             this.setState({ error });
+          }
+          if (event.data.state.desktopIdeLink) {
+            const label = event.data.state.desktopIdeLabel || "Open Desktop IDE";
+            this.setState({ desktopIde: { link: event.data.state.desktopIdeLink, label } });
           }
         }
       }
@@ -269,8 +277,26 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         if (isHeadless) {
           return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
         }
-        phase = StartPhase.Running;
-        statusMessage = <p className="text-base text-gray-400">Opening IDE …</p>;
+        if (!this.state.desktopIde) {
+          phase = StartPhase.Running;
+          statusMessage = <p className="text-base text-gray-400">Opening IDE …</p>;
+        } else {
+          phase = StartPhase.IdeReady;
+          statusMessage = <div>
+            <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
+              <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
+              <div>
+                <p className="text-gray-700 dark:text-gray-200 font-semibold">{this.state.workspaceInstance.workspaceId}</p>
+                <a target="_parent" href={this.state.workspace?.contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{this.state.workspace?.contextURL}</p></a>
+              </div>
+            </div>
+            <div className="mt-10 justify-center flex space-x-2">
+              <a target="_blank" href={this.state.desktopIde.link}><button>{this.state.desktopIde.label}</button></a>
+              <button className="secondary" onClick={() => window.parent.postMessage({ type: 'openBrowserIde' }, '*')}>Open VS Code in Browser</button>
+            </div>
+          </div>;
+        }
+
         break;
 
       // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.

--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -20,7 +20,7 @@ export class SupervisorServiceClient {
         private readonly gitpodServiceClient: GitpodServiceClient
     ) { }
 
-    private async checkReady(kind: 'content' | 'ide' | 'supervisor', delay?: boolean): Promise<void> {
+    private async checkReady(kind: 'content' | 'ide' | 'supervisor', delay?: boolean): Promise<any> {
         if (delay) {
             await new Promise((resolve) => setTimeout(resolve, 1000));
         }
@@ -54,7 +54,7 @@ export class SupervisorServiceClient {
                     return;
                 }
                 if (kind === 'ide' && (result as IDEStatusResponse.AsObject).ok) {
-                    return;
+                    return result;
                 }
             }
             console.debug(`failed to check whether ${kind} is ready, trying again...`, response.status, response.statusText, JSON.stringify(result, undefined, 2));

--- a/components/supervisor/frontend/src/shared/loading-frame.ts
+++ b/components/supervisor/frontend/src/shared/loading-frame.ts
@@ -22,13 +22,13 @@ window.addEventListener('message', relocateListener, false);
 
 let resolveSessionId: (sessionId: string) => void;
 const sessionId = new Promise<string>(resolve => resolveSessionId = resolve);
-const setSessinoIdListener = (event: MessageEvent) => {
+const setSessionIdListener = (event: MessageEvent) => {
     if (event.origin === serverOrigin && event.data.type == '$setSessionId' && event.data.sessionId) {
-        window.removeEventListener('message', setSessinoIdListener);
+        window.removeEventListener('message', setSessionIdListener);
         resolveSessionId(event.data.sessionId);
     }
 };
-window.addEventListener('message', setSessinoIdListener, false);
+window.addEventListener('message', setSessionIdListener, false);
 
 export function load({ gitpodService }: {
     gitpodService: ReturnType<typeof createGitpodService>


### PR DESCRIPTION
## Description
This PR has the parts of the umbrella PR #6270 that change `supervisor` frontend to support desktop IDE images.

See https://github.com/gitpod-io/gitpod/pull/6270#issuecomment-949786034 for more info.


## Release Notes
```release-note
NONE
```
