### PR TITLE
[ws-deployment] Add retry support within steps

### DIFF
--- a/operations/workspace/deployment/cmd/deploy.go
+++ b/operations/workspace/deployment/cmd/deploy.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
 	"time"
 
@@ -56,10 +57,15 @@ var deployCmd = &cobra.Command{
 			Overrides: &common.Overrides{
 				DryRun:            dryRun,
 				OverwriteExisting: overwriteExisting,
+				RetryAttempt:      common.DefaultRetryAttempts,
 			},
 		}
 
-		orchestrate.Deploy(&context, cfg.WorkspaceClusters)
+		err = orchestrate.Deploy(&context, cfg.WorkspaceClusters)
+		if err != nil {
+			log.Errorf("deploy command failed: %s", err)
+			os.Exit(1)
+		}
 	},
 }
 

--- a/operations/workspace/deployment/pkg/common/cluster.go
+++ b/operations/workspace/deployment/pkg/common/cluster.go
@@ -12,6 +12,8 @@ const (
 	ClusterTypeGKE ClusterType = "gke"
 	// ClusterTypeK3s represents a kubernetes cluster created using k3s distribution on GCP
 	ClusterTypeK3s ClusterType = "k3s"
+	// DefaultRetryAttempts is the default value of retry attempts
+	DefaultRetryAttempts = 2
 )
 
 // MetaCluster represents a meta cluster
@@ -41,4 +43,6 @@ type Overrides struct {
 	// value set, then it will just update the cluster configuration
 	// if this flag is not set then it will error out complaining that the cluster already exists
 	OverwriteExisting bool
+	// RetryAttempt is used to specify maximum retry attempts that can be made if error occurs
+	RetryAttempt int
 }

--- a/operations/workspace/deployment/pkg/orchestrate/deploy.go
+++ b/operations/workspace/deployment/pkg/orchestrate/deploy.go
@@ -47,7 +47,6 @@ func installGitpod(context *common.Context, cluster *common.WorkspaceCluster) er
 }
 
 func createCluster(context *common.Context, cluster *common.WorkspaceCluster) error {
-	// TODO(prs): add retry logic below
 	err := step.CreateCluster(context, cluster)
 	if err != nil {
 		log.Log.Infof("error creating cluster %s: %s", cluster.Name, err)

--- a/operations/workspace/deployment/pkg/step/createcluster.go
+++ b/operations/workspace/deployment/pkg/step/createcluster.go
@@ -43,11 +43,15 @@ func CreateCluster(context *common.Context, cluster *common.WorkspaceCluster) er
 	if err != nil {
 		return err
 	}
-	err = applyTerraformModules(context, cluster)
-	if err != nil {
-		return err
+	// Terraform apply step is prone to failure and recover on retry
+	// So only retry this step
+	for attempt := 0; attempt <= context.Overrides.RetryAttempt; attempt++ {
+		err = applyTerraformModules(context, cluster)
+		if err == nil {
+			break
+		}
 	}
-	return nil
+	return err
 }
 
 func doesClusterExist(context *common.Context, cluster *common.WorkspaceCluster) (bool, error) {

--- a/operations/workspace/deployment/pkg/step/installgitpod.go
+++ b/operations/workspace/deployment/pkg/step/installgitpod.go
@@ -34,13 +34,23 @@ func InstallGitpod(context *common.Context, cluster *common.WorkspaceCluster) er
 		credFileEnvVar = ""
 	}
 
-	cmd := exec.Command(DefaultGitpodInstallationScript, "-g", context.Project.Id, "-l", cluster.Region, "-n", cluster.Name, "-v", context.Gitpod.VersionsManifestFilePath, "-a", getValuesFilesArgString(cluster.ValuesFiles))
-	// Set the env variable
-	cmd.Env = append(os.Environ(), credFileEnvVar)
-	// we will route the output to standard devices
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	var err error
+	// Script execution is prone to failure and recover on retry
+	// So only retry part of the code
+	for attempt := 0; attempt <= context.Overrides.RetryAttempt; attempt++ {
+		cmd := exec.Command(DefaultGitpodInstallationScript, "-g", context.Project.Id, "-l", cluster.Region, "-n", cluster.Name, "-v", context.Gitpod.VersionsManifestFilePath, "-a", getValuesFilesArgString(cluster.ValuesFiles))
+		// Set the env variable
+		cmd.Env = append(os.Environ(), credFileEnvVar)
+		// we will route the output to standard devices
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err = cmd.Run()
+		if err == nil {
+			break
+		}
+	}
+	return err
 
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A step during automated ws cluster creation may fail. Retrying the step can often solve the problem.
This PR adds support for retries. Each step can accept a retryattempt in the form of an override variable and then internally retry based on this variable. The default retries count is set to 2 so a max of 3 attempts would be made within each step if it fails.

Also, exit with code (1) if there were errors.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # https://github.com/gitpod-io/gitpod/issues/6332

## How to test
<!-- Provide steps to test this PR -->
Tested it by [triggering a werft job ](https://werft.gitpod-io-dev.com/job/ops-workspace-deploy-workspace-prs-test-retry.2)manually through CLI. 
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
