### PR TITLE
[installer]: allow use of external container registry

### DIFF
--- a/installer/pkg/components/blobserve/configmap.go
+++ b/installer/pkg/components/blobserve/configmap.go
@@ -78,7 +78,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				MaxSize:  MaxSizeBytes,
 			},
 		},
-		// todo(sje): make conditional on the workspace having a pull secret
 		AuthCfg:        "/mnt/pull-secret.json",
 		PProfAddr:      ":6060",
 		PrometheusAddr: "127.0.0.1:9500",

--- a/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/installer/pkg/components/image-builder-mk3/deployment.go
@@ -34,27 +34,21 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		hashObj = append(hashObj, objs...)
 	}
 
-	var volumes []corev1.Volume
-	var volumeMounts []corev1.VolumeMount
-
+	var secretName string
 	if pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "pull-secret",
-			MountPath: PullSecretFile,
-			SubPath:   ".dockerconfigjson",
-		})
-		volumes = append(volumes, corev1.Volume{
-			Name: "pull-secret",
-			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-				SecretName: dockerregistry.BuiltInRegistryAuth,
-			}},
-		})
-		if objs, err := common.DockerRegistryHash(ctx); err != nil {
-			return nil, err
-		} else {
-			hashObj = append(hashObj, objs...)
-		}
+		secretName = dockerregistry.BuiltInRegistryAuth
+	} else if ctx.Config.ContainerRegistry.External != nil {
+		secretName = ctx.Config.ContainerRegistry.External.Certificate.Name
+	} else {
+		return nil, fmt.Errorf("%s: invalid container registry config", Component)
 	}
+
+	if objs, err := common.DockerRegistryHash(ctx); err != nil {
+		return nil, err
+	} else {
+		hashObj = append(hashObj, objs...)
+	}
+
 	configHash, err := common.ObjectHash(hashObj, nil)
 	if err != nil {
 		return nil, err
@@ -87,7 +81,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					DNSPolicy:                     "ClusterFirst",
 					RestartPolicy:                 "Always",
 					TerminationGracePeriodSeconds: pointer.Int64(30),
-					Volumes: append([]corev1.Volume{{
+					Volumes: []corev1.Volume{{
 						Name: "configuration",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -108,7 +102,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								SecretName: wsmanager.TLSSecretNameClient,
 							},
 						},
-					}}, volumes...),
+					}, {
+						Name: "pull-secret",
+						VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+							SecretName: secretName,
+						}},
+					}},
 					Containers: []corev1.Container{{
 						Name:            Component,
 						Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.ImageBuilderMk3.Version),
@@ -136,7 +135,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Privileged: pointer.Bool(false),
 							RunAsUser:  pointer.Int64(33333),
 						},
-						VolumeMounts: append([]corev1.VolumeMount{{
+						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "configuration",
 							MountPath: "/config/image-builder.json",
 							SubPath:   "image-builder.json",
@@ -148,7 +147,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:      "wsman-tls-certs",
 							MountPath: "/wsman-certs",
 							ReadOnly:  true,
-						}}, volumeMounts...),
+						}, {
+							Name:      "pull-secret",
+							MountPath: PullSecretFile,
+							SubPath:   ".dockerconfigjson",
+						}},
 					}, *common.KubeRBACProxyContainer()},
 				},
 			},

--- a/installer/pkg/components/registry-facade/configmap.go
+++ b/installer/pkg/components/registry-facade/configmap.go
@@ -48,7 +48,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Type: "image",
 			}},
 		},
-		// todo(sje): only enabled if the pullSecret is not nil in daemonset
 		AuthCfg:        "/mnt/pull-secret.json",
 		PProfAddr:      ":6060",
 		PrometheusAddr: "127.0.0.1:9500",

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -5,6 +5,7 @@
 package registryfacade
 
 import (
+	"fmt"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	dockerregistry "github.com/gitpod-io/gitpod/installer/pkg/components/docker-registry"
@@ -48,32 +49,25 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		})
 	}
 
-	if pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
-		name := "pull-secret"
-		volumes = append(volumes, corev1.Volume{
-			Name: name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: dockerregistry.BuiltInRegistryAuth,
-				},
-			},
-		})
-
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      name,
-			MountPath: "/mnt/pull-secret.json",
-			SubPath:   ".dockerconfigjson",
-		})
-
-		if objs, err := common.DockerRegistryHash(ctx); err != nil {
-			return nil, err
-		} else {
-			hashObj = append(hashObj, objs...)
-		}
+	if objs, err := common.DockerRegistryHash(ctx); err != nil {
+		return nil, err
+	} else {
+		hashObj = append(hashObj, objs...)
 	}
+
 	configHash, err := common.ObjectHash(hashObj, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	name := "pull-secret"
+	var secretName string
+	if pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
+		secretName = dockerregistry.BuiltInRegistryAuth
+	} else if ctx.Config.ContainerRegistry.External != nil {
+		secretName = ctx.Config.ContainerRegistry.External.Certificate.Name
+	} else {
+		return nil, fmt.Errorf("%s: invalid container registry config", Component)
 	}
 
 	return []runtime.Object{&appsv1.DaemonSet{
@@ -141,6 +135,10 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:      "ws-manager-client-tls-certs",
 							MountPath: "/ws-manager-client-tls-certs",
 							ReadOnly:  true,
+						}, {
+							Name:      name,
+							MountPath: "/mnt/pull-secret.json",
+							SubPath:   ".dockerconfigjson",
 						}}, volumeMounts...),
 					}, *common.KubeRBACProxyContainer()},
 					Volumes: append([]corev1.Volume{{
@@ -156,6 +154,13 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName: wsmanager.TLSSecretNameClient,
+							},
+						},
+					}, {
+						Name: name,
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: secretName,
 							},
 						},
 					}}, volumes...),

--- a/installer/pkg/components/ws-manager/configmap_test.go
+++ b/installer/pkg/components/ws-manager/configmap_test.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 func TestBuildWorkspaceTemplates(t *testing.T) {
@@ -22,9 +23,10 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 		Data      map[string]bool
 	}
 	tests := []struct {
-		Name        string
-		Config      *configv1.WorkspaceTemplates
-		Expectation Expectation
+		Name              string
+		Config            *configv1.WorkspaceTemplates
+		ContainerRegistry *configv1.ContainerRegistry
+		Expectation       Expectation
 	}{
 		{
 			Name: "no templates",
@@ -124,7 +126,15 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 				objs []runtime.Object
 				err  error
 			)
-			act.TplConfig, objs, err = buildWorkspaceTemplates(&common.RenderContext{Config: configv1.Config{Workspace: configv1.Workspace{Templates: test.Config}}})
+
+			if test.ContainerRegistry == nil {
+				test.ContainerRegistry = &configv1.ContainerRegistry{InCluster: pointer.Bool(true)}
+			}
+
+			act.TplConfig, objs, err = buildWorkspaceTemplates(&common.RenderContext{Config: configv1.Config{
+				ContainerRegistry: *test.ContainerRegistry,
+				Workspace:         configv1.Workspace{Templates: test.Config},
+			}})
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Configure external container registry

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6565 

## How to test
<!-- Provide steps to test this PR -->

Get create container registry in GCP and get a service account key

To create secret:
```
kubectl create secret docker-registry \
  registry-secret \
  --docker-server=gcr.io/<projectId>/gitpod \
  --docker-username=_json_key \
  --docker-password="$(cat /path/to/credentials.json)"
```

Then change the config to:
```
containerRegistry:
  inCluster: false
  external:
    url: gcr.io/<projectId>/gitpod
    certificate:
      kind: secret
      name: registry-secret
```

Deploy the changes and create a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow use of external container registry
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
