### PR TITLE
[workspace] fix workspace leak on short-lived workspace

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -365,6 +365,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			Namespace:   m.Config.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
+			Finalizers:  []string{"gitpod.io/finalizer"},
 		},
 		Spec: corev1.PodSpec{
 			AutomountServiceAccountToken: &boolFalse,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -33,7 +33,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -34,7 +34,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_ghost.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -33,7 +33,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -32,7 +32,10 @@
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",
                 "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
-            }
+            },
+            "finalizers": [
+                "gitpod.io/finalizer"
+            ]
         },
         "spec": {
             "volumes": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Workspace leak because short-lived workspace haven't had a chance to set the finalizer

We can advance the setfinalizer to the WorkspacePhase_CREATING phase, since the initializeWorkspaceContent phase is already underway at this point and requires a subsequent cleanup process

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6435 
Fixes #5573

## How to test
<!-- Provide steps to test this PR -->
Start a short-lived workspace
and check /var/gitpod/workspaces/

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
