### PR TITLE
[server] Pass selected desktop IDE to ws-manager

### DIFF
--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -212,4 +212,7 @@ export interface WorkspaceInstanceConfiguration {
 
     // ideImage is the ref of the IDE image this instance uses.
     ideImage: string;
+
+    // desktopIdeImage is the ref of the desktop IDE image this instance uses.
+    desktopIdeImage?: string
 }

--- a/components/server/src/ide-config.ts
+++ b/components/server/src/ide-config.ts
@@ -17,6 +17,7 @@ interface RawIDEConfig {
     ideVersion: string;
     ideImageRepo: string;
     ideImageAliases?: { [index: string]: string };
+    desktopIdeImageAliases?: { [index: string]: string };
 }
 const scheme = {
     "type": "object",
@@ -30,7 +31,11 @@ const scheme = {
         "ideImageAliases": {
             "type": "object",
             "additionalProperties": { "type": "string" }
-        }
+        },
+        "desktopIdeImageAliases": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        },
     },
     "required": [
         "ideVersion",
@@ -42,7 +47,7 @@ export interface IDEConfig {
     ideVersion: string;
     ideImageRepo: string;
     ideImageAliases: { [index: string]: string };
-
+    desktopIdeImageAliases: { [index: string]: string };
     ideImage: string;
 }
 
@@ -112,6 +117,9 @@ export class IDEConfigService {
                     ideImageAliases: {
                         ...raw.ideImageAliases,
                         "theia": ideImage,
+                    },
+                    desktopIdeImageAliases: {
+                        ...raw.desktopIdeImageAliases
                     }
                 }
             }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -323,6 +323,21 @@ export class WorkspaceStarter {
             }
         }
 
+        const useDesktopIdeChoice = user.additionalData?.ideSettings?.useDesktopIde || false;
+        if (useDesktopIdeChoice) {
+            const desktopIdeChoice = user.additionalData?.ideSettings?.defaultDesktopIde;
+            if (!!desktopIdeChoice) {
+                const mappedImage = ideConfig.desktopIdeImageAliases[desktopIdeChoice];
+                if (!!mappedImage) {
+                    configuration.desktopIdeImage = mappedImage;
+                } else if (this.authService.hasPermission(user, "ide-settings")) {
+                    // if the IDE choice isn't one of the preconfiured choices, we assume its the image name.
+                    // For now, this feature requires special permissions.
+                    configuration.desktopIdeImage = desktopIdeChoice;
+                }
+            }
+        }
+
         let featureFlags: NamedWorkspaceFeatureFlag[] = workspace.config._featureFlags || [];
         featureFlags = featureFlags.concat(this.config.workspaceDefaults.defaultFeatureFlags);
         if (user.featureFlags && user.featureFlags.permanentWSFeatureFlags) {
@@ -732,6 +747,7 @@ export class WorkspaceStarter {
         spec.setInitializer((await initializerPromise).initializer);
         const startWorkspaceSpecIDEImage = new IDEImage();
         startWorkspaceSpecIDEImage.setWebRef(ideImage);
+        startWorkspaceSpecIDEImage.setDesktopRef(instance.configuration?.desktopIdeImage || "");
         spec.setIdeImage(startWorkspaceSpecIDEImage);
         spec.setDeprecatedIdeImage(ideImage);
         spec.setWorkspaceImage(instance.workspaceImage);


### PR DESCRIPTION
## Description
This PR has the parts of the umbrella PR #6270 that change the `server` to choose a desktop IDE. ~~This also includes the following changes in order to compile:~~
- #6364
- #6368

See https://github.com/gitpod-io/gitpod/pull/6270#issuecomment-949786034 for more info.


## Release Notes
```release-note
NONE
```
