### PR TITLE
Preserve team scope in dashboard

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -85,7 +85,7 @@ export class GitpodHostUrl {
     }
 
     asDashboard(): GitpodHostUrl {
-        return this.with(url => ({ pathname: '/projects' }));
+        return this.with(url => ({ pathname: '/' }));
     }
 
     asLogin(): GitpodHostUrl {


### PR DESCRIPTION
## Description

This will change the default dashboard URL from `/projects` to `/` as we already handle this redirect when needed and redirect back to the last selected team. See also relevant comment in https://github.com/gitpod-io/gitpod/pull/6048#discussion_r722154566.

## Risk

Worth checking what happens after deleting a team.

## Related Issue(s)

An attempt to fix https://github.com/gitpod-io/gitpod/issues/6575.

## How to test
1. Create a team
2. Add a project
3. Start a workspace for the added project
4. Stop the workspace
5. Click on the Go to Dashboard button
6. Land in projects within the newly created team instead of projects within the personal account

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Preserve team scope in dashboard
```