### PR TITLE
[dashboard] add additional prebuild state to UI

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -258,12 +258,21 @@ export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInst
                 </div>;
             details = <div className="flex space-x-1 items-center text-gray-400">
                 <img className="h-4 w-4 animate-spin" src={Spinner} />
-                <span>Prebuild in progress ...</span>
+                <span>Preparing prebuild ...</span>
                 </div>;
             break;
         case 'preparing': // Fall through
         case 'pending': // Fall through
         case 'creating': // Fall through
+            status = <div className="flex space-x-1 items-center text-yellow-800">
+                <img className="h-4 w-4" src={StatusRunning} />
+                <span>PREPARING</span>
+                </div>;
+            details = <div className="flex space-x-1 items-center text-gray-400">
+                <img className="h-4 w-4 animate-spin" src={Spinner} />
+                <span>Preparing prebuild ...</span>
+                </div>;
+            break;
         case 'initializing': // Fall  through
         case 'running': // Fall through
         case 'interrupted': // Fall through

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -251,22 +251,13 @@ export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInst
     let details = <></>;
     switch (props.prebuildInstance?.status.phase) {
         case undefined: // Fall through
+        case 'preparing': // Fall through
+        case 'pending': // Fall through
+        case 'creating': // Fall through
         case 'unknown':
             status = <div className="flex space-x-1 items-center text-yellow-600">
                 <img className="h-4 w-4" src={StatusPaused} />
                 <span>PENDING</span>
-                </div>;
-            details = <div className="flex space-x-1 items-center text-gray-400">
-                <img className="h-4 w-4 animate-spin" src={Spinner} />
-                <span>Preparing prebuild ...</span>
-                </div>;
-            break;
-        case 'preparing': // Fall through
-        case 'pending': // Fall through
-        case 'creating': // Fall through
-            status = <div className="flex space-x-1 items-center text-yellow-800">
-                <img className="h-4 w-4" src={StatusRunning} />
-                <span>PREPARING</span>
                 </div>;
             details = <div className="flex space-x-1 items-center text-gray-400">
                 <img className="h-4 w-4 animate-spin" src={Spinner} />


### PR DESCRIPTION
## Description
Add an additional state in the UI for prebuilds that are in preparing

## Related Issue(s)
Fixes #5904

## How to test
- I've installed the GitHub app already and disabled the sweeper, so this should still work
- log in to https://jk-show-additional-prebuild-phase.staging.gitpod-dev.com
- create a new project and start a prebuild
- Note the new state "PREPARING" between "PENDING" and "RUNNING"

## Release Notes
```release-note
improved dashboard UI feedback on pre-build startups
```