### PR TITLE
[ws-manager]: change affinities to match the installer values

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -339,7 +339,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 						{
 							MatchExpressions: []corev1.NodeSelectorRequirement{
 								{
-									Key:      "gitpod.io/workloads/workspace/" + workloadType,
+									Key:      "gitpod.io/workload_workspace_" + workloadType,
 									Operator: corev1.NodeSelectorOpExists,
 								},
 							},

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -207,7 +207,7 @@
                             {
                                 "matchExpressions": [
                                     {
-                                        "key": "gitpod.io/workloads/workspace/regular",
+                                        "key": "gitpod.io/workload_workspace_regular",
                                         "operator": "Exists"
                                     }
                                 ]

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -211,7 +211,7 @@
                             {
                                 "matchExpressions": [
                                     {
-                                        "key": "gitpod.io/workloads/workspace/headless",
+                                        "key": "gitpod.io/workload_workspace_headless",
                                         "operator": "Exists"
                                     }
                                 ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change affinities to match the installer values

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6404 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Change affinities to match the installer values
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
