### PR TITLE
Remove team when sole owner and remove projects

### DIFF
--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -11,6 +11,7 @@ export interface TeamDB {
     findTeamById(teamId: string): Promise<Team | undefined>;
     findMembersByTeam(teamId: string): Promise<TeamMemberInfo[]>;
     findTeamsByUser(userId: string): Promise<Team[]>;
+    findTeamsByUserAsSoleOwner(userId: string): Promise<Team[]>;
     createTeam(userId: string, name: string): Promise<Team>;
     addMemberToTeam(userId: string, teamId: string): Promise<void>;
     setTeamMemberRole(userId: string, teamId: string, role: TeamMemberRole): Promise<void>;

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import { UserDB, WorkspaceDB, UserStorageResourcesDB, TeamDB } from '@gitpod/gitpod-db/lib';
+import { UserDB, WorkspaceDB, UserStorageResourcesDB, TeamDB, ProjectDB } from '@gitpod/gitpod-db/lib';
 import { User, Workspace } from "@gitpod/gitpod-protocol";
 import { StorageClient } from "../storage/storage-client";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
@@ -23,6 +23,7 @@ export class UserDeletionService {
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
     @inject(UserStorageResourcesDB) protected readonly userStorageResourcesDb: UserStorageResourcesDB;
     @inject(TeamDB) protected readonly teamDb: TeamDB;
+    @inject(ProjectDB) protected readonly projectDb: ProjectDB;
     @inject(StorageClient) protected readonly storageClient: StorageClient;
     @inject(WorkspaceManagerClientProvider) protected readonly workspaceManagerClientProvider: WorkspaceManagerClientProvider;
     @inject(WorkspaceDeletionService) protected readonly workspaceDeletionService: WorkspaceDeletionService;
@@ -74,8 +75,12 @@ export class UserDeletionService {
             this.userStorageResourcesDb.deleteAllForUser(user.id),
             // Bucket
             this.deleteUserBucket(id),
+            // Teams owned only by this user
+            this.deleteSoleOwnedTeams(id),
             // Team memberships
             this.deleteTeamMemberships(id),
+            // User projects
+            this.deleteUserProjects(id),
         ]);
 
         // Track the deletion Event for Analytics Purposes
@@ -138,6 +143,23 @@ export class UserDeletionService {
     protected async deleteTeamMemberships(userId: string) {
         const teams = await this.teamDb.findTeamsByUser(userId);
         await Promise.all(teams.map(t => this.teamDb.removeMemberFromTeam(userId, t.id)));
+    }
+
+    protected async deleteSoleOwnedTeams(userId: string) {
+        const ownedTeams = await this.teamDb.findTeamsByUserAsSoleOwner(userId);
+
+        for (const team of ownedTeams) {
+            const teamProjects = await this.projectDb.findTeamProjects(team.id);
+            await Promise.all(teamProjects.map(project => this.projectDb.markDeleted(project.id)));
+        }
+
+        await Promise.all(ownedTeams.map(t => this.teamDb.deleteTeam(t.id)));
+    }
+
+    protected async deleteUserProjects(id: string) {
+        const userProjects = await this.projectDb.findUserProjects(id);
+
+        await Promise.all(userProjects.map(project => this.projectDb.markDeleted(project.id)));
     }
 
     anonymizeWorkspace(ws: Workspace) {


### PR DESCRIPTION
## Description
1. Removes user projects
2. Removes teams when user is sole owner of the teams
3. Removes projects of those sole-owned teams

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6655

## How to test
The testing is quite extensive.
Test 1:
1. Create a team
2. Add a member to that team
3. Add a project to that team
4. Set one team as owner, one as member
5. Have the owner delete their **user** account. Expectation: team and project should be deleted.

Test 2:
1. Redo steps 1-4 above.
2. Have the member delete their **user** account. Expectation: team and project should not be deleted.

Test 3:
1. Redo steps 1-3 above.
2. Set both members as owners.
3. Have one owner delete their **user** account. Expectation: team and project should not be deleted.

Test 4:
1. Add project to the user.
2. Delete the user. Expectation: project should be deleted, i.e. that project is available to be added again.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
When a user deletes their account, own projects will be deleted and made available to be added again.
When the user is the sole owner of a team, that team and its projects will be deleted and made available to be added again.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
