### PR TITLE
[openvsx-proxy] Disable debug logging

### DIFF
--- a/chart/templates/openvsx-proxy-configmap.yaml
+++ b/chart/templates/openvsx-proxy-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   config.json: |
     {
-      "log_debug": true,
+      "log_debug": false,
       "cache_duration_regular": "{{ .Values.components.openVsxProxy.cacheDurationRegular | default "1m" }}",
       "cache_duration_backup": "{{ .Values.components.openVsxProxy.cacheDurationBackup | default "72h" }}",
       "url_upstream": "{{ .Values.components.openVsxProxy.vsxRegistryUrl | default "https://open-vsx.org" }}",

--- a/components/openvsx-proxy/pkg/handler.go
+++ b/components/openvsx-proxy/pkg/handler.go
@@ -75,7 +75,7 @@ func (o *OpenVSXProxy) Handler(p *httputil.ReverseProxy) func(http.ResponseWrite
 					minDate := time.Now().Add(-time.Duration(o.Config.CacheDurationRegular))
 					if t.After(minDate) {
 						hitCacheRegular = true
-						log.WithFields(logFields).Infof("cached value is younger than %s - using cached value", o.Config.CacheDurationRegular)
+						log.WithFields(logFields).Debugf("cached value is younger than %s - using cached value", o.Config.CacheDurationRegular)
 						for k, v := range cached.Header {
 							for i, val := range v {
 								if i == 0 {
@@ -95,7 +95,7 @@ func (o *OpenVSXProxy) Handler(p *httputil.ReverseProxy) func(http.ResponseWrite
 						o.metrics.DurationRequestProcessingHistogram.Observe(time.Since(start).Seconds())
 						return
 					} else {
-						log.WithFields(logFields).Infof("cached value is older than %s - ignoring cached value", o.Config.CacheDurationRegular)
+						log.WithFields(logFields).Debugf("cached value is older than %s - ignoring cached value", o.Config.CacheDurationRegular)
 					}
 				}
 			}


### PR DESCRIPTION
## Description
This PR disables the debug log of the `openvsx-proxy`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5823

## How to test
When the openvsx-proxy and workspaces start then everything is fine.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```