### PR TITLE
[ws-deployment] Introduce versions manifest flag and minor fixes

### DIFF
--- a/operations/workspace/deployment/README.md
+++ b/operations/workspace/deployment/README.md
@@ -22,7 +22,7 @@ Broadly these are the steps/things that it does in the given order:
 
 Use the below command to get started:
 ```sh
-go run main.go deploy --config /path/to/config.yaml
+go run main.go deploy --config /path/to/config.yaml --versions-manifest /path/to/versions.yaml
 ```
 
 ## Overall Flow Diagram
@@ -36,7 +36,6 @@ This is the flow that we are building to achive automated gitpod deployment:
     version: v1
     project:
       id: gitpod-dev-staging
-      environment: dev-staging
       gcpSACredFile: /mnt/secrets/gcp-sa/service-account.json
       network: gitpod-dev-staging
       dnsZone: gitpod-dev-staging-com

--- a/operations/workspace/deployment/cmd/deploy.go
+++ b/operations/workspace/deployment/cmd/deploy.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os/exec"
+	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-deployment/pkg/orchestrate"
@@ -31,6 +32,10 @@ var deployCmd = &cobra.Command{
 	Short: "Creates a new workspace cluster and installs gitpod on it",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := getConfig()
+
+		verifyVersionsManifestFilePath(versionsManifestFile)
+
+		rand.Seed(time.Now().UnixNano())
 		randomId := fmt.Sprintf("%d", rand.Intn(200)+100)
 		cfg.InitializeWorkspaceClusterNames(randomId) // TODO(prs):revisit and update this
 		log.Log.Infof("%+v", cfg)

--- a/operations/workspace/deployment/cmd/root.go
+++ b/operations/workspace/deployment/cmd/root.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,6 +24,7 @@ var (
 )
 
 var cfgFile string
+var versionsManifestFile string
 var jsonLog bool
 var verbose bool
 
@@ -46,7 +48,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "c", "config file (default is $HOME/ws-deployment.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "./ws-deployment.yaml", "config file (default is ./ws-deployment.yaml)")
+	rootCmd.PersistentFlags().StringVar(&versionsManifestFile, "versions-manifest", "./versions.yaml", "versions manifest file (default is ./versions.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
 }
 
@@ -64,4 +67,10 @@ func getConfig() *v1.Config {
 	}
 
 	return &cfg
+}
+
+func verifyVersionsManifestFilePath(path string) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		log.WithError(err).Fatal("versions manifest file path does not exist. Maybe incorrect file path ?")
+	}
 }

--- a/operations/workspace/deployment/pkg/common/context.go
+++ b/operations/workspace/deployment/pkg/common/context.go
@@ -16,6 +16,12 @@ type ProjectContext struct {
 	Bucket        string `yaml:"bucket"`
 }
 
+// GitpodContext is a wraper over data that is required
+// to install gitpod on a cluster
+type GitpodContext struct {
+	VersionsManifestFilePath string
+}
+
 // ClusterContext contains the context to access the cluster
 type ClusterContext struct {
 	KubeconfigPath string


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Introduces a new flag `--versions-manifest` for ws-deployment cli which refers to the file path of versions manifest file
* Update randomization code to use current time as seed
* Update the default values to sensible defaults
* Update Readme

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
https://github.com/gitpod-io/gitpod/issues/6332

## How to test
<!-- Provide steps to test this PR -->
Build and run the cli. It should not give an error if you pass the `--versions-manifest` flag:

```sh
go build
./ws-deployment --config example-config.yaml --versions-manifest /some/file/which/exists.yaml
```
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


- [x] /werft with-clean-slate-deployment