### PR TITLE
[test] Add manual testing instructions for integration tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,9 @@ Such tests are for example:
 - API access: to all internal APIs, including ws-manager, ws-daemon, image-builder, registry-facade, server
 - DB access to the Gitpod DB
 
-## Run
+## Running the tests
+
+### Automatically at Gitpod
 
 There is a [werft job](../.werft/run-integration-tests.yaml) that runs the integration tests against `core-dev` preview environments.
 
@@ -29,3 +31,20 @@ Example command:
 ```
 werft job run github -j .werft/run-integration-tests.yaml -a namespace=staging-gpl-2658-int-tests -a version=gpl-2658-int-tests.57 -f
 ```
+
+### Manually against a Kubernetes cluster
+
+You may want to run tests to assert whether your Gitpod installation is successfully integrated.
+
+To test your Gitpod installation:
+
+1. Set your kubectl context to the cluster you want to test
+2. Integrate the Gitpod installation with OAuth for Github and/or Gitlab, otherwise related tests may fail
+3. Clone this repo, and `cd` to `./gitpod/test`
+4. Run the tests like so
+  ```bash
+  go test -v ./... \
+  -kubeconfig=<path_to_kube_config_file> \
+  -namespace=<namespace_where_gitpod_is_installed> \
+  -username=<a_user_in_the_gitpod_database>
+  ```


### PR DESCRIPTION
## Description
Add manual testing instructions for integration tests

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to  #6518

## How to test
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```