### PR TITLE
[Installer]: additional bugfixes

### DIFF
--- a/components/ee/ws-scheduler/pkg/scaler/controller.go
+++ b/components/ee/ws-scheduler/pkg/scaler/controller.go
@@ -6,6 +6,7 @@ package scaler
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 	"time"
@@ -94,6 +95,17 @@ func (f *ConstantSetpointController) Control(ctx context.Context, workspaceCount
 
 // TimeOfDay is a time during the day. It unmarshals from JSON as hh:mm:ss string.
 type TimeOfDay time.Time
+
+// MarshalJSON converts the TimeOfDay into a string
+func (t TimeOfDay) MarshalJSON() ([]byte, error) {
+	str := time.Time(t).String()
+	res, err := time.Parse("2006-01-02 15:04:05 -0700 MST", str)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(res.Format("15:04:05"))
+}
 
 // UnmarshalJSON unmarshales a time of day
 func (t *TimeOfDay) UnmarshalJSON(data []byte) error {

--- a/components/ee/ws-scheduler/pkg/scaler/controller_test.go
+++ b/components/ee/ws-scheduler/pkg/scaler/controller_test.go
@@ -205,6 +205,51 @@ func TestSwitchedSetpointController(t *testing.T) {
 	}
 }
 
+func TestTimeOfDayMarshalJSON(t *testing.T) {
+	tests := []struct {
+		Input       time.Time
+		Expectation string
+		Error       string
+	}{
+		{time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC), "00:00:00", ""},
+		{time.Date(0, 1, 1, 23, 59, 59, 0, time.UTC), "23:59:59", ""},
+		{time.Date(0, 1, 1, 12, 0, 0, 0, time.UTC), "12:00:00", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Expectation, func(t *testing.T) {
+			input := TimeOfDay(test.Input)
+			b, err := json.Marshal(input)
+
+			var errmsg string
+			if err != nil {
+				errmsg = err.Error()
+			}
+			if errmsg != test.Error {
+				t.Fatalf("unepxected error: want %v, got %v", test.Error, errmsg)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			e, err := json.Marshal(test.Expectation)
+			if err != nil {
+				t.Fatal(err.Error())
+				return
+			}
+
+			marshalled := string(b)
+			expectation := string(e)
+
+			if marshalled != expectation {
+				t.Fatalf("unexpected result: want %v, got %v", expectation, marshalled)
+				return
+			}
+		})
+	}
+}
+
 func TestTimeOfDayUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		Input       string

--- a/installer/cmd/versions.yaml
+++ b/installer/cmd/versions.yaml
@@ -2,93 +2,97 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-version: main.1640
+version: main.1732
 components:
   agentSmith:
-    version: pd-add-missing-go-dep2-fork.0
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   blobserve:
-    version: commit-4e89f0f82d746317af800032439f7c790edfaec8
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   contentService:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   dashboard:
-    version: commit-0c4c21259571ce3eaf3cbeb60e2b559ecc899dee
+    version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
   dbMigrations:
-    version: commit-4425adc68e4141544adb783867a3e398359f8ecc
+    version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
   dbSync:
-    version: commit-4425adc68e4141544adb783867a3e398359f8ecc
+    version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
   imageBuilder:
-    version: commit-1d7d20c9cb289a047b8559b2141adf73ecf3876f
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   imageBuilderMk3:
     builderImage:
-      version: 93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+      version: aeebb3aec50715754842e767732963693f1a5679
 
-    version: commit-1d7d20c9cb289a047b8559b2141adf73ecf3876f
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   integrationTest:
-    version: commit-1d7d20c9cb289a047b8559b2141adf73ecf3876f
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   kedge:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   openVsxProxy:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   paymentEndpoint:
-    version: commit-4425adc68e4141544adb783867a3e398359f8ecc
+    version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
   proxy:
-    version: commit-cb09a691840416451c628515ddc35e721759ebc3
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   registryFacade:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   server:
-    version: commit-1d7d20c9cb289a047b8559b2141adf73ecf3876f
+    version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
   serviceWaiter:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   workspace:
     codeImage:
-      version: commit-5c97db5258faab662b945211469f0d2d715cb44a
+      version: commit-aeebb3aec50715754842e767732963693f1a5679
 
-    codeImageStable:
-      version: not-a-valid-version
+    desktopIdeImages:
+      goland:
+        version: commit-aeebb3aec50715754842e767732963693f1a5679
+
+      intellij:
+        version: commit-aeebb3aec50715754842e767732963693f1a5679
 
     dockerUp:
-      version: commit-cb09a691840416451c628515ddc35e721759ebc3
+      version: commit-aeebb3aec50715754842e767732963693f1a5679
 
     supervisor:
-      version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+      version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
     theiaImage:
-      version: commit-cb09a691840416451c628515ddc35e721759ebc3
+      version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   wsDaemon:
     userNamespaces:
       seccompProfileInstaller:
-        version: commit-cb09a691840416451c628515ddc35e721759ebc3
+        version: commit-aeebb3aec50715754842e767732963693f1a5679
 
       shiftfsModuleLoader:
-        version: commit-cb09a691840416451c628515ddc35e721759ebc3
+        version: commit-aeebb3aec50715754842e767732963693f1a5679
 
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   wsManager:
-    version: commit-1d7d20c9cb289a047b8559b2141adf73ecf3876f
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   wsManagerBridge:
-    version: commit-4425adc68e4141544adb783867a3e398359f8ecc
+    version: commit-d75a88003668aa699b61bc8a5ba7f76f67c3c9c1
 
   wsProxy:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679
 
   wsScheduler:
-    version: commit-93170cc9bf3c9c08dc9c50c5522b480cfc27e5ab
+    version: commit-aeebb3aec50715754842e767732963693f1a5679

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -6,6 +6,7 @@ package common
 
 import (
 	"fmt"
+	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"io"
 	"math/rand"
 	"strings"
@@ -42,7 +43,9 @@ var AffinityList = []string{
 
 func DefaultLabels(component string) map[string]string {
 	return map[string]string{
-		"component": component,
+		"app":                        AppName,
+		"component":                  component,
+		wsk8s.GitpodNodeServiceLabel: component,
 	}
 }
 

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -303,6 +303,14 @@ func Affinity(orLabels ...string) *corev1.Affinity {
 }
 
 func ImageName(repo, name, tag string) string {
+	// Use convention if empty values found
+	if repo == "" {
+		repo = "docker.io"
+	}
+	if tag == "" {
+		tag = "latest"
+	}
+
 	ref := fmt.Sprintf("%s/%s:%s", strings.TrimSuffix(repo, "/"), name, tag)
 	pref, err := reference.ParseNamed(ref)
 	if err != nil {

--- a/installer/pkg/common/constants.go
+++ b/installer/pkg/common/constants.go
@@ -7,6 +7,7 @@ package common
 // This file exists to break cyclic-dependency errors
 
 const (
+	AppName                   = "gitpod"
 	BlobServeServicePort      = 4000
 	CertManagerCAIssuer       = "ca-issuer"
 	DockerRegistryName        = "registry"

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -75,7 +75,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Spec: corev1.PodSpec{
 					PriorityClassName: common.SystemNodeCritical,
 					// todo(sje): do we need affinity?
-					Affinity:                      &corev1.Affinity{},
+					Affinity:                      common.Affinity(common.AffinityLabelWorkspacesRegular, common.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/installer/pkg/components/server/ide-configmap.go
+++ b/installer/pkg/components/server/ide-configmap.go
@@ -21,8 +21,8 @@ func ideconfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		IDEVersion:   ctx.VersionManifest.Components.Workspace.CodeImageStable.Version,
 		IDEImageRepo: workspace.IDEImageRepo,
 		IDEImageAliases: map[string]string{
-			"code":        fmt.Sprintf("%s%s:%s", ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImageStable.Version),
-			"code-latest": fmt.Sprintf("%s%s:%s", ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
+			"code":        common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImageStable.Version),
+			"code-latest": common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
 		},
 	}
 

--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -229,7 +229,7 @@ fi
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:             "working-area",
-									MountPath:        "/mnt/workingarea",
+									MountPath:        "/mnt/wsdaemon-workingarea",
 									MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationBidirectional; return &r }(),
 								},
 								{

--- a/installer/pkg/components/ws-daemon/tlssecret.go
+++ b/installer/pkg/components/ws-daemon/tlssecret.go
@@ -33,6 +33,7 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 					fmt.Sprintf("gitpod.%s", ctx.Namespace),
 					fmt.Sprintf("%s.%s.svc", Component, ctx.Namespace),
 					Component,
+					"wsdaemon", // Seems this is hardcoded in WSManager
 				},
 				IssuerRef: cmmeta.ObjectReference{
 					Name:  common.CertManagerCAIssuer,

--- a/installer/pkg/components/ws-manager/configmap.go
+++ b/installer/pkg/components/ws-manager/configmap.go
@@ -99,7 +99,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			//EventTraceLog:                "", // todo(sje): make conditional based on config
 			ReconnectionInterval:         util.Duration(30 * time.Second),
-			RegistryFacadeHost:           fmt.Sprintf("reg.%s:%v", common.RegistryFacadeComponent, common.RegistryFacadeServicePort),
+			RegistryFacadeHost:           fmt.Sprintf("reg.%s:%d", ctx.Config.Domain, common.RegistryFacadeServicePort),
 			EnforceWorkspaceNodeAffinity: true,
 		},
 		Content: struct {

--- a/installer/pkg/components/ws-scheduler/configmap.go
+++ b/installer/pkg/components/ws-scheduler/configmap.go
@@ -81,10 +81,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PrivateKey:  "/ws-manager-client-tls-certs/tls.key",
 				},
 			},
-			WorkspaceImage:     fmt.Sprintf("%s:%s", workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
-			IDEImage:           fmt.Sprintf("%s%s:%s", ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
+			WorkspaceImage:     common.ImageName("", workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
+			IDEImage:           common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
 			FeatureFlags:       nil,
-			MaxGhostWorkspaces: 80,
+			MaxGhostWorkspaces: 10,
 			SchedulerInterval:  util.Duration(time.Second * 5),
 			Renewal: struct {
 				Interval   util.Duration `json:"interval"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
More bugfixes on the installation. These are mostly due to finding errors with image building

 - add configmap to `ws-scheduler`
 - add `MarshalJSON` function to `TimeOfDay` to reverse the `UnmarshalJSON`
 - handle error if `IdeImage` not sent to ws-manager
 - more bugfixes

This is still not a complete deployment to GKE InCluster, but exists so as to share the workload

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
More bugfixes on the installation

 - add configmap to `ws-scheduler`
 - add `MarshalJSON` function to `TimeOfDay` to reverse the `UnmarshalJSON`
 - handle error if `IdeImage` not sent to ws-manager
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
