### PR TITLE
[code] switch nightly job to main again

### DIFF
--- a/.werft/code-nightly.yaml
+++ b/.werft/code-nightly.yaml
@@ -56,7 +56,7 @@ pod:
         gcloud auth activate-service-account --key-file "/mnt/secrets/gcp-sa/service-account.json"
         gcloud auth configure-docker --quiet
 
-        headCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/release/1.62)
+        headCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main)
 
         cd /workspace/components/ide/code
         leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit .:docker


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Switch nightly to gp-code/main branch again now the 1.62 release is done.

## How to test
Nothing, changes to gp-code/main are deployed to Insiders the next day.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

