### PR TITLE
[supervisor] Remove old gp bin before symlink

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -410,8 +410,14 @@ func symlinkBinaries(cfg *Config) {
 			from = filepath.Join(base, k)
 			to   = filepath.Join("/usr/bin", v)
 		)
+
+		// remove possibly existing symlink target
+		if err = os.Remove(to); err != nil && !os.IsNotExist(err) {
+			log.WithError(err).WithField("to", to).Warn("cannot remove possibly existing symlink target")
+		}
+
 		err = os.Symlink(from, to)
-		if err != nil && !os.IsExist(err) {
+		if err != nil {
 			log.WithError(err).WithField("from", from).WithField("to", to).Warn("cannot create symlink")
 		}
 	}


### PR DESCRIPTION
## Description
This PR makes sure that the `gp` binary that is shipped with the supervisor is used even when a `gp` bin is already present in `/usr/bin`. This allows to ship a new `gp` version even with `image-builder` mk2.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6533

## How to test
<!-- Provide steps to test this PR -->
I tested this with `image-builder` as well as `image-builder-mk3` like this:
- Edit [server-config](https://console.cloud.google.com/kubernetes/configmap/europe-west1-b/core-dev/staging-clu-deploy-gp-cli-6533/server-config/details?project=gitpod-core-dev) and set `imageBuilderAddr` to `"image-builder:8080"` resp. `"image-builder-mk3:8080"`
- Restart server after changing the configmap: `$ kubectl rollout restart deployment server`
- Start a workspace
- Make sure there is no error/warning regarding creating the symlink, e.g. use this search query in the GCP Logs Explorer:
  ```
  resource.labels.namespace_name="staging-clu-deploy-gp-cli-6533"
  resource.labels.container_name="workspace"
  "symlink"
  ```
  as well as that `gp` works.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```