### PR TITLE
Add JetBrains Update GitHub action

### DIFF
--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -1,0 +1,100 @@
+name: Check for new JetBrains IDE releases
+on:
+  schedule:
+    # At 11:00 on every day-of-week from Monday through Friday.
+    - cron: "0 11 * * 1-5"
+
+jobs:
+  intellij:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Latest Release
+        id: latest-release
+        run: |
+          data=$(curl -sSL "https://data.services.jetbrains.com/products?code=IIU&release.type=eap%2Crc&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000")
+          link=$(echo "$data" | jq -r '.[0].releases[0].downloads.linux.link')
+          build=$(echo "$data" | jq -r '.[0].releases[0].build')
+          build2=$(echo "$build" | sed 's/\./-/g')
+          echo "::set-output name=result::$link"
+          echo "::set-output name=version::$build"
+          echo "::set-output name=version2::$build2"
+      - uses: actions/checkout@v2
+      - name: Used Release
+        id: used-release
+        run: echo "::set-output name=result::$(yq e '.packages[] | select(.name == "intellij") | .config.buildArgs.JETBRAINS_BACKEND_URL' components/ide/jetbrains/image/BUILD.yaml)"
+      - name: No Update Available
+        if: steps.latest-release.outputs.result == steps.used-release.outputs.result
+        run: |
+          echo "Nothing to do."
+          echo "Latest release: ${{ steps.latest-release.outputs.result }}"
+          echo "Used release:   ${{ steps.used-release.outputs.result }}"
+      - name: Update Available
+        if: steps.latest-release.outputs.result != steps.used-release.outputs.result
+        run: |
+          echo "There is an update available!"
+          echo "Latest release: ${{ steps.latest-release.outputs.result }}"
+          echo "Used release:   ${{ steps.used-release.outputs.result }}"
+          yq -i e '(.packages[] | select(.name == "intellij") | .config.buildArgs.JETBRAINS_BACKEND_URL) = "${{ steps.latest-release.outputs.result }}"' components/ide/jetbrains/image/BUILD.yaml
+          git diff
+      - name: Create Pull Request
+        if: steps.latest-release.outputs.result != steps.used-release.outputs.result
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "[intellij] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
+          body: |
+            ## Description
+            This PR updates the IntelliJ IDE image to the latest release version.
+
+            ## Release Notes
+            ```release-note
+            Update IntelliJ IDE image to version ${{ steps.latest-release.outputs.version }}.
+            ```
+          commit-message: "[intellij] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
+          branch: "jetbrains/intellij-${{ steps.latest-release.outputs.version2 }}"
+
+  goland:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Latest Release
+        id: latest-release
+        run: |
+          data=$(curl -sSL "https://data.services.jetbrains.com/products?code=GO&release.type=eap%2Crc&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000")
+          link=$(echo "$data" | jq -r '.[0].releases[0].downloads.linux.link')
+          build=$(echo "$data" | jq -r '.[0].releases[0].build')
+          build2=$(echo "$build" sed 's/\./-/g')
+          echo "::set-output name=result::$link"
+          echo "::set-output name=version::$build"
+          echo "::set-output name=version2::$build2"
+      - uses: actions/checkout@v2
+      - name: Used Release
+        id: used-release
+        run: echo "::set-output name=result::$(yq e '.packages[] | select(.name == "goland") | .config.buildArgs.JETBRAINS_BACKEND_URL' components/ide/jetbrains/image/BUILD.yaml)"
+      - name: No Update Available
+        if: steps.latest-release.outputs.result == steps.used-release.outputs.result
+        run: |
+          echo "Nothing to do."
+          echo "Latest release: ${{ steps.latest-release.outputs.result }}"
+          echo "Used release:   ${{ steps.used-release.outputs.result }}"
+      - name: Update Available
+        if: steps.latest-release.outputs.result != steps.used-release.outputs.result
+        run: |
+          echo "There is an update available!"
+          echo "Latest release: ${{ steps.latest-release.outputs.result }}"
+          echo "Used release:   ${{ steps.used-release.outputs.result }}"
+          yq -i e '(.packages[] | select(.name == "goland") | .config.buildArgs.JETBRAINS_BACKEND_URL) = "${{ steps.latest-release.outputs.result }}"' components/ide/jetbrains/image/BUILD.yaml
+          git diff
+      - name: Create Pull Request
+        if: steps.latest-release.outputs.result != steps.used-release.outputs.result
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "[goland] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
+          body: |
+            ## Description
+            This PR updates the GoLand IDE image to the latest release version.
+
+            ## Release Notes
+            ```release-note
+            Update GoLand IDE image to version ${{ steps.latest-release.outputs.version }}.
+            ```
+          commit-message: "[goland] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
+          branch: "jetbrains/goland-${{ steps.latest-release.outputs.version2 }}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a GitHub action that checks if there is a new release for our JetBrains images and creates a PR in case.

_Comments / suggestions for improvements are very welcome._

/cc @akosyakov @loujaybee 

/werft no-preview

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6726

## How to test
<!-- Provide steps to test this PR -->
see it here in action: https://github.com/gitpod-io/gitpod/actions/workflows/jetbrains-updates.yml

sample PR: https://github.com/gitpod-io/gitpod/pull/6752

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
