### PR TITLE
[dashboard] Change default color theme from Light → System

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -142,7 +142,7 @@ function App() {
 
     useEffect(() => {
         const updateTheme = () => {
-            const isDark = localStorage.theme === 'dark' || (localStorage.theme === 'system' && window.matchMedia("(prefers-color-scheme: dark)").matches);
+            const isDark = localStorage.theme === 'dark' || (!localStorage.theme && window.matchMedia("(prefers-color-scheme: dark)").matches);
             setIsDark(isDark);
         }
         updateTheme();

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -58,14 +58,14 @@ export default function Preferences() {
         setUseDesktopIde(value);
     }
 
-    const [theme, setTheme] = useState<Theme>(localStorage.theme || 'light');
+    const [theme, setTheme] = useState<Theme>(localStorage.theme || 'system');
     const actuallySetTheme = (theme: Theme) => {
-        if (theme === 'dark' || theme === 'system') {
+        if (theme === 'dark' || theme === 'light') {
             localStorage.theme = theme;
         } else {
             localStorage.removeItem('theme');
         }
-        const isDark = localStorage.theme === 'dark' || (localStorage.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        const isDark = localStorage.theme === 'dark' || (!localStorage.theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
         setIsDark(isDark);
         setTheme(theme);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Until today, the default color theme in the dashboard was Light (regardless of your system preference).

However, changing the default to System makes more sense: This will cause Gitpod's theme to remain light, _except_ if you've told your OS that all apps should be dark (in which case Gitpod will now honor that preference by default).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6395

## How to test
<!-- Provide steps to test this PR -->

1. Open the preview environment (the login screen should already match your OS preference for light or dark)
2. https://jx-default-system-theme.staging.gitpod-dev.com/preferences should have "System" theme pre-selected
3. If you change your OS color theme preference, the preview theme should automatically respond (without even needing a refresh)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Change default color theme from Light → System
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc