### PR TITLE
[supervisor] use internal slirp4netns

### DIFF
--- a/components/supervisor/leeway.Dockerfile
+++ b/components/supervisor/leeway.Dockerfile
@@ -2,6 +2,11 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+FROM alpine:3.14 as download
+ENV SLIRP4NETNS_VERSION=v1.1.12
+WORKDIR /download
+RUN wget https://github.com/rootless-containers/slirp4netns/releases/download/${SLIRP4NETNS_VERSION}/slirp4netns-x86_64 -O slirp4netns && chmod 755 slirp4netns
+
 FROM scratch
 
 # BEWARE: This must be the first layer in the image, s.t. that blobserve
@@ -16,6 +21,7 @@ COPY components-supervisor--app/supervisor \
      components-workspacekit--fuse-overlayfs/fuse-overlayfs \
      components-gitpod-cli--app/gitpod-cli \
      ./
+COPY --from=download /download/slirp4netns .
 
 WORKDIR "/.supervisor/ssh"
 COPY components-supervisor-openssh--app/usr/sbin/sshd .

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -461,7 +461,7 @@ var ring1Cmd = &cobra.Command{
 		}
 
 		if wrapNetns {
-			slirpCmd := exec.Command("slirp4netns",
+			slirpCmd := exec.Command(filepath.Join(filepath.Dir(ring2Opts.SupervisorPath), "slirp4netns"),
 				"--configure",
 				"--mtu=65520",
 				"--disable-host-loopback",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
in some case, the image doesn't provider slirp4netns like workspace-base
use internal slirp4netns can prevent crash

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Start a workspace with ExperimentalNetwork and image gitpod/workspace-base:latest

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
