### PR TITLE
[docker-up] Sligh wrap netns cleanup

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -359,7 +359,7 @@ var ring1Cmd = &cobra.Command{
 			env = append(env, e)
 		}
 		if wrapNetns {
-			env = append(env, "DOCKER_NOT_USE_NETNS=true")
+			env = append(env, "WORKSPACEKIT_WRAP_NETNS=true")
 		}
 
 		socketFN := filepath.Join(os.TempDir(), fmt.Sprintf("workspacekit-ring1-%d.unix", time.Now().UnixNano()))


### PR DESCRIPTION
## Description
This PR slightly cleans up the docker-up wrapns mechanism.

## How to test
1. Open the gitpod/template-tailscale repo (doesn't matter if the build fails - use the "default image")
2. Run `docker run --rm -it -p 5000:5000 alpine:latest`
3. `ip a` outside of the container should result in a `docker0` and `veth` device

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
