### PR TITLE
[test] Build DBConfig from env var secrets

### DIFF
--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -528,9 +528,15 @@ OuterLoop:
 			var findErr error
 			if v.Name == "DB_PASSWORD" {
 				password, findErr = FindValueFromEnvVar(v, client, namespace)
+				if findErr != nil {
+					return nil, findErr
+				}
 			} else if v.Name == "DB_PORT" {
 				var portStr string
 				portStr, findErr = FindValueFromEnvVar(v, client, namespace)
+				if findErr != nil {
+					return nil, findErr
+				}
 				pPort, err := strconv.ParseUint(portStr, 10, 16)
 				if err != nil {
 					return nil, xerrors.Errorf("error parsing DB_PORT '%s' on pod %s!", v.Value, pod.Name)
@@ -538,9 +544,9 @@ OuterLoop:
 				port = int32(pPort)
 			} else if v.Name == "DB_HOST" {
 				host, findErr = FindValueFromEnvVar(v, client, namespace)
-			}
-			if findErr != nil {
-				return nil, findErr
+				if findErr != nil {
+					return nil, findErr
+				}
 			}
 			if password != "" && port != 0 && host != "" {
 				break OuterLoop


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update integration tests to connect to database for self-hosted envs that used the installer (it uses a secret to store database connectivity details, which are made accessible through a secretRef as ENV VARs).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6604

## How to test
<!-- Provide steps to test this PR -->
[Run this and have tests pass.](https://github.com/gitpod-io/gitpod/tree/main/test#manually-against-a-kubernetes-cluster)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```