### PR TITLE
[ws-deployment] Refactor deployment methods so that steps(cluster create and gitpod installation) can be run for each cluster in parallel.

### DIFF
--- a/operations/workspace/deployment/go.mod
+++ b/operations/workspace/deployment/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.2.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/client-go v0.0.0-00010101000000-000000000000

--- a/operations/workspace/deployment/go.sum
+++ b/operations/workspace/deployment/go.sum
@@ -492,6 +492,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/operations/workspace/deployment/pkg/orchestrate/deploy.go
+++ b/operations/workspace/deployment/pkg/orchestrate/deploy.go
@@ -5,26 +5,48 @@
 package orchestrate
 
 import (
-	"sync"
-
 	log "github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-deployment/pkg/common"
 	"github.com/gitpod-io/gitpod/ws-deployment/pkg/step"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
 )
 
+// Deploy creates given workspace clusters and then deploys gitpod on them
 func Deploy(context *common.ProjectContext, clusters []*common.WorkspaceCluster) error {
-	var wg sync.WaitGroup
-	wg.Add(len(clusters))
-
-	for _, cluster := range clusters {
-		go func(context *common.ProjectContext, cluster *common.WorkspaceCluster) {
-			defer wg.Done()
-			err := step.CreateCluster(context, cluster)
+	eg := new(errgroup.Group)
+	for _, c := range clusters {
+		c := c
+		eg.Go(func() error {
+			err := createCluster(context, c)
 			if err != nil {
-				log.Log.Infof("error creating cluster %s: %s", cluster.Name, err)
+				return err
 			}
-		}(context, cluster)
+			err = installGitpod(context, c)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
 	}
-	wg.Wait()
+	if err := eg.Wait(); err != nil {
+		return xerrors.New(err.Error())
+	}
 	return nil
+}
+
+// TODO(prs): Add implementation once we have scripts in ops repo tested and
+// install step implemented
+func installGitpod(context *common.ProjectContext, cluster *common.WorkspaceCluster) error {
+	log.Log.Infof("received request to install gitpod on cluster: %s cannot be processed. Implementation pending", cluster.Name)
+	return nil
+}
+
+func createCluster(context *common.ProjectContext, cluster *common.WorkspaceCluster) error {
+	// TODO(prs): add retry logic below
+	err := step.CreateCluster(context, cluster)
+	if err != nil {
+		log.Log.Infof("error creating cluster %s: %s", cluster.Name, err)
+	}
+	return err
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactor deployment methods so that steps(cluster create and gitpod installation) can be run for each cluster in parallel.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially addresses https://github.com/gitpod-io/gitpod/issues/6332

## How to test
<!-- Provide steps to test this PR -->
No special steps. You should just see extra logs of gitpod installation step when you run the cli.

I have tested this for regression here: https://werft.gitpod-io-dev.com/job/ops-workspace-deploy-workspace-prs-add-tf-doc.1

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
