### PR TITLE
[jetbrains] Fix Heartbeat plugin connection error

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/ide/jetbrains/backend/services/ControllerStatusProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/ide/jetbrains/backend/services/ControllerStatusProvider.kt
@@ -31,11 +31,12 @@ class ControllerStatusProvider {
         val response: Response = try {
             client.get("http://localhost:$PORT/codeWithMe/unattendedHostStatus?token=$cwmToken")
         } catch (e: Exception) {
-            logger.error(e)
-            throw ConnectionFailed(cwmToken)
+            logger.error("Error fetching host status: $e")
+            return ControllerStatus(false, 0)
         }
 
         if (response.projects.isEmpty()) {
+            logger.error("response.projects is empty")
             return ControllerStatus(false, 0)
         }
 
@@ -49,9 +50,6 @@ class ControllerStatusProvider {
         private const val PORT = 63342
 
         data class ControllerStatus(val connected: Boolean, val secondsSinceLastActivity: Int)
-
-        class ConnectionFailed(token: String) :
-            Exception("Couldn't connect to Jetbrains IDE backend at port $PORT with token $token ")
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         private data class Response(


### PR DESCRIPTION
## Description
This PR changes the handling of connection errors to the backend service. Instead of throwing an exception, it just returns not connected. That prevents that the plugins exists when a connection error occurs.

An alternative would be to handle the exception in `HeartbeatService.kt`.

@atduarte What do you think about this solution?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6523

## How to test
<!-- Provide steps to test this PR -->
- Start a workspace with selected JetBrains IDE.
- Connect thin client to the workspace.
- Verify that `Heartbeat sent` is logged in `/home/gitpod/.CwmHost-IU-system/_workspace.../log/idea.log` 
- Close all browser tabs, work in the thin client and make verify that the workspace does not stop.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
