### PR TITLE
[ws-proxy] Get supervisor image from pod annotation instead from ws-proxy config

### DIFF
--- a/components/ws-proxy/BUILD.yaml
+++ b/components/ws-proxy/BUILD.yaml
@@ -51,3 +51,6 @@ packages:
       - GOOS=linux
     config:
       packaging: library
+      # it's already tested in :app and running both tests for :app and :lib in
+      # parallel leads to port already in use errors
+      dontTest: true

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -11,6 +11,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation"
 	"golang.org/x/xerrors"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/util"
 )
 
@@ -70,8 +71,9 @@ func (c *HostBasedIngressConfig) Validate() error {
 
 // WorkspacePodConfig contains config around the workspace pod.
 type WorkspacePodConfig struct {
-	TheiaPort       uint16 `json:"theiaPort"`
-	SupervisorPort  uint16 `json:"supervisorPort"`
+	TheiaPort      uint16 `json:"theiaPort"`
+	SupervisorPort uint16 `json:"supervisorPort"`
+	// SupervisorImage is deprecated
 	SupervisorImage string `json:"supervisorImage"`
 }
 
@@ -84,8 +86,10 @@ func (c *WorkspacePodConfig) Validate() error {
 	err := validation.ValidateStruct(c,
 		validation.Field(&c.TheiaPort, validation.Required),
 		validation.Field(&c.SupervisorPort, validation.Required),
-		validation.Field(&c.SupervisorImage, validation.Required),
 	)
+	if len(c.SupervisorImage) > 0 {
+		log.Warn("config value 'workspacePodConfig.supervisorImage' is deprected, use it only to be backwards compatible")
+	}
 	if err != nil {
 		return err
 	}

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -49,7 +49,8 @@ type WorkspaceInfo struct {
 	InstanceID  string
 	URL         string
 
-	IDEImage string
+	IDEImage        string
+	SupervisorImage string
 
 	// (parsed from URL)
 	IDEPublicPort string
@@ -148,15 +149,16 @@ func mapPodToWorkspaceInfo(pod *corev1.Pod) *WorkspaceInfo {
 	workspaceURL := pod.Annotations[kubernetes.WorkspaceURLAnnotation]
 
 	return &WorkspaceInfo{
-		WorkspaceID:   pod.Labels[kubernetes.MetaIDLabel],
-		InstanceID:    pod.Labels[kubernetes.WorkspaceIDLabel],
-		URL:           workspaceURL,
-		IDEImage:      imageSpec.IdeRef,
-		IDEPublicPort: getPortStr(workspaceURL),
-		IPAddress:     pod.Status.PodIP,
-		Ports:         extractExposedPorts(pod).Ports,
-		Auth:          &wsapi.WorkspaceAuthentication{Admission: admission, OwnerToken: ownerToken},
-		StartedAt:     pod.CreationTimestamp.Time,
+		WorkspaceID:     pod.Labels[kubernetes.MetaIDLabel],
+		InstanceID:      pod.Labels[kubernetes.WorkspaceIDLabel],
+		URL:             workspaceURL,
+		IDEImage:        imageSpec.IdeRef,
+		IDEPublicPort:   getPortStr(workspaceURL),
+		SupervisorImage: imageSpec.SupervisorRef,
+		IPAddress:       pod.Status.PodIP,
+		Ports:           extractExposedPorts(pod).Ports,
+		Auth:            &wsapi.WorkspaceAuthentication{Admission: admission, OwnerToken: ownerToken},
+		StartedAt:       pod.CreationTimestamp.Time,
 	}
 }
 

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -33,7 +33,8 @@ const (
 var (
 	workspaces = []WorkspaceInfo{
 		{
-			IDEImage: "gitpod-io/ide:latest",
+			IDEImage:        "gitpod-io/ide:latest",
+			SupervisorImage: "gitpod-io/supervisor:latest",
 			Auth: &api.WorkspaceAuthentication{
 				Admission:  api.AdmissionLevel_ADMIT_OWNER_ONLY,
 				OwnerToken: "owner-token",
@@ -72,9 +73,8 @@ var (
 			Scheme: "http",
 		},
 		WorkspacePodConfig: &WorkspacePodConfig{
-			TheiaPort:       workspacePort,
-			SupervisorPort:  supervisorPort,
-			SupervisorImage: "gitpod-io/supervisor:latest",
+			TheiaPort:      workspacePort,
+			SupervisorPort: supervisorPort,
 		},
 		BuiltinPages: BuiltinPagesConfig{
 			Location: "../../public",
@@ -203,7 +203,6 @@ func TestRoutes(t *testing.T) {
 		Desc        string
 		Config      *Config
 		Request     *http.Request
-		Workspaces  []WorkspaceInfo
 		Router      RouterFactory
 		Targets     *Targets
 		IgnoreBody  bool


### PR DESCRIPTION
## Description
This PR removes the `ws-proxy` config value that specifies the supervisor image. Instead of using this config value, the `supervisor` image from the `ImageSpec` annotation is used. This …
1. allows deploying new supervisor images without the need to change the `ws-proxy` config + pod restart, and
2. supports that workspaces use different `supervisor` images.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6512

## How to test
- Make sure the unit tests pass
- Start a workspace, make sure there is no such error in the `ws-proxy` logs like `no workspace information available - cannot resolve supervisor route`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
