### PR TITLE
[Analytics] Strip quotes of anonymous_id for identify call

### DIFF
--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -39,7 +39,7 @@ function fullIdentify(user: User, request: Request, analytics: IAnalyticsWriter)
     //makes a full identify call for authenticated users
     const coords = request.get("x-glb-client-city-lat-long")?.split(", ");
     analytics.identify({
-        anonymousId: request.cookies.ajs_anonymous_id,
+        anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
         userId:user.id,
         context: {
             "ip": maskIp(request.ips[0]),
@@ -87,4 +87,13 @@ function resolveIdentities(user: User) {
         }
     });
     return identities;
+}
+
+function stripCookie(cookie: string) {
+    if (cookie && cookie.length >= 2 && cookie.charAt(0) == '"' && cookie.charAt(cookie.length - 1) == '"') {
+        return cookie.substring(1, cookie.length - 1);
+    }
+    else {
+        return cookie;
+    }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Since November 2, some of the anonymous IDs are sent with surrounding quotes, which breaks the correct association of users with some of their activities. This PR introduces a function that strips the surrounding quotes of a string if it contains them.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
- go to the Debugger of Segment's staging untrusted source
- Sign up for Gitpod in the preview environment
- Ensure that the `anonymous_id` of identify calls are not enclosed in double quotes (i.e. the only quotes are those denoting the start and end of the string)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe