### PR TITLE
Introduce project slug

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -170,6 +170,7 @@ export default function NewProject() {
         try {
             await getGitpodService().server.createProject({
                 name: repo.name,
+                slug: (repo.path ? repo.path : repo.name),
                 cloneUrl: repo.cloneUrl,
                 account: repo.account,
                 provider,

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -26,7 +26,7 @@ export default function () {
     const team = getCurrentTeam(location, teams);
 
     const match = useRouteMatch<{ team: string, resource: string }>("/(t/)?:team/:resource");
-    const projectName = match?.params?.resource;
+    const projectSlug = match?.params?.resource;
 
     const [project, setProject] = useState<Project | undefined>();
 
@@ -61,14 +61,18 @@ export default function () {
     }, [project]);
 
     const updateProject = async () => {
-        if (!teams || !projectName) {
+        if (!teams || !projectSlug) {
             return;
         }
         const projects = (!!team
             ? await getGitpodService().server.getTeamProjects(team.id)
             : await getGitpodService().server.getUserProjects());
 
-        const project = projectName && projects.find(p => p.name === projectName);
+        // Find project matching with slug, otherwise with name
+        const project = projectSlug && projects.find(
+            p => p.slug ? p.slug === projectSlug :
+            p.name === projectSlug);
+
         if (!project) {
             return;
         }
@@ -239,7 +243,7 @@ export default function () {
                                 </div>
                             </ItemField>
                             <ItemField className="flex items-center">
-                                <a className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1 cursor-pointer" href={prebuild ? `/${!!team ? 't/' + team.slug : 'projects'}/${projectName}/${prebuild.info.id}` : 'javascript:void(0)'}>
+                                <a className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1 cursor-pointer" href={prebuild ? `/${!!team ? 't/' + team.slug : 'projects'}/${projectSlug}/${prebuild.info.id}` : 'javascript:void(0)'}>
                                     {prebuild ? (<><div className="inline-block align-text-bottom mr-2 w-4 h-4">{statusIcon}</div>{status}</>) : (<span> </span>)}
                                 </a>
                                 <span className="flex-grow" />

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -85,10 +85,28 @@ export default function () {
         return moment(lastPrebuilds.get(p1.id)?.info?.startedAt || '1970-01-01').diff(moment(lastPrebuilds.get(p0.id)?.info?.startedAt || '1970-01-01'));
     }
 
-    const teamOrUserSlug = !!team ? 't/'+team.slug : 'projects';
     let [ isRemoveModalVisible, setRemoveModalVisible ] = useState(false);
     let [ removeProjectHandler, setRemoveProjectHandler ] = useState<() => void>(()=> () => {})
     let [ willRemoveProject, setWillRemoveProject ] = useState<Project>()
+
+    function renderProjectLink(project: Project): React.ReactElement {
+        let slug = '';
+        const name = project.name;
+
+        if (project.slug) {
+            slug = project.slug;
+        } else {
+            // For existing GitLab projects that don't have a slug yet
+            slug = name;
+        }
+
+        return (
+            <Link to={`/${teamOrUserSlug}/${slug}`}>
+                <span className="text-xl font-semibold">{name}</span>
+            </Link>)
+    }
+
+    const teamOrUserSlug = !!team ? 't/' + team.slug : 'projects';
 
     return <>
 
@@ -137,9 +155,7 @@ export default function () {
                         <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
                             <div className="h-32 p-6">
                                 <div className="flex text-gray-700 dark:text-gray-200 font-medium">
-                                    <Link to={`/${teamOrUserSlug}/${p.name}`}>
-                                        <span className="text-xl font-semibold">{p.name}</span>
-                                    </Link>
+                                    {renderProjectLink(p)}
                                     <span className="flex-grow" />
                                     <div className="justify-end">
                                         <ContextMenu menuEntries={[

--- a/components/gitpod-db/src/typeorm/entity/db-project.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project.ts
@@ -19,6 +19,9 @@ export class DBProject {
   name: string;
 
   @Column()
+  slug?: string;
+
+  @Column()
   cloneUrl: string;
 
   @Column({

--- a/components/gitpod-db/src/typeorm/migration/1634894637934-AddSlugToProject.ts
+++ b/components/gitpod-db/src/typeorm/migration/1634894637934-AddSlugToProject.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class AddSlugToProject1634894637934 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        if (!(await columnExists(queryRunner, "d_b_project", "slug"))) {
+            await queryRunner.query("ALTER TABLE d_b_project ADD COLUMN `slug` varchar(255) NULL");
+        }
+        if (await columnExists(queryRunner, "d_b_project", "slug")) {
+            await queryRunner.query("UPDATE d_b_project SET slug = name WHERE cloneUrl LIKE '%github%' AND slug IS NULL;");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -235,6 +235,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
 export interface CreateProjectParams {
     name: string;
+    slug?: string;
     account: string;
     provider: string;
     cloneUrl: string;
@@ -256,6 +257,7 @@ export interface GetProviderRepositoriesParams {
 }
 export interface ProviderRepository {
     name: string;
+    path?: string;
     account: string;
     accountAvatarUrl: string;
     cloneUrl: string;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -14,6 +14,7 @@ export interface ProjectConfig {
 export interface Project {
     id: string;
     name: string;
+    slug?: string;
     cloneUrl: string;
     teamId?: string;
     userId?: string;

--- a/components/server/ee/src/gitlab/gitlab-app-support.ts
+++ b/components/server/ee/src/gitlab/gitlab-app-support.ts
@@ -37,6 +37,7 @@ export class GitLabAppSupport {
         const projectsWithAccess = await api.Projects.all({ min_access_level: "40", perPage: 100 });
         for (const project of projectsWithAccess) {
             const anyProject = project as any;
+            const path = anyProject.path as string;
             const fullPath = anyProject.path_with_namespace as string;
             const cloneUrl = anyProject.http_url_to_repo as string;
             const updatedAt = anyProject.last_activity_at as string;
@@ -45,6 +46,7 @@ export class GitLabAppSupport {
 
             (account === usersGitLabAccount ? ownersRepos : result).push({
                 name: project.name,
+                path,
                 account,
                 cloneUrl,
                 updatedAt,

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -90,13 +90,14 @@ export class ProjectsService {
         return result;
     }
 
-    async createProject({ name, cloneUrl, teamId, userId, appInstallationId }: CreateProjectParams): Promise<Project> {
+    async createProject({ name, slug, cloneUrl, teamId, userId, appInstallationId }: CreateProjectParams): Promise<Project> {
         const projects = await this.getProjectsByCloneUrls([cloneUrl]);
         if (projects.length > 0) {
             throw new Error("Project for repository already exists.");
         }
         const project = Project.create({
             name,
+            slug,
             cloneUrl,
             ...(!!userId ? { userId } : { teamId }),
             appInstallationId


### PR DESCRIPTION
## Description
This PR:
1. Introduces a slug column for d_b_project
2. Adds the ['path' attribute provided by the GitLab API](https://docs.gitlab.com/ee/api/projects.html#create-project) on project creation
3. For existing Github projects, the slug column gets populated according to the name column (because already slugified)

<img width="413" alt="Screenshot 2021-10-25 at 01 22 18" src="https://user-images.githubusercontent.com/8015191/138617288-957c0033-455c-486b-a1b6-c6976bc225ea.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Maybe partially fixes #5847 because this PR does not tackle existing GitLab projects. Detailed thoughts [in the issue here](https://github.com/gitpod-io/gitpod/issues/5847#issuecomment-950418026).

## How to test
1. Create a GitLab project in a GitLab account
2. Add that project as a Gitpod project
3. Click on that project, get redirected to that project's page
4. URL should be slugified.

Note: I do not have a GitHub app in my preview envs. If anyone could test it with theirs, please do. Nothing should change for GitHub projects.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
New GitLab projects will have a slugified Project url
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
