### PR TITLE
[ws-manager-api] Log ws-manager call error

### DIFF
--- a/components/ws-manager-api/typescript/src/promisified-client.ts
+++ b/components/ws-manager-api/typescript/src/promisified-client.ts
@@ -11,6 +11,7 @@ import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
 import * as opentracing from 'opentracing';
 import * as grpc from "@grpc/grpc-js";
 import { Disposable } from "@gitpod/gitpod-protocol";
+import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 
 export function withTracing(ctx: TraceContext) {
     const metadata = new grpc.Metadata();
@@ -46,7 +47,7 @@ async function linearBackoffRetry<Res>(run: (attempt: number) => Promise<Res>, a
                 throw err;
             }
 
-            console.warn(`ws-manager unavailable - retrying in ${delayMS}ms`);
+            log.warn(`ws-manager unavailable - retrying in ${delayMS}ms`, err);
             await new Promise((retry, _) => setTimeout(retry, delayMS));
         }
 
@@ -55,7 +56,7 @@ async function linearBackoffRetry<Res>(run: (attempt: number) => Promise<Res>, a
         }
     }
 
-    console.error(`ws-manager unavailable - no more attempts left`);
+    log.error(`ws-manager unavailable - no more attempts left`);
     throw error;
 }
 


### PR DESCRIPTION
## Description

In case of errors, `ws-manager-bridge` only shows a warning without any context.

```
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","serviceContext":{"service":"ws-manager-bridge","version":"<ts-not-set>"},"component":"ws-manager-bridge","severity":"WARNING","time":"2021-11-18T14:02:12.043Z","environment":"production","message":"ws-manager unavailable - retrying in 1000ms","loggedViaConsole":true}
```

## Release Notes
```release-note
NONE
```
