### PR TITLE
Support custom CA certificates in Helm

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -357,6 +357,39 @@ storage:
 {{- end -}}
 {{- end -}}
 
+{{/* custom ca bundle volume and volumeMount */}}
+{{- define "gitpod.caBundleVolume" -}}
+{{- if .Values.fullCABundleSecretName -}}
+- name: ca-bundle-certs
+  secret:
+    secretName: {{ .Values.fullCABundleSecretName }}
+{{- end -}}
+{{- end -}}
+
+{{- define "gitpod.caBundleVolumeMount" -}}
+{{- if .Values.fullCABundleSecretName -}}
+- name: ca-bundle-certs
+  mountPath: /etc/ssl/certs/ca-certificates.crt
+  subPath: ca-certificates.crt
+{{- end -}}
+{{- end -}}
+
+{{- define "gitpod.extraCABundleVolume" -}}
+{{- if .Values.extraCABundleSecretName -}}
+- name: extra-certs
+  secret:
+    secretName: {{ .Values.extraCABundleSecretName }}
+{{- end -}}
+{{- end -}}
+
+{{- define "gitpod.extraCABundleVolumeMount" -}}
+{{- if .Values.extraCABundleSecretName -}}
+- name: extra-certs
+  mountPath: /etc/ssl/certs/extra/ca-certificates.crt
+  subPath: ca-certificates.crt
+{{- end -}}
+{{- end -}}
+
 {{- define "gitpod.kube-rbac-proxy" -}}
 - name: kube-rbac-proxy
   image: quay.io/brancz/kube-rbac-proxy:v0.11.0

--- a/chart/templates/blobserve-deployment.yaml
+++ b/chart/templates/blobserve-deployment.yaml
@@ -65,6 +65,9 @@ spec:
           mountPath: /mnt/pull-secret.json
           subPath: .dockerconfigjson
         {{- end }}
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       volumes:
       - name: cache
@@ -76,6 +79,9 @@ spec:
       - name: pull-secret
         secret:
           secretName: {{ .Values.components.workspace.pullSecret.secretName }}
+      {{- end }}
+      {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
       {{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/templates/content-service-deployment.yaml
+++ b/chart/templates/content-service-deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - name: config
           mountPath: "/config"
           readOnly: true
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if $comp.volumeMounts }}
 {{ toYaml $comp.volumeMounts | indent 8 }}
 {{- end }}
@@ -68,6 +71,9 @@ spec:
       - name: config
         configMap:
           name: {{ template "gitpod.comp.configMap" $this }}
+      {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
+      {{- end }}
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}

--- a/chart/templates/image-builder-deployment.yaml
+++ b/chart/templates/image-builder-deployment.yaml
@@ -64,6 +64,9 @@ spec:
         secret:
           secretName: {{ $sec.secret }}
 {{- end }}
+      {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
+      {{- end }}
       enableServiceLinks: false
       containers:
       - name: dind
@@ -80,6 +83,9 @@ spec:
         - mountPath: /etc/docker/certs.d/{{- if eq $sec.name "builtin" -}}{{ template "gitpod.builtinRegistry.name" $this.root }}{{ else }}{{ $sec.name }}{{ end }}
           name: docker-tls-certs-{{ $idx }}
 {{- end }}
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if $comp.dindResources }}
         resources:
 {{ toYaml $comp.dindResources | indent 10 }}
@@ -105,6 +111,9 @@ spec:
           name: pull-secret
 {{- end }}
 {{- end }}
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
         resources:
           requests:
             cpu: {{ $.Values.resources.default.cpu }}

--- a/chart/templates/image-builder-mk3-deployment.yaml
+++ b/chart/templates/image-builder-mk3-deployment.yaml
@@ -60,6 +60,9 @@ spec:
       - name: wsman-tls-certs
         secret:
           secretName: {{ .Values.components.wsManager.tls.server.secretName }}
+      {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
+      {{- end }}
       enableServiceLinks: false
       containers:
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
@@ -86,6 +89,9 @@ spec:
           name: pull-secret
 {{- end }}
 {{- end }}
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
         resources:
           requests:
             cpu: {{ $.Values.resources.default.cpu }}

--- a/chart/templates/proxy-deployment.yaml
+++ b/chart/templates/proxy-deployment.yaml
@@ -105,6 +105,9 @@ spec:
 {{- end }}
         - name: config-certificates
           mountPath: "/etc/caddy/certificates"
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{ include "gitpod.container.defaultEnv" (dict "root" . "gp" $.Values "comp" $comp) | indent 8 }}
         - name: PROXY_DOMAIN
           value: "{{ $.Values.hostname }}"
@@ -123,5 +126,8 @@ spec:
       - name: config-certificates
         secret:
           secretName: {{ $.Values.certificatesSecret.secretName }}
+      {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
+      {{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -71,6 +71,9 @@ spec:
         - name: https-certificates
           mountPath: "/mnt/certificates"
         {{- end }}
+        {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       volumes:
       - name: cache
@@ -90,6 +93,9 @@ spec:
       - name: https-certificates
         secret:
           secretName: {{ .Values.certificatesSecret.secretName }}
+      {{- end }}
+      {{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
       {{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -105,6 +105,9 @@ spec:
           mountPath: "{{ dir $comp.githubApp.certPath }}"
           readOnly: true
 {{- end }}
+{{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
+{{- end }}
 {{- if $comp.serverContainer.volumeMounts }}
 {{ toYaml $comp.serverContainer.volumeMounts | indent 8 }}
 {{- end }}
@@ -144,6 +147,9 @@ spec:
 {{- end }}
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
 {{- end }}
 {{ toYaml .Values.defaults | indent 6 }}
 {{ end }}

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -101,6 +101,9 @@ spec:
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}
+{{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolume" . | indent 6 }}
+{{- end }}
       enableServiceLinks: false
 {{- if (or $comp.userNamespaces.shiftfsModuleLoader.enabled $comp.userNamespaces.seccompProfileInstaller.enabled) }}
       initContainers:
@@ -267,6 +270,9 @@ spec:
           name: tls-certs
 {{- if $comp.volumeMounts }}
 {{ toYaml $comp.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.fullCABundleSecretName }}
+{{ include "gitpod.caBundleVolumeMount" . | indent 8 }}
 {{- end }}
         args: ["run", "--config", "/config/config.json"]
         image: {{ template "gitpod.comp.imageFull" $this }}

--- a/chart/templates/ws-manager-deployment.yaml
+++ b/chart/templates/ws-manager-deployment.yaml
@@ -56,6 +56,9 @@ spec:
       - name: workspace-template
         configMap:
           name: workspace-template
+      {{- if .Values.extraCABundleSecretName }}
+{{ include "gitpod.extraCABundleVolume" . | indent 6 }}
+      {{- end }}
 {{- if $comp.volumes }}
 {{ toYaml $comp.volumes | indent 6 }}
 {{- end }}
@@ -81,6 +84,9 @@ spec:
         - mountPath: /certs
           name: tls-certs
           readOnly: true
+        {{- if .Values.extraCABundleSecretName }}
+{{ include "gitpod.extraCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if $comp.volumeMounts }}
 {{ toYaml $comp.volumeMounts | indent 8 }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -761,3 +761,5 @@ cert-manager:
     certificate:
       selfSigned: true
       secretName: gitpod-ca-certificate
+
+# fullCABundleSecretName: full-ca-bundle

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -567,6 +568,14 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 	// TODO(ak) remove THEIA_WEBVIEW_EXTERNAL_ENDPOINT and THEIA_MINI_BROWSER_HOST_PATTERN when Theia is removed
 	result = append(result, corev1.EnvVar{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"})
 	result = append(result, corev1.EnvVar{Name: "THEIA_MINI_BROWSER_HOST_PATTERN", Value: "browser-{{hostname}}"})
+
+	if _, err := os.Stat("/etc/ssl/certs/extra/ca-certificates.crt"); err == nil {
+		crt, err := os.ReadFile("/etc/ssl/certs/extra/ca-certificates.crt")
+		if err == nil {
+			base64Crt := base64.RawStdEncoding.EncodeToString(crt)
+			result = append(result, corev1.EnvVar{Name: "GITPOD_EXTRA_CA_BUNDLE", Value: base64Crt})
+		}
+	}
 
 	// We don't require that Git be configured for workspaces
 	if spec.Git != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds support to Helm charts for custom CA certificates. 
Origin PR is #2984 Thanks to @jgallucci32

1. split ca bundle to (full-ca-bundle and extra-ca-bundle)
    A. full-ca-bundle used for normal components, like ws-daemon, server etc.. it contain full chain ca bundle
    B. extra-ca-bundle is only contain custom ca bundle, which is used for workspace, use supervisor to inject exist `ca-certificates.crt`
2. implement supervisor inject

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #2615

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
