### PR TITLE
[dashboard] Prefer project.slug over project.name in Projects page links

### DIFF
--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -184,13 +184,13 @@ export default function () {
                             </div>
                             <div className="h-10 px-6 py-1 text-gray-400 text-sm">
                                 <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                                    <Link to={`/${teamOrUserSlug}/${p.name}`}>
+                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}`}>
                                         Branches
                                     </Link>
                                 </span>
                                 <span className="mx-2 my-auto">·</span>
                                 <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                                    <Link to={`/${teamOrUserSlug}/${p.name}/prebuilds`}>
+                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`}>
                                         Prebuilds
                                     </Link>
                                 </span>
@@ -199,13 +199,13 @@ export default function () {
                         <div className="h-10 px-4 border rounded-b-xl dark:border-gray-800 bg-gray-100 border-gray-100 dark:bg-gray-800">
                             {lastPrebuilds.get(p.id)
                                 ? (<div className="flex flex-row h-full text-sm space-x-4">
-                                    <Link to={`/${teamOrUserSlug}/${p.name}/${lastPrebuilds.get(p.id)?.info?.id}`} className="flex-grow flex items-center group space-x-2 truncate">
+                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/${lastPrebuilds.get(p.id)?.info?.id}`} className="flex-grow flex items-center group space-x-2 truncate">
                                         {prebuildStatusIcon(lastPrebuilds.get(p.id))}
                                         <div className="font-semibold text-gray-500 dark:text-gray-400 truncate" title={lastPrebuilds.get(p.id)?.info?.branch}>{lastPrebuilds.get(p.id)?.info?.branch}</div>
                                         <span className="flex-shrink-0 mx-1 text-gray-400 dark:text-gray-600">·</span>
                                         <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">{moment(lastPrebuilds.get(p.id)?.info?.startedAt).fromNow()}</div>
                                     </Link>
-                                    <Link to={`/${teamOrUserSlug}/${p.name}/prebuilds`} className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">View All &rarr;</Link>
+                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`} className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">View All &rarr;</Link>
                                 </div>)
                                 : (<div className="flex h-full text-md">
                                     <p className="my-auto ">No recent prebuilds</p>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

I noticed a few links in the Projects overview page that were still using `project.name` in URLs.

This PR makes them use `project.slug` if available.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc