### PR TITLE
[workspacekit] Make resolv.conf writeable

### DIFF
--- a/components/workspacekit/cmd/rings_test.go
+++ b/components/workspacekit/cmd/rings_test.go
@@ -30,7 +30,6 @@ func TestFindBindMountCandidates(t *testing.T) {
 				"/workspace",
 				"/etc/hosts",
 				"/etc/hostname",
-				"/etc/resolv.conf",
 			},
 		},
 		{
@@ -42,7 +41,6 @@ func TestFindBindMountCandidates(t *testing.T) {
 				"/sys",
 				"/etc/hosts",
 				"/etc/hostname",
-				"/etc/resolv.conf",
 			},
 		},
 		{
@@ -60,7 +58,6 @@ func TestFindBindMountCandidates(t *testing.T) {
 				"/workspace",
 				"/etc/hosts",
 				"/etc/hostname",
-				"/etc/resolv.conf",
 				"/custom-certs",
 			},
 		},


### PR DESCRIPTION
## Description
This change makes `/etc/resolv.conf` writeable by copying it over from the Kubernetes container, rather than bind-mounting it.

![image](https://user-images.githubusercontent.com/3210701/139589527-a75db4b0-fe68-4af0-88ff-9a3111ace094.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6457

## How to test
- start a workspace
- make changes to `/etc/resolv.conf` and save the file

better yet:
- start a workspace from https://github.com/gitpod-io/template-tailscale
- run `tailscale status` - you should not see a message about failing operations regarding `resolv.conf`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
`/etc/resolv.conf` is now writeable
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
