### PR TITLE
[dashboard] Fixes Project URLs with dots are broken

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -371,7 +371,7 @@ function App() {
         toRender = <CreateWorkspace contextUrl={hash} />;
     } else if (isWsStart) {
         toRender = <StartWorkspace workspaceId={hash} />;
-    } else if (/.+?\..+?\/.+?/i.test(window.location.pathname)) {
+    } else if (/^(github|gitlab)\.com\/.+?/i.test(window.location.pathname)) {
         let url = new URL(window.location.href)
         url.hash = url.pathname
         url.pathname = '/'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes Project URLs with dots are broken

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6680

## How to test
<!-- Provide steps to test this PR -->
1. create a repo with a dot in its name (e.g. "foo.bar")
2. add that repo as a new project to a team
3. navigate to /t/acme/foo.bar/workspaces and see it's not redirected to /#t/acme/foo.bar/workspaces


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
