### PR TITLE
[werft] Fix version drift to make sure yarn.lock stays clean

### DIFF
--- a/.werft/package.json
+++ b/.werft/package.json
@@ -14,7 +14,7 @@
     "@opentelemetry/sdk-node": "^0.26.0",
     "semver": "7.3.5",
     "shelljs": "^0.8.4",
-    "ts-node": "^10.4.0",
+    "ts-node": "^9.0.0",
     "typescript": "~4.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Adjust `ts-node` version in `.werft/package.json` with other versions to keep `yarn.lock` clean.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
