### PR TITLE
Make workspaces start using the "installer"

### DIFF
--- a/components/content-service-api/go/config/config.go
+++ b/components/content-service-api/go/config/config.go
@@ -24,10 +24,10 @@ type StorageConfig struct {
 	Kind RemoteStorageType `json:"kind"`
 
 	// GCloudConfig configures the Google Bucket remote storage
-	GCloudConfig GCPConfig `json:"gcloud"`
+	GCloudConfig GCPConfig `json:"gcloud,omitempty"`
 
 	// MinIOConfig configures the MinIO remote storage
-	MinIOConfig MinIOConfig `json:"minio"`
+	MinIOConfig MinIOConfig `json:"minio,omitempty"`
 
 	// BackupTrail maintains a number of backups for the same workspace
 	BackupTrail struct {

--- a/components/server/src/debug-app.ts
+++ b/components/server/src/debug-app.ts
@@ -47,6 +47,7 @@ export class DebugApp {
                 const newLogLevel = levelRequest.level;
                 log.setLogLevel(newLogLevel);
                 log.info("set log level", { newLogLevel });
+                res.status(200).end(JSON.stringify(levelRequest));
             } catch (err) {
                 res.status(500).end(err);
             }

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,0 +1,1 @@
+installer

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -311,9 +311,6 @@ func ImageName(repo, name, tag string) string {
 	if repo == "" {
 		repo = "docker.io"
 	}
-	if tag == "" {
-		tag = "latest"
-	}
 
 	ref := fmt.Sprintf("%s/%s:%s", strings.TrimSuffix(repo, "/"), name, tag)
 	pref, err := reference.ParseNamed(ref)

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -324,14 +324,14 @@ func ImageName(repo, name, tag string) string {
 	return ref
 }
 
-func StorageConfig(cfg *config.Config) storageconfig.StorageConfig {
+func StorageConfig(context RenderContext) storageconfig.StorageConfig {
 	var res *storageconfig.StorageConfig
-	if cfg.ObjectStorage.CloudStorage != nil {
+	if context.Config.ObjectStorage.CloudStorage != nil {
 		// TODO(cw): where do we get the GCP project from? Is it even still needed?
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.GCloudStorage,
 			GCloudConfig: storageconfig.GCPConfig{
-				Region:             cfg.Metadata.Region,
+				Region:             context.Config.Metadata.Region,
 				Project:            "TODO",
 				CredentialsFile:    "/mnt/secrets/gcp-storage/service-account.json",
 				ParallelUpload:     6,
@@ -339,7 +339,7 @@ func StorageConfig(cfg *config.Config) storageconfig.StorageConfig {
 			},
 		}
 	}
-	if cfg.ObjectStorage.S3 != nil {
+	if context.Config.ObjectStorage.S3 != nil {
 		// TODO(cw): where do we get the AWS secretKey and accessKey from?
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.MinIOStorage,
@@ -348,20 +348,20 @@ func StorageConfig(cfg *config.Config) storageconfig.StorageConfig {
 				AccessKeyID:     "TODO",
 				SecretAccessKey: "TODO",
 				Secure:          true,
-				Region:          cfg.Metadata.Region,
+				Region:          context.Config.Metadata.Region,
 				ParallelUpload:  6,
 			},
 		}
 	}
-	if b := cfg.ObjectStorage.InCluster; b != nil && *b {
+	if b := context.Config.ObjectStorage.InCluster; b != nil && *b {
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.MinIOStorage,
 			MinIOConfig: storageconfig.MinIOConfig{
-				Endpoint:        "minio",
-				AccessKeyID:     "TODO",
-				SecretAccessKey: "TODO",
-				Secure:          true,
-				Region:          cfg.Metadata.Region,
+				Endpoint:        "minio:9000",
+				AccessKeyID:     context.Values.StorageAccessKey,
+				SecretAccessKey: context.Values.StorageSecretKey,
+				Secure:          false,
+				Region:          context.Config.Metadata.Region,
 				ParallelUpload:  6,
 			},
 		}

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -6,10 +6,11 @@ package common
 
 import (
 	"fmt"
-	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"io"
 	"math/rand"
 	"strings"
+
+	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 
 	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
@@ -500,12 +501,6 @@ var (
 		Kind:       "Job",
 	}
 )
-
-type TLS struct {
-	Authority   string `json:"ca"`
-	Certificate string `json:"cert"`
-	Key         string `json:"key"`
-}
 
 // validCookieChars contains all characters which may occur in an HTTP Cookie value (unicode \u0021 through \u007E),
 // without the characters , ; and / ... I did not find more details about permissible characters in RFC2965, so I took

--- a/installer/pkg/common/common_test.go
+++ b/installer/pkg/common/common_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRepoName(t *testing.T) {
+	type Expectation struct {
+		Result string
+		Panics bool
+	}
+	tests := []struct {
+		Repo        string
+		Name        string
+		Expectation Expectation
+	}{
+		{
+			Name: "gitpod-io/workspace-full",
+			Expectation: Expectation{
+				Result: "docker.io/gitpod-io/workspace-full",
+			},
+		},
+		{
+			Repo: "some-repo.com",
+			Name: "some-image",
+			Expectation: Expectation{
+				Result: "some-repo.com/some-image",
+			},
+		},
+		{
+			Repo: "some-repo",
+			Name: "not@avalid#image-name",
+			Expectation: Expectation{
+				Panics: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Repo+"/"+test.Name, func(t *testing.T) {
+			var act Expectation
+			func() {
+				defer func() {
+					if recover() != nil {
+						act.Panics = true
+					}
+				}()
+				act.Result = common.RepoName(test.Repo, test.Name)
+			}()
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("RepoName() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/installer/pkg/common/constants.go
+++ b/installer/pkg/common/constants.go
@@ -24,4 +24,6 @@ const (
 	WSManagerBridgeComponent  = "ws-manager-bridge"
 	WSProxyComponent          = "ws-proxy"
 	WSSchedulerComponent      = "ws-scheduler"
+
+	AnnotationConfigChecksum = "gitpod.io/checksum_config"
 )

--- a/installer/pkg/common/render.go
+++ b/installer/pkg/common/render.go
@@ -82,6 +82,7 @@ type GeneratedValues struct {
 	StorageSecretKey         string
 	InternalRegistryUsername string
 	InternalRegistryPassword string
+	ImageBuilderAuthKey      string
 }
 
 type RenderContext struct {
@@ -117,6 +118,12 @@ func (r *RenderContext) generateValues() error {
 		return err
 	}
 	r.Values.InternalRegistryPassword = internalRegistryPassword
+
+	imageBuilderAuthKey, err := RandomString(32)
+	if err != nil {
+		return err
+	}
+	r.Values.ImageBuilderAuthKey = imageBuilderAuthKey
 
 	return nil
 }

--- a/installer/pkg/components/agent-smith/daemonset.go
+++ b/installer/pkg/components/agent-smith/daemonset.go
@@ -33,8 +33,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					// todo(sje): do we need affinity?
-					Affinity:                      &corev1.Affinity{},
+					Affinity:                      common.Affinity(common.AffinityLabelWorkspacesRegular, common.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					HostPID:                       true,
 					EnableServiceLinks:            pointer.Bool(false),

--- a/installer/pkg/components/agent-smith/daemonset.go
+++ b/installer/pkg/components/agent-smith/daemonset.go
@@ -18,12 +18,20 @@ import (
 func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
 	return []runtime.Object{&appsv1.DaemonSet{
 		TypeMeta: common.TypeMetaDaemonset,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Component,
 			Namespace: ctx.Namespace,
 			Labels:    labels,
+			Annotations: map[string]string{
+				common.AnnotationConfigChecksum: configHash,
+			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},

--- a/installer/pkg/components/blobserve/configmap.go
+++ b/installer/pkg/components/blobserve/configmap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gitpod-io/gitpod/blobserve/pkg/config"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,12 +35,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Port:    ContainerPort,
 			Timeout: util.Duration(time.Second * 5),
 			Repos: map[string]blobserve.Repo{
-				// @todo get the correct values for all the map keys and PrePulls
-				"1": {
-					PrePull: []string{},
-					Workdir: "/theia/theia-app/app/lib",
-				},
-				"2": {
+				common.RepoName(ctx.Config.Repository, workspace.IDEImageRepo): {
 					PrePull: []string{},
 					Workdir: "/ide",
 					Replacements: []blobserve.StringReplacement{{
@@ -72,7 +68,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Replacement: "${supervisor}",
 					}},
 				},
-				"3": {
+				common.RepoName(ctx.Config.Repository, workspace.SupervisorImage): {
 					PrePull: []string{},
 					Workdir: "/.supervisor/frontend",
 				},

--- a/installer/pkg/components/image-builder-mk3/secret.go
+++ b/installer/pkg/components/image-builder-mk3/secret.go
@@ -15,11 +15,6 @@ import (
 )
 
 func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
-	key, err := common.RandomString(32)
-	if err != nil {
-		return nil, err
-	}
-
 	return []runtime.Object{&corev1.Secret{
 		TypeMeta: common.TypeMetaSecret,
 		ObjectMeta: metav1.ObjectMeta{
@@ -28,7 +23,7 @@ func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Labels:    common.DefaultLabels(Component),
 		},
 		Data: map[string][]byte{
-			"keyfile": []byte(key),
+			"keyfile": []byte(ctx.Values.ImageBuilderAuthKey),
 		},
 	}}, nil
 }

--- a/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -6,6 +6,7 @@ package openvsx_proxy
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -19,6 +20,11 @@ import (
 func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 	// todo(sje): add redis
+
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
 
 	return []runtime.Object{&appsv1.StatefulSet{
 		TypeMeta: common.TypeMetaStatefulSet,
@@ -39,6 +45,9 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Name:      Component,
 					Namespace: ctx.Namespace,
 					Labels:    labels,
+					Annotations: map[string]string{
+						common.AnnotationConfigChecksum: configHash,
+					},
 				},
 				Spec: v1.PodSpec{
 					Affinity:                      &v1.Affinity{},

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -20,6 +20,11 @@ import (
 func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
 
@@ -71,6 +76,9 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   Component,
 					Labels: labels,
+					Annotations: map[string]string{
+						common.AnnotationConfigChecksum: configHash,
+					},
 				},
 				Spec: corev1.PodSpec{
 					PriorityClassName: common.SystemNodeCritical,

--- a/installer/pkg/components/server/deployment.go
+++ b/installer/pkg/components/server/deployment.go
@@ -24,6 +24,11 @@ import (
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
 	// Convert to a JSON string
 	fc, err := json.MarshalIndent(wsmanagerbridge.WSManagerList(), "", " ")
 	if err != nil {
@@ -49,6 +54,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
+						Annotations: map[string]string{
+							common.AnnotationConfigChecksum: configHash,
+						},
 					},
 					Spec: corev1.PodSpec{
 						Affinity:           &corev1.Affinity{},

--- a/installer/pkg/components/server/ide-configmap.go
+++ b/installer/pkg/components/server/ide-configmap.go
@@ -17,11 +17,16 @@ import (
 )
 
 func ideconfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	stableVersion := ctx.VersionManifest.Components.Workspace.CodeImageStable.Version
+	if stableVersion == "" {
+		stableVersion = ctx.VersionManifest.Components.Workspace.CodeImage.Version
+	}
+
 	idecfg := IDEConfig{
-		IDEVersion:   ctx.VersionManifest.Components.Workspace.CodeImageStable.Version,
+		IDEVersion:   stableVersion,
 		IDEImageRepo: workspace.IDEImageRepo,
 		IDEImageAliases: map[string]string{
-			"code":        common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImageStable.Version),
+			"code":        common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, stableVersion),
 			"code-latest": common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
 		},
 	}

--- a/installer/pkg/components/ws-daemon/configmap.go
+++ b/installer/pkg/components/ws-daemon/configmap.go
@@ -57,7 +57,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Content: content.Config{
 				WorkingArea:     "/mnt/workingarea",
-				WorkingAreaNode: HostWorkspacePath,
+				WorkingAreaNode: HostWorkingArea,
 				TmpDir:          "/tmp",
 				UserNamespaces: content.UserNamespacesConfig{
 					FSShift: content.FSShiftMethod(fsshift),

--- a/installer/pkg/components/ws-daemon/configmap.go
+++ b/installer/pkg/components/ws-daemon/configmap.go
@@ -62,7 +62,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				UserNamespaces: content.UserNamespacesConfig{
 					FSShift: content.FSShiftMethod(fsshift),
 				},
-				Storage: common.StorageConfig(&ctx.Config),
+				Storage: common.StorageConfig(ctx),
 				Backup: content.BackupConfig{
 					Timeout:  util.Duration(time.Minute * 5),
 					Attempts: 3,

--- a/installer/pkg/components/ws-daemon/constants.go
+++ b/installer/pkg/components/ws-daemon/constants.go
@@ -5,9 +5,10 @@
 package wsdaemon
 
 const (
-	Component         = "ws-daemon"
-	ServicePort       = 8080
-	HostWorkspacePath = "/var/gitpod/workspaces"
-	TLSSecretName     = "ws-daemon-tls"
-	VolumeTLSCerts    = "ws-daemon-tls-certs"
+	Component            = "ws-daemon"
+	ServicePort          = 8080
+	HostWorkingArea      = "/var/gitpod/workspaces"
+	ContainerWorkingArea = "/mnt/workingarea"
+	TLSSecretName        = "ws-daemon-tls"
+	VolumeTLSCerts       = "ws-daemon-tls-certs"
 )

--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -23,6 +23,11 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := ctx.Config
 	labels := common.DefaultLabels(Component)
 
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
 	initContainers := []corev1.Container{
 		{
 			Name:  "disable-kube-health-monitor",
@@ -114,6 +119,7 @@ fi
 					Labels: labels,
 					Annotations: map[string]string{
 						"seccomp.security.alpha.kubernetes.io/shiftfs-module-loader": "unconfined",
+						common.AnnotationConfigChecksum:                              configHash,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -6,6 +6,7 @@ package wsdaemon
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 
@@ -126,7 +127,7 @@ fi
 						{
 							Name: "working-area",
 							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-								Path: HostWorkspacePath,
+								Path: HostWorkingArea,
 								Type: func() *corev1.HostPathType { r := corev1.HostPathDirectoryOrCreate; return &r }(),
 							}},
 						},
@@ -229,7 +230,7 @@ fi
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:             "working-area",
-									MountPath:        "/mnt/wsdaemon-workingarea",
+									MountPath:        ContainerWorkingArea,
 									MountPropagation: func() *corev1.MountPropagationMode { r := corev1.MountPropagationBidirectional; return &r }(),
 								},
 								{

--- a/installer/pkg/components/ws-manager-bridge/objects.go
+++ b/installer/pkg/components/ws-manager-bridge/objects.go
@@ -20,9 +20,9 @@ var Objects = common.CompositeRenderFunc(
 
 func WSManagerList() []WorkspaceCluster {
 	return []WorkspaceCluster{{
-		Name: "", // todo(sje): generate the installation shortname
+		Name: "default",
 		URL:  fmt.Sprintf("dns:///%s:%d", wsmanager.Component, wsmanager.RPCPort),
-		TLS: common.TLS{
+		TLS: WorkspaceClusterTLS{
 			Authority:   "/ws-manager-client-tls-certs/ca.crt",
 			Certificate: "/ws-manager-client-tls-certs/tls.crt",
 			Key:         "/ws-manager-client-tls-certs/tls.key",

--- a/installer/pkg/components/ws-manager-bridge/types.go
+++ b/installer/pkg/components/ws-manager-bridge/types.go
@@ -4,10 +4,6 @@
 
 package wsmanagerbridge
 
-import (
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
-)
-
 // Configuration from components/ws-manager-bridge/src/config.ts
 type Configuration struct {
 	Installation                        string             `json:"installation"`
@@ -36,12 +32,19 @@ type Timeouts struct {
 type WorkspaceCluster struct {
 	Name                 string                `json:"name"`
 	URL                  string                `json:"url"`
-	TLS                  common.TLS            `json:"tls"`
+	TLS                  WorkspaceClusterTLS   `json:"tls"`
 	State                WorkspaceClusterState `json:"state"`
 	MaxScore             int32                 `json:"maxScore"`
 	Score                int32                 `json:"score"`
 	Govern               bool                  `json:"govern"`
 	AdmissionConstraints []AdmissionConstraint `json:"admissionConstraints"`
+}
+
+// WorkspaceClusterTLS is the struct we use in ws-manager-bridge cluster registrations.
+type WorkspaceClusterTLS struct {
+	Authority   string `json:"ca"`
+	Certificate string `json:"crt"`
+	Key         string `json:"key"`
 }
 
 // WorkspaceClusterState from components/gitpod-protocol/src/workspace-cluster.ts

--- a/installer/pkg/components/ws-manager/configmap.go
+++ b/installer/pkg/components/ws-manager/configmap.go
@@ -85,7 +85,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			WorkspaceURLTemplate:     fmt.Sprintf("https://{{ .Prefix }}.ws.%s", ctx.Config.Domain),
 			WorkspacePortURLTemplate: fmt.Sprintf("https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.%s", ctx.Config.Domain),
-			WorkspaceHostPath:        wsdaemon.HostWorkspacePath,
+			WorkspaceHostPath:        wsdaemon.HostWorkingArea,
 			WorkspacePodTemplate:     templatesCfg,
 			Timeouts: config.WorkspaceTimeoutConfiguration{
 				AfterClose:          util.Duration(2 * time.Minute),

--- a/installer/pkg/components/ws-manager/deployment.go
+++ b/installer/pkg/components/ws-manager/deployment.go
@@ -18,6 +18,11 @@ import (
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
@@ -36,6 +41,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
+						Annotations: map[string]string{
+							common.AnnotationConfigChecksum: configHash,
+						},
 					},
 					Spec: corev1.PodSpec{
 						PriorityClassName:  common.SystemNodeCritical,

--- a/installer/pkg/components/ws-proxy/deployment.go
+++ b/installer/pkg/components/ws-proxy/deployment.go
@@ -21,6 +21,11 @@ import (
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
 	if ctx.Config.Certificate.Name != "" {
@@ -57,6 +62,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
+						Annotations: map[string]string{
+							common.AnnotationConfigChecksum: configHash,
+						},
 					},
 					Spec: corev1.PodSpec{
 						PriorityClassName:  common.SystemNodeCritical,

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -85,7 +85,7 @@ type Config struct {
 }
 
 type Metadata struct {
-	Region string `json:"region"`
+	Region string `json:"region" validate:"required"`
 }
 
 type Observability struct {


### PR DESCRIPTION
## Description
This PR contains the necessary changes (and then some) to make workspaces start with an in-cluster configuration, i.e. using minio and the built-in registry.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6519

## How to test
Run the installer against a fresh cluster, log in and start a workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
