### PR TITLE
[installer]: fix jaeger operator misconfiguration

### DIFF
--- a/installer/example-config.yaml
+++ b/installer/example-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
+authProviders: []
 blockNewUsers:
   enabled: false
+  passlist: []
 certificate:
   kind: secret
   name: https-certificates
@@ -14,7 +16,7 @@ jaegerOperator:
   inCluster: true
 kind: Full
 metadata:
-  region: "local"
+  region: local
 objectStorage:
   inCluster: true
 observability:

--- a/installer/pkg/components/jaeger-operator/helm.go
+++ b/installer/pkg/components/jaeger-operator/helm.go
@@ -18,9 +18,8 @@ var Helm = common.CompositeHelmFunc(
 			Enabled: pointer.BoolDeref(cfg.Config.Jaeger.InCluster, false),
 			Values: &values.Options{
 				Values: []string{
-					"installCRDs=true",
-					"crd.install=false",
-					"rbac.clusterRole=true",
+					helm.KeyValue("jaeger-operator.crd.install", "true"),
+					helm.KeyValue("jaeger-operator.rbac.clusterRole", "true"),
 				},
 			},
 		}, nil

--- a/installer/third_party/charts/jaeger-operator/values.yaml
+++ b/installer/third_party/charts/jaeger-operator/values.yaml
@@ -2,5 +2,4 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-docker-registry:
-  fullnameOverride: registry
+jaeger-operator: {}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixed copy/pasta errors in the Jaeger operator

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6759

## How to test
<!-- Provide steps to test this PR -->
Update the config:

```yaml
observability:
  logLevel: info
  tracing:
    endpoint: http://jaeger-collector:14268/api/traces
```

Deploy [Jaeger](https://github.com/gitpod-io/gitpod/blob/ee92ed0de957b14035a9dcd460b50f4f57c32f40/.werft/jaeger.yaml#L35), changing the `nodeAffinity` key to `gitpod.io/workload_meta`

Create a port forwarder to the jaeger deployment `kubectl port-forward jaeger-5945545574-g5jgc 3000:16686`.

Go to [localhost:3000](HTTP://localhost:3000) and check that there are traces flowing in

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: fix jaeger operator misconfiguration
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
