### PR TITLE
Update canceled prebuild status icon

### DIFF
--- a/components/dashboard/src/icons/StatusCanceled.svg
+++ b/components/dashboard/src/icons/StatusCanceled.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20"><path fill="#A8A29E" fill-rule="evenodd" d="M15.657 4.343A8 8 0 1 0 4.343 15.657 8 8 0 0 0 15.657 4.343Zm-4.243 8.485a1 1 0 1 0 1.414-1.414L8.586 7.172a1 1 0 1 0-1.414 1.414l4.242 4.242Z" clip-rule="evenodd"/></svg>
+<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.657 13.657A8 8 0 1 0 2.343 2.343a8 8 0 0 0 11.314 11.314ZM5.172 9.414a1 1 0 1 0 1.414 1.414l4.242-4.242a1 1 0 0 0-1.414-1.414L5.172 9.414Z" fill="#A8A29E"/></svg>


### PR DESCRIPTION
## Description

This will update canceled prebuild status icon. Noticed this while reviewing https://github.com/gitpod-io/gitpod/pull/6424.

// TODO: Screenshots to be added once the preview environment is up and running.

| BEFORE | AFTER |
|-|-|
|||

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

1. Add a project
2. Trigger a prebuild
3. Cancel the running prebuild
4. Trigger another prebuild for a different branch
5. Notice the canceled prebuild status icon
6. Icon should be aligned and have similar size as the `RUNNING` prebuild

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```