### PR TITLE
Update gp-cli CODEOWNERS

### DIFF
--- a/components/gitpod-cli/OWNERS
+++ b/components/gitpod-cli/OWNERS
@@ -3,7 +3,7 @@ options:
   no_parent_owners: true
 
 approvers:
-  - engineering-workspace
+  - engineering-ide
 
 labels:
-  - "team: workspace"
+  - "team: IDE"


### PR DESCRIPTION
## Description

Change owners for GP CLI to the IDE team.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```