### PR TITLE
Change MyApplicationActivationListener visibility

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/ide/jetbrains/backend/listeners/MyApplicationActivationListener.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/ide/jetbrains/backend/listeners/MyApplicationActivationListener.kt
@@ -11,7 +11,7 @@ import io.gitpod.ide.jetbrains.backend.services.HeartbeatService
 import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.components.service
 
-internal class MyApplicationActivationListener : ApplicationActivationListener {
+class MyApplicationActivationListener : ApplicationActivationListener {
     override fun applicationActivated(ideFrame: IdeFrame) {
         service<HeartbeatService>() // Services are not loaded if not referenced
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Jetbrains IDE now seems not to be able to instantiate `MyApplicationActivationListener` if it is `internal`.

## How to test
<!-- Provide steps to test this PR -->
Run the plugin in a Jetbrains installation. No errors are expected and the idea.log should contain a line with "HeartbeatService - Service initiated"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
