### PR TITLE
[Analytics] Fix domain and Expiration date in Dashboard's Segment Cookie

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -35,7 +35,7 @@ export const getAnonymousId = (): string => {
   }
   else {
     anonymousId = v4();
-    Cookies.set('ajs_anonymous_id', anonymousId);
+    Cookies.set('ajs_anonymous_id', anonymousId, {domain: '.'+window.location.hostname, expires: 365});
   };
   return anonymousId;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR introduces two minor changes to the dashboard's cookie:
- the expiration date of `ajs_anonymous_id` is set to a year
- the domain of `ajs_anonymous_id` is prefixed with a dot
The former ensures that we can recognize a visitor who has been to the dashboard before, the latter ensures that the website does not set its own value for `ajs_anonymous_id`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
- open any page on the preview environment.
- ensure in dev tools -> Applications -> Cookies that a cookie with the anonymous ID of the user was set for the domain `.<preview_env_url>` with an expiration date of a year

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe