### PR TITLE
[installer] Support GCP container registry

### DIFF
--- a/installer/pkg/components/docker-registry/objects.go
+++ b/installer/pkg/components/docker-registry/objects.go
@@ -6,8 +6,17 @@ package dockerregistry
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
-var Objects = common.CompositeRenderFunc(
-	secret,
-)
+var Objects common.RenderFunc = func(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if !pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
+		return nil, nil
+	}
+
+	return common.CompositeRenderFunc(
+		secret,
+	)(ctx)
+}

--- a/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/installer/pkg/components/image-builder-mk3/deployment.go
@@ -53,6 +53,18 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				SecretName: dockerregistry.BuiltInRegistryAuth,
 			}},
 		})
+	} else if ctx.Config.ContainerRegistry.External != nil {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "pull-secret",
+			MountPath: PullSecretFile,
+			SubPath:   "dockerconfig.json",
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "pull-secret",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+				SecretName: ctx.Config.ContainerRegistry.External.Credentials.Name,
+			}},
+		})
 	}
 
 	return []runtime.Object{&appsv1.Deployment{
@@ -82,69 +94,78 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					DNSPolicy:                     "ClusterFirst",
 					RestartPolicy:                 "Always",
 					TerminationGracePeriodSeconds: pointer.Int64(30),
-					Volumes: append([]corev1.Volume{{
-						Name: "configuration",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", Component)},
+					Volumes: append([]corev1.Volume{
+						{
+							Name: "configuration",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", Component)},
+								},
 							},
-						},
-					}, {
-						Name: "authkey",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: fmt.Sprintf("%s-authkey", Component),
-							},
-						},
-					}, {
-						Name: "wsman-tls-certs",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: wsmanager.TLSSecretNameClient,
-							},
-						},
-					}}, volumes...),
-					Containers: []corev1.Container{{
-						Name:            Component,
-						Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.ImageBuilderMk3.Version),
-						ImagePullPolicy: corev1.PullIfNotPresent,
-						Args: []string{
-							"run",
-							"--config",
-							"/config/image-builder.json",
-						},
-						Env: common.MergeEnv(
-							common.DefaultEnv(&ctx.Config),
-							common.TracingEnv(&ctx.Config),
-						),
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								"cpu":    resource.MustParse("100m"),
-								"memory": resource.MustParse("200Mi"),
-							},
-						},
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: RPCPort,
-							Name:          RPCPortName,
-						}},
-						SecurityContext: &corev1.SecurityContext{
-							Privileged: pointer.Bool(false),
-							RunAsUser:  pointer.Int64(33333),
-						},
-						VolumeMounts: append([]corev1.VolumeMount{{
-							Name:      "configuration",
-							MountPath: "/config/image-builder.json",
-							SubPath:   "image-builder.json",
 						}, {
-							Name:      "authkey",
-							MountPath: "/config/authkey",
-							SubPath:   "keyfile",
+							Name: "authkey",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: fmt.Sprintf("%s-authkey", Component),
+								},
+							},
 						}, {
-							Name:      "wsman-tls-certs",
-							MountPath: "/wsman-certs",
-							ReadOnly:  true,
-						}}, volumeMounts...),
-					}, *common.KubeRBACProxyContainer()},
+							Name: "wsman-tls-certs",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: wsmanager.TLSSecretNameClient,
+								},
+							},
+						},
+					}, volumes...),
+					Containers: []corev1.Container{
+						{
+							Name:            Component,
+							Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.ImageBuilderMk3.Version),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"run",
+								"--config",
+								"/config/image-builder.json",
+							},
+							Env: common.MergeEnv(
+								common.DefaultEnv(&ctx.Config),
+								common.TracingEnv(&ctx.Config),
+							),
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("100m"),
+									"memory": resource.MustParse("200Mi"),
+								},
+							},
+							Ports: []corev1.ContainerPort{{
+								ContainerPort: RPCPort,
+								Name:          RPCPortName,
+							}},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.Bool(false),
+								RunAsUser:  pointer.Int64(33333),
+							},
+							VolumeMounts: append([]corev1.VolumeMount{
+								{
+									Name:      "configuration",
+									MountPath: "/config/image-builder.json",
+									SubPath:   "image-builder.json",
+								},
+								{
+									Name:      "authkey",
+									MountPath: "/config/authkey",
+									SubPath:   "keyfile",
+								},
+								{
+									Name:      "wsman-tls-certs",
+									MountPath: "/wsman-certs",
+									ReadOnly:  true,
+								},
+							}, volumeMounts...),
+						},
+						*common.KubeRBACProxyContainer(),
+					},
 				},
 			},
 		},

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -153,13 +153,13 @@ const (
 )
 
 type ContainerRegistry struct {
-	InCluster *bool                      `json:"inCluster,omitempty" validate:"required"`
+	InCluster *bool                      `json:"inCluster,omitempty"`
 	External  *ContainerRegistryExternal `json:"external,omitempty" validate:"required_if=InCluster false"`
 }
 
 type ContainerRegistryExternal struct {
-	URL         string    `json:"url" validate:"required"`
-	Certificate ObjectRef `json:"certificate" validate:"required"`
+	Repo        string    `json:"repo" validate:"required,oci_repo"`
+	Credentials ObjectRef `json:"credentials" validate:"required"`
 }
 
 type Jaeger struct {


### PR DESCRIPTION
## Description
Adds support for the GCP container registry

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6565

## How to test
1. Change your config to use an external registry
    ```YAML
    containerRegistry:
      external:
        repo: eu.gcr.io/sje-self-hosted-playground/images
        credentials:
          kind: secret
          name: gcp-sa
    ```
2. Ensure the secret in your cluster has the required fields
    ```bash
    installer validate cluster --config config.yaml
    ```
3. Render and apply
    ```bash
    installer render --config config.yaml | kubectl apply -f
    ```
4. Start a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
