### PR TITLE
[payment-endpoint] Error instead of oom on too many slots per TS

### DIFF
--- a/components/ee/payment-endpoint/src/config.ts
+++ b/components/ee/payment-endpoint/src/config.ts
@@ -36,6 +36,8 @@ export GITPOD_GITHUB_APP_MKT_NAME=gitpod-draft-development-app
     readonly githubAppAppID: number = process.env.GITPOD_GITHUB_APP_ID ? parseInt(process.env.GITPOD_GITHUB_APP_ID) : 0;
     readonly githubAppWebhookSecret: string = process.env.GITPOD_GITHUB_APP_WEBHOOK_SECRET || "unknown";
     readonly githubAppCertPath: string = process.env.GITPOD_GITHUB_APP_CERT_PATH || "unknown";
+
+    readonly maxTeamSlotsOnCreation: number = !!process.env.TS_MAX_SLOTS_ON_CREATION ? parseInt(process.env.TS_MAX_SLOTS_ON_CREATION) : 1000;
 }
 
 export interface ChargebeeWebhook {

--- a/components/gitpod-db/src/team-subscription-db.ts
+++ b/components/gitpod-db/src/team-subscription-db.ts
@@ -9,7 +9,7 @@ import { DeepPartial } from "typeorm";
 
 export const TeamSubscriptionDB = Symbol('TeamSubscriptionDB');
 export interface TeamSubscriptionDB {
-    storeTeamSubscriptionEntry(ts: TeamSubscription): void;
+    storeTeamSubscriptionEntry(ts: TeamSubscription): Promise<void>;
     findTeamSubscriptionById(id: string): Promise<TeamSubscription | undefined>;
     findTeamSubscriptionByPaymentRef(userId: string, paymentReference: string): Promise<TeamSubscription | undefined>;
     findTeamSubscriptionsForUser(userId: string, date: string): Promise<TeamSubscription[]>;

--- a/components/gitpod-db/src/typeorm/team-subscription-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-subscription-db-impl.ts
@@ -41,8 +41,9 @@ export class TeamSubscriptionDBImpl implements TeamSubscriptionDB {
      * Team Subscriptions
      */
 
-    async storeTeamSubscriptionEntry(ts: TeamSubscription): Promise<TeamSubscription> {
-        return (await this.getRepo()).save(ts);
+    async storeTeamSubscriptionEntry(ts: TeamSubscription): Promise<void> {
+        const repo = await this.getRepo();
+        await repo.save(ts);
     }
 
     async findTeamSubscriptionById(id: string): Promise<TeamSubscription | undefined> {


### PR DESCRIPTION
## Description
Adds a simple sanity check for "too many slots per TS creation"

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6746

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
