### PR TITLE
[code] upgrade to vscode 1.62.3

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -5,7 +5,7 @@ defaultArgs:
   npmPublishTrigger: "false"
   publishToNPM: true
   localAppVersion: unknown
-  codeCommit: e9535bab01c1f267edd9550387056b787f851e71
+  codeCommit: 25d9dd4c307716427469c02e8160b15cee4959f1
 
 defaultVariant:
   srcs:


### PR DESCRIPTION
## Description
Upgrade to VS Code 1.62.3 recovery release
Picks up fixes for the following upstream issues https://github.com/Microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22October+2021+Recovery+3%22

## How to test
<!-- Provide steps to test this PR -->
- Switch to latest VS Code in settings.
- Start a workspace.
- Use about dialog to check that version is 1.62.3

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
