### PR TITLE
[server] Allow all team members to cancel a team prebuild

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -80,8 +80,16 @@ export default function () {
         </div>)
     };
 
-    const onInstanceUpdate = (instance: WorkspaceInstance) => {
+    const onInstanceUpdate = async (instance: WorkspaceInstance) => {
         setPrebuildInstance(instance);
+        if (!prebuild) {
+            return;
+        }
+        const prebuilds = await getGitpodService().server.findPrebuilds({
+            projectId: prebuild.info.projectId,
+            prebuildId
+        });
+        setPrebuild(prebuilds[0]);
     }
 
     const rerunPrebuild = async () => {
@@ -132,7 +140,7 @@ export default function () {
                             <span>Rerun Prebuild ({prebuild.info.branch})</span>
                         </button>
                         : (prebuild?.status === 'building'
-                            ? <button className="danger flex items-center space-x-2" disabled={isCancellingPrebuild} onClick={cancelPrebuild}>
+                            ? <button className="danger flex items-center space-x-2" disabled={isCancellingPrebuild || (prebuildInstance?.status.phase !== "initializing" && prebuildInstance?.status.phase !== "running")} onClick={cancelPrebuild}>
                                 {isCancellingPrebuild && <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />}
                                 <span>Cancel Prebuild</span>
                             </button>

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1597,7 +1597,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodSer
             throw new ResponseError(ErrorCodes.NOT_FOUND, "Prebuild not found");
         }
         // Explicitly stopping the prebuild workspace now automaticaly cancels the prebuild
-        // TODO(janx): Make access guards compatible with teams
         await this.stopWorkspace(prebuild.buildWorkspaceId);
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allow all team members to cancel a team prebuild.

Drive-by: Fix `Cancel Prebuild` button state in Prebuild page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6549

## How to test
<!-- Provide steps to test this PR -->

1. Have a team with at least two users: let's call them user A and user B
2. Start a prebuild as user A
3. Try to cancel the prebuild as user B

The cancellation should work, instead of logging an access error.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow all team members to cancel a team prebuild
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc