### PR TITLE
[db] Make hand-written transformers more robust against odd DB values

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-prebuild-info-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuild-info-entry.ts
@@ -16,7 +16,7 @@ export class DBPrebuildInfo  {
     prebuildId: string;
 
     @Column({
-        type: 'simple-json',
+        type: 'text',
         transformer: (() => {
             return {
                 to(value: any): any {
@@ -27,6 +27,7 @@ export class DBPrebuildInfo  {
                         const obj = JSON.parse(value);
                         return PrebuildInfo.is(obj) ? obj : undefined;
                     } catch (error) {
+                        return undefined;
                     }
                 }
             };


### PR DESCRIPTION
## Description
Make hand-written transformers more robust against odd DB values

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6642

## How to test
 1. Add an entry to `d_b_workspace_cluster` and set `admissionPreferences`/`admissionConstraints` to odd values like: `[`, `]` or `NULL`
    1. one terminal: `kubectl port-forward mysl-0 3306`
    2. another terminal: `mysql -u gitpod -h 127.0.0.1 -p`
    3. insert: `INSERT INTO d_b_workspace_cluster SET name = "test", url = "https://example.dev", state = "available", score = 100, maxScore = 100, govern = TRUE, tls = "{", admissionConstraints = "[", admissionPreferences = "]";`
 3. see that `ws-manager-bridge` logs errors (and failing re-tries), but you're still able to start a workspace
    1. grep for: `error parsing value ws-cluster from DB`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
make DB layer more robust against odd DB values
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
