### PR TITLE
[jetbrains-image] Improve logging

### DIFF
--- a/components/ide/jetbrains/image/startup.sh
+++ b/components/ide/jetbrains/image/startup.sh
@@ -13,4 +13,6 @@ trap "jobs -p | xargs -r kill" SIGINT SIGTERM EXIT
 export CWM_NON_INTERACTIVE=1
 export CWM_HOST_PASSWORD=gitpod
 export CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod
-/ide-desktop/backend/bin/remote-dev-server.sh cwmHost "$GITPOD_REPO_ROOT"
+/ide-desktop/backend/bin/remote-dev-server.sh cwmHost "$GITPOD_REPO_ROOT" > >(sed 's/^/JetBrains remote-dev-server.sh (out): /') 2> >(sed 's/^/JetBrains remote-dev-server.sh (err): /' >&2)
+
+echo "Desktop IDE startup script exited"

--- a/components/ide/jetbrains/image/status/main.go
+++ b/components/ide/jetbrains/image/status/main.go
@@ -26,6 +26,8 @@ func main() {
 		label = os.Args[2]
 	}
 
+	errlog := log.New(os.Stderr, "JetBrains IDE status: ", log.LstdFlags)
+
 	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		var (
 			url    = "http://localhost:63342/codeWithMe/unattendedHostStatus?token=gitpod"
@@ -40,12 +42,13 @@ func main() {
 
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
+			errlog.Printf("Error reading body: %v\n", err)
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			// log.Printf("Desktop IDE status proxy: getting non-200 status - %d\n%s\n", resp.StatusCode, bodyBytes)
+			errlog.Printf("Getting non-200 status - %d\n%s\n", resp.StatusCode, bodyBytes)
 			http.Error(w, string(bodyBytes), resp.StatusCode)
 			return
 		}
@@ -60,10 +63,12 @@ func main() {
 		err = json.Unmarshal(bodyBytes, &jsonResp)
 
 		if err != nil {
+			errlog.Printf("Error parsing JSON body from IDE status probe: %v\n", err)
 			http.Error(w, "Error parsing JSON body from IDE status probe.", http.StatusServiceUnavailable)
 			return
 		}
 		if len(jsonResp.Projects) != 1 {
+			errlog.Printf("projects size != 1\n")
 			http.Error(w, "projects size != 1", http.StatusServiceUnavailable)
 			return
 		}


### PR DESCRIPTION
## Description
This PR improves the logging in the workspace pod for the JetBrains IntelliJ image. It
a) adds the prefix `JetBrains remote-dev-server.sh` to stdout/stderr output of the `remove-dev-server.sh` script to identify the output in the pod logs
b) adds error logs when the JetBrains status endpoint cannot be reached etc.

## How to test
Start a workspace with the IntelliJ image and view the logs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

