### PR TITLE
[server] Add config "experimantalNetwork" which translates to "WORKSPACEKIT_USE_NETNS"

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -206,6 +206,10 @@
                     }
                 }
             }
+        },
+        "experimentalNetwork": {
+            "type": "boolean",
+            "description": "Experimental network configuration in workspaces"
         }
     },
     "additionalProperties": false

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -559,6 +559,9 @@ export interface WorkspaceConfig {
     github?: GithubAppConfig;
     vscode?: VSCodeConfig;
 
+    /** tailscale demo */
+    experimentalNetwork?: boolean;
+
     /**
      * Where the config object originates from.
      *

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -637,6 +637,13 @@ export class WorkspaceStarter {
         vsxRegistryUrl.setValue(this.config.vsxRegistryUrl);
         envvars.push(vsxRegistryUrl);
 
+        if (workspace.config.experimentalNetwork) {
+            const useNetnsVar = new EnvironmentVariable();
+            useNetnsVar.setName("WORKSPACEKIT_USE_NETNS");
+            useNetnsVar.setValue("true");
+            envvars.push(useNetnsVar);
+        }
+
         const createGitpodTokenPromise = (async () => {
             const scopes = this.createDefaultGitpodAPITokenScopes(workspace, instance);
             const token = crypto.randomBytes(30).toString('hex');


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- https://gpl-tailscale-demo.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod-test-repo/tree/gpl/experimental-network

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
