### PR TITLE
[installer]: add support for S3-based object storage

### DIFF
--- a/components/content-service-api/go/config/config.go
+++ b/components/content-service-api/go/config/config.go
@@ -103,10 +103,12 @@ type GCPConfig struct {
 
 // MinIOConfig MinIOconfigures the MinIO remote storage backend
 type MinIOConfig struct {
-	Endpoint        string `json:"endpoint"`
-	AccessKeyID     string `json:"accessKey"`
-	SecretAccessKey string `json:"secretKey"`
-	Secure          bool   `json:"secure,omitempty"`
+	Endpoint            string `json:"endpoint"`
+	AccessKeyID         string `json:"accessKey"`
+	AccessKeyIdFile     string `json:"accessKeyFile"`
+	SecretAccessKey     string `json:"secretKey"`
+	SecretAccessKeyFile string `json:"secretKeyFile"`
+	Secure              bool   `json:"secure,omitempty"`
 
 	Region         string `json:"region"`
 	ParallelUpload uint   `json:"parallelUpload,omitempty"`

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -127,7 +127,8 @@ type ObjectStorage struct {
 }
 
 type ObjectStorageS3 struct {
-	Certificate ObjectRef `json:"certificate"`
+	Endpoint    string    `json:"endpoint" validate:"required"`
+	Credentials ObjectRef `json:"credentials" validate:"required"`
 }
 
 type ObjectStorageCloudStorage struct {
@@ -136,7 +137,7 @@ type ObjectStorageCloudStorage struct {
 }
 
 type ObjectStorageAzure struct {
-	Credentials ObjectRef `json:"credentials"`
+	Credentials ObjectRef `json:"credentials" validate:"required"`
 }
 
 type InstallationKind string

--- a/installer/pkg/config/v1/validation.go
+++ b/installer/pkg/config/v1/validation.go
@@ -82,6 +82,11 @@ func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
 		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("accountName", "accountKey")))
 	}
 
+	if cfg.ObjectStorage.S3 != nil {
+		secretName := cfg.ObjectStorage.S3.Credentials.Name
+		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("accessKeyId", "secretAccessKey")))
+	}
+
 	if cfg.ContainerRegistry.External != nil {
 		secretName := cfg.ContainerRegistry.External.Certificate.Name
 		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData(".dockerconfigjson")))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add support for S3-based object storage. This also makes a change to the `content-service` to allow reading a file - this is needed as we pass in a ConfigMap, but the credentials are in a Secret.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6772

## How to test
<!-- Provide steps to test this PR -->

Create a secret. The username/password are an AWS IAM with `AmazonS3FullAccess` policy 

```shell
kubectl create secret generic s3-storage-token --from-literal accessKeyId=xxx --from-literal secretAccessKey=xxx
```

Update the config

```yaml
objectStorage:
  s3:
    endpoint: s3.amazonaws.com
    credentials:
      kind: secret
      name: s3-storage-token
```

Run the Installer, create a workspace and check a bucket has been created

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
