### PR TITLE
[build] Add commit to version manifest

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -63,8 +63,8 @@ packages:
       - dev/version-manifest:app
     config:
       commands:
-        - ["sh", "-c", "echo \"commit: ${__git_commit}\" > commit.yaml"]
-        - ["sh", "-c", "echo \"version: ${version}\" > versions.yaml"]
+        - ["sh", "-c", "echo \"commit: ${__git_commit}\" > versions.yaml"]
+        - ["sh", "-c", "echo \"version: ${version}\" >> versions.yaml"]
         - ["sh", "-c", "dev-version-manifest--app/version-manifest >> versions.yaml"]
         - ["sh", "-c", "rm -r components* dev-*"]
   - name: publish-api

--- a/components/leeway.Dockerfile
+++ b/components/leeway.Dockerfile
@@ -3,5 +3,4 @@
 # See License-AGPL.txt in the project root for license information.
 
 FROM alpine:3.14
-COPY components--all-docker/commit.yaml /
 COPY components--all-docker/versions.yaml /


### PR DESCRIPTION
## Description
Adds the commit to the version manifest, i.e. the `versions.yaml` we produce as result of a build.

## How to test
```
docker run --rm -it eu.gcr.io/gitpod-core-dev/build/versions:cw-commit-in-versions.1 cat /versions.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
