### PR TITLE
[jetbrains] Update to version 213.5744

### DIFF
--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -22,7 +22,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.intellij
       buildArgs:
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/idea/code-with-me/remote-dev/ideaIU-213.4958.tar.gz"
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/idea/ideaIU-213.5744.18.tar.gz"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
       image:
         - ${imageRepoBase}/ide/intellij:${version}
@@ -44,7 +44,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.goland
       buildArgs:
-        JETBRAINS_BACKEND_URL: ${GOLAND_BACKEND_URL}
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/go/goland-213.5744.26.tar.gz"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_goland.json
       image:
         - ${imageRepoBase}/ide/goland:${version}


### PR DESCRIPTION
## Description
This PR updates the JetBrains backends to the latest version.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6685

## How to test
- Go to preferences and change to IntelliJ resp. GoLang IDE and start a workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

