### PR TITLE
[installer] Embed helm dependencies

### DIFF
--- a/installer/BUILD.yaml
+++ b/installer/BUILD.yaml
@@ -30,6 +30,8 @@ packages:
       - components/openvsx-proxy:lib
     env:
       - CGO_ENABLED=0
+    prep:
+      - ["sh", "-c", "ls -d third_party/charts/*/ | while read f; do echo \"cd $f && helm dep up && cd -\"; done | sh"]
     config:
       packaging: app
   - name: app

--- a/installer/third_party/charts/dockerRegistry.go
+++ b/installer/third_party/charts/dockerRegistry.go
@@ -5,21 +5,18 @@
 package charts
 
 import (
-	_ "embed"
+	"embed"
 )
 
 // Imported from https://github.com/twuni/docker-registry.helm
 
-//go:embed docker-registry/Chart.yaml
-var dockerRegistryChart []byte
-
-//go:embed docker-registry/values.yaml
-var dockerRegistryValues []byte
+//go:embed docker-registry/*
+var dockerRegistry embed.FS
 
 func DockerRegistry() *Chart {
 	return &Chart{
-		Name:   "docker-registry",
-		Chart:  dockerRegistryChart,
-		Values: dockerRegistryValues,
+		Name:     "docker-registry",
+		Location: "docker-registry/",
+		Content:  &dockerRegistry,
 	}
 }

--- a/installer/third_party/charts/jaegerOperator.go
+++ b/installer/third_party/charts/jaegerOperator.go
@@ -5,27 +5,21 @@
 package charts
 
 import (
-	_ "embed"
+	"embed"
 )
 
 // Imported from https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator
 
-//go:embed jaeger-operator/Chart.yaml
-var jaegerOperatorChart []byte
-
-//go:embed jaeger-operator/values.yaml
-var jaegerOperatorValues []byte
-
-//go:embed jaeger-operator/crd.yaml
-var jaegerOperatorCrd []byte
+//go:embed jaeger-operator/*
+var jaegerOperator embed.FS
 
 func JaegerOperator() *Chart {
 	return &Chart{
-		Name:   "jaeger-operator",
-		Chart:  jaegerOperatorChart,
-		Values: jaegerOperatorValues,
-		KubeObjects: [][]byte{
-			jaegerOperatorCrd,
+		Name:     "jaeger-operator",
+		Content:  &jaegerOperator,
+		Location: "jaeger-operator/",
+		AdditionalFiles: []string{
+			"jaeger-operator/crd.yaml",
 		},
 	}
 }

--- a/installer/third_party/charts/minio.go
+++ b/installer/third_party/charts/minio.go
@@ -5,21 +5,18 @@
 package charts
 
 import (
-	_ "embed"
+	"embed"
 )
 
 // Imported from https://github.com/bitnami/charts/tree/master/bitnami/minio
 
-//go:embed minio/Chart.yaml
-var minioChart []byte
-
-//go:embed minio/values.yaml
-var minioValues []byte
+//go:embed minio/*
+var minio embed.FS
 
 func Minio() *Chart {
 	return &Chart{
-		Name:   "Minio",
-		Chart:  minioChart,
-		Values: minioValues,
+		Name:     "Minio",
+		Location: "minio/",
+		Content:  &minio,
 	}
 }

--- a/installer/third_party/charts/mysql.go
+++ b/installer/third_party/charts/mysql.go
@@ -5,21 +5,18 @@
 package charts
 
 import (
-	_ "embed"
+	"embed"
 )
 
 // Imported from https://github.com/bitnami/charts/tree/master/bitnami/mysql
 
-//go:embed mysql/Chart.yaml
-var mysqlChart []byte
-
-//go:embed mysql/values.yaml
-var mysqlValues []byte
+//go:embed mysql/*
+var mysql embed.FS
 
 func MySQL() *Chart {
 	return &Chart{
-		Name:   "MySQL",
-		Chart:  mysqlChart,
-		Values: mysqlValues,
+		Name:     "MySQL",
+		Location: "mysql/",
+		Content:  &mysql,
 	}
 }

--- a/installer/third_party/charts/rabbitmq.go
+++ b/installer/third_party/charts/rabbitmq.go
@@ -5,21 +5,18 @@
 package charts
 
 import (
-	_ "embed"
+	"embed"
 )
 
 // Imported from https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq
 
-//go:embed rabbitmq/Chart.yaml
-var rabbitMQChart []byte
-
-//go:embed rabbitmq/values.yaml
-var rabbitMQValues []byte
+//go:embed rabbitmq/*
+var rabbitMQ embed.FS
 
 func RabbitMQ() *Chart {
 	return &Chart{
-		Name:   "RabbitMQ",
-		Chart:  rabbitMQChart,
-		Values: rabbitMQValues,
+		Name:     "RabbitMQ",
+		Location: "rabbitmq/",
+		Content:  &rabbitMQ,
 	}
 }


### PR DESCRIPTION
## Description
This PR embeds the helm dependencies in the installer binaries, which makes the render process much quicker and more reliable.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6570

## How to test
Run `installer render` and observe the fast render time (less than 2 seconds).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
