### PR TITLE
[image-builder-mk3] Fix docker.io interaction

### DIFF
--- a/components/image-builder-bob/pkg/proxy/proxy.go
+++ b/components/image-builder-bob/pkg/proxy/proxy.go
@@ -22,6 +22,12 @@ func NewProxy(host *url.URL, aliases map[string]Repo) (*Proxy, error) {
 	if host.Host == "" || host.Scheme == "" {
 		return nil, fmt.Errorf("host Host or Scheme are missing")
 	}
+	for k, v := range aliases {
+		// We need to translate the default hosts for the Docker registry.
+		// If we don't do this, pulling from docker.io will fail.
+		v.Host, _ = docker.DefaultHost(v.Host)
+		aliases[k] = v
+	}
 	return &Proxy{
 		Host:    *host,
 		Aliases: aliases,


### PR DESCRIPTION
## Description
This PR makes image-builder-mk3 work with docker.io by properly translating the registry hosts.

## How to test
Launch any template workspace with a built-in registry

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
