### PR TITLE
[dashboard] Remove feature flag for desktop IDEs

### DIFF
--- a/components/dashboard/src/components/PillLabel.tsx
+++ b/components/dashboard/src/components/PillLabel.tsx
@@ -10,10 +10,13 @@
  * **type**\
  * info: Renders a blue pile label (default).\
  * warn: Renders an orange pile label.
+ *
+ * **className**\
+ * Add additional css classes to style this component.
  */
-export default function PillLabel(props: { children?: React.ReactNode, type?: "info" | "warn" }) {
+export default function PillLabel(props: { children?: React.ReactNode, type?: "info" | "warn", className?: string }) {
     const infoStyle = "bg-blue-50 text-blue-500 dark:bg-blue-500 dark:text-blue-100";
     const warnStyle = "bg-orange-100 text-orange-700 dark:bg-orange-600 dark:text-orange-100";
-    const style = `ml-2 px-3 py-1 text-sm uppercase rounded-xl ${props.type === "warn" ? warnStyle : infoStyle}`;
+    const style = `ml-2 px-3 py-1 text-sm uppercase rounded-xl ${props.type === "warn" ? warnStyle : infoStyle} ${props.className}`;
     return <span className={style}>{props.children}</span>;
 }

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -6,12 +6,15 @@
 
 import { useContext, useState } from "react";
 import CheckBox from "../components/CheckBox";
+import CodeText from "../components/CodeText";
+import InfoBox from "../components/InfoBox";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import PillLabel from "../components/PillLabel";
 import SelectableCard from "../components/SelectableCard";
 import Tooltip from "../components/Tooltip";
-import vscode from '../images/vscode.svg';
-import ideaLogo from '../images/intellijIdeaLogo.svg';
 import golandLogo from '../images/golandLogo.svg';
+import ideaLogo from '../images/intellijIdeaLogo.svg';
+import vscode from '../images/vscode.svg';
 import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
@@ -82,7 +85,7 @@ export default function Preferences() {
                         <div className="flex justify-center mt-3">
                             <img className="w-16 filter-grayscale self-center" src={vscode} />
                         </div>
-                        <span className="mt-2 ml-2 self-center rounded-xl py-0.5 px-2 text-sm bg-orange-100 text-orange-700 dark:bg-orange-600 dark:text-orange-100 font-semibold">INSIDERS</span>
+                        <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Insiders</PillLabel>
                     </SelectableCard>
                 </Tooltip>
             </div>
@@ -93,20 +96,26 @@ export default function Preferences() {
                     checked={useDesktopIde}
                     onChange={(evt) => actuallySetUseDesktopIde(evt.target.checked)} />
             </div>
-            {useDesktopIde &&
+            {useDesktopIde && <>
                 <div className="mt-4 space-x-4 flex">
                     <SelectableCard className="w-36 h-40" title="IntelliJ IDEA" selected={defaultDesktopIde === 'intellij'} onClick={() => actuallySetDefaultDesktopIde('intellij')}>
                         <div className="flex justify-center mt-3">
-                        <img className="w-16 filter-grayscale self-center" src={ideaLogo} />
+                            <img className="w-16 filter-grayscale self-center" src={ideaLogo} />
                         </div>
+                        <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel>
                     </SelectableCard>
                     <SelectableCard className="w-36 h-40" title="GoLand" selected={defaultDesktopIde === 'goland'} onClick={() => actuallySetDefaultDesktopIde('goland')}>
                         <div className="flex justify-center mt-3">
-                        <img className="w-16 filter-grayscale self-center" src={golandLogo} />
+                            <img className="w-16 filter-grayscale self-center" src={golandLogo} />
                         </div>
+                        <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel>
                     </SelectableCard>
                 </div>
-            }
+                <InfoBox className="my-5">While in beta, when you open a workspace using a JetBrains IDE you will need to use the following password: <CodeText>gitpod</CodeText></InfoBox>
+                <p className="text-left w-full text-gray-500">
+                    The <strong>JetBrains desktop IDEs</strong> are currently in beta. <a href="https://github.com/gitpod-io/gitpod/issues/6576" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a> · <a href="https://www.gitpod.io/docs/integrations/jetbrains" target="_blank" rel="noopener" className="gp-link">Documentation</a>
+                </p>
+            </>}
             <h3 className="mt-12">Theme</h3>
             <p className="text-base text-gray-500">Early bird or night owl? Choose your side.</p>
             <div className="mt-4 space-x-4 flex">

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -33,8 +33,6 @@ export default function Preferences() {
         setDefaultIde(value);
     }
 
-    const desktopIdeFeatureEnabled = !!user?.rolesOrPermissions?.includes('admin');
-
     const [defaultDesktopIde, setDefaultDesktopIde] = useState<string>(user?.additionalData?.ideSettings?.defaultDesktopIde || 'intellij');
     const actuallySetDefaultDesktopIde = async (value: string) => {
         const additionalData = user?.additionalData || {};
@@ -88,16 +86,14 @@ export default function Preferences() {
                     </SelectableCard>
                 </Tooltip>
             </div>
-            {desktopIdeFeatureEnabled &&
-                <div className="mt-4 space-x-4 flex">
-                    <CheckBox
-                        title="Open in Desktop IDE"
-                        desc="Choose whether you would like to open your workspace in a desktop IDE instead."
-                        checked={useDesktopIde}
-                        onChange={(evt) => actuallySetUseDesktopIde(evt.target.checked)} />
-                </div>
-            }
-            {desktopIdeFeatureEnabled && useDesktopIde &&
+            <div className="mt-4 space-x-4 flex">
+                <CheckBox
+                    title="Open in Desktop IDE"
+                    desc="Choose whether you would like to open your workspace in a desktop IDE instead."
+                    checked={useDesktopIde}
+                    onChange={(evt) => actuallySetUseDesktopIde(evt.target.checked)} />
+            </div>
+            {useDesktopIde &&
                 <div className="mt-4 space-x-4 flex">
                     <SelectableCard className="w-36 h-40" title="IntelliJ IDEA" selected={defaultDesktopIde === 'intellij'} onClick={() => actuallySetDefaultDesktopIde('intellij')}>
                         <div className="flex justify-center mt-3">


### PR DESCRIPTION
## Description
This PR removes the check that hides the desktop IDE preferences for non-admin users.

![image](https://user-images.githubusercontent.com/24960040/140496503-a6b9e078-cfdc-42d1-8106-9831257b2ed3.png)

## To Do
- [x] Set proper feedback issue link

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6485

## How to test
Open the preferences page as a not-admin user (remove the role in the admin page) and make sure the desktop IDE settings are present.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Open up JetBrains desktop IDE feature (BETA) for all users
```

/no-cc