### PR TITLE
Handle private GitHub repos on Config Page

### DIFF
--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -111,6 +111,10 @@ export default function () {
                     setShowAuthBanner({ host: new URL(project.cloneUrl).hostname });
                 } else {
                     console.error('Getting project configuration failed', error);
+                    setIsDetecting(false);
+                    setIsEditorDisabled(true);
+                    setEditorMessage(<EditorMessage type="warning" heading="Project type could not be detected." message="Fetching project information failed." />);
+                    setGitpodYml(TASKS.Other);
                 }
             }
         })();
@@ -160,7 +164,7 @@ export default function () {
 
     const onConfirmShowAuthModal = async (host: string, scope?: string) => {
         setShowAuthBanner(undefined);
-        await tryAuthorize({host, onSuccess: async () => {
+        await tryAuthorize({host, scope, onSuccess: async () => {
             // update remote session
             await getGitpodService().reconnect();
 
@@ -259,7 +263,7 @@ export default function () {
                                     No Access
                                 </div>
                                 <div className="text-center dark:text-gray-400 pb-3">
-                                    Authorize {showAuthBanner.host} <br />{showAuthBanner.scope ? (<>and grant <strong>{showAuthBanner.scope}</strong> permission</>) : ""} to access project configuration.
+                                    Authorize {showAuthBanner.host} {showAuthBanner.scope ? (<>and grant <strong>{showAuthBanner.scope}</strong> permission</>) : ""}  <br /> to access project configuration.
                                 </div>
                                 <button className={`primary mr-2 py-2`} onClick={() => onConfirmShowAuthModal(showAuthBanner.host, showAuthBanner.scope)}>Authorize Provider</button>
                             </div>


### PR DESCRIPTION
Fixes #6168

To be more specific what this PR resolves and how to verify:

1. ensure you have just user:email permissions for GitHub on https://at-config-private-repo-6168.staging.gitpod-dev.com/integrations
2. go to https://at-config-private-repo-6168.staging.gitpod-dev.com/new and import a private repo from your account as a project
3. on the configuration page you should now see the `Authorize` button 
4. do authorize and grant `repo` permissions
5. the project configuration fetch should be repeated automatically

![2021-10-29 14 15 17](https://user-images.githubusercontent.com/914497/139432896-36299039-5015-47cd-8fb9-0046b113e471.gif)


```release-note
Handle private GitHub repos on Config Page
```