### PR TITLE
[server] fix gitlab prebuild stucks in some case

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -828,7 +828,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
                 } else {
                     if (await services.repositoryService.canInstallAutomatedPrebuilds(user, cloneUrl)) {
                         console.log('Installing automated prebuilds for ' + cloneUrl);
-                        services.repositoryService.installAutomatedPrebuilds(user, cloneUrl);
+                        await services.repositoryService.installAutomatedPrebuilds(user, cloneUrl);
                     }
                 }
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
fix gitlab prebuild stucks when add prebuild webhook failed
It should be await, and catch error by try catch code block
current it only stuck start workspace step in "Prepare worksapce", when upgrade to nodev16, it will cause crash

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
