### PR TITLE
[server] make prebuild webhook install async

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -826,10 +826,14 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
                 if (!hostContext || !services) {
                     console.error('Unknown host: ' + host);
                 } else {
-                    if (await services.repositoryService.canInstallAutomatedPrebuilds(user, cloneUrl)) {
-                        console.log('Installing automated prebuilds for ' + cloneUrl);
-                        await services.repositoryService.installAutomatedPrebuilds(user, cloneUrl);
-                    }
+                    // on purpose to not await on that installation process, because it‘s not required of workspace start
+                    // See https://github.com/gitpod-io/gitpod/pull/6420#issuecomment-953499632 for more detail
+                    (async () => {
+                        if (await services.repositoryService.canInstallAutomatedPrebuilds(user, cloneUrl)) {
+                            console.log('Installing automated prebuilds for ' + cloneUrl);
+                            await services.repositoryService.installAutomatedPrebuilds(user, cloneUrl);
+                        }
+                    })().catch((e) => console.error('Install automated prebuilds failed', e))
                 }
             }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
make prebuild webhook install async
See https://github.com/gitpod-io/gitpod/pull/6420#issuecomment-953499632 for detail

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
