### PR TITLE
[ws-deployment] Introduce context wrapper and overrides

### DIFF
--- a/operations/workspace/deployment/cmd/deploy.go
+++ b/operations/workspace/deployment/cmd/deploy.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/ws-deployment/pkg/common"
 	"github.com/gitpod-io/gitpod/ws-deployment/pkg/orchestrate"
 	"github.com/spf13/cobra"
 )
@@ -45,7 +46,20 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			log.Log.Infof("error while trying to activate service account: %s. Assuming SA is already activated and configured %s", out)
 		}
-		orchestrate.Deploy(&cfg.Project, cfg.WorkspaceClusters)
+
+		// Wrap contexts into common.Context object
+		context := common.Context{
+			Project: &cfg.Project,
+			Gitpod: &common.GitpodContext{
+				VersionsManifestFilePath: versionsManifestFile,
+			},
+			Overrides: &common.Overrides{
+				DryRun:            dryRun,
+				OverwriteExisting: overwriteExisting,
+			},
+		}
+
+		orchestrate.Deploy(&context, cfg.WorkspaceClusters)
 	},
 }
 

--- a/operations/workspace/deployment/cmd/root.go
+++ b/operations/workspace/deployment/cmd/root.go
@@ -27,6 +27,8 @@ var cfgFile string
 var versionsManifestFile string
 var jsonLog bool
 var verbose bool
+var dryRun bool
+var overwriteExisting bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -51,6 +53,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "./ws-deployment.yaml", "config file (default is ./ws-deployment.yaml)")
 	rootCmd.PersistentFlags().StringVar(&versionsManifestFile, "versions-manifest", "./versions.yaml", "versions manifest file (default is ./versions.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", true, "produce JSON log output on verbose level")
+	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "performs a dry run without creating or modifying any resources in the cloud")
+	rootCmd.PersistentFlags().BoolVar(&overwriteExisting, "overwrite", false, "overwrites any existing settings/configuration of a deployment if it exists")
 }
 
 func getConfig() *v1.Config {

--- a/operations/workspace/deployment/pkg/common/cluster.go
+++ b/operations/workspace/deployment/pkg/common/cluster.go
@@ -30,3 +30,15 @@ type WorkspaceCluster struct {
 	ClusterType ClusterType `yaml:"type"`
 	ValuesFiles []string    `yaml:"valuesFiles"`
 }
+
+// Overrides are used to override some of the default behaviour
+// of deployment
+type Overrides struct {
+	// DryRun specifies if the resources should be actually created or not
+	DryRun bool
+	// OverwriteExisting is used to overwrite existing cluster configuration
+	// e.g. if a cluster X already exist and you run the deployment with this
+	// value set, then it will just update the cluster configuration
+	// if this flag is not set then it will error out complaining that the cluster already exists
+	OverwriteExisting bool
+}

--- a/operations/workspace/deployment/pkg/common/context.go
+++ b/operations/workspace/deployment/pkg/common/context.go
@@ -4,7 +4,12 @@
 
 package common
 
-import "k8s.io/client-go/kubernetes"
+// Context is a wrapper over other contexts
+type Context struct {
+	Project   *ProjectContext
+	Gitpod    *GitpodContext
+	Overrides *Overrides
+}
 
 // ProjectContext is a wrapper which contains information required to communicate to the
 // right GCP project with correct inputs
@@ -24,10 +29,4 @@ type GitpodContext struct {
 	// ValuesFiles an array of values files that would be used to set
 	// configuration of gitpod
 	ValuesFiles []string
-}
-
-// ClusterContext contains the context to access the cluster
-type ClusterContext struct {
-	KubeconfigPath string
-	Client         *kubernetes.Clientset
 }

--- a/operations/workspace/deployment/pkg/orchestrate/deploy.go
+++ b/operations/workspace/deployment/pkg/orchestrate/deploy.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Deploy creates given workspace clusters and then deploys gitpod on them
-func Deploy(context *common.ProjectContext, clusters []*common.WorkspaceCluster) error {
+func Deploy(context *common.Context, clusters []*common.WorkspaceCluster) error {
 	eg := new(errgroup.Group)
 	for _, c := range clusters {
 		c := c
@@ -37,12 +37,12 @@ func Deploy(context *common.ProjectContext, clusters []*common.WorkspaceCluster)
 
 // TODO(prs): Add implementation once we have scripts in ops repo tested and
 // install step implemented
-func installGitpod(context *common.ProjectContext, cluster *common.WorkspaceCluster) error {
+func installGitpod(context *common.Context, cluster *common.WorkspaceCluster) error {
 	log.Log.Infof("received request to install gitpod on cluster: %s cannot be processed. Implementation pending", cluster.Name)
 	return nil
 }
 
-func createCluster(context *common.ProjectContext, cluster *common.WorkspaceCluster) error {
+func createCluster(context *common.Context, cluster *common.WorkspaceCluster) error {
 	// TODO(prs): add retry logic below
 	err := step.CreateCluster(context, cluster)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Introduced a wrapper struct `Context` to wrap all kinds of context. This will reduce argument size of various methods.
Introduced a new struct `Overrides` that can be used to override the default behaviour of deployment.
Updated methods which are affected by above change.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
use the flags `--dry-run` and you should not see any resources being created, however the relevant artifacts like terraform scripts will be created.
I have tested it here https://werft.gitpod-io-dev.com/job/ops-workspace-deploy-workspace-main.14/raw

To test `--overwrite` flag you can use werft sideload feature to overwrite the name of the clusters in the config.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
