### PR TITLE
[gpctl] Add debug command

### DIFF
--- a/dev/gpctl/cmd/debug-log.go
+++ b/dev/gpctl/cmd/debug-log.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/gpctl/pkg/util"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+// debugLogCmd represents the debugLogCmd command
+var debugLogCmd = &cobra.Command{
+	Use:   "log <component>",
+	Short: "Enables the debug log level for a component",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		comp := args[0]
+		if comp == "supervisor" {
+			log.Fatal("cannot enable supervisor debug logging yet - please edit the default workspace template and add an env var SUPERVISOR_DEBUG=true")
+		}
+
+		err := func() error {
+			cfg, namespace, err := getKubeconfig()
+			if err != nil {
+				return err
+			}
+			clientSet, err := kubernetes.NewForConfig(cfg)
+			if err != nil {
+				return err
+			}
+
+			freePort, err := GetFreePort()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			port := fmt.Sprintf("%d:6060", freePort)
+			podName, err := util.FindAnyPodForComponent(clientSet, namespace, comp)
+			if err != nil {
+				return err
+			}
+			readychan, errchan := util.ForwardPort(ctx, cfg, namespace, podName, port)
+			select {
+			case <-readychan:
+			case err := <-errchan:
+				return err
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			_, err = http.Post(fmt.Sprintf("http://localhost:%d/debug/logging", freePort), "", bytes.NewReader([]byte(`{"level":"debug"}`)))
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	debugCmd.AddCommand(debugLogCmd)
+}

--- a/dev/gpctl/cmd/debug.go
+++ b/dev/gpctl/cmd/debug.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// debugCmd represents the debugCmd command
+var debugCmd = &cobra.Command{
+	Use:   "debug",
+	Short: "Helps with debugging a component",
+	Args:  cobra.ExactArgs(1),
+}
+
+func init() {
+	rootCmd.AddCommand(debugCmd)
+}


### PR DESCRIPTION
## Description
Adds `gpctl debug log <component>` which enables the debug logging for that component.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6479

## How to test
```
gpctl debug log image-builder-mk3
```
start an image build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gpctl] Add debug command to aid in debugging components
```
