### PR TITLE
[werft/observability] Reuse preview certificate instead of requestin new ones

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -43,8 +43,8 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
     --ext-str namespace="${params.satelliteNamespace}" \
     --ext-str cluster_name="${params.satelliteNamespace}" \
     --ext-str node_exporter_port="${params.nodeExporterPort}" \
-    --ext-str prometheus_dns_name="prometheus-${params.previewDomain}" \
-    --ext-str grafana_dns_name="grafana-${params.previewDomain}" \
+    --ext-str prometheus_dns_name="prometheus.${params.previewDomain}" \
+    --ext-str grafana_dns_name="grafana.${params.previewDomain}" \
     --ext-str node_affinity_label="gitpod.io/workload_services" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Extends the preview certificate issuer to add monitoring-satellite subdomains while  https://github.com/gitpod-io/observability/pull/11 removes all certificates that are requested by the observability repository.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6291, also needs https://github.com/gitpod-io/observability/pull/11 to make it work.

## How to test
<!-- Provide steps to test this PR -->
Run the werft job, but add the appropriate annotations `with-observability` and `withObservabilityBranch=as/dns-rate-limit`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
