### PR TITLE
GCP object storage bugfixes

### DIFF
--- a/installer/example-config.yaml
+++ b/installer/example-config.yaml
@@ -14,7 +14,7 @@ jaegerOperator:
   inCluster: true
 kind: Full
 metadata:
-  region: "foobar"
+  region: "local"
 objectStorage:
   inCluster: true
 observability:

--- a/installer/pkg/common/objects.go
+++ b/installer/pkg/common/objects.go
@@ -5,8 +5,6 @@
 package common
 
 import (
-	"fmt"
-	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,31 +71,6 @@ func GenerateService(component string, ports map[string]ServicePort, mod ...func
 
 		return []runtime.Object{service}, nil
 	}
-}
-
-func StorageConfiguration(ctx *RenderContext) (*storageconfig.StorageConfig, error) {
-	accessKey := ctx.Values.StorageAccessKey
-	if accessKey == "" {
-		return nil, fmt.Errorf("unknown value: storage access key")
-	}
-	secretKey := ctx.Values.StorageSecretKey
-	if secretKey == "" {
-		return nil, fmt.Errorf("unknown value: storage secret key")
-	}
-
-	// todo(sje): support non-Minio storage configuration
-	// todo(sje): this has been set up with only the default values - receive configuration
-	return &storageconfig.StorageConfig{
-		Kind:      "minio",
-		BlobQuota: 0,
-		MinIOConfig: storageconfig.MinIOConfig{
-			Endpoint:        fmt.Sprintf("minio.%s.svc.cluster.local:%d", ctx.Namespace, MinioServiceAPIPort),
-			AccessKeyID:     accessKey,
-			SecretAccessKey: secretKey,
-			Secure:          false,
-			Region:          "local",
-		},
-	}, nil
 }
 
 // DockerRegistryHash creates a sample pod spec that can be converted into a hash for annotations

--- a/installer/pkg/common/storage.go
+++ b/installer/pkg/common/storage.go
@@ -50,7 +50,7 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 				AccessKeyID:     context.Values.StorageAccessKey,
 				SecretAccessKey: context.Values.StorageSecretKey,
 				Secure:          false,
-				Region:          context.Config.Metadata.Region,
+				Region:          "local", // Local Minio requires this value - workspace allocation fails if not set to this
 				ParallelUpload:  6,
 			},
 		}

--- a/installer/pkg/common/storage.go
+++ b/installer/pkg/common/storage.go
@@ -6,7 +6,6 @@ package common
 
 import (
 	"fmt"
-
 	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
 
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +46,7 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.MinIOStorage,
 			MinIOConfig: storageconfig.MinIOConfig{
-				Endpoint:        "minio:9000",
+				Endpoint:        fmt.Sprintf("minio.%s.svc.cluster.local:%d", context.Namespace, MinioServiceAPIPort),
 				AccessKeyID:     context.Values.StorageAccessKey,
 				SecretAccessKey: context.Values.StorageSecretKey,
 				Secure:          false,

--- a/installer/pkg/components/content-service/configmap.go
+++ b/installer/pkg/components/content-service/configmap.go
@@ -17,11 +17,6 @@ import (
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	storageConfig, err := common.StorageConfiguration(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	cscfg := config.ServiceConfig{
 		Service: config.Service{
 			Addr: fmt.Sprintf(":%d", RPCPort),
@@ -32,7 +27,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		PProf: config.PProf{
 			Addr: fmt.Sprintf(":%d", PProfPort),
 		},
-		Storage: *storageConfig,
+		Storage: common.StorageConfig(ctx),
 	}
 
 	fc, err := json.MarshalIndent(cscfg, "", " ")

--- a/installer/pkg/components/ws-manager/configmap.go
+++ b/installer/pkg/components/ws-manager/configmap.go
@@ -39,11 +39,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return (&q).String()
 	}
 
-	storage, err := common.StorageConfiguration(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	wsmcfg := config.ServiceConfiguration{
 		Manager: config.Configuration{
 			Namespace:      ctx.Namespace,
@@ -104,7 +99,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		Content: struct {
 			Storage storageconfig.StorageConfig `json:"storage"`
-		}{Storage: *storage},
+		}{Storage: common.StorageConfig(ctx)},
 		RPCServer: struct {
 			Addr string `json:"addr"`
 			TLS  struct {

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -43,6 +43,7 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Certificate.Kind = ObjectRefSecret
 	cfg.Certificate.Name = "https-certificates"
 	cfg.Database.InCluster = pointer.Bool(true)
+	cfg.Metadata.Region = "local"
 	cfg.ObjectStorage.InCluster = pointer.Bool(true)
 	cfg.ContainerRegistry.InCluster = pointer.Bool(true)
 	cfg.Jaeger.InCluster = pointer.Bool(true)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

> Depends on #6621 being merged to `main` first

- remove `minio.<domain>` from proxy if using GCP cloud storage
- removed duplicate `storageConfiguration` function in common module
- update the config generator to make `metadata.region` to be `local`. Enforce this value in the storage configuration if using Minio - I've found that if the config value is not `local`, it causes connectivity issues.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create a service account with `"roles/storage.admin` and `roles/storage.objectAdmin` roles  and create a secret:
```
kubectl create secret generic remote-storage-gcloud --from-file=service-account.json=./gs-credentials.json
```

Deploy using config:
```
objectStorage:
  cloudStorage:
    serviceAccount:
      kind: secret
      name: remote-storage-gcloud
    project: sje-self-hosted-playground
```

Ensure that incluster config is fine by running `objectStorage.inCluster: true`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
GCP object storage bugfixes 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
