### PR TITLE
Remove docker slirp4netns in ExperimentalNetwork and support docker0 bridge

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -358,6 +358,9 @@ var ring1Cmd = &cobra.Command{
 			}
 			env = append(env, e)
 		}
+		if wrapNetns {
+			env = append(env, "DOCKER_NOT_USE_NETNS=true")
+		}
 
 		socketFN := filepath.Join(os.TempDir(), fmt.Sprintf("workspacekit-ring1-%d.unix", time.Now().UnixNano()))
 		skt, err := net.Listen("unix", socketFN)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove docker slirp4netns in ExperimentalNetwork
Since ExperimentalNetwork bring full netns, the docker not need use slirp4netns

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5660 
Fixes #6446

## How to test
<!-- Provide steps to test this PR -->
1. Create a workspace with ExperimentalNetwork
2. run `docker ps`
3. run `ip addr` see network interface docker0
4. run `ps -auxww` see there is not slirp4netns
5. run `docker run --rm -it -p 8080:80 nginx` check port export
6. use `ping docker-internal-ip` check ping

![image](https://user-images.githubusercontent.com/8299500/140650795-4c9043eb-3fa1-4ec1-bccc-07d78a73614a.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
