### PR TITLE
[ws-deployment] Refactor code to include k3s cluster creation

### DIFF
--- a/operations/workspace/deployment/pkg/common/cluster.go
+++ b/operations/workspace/deployment/pkg/common/cluster.go
@@ -4,6 +4,11 @@
 
 package common
 
+import (
+	"crypto/rand"
+	"math/big"
+)
+
 // ClusterType is the type of cluster to be created e.g. k3s, gke etc
 type ClusterType string
 
@@ -14,6 +19,8 @@ const (
 	ClusterTypeK3s ClusterType = "k3s"
 	// DefaultRetryAttempts is the default value of retry attempts
 	DefaultRetryAttempts = 2
+	// TokenCharset contains characters that can be used to create a random token
+	TokenCharset = "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 // MetaCluster represents a meta cluster
@@ -45,4 +52,20 @@ type Overrides struct {
 	OverwriteExisting bool
 	// RetryAttempt is used to specify maximum retry attempts that can be made if error occurs
 	RetryAttempt int
+}
+
+func stringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			panic(err)
+		}
+		b[i] = charset[num.Uint64()]
+	}
+	return string(b)
+}
+
+func CreateRandomTokenString(length int) string {
+	return stringWithCharset(length, TokenCharset)
 }

--- a/operations/workspace/deployment/pkg/step/installgitpod.go
+++ b/operations/workspace/deployment/pkg/step/installgitpod.go
@@ -26,6 +26,19 @@ func InstallGitpod(context *common.Context, cluster *common.WorkspaceCluster) er
 		log.Log.Infof("dry run not supported for gitpod installation. skipping...")
 		return nil
 	}
+	if cluster.ClusterType == common.ClusterTypeGKE {
+		return installGitpodOnGKECluster(context, cluster)
+	} else {
+		return installGitpodOnK3sCluster(context, cluster)
+	}
+}
+
+func installGitpodOnK3sCluster(context *common.Context, cluster *common.WorkspaceCluster) error {
+	log.Infof("gitpod installation on k3s not supported yet")
+	return nil
+}
+
+func installGitpodOnGKECluster(context *common.Context, cluster *common.WorkspaceCluster) error {
 	credFileEnvVar := fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", context.Project.GCPSACredFile)
 	if _, err := os.Stat(context.Project.GCPSACredFile); errors.Is(err, os.ErrNotExist) {
 		// reset this to empty string so that we can fallback to default


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add support to create k3s cluster.
Step to create other resources like certmanager installation etc is not included.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Tested [here](https://werft.gitpod-io-dev.com/job/ops-workspace-deploy-workspace-prs-test.13). The script up.sh was modified to exit early without actual logic execution.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
