### PR TITLE
Run integration tests from a pod

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -32,11 +32,25 @@ Example command:
 werft job run github -j .werft/run-integration-tests.yaml -a namespace=staging-gpl-2658-int-tests -a version=gpl-2658-int-tests.57 -f
 ```
 
-### Manually against a Kubernetes cluster
+### Manually
 
-You may want to run tests to assert whether your Gitpod installation is successfully integrated.
+You may want to run tests to assert whether a Gitpod installation is successfully integrated.
 
-To test your Gitpod installation:
+#### Using a pod
+
+This approach is best for when you want to validate a deployed environment.
+
+1. Create a service account, role, and role-binding for integration testing.
+   * [`kubectl apply -f ./integration.yaml`](./integration.yaml)
+2. Run a pod to execute the tests like so:
+
+  ```bash
+  kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.1826 -it integ-tests --serviceaccount=integration-svc -- /bin/sh
+  ```
+
+#### Go test
+
+This approach is best for when you're actively developing Gitpod.
 
 1. Set your kubectl context to the cluster you want to test
 2. Integrate the Gitpod installation with OAuth for Github and/or Gitlab, otherwise related tests may fail

--- a/test/README.md
+++ b/test/README.md
@@ -43,18 +43,18 @@ Best for when you want to validate an environment.
 1. Create a service account, role, and role-binding for integration testing.
    * [`kubectl apply -f ./integration.yaml`](./integration.yaml)
 2. Run a pod to execute the tests like so:
-
-  ```bash
-  # Replace <number>, <namespace>, and <gitpod_username> with meaningful values
-  kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.<number> \
-  integ-tests --serviceaccount=integration-svc \
-  --restart=Never \
-  --requests='cpu=2,memory=4Gi' \
-  -- /bin/sh -namespace=<namespace> -username=<gitpod_username>
-  ```
-3. Check logs to inspect status `kubectl logs -f integ-tests`.
-4. Tear down the integration user when testing is done.
+    ```bash
+    # Replace <number>, <namespace>, and <gitpod_username> with meaningful values
+    kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.<number> \
+    integ-tests --serviceaccount=integration-svc \
+    --restart=Never \
+    --requests='cpu=2,memory=4Gi' \
+    -- /bin/sh -namespace=<namespace> -username=<gitpod_username>
+    ```
+3. Check logs to inspect test results like so `kubectl logs -f integ-tests`.
+4. Tear down the integration user and pod when testing is done.
    * [`kubectl delete -f ./integration.yaml`](./integration.yaml)
+   * `kubectl delete pod integ-user`
 
 #### Go test
 

--- a/test/README.md
+++ b/test/README.md
@@ -38,19 +38,27 @@ You may want to run tests to assert whether a Gitpod installation is successfull
 
 #### Using a pod
 
-This approach is best for when you want to validate a deployed environment.
+Best for when you want to validate an environment.
 
 1. Create a service account, role, and role-binding for integration testing.
    * [`kubectl apply -f ./integration.yaml`](./integration.yaml)
 2. Run a pod to execute the tests like so:
 
   ```bash
-  kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.1826 -it integ-tests --serviceaccount=integration-svc -- /bin/sh
+  # Replace <number>, <namespace>, and <gitpod_username> with meaningful values
+  kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.<number> \
+  integ-tests --serviceaccount=integration-svc \
+  --restart=Never \
+  --requests='cpu=2,memory=4Gi' \
+  -- /bin/sh -namespace=<namespace> -username=<gitpod_username>
   ```
+3. Check logs to inspect status `kubectl logs -f integ-tests`.
+4. Tear down the integration user when testing is done.
+   * [`kubectl delete -f ./integration.yaml`](./integration.yaml)
 
 #### Go test
 
-This approach is best for when you're actively developing Gitpod.
+Best for when you're actively developing Gitpod.
 
 1. Set your kubectl context to the cluster you want to test
 2. Integrate the Gitpod installation with OAuth for Github and/or Gitlab, otherwise related tests may fail

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -11,7 +11,7 @@ export PATH=$PATH:/tests
 
 FAILURE_COUNT=0
 # shellcheck disable=SC2045
-for i in $(find /tests/ -name "*.test" | sort -R); do
+for i in $(find /tests/ -name "*.test" | sort); do
     "$i" "$@";
     TEST_STATUS=$?
     if [ "$TEST_STATUS" -ne "0" ]; then

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -15,7 +15,7 @@ for i in $(find /tests/ -name "*.test" | sort -R); do
     "$i" "$@";
     TEST_STATUS=$?
     if [ "$TEST_STATUS" -ne "0" ]; then
-        FAILURE_COUNT=$FAILURE_COUNT+1
+        FAILURE_COUNT=$((FAILURE_COUNT+1))
     fi;
 done
 

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -3,11 +3,23 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-set -ex
+# exclude 'e' (exit on any error)
+# there are many test binaries, each can have failures
+set -x
 
 export PATH=$PATH:/tests
 
+FAILURE_COUNT=0
 # shellcheck disable=SC2045
 for i in $(find /tests/ -name "*.test" | sort -R); do
     "$i" "$@";
+    TEST_STATUS=$?
+    if [ "$TEST_STATUS" -ne "0" ]; then
+        FAILURE_COUNT=$FAILURE_COUNT+1
+    fi;
 done
+
+if [ "$FAILURE_COUNT" -ne "0" ]; then
+    # exit with the number of test binaries that failed
+    exit $FAILURE_COUNT
+fi;

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -17,9 +17,13 @@ for i in $(find /tests/ -name "*.test" | sort -R); do
     if [ "$TEST_STATUS" -ne "0" ]; then
         FAILURE_COUNT=$((FAILURE_COUNT+1))
     fi;
+    echo "Test completed at $(date)"
 done
 
 if [ "$FAILURE_COUNT" -ne "0" ]; then
     # exit with the number of test binaries that failed
+    echo "Test suite ended with failure at $(date)"
     exit $FAILURE_COUNT
 fi;
+
+echo "Test suite finished at $(date)"

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -16,8 +16,10 @@ for i in $(find /tests/ -name "*.test" | sort -R); do
     TEST_STATUS=$?
     if [ "$TEST_STATUS" -ne "0" ]; then
         FAILURE_COUNT=$((FAILURE_COUNT+1))
+        echo "Test failed at $(date)"
+    else
+        echo "Test succeeded at $(date)"
     fi;
-    echo "Test completed at $(date)"
 done
 
 if [ "$FAILURE_COUNT" -ne "0" ]; then
@@ -26,4 +28,4 @@ if [ "$FAILURE_COUNT" -ne "0" ]; then
     exit $FAILURE_COUNT
 fi;
 
-echo "Test suite finished at $(date)"
+echo "Test suite ended with success at $(date)"

--- a/test/integration.yaml
+++ b/test/integration.yaml
@@ -2,23 +2,29 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: integration-svc
-    namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
     name: integration-role
-    namespace: default
 rules:
     - apiGroups:
         - ''
       resources:
         - 'pods'
         - 'secrets'
+        - 'services'
+        - 'configmaps'
       verbs:
         - 'list'
         - 'get'
-        - 'watch'
+    - apiGroups:
+        - ''
+      resources:
+        - 'pods/portforward'
+      verbs:
+        - 'create'
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -27,7 +33,6 @@ metadata:
 subjects:
     - kind: ServiceAccount
       name: integration-svc
-      namespace: default
 roleRef:
     kind: Role
     name: integration-role

--- a/test/integration.yaml
+++ b/test/integration.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: integration-svc
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: integration-role
+    namespace: default
+rules:
+    - apiGroups:
+        - ''
+      resources:
+        - 'pods'
+        - 'secrets'
+      verbs:
+        - 'list'
+        - 'get'
+        - 'watch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: integration-rolebind
+subjects:
+    - kind: ServiceAccount
+      name: integration-svc
+      namespace: default
+roleRef:
+    kind: Role
+    name: integration-role
+    apiGroup: rbac.authorization.k8s.io

--- a/test/leeway.Dockerfile
+++ b/test/leeway.Dockerfile
@@ -8,7 +8,8 @@ FROM alpine:3.14
 RUN  apk upgrade --no-cache \
   && apk add --no-cache \
     ca-certificates \
-    coreutils
+    coreutils \
+    curl
 
 # convenience scripting tools
 RUN apk add --no-cache bash moreutils

--- a/test/leeway.Dockerfile
+++ b/test/leeway.Dockerfile
@@ -13,6 +13,10 @@ RUN  apk upgrade --no-cache \
 # convenience scripting tools
 RUN apk add --no-cache bash moreutils
 
+# deps for tests to run
+RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
+  && chmod +x /usr/local/bin/kubectl
+
 COPY test--app/bin /tests
 ENV PATH=$PATH:/tests
 COPY entrypoint.sh /entrypoint.sh

--- a/test/tests/components/ws-daemon/storage_test.go
+++ b/test/tests/components/ws-daemon/storage_test.go
@@ -23,6 +23,7 @@ func TestCreateBucket(t *testing.T) {
 		Assess("it should create a bucket", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
+			t.Logf("Starting TestCreateBucket")
 
 			rsa, closer, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), cfg.Client(),
 				integration.WithWorkspacekitLift(false),
@@ -32,6 +33,7 @@ func TestCreateBucket(t *testing.T) {
 				t.Fatal(err)
 			}
 			integration.DeferCloser(t, closer)
+			t.Logf("Closer deferred")
 
 			var resp agent.CreateBucketResponse
 			err = rsa.Call("DaemonAgent.CreateBucket", agent.CreateBucketRequest{

--- a/test/tests/components/ws-daemon/storage_test.go
+++ b/test/tests/components/ws-daemon/storage_test.go
@@ -23,7 +23,7 @@ func TestCreateBucket(t *testing.T) {
 		Assess("it should create a bucket", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
-			t.Logf("Starting TestCreateBucket")
+			t.Errorf("Starting TestCreateBucket")
 
 			rsa, closer, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), cfg.Client(),
 				integration.WithWorkspacekitLift(false),
@@ -33,7 +33,7 @@ func TestCreateBucket(t *testing.T) {
 				t.Fatal(err)
 			}
 			integration.DeferCloser(t, closer)
-			t.Logf("Closer deferred")
+			t.Errorf("Closer deferred")
 
 			var resp agent.CreateBucketResponse
 			err = rsa.Call("DaemonAgent.CreateBucket", agent.CreateBucketRequest{

--- a/test/tests/components/ws-daemon/storage_test.go
+++ b/test/tests/components/ws-daemon/storage_test.go
@@ -23,7 +23,6 @@ func TestCreateBucket(t *testing.T) {
 		Assess("it should create a bucket", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
-			t.Errorf("Starting TestCreateBucket")
 
 			rsa, closer, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), cfg.Client(),
 				integration.WithWorkspacekitLift(false),
@@ -33,7 +32,6 @@ func TestCreateBucket(t *testing.T) {
 				t.Fatal(err)
 			}
 			integration.DeferCloser(t, closer)
-			t.Errorf("Closer deferred")
 
 			var resp agent.CreateBucketResponse
 			err = rsa.Call("DaemonAgent.CreateBucket", agent.CreateBucketRequest{


### PR DESCRIPTION
## Description
Run integration tests from a pod

- [x] create separate issues for failing tests in self-hosted (#6792)

## Related Issue(s)
#6518

## How to test

```bash
# setup the integration role, sa, and role binding
kubectl apply -f ./test/integration.yaml`
# run the test pod
kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:kyleb-installer-integration.10 \
integ-tests --serviceaccount=integration-svc \
--restart=Never \
--requests='cpu=2,memory=4Gi' \
-- /bin/sh -namespace=default -username=kylos101
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
