### PR TITLE
[installer]: add persistent volume claim to in cluster container registry

### DIFF
--- a/installer/third_party/charts/docker-registry/values.yaml
+++ b/installer/third_party/charts/docker-registry/values.yaml
@@ -2,4 +2,6 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-docker-registry: { }
+docker-registry:
+  persistence:
+    enabled: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In cluster registry data was all stored in memory, meaning that images didn't persist across container restarts. Enabling the PVC reduces unnecessary build time

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add persistent volume to in cluster container registry
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
