### PR TITLE
[dev] Make job 'wipe-devstaging' more reliable

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/code-nightly.yaml
+++ b/.werft/code-nightly.yaml
@@ -17,7 +17,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -39,7 +39,7 @@ function uninstallHelm(pathToKubeConfig: string, installationName: string, names
         return;
     }
 
-    exec(`export KUBECONFIG=${pathToKubeConfig} && helm --namespace ${namespace} delete ${installationName}`, shellOpts);
+    exec(`export KUBECONFIG=${pathToKubeConfig} && helm --namespace ${namespace} delete ${installationName} --wait`, shellOpts);
 }
 
 function deleteAllWorkspaces(pathToKubeConfig: string, namespace: string, shellOpts: ExecOptions) {

--- a/.werft/wipe-devstaging.ts
+++ b/.werft/wipe-devstaging.ts
@@ -34,8 +34,7 @@ async function k3sCleanup() {
 
         // Since werft creates static external IP for ws-proxy of k3s using gcloud
         // we delete it here. We retry because the ws-proxy-service which binds to this IP might not be deleted immediately
-        const k3sWsProxyIP =
-            deleteExternalIp("wipe", namespace_raw)
+        /* no await */ deleteExternalIp("wipe", namespace_raw || "not-set");
     } else {
         werft.log("wipe", `file /workspace/k3s-external.yaml does not exist, no cleanup for k3s cluster`)
     }

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -36,5 +36,6 @@ pod:
       sudo chown -R gitpod:gitpod /workspace
       kubectl get secret k3sdev -n werft -ojsonpath='{.data}' | jq -r .[] | base64 -d > /workspace/k3s-external.yaml
 
-      npm install shelljs semver ts-node typescript @types/shelljs @types/node @types/semver
-      npx ts-node .werft/wipe-devstaging.ts
+      cd .werft
+      yarn install
+      npx ts-node ./wipe-devstaging.ts

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/supervisor/pkg/config/gitpod-config_test.go
+++ b/components/supervisor/pkg/config/gitpod-config_test.go
@@ -27,7 +27,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-protoc.4
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -46,7 +46,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &gitpod.GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-protoc.4",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:gpl-dev-reliable-wipe.19",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*gitpod.PortsItems{

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full-vnc:latest
 
-ENV TRIGGER_REBUILD 14
+ENV TRIGGER_REBUILD 16
 ENV WORKSPACE_KERNEL 5.4.0-1051-gke
 
 USER root
@@ -27,7 +27,7 @@ RUN curl -fsSL https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 > $CLO
 
 ### Helm3 ###
 RUN mkdir -p /tmp/helm/ \
-    && curl -fsSL https://get.helm.sh/helm-v3.6.0-linux-amd64.tar.gz | tar -xzvC /tmp/helm/ --strip-components=1 \
+    && curl -fsSL https://get.helm.sh/helm-v3.7.1-linux-amd64.tar.gz | tar -xzvC /tmp/helm/ --strip-components=1 \
     && cp /tmp/helm/helm /usr/local/bin/helm \
     && cp /tmp/helm/helm /usr/local/bin/helm3 \
     && rm -rf /tmp/helm/ \


### PR DESCRIPTION
## Description
Currently we `wipe-devstaging` fails rather often because of a race that happens on `helm uninstall`: We execute the command, and right after, try to delete all pods. But because some pod-creating workloads (ws-scheduler, ws-manager) are still running, sometimes there is a race, leading to dangling pods - and in consequence, to namespaces "stuck in terminating".

This PR updates helm to version `3.7.1` which includes a `--wait` flag on `uninstall` which should help mitigate this race.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- note that the deploy job works: https://werft.gitpod-dev.com/job/gitpod-build-gpl-dev-reliable-wipe.15
- note that the wipe job works: https://werft.gitpod-dev.com/job/gitpod-wipe-devstaging-gpl-dev-reliable-wipe.2

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
