### PR TITLE
[installer]: validate the AuthProvider config value

### DIFF
--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -81,7 +81,7 @@ type Config struct {
 
 	Workspace Workspace `json:"workspace" validate:"required"`
 
-	AuthProviders []AuthProviderConfigs `json:"authProviders"`
+	AuthProviders []AuthProviderConfigs `json:"authProviders" validate:"dive"`
 	BlockNewUsers BlockNewUsers         `json:"blockNewUsers"`
 }
 
@@ -224,9 +224,12 @@ const (
 
 // todo(sje): I don't know if we want to put this in the config YAML
 type AuthProviderConfigs struct {
+	ID                  string            `json:"id" validate:"required"`
+	Host                string            `json:"host" validate:"required"`
+	Type                string            `json:"type" validate:"required"`
 	BuiltIn             string            `json:"builtin"`
 	Verified            string            `json:"verified"`
-	OAuth               OAuth             `json:"oauth"`
+	OAuth               OAuth             `json:"oauth" validate:"required"`
 	Params              map[string]string `json:"params"`
 	HiddenOnDashboard   bool              `json:"hiddenOnDashboard"`
 	LoginContextMatcher string            `json:"loginContextMatcher"`
@@ -242,9 +245,9 @@ type BlockNewUsers struct {
 }
 
 type OAuth struct {
-	ClientId            string            `json:"clientId"`
-	ClientSecret        string            `json:"clientSecret"`
-	CallBackUrl         string            `json:"callBackUrl"`
+	ClientId            string            `json:"clientId" validate:"required"`
+	ClientSecret        string            `json:"clientSecret" validate:"required"`
+	CallBackUrl         string            `json:"callBackUrl" validate:"required"`
 	AuthorizationUrl    string            `json:"authorizationUrl"`
 	TokenUrl            string            `json:"tokenUrl"`
 	Scope               string            `json:"scope"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Gets the auth provider config working. Adds the id, host and type params to the AuthProvider and also adds validation on the required fields

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6750

## How to test
<!-- Provide steps to test this PR -->
Run installer with config:

```yaml
authProviders:
  - id: Public-GitHub
    host: github.com
    type: GitHub
    oauth:
      clientId: xxx
      clientSecret: xxx
      callBackUrl: https://<URL>/auth/github.com/callback
      settingsUrl: https://github.com/organizations/openapiary/settings/applications/<id>
    description: ""
    icon: ""
```

Remove one of the ones marked `required` in there and the validation should fail

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: fix the auth provider config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
