### PR TITLE
[openvsx-proxy] Fix Access-Control-Allow-Origin header for cached values

### DIFF
--- a/components/openvsx-proxy/pkg/errorhandler.go
+++ b/components/openvsx-proxy/pkg/errorhandler.go
@@ -62,6 +62,9 @@ func (o *OpenVSXProxy) ErrorHandler(rw http.ResponseWriter, r *http.Request, e e
 			}
 		}
 	}
+	if v := rw.Header().Get("Access-Control-Allow-Origin"); v != "" && v != "*" {
+		rw.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+	}
 	rw.WriteHeader(cached.StatusCode)
 	rw.Write(cached.Body)
 	log.WithFields(logFields).Info("used cached response due to a proxy error")

--- a/components/openvsx-proxy/pkg/handler.go
+++ b/components/openvsx-proxy/pkg/handler.go
@@ -85,6 +85,9 @@ func (o *OpenVSXProxy) Handler(p *httputil.ReverseProxy) func(http.ResponseWrite
 								}
 							}
 						}
+						if v := rw.Header().Get("Access-Control-Allow-Origin"); v != "" && v != "*" {
+							rw.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+						}
 						rw.Header().Set("X-Cache", "HIT")
 						rw.WriteHeader(cached.StatusCode)
 						rw.Write(cached.Body)

--- a/components/openvsx-proxy/pkg/modifyresponse.go
+++ b/components/openvsx-proxy/pkg/modifyresponse.go
@@ -81,6 +81,9 @@ func (o *OpenVSXProxy) ModifyResponse(r *http.Response) error {
 			return nil
 		}
 		r.Header = cached.Header
+		if v := r.Header.Get("Access-Control-Allow-Origin"); v != "" && v != "*" {
+			r.Header.Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+		}
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(cached.Body))
 		r.ContentLength = int64(len(cached.Body))
 		r.StatusCode = cached.StatusCode


### PR DESCRIPTION
## Description
OpenVSX proxy serves cached values with `Access-Control-Allow-Origin` header from previous calls. This change fixes the header and sets the actual `Origin` instead.

/cc @akosyakov 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6374

## How to test
<!-- Provide steps to test this PR -->
- Open 2 workspaces.
- Install an extension in the first workspace (install with do not sync), e.g. the `vim` extension
- Within 5 minutes, install the same extension in the second workspace.

Expected outcome: The requests will be cached and the installation should work (compare it with production where this fails).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

