### PR TITLE
[helm-chart] Fix ws-daemon raid deployment

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -154,8 +154,7 @@ spec:
             RAID_DEVICE="/dev/md42"
             RAID_DIR="/mnt/hostfs{{ $comp.hostWorkspaceArea }}"
             DISK_DEV_PREFIX="/dev/sd"
-            ls -l /dev/md*
-            cat /proc/mdstat
+
             # If the disk has already been created, sleep indefinitely
             if [ -b "${RAID_DEVICE}" ] && [ -d "${RAID_DIR}" ]; then
                 echo "raid array already created!"


### PR DESCRIPTION
## Description

In new clusters, there are no `/dev/md*` devices. This lines terminate the script

## Release Notes
```release-note
NONE
```
