### PR TITLE
[dashboard] Show loading indicator when switching git providers to add a new project

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -90,27 +90,24 @@ export default function NewProject() {
         }
         (async () => {
             updateOrgsState();
-            const repos = await updateReposInAccounts();
-            const first = repos[0];
-            if (first) {
-                setSelectedAccount(first.account);
-            }
-            setLoaded(true);
+            await updateReposInAccounts();
         })();
     }, [provider]);
 
     const isGitHub = () => provider === "github.com";
 
     const updateReposInAccounts = async (installationId?: string) => {
+        setLoaded(false);
+        setReposInAccounts([]);
         if (!provider) {
             return [];
         }
         try {
             const repos = await getGitpodService().server.getProviderRepositoriesForUser({ provider, hints: { installationId } });
             setReposInAccounts(repos);
+            setLoaded(true);
             return repos;
         } catch (error) {
-            setReposInAccounts([]);
             console.log(error);
         }
         return [];
@@ -318,7 +315,7 @@ export default function NewProject() {
         </>
         );
 
-        const renderEmptyState = () => (<div>
+        const renderLoadingState = () => (<div>
             <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
                 <div>
                     <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
@@ -339,7 +336,7 @@ export default function NewProject() {
         }
 
         if (!loaded) {
-            return renderEmptyState();
+            return renderLoadingState();
         }
 
         if (showGitProviders) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Show loading indicator when switching git providers to add a new project

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6654

## How to test
<!-- Provide steps to test this PR -->

1. Go to https://jx-switch-load.staging.gitpod-dev.com/new
2. Switch between Git providers (hint: click on "change" next to **github.com** or **gitlab.com** near the top)

The switch should show the loading indicator while loading (and not the previous list of repos from the old provider)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Show loading indicator when switching git providers to add a new project
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc