### PR TITLE
[installer]: allow img-builder ingress from server

### DIFF
--- a/installer/pkg/components/image-builder-mk3/networkpolicy.go
+++ b/installer/pkg/components/image-builder-mk3/networkpolicy.go
@@ -6,6 +6,7 @@ package image_builder_mk3
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +28,9 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 			PolicyTypes: []networkingv1.PolicyType{"Ingress", "Egress"},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
-					PodSelector: &metav1.LabelSelector{MatchLabels: labels},
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": server.Component,
+					}},
 				}},
 			}},
 			Egress: []networkingv1.NetworkPolicyEgressRule{{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update network policy for image builder mk3

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
allow img-builder ingress from server
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
