### PR TITLE
Include GitLab subgroups

### DIFF
--- a/components/dashboard/src/projects/ConfigureProject.tsx
+++ b/components/dashboard/src/projects/ConfigureProject.tsx
@@ -63,6 +63,7 @@ export default function () {
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
     const routeMatch = useRouteMatch<{ teamSlug: string, projectSlug: string }>("/(t/)?:teamSlug/:projectSlug/configure");
+    const projectSlug = routeMatch?.params.projectSlug;
     const [project, setProject] = useState<Project | undefined>();
     const [gitpodYml, setGitpodYml] = useState<string>('');
     const [dockerfile, setDockerfile] = useState<string>('');
@@ -93,7 +94,11 @@ export default function () {
             const projects = (!!team
                 ? await getGitpodService().server.getTeamProjects(team.id)
                 : await getGitpodService().server.getUserProjects());
-            const project = projects.find(p => p.name === routeMatch?.params.projectSlug);
+
+        const project = projectSlug && projects.find(
+            p => p.slug ? p.slug === projectSlug :
+            p.name === projectSlug);
+
             if (!project) {
                 setIsDetecting(false);
                 setEditorMessage(<EditorMessage type="warning" heading="Couldn't load project information." message="Please try to reload this page." />);

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -162,7 +162,7 @@ export default function NewProject() {
         if (!provider) {
             return;
         }
-        const repo = reposInAccounts.find(r => r.account === selectedAccount && r.name === selectedRepo);
+        const repo = reposInAccounts.find(r => r.account === selectedAccount && r.path === selectedRepo);
         if (!repo) {
             console.error("No repo selected!")
             return;
@@ -179,7 +179,7 @@ export default function NewProject() {
                 appInstallationId: String(repo.installationId),
             });
 
-            history.push(`/${User.is(teamOrUser) ? 'projects' : 't/'+teamOrUser.slug}/${repo.name}/configure`);
+            history.push(`/${User.is(teamOrUser) ? 'projects' : 't/'+teamOrUser.slug}/${repo.path}/configure`);
         } catch (error) {
             const message = (error && error?.message) || "Failed to create new project."
             window.alert(message);
@@ -269,7 +269,7 @@ export default function NewProject() {
                                     <div className="flex justify-end">
                                         <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100">
                                             {!r.inUse ? (
-                                                <button className="primary" onClick={() => setSelectedRepo(r.name)}>Select</button>
+                                                <button className="primary" onClick={() => setSelectedRepo(r.path)}>Select</button>
                                             ) : (
                                                 <p className="my-auto">already taken</p>
                                             )}

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -30,7 +30,7 @@ export default function () {
     const team = getCurrentTeam(location, teams);
 
     const match = useRouteMatch<{ team: string, resource: string }>("/(t/)?:team/:resource");
-    const projectName = match?.params?.resource;
+    const projectSlug = match?.params?.resource;
 
     const [project, setProject] = useState<Project | undefined>();
 
@@ -70,7 +70,10 @@ export default function () {
                 ? await getGitpodService().server.getTeamProjects(team.id)
                 : await getGitpodService().server.getUserProjects());
 
-            const newProject = projectName && projects.find(p => p.name === projectName);
+        const newProject = projectSlug && projects.find(
+            p => p.slug ? p.slug === projectSlug :
+            p.name === projectSlug);
+
             if (newProject) {
                 setProject(newProject);
             }
@@ -180,7 +183,7 @@ export default function () {
                 </Item>
                 {prebuilds.filter(filter).sort(prebuildSorter).map((p, index) => <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">
                     <ItemField className="flex items-center">
-                        <Link to={`/${!!team ? 't/'+team.slug : 'projects'}/${projectName}/${p.info.id}`} className="cursor-pointer">
+                        <Link to={`/${!!team ? 't/'+team.slug : 'projects'}/${projectSlug}/${p.info.id}`} className="cursor-pointer">
                             <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1">
                                 <div className="inline-block align-text-bottom mr-2 w-4 h-4">{prebuildStatusIcon(p)}</div>
                                 {prebuildStatusLabel(p)}

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -34,7 +34,7 @@ export default function () {
     const { teams } = useContext(TeamsContext);
     const team = getCurrentTeam(location, teams);
     const match = useRouteMatch<{ team: string, resource: string }>("/(t/)?:team/:resource");
-    const projectName = match?.params?.resource !== 'workspaces' ? match?.params?.resource : undefined;
+    const projectSlug = match?.params?.resource !== 'workspaces' ? match?.params?.resource : undefined;
     const [projects, setProjects] = useState<Project[]>([]);
     const [activeWorkspaces, setActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [inactiveWorkspaces, setInactiveWorkspaces] = useState<WorkspaceInfo[]>([]);
@@ -59,7 +59,7 @@ export default function () {
 
     useEffect(() => {
         // only show example repos on the global user context
-        if (!team && !projectName) {
+        if (!team && !projectSlug) {
             getGitpodService().server.getFeaturedRepositories().then(setRepos);
         }
         (async () => {
@@ -68,8 +68,8 @@ export default function () {
                 : await getGitpodService().server.getUserProjects());
 
             let project: Project | undefined = undefined;
-            if (projectName) {
-                project = projects.find(p => p.name === projectName);
+            if (projectSlug) {
+                project = projects.find(p => p.slug ? p.slug === projectSlug : p.name === projectSlug);
                 if (project) {
                     setProjects([project]);
                 }
@@ -95,7 +95,7 @@ export default function () {
     const hideStartWSModal = () => setIsTemplateModelOpen(false);
 
     const getRecentSuggestions: () => WsStartEntry[] = () => {
-        if (projectName || team) {
+        if (projectSlug || team) {
             return projects.map(p => {
                 const remoteUrl = toRemoteURL(p.cloneUrl);
                 return {

--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -11,7 +11,6 @@ export interface ProjectDB {
     findProjectById(projectId: string): Promise<Project | undefined>;
     findProjectByCloneUrl(cloneUrl: string): Promise<Project | undefined>;
     findProjectsByCloneUrls(cloneUrls: string[]): Promise<Project[]>;
-    findProjectByTeamAndName(teamId: string, projectName: string): Promise<Project | undefined>;
     findTeamProjects(teamId: string): Promise<Project[]>;
     findUserProjects(userId: string): Promise<Project[]>;
     storeProject(project: Project): Promise<Project>;

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -45,11 +45,6 @@ export class ProjectDBImpl implements ProjectDB {
         return result;
     }
 
-    public async findProjectByTeamAndName(teamId: string, projectName: string): Promise<Project | undefined> {
-        const projects = await this.findTeamProjects(teamId);
-        return projects.find(p => p.name === projectName);
-    }
-
     public async findTeamProjects(teamId: string): Promise<Project[]> {
         const repo = await this.getRepo();
         return repo.find({ teamId, markedDeleted: false });

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -16,7 +16,7 @@ import { ResponseError } from 'vscode-jsonrpc';
 import { ErrorCodes } from '@gitpod/gitpod-protocol/lib/messaging/error';
 import { generateWorkspaceID } from '@gitpod/gitpod-protocol/lib/util/generate-workspace-id';
 import { HostContextProvider } from '../../../src/auth/host-context-provider';
-import { parseRepoUrl } from '../../../src/repohost';
+import { RepoURL } from '../../../src/repohost';
 
 @injectable()
 export class WorkspaceFactoryEE extends WorkspaceFactory {
@@ -153,7 +153,7 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
     protected async storePrebuildInfo(ctx: TraceContext, project: Project, pws: PrebuiltWorkspace, ws: Workspace, user: User) {
         const span = TraceContext.startSpan("storePrebuildInfo", ctx);
         const { userId, teamId, name: projectName, id: projectId } = project;
-        const parsedUrl = parseRepoUrl(project.cloneUrl);
+        const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         if (!parsedUrl) {
             return;
         }

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -6,7 +6,7 @@
 
 import { Branch, CommitInfo, Repository, User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from 'inversify';
-import { parseRepoUrl } from '../repohost/repo-url';
+import { RepoURL } from '../repohost/repo-url';
 import { RepositoryProvider } from '../repohost/repository-provider';
 import { BitbucketApiFactory } from './bitbucket-api-factory';
 
@@ -19,7 +19,7 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
         const api = await this.apiFactory.create(user);
         const repo = (await api.repositories.get({ workspace: owner, repo_slug: name })).data;
         const cloneUrl = repo.links!.clone!.find((x: any) => x.name === "https")!.href!;
-        const host = parseRepoUrl(cloneUrl)!.host;
+        const host = RepoURL.parseRepoUrl(cloneUrl)!.host;
         const description = repo.description;
         const avatarUrl = repo.owner!.links!.avatar!.href;
         const webUrl = repo.links!.html!.href;

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -9,7 +9,7 @@ import { injectable, inject } from 'inversify';
 import { User, Repository } from "@gitpod/gitpod-protocol"
 import { GitHubGraphQlEndpoint, GitHubRestApi } from "./api";
 import { RepositoryProvider } from '../repohost/repository-provider';
-import { parseRepoUrl } from '../repohost/repo-url';
+import { RepoURL } from '../repohost/repo-url';
 import { Branch, CommitInfo } from '@gitpod/gitpod-protocol/src/protocol';
 
 @injectable()
@@ -20,7 +20,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
     async getRepo(user: User, owner: string, repo: string): Promise<Repository> {
         const repository = await this.github.getRepository(user, { owner, repo });
         const cloneUrl = repository.clone_url;
-        const host = parseRepoUrl(cloneUrl)!.host;
+        const host = RepoURL.parseRepoUrl(cloneUrl)!.host;
         const description = repository.description;
         const avatarUrl = repository.owner.avatar_url;
         const webUrl = repository.html_url;

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -9,7 +9,7 @@ import { injectable, inject } from 'inversify';
 import { User, Repository, Branch, CommitInfo } from "@gitpod/gitpod-protocol"
 import { GitLabApi, GitLab } from "./api";
 import { RepositoryProvider } from '../repohost/repository-provider';
-import { parseRepoUrl } from '../repohost/repo-url';
+import { RepoURL } from '../repohost/repo-url';
 
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 
@@ -26,7 +26,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
         }
         const cloneUrl = response.http_url_to_repo;
         const description = response.default_branch;
-        const host = parseRepoUrl(cloneUrl)!.host;
+        const host = RepoURL.parseRepoUrl(cloneUrl)!.host;
         const avatarUrl = response.owner?.avatar_url || undefined;
         const webUrl = response.web_url;
         const defaultBranch = response.default_branch

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -9,7 +9,7 @@ import { DBWithTracing, ProjectDB, TeamDB, TracedWorkspaceDB, UserDB, WorkspaceD
 import { Branch, CommitContext, PrebuildWithStatus, CreateProjectParams, FindPrebuildsParams, Project, ProjectConfig, User, WorkspaceConfig } from "@gitpod/gitpod-protocol";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { HostContextProvider } from "../auth/host-context-provider";
-import { FileProvider, parseRepoUrl } from "../repohost";
+import { FileProvider, RepoURL } from "../repohost";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { ContextParser } from "../workspace/context-parser-service";
 import { ConfigInferrer } from "./config-inferrer";
@@ -46,13 +46,13 @@ export class ProjectsService {
     }
 
     protected getRepositoryProvider(project: Project) {
-        const parsedUrl = parseRepoUrl(project.cloneUrl);
+        const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         const repositoryProvider = parsedUrl && this.hostContextProvider.get(parsedUrl.host)?.services?.repositoryProvider;
         return repositoryProvider;
     }
 
     async getBranchDetails(user: User, project: Project, branchName?: string): Promise<Project.BranchDetails[]> {
-        const parsedUrl = parseRepoUrl(project.cloneUrl);
+        const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         if (!parsedUrl) {
             return [];
         }
@@ -109,7 +109,7 @@ export class ProjectsService {
 
     protected async onDidCreateProject(project: Project) {
         let { userId, teamId, cloneUrl } = project;
-        const parsedUrl = parseRepoUrl(project.cloneUrl);
+        const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         if ("gitlab.com" === parsedUrl?.host) {
             const repositoryService = this.hostContextProvider.get(parsedUrl?.host)?.services?.repositoryService;
             if (repositoryService) {
@@ -140,7 +140,7 @@ export class ProjectsService {
         if (!project) {
             return [];
         }
-        const parsedUrl = parseRepoUrl(project.cloneUrl);
+        const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         if (!parsedUrl) {
             return [];
         }

--- a/components/server/src/repohost/repo-url.spec.ts
+++ b/components/server/src/repohost/repo-url.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as chai from 'chai';
+import { suite, test } from 'mocha-typescript';
+import { RepoURL } from './repo-url';
+
+const expect = chai.expect;
+
+@suite
+export class RepoUrlTest {
+
+    @test public parseRepoUrl() {
+        const testUrl = RepoURL.parseRepoUrl("https://gitlab.com/hello-group/my-cool-project.git")
+        expect(testUrl).to.deep.equal({
+            host: 'gitlab.com',
+            owner: 'hello-group',
+            repo: 'my-cool-project'
+        });
+    }
+
+    @test public parseSubgroupOneLevel() {
+        const testUrl = RepoURL.parseRepoUrl("https://gitlab.com/hello-group/my-subgroup/my-cool-project.git")
+        expect(testUrl).to.deep.equal({
+            host: 'gitlab.com',
+            owner: 'hello-group/my-subgroup',
+            repo: 'my-cool-project'
+        });
+    }
+
+    @test public parseSubgroupTwoLevels() {
+        const testUrl = RepoURL.parseRepoUrl("https://gitlab.com/hello-group/my-subgroup/my-sub-subgroup/my-cool-project.git")
+        expect(testUrl).to.deep.equal({
+            host: 'gitlab.com',
+            owner: 'hello-group/my-subgroup/my-sub-subgroup',
+            repo: 'my-cool-project'
+        });
+    }
+
+    @test public parseSubgroupThreeLevels() {
+        const testUrl = RepoURL.parseRepoUrl(
+            "https://gitlab.com/hello-group/my-subgroup/my-sub-subgroup/my-sub-sub-subgroup/my-cool-project.git")
+        expect(testUrl).to.deep.equal({
+            host: 'gitlab.com',
+            owner: 'hello-group/my-subgroup/my-sub-subgroup/my-sub-sub-subgroup',
+            repo: 'my-cool-project'
+        });
+    }
+
+    @test public parseSubgroupFourLevels() {
+        const testUrl = RepoURL.parseRepoUrl(
+            "https://gitlab.com/hello-group/my-subgroup/my-sub-subgroup/my-sub-sub-subgroup/my-sub-sub-sub-subgroup/my-cool-project.git")
+        expect(testUrl).to.deep.equal({
+            host: 'gitlab.com',
+            owner: 'hello-group/my-subgroup/my-sub-subgroup/my-sub-sub-subgroup/my-sub-sub-sub-subgroup',
+            repo: 'my-cool-project'
+        });
+    }
+
+}
+
+module.exports = new RepoUrlTest()

--- a/components/server/src/repohost/repo-url.ts
+++ b/components/server/src/repohost/repo-url.ts
@@ -6,16 +6,24 @@
 
 
 import * as url from 'url';
-
-export function parseRepoUrl(repoUrl: string): { host: string, owner: string, repo: string} | undefined {
-    const u = url.parse(repoUrl);
-    const host = u.hostname || '';
-    const path = u.pathname || '';
-    const segments = path.split('/').filter(s => !!s); // e.g. [ 'gitpod-io', 'gitpod.git' ]
-    if (segments.length === 2) {
-        const owner = segments[0];
-        const repo = segments[1].endsWith('.git') ? segments[1].slice(0, -4) : segments[1];
-        return { host, owner, repo };
+export namespace RepoURL {
+    export function parseRepoUrl(repoUrl: string): { host: string, owner: string, repo: string} | undefined {
+        const u = url.parse(repoUrl);
+        const host = u.hostname || '';
+        const path = u.pathname || '';
+        const segments = path.split('/').filter(s => !!s); // e.g. [ 'gitpod-io', 'gitpod.git' ]
+        if (segments.length === 2) {
+            const owner = segments[0];
+            const repo = segments[1].endsWith('.git') ? segments[1].slice(0, -4) : segments[1];
+            return { host, owner, repo };
+        }
+        if (segments.length > 2) {
+            const endSegment = segments[segments.length - 1];
+            const ownerSegments = segments.slice(0, segments.length-1);
+            const owner = ownerSegments.join("/");
+            const repo = endSegment.endsWith('.git') ? endSegment.slice(0, -4) : endSegment;
+            return { host, owner, repo };
+        }
+        return undefined;
     }
-    return undefined;
 }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -34,7 +34,7 @@ import { HostContextProvider } from '../auth/host-context-provider';
 import { GuardedResource, ResourceAccessGuard, ResourceAccessOp } from '../auth/resource-access';
 import { Config } from '../config';
 import { NotFoundError, UnauthorizedError } from '../errors';
-import { parseRepoUrl } from '../repohost/repo-url';
+import { RepoURL } from '../repohost/repo-url';
 import { TermsProvider } from '../terms/terms-provider';
 import { TheiaPluginService } from '../theia-plugin/theia-plugin-service';
 import { AuthorizationService } from '../user/authorization-service';
@@ -970,7 +970,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         return (await Promise.all(repositories
             .filter(repo => repo.url != undefined)
             .map(async whitelistedRepo => {
-                const repoUrl = parseRepoUrl(whitelistedRepo.url!);
+                const repoUrl = RepoURL.parseRepoUrl(whitelistedRepo.url!);
                 if (!repoUrl) return undefined;
 
                 const { host, owner, repo } = repoUrl;


### PR DESCRIPTION
Fixes #6068

## Description
This PR allows GitLab projects in subgroups and nested subgroups to be accessible. This PR also includes additional fixes related to the [GitLab slug](https://github.com/gitpod-io/gitpod/pull/6376) issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6068

## How to test
1. Create a subgroup and a subgroup inside that subgroup (however nested you like) in GitLab
2. Create a project within each of those subgroups
3. Add those projects in Gitpod. Run prebuilds for each of them.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Prebuilds can run for GitLab subgroup projects. 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
