### PR TITLE
[ws-manager] Add test for affinity template merge

### DIFF
--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -1,0 +1,242 @@
+{
+    "reason": {
+        "metadata": {
+            "name": "ws-test",
+            "namespace": "default",
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/networkpolicy": "default",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            },
+            "annotations": {
+                "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+                "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/requiredNodeServices": "ws-daemon,registry-facade",
+                "gitpod/admission": "admit_owner_only",
+                "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
+                "gitpod/id": "test",
+                "gitpod/imageSpec": "Cghzb21lLXJlZhI0ZXUuZ2NyLmlvL2dpdHBvZC1jb3JlLWRldi9idWlkL3RoZWlhLWlkZTpzb21ldmVyc2lvbg==",
+                "gitpod/never-ready": "true",
+                "gitpod/ownerToken": "%7J'[Of/8NDiWE+9F,I6^Jcj_1\u0026}-F8p",
+                "gitpod/servicePrefix": "foobarservice",
+                "gitpod/traceid": "",
+                "gitpod/url": "test-foobarservice-gitpod.io",
+                "prometheus.io/path": "/metrics",
+                "prometheus.io/port": "23000",
+                "prometheus.io/scrape": "true",
+                "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
+            }
+        },
+        "spec": {
+            "volumes": [
+                {
+                    "name": "vol-this-workspace",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test",
+                        "type": "DirectoryOrCreate"
+                    }
+                },
+                {
+                    "name": "daemon-mount",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test-daemon",
+                        "type": "DirectoryOrCreate"
+                    }
+                }
+            ],
+            "containers": [
+                {
+                    "name": "workspace",
+                    "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/workspacekit",
+                        "ring0"
+                    ],
+                    "ports": [
+                        {
+                            "containerPort": 23000
+                        }
+                    ],
+                    "env": [
+                        {
+                            "name": "GITPOD_REPO_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_CLI_APITOKEN",
+                            "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_ID",
+                            "value": "foobar"
+                        },
+                        {
+                            "name": "GITPOD_INSTANCE_ID",
+                            "value": "test"
+                        },
+                        {
+                            "name": "GITPOD_THEIA_PORT",
+                            "value": "23000"
+                        },
+                        {
+                            "name": "THEIA_WORKSPACE_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_HOST",
+                            "value": "gitpod.io"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_URL",
+                            "value": "test-foobarservice-gitpod.io"
+                        },
+                        {
+                            "name": "THEIA_SUPERVISOR_ENDPOINT",
+                            "value": ":22999"
+                        },
+                        {
+                            "name": "THEIA_WEBVIEW_EXTERNAL_ENDPOINT",
+                            "value": "webview-{{hostname}}"
+                        },
+                        {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_NAME",
+                            "value": "usernameGoesHere"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_EMAIL",
+                            "value": "some@user.com"
+                        },
+                        {
+                            "name": "GITPOD_INTERVAL",
+                            "value": "30000"
+                        },
+                        {
+                            "name": "GITPOD_MEMORY",
+                            "value": "999"
+                        }
+                    ],
+                    "resources": {
+                        "limits": {
+                            "cpu": "900m",
+                            "memory": "1G"
+                        },
+                        "requests": {
+                            "cpu": "899m",
+                            "ephemeral-storage": "5Gi",
+                            "memory": "999M"
+                        }
+                    },
+                    "volumeMounts": [
+                        {
+                            "name": "vol-this-workspace",
+                            "mountPath": "/workspace",
+                            "mountPropagation": "HostToContainer"
+                        },
+                        {
+                            "name": "daemon-mount",
+                            "mountPath": "/.workspace",
+                            "mountPropagation": "HostToContainer"
+                        }
+                    ],
+                    "readinessProbe": {
+                        "httpGet": {
+                            "path": "/_supervisor/v1/status/content/wait/true",
+                            "port": 22999,
+                            "scheme": "HTTP"
+                        },
+                        "initialDelaySeconds": 4,
+                        "timeoutSeconds": 1,
+                        "periodSeconds": 1,
+                        "successThreshold": 1,
+                        "failureThreshold": 600
+                    },
+                    "terminationMessagePolicy": "File",
+                    "imagePullPolicy": "IfNotPresent",
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "AUDIT_WRITE",
+                                "FSETID",
+                                "KILL",
+                                "NET_BIND_SERVICE",
+                                "SYS_PTRACE"
+                            ],
+                            "drop": [
+                                "SETPCAP",
+                                "CHOWN",
+                                "NET_RAW",
+                                "DAC_OVERRIDE",
+                                "FOWNER",
+                                "SYS_CHROOT",
+                                "SETFCAP",
+                                "SETUID",
+                                "SETGID"
+                            ]
+                        },
+                        "privileged": false,
+                        "runAsUser": 33333,
+                        "runAsGroup": 33333,
+                        "runAsNonRoot": true,
+                        "readOnlyRootFilesystem": false,
+                        "allowPrivilegeEscalation": true
+                    }
+                }
+            ],
+            "restartPolicy": "Never",
+            "serviceAccountName": "workspace",
+            "automountServiceAccountToken": false,
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "gitpod.io/workload_workspace_regular",
+                                        "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "foobar",
+                                        "operator": "Exists"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "schedulerName": "workspace-scheduler",
+            "tolerations": [
+                {
+                    "key": "node.kubernetes.io/disk-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/memory-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/network-unavailable",
+                    "operator": "Exists",
+                    "effect": "NoExecute",
+                    "tolerationSeconds": 30
+                }
+            ],
+            "enableServiceLinks": false
+        },
+        "status": {}
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.json
@@ -1,0 +1,38 @@
+{
+  "enforceAffinity": true,
+  "defaultTemplate": {
+      "spec": {
+          "affinity": {
+              "nodeAffinity": {
+                  "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "nodeSelectorTerms": [
+                          {
+                              "matchExpressions": [
+                                  {
+                                      "key": "foobar",
+                                      "operator": "Exists"
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              }
+          }
+      }
+  },
+  "spec": {
+      "ideImage": {
+          "webRef": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion"
+      },
+      "workspaceImage": "some-ref",
+      "initializer": {
+          "snapshot": {
+              "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"
+          }
+      },
+      "git": {
+          "username": "usernameGoesHere",
+          "email": "some@user.com"
+      }
+  }
+}


### PR DESCRIPTION
## Description
With the new installer, we're no longer setting node affinity as part of the workspace templates, but rather have ws-manager force the affinity. This PR adds a CDWP fixture test to ensure that if a user wants to control the workspace pod affinity using the workspace template, the `matchExpressions` get merged so that:

> If you specify multiple matchExpressions associated with nodeSelectorTerms, then the pod can be scheduled onto a node only if all matchExpressions is satisfied.

## How to test
See unit test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
