### PR TITLE
[dashboard] hidden Plans and Team Plans on self-hosted instance

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -23,6 +23,7 @@ export default function UserDetail(p: { user: User }) {
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
     const [viewAccountStatement, setViewAccountStatement] = useState(false);
     const [isStudent, setIsStudent] = useState<boolean>();
+    const [isShowPayment, setIsShowPayment] = useState<boolean>();
     const [editFeatureFlags, setEditFeatureFlags] = useState(false);
     const [editRoles, setEditRoles] = useState(false);
     const userRef = useRef(user);
@@ -31,6 +32,7 @@ export default function UserDetail(p: { user: User }) {
 
     useEffect(() => {
         setUser(p.user);
+        getGitpodService().server.getShowPaymentUI().then(setIsShowPayment).catch(console.error)
         getGitpodService().server.adminGetAccountStatement(p.user.id).then(
             as =>
                 setAccountStatement(as)
@@ -101,9 +103,9 @@ export default function UserDetail(p: { user: User }) {
                     <img className="rounded-full h-28 w-28" alt={user.fullName} src={user.avatarUrl} />
                 </div>
                 <div className="flex flex-col w-full">
-                    <div className="flex w-full mt-6">
+                    <div className="grid w-full mt-6 grid-cols-3">
                         <Property name="Sign Up Date">{moment(user.creationDate).format('MMM D, YYYY')}</Property>
-                        <Property name="Remaining Hours"
+                        {isShowPayment ? <Property name="Remaining Hours"
                             actions={
                                 accountStatement && [{
                                     label: 'View Account Statement',
@@ -116,8 +118,8 @@ export default function UserDetail(p: { user: User }) {
                                     }
                                 }]
                             }
-                        >{accountStatement?.remainingHours ? accountStatement?.remainingHours.toString() : '---'}</Property>
-                        <Property
+                        >{accountStatement?.remainingHours ? accountStatement?.remainingHours.toString() : '---'}</Property> : null}
+                        {isShowPayment ? <Property
                             name="Plan"
                             actions={accountStatement && [{
                                 label: (isProfessionalOpenSource ? 'Disable' : 'Enable') + ' Professional OSS',
@@ -126,9 +128,7 @@ export default function UserDetail(p: { user: User }) {
                                     setAccountStatement(await getGitpodService().server.adminGetAccountStatement(user.id));
                                 }
                             }]}
-                        >{accountStatement?.subscriptions ? accountStatement.subscriptions.filter(s => Subscription.isActive(s, new Date().toISOString())).map(s => Plans.getById(s.planId)?.name).join(', ') : '---'}</Property>
-                    </div>
-                    <div className="flex w-full mt-6">
+                        >{accountStatement?.subscriptions ? accountStatement.subscriptions.filter(s => Subscription.isActive(s, new Date().toISOString())).map(s => Plans.getById(s.planId)?.name).join(', ') : '---'}</Property> : null}
                         <Property name="Feature Flags"
                             actions={[{
                                 label: 'Edit Feature Flags',
@@ -145,12 +145,12 @@ export default function UserDetail(p: { user: User }) {
                                 }
                             }]}
                         >{user.rolesOrPermissions?.join(', ') || '---'}</Property>
-                        <Property name="Student"
+                        {isShowPayment ? <Property name="Student"
                             actions={ !isStudent ? [{
                                 label: `Make '${emailDomain}' a student domain`,
                                 onClick: addStudentDomain
                             }] :  undefined}
-                        >{isStudent === undefined ? '---' : (isStudent ? 'Enabled' : 'Disabled')}</Property>
+                        >{isStudent === undefined ? '---' : (isStudent ? 'Enabled' : 'Disabled')}</Property> : null}
                     </div>
                 </div>
             </div>
@@ -193,7 +193,7 @@ function Label(p: { text: string, color: string }) {
 }
 
 export function Property(p: { name: string, children: string | ReactChild, actions?: { label: string, onClick: () => void }[] }) {
-    return <div className="ml-3 flex flex-col w-4/12 truncate">
+    return <div className="ml-3 truncate">
         <div className="text-base text-gray-500 truncate">
             {p.name}
         </div>

--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -9,7 +9,7 @@ import { useContext, useState } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 import ConfirmationModal from "../components/ConfirmationModal";
 import CodeText from "../components/CodeText";
 
@@ -27,6 +27,10 @@ export default function Account() {
     };
 
     const close = () => setModal(false);
+
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
+
     return <div>
         <ConfirmationModal
             title="Delete Account"

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -11,7 +11,7 @@ import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/
 import Modal from "../components/Modal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 import CodeText from "../components/CodeText";
 
 interface EnvVarModalProps {
@@ -181,7 +181,8 @@ export default function EnvVars() {
         return '';
     };
 
-
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
 
     return <PageWithSubMenu subMenu={settingsMenu} title='Variables' subtitle='Configure environment variables for all workspaces.'>
         {isAddEnvVarModalVisible && <AddEnvVarModal

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -20,9 +20,12 @@ import { openAuthorizeWindow } from "../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { SelectAccountModal } from "./SelectAccountModal";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 
 export default function Integrations() {
+
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
 
     return (<div>
         <PageWithSubMenu subMenu={settingsMenu} title='Integrations' subtitle='Manage permissions for Git providers and integrations.'>

--- a/components/dashboard/src/settings/Notifications.tsx
+++ b/components/dashboard/src/settings/Notifications.tsx
@@ -9,7 +9,7 @@ import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import CheckBox from "../components/CheckBox";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 
 export default function Notifications() {
     const { user, setUser } = useContext(UserContext);
@@ -79,6 +79,9 @@ export default function Notifications() {
             setDevXMail(newIsDevXMail);
         }
     }
+
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
 
     return (
     <div>

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -18,7 +18,7 @@ import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import Tooltip from "../components/Tooltip";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 
 type PlanWithOriginalPrice = Plan & { originalPrice?: number };
 type Pending = { pendingSince: number };
@@ -424,6 +424,9 @@ export default function () {
         planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={targetPlan} isCurrent={!!isUnleashedTsAssigned} onUpgrade={onUpgrade} isTsAssigned={isUnleashedTsAssigned}>{unleashedFeatures}</PlanCard>);
     }
 
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
+    
     return <div>
         <PageWithSubMenu subMenu={settingsMenu}  title='Plans' subtitle='Manage account usage and billing.'>
             {showPaymentUI && <div className="w-full text-center">

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -18,7 +18,7 @@ import vscode from '../images/vscode.svg';
 import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -69,6 +69,9 @@ export default function Preferences() {
         setIsDark(isDark);
         setTheme(theme);
     }
+
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
 
     return <div>
         <PageWithSubMenu subMenu={settingsMenu} title='Preferences' subtitle='Configure user preferences.'>

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -18,11 +18,13 @@ import copy from '../images/copy.svg';
 import exclamation from '../images/exclamation.svg';
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { poll, PollOptions } from "../utils";
-import settingsMenu from "./settings-menu";
+import { getMenu } from "./settings-menu";
 import { Disposable } from "@gitpod/gitpod-protocol";
 
 export default function Teams() {
-
+    const [settingsMenu, setSettingsMenu] = useState<{title: string,link: string[]}[]>([])
+    getMenu().then(setSettingsMenu)
+    
     return (<div>
         <PageWithSubMenu subMenu={settingsMenu} title='Teams' subtitle='View and manage subscriptions for your team with one centralized billing.'>
             <AllTeams />

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -4,6 +4,59 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { getGitpodService } from "../service/service";
+
+let cache: {
+    title: string,
+    link: string[]
+}[] = []
+
+let menuWithPayment = [
+    {
+        title: 'Account',
+        link: ['/account','/settings']
+    },
+    {
+        title: 'Notifications',
+        link: ['/notifications']
+    },
+    {
+        title: 'Plans',
+        link: ['/plans']
+    },
+    {
+        title: 'Team Plans',
+        link: ['/teams']
+    },
+    {
+        title: 'Variables',
+        link: ['/variables']
+    },
+    {
+        title: 'Integrations',
+        link: ["/integrations", "/access-control"]
+    },
+    {
+        title: 'Preferences',
+        link: ['/preferences']
+    },
+]
+
+let menuWithoutPayment = menuWithPayment.filter(menu => menu.title !== "Plans" && menu.title !== 'Team Plans')
+
+export async function getMenu() {
+    if (cache.length !== 0) {
+        return cache
+    }
+    let show = await getGitpodService().server.getShowPaymentUI()
+    if (show === false) {
+        cache = menuWithoutPayment
+    } else {
+        cache = menuWithPayment
+    }
+    return cache
+}
+
 export default [
     {
         title: 'Account',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[dashboard] hidden Plans and Team Plans on self-hosted instance

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
No need display `Plans` and `Team Plans` setting menu in self-hosted cluster.
![image](https://user-images.githubusercontent.com/8299500/141338004-bcd7232e-fee0-4126-a320-8d0dcf37dcc7.png)

No need display `Remaining Hours`, `Plan`, `Student` field in admin dashboard in self-hosted cluster


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
