### PR TITLE
[db] Automatically migrate the 'migrations' table

### DIFF
--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -81,6 +81,7 @@ packages:
       - migrate_gcp.sh
       - typeorm.sh
       - typeorm_gcp.sh
+      - migrate-migrations/**
     deps:
       - :migrations
     argdeps:

--- a/components/gitpod-db/leeway.Dockerfile
+++ b/components/gitpod-db/leeway.Dockerfile
@@ -17,6 +17,7 @@ COPY migrate.sh /app/migrate.sh
 COPY migrate_gcp.sh /app/migrate_gcp.sh
 COPY typeorm.sh /app/typeorm.sh
 COPY typeorm_gcp.sh /app/typeorm_gcp.sh
+COPY migrate-migrations /app/migrate-migrations
 RUN mkdir /home/jenkins && chown -R 10000 /home/jenkins
 COPY --from=proxy /bin/cloud_sql_proxy /bin/cloud_sql_proxy
 COPY --from=proxy /etc/ssl/certs/ /etc/ssl/certs/

--- a/components/gitpod-db/migrate-migrations/0_2_0_down_procedure.sql
+++ b/components/gitpod-db/migrate-migrations/0_2_0_down_procedure.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+-- Licensed under the GNU Affero General Public License (AGPL).
+-- See License-AGPL.txt in the project root for license information.
+
+create procedure migrations_0_2_0_down()
+begin
+
+    set @is_id_column_present := (SELECT true
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE   table_schema = 'gitpod'
+            AND table_name = 'migrations'
+            AND column_name = 'id');
+
+    if @is_id_column_present IS NOT NULL then
+        ALTER TABLE migrations MODIFY COLUMN id int(11);
+        ALTER TABLE migrations DROP PRIMARY KEY;
+        ALTER TABLE migrations ADD PRIMARY KEY (timestamp);
+        ALTER TABLE migrations DROP COLUMN id;
+    end if;
+
+end;

--- a/components/gitpod-db/migrate-migrations/0_2_0_up_procedure.sql
+++ b/components/gitpod-db/migrate-migrations/0_2_0_up_procedure.sql
@@ -1,0 +1,27 @@
+-- Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+-- Licensed under the GNU Affero General Public License (AGPL).
+-- See License-AGPL.txt in the project root for license information.
+
+create procedure migrations_0_2_0_up()
+begin
+    set @is_id_column_present := (SELECT true
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE   table_schema = 'gitpod'
+            AND table_name = 'migrations'
+            AND column_name = 'id');
+
+    if @is_id_column_present IS NULL then
+        ALTER TABLE migrations ADD COLUMN id int(11) NOT NULL;
+
+        SET @next_id := 0;
+        UPDATE migrations
+        SET id = @next_id := @next_id + 1
+        ORDER BY timestamp ASC;
+
+        ALTER TABLE migrations DROP PRIMARY KEY;
+        ALTER TABLE migrations ADD PRIMARY KEY (id);
+        ALTER TABLE migrations MODIFY COLUMN id int(11) NOT NULL AUTO_INCREMENT;
+    end if;
+end;
+
+

--- a/components/gitpod-db/migrate.sh
+++ b/components/gitpod-db/migrate.sh
@@ -5,4 +5,9 @@
 
 set -euo pipefail
 
+# perform migration of 'migrations' table
+/app/typeorm.sh query "$(sed '/^--/d' < /app/migrate-migrations/0_2_0_up_procedure.sql)"
+/app/typeorm.sh query "CALL migrations_0_2_0_up();"
+/app/typeorm.sh query "DROP PROCEDURE IF EXISTS migrations_0_2_0_up;"
+
 /app/typeorm.sh migrations:run

--- a/components/gitpod-db/migrate_gcp.sh
+++ b/components/gitpod-db/migrate_gcp.sh
@@ -19,4 +19,9 @@
 
 set -euo pipefail
 
+# perform migration of 'migrations' table
+/app/typeorm.sh query "$(sed '/^--/d' < /app/migrate-migrations/0_2_0_up_procedure.sql)"
+/app/typeorm.sh query "CALL migrations_0_2_0_up();"
+/app/typeorm.sh query "DROP PROCEDURE IF EXISTS migrations_0_2_0_up;"
+
 /app/typeorm_gcp.sh migrations:run


### PR DESCRIPTION
Issue: https://github.com/typeorm/typeorm/issues/4941#issuecomment-706222653

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
Context: https://github.com/gitpod-io/gitpod/issues/6502

## How to test
<!-- Provide steps to test this PR -->
 - open workspace on this branch
 - `cd components/gitpod-db`
 - `kubectl port-forward mysql-0 23306:3306
 - `yarn typeorm query "$(sed '/^--/d' < ./migrate-migrations/0_2_0_up_procedure.sql)"`
 - `yarn typeorm query "CALL migrations_0_2_0_up();"`
 - see how the new schema is applied: `mysql -u gitpod -h 127.0.0.1 -P 23306 -p` and `describe migrations;`
 - repeat `yarn typeorm query "CALL migrations_0_2_0_up();"` and notice how the procedure is idempotent

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
