### PR TITLE
[installer] Simplify config surface

### DIFF
--- a/installer/pkg/components/proxy/objects.go
+++ b/installer/pkg/components/proxy/objects.go
@@ -5,8 +5,11 @@
 package proxy
 
 import (
+	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var Objects = common.CompositeRenderFunc(
@@ -14,21 +17,25 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		ContainerHTTPName: {
-			ContainerPort: ContainerHTTPPort,
-			ServicePort:   ContainerHTTPPort,
-		},
-		ContainerHTTPSName: {
-			ContainerPort: ContainerHTTPSPort,
-			ServicePort:   ContainerHTTPSPort,
-		},
-		MetricsContainerName: {
-			ContainerPort: PrometheusPort,
-			ServicePort:   PrometheusPort,
-		},
-	}, func(spec *corev1.ServiceSpec) {
-		spec.Type = corev1.ServiceTypeLoadBalancer
-	}),
+	func(cfg *common.RenderContext) ([]runtime.Object, error) {
+		return common.GenerateService(Component, map[string]common.ServicePort{
+			ContainerHTTPName: {
+				ContainerPort: ContainerHTTPPort,
+				ServicePort:   ContainerHTTPPort,
+			},
+			ContainerHTTPSName: {
+				ContainerPort: ContainerHTTPSPort,
+				ServicePort:   ContainerHTTPSPort,
+			},
+			MetricsContainerName: {
+				ContainerPort: PrometheusPort,
+				ServicePort:   PrometheusPort,
+			},
+		}, func(service *corev1.Service) {
+			service.Spec.Type = corev1.ServiceTypeLoadBalancer
+			service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", cfg.Config.Domain, cfg.Config.Domain, cfg.Config.Domain)
+			service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
+		})(cfg)
+	},
 	common.DefaultServiceAccount(Component),
 )

--- a/installer/pkg/components/ws-daemon/objects.go
+++ b/installer/pkg/components/ws-daemon/objects.go
@@ -16,8 +16,8 @@ var Objects = common.CompositeRenderFunc(
 	daemonset,
 	networkpolicy,
 	rolebinding,
-	common.GenerateService(Component, nil, func(spec *corev1.ServiceSpec) {
-		spec.ClusterIP = "None"
+	common.GenerateService(Component, nil, func(service *corev1.Service) {
+		service.Spec.ClusterIP = "None"
 	}),
 	tlssecret,
 )

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -206,15 +206,10 @@ type WorkspaceTemplates struct {
 	Probe      *corev1.Pod `json:"probe"`
 }
 
-type WorkspaceComponent struct {
-	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
-}
-
 type Workspace struct {
-	Runtime    WorkspaceRuntime              `json:"runtime" validate:"required"`
-	Resources  Resources                     `json:"resources" validate:"required"`
-	Templates  *WorkspaceTemplates           `json:"templates,omitempty"`
-	Components map[string]WorkspaceComponent `json:"components,omitempty"`
+	Runtime   WorkspaceRuntime    `json:"runtime" validate:"required"`
+	Resources Resources           `json:"resources" validate:"required"`
+	Templates *WorkspaceTemplates `json:"templates,omitempty"`
 }
 
 type FSShiftMethod string


### PR DESCRIPTION
## Description
This PR simplifies the installer configuration by removing component specific configuration. Having this field is a very slippery slope and opens the door for pushing complexity to the user.
Annotations are a no-op when the infrastructure that interprets them is not present in the cluster, hence adding them by default should do little harm.

If we find them to be a problem in the future, we can think of sensible abstractions that solve the problem.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
