### PR TITLE
[jetbrains] Wait for content before backend start

### DIFF
--- a/components/ide/jetbrains/image/startup.sh
+++ b/components/ide/jetbrains/image/startup.sh
@@ -10,6 +10,12 @@ trap "jobs -p | xargs -r kill" SIGINT SIGTERM EXIT
 
 /ide-desktop/status 24000 "$1" &
 
+echo "Desktop IDE: Waiting for the content initializer ..."
+until curl -sS "$SUPERVISOR_ADDR"/_supervisor/v1/status/content/wait/true | grep '"available":true' > /dev/null; do
+    sleep 1
+done
+echo "Desktop IDE: Content available."
+
 export CWM_NON_INTERACTIVE=1
 export CWM_HOST_PASSWORD=gitpod
 export CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod


### PR DESCRIPTION
## Description
When the JetBrains backend starts and the workspace content is not ready yet it results to an error like this:
```
JetBrains remote-dev-server.sh (err): Path does not exist: /workspace/gitpod
```

This PR adds a step that waits for the content before it starts the JetBrains backend.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6651

## How to test
<!-- Provide steps to test this PR -->
It's hard to reproduce the actual error but testing that a workspace with JetBrains backend starts (change it in the preferences) should be good enough.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
