### PR TITLE
[intellij] Update to version ideaIU-213.4958

### DIFF
--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -17,13 +17,12 @@ packages:
       - components/ide/jetbrains/backend-plugin:plugin
     argdeps:
       - imageRepoBase
-      - INTELLIJ_BACKEND_URL
     config:
       dockerfile: leeway.Dockerfile
       metadata:
         helm-component: workspace.desktopIdeImages.intellij
       buildArgs:
-        JETBRAINS_BACKEND_URL: ${INTELLIJ_BACKEND_URL}
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/idea/code-with-me/remote-dev/ideaIU-213.4958.tar.gz"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
       image:
         - ${imageRepoBase}/ide/intellij:${version}


### PR DESCRIPTION
## Description
This PR updates the IntelliJ IDE image to the backend version `213.4958`.

/cc @atduarte 

## How to test
Choose IntelliJ in the settings and start a workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
