### PR TITLE
[dashboard] Add autofocus to some modal

### DIFF
--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -42,7 +42,7 @@ export default function Account() {
                 <li className="ml-5">Your subscription will be cancelled. If you obtained a Gitpod subscription through the GitHub marketplace, you need to cancel your plan there.</li>
             </ol>
             <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">Type your email to confirm</p>
-            <input className="w-full" type="text" onChange={e => setTypedEmail(e.target.value)}></input>
+            <input autoFocus className="w-full" type="text" onChange={e => setTypedEmail(e.target.value)}></input>
         </ConfirmationModal>
 
         <PageWithSubMenu subMenu={settingsMenu}  title='Account' subtitle='Manage account and git configuration.'>

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -59,7 +59,7 @@ function AddEnvVarModal(p: EnvVarModalProps) {
             </div> : null}
             <div>
                 <h4>Name</h4>
-                <input className="w-full" type="text" value={ev.name} onChange={(v) => { update({name: v.target.value}) }} />
+                <input autoFocus className="w-full" type="text" value={ev.name} onChange={(v) => { update({name: v.target.value}) }} />
             </div>
             <div className="mt-4">
                 <h4>Value</h4>

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -37,7 +37,7 @@ export default function () {
             <div className="border rounded-xl p-6 border-gray-100 dark:border-gray-800">
                 <h3 className="text-center text-xl mb-6">What's your team's name?</h3>
                 <h4>Team Name</h4>
-                <input className={`w-full${!!creationError ? ' error' : ''}`} type="text" onChange={event => name = event.target.value} />
+                <input autoFocus className={`w-full${!!creationError ? ' error' : ''}`} type="text" onChange={event => name = event.target.value} />
                 {!!creationError && <p className="text-gitpod-red">{creationError.message.replace(/Request \w+ failed with message: /, '')}</p>}
             </div>
             <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-2">

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -74,7 +74,7 @@ export default function TeamSettings() {
                 <li className="ml-5">All <b>members</b> of this team will lose access to this team, associated projects and workspaces.</li>
             </ol>
             <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">Type <CodeText>{team?.slug}</CodeText> to confirm</p>
-            <input className="w-full" type="text" onChange={e => setTeamSlug(e.target.value)}></input>
+            <input autoFocus className="w-full" type="text" onChange={e => setTeamSlug(e.target.value)}></input>
         </ConfirmationModal>
     </>
 }

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -175,7 +175,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                         {errorMessage}
                     </div>
                     : null}
-                <input className="w-full truncate" type="text" defaultValue={workspaceDescription} ref={renameInputRef} />
+                <input autoFocus className="w-full truncate" type="text" defaultValue={workspaceDescription} ref={renameInputRef} />
                 <div className="mt-1">
                     <p className="text-gray-500">Change the description to make it easier to go back to a workspace.</p>
                     <p className="text-gray-500">Workspace URLs and endpoints will remain the same.</p>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add autofocus when renaming a workspace, deleting account, deleting team, add environment, add team

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6371

## How to test
<!-- Provide steps to test this PR -->
1. Create a team
2. Go to team settings
3. Click Delete Team
4. You will see the input field auto focus

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
