### PR TITLE
[Installer]: configure minio to act as gateway to azure blob storage

### DIFF
--- a/installer/pkg/components/minio/azure/minio.go
+++ b/installer/pkg/components/minio/azure/minio.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package azure
+
+import (
+	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/helm"
+	"github.com/gitpod-io/gitpod/installer/third_party/charts"
+	"helm.sh/helm/v3/pkg/cli/values"
+)
+
+var Helm = func(apiPort int32, consolePort int32) common.HelmFunc {
+	return common.CompositeHelmFunc(
+		helm.ImportTemplate(charts.Minio(), helm.TemplateConfig{}, func(cfg *common.RenderContext) (*common.HelmConfig, error) {
+			return &common.HelmConfig{
+				Enabled: true,
+				Values: &values.Options{
+					Values: []string{
+						helm.KeyValue("minio.gateway.enabled", "true"),
+						helm.KeyValue("minio.gateway.auth.azure.accessKey", cfg.Values.StorageAccessKey), // Azure value actually taken from secret - used for console/API access
+						helm.KeyValue("minio.gateway.auth.azure.secretKey", cfg.Values.StorageSecretKey), // Ditto
+						helm.KeyValue("minio.gateway.auth.azure.storageAccountNameExistingSecret", cfg.Config.ObjectStorage.Azure.Credentials.Name),
+						helm.KeyValue("minio.gateway.auth.azure.storageAccountNameExistingSecretKey", "accountName"),
+						helm.KeyValue("minio.gateway.auth.azure.storageAccountKeyExistingSecret", cfg.Config.ObjectStorage.Azure.Credentials.Name),
+						helm.KeyValue("minio.gateway.auth.azure.storageAccountKeyExistingSecretKey", "accountKey"),
+						helm.KeyValue("minio.gateway.replicaCount", "2"),
+						helm.KeyValue("minio.gateway.type", "azure"),
+						helm.KeyValue("minio.persistence.enabled", "false"),
+						helm.KeyValue("minio.service.ports.api", fmt.Sprintf("%d", apiPort)),
+						helm.KeyValue("minio.service.ports.console", fmt.Sprintf("%d", consolePort)),
+					},
+				},
+			}, nil
+		}),
+	)
+}

--- a/installer/pkg/components/minio/helm.go
+++ b/installer/pkg/components/minio/helm.go
@@ -2,38 +2,22 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
+// Minio is used for both incluster deployments and as a facade for non-GCP storage providers
+
 package minio
 
 import (
-	"fmt"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/helm"
-	"github.com/gitpod-io/gitpod/installer/third_party/charts"
-	"helm.sh/helm/v3/pkg/cli/values"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/minio/incluster"
 	"k8s.io/utils/pointer"
 )
 
 var Helm = common.CompositeHelmFunc(
-	helm.ImportTemplate(charts.Minio(), helm.TemplateConfig{}, func(cfg *common.RenderContext) (*common.HelmConfig, error) {
-		accessKey := cfg.Values.StorageAccessKey
-		if accessKey == "" {
-			return nil, fmt.Errorf("unknown value: storage access key")
-		}
-		secretKey := cfg.Values.StorageSecretKey
-		if secretKey == "" {
-			return nil, fmt.Errorf("unknown value: storage secret key")
+	func(cfg *common.RenderContext) ([]string, error) {
+		if pointer.BoolDeref(cfg.Config.ObjectStorage.InCluster, false) {
+			return incluster.Helm(ServiceAPIPort, ServiceConsolePort)(cfg)
 		}
 
-		return &common.HelmConfig{
-			Enabled: pointer.BoolDeref(cfg.Config.ObjectStorage.InCluster, false),
-			Values: &values.Options{
-				Values: []string{
-					helm.KeyValue("minio.auth.rootUser", accessKey),
-					helm.KeyValue("minio.auth.rootPassword", secretKey),
-					helm.KeyValue("service.ports.api", fmt.Sprintf("%d", ServiceAPIPort)),
-					helm.KeyValue("service.ports.console", fmt.Sprintf("%d", ServiceConsolePort)),
-				},
-			},
-		}, nil
-	}),
+		return nil, nil
+	},
 )

--- a/installer/pkg/components/minio/helm.go
+++ b/installer/pkg/components/minio/helm.go
@@ -2,12 +2,13 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-// Minio is used for both incluster deployments and as a facade for non-GCP storage providers
+// Minio is used for both in-cluster deployments and as a facade for non-GCP storage providers
 
 package minio
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/minio/azure"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/minio/incluster"
 	"k8s.io/utils/pointer"
 )
@@ -16,6 +17,9 @@ var Helm = common.CompositeHelmFunc(
 	func(cfg *common.RenderContext) ([]string, error) {
 		if pointer.BoolDeref(cfg.Config.ObjectStorage.InCluster, false) {
 			return incluster.Helm(ServiceAPIPort, ServiceConsolePort)(cfg)
+		}
+		if cfg.Config.ObjectStorage.Azure != nil {
+			return azure.Helm(ServiceAPIPort, ServiceConsolePort)(cfg)
 		}
 
 		return nil, nil

--- a/installer/pkg/components/minio/incluster/minio.go
+++ b/installer/pkg/components/minio/incluster/minio.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package incluster
+
+import (
+	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/helm"
+	"github.com/gitpod-io/gitpod/installer/third_party/charts"
+	"helm.sh/helm/v3/pkg/cli/values"
+)
+
+var Helm = func(apiPort int32, consolePort int32) common.HelmFunc {
+	return common.CompositeHelmFunc(
+		helm.ImportTemplate(charts.Minio(), helm.TemplateConfig{}, func(cfg *common.RenderContext) (*common.HelmConfig, error) {
+			return &common.HelmConfig{
+				Enabled: true,
+				Values: &values.Options{
+					Values: []string{
+						helm.KeyValue("minio.auth.rootUser", cfg.Values.StorageAccessKey),
+						helm.KeyValue("minio.auth.rootPassword", cfg.Values.StorageSecretKey),
+						helm.KeyValue("minio.service.ports.api", fmt.Sprintf("%d", apiPort)),
+						helm.KeyValue("minio.service.ports.console", fmt.Sprintf("%d", consolePort)),
+					},
+				},
+			}, nil
+		}),
+	)
+}

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -123,6 +123,7 @@ type ObjectStorage struct {
 	InCluster    *bool                      `json:"inCluster,omitempty"`
 	S3           *ObjectStorageS3           `json:"s3,omitempty"`
 	CloudStorage *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
+	Azure        *ObjectStorageAzure        `json:"azure,omitempty"`
 }
 
 type ObjectStorageS3 struct {
@@ -132,6 +133,10 @@ type ObjectStorageS3 struct {
 type ObjectStorageCloudStorage struct {
 	ServiceAccount ObjectRef `json:"serviceAccount" validate:"required"`
 	Project        string    `json:"project" validate:"required"`
+}
+
+type ObjectStorageAzure struct {
+	Credentials ObjectRef `json:"credentials"`
 }
 
 type InstallationKind string

--- a/installer/pkg/config/v1/validation.go
+++ b/installer/pkg/config/v1/validation.go
@@ -77,6 +77,11 @@ func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
 		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("service-account.json")))
 	}
 
+	if cfg.ObjectStorage.Azure != nil {
+		secretName := cfg.ObjectStorage.Azure.Credentials.Name
+		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("accountName", "accountKey")))
+	}
+
 	if cfg.ContainerRegistry.External != nil {
 		secretName := cfg.ContainerRegistry.External.Certificate.Name
 		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData(".dockerconfigjson")))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Refactor Minio component to make it easier to distinguish in-cluster and each gateway configuration
- Add Azure config
- Validate the Azure blob storage secret

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod-microsoft-aks-guide/issues/6

## How to test
<!-- Provide steps to test this PR -->
Create Azure storage account and create a secret:
```sh
kubectl create secret generic az-storage-token \
      --from-literal=accountName="${STORAGE_ACCOUNT_NAME}" \
      --from-literal=accountKey="${STORAGE_ACCOUNT_KEY}" \
      --dry-run=client -o yaml | \
      kubectl replace --force -f -
```
Now update the config:
```yaml
objectStorage:
  inCluster: false
  azure:
    certificate:
      kind: secret
      name: az-storage-token
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Configure Azure blob storage for installer
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
