### PR TITLE
[dashboard] Extract IDE preferences data

### DIFF
--- a/components/dashboard/src/components/CheckBox.tsx
+++ b/components/dashboard/src/components/CheckBox.tsx
@@ -31,7 +31,7 @@ function CheckBox(props: {
         />
         <div className="flex flex-col ml-2">
             <label htmlFor={checkboxId} className="text-gray-800 dark:text-gray-100 text-md font-semibold cursor-pointer tracking-wide">{props.title}</label>
-            <div className="text-gray-400 text-md">{props.desc}</div>
+            <div className="text-gray-500 dark:text-gray-400 text-md">{props.desc}</div>
         </div>
     </div>
 }

--- a/components/dashboard/src/components/SelectableCard.tsx
+++ b/components/dashboard/src/components/SelectableCard.tsx
@@ -15,7 +15,7 @@ export interface SelectableCardProps {
 function SelectableCard(props: SelectableCardProps) {
     return <div className={`rounded-xl px-3 py-3 flex flex-col cursor-pointer group border-2 transition ease-in-out ${props.selected ? 'border-green-500' : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-400'} ${props.className || ''}`} onClick={props.onClick}>
         <div className="flex items-center">
-            <p className={`w-full pl-1 text-base font-semibold truncate ${props.selected ? 'text-green-500' : 'text-gray-400'}`} title={props.title}>{props.title}</p>
+            <p className={`w-full pl-1 text-base font-semibold truncate ${props.selected ? 'text-green-500' : 'text-gray-500 dark:text-gray-400'}`} title={props.title}>{props.title}</p>
             <input className={'text-green-500 ' + (props.selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')} type="radio" checked={props.selected} />
         </div>
         {props.children}

--- a/components/dashboard/src/images/ideLogos.ts
+++ b/components/dashboard/src/images/ideLogos.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+import goland from './golandLogo.svg';
+import intellijIdea from './intellijIdeaLogo.svg';
+import vscode from './vscode.svg';
+import vscodeInsiders from './vscodeInsiders.svg';
+
+const ideLogos: {[key:string]: string} = {
+    "vscode": vscode,
+    "vscode-insiders":vscodeInsiders,
+    "intellij-idea": intellijIdea,
+    "goland": goland,
+}
+
+export default ideLogos;


### PR DESCRIPTION
## Description
This PR is a minimum viable change towards an independent deployment of IDE preferences of the IDE team. It extracts a data structure `IdePreferences`. In the next step,  this preferences object should be served by `server` from the `server-ide-configmap`. That should allow us to change the IDE options by deploying a new configmap (no need for a dashboard deployment anymore).

Also, this opens the doors to deliver different IDE options to individual users (think A/B tests, etc.). 

---


This PR also includes a separate commit with some **UI improvements** suggested by @gtsiolis. Feel free to start discussions about more UI improvements. I would be happy to add them as well to this PR.

![image](https://user-images.githubusercontent.com/24960040/142489685-a2b24c88-7c12-4fbc-ba40-94763c9001fb.png)

---

### Next steps in follow-up PRs
- Move `IdePreferences` interface to gitpod-protocol
- Add `idePreferences` object to `server-ide-configmap`
- Serve the `idePreferences` from `server`



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #6601

## How to test
<!-- Provide steps to test this PR -->
Go to https://clu-ide-preferences.staging.gitpod-dev.com/projects and make sure that the available IDE options still work.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


