### PR TITLE
[installer]: set the number of replicas for deployments/statefulsets

### DIFF
--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -509,3 +509,17 @@ func RandomString(length int) (string, error) {
 	}
 	return string(b), nil
 }
+
+func Replicas(ctx *RenderContext) *int32 {
+	var defaultReplicas *int32
+
+	// Get the default replicas
+	if ctx.Config.Workspace.Replicas != nil && ctx.Config.Workspace.Replicas.Default != nil {
+		defaultReplicas = ctx.Config.Workspace.Replicas.Default
+	} else {
+		// Not set - default to 2
+		defaultReplicas = pointer.Int32(2)
+	}
+
+	return defaultReplicas
+}

--- a/installer/pkg/components/blobserve/deployment.go
+++ b/installer/pkg/components/blobserve/deployment.go
@@ -57,7 +57,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/content-service/deployment.go
+++ b/installer/pkg/components/content-service/deployment.go
@@ -95,7 +95,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: v1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/dashboard/deployment.go
+++ b/installer/pkg/components/dashboard/deployment.go
@@ -29,8 +29,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/database/cloudsql/deployment.go
+++ b/installer/pkg/components/database/cloudsql/deployment.go
@@ -35,8 +35,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      Component,

--- a/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/installer/pkg/components/image-builder-mk3/deployment.go
@@ -66,7 +66,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
-			Replicas: pointer.Int32(1),
+			Replicas: common.Replicas(ctx),
 			Strategy: common.DeploymentStrategy,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -38,8 +38,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 				MatchLabels: labels,
 			},
 			ServiceName: Component,
-			// todo(sje): receive config value
-			Replicas: pointer.Int32(1),
+			Replicas:    common.Replicas(ctx),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      Component,

--- a/installer/pkg/components/proxy/deployment.go
+++ b/installer/pkg/components/proxy/deployment.go
@@ -103,7 +103,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/server/deployment.go
+++ b/installer/pkg/components/server/deployment.go
@@ -46,8 +46,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -51,7 +51,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/ws-manager/deployment.go
+++ b/installer/pkg/components/ws-manager/deployment.go
@@ -119,7 +119,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/ws-proxy/deployment.go
+++ b/installer/pkg/components/ws-proxy/deployment.go
@@ -54,8 +54,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/ws-scheduler/deployment.go
+++ b/installer/pkg/components/ws-scheduler/deployment.go
@@ -34,7 +34,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
-			Replicas: pointer.Int32(1),
+			Replicas: common.Replicas(ctx),
 			Strategy: common.DeploymentStrategy,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -200,6 +200,10 @@ type WorkspaceRuntime struct {
 	ContainerDSocket     string        `json:"containerdSocket" validate:"required,startswith=/"`
 }
 
+type Replicas struct {
+	Default *int32 `json:"default"`
+}
+
 type WorkspaceTemplates struct {
 	Default    *corev1.Pod `json:"default"`
 	Prebuild   *corev1.Pod `json:"prebuild"`
@@ -210,6 +214,7 @@ type WorkspaceTemplates struct {
 }
 
 type Workspace struct {
+	Replicas  *Replicas           `json:"replicas"`
 	Runtime   WorkspaceRuntime    `json:"runtime" validate:"required"`
 	Resources Resources           `json:"resources" validate:"required"`
 	Templates *WorkspaceTemplates `json:"templates,omitempty"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set the number of replicas on deployment and stateful set. This doesn't set the number of replicas in Helm dependencies (which largely can't be set anyway).

It introduces `replicas.default` to the workspace object in the config. This defaults to `2` unless set. The reason for adding like is to allow for adding a `components: map[string]struct{}` in future if we find that we need to control the number of replicas on individual components.

It's useful being able to control the number of replicas when debugging deployments.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6357

## How to test
<!-- Provide steps to test this PR -->
Deploy as normal, setting the value (or not) as desired

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Set number of replicas for deployed components
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
