### PR TITLE
Fix Leeway to use correct cache bucket

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -87,8 +87,8 @@ pod:
     - name: LEEWAY_WORKSPACE_ROOT
       value: /workspace
     - name: LEEWAY_REMOTE_CACHE_BUCKET
-      {{- if eq .Repository.Ref "refs/heads/master" }}
-      value: gitpod-core-leeway-cache-master
+      {{- if eq .Repository.Ref "refs/heads/main" }}
+      value: gitpod-core-leeway-cache-main
       {{- else }}
       value: gitpod-core-leeway-cache-branch
       {{- end }}


### PR DESCRIPTION
## Description
The build on `main` should use its own cache bucket. 

I did create the new bucket [gitpod-core-leeway-cache-main](https://console.cloud.google.com/storage/browser/gitpod-core-leeway-cache-main;tab=objects?project=gitpod-core-dev&prefix=&forceOnObjectsSortingFiltering=false)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
I don't see a way to test this before merging the PR.

After merging this PR, we can confirm that it works by looking at the cache bucket [`gitpod-core-leeway-cache-main`](https://console.cloud.google.com/storage/browser/gitpod-core-leeway-cache-main;tab=objects?project=gitpod-core-dev&prefix=&forceOnObjectsSortingFiltering=false) and confirming that it holds the leeway cache data.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
