### PR TITLE
Add jetbrains-backend-plugin resources as build srcs

### DIFF
--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -11,6 +11,7 @@ packages:
       - "gradle/wrapper/*"
       - "gradlew"
       - "settings.gradle.kts"
+      - "src/main/resources/*"
     argdeps:
       - INTELLIJ_PLUGIN_PLATFORM_VERSION
     env:

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,3 +1,9 @@
+<!--
+ Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+
 <idea-plugin>
     <id>io.gitpod.ide.jetbrains.backend</id>
     <name>Gitpod</name>


### PR DESCRIPTION
## Description
Leeway is not copying the resources of the `ide/jetbrains/backend-plugin`, including the `plugin.xml` which is required for an IntelliJ IDE to recognize the plugin.

Kudos to @corneliusludmann for the catch 🎉 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6523

## How to test
<!-- Provide steps to test this PR -->
Use Gitpod with IntelliJ IDEA and check the log at `/home/gitpod/.CwmHost-IU-system/_workspace.../log/idea.log`. It should include a line containing the string "HeartbeatService - Service initiated". Additionally, the workspace should not time out while using the local Jetbrains IDE.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
