### PR TITLE
[Dashboard] Beta notice for New Teams and New Projects

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -308,6 +308,9 @@ export default function NewProject() {
                         )}
                     </div>
             )}
+            <p className="text-left w-full mt-12 text-gray-500">
+                <strong>Teams &amp; Projects</strong> are currently in Beta. <a href="https://github.com/gitpod-io/gitpod/issues/5095" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a> or open a <a href="/workspaces" className="gp-link">New Workspace</a> with an example repository.
+            </p>
         </>
         );
 

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -45,5 +45,8 @@ export default function () {
                 <button className="secondary" onClick={() => history.push('/')}>Cancel</button>
             </div>
         </form>
+        <p className="text-center w-full mt-12 text-gray-500">
+            <strong>Teams &amp; Projects</strong> are currently in Beta. <a href="https://github.com/gitpod-io/gitpod/issues/5095" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a>
+        </p>
     </div>;
 }


### PR DESCRIPTION
## Description

- Adds footers with Beta notice and link to docs on `New Projects` and `New Teams` pages.

- Also adds link to Workspaces from the `New Projects` page, in order to provide a path for onboarding users to access example repos when we ship gitpod-io/website#1139.

![Screenshot 2021-10-28 at 23 09 29](https://user-images.githubusercontent.com/849592/139343425-7fc5dd71-7218-45b1-96ba-d6aadfc6241d.png) ![Screenshot 2021-10-28 at 23 09 00](https://user-images.githubusercontent.com/849592/139343439-df338d97-a9a2-48d2-880f-150894bd3015.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6010

## Release Notes
```release-note
NONE
```