### PR TITLE
[ws-manager]: handle if IdeImage not included on the request spec

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -237,14 +237,16 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 	}
 
 	ideRef := startContext.Request.Spec.DeprecatedIdeImage
-	if len(startContext.Request.Spec.IdeImage.WebRef) > 0 {
+	var desktopIdeRef string
+	if startContext.Request.Spec.IdeImage != nil && len(startContext.Request.Spec.IdeImage.WebRef) > 0 {
 		ideRef = startContext.Request.Spec.IdeImage.WebRef
+		desktopIdeRef = startContext.Request.Spec.IdeImage.DesktopRef
 	}
 
 	spec := regapi.ImageSpec{
 		BaseRef:       startContext.Request.Spec.WorkspaceImage,
 		IdeRef:        ideRef,
-		DesktopIdeRef: startContext.Request.Spec.IdeImage.DesktopRef,
+		DesktopIdeRef: desktopIdeRef,
 	}
 	imageSpec, err := spec.ToBase64()
 	if err != nil {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -1,0 +1,224 @@
+{
+    "reason": {
+        "metadata": {
+            "name": "ws-test",
+            "namespace": "default",
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/networkpolicy": "default",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            },
+            "annotations": {
+                "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+                "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/requiredNodeServices": "ws-daemon,registry-facade",
+                "gitpod/admission": "admit_owner_only",
+                "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
+                "gitpod/id": "test",
+                "gitpod/imageSpec": "Cm1ldS5nY3IuaW8vZ2l0cG9kLWRldi93b3Jrc3BhY2UtYmFzZS1pbWFnZXMvZ2l0aHViLmNvbS90eXBlZm94L2dpdHBvZDo4MGE3ZDQyN2ExZmNkMzQ2ZDQyMDYwM2Q4MGEzMWQ1N2NmNzVhN2Fm",
+                "gitpod/never-ready": "true",
+                "gitpod/ownerToken": "%7J'[Of/8NDiWE+9F,I6^Jcj_1\u0026}-F8p",
+                "gitpod/servicePrefix": "foobarservice",
+                "gitpod/traceid": "",
+                "gitpod/url": "test-foobarservice-gitpod.io",
+                "prometheus.io/path": "/metrics",
+                "prometheus.io/port": "23000",
+                "prometheus.io/scrape": "true",
+                "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
+            }
+        },
+        "spec": {
+            "volumes": [
+                {
+                    "name": "vol-this-workspace",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test",
+                        "type": "DirectoryOrCreate"
+                    }
+                },
+                {
+                    "name": "daemon-mount",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test-daemon",
+                        "type": "DirectoryOrCreate"
+                    }
+                }
+            ],
+            "containers": [
+                {
+                    "name": "workspace",
+                    "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/workspacekit",
+                        "ring0"
+                    ],
+                    "ports": [
+                        {
+                            "containerPort": 23000
+                        }
+                    ],
+                    "env": [
+                        {
+                            "name": "GITPOD_REPO_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_CLI_APITOKEN",
+                            "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_ID",
+                            "value": "foobar"
+                        },
+                        {
+                            "name": "GITPOD_INSTANCE_ID",
+                            "value": "test"
+                        },
+                        {
+                            "name": "GITPOD_THEIA_PORT",
+                            "value": "23000"
+                        },
+                        {
+                            "name": "THEIA_WORKSPACE_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_HOST",
+                            "value": "gitpod.io"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_URL",
+                            "value": "test-foobarservice-gitpod.io"
+                        },
+                        {
+                            "name": "THEIA_SUPERVISOR_ENDPOINT",
+                            "value": ":22999"
+                        },
+                        {
+                            "name": "THEIA_WEBVIEW_EXTERNAL_ENDPOINT",
+                            "value": "webview-{{hostname}}"
+                        },
+                        {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_NAME",
+                            "value": "usernameGoesHere"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_EMAIL",
+                            "value": "some@user.com"
+                        },
+                        {
+                            "name": "foo",
+                            "value": "bar"
+                        },
+                        {
+                            "name": "GITPOD_INTERVAL",
+                            "value": "30000"
+                        },
+                        {
+                            "name": "GITPOD_MEMORY",
+                            "value": "0"
+                        }
+                    ],
+                    "resources": {
+                        "limits": {
+                            "cpu": "900m",
+                            "memory": "1G"
+                        },
+                        "requests": {
+                            "cpu": "5m"
+                        }
+                    },
+                    "volumeMounts": [
+                        {
+                            "name": "vol-this-workspace",
+                            "mountPath": "/workspace",
+                            "mountPropagation": "HostToContainer"
+                        },
+                        {
+                            "name": "daemon-mount",
+                            "mountPath": "/.workspace",
+                            "mountPropagation": "HostToContainer"
+                        }
+                    ],
+                    "readinessProbe": {
+                        "httpGet": {
+                            "path": "/_supervisor/v1/status/content/wait/true",
+                            "port": 22999,
+                            "scheme": "HTTP"
+                        },
+                        "initialDelaySeconds": 4,
+                        "timeoutSeconds": 1,
+                        "periodSeconds": 1,
+                        "successThreshold": 1,
+                        "failureThreshold": 600
+                    },
+                    "terminationMessagePolicy": "File",
+                    "imagePullPolicy": "IfNotPresent",
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "AUDIT_WRITE",
+                                "FSETID",
+                                "KILL",
+                                "NET_BIND_SERVICE",
+                                "SYS_PTRACE"
+                            ],
+                            "drop": [
+                                "SETPCAP",
+                                "CHOWN",
+                                "NET_RAW",
+                                "DAC_OVERRIDE",
+                                "FOWNER",
+                                "SYS_CHROOT",
+                                "SETFCAP",
+                                "SETUID",
+                                "SETGID"
+                            ]
+                        },
+                        "privileged": false,
+                        "runAsUser": 33333,
+                        "runAsGroup": 33333,
+                        "runAsNonRoot": true,
+                        "readOnlyRootFilesystem": false,
+                        "allowPrivilegeEscalation": true
+                    }
+                }
+            ],
+            "restartPolicy": "Never",
+            "serviceAccountName": "workspace",
+            "automountServiceAccountToken": false,
+            "schedulerName": "workspace-scheduler",
+            "tolerations": [
+                {
+                    "key": "node.kubernetes.io/disk-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/memory-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/network-unavailable",
+                    "operator": "Exists",
+                    "effect": "NoExecute",
+                    "tolerationSeconds": 30
+                }
+            ],
+            "enableServiceLinks": false
+        },
+        "status": {}
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.json
@@ -1,0 +1,30 @@
+{
+  "spec": {
+    "workspaceImage": "eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+    "initializer": {
+      "snapshot": {
+        "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"
+      }
+    },
+    "ports": [
+      {
+        "port": 8080,
+        "target": 38080
+      }
+    ],
+    "envvars": [
+      {
+        "name": "foo",
+        "value": "bar"
+      }
+    ],
+    "git": {
+      "username": "usernameGoesHere",
+      "email": "some@user.com"
+    }
+  },
+  "resourceRequests": {
+    "cpu": "5m",
+    "memory": "0Gi"
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In WS Manager, if the `IdeImage` is not, the application panics. This happens when using `image-builder-mk3`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager]: Add check for IdeImage not being present in the spec
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
