### PR TITLE
[server] Add and use supervisor image config

### DIFF
--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -48,6 +48,7 @@ data:
         "ideVersion": "{{ .Values.components.workspace.codeImage.stableVersion }}",
         "ideImageRepo": "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) }}",
         "ideImageAliases": {{ (include "ide-images-aliases" (dict "root" . "gp" $.Values)) | fromYaml | toJson }},
-        "desktopIdeImageAliases": {{ (include "desktop-ide-images-aliases" (dict "root" . "gp" $.Values)) | fromYaml | toJson }}
+        "desktopIdeImageAliases": {{ (include "desktop-ide-images-aliases" (dict "root" . "gp" $.Values)) | fromYaml | toJson }},
+        "supervisorImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}"
     }
 {{- end }}

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -209,4 +209,7 @@ export interface WorkspaceInstanceConfiguration {
 
     // desktopIdeImage is the ref of the desktop IDE image this instance uses.
     desktopIdeImage?: string
+
+    // supervisorImage is the ref of the supervisor image this instance uses.
+    supervisorImage?: string;
 }

--- a/components/server/src/ide-config.ts
+++ b/components/server/src/ide-config.ts
@@ -18,6 +18,7 @@ interface RawIDEConfig {
     ideImageRepo: string;
     ideImageAliases?: { [index: string]: string };
     desktopIdeImageAliases?: { [index: string]: string };
+    supervisorImage: string;
 }
 const scheme = {
     "type": "object",
@@ -36,10 +37,14 @@ const scheme = {
             "type": "object",
             "additionalProperties": { "type": "string" }
         },
+        "supervisorImage": {
+            "type": "string"
+        },
     },
     "required": [
         "ideVersion",
-        "ideImageRepo"
+        "ideImageRepo",
+        "supervisorImage",
     ]
 };
 
@@ -49,6 +54,7 @@ export interface IDEConfig {
     ideImageAliases: { [index: string]: string };
     desktopIdeImageAliases: { [index: string]: string };
     ideImage: string;
+    supervisorImage: string;
 }
 
 @injectable()
@@ -120,7 +126,7 @@ export class IDEConfigService {
                     },
                     desktopIdeImageAliases: {
                         ...raw.desktopIdeImageAliases
-                    }
+                    },
                 }
             }
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -309,6 +309,7 @@ export class WorkspaceStarter {
         const configuration: WorkspaceInstanceConfiguration = {
             theiaVersion: ideConfig.ideVersion,
             ideImage: ideConfig.ideImage,
+            supervisorImage: ideConfig.supervisorImage,
         };
 
         const ideChoice = user.additionalData?.ideSettings?.defaultIde;
@@ -745,6 +746,7 @@ export class WorkspaceStarter {
         const startWorkspaceSpecIDEImage = new IDEImage();
         startWorkspaceSpecIDEImage.setWebRef(ideImage);
         startWorkspaceSpecIDEImage.setDesktopRef(instance.configuration?.desktopIdeImage || "");
+        startWorkspaceSpecIDEImage.setSupervisorRef(instance.configuration?.supervisorImage || "");
         spec.setIdeImage(startWorkspaceSpecIDEImage);
         spec.setDeprecatedIdeImage(ideImage);
         spec.setWorkspaceImage(instance.workspaceImage);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds the supervisor image to the `server-ide-configmap` and passes this value to the registry facade. That allows to change the supervisor image just by altering the config and thus allows to deploy a new supervisor image by the IDE team on its own.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6512

~~_This aspect is still not solved: https://github.com/gitpod-io/gitpod/issues/6512#issuecomment-963216053. That is why this PR does not close the issue yet._~~

## How to test
- Start a workspace and see in the logs the supervisor version. Log filter:
  ```
  resource.labels.namespace_name="staging-clu-server-supervisor-config"
  jsonPayload.serviceContext.service="supervisor"
  ```
  `jsonPayload.serviceContext.version` has the version.
- Change the supervisor version in [server-ide-config configmap](https://console.cloud.google.com/kubernetes/configmap/europe-west1-b/core-dev/staging-clu-server-supervisor-config/server-ide-config/details?project=gitpod-core-dev), e.g. use version `commit-a7166daa720e8c05c1f200257f567646d427b79b`. No server restart necessary.
- Start another workspace and verify that the version in the logs has been changed.

_**Note:** The version in the configmap can differ from what it is in the logs because images can have multiple tags. E.g. when you have `commit-93104671b75c9f81b2cc8b5a542dc8680e36928f` in the configmap, it's logged as version `commit-20e06321092f0e658622332880889ddda2b77f59` but [you can see in the registry](https://console.cloud.google.com/gcr/images/gitpod-core-dev/eu/build/supervisor?organizationId=585692962993&project=gitpod-core-dev) that both are valid tags for the same image._

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
