### PR TITLE
[code] update stable to 1.62.0

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -399,7 +399,7 @@ components:
       imageName: "ide/theia"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-7107fb8bde0b1f92265402ad5fa09a51022b14dd"
+      stableVersion: "commit-636ef165f4255931c23fb2948e81c73cc75c4fb9"
       insidersVersion: "nightly"
     desktopIdeImages:
       intellij:


### PR DESCRIPTION
## Description
Aligns stable VS Code Web with insiders.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Start a workspace.
- Use about dialog to check that version is 1.62.0.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update VS Code Web to 1.62.0
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
