### PR TITLE
Set version in Go components during build time

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -15,7 +15,7 @@ defaultVariant:
   config:
     go:
       lintCommand: ["sh", "-c", "gokart scan && golangci-lint run --disable govet,errcheck,typecheck,staticcheck --allow-parallel-runners --timeout 5m"]
-      buildFlags: ["-trimpath", "-ldflags='-buildid= -w -s'"]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
 
 variants:
 - name: oss

--- a/components/blobserve/BUILD.yaml
+++ b/components/blobserve/BUILD.yaml
@@ -15,6 +15,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/blobserve/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/content-service/BUILD.yaml
+++ b/components/content-service/BUILD.yaml
@@ -28,6 +28,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/content-service/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/ee/agent-smith/BUILD.yaml
+++ b/components/ee/agent-smith/BUILD.yaml
@@ -14,6 +14,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/agent-smith/cmd.Version=commit-${__git_commit}'"]
   - name: lib
     type: go
     srcs:
@@ -29,6 +30,7 @@ packages:
       - GOOS=linux
     config:
       packaging: library
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/agent-smith/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/ee/kedge/BUILD.yaml
+++ b/components/ee/kedge/BUILD.yaml
@@ -13,6 +13,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/kedge/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/ee/ws-scheduler/BUILD.yaml
+++ b/components/ee/ws-scheduler/BUILD.yaml
@@ -14,6 +14,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/ws-scheduler/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/image-builder-mk3/BUILD.yaml
+++ b/components/image-builder-mk3/BUILD.yaml
@@ -18,6 +18,7 @@ packages:
   - GOOS=linux
   config:
     packaging: app
+    buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/image-builder/cmd.Version=commit-${__git_commit}'"]
 - name: docker
   type: docker
   deps:

--- a/components/image-builder/BUILD.yaml
+++ b/components/image-builder/BUILD.yaml
@@ -15,6 +15,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/image-builder/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/registry-facade/BUILD.yaml
+++ b/components/registry-facade/BUILD.yaml
@@ -15,6 +15,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/registry-facade/cmd.Version=commit-${__git_commit}'"]
   - name: lib
     type: go
     srcs:

--- a/components/service-waiter/BUILD.yaml
+++ b/components/service-waiter/BUILD.yaml
@@ -12,6 +12,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/service-waiter/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -15,6 +15,8 @@ packages:
     env:
       - CGO_ENABLED=0
       - GOOS=linux
+    config:
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/supervisor/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     srcs:

--- a/components/workspacekit/BUILD.yaml
+++ b/components/workspacekit/BUILD.yaml
@@ -14,7 +14,7 @@ packages:
       - ["sh", "-c", "pkg-config --atleast-version=2.5.0 libseccomp || (echo \"requires libseccomp > 2.5.0\"; exit 1)"]
     config:
       packaging: app
-      buildCommand: ["go", "build", "-ldflags", "-w -extldflags \"-static\""]
+      buildCommand: ["go", "build", "-ldflags", "-w -extldflags \"-static\" -X 'github.com/gitpod-io/gitpod/workspacekit/cmd.Version=commit-${__git_commit}'"]
   - name: fuse-overlayfs
     type: generic
     config:

--- a/components/ws-daemon/BUILD.yaml
+++ b/components/ws-daemon/BUILD.yaml
@@ -17,7 +17,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
-      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid="]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid= -X 'github.com/gitpod-io/gitpod/ws-daemon/cmd.Version=commit-${__git_commit}'"]
   - name: lib
     type: go
     srcs:

--- a/components/ws-manager/BUILD.yaml
+++ b/components/ws-manager/BUILD.yaml
@@ -18,6 +18,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/ws-manager/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/ws-proxy/BUILD.yaml
+++ b/components/ws-proxy/BUILD.yaml
@@ -17,7 +17,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
-      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid="]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags=-buildid= -X 'github.com/gitpod-io/gitpod/ws-proxy/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     srcs:

--- a/dev/poolkeeper/BUILD.yaml
+++ b/dev/poolkeeper/BUILD.yaml
@@ -12,6 +12,7 @@ packages:
       - components/common-go:lib
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/poolkeeper/cmd.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/operations/workspace/deployment/BUILD.yaml
+++ b/operations/workspace/deployment/BUILD.yaml
@@ -11,4 +11,4 @@ packages:
       - CGO_ENABLED=0
     config:
       packaging: app
-
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/ws-deployment/cmd.Version=commit-${__git_commit}'"]


### PR DESCRIPTION
## Description
This PR implements the proposal to sets the version variable in Go components during the build again. See also [internal discussion](https://gitpod.slack.com/archives/C01KGM9AW4W/p1636447955097600).

## How to test
- Carefully check that the package name for each prefix is correct for each component.
- See that the version is set in the logs: `jsonPayload.serviceContext.version`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```