### PR TITLE
[build] Use buildFlags to not break Go library builds

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -225,7 +225,7 @@ export async function build(context, version) {
                 continue
             }
             let flag = file.substring(0, file.length - "-coverage.out".length);
-            exec(`codecov -N "${parent_commit}" --flags=${flag} --file "${coverageOutput}/${file}"`);
+            exec(`codecov -N "${parent_commit}" --flags=${flag} --file "${coverageOutput}/${file}"`, {slice: "coverage"});
         }
 
         werft.done('coverage');

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -15,7 +15,6 @@ defaultVariant:
   config:
     go:
       lintCommand: ["sh", "-c", "gokart scan && golangci-lint run --disable govet,errcheck,typecheck,staticcheck --allow-parallel-runners --timeout 5m"]
-      buildCommand: ["go", "build", "-trimpath", "-ldflags='-buildid= -w -s'"]
 
 variants:
 - name: oss

--- a/components/openvsx-proxy/BUILD.yaml
+++ b/components/openvsx-proxy/BUILD.yaml
@@ -16,6 +16,7 @@ packages:
       - GOOS=linux
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/openvsx-proxy/cmd.Version=commit-${__git_commit}'"]
   - name: lib
     type: go
     deps:

--- a/installer/BUILD.yaml
+++ b/installer/BUILD.yaml
@@ -34,6 +34,7 @@ packages:
       - ["sh", "-c", "ls -d third_party/charts/*/ | while read f; do echo \"cd $f && helm dep up && cd -\"; done | sh"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/installer/cmd.Version=commit-${__git_commit}'"]
   - name: app
     type: generic
     deps:


### PR DESCRIPTION
## Description
Due to a [bug in leeway](https://github.com/gitpod-io/leeway/commit/bc6c6ddc0bd99c47a1aa64d3e595a180ce0009db)  recent changes (#6624) broke go library builds. This change works around that issue.

## How to test
If the build is green things are ok

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
