### PR TITLE
[werft/observability] Enable tracing with open-telemetry collector

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -13,7 +13,7 @@ imagePullPolicy: Always
 
 authProviders: []
 tracing:
-  endoint: http://jaeger-collector:14268/api/traces
+  endoint: http://otel-collector:14268/api/traces
   samplerType: const
   samplerParam: "1"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As one of our first experiments with tracing with honeycomb, we want to push traces from Gitpod components to Honeycomb and learn how to work with it.

OpenTelemetry configuration is being added to monitoring-satellite, behind the external variable `is_preview`. More details in the [development branch](https://github.com/gitpod-io/observability/pull/18).


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/195

## How to test
<!-- Provide steps to test this PR -->
Comment below:
```
/werft run with-observability
```
You can spin up a workspace from this branch and notice how OpenTelemetry collector's pod is configured and its logs or you could also search for the traces in [Honeycomb's dataset](https://ui.honeycomb.io/gitpod/datasets/preview-environments).


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

### Note worthy comments

We probably want to add some [processing pipelines](https://opentelemetry.io/docs/collector/configuration/#processors) to the collector that adds the branch name that is emitting these traces as an attribute. 

I'm hoping that this could be done in a follow-up PR.
