### PR TITLE
[installer] Disable debug logging for openvsx-proxy

### DIFF
--- a/installer/pkg/components/openvsx-proxy/configmap.go
+++ b/installer/pkg/components/openvsx-proxy/configmap.go
@@ -19,7 +19,7 @@ import (
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	// todo(sje): enable redis config
 	imgcfg := openvsx.Config{
-		LogDebug:             true,
+		LogDebug:             false,
 		CacheDurationRegular: util.Duration(time.Minute),
 		CacheDurationBackup:  util.Duration(time.Hour * 72),
 		URLUpstream:          "https://open-vsx.org", // todo(sje): make configurable


### PR DESCRIPTION
## Description

Disable debug logging for openvsx-proxy in the installer. See also: https://github.com/gitpod-io/gitpod/pull/6774

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5823

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
