### PR TITLE
[ws-scheduler] Set supervisor ref for ghosts

### DIFF
--- a/chart/templates/ws-scheduler-configmap.yaml
+++ b/chart/templates/ws-scheduler-configmap.yaml
@@ -50,7 +50,8 @@ data:
                     }
                 },
                 "workspaceImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.defaultImage) }}",
-                "ideImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.theiaImage) }}",
+                "ideImage": "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) }}:{{ .Values.components.workspace.codeImage.stableVersion }}",
+                "supervisorImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}",
                 "maxGhostWorkspaces": {{ $comp.scaler.maxGhostWorkspaces | default 0 }},
                 "schedulerInterval": "{{ $comp.scaler.schedulerInterval | default "5s" }}",
                 "renewal": {

--- a/components/ee/ws-scheduler/pkg/scaler/driver.go
+++ b/components/ee/ws-scheduler/pkg/scaler/driver.go
@@ -34,11 +34,12 @@ const (
 
 // WorkspaceManagerPrescaleDriverConfig configures a ws-manager based prescale driver
 type WorkspaceManagerPrescaleDriverConfig struct {
-	WsManager      WorkspaceManagerConfig     `json:"wsman"`
-	GhostOwner     string                     `json:"ghostOwner"`
-	WorkspaceImage string                     `json:"workspaceImage"`
-	IDEImage       string                     `json:"ideImage"`
-	FeatureFlags   []api.WorkspaceFeatureFlag `json:"featureFlags"`
+	WsManager       WorkspaceManagerConfig     `json:"wsman"`
+	GhostOwner      string                     `json:"ghostOwner"`
+	WorkspaceImage  string                     `json:"workspaceImage"`
+	IDEImage        string                     `json:"ideImage"`
+	SupervisorImage string                     `json:"supervisorImage"`
+	FeatureFlags    []api.WorkspaceFeatureFlag `json:"featureFlags"`
 
 	MaxGhostWorkspaces int           `json:"maxGhostWorkspaces"`
 	SchedulerInterval  util.Duration `json:"schedulerInterval"`
@@ -291,7 +292,8 @@ func (wspd *WorkspaceManagerPrescaleDriver) startGhostWorkspaces(ctx context.Con
 				},
 				DeprecatedIdeImage: wspd.Config.IDEImage,
 				IdeImage: &api.IDEImage{
-					WebRef: wspd.Config.IDEImage,
+					WebRef:        wspd.Config.IDEImage,
+					SupervisorRef: wspd.Config.SupervisorImage,
 				},
 				Initializer: &csapi.WorkspaceInitializer{
 					Spec: &csapi.WorkspaceInitializer_Empty{

--- a/installer/pkg/components/ws-scheduler/configmap.go
+++ b/installer/pkg/components/ws-scheduler/configmap.go
@@ -83,6 +83,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			WorkspaceImage:     common.ImageName("", workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
 			IDEImage:           common.ImageName(ctx.Config.Repository, workspace.IDEImageRepo, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
+			SupervisorImage:    common.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
 			FeatureFlags:       nil,
 			MaxGhostWorkspaces: 10,
 			SchedulerInterval:  util.Duration(time.Second * 5),


### PR DESCRIPTION
## Description
This PR set the **supervisor ref** in the StartWorkspaceSpec for ghost workspaces.

This PR also updates the **IDE image** of the ghost workspaces to **code stable instead of Theia**.

## How to test
<!-- Provide steps to test this PR -->
Make sure that ghost workspaces start. You could also decode the imageSpec annotation.

## Issues
Also part of #6512

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
