### PR TITLE
[installer] Support GCP cloud storage

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -48,8 +48,19 @@ A config file is required which can be generated with the init command.`,
 		}
 
 		if !renderOpts.ValidateConfigDisabled {
-			if err = runConfigValidation(cfgVersion, cfg); err != nil {
+			apiVersion, err := config.LoadConfigVersion(cfgVersion)
+			if err != nil {
 				return err
+			}
+			res, err := config.Validate(apiVersion, cfg)
+			if err != nil {
+				return err
+			}
+
+			if !res.Valid {
+				res.Marshal(os.Stderr)
+				fmt.Fprintln(os.Stderr, "configuration is invalid")
+				os.Exit(1)
 			}
 		}
 

--- a/installer/pkg/cluster/affinity.go
+++ b/installer/pkg/cluster/affinity.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cluster
+
+// Valid characters for affinities are alphanumeric, -, _, . and one / as a subdomain prefix
+const (
+	AffinityLabelMeta               = "gitpod.io/workload_meta"
+	AffinityLabelIDE                = "gitpod.io/workload_ide"
+	AffinityLabelWorkspaceServices  = "gitpod.io/workload_workspace_services"
+	AffinityLabelWorkspacesRegular  = "gitpod.io/workload_workspace_regular"
+	AffinityLabelWorkspacesHeadless = "gitpod.io/workload_workspace_headless"
+)
+
+var AffinityList = []string{
+	AffinityLabelMeta,
+	AffinityLabelIDE,
+	AffinityLabelWorkspaceServices,
+	AffinityLabelWorkspacesRegular,
+	AffinityLabelWorkspacesHeadless,
+}

--- a/installer/pkg/cluster/checks.go
+++ b/installer/pkg/cluster/checks.go
@@ -8,25 +8,29 @@ import (
 	"context"
 	"strings"
 
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
-
 	"github.com/Masterminds/semver"
 	certmanager "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
 
 // checkAffinityLabels validates that the nodes have all the required affinity labels applied
 // It assumes all the values are `true`
-func checkAffinityLabels(list *v1.NodeList, _ *rest.Config) []ValidationError {
+func checkAffinityLabels(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
+	nodes, err := listNodesFromContext(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
 	affinityList := map[string]bool{}
-	for _, affinity := range common.AffinityList {
+	for _, affinity := range AffinityList {
 		affinityList[affinity] = false
 	}
 
-	var resultErr []ValidationError
-	for _, node := range list.Items {
+	var res []ValidationError
+	for _, node := range nodes {
 		for k, v := range node.GetLabels() {
 			if _, found := affinityList[k]; found {
 				affinityList[k] = v == "true"
@@ -37,32 +41,29 @@ func checkAffinityLabels(list *v1.NodeList, _ *rest.Config) []ValidationError {
 	// Check all the values in the map are `true`
 	for k, v := range affinityList {
 		if !v {
-			resultErr = append(resultErr, ValidationError{
+			res = append(res, ValidationError{
 				Message: "Affinity label not found in cluster: " + k,
 				Type:    ValidationStatusError,
 			})
 		}
 	}
-	return resultErr
+	return res, nil
 }
 
 // checkCertManagerInstalled checks that cert-manager is installed as a cluster dependency
-func checkCertManagerInstalled(_ *v1.NodeList, restConfig *rest.Config) []ValidationError {
-	clientset, err := certmanager.NewForConfig(restConfig)
+func checkCertManagerInstalled(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
+	client, err := certmanager.NewForConfig(config)
 	if err != nil {
-		return []ValidationError{{
-			Message: err.Error(),
-			Type:    ValidationStatusError,
-		}}
+		return nil, err
 	}
 
-	clusterIssuers, err := clientset.CertmanagerV1().ClusterIssuers().List(context.TODO(), metav1.ListOptions{})
+	clusterIssuers, err := client.CertmanagerV1().ClusterIssuers().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		// If cert-manager not installed, this will error
 		return []ValidationError{{
 			Message: err.Error(),
 			Type:    ValidationStatusError,
-		}}
+		}}, nil
 	}
 
 	if len(clusterIssuers.Items) == 0 {
@@ -70,26 +71,59 @@ func checkCertManagerInstalled(_ *v1.NodeList, restConfig *rest.Config) []Valida
 		return []ValidationError{{
 			Message: "no cluster issuers configured",
 			Type:    ValidationStatusWarning,
-		}}
+		}}, nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 // checkContainerDRuntime checks that the nodes are running with the containerd runtime
-func checkContainerDRuntime(list *v1.NodeList, _ *rest.Config) []ValidationError {
-	var resultErr []ValidationError
-	for _, node := range list.Items {
+func checkContainerDRuntime(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
+	nodes, err := listNodesFromContext(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []ValidationError
+	for _, node := range nodes {
 		runtime := node.Status.NodeInfo.ContainerRuntimeVersion
 		if !strings.Contains(runtime, "containerd") {
-			resultErr = append(resultErr, ValidationError{
+			res = append(res, ValidationError{
 				Message: "container runtime not containerd on node: " + node.Name + ", runtime: " + runtime,
 				Type:    ValidationStatusError,
 			})
 		}
 	}
 
-	return resultErr
+	return res, nil
+}
+
+// CheckSecret produces a new check for an in-cluster secret
+func CheckSecret(name string, validator func(*corev1.Secret) ([]ValidationError, error)) ValidationCheck {
+	return ValidationCheck{
+		Name:        name + " is present and valid",
+		Description: "ensures the " + name + " secret is present and contains the required data",
+		Check: func(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
+			client, err := clientsetFromContext(ctx, config)
+			if err != nil {
+				return nil, err
+			}
+
+			secret, err := client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if errors.IsNotFound(err) {
+				return []ValidationError{
+					{
+						Message: "secret " + name + " not found",
+						Type:    ValidationStatusError,
+					},
+				}, nil
+			} else if err != nil {
+				return nil, err
+			}
+
+			return validator(secret)
+		},
+	}
 }
 
 const (
@@ -99,25 +133,26 @@ const (
 )
 
 // checkKernelVersion checks the nodes are using the correct linux Kernel version
-func checkKernelVersion(list *v1.NodeList, _ *rest.Config) []ValidationError {
-
+func checkKernelVersion(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
 	constraint, err := semver.NewConstraint(kernelVersionConstraint)
 	if err != nil {
-		return []ValidationError{{
-			Message: err.Error(),
-			Type:    ValidationStatusError,
-		}}
+		return nil, err
 	}
 
-	var resultErr []ValidationError
-	for _, node := range list.Items {
+	nodes, err := listNodesFromContext(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []ValidationError
+	for _, node := range nodes {
 		kernelVersion := node.Status.NodeInfo.KernelVersion
 		// Some GCP kernel versions contain a non-semver compatible suffix
 		kernelVersion = strings.TrimSuffix(kernelVersion, "+")
 		version, err := semver.NewVersion(kernelVersion)
 		if err != nil {
 			// This means that the given version doesn't conform to semver format - user must decide
-			resultErr = append(resultErr, ValidationError{
+			res = append(res, ValidationError{
 				Message: err.Error() + " kernel version: " + kernelVersion,
 				Type:    ValidationStatusWarning,
 			})
@@ -127,12 +162,12 @@ func checkKernelVersion(list *v1.NodeList, _ *rest.Config) []ValidationError {
 		valid := constraint.Check(version)
 
 		if !valid {
-			resultErr = append(resultErr, ValidationError{
+			res = append(res, ValidationError{
 				Message: "kernel version " + kernelVersion + " does not satisfy " + kernelVersionConstraint + " on node: " + node.Name,
 				Type:    ValidationStatusError,
 			})
 		}
 	}
 
-	return resultErr
+	return res, nil
 }

--- a/installer/pkg/common/storage.go
+++ b/installer/pkg/common/storage.go
@@ -18,12 +18,11 @@ import (
 func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 	var res *storageconfig.StorageConfig
 	if context.Config.ObjectStorage.CloudStorage != nil {
-		// TODO(cw): where do we get the GCP project from? Is it even still needed?
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.GCloudStorage,
 			GCloudConfig: storageconfig.GCPConfig{
 				Region:             context.Config.Metadata.Region,
-				Project:            "TODO",
+				Project:            context.Config.ObjectStorage.CloudStorage.Project,
 				CredentialsFile:    "/mnt/secrets/gcp-storage/service-account.json",
 				ParallelUpload:     6,
 				MaximumBackupCount: 3,

--- a/installer/pkg/common/storage.go
+++ b/installer/pkg/common/storage.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package common
+
+import (
+	"fmt"
+
+	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+// StorageConfig produces config service configuration from the installer config
+
+func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
+	var res *storageconfig.StorageConfig
+	if context.Config.ObjectStorage.CloudStorage != nil {
+		// TODO(cw): where do we get the GCP project from? Is it even still needed?
+		res = &storageconfig.StorageConfig{
+			Kind: storageconfig.GCloudStorage,
+			GCloudConfig: storageconfig.GCPConfig{
+				Region:             context.Config.Metadata.Region,
+				Project:            "TODO",
+				CredentialsFile:    "/mnt/secrets/gcp-storage/service-account.json",
+				ParallelUpload:     6,
+				MaximumBackupCount: 3,
+			},
+		}
+	}
+	if context.Config.ObjectStorage.S3 != nil {
+		// TODO(cw): where do we get the AWS secretKey and accessKey from?
+		res = &storageconfig.StorageConfig{
+			Kind: storageconfig.MinIOStorage,
+			MinIOConfig: storageconfig.MinIOConfig{
+				Endpoint:        "some-magic-amazon-value?",
+				AccessKeyID:     "TODO",
+				SecretAccessKey: "TODO",
+				Secure:          true,
+				Region:          context.Config.Metadata.Region,
+				ParallelUpload:  6,
+			},
+		}
+	}
+	if b := context.Config.ObjectStorage.InCluster; b != nil && *b {
+		res = &storageconfig.StorageConfig{
+			Kind: storageconfig.MinIOStorage,
+			MinIOConfig: storageconfig.MinIOConfig{
+				Endpoint:        "minio:9000",
+				AccessKeyID:     context.Values.StorageAccessKey,
+				SecretAccessKey: context.Values.StorageSecretKey,
+				Secure:          false,
+				Region:          context.Config.Metadata.Region,
+				ParallelUpload:  6,
+			},
+		}
+	}
+
+	if res == nil {
+		panic("no valid storage configuration set")
+	}
+
+	// todo(sje): create exportable type
+	res.BackupTrail = struct {
+		Enabled   bool `json:"enabled"`
+		MaxLength int  `json:"maxLength"`
+	}{
+		Enabled:   true,
+		MaxLength: 3,
+	}
+	// 5 GiB
+	res.BlobQuota = 5 * 1024 * 1024 * 1024
+
+	return *res
+}
+
+// AddStorageMounts adds mounts and volumes to a pod which are required for
+// the storage configration to function. If a list of containers is provided,
+// the mounts are only added to those container. If the list is empty, they're
+// addded to all containers.
+func AddStorageMounts(ctx *RenderContext, pod *corev1.PodSpec, container ...string) error {
+	if ctx.Config.ObjectStorage.CloudStorage != nil {
+		volumeName := "storage-config-cloudstorage"
+		pod.Volumes = append(pod.Volumes,
+			corev1.Volume{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: ctx.Config.ObjectStorage.CloudStorage.ServiceAccount.Name,
+					},
+				},
+			},
+		)
+
+		idx := make(map[string]struct{}, len(container))
+		if len(container) == 0 {
+			for _, c := range pod.Containers {
+				idx[c.Name] = struct{}{}
+			}
+		} else {
+			for _, c := range container {
+				idx[c] = struct{}{}
+			}
+		}
+
+		for i := range pod.Containers {
+			if _, ok := idx[pod.Containers[i].Name]; !ok {
+				continue
+			}
+
+			pod.Containers[i].VolumeMounts = append(pod.Containers[i].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      volumeName,
+					ReadOnly:  true,
+					MountPath: "/mnt/secrets/gcp-storage",
+				},
+			)
+		}
+
+		return nil
+	}
+
+	if ctx.Config.ObjectStorage.S3 != nil {
+		return nil
+	}
+
+	if pointer.BoolDeref(ctx.Config.ObjectStorage.InCluster, false) {
+		// builtin storage needs no extra mounts
+		return nil
+	}
+
+	return fmt.Errorf("no valid storage confniguration set")
+}

--- a/installer/pkg/components/agent-smith/daemonset.go
+++ b/installer/pkg/components/agent-smith/daemonset.go
@@ -5,6 +5,7 @@
 package agentsmith
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,7 +42,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					Affinity:                      common.Affinity(common.AffinityLabelWorkspacesRegular, common.AffinityLabelWorkspacesHeadless),
+					Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					HostPID:                       true,
 					EnableServiceLinks:            pointer.Bool(false),

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -5,6 +5,7 @@
 package registryfacade
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	dockerregistry "github.com/gitpod-io/gitpod/installer/pkg/components/docker-registry"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
@@ -83,7 +84,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Spec: corev1.PodSpec{
 					PriorityClassName: common.SystemNodeCritical,
 					// todo(sje): do we need affinity?
-					Affinity:                      common.Affinity(common.AffinityLabelWorkspacesRegular, common.AffinityLabelWorkspacesHeadless),
+					Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/installer/pkg/components/ws-daemon/constants.go
+++ b/installer/pkg/components/ws-daemon/constants.go
@@ -9,6 +9,7 @@ const (
 	ServicePort          = 8080
 	HostWorkingArea      = "/var/gitpod/workspaces"
 	ContainerWorkingArea = "/mnt/workingarea"
+	HostBackupPath       = "/var/gitpod/tmp/backup"
 	TLSSecretName        = "ws-daemon-tls"
 	VolumeTLSCerts       = "ws-daemon-tls-certs"
 )

--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -7,6 +7,7 @@ package wsdaemon
 import (
 	"fmt"
 
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 
@@ -287,7 +288,7 @@ fi
 		DNSPolicy:                     "ClusterFirst",
 		ServiceAccountName:            Component,
 		HostPID:                       true,
-		Affinity:                      common.Affinity(common.AffinityLabelWorkspacesRegular, common.AffinityLabelWorkspacesHeadless),
+		Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "node.kubernetes.io/disk-pressure",

--- a/installer/pkg/components/ws-manager/deployment.go
+++ b/installer/pkg/components/ws-manager/deployment.go
@@ -23,6 +23,92 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
+	podSpec := corev1.PodSpec{
+		PriorityClassName:  common.SystemNodeCritical,
+		Affinity:           &corev1.Affinity{},
+		EnableServiceLinks: pointer.Bool(false),
+		ServiceAccountName: Component,
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: pointer.Int64(31002),
+		},
+		Containers: []corev1.Container{{
+			Name:            Component,
+			Args:            []string{"run", "-v", "--config", "/config/config.json"},
+			Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManager.Version),
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("100m"),
+					"memory": resource.MustParse("32Mi"),
+				},
+			},
+			Ports: []corev1.ContainerPort{{
+				Name:          RPCPortName,
+				ContainerPort: RPCPort,
+			}},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: pointer.Bool(false),
+			},
+			Env: common.MergeEnv(
+				common.DefaultEnv(&ctx.Config),
+				common.TracingEnv(&ctx.Config),
+				[]corev1.EnvVar{{Name: "GRPC_GO_RETRY", Value: "on"}},
+			),
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      VolumeConfig,
+				MountPath: "/config",
+				ReadOnly:  true,
+			}, {
+				Name:      VolumeWorkspaceTemplate,
+				MountPath: WorkspaceTemplatePath,
+				ReadOnly:  true,
+			}, {
+				Name:      wsdaemon.VolumeTLSCerts,
+				MountPath: "/ws-daemon-tls-certs",
+				ReadOnly:  true,
+			}, {
+				Name:      VolumeTLSCerts,
+				MountPath: "/certs",
+				ReadOnly:  true,
+			}},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: VolumeConfig,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: Component},
+					},
+				},
+			},
+			{
+				Name: VolumeWorkspaceTemplate,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: WorkspaceTemplateConfigMap},
+					},
+				},
+			},
+			{
+				Name: wsdaemon.VolumeTLSCerts,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: wsdaemon.TLSSecretName},
+				},
+			},
+			{
+				Name: VolumeTLSCerts,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: TLSSecretNameSecret},
+				},
+			},
+		},
+	}
+
+	err = common.AddStorageMounts(ctx, &podSpec, Component)
+	if err != nil {
+		return nil, err
+	}
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
@@ -33,7 +119,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
 				Replicas: pointer.Int32(1),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
@@ -45,86 +130,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							common.AnnotationConfigChecksum: configHash,
 						},
 					},
-					Spec: corev1.PodSpec{
-						PriorityClassName:  common.SystemNodeCritical,
-						Affinity:           &corev1.Affinity{},
-						EnableServiceLinks: pointer.Bool(false),
-						ServiceAccountName: Component,
-						SecurityContext: &corev1.PodSecurityContext{
-							RunAsUser: pointer.Int64(31002),
-						},
-						Containers: []corev1.Container{{
-							Name:            Component,
-							Args:            []string{"run", "-v", "--config", "/config/config.json"},
-							Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManager.Version),
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("32Mi"),
-								},
-							},
-							Ports: []corev1.ContainerPort{{
-								Name:          RPCPortName,
-								ContainerPort: RPCPort,
-							}},
-							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
-							},
-							Env: common.MergeEnv(
-								common.DefaultEnv(&ctx.Config),
-								common.TracingEnv(&ctx.Config),
-								[]corev1.EnvVar{{Name: "GRPC_GO_RETRY", Value: "on"}},
-							),
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      VolumeConfig,
-								MountPath: "/config",
-								ReadOnly:  true,
-							}, {
-								Name:      VolumeWorkspaceTemplate,
-								MountPath: WorkspaceTemplatePath,
-								ReadOnly:  true,
-							}, {
-								Name:      wsdaemon.VolumeTLSCerts,
-								MountPath: "/ws-daemon-tls-certs",
-								ReadOnly:  true,
-							}, {
-								Name:      VolumeTLSCerts,
-								MountPath: "/certs",
-								ReadOnly:  true,
-							}},
-						}},
-						Volumes: []corev1.Volume{
-							{
-								Name: VolumeConfig,
-								VolumeSource: corev1.VolumeSource{
-									ConfigMap: &corev1.ConfigMapVolumeSource{
-										LocalObjectReference: corev1.LocalObjectReference{Name: Component},
-									},
-								},
-							},
-							{
-								Name: VolumeWorkspaceTemplate,
-								VolumeSource: corev1.VolumeSource{
-									ConfigMap: &corev1.ConfigMapVolumeSource{
-										LocalObjectReference: corev1.LocalObjectReference{Name: WorkspaceTemplateConfigMap},
-									},
-								},
-							},
-							{
-								Name: wsdaemon.VolumeTLSCerts,
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{SecretName: wsdaemon.TLSSecretName},
-								},
-							},
-							{
-								Name: VolumeTLSCerts,
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{SecretName: TLSSecretNameSecret},
-								},
-							},
-						},
-					},
+					Spec: podSpec,
 				},
 			},
 		},

--- a/installer/pkg/config/loader.go
+++ b/installer/pkg/config/loader.go
@@ -6,8 +6,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/go-playground/validator/v10"
 	"io/ioutil"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/go-playground/validator/v10"
 
 	"sigs.k8s.io/yaml"
 )
@@ -42,6 +44,9 @@ type ConfigVersion interface {
 
 	// LoadValidationFuncs loads the custom validation functions
 	LoadValidationFuncs(*validator.Validate) error
+
+	// ClusterValidation introduces configuration specific cluster validation checks
+	ClusterValidation(cfg interface{}) cluster.ValidationChecks
 }
 
 // AddVersion adds a new version.

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -40,7 +40,7 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Observability = Observability{
 		LogLevel: LogLevelInfo,
 	}
-	cfg.Certificate.Kind = CertificateRefSecret
+	cfg.Certificate.Kind = ObjectRefSecret
 	cfg.Certificate.Name = "https-certificates"
 	cfg.Database.InCluster = pointer.Bool(true)
 	cfg.ObjectStorage.InCluster = pointer.Bool(true)
@@ -58,7 +58,7 @@ func (v version) Defaults(in interface{}) error {
 }
 
 type Config struct {
-	Kind       InstallationKind `json:"kind" validate:"required,installationKind"`
+	Kind       InstallationKind `json:"kind" validate:"required,installation_kind"`
 	Domain     string           `json:"domain" validate:"required,fqdn"`
 	Metadata   Metadata         `json:"metadata"`
 	Repository string           `json:"repository" validate:"required,ascii"`
@@ -89,7 +89,7 @@ type Metadata struct {
 }
 
 type Observability struct {
-	LogLevel LogLevel `json:"logLevel" validate:"required,logLevel"`
+	LogLevel LogLevel `json:"logLevel" validate:"required,log_level"`
 	Tracing  *Tracing `json:"tracing,omitempty"`
 }
 
@@ -128,8 +128,8 @@ type ObjectStorageS3 struct {
 }
 
 type ObjectStorageCloudStorage struct {
-	ServiceAccount ObjectRef `json:"serviceAccount"`
-	Project        string    `json:"project"`
+	ServiceAccount ObjectRef `json:"serviceAccount" validate:"required"`
+	Project        string    `json:"project" validate:"required"`
 }
 
 type InstallationKind string
@@ -141,14 +141,14 @@ const (
 )
 
 type ObjectRef struct {
-	Kind CertificateRefKind `json:"kind" validate:"required,certificateKind"`
-	Name string             `json:"name" validate:"required"`
+	Kind ObjectRefKind `json:"kind" validate:"required,objectref_kind"`
+	Name string        `json:"name" validate:"required"`
 }
 
-type CertificateRefKind string
+type ObjectRefKind string
 
 const (
-	CertificateRefSecret CertificateRefKind = "secret"
+	ObjectRefSecret ObjectRefKind = "secret"
 )
 
 type ContainerRegistry struct {
@@ -193,7 +193,7 @@ type Resources struct {
 }
 
 type WorkspaceRuntime struct {
-	FSShiftMethod        FSShiftMethod `json:"fsShiftMethod" validate:"required,fsShiftMethod"`
+	FSShiftMethod        FSShiftMethod `json:"fsShiftMethod" validate:"required,fs_shift_method"`
 	ContainerDRuntimeDir string        `json:"containerdRuntimeDir" validate:"required,startswith=/"`
 	ContainerDSocket     string        `json:"containerdSocket" validate:"required,startswith=/"`
 }

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -128,7 +128,8 @@ type ObjectStorageS3 struct {
 }
 
 type ObjectStorageCloudStorage struct {
-	Certificate ObjectRef `json:"certificate"`
+	ServiceAccount ObjectRef `json:"serviceAccount"`
+	Project        string    `json:"project"`
 }
 
 type InstallationKind string

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -114,7 +114,8 @@ type DatabaseRDS struct {
 }
 
 type DatabaseCloudSQL struct {
-	Certificate ObjectRef `json:"certificate"`
+	ServiceAccount ObjectRef `json:"serviceAccount"`
+	Project        string    `json:"project" validate:"required"`
 }
 
 type ObjectStorage struct {

--- a/installer/pkg/config/v1/load.go
+++ b/installer/pkg/config/v1/load.go
@@ -47,6 +47,7 @@ func LoadMock() *Config {
 			InCluster: pointer.Bool(true),
 		},
 		Certificate: ObjectRef{
+			Kind: ObjectRefSecret,
 			Name: "https-certs",
 		},
 		Workspace: Workspace{

--- a/installer/pkg/config/v1/validation.go
+++ b/installer/pkg/config/v1/validation.go
@@ -5,7 +5,12 @@
 package config
 
 import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+
 	"github.com/go-playground/validator/v10"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var InstallationKindList = map[InstallationKind]struct{}{
@@ -61,4 +66,29 @@ func (v version) LoadValidationFuncs(validate *validator.Validate) error {
 	}
 
 	return nil
+}
+
+// ClusterValidation introduces configuration specific cluster validation checks
+func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
+	cfg := rcfg.(*Config)
+
+	var res cluster.ValidationChecks
+	if cfg.ObjectStorage.CloudStorage != nil {
+		secretName := cfg.ObjectStorage.CloudStorage.ServiceAccount.Name
+		res = append(res, cluster.CheckSecret(secretName, func(s *corev1.Secret) ([]cluster.ValidationError, error) {
+			key := "service-account.json"
+			if _, exists := s.Data[key]; !exists {
+				return []cluster.ValidationError{
+					{
+						Message: fmt.Sprintf("secret %s has no %s entry", secretName, key),
+						Type:    cluster.ValidationStatusError,
+					},
+				}, nil
+			}
+
+			return nil, nil
+		}))
+	}
+
+	return res
 }

--- a/installer/pkg/config/v1/validation.go
+++ b/installer/pkg/config/v1/validation.go
@@ -24,8 +24,8 @@ var LogLevelList = map[LogLevel]struct{}{
 	LogLevelPanic:   {},
 }
 
-var CertificateRefKindList = map[CertificateRefKind]struct{}{
-	CertificateRefSecret: {},
+var ObjectRefKindList = map[ObjectRefKind]struct{}{
+	ObjectRefSecret: {},
 }
 
 var FSShiftMethodList = map[FSShiftMethod]struct{}{
@@ -35,34 +35,29 @@ var FSShiftMethodList = map[FSShiftMethod]struct{}{
 
 // LoadValidationFuncs load custom validation functions for this version of the config API
 func (v version) LoadValidationFuncs(validate *validator.Validate) error {
-	var err error
-
-	if err = validate.RegisterValidation("certificateKind", func(fl validator.FieldLevel) bool {
-		_, ok := CertificateRefKindList[CertificateRefKind(fl.Field().String())]
-		return ok
-	}); err != nil {
-		return err
+	funcs := map[string]validator.Func{
+		"objectref_kind": func(fl validator.FieldLevel) bool {
+			_, ok := ObjectRefKindList[ObjectRefKind(fl.Field().String())]
+			return ok
+		},
+		"fs_shift_method": func(fl validator.FieldLevel) bool {
+			_, ok := FSShiftMethodList[FSShiftMethod(fl.Field().String())]
+			return ok
+		},
+		"installation_kind": func(fl validator.FieldLevel) bool {
+			_, ok := InstallationKindList[InstallationKind(fl.Field().String())]
+			return ok
+		},
+		"log_level": func(fl validator.FieldLevel) bool {
+			_, ok := LogLevelList[LogLevel(fl.Field().String())]
+			return ok
+		},
 	}
-
-	if err = validate.RegisterValidation("fsShiftMethod", func(fl validator.FieldLevel) bool {
-		_, ok := FSShiftMethodList[FSShiftMethod(fl.Field().String())]
-		return ok
-	}); err != nil {
-		return err
-	}
-
-	if err = validate.RegisterValidation("installationKind", func(fl validator.FieldLevel) bool {
-		_, ok := InstallationKindList[InstallationKind(fl.Field().String())]
-		return ok
-	}); err != nil {
-		return err
-	}
-
-	if err = validate.RegisterValidation("logLevel", func(fl validator.FieldLevel) bool {
-		_, ok := LogLevelList[LogLevel(fl.Field().String())]
-		return ok
-	}); err != nil {
-		return err
+	for n, f := range funcs {
+		err := validate.RegisterValidation(n, f)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/installer/pkg/config/validation.go
+++ b/installer/pkg/config/validation.go
@@ -5,23 +5,63 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
 	"github.com/go-playground/validator/v10"
 )
 
-func Validate(version ConfigVersion, cfg interface{}) ([]validator.FieldError, error) {
+type ValidationResult struct {
+	Valid    bool     `json:"valid"`
+	Warnings []string `json:"warn,omitempty"`
+	Fatal    []string `json:"fatal,omitempty"`
+}
+
+func Validate(version ConfigVersion, cfg interface{}) (r *ValidationResult, err error) {
+	defer func() {
+		if r != nil {
+			r.Valid = len(r.Fatal) == 0
+		}
+	}()
+
 	validate := validator.New()
-	err := version.LoadValidationFuncs(validate)
+	err = version.LoadValidationFuncs(validate)
 	if err != nil {
 		return nil, err
 	}
 
+	var res ValidationResult
 	err = validate.Struct(cfg)
-
 	if err != nil {
 		validationErrors := err.(validator.ValidationErrors)
 
-		return validationErrors, nil
+		if len(validationErrors) > 0 {
+			for _, v := range validationErrors {
+				switch v.Tag() {
+				case "required":
+					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' is required", v.Namespace()))
+				case "required_if", "required_unless", "required_with":
+					tag := strings.Replace(v.Tag(), "_", " ", -1)
+					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' is %s '%s'", v.Namespace(), tag, v.Param()))
+				case "startswith":
+					fmt.Printf("Field '%s' must start with '%s'", v.Namespace(), v.Param())
+				default:
+					// General error message
+					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' failed %s validation", v.Namespace(), v.Tag()))
+				}
+			}
+			return &res, nil
+		}
 	}
 
-	return nil, nil
+	return &res, nil
+}
+
+// Marshal marshals this result to JSON
+func (r *ValidationResult) Marshal(w io.Writer) {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.Encode(r)
 }


### PR DESCRIPTION
## Description
This PR adds Google Cloud Storage support to the installer.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6556 

## How to test
1. Set your config to use CloudStorage:
```
objectStorage:
  cloudStorage:
    project: "<YOUR-GCP-PROJECT>"
    serviceAccount:
      kind: "secret"
      name: "gcp-sa"
```

2. Produce a service account with the `roles/storage.admin` and `roles/storage.objectAdmin` roles, save the service-account key in `service-account.json` and add the secret to the cluster:
```bash
export PROJECT_NAME=<YOUR-GCP-PROJECT>
export OBJECT_STORAGE_SA=gitpod-storage
export OBJECT_STORAGE_SA_EMAIL="${OBJECT_STORAGE_SA}"@"${PROJECT_NAME}".iam.gserviceaccount.com

# create service account with roles
gcloud iam service-accounts create "${OBJECT_STORAGE_SA}" --display-name "${OBJECT_STORAGE_SA}"
gcloud projects add-iam-policy-binding "${PROJECT_NAME}" --member serviceAccount:"${OBJECT_STORAGE_SA_EMAIL}" --role="roles/storage.admin"
gcloud projects add-iam-policy-binding "${PROJECT_NAME}" --member serviceAccount:"${OBJECT_STORAGE_SA_EMAIL}" --role="roles/storage.objectAdmin"

# export keys
gcloud iam service-accounts keys create --iam-account "${OBJECT_STORAGE_SA_EMAIL}" "service-account.json"

# create secret
kubectl create secret generic gcp-sa --from-file service-account.json
```

3. Render the kubernetes YAML and `kubectl apply`
4. Start a workspace, make a change and stop it again

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
