### PR TITLE
[server] Serve IDE config via gitpod-protocol

### DIFF
--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -18,6 +18,7 @@
 {{ template "gitpod.comp.imageRepo" . }}:{{- $comp.insidersVersion | default (include "gitpod.comp.version" .) -}}
 {{- end -}}
 
+# For backwards compability - remove me soon
 {{- define "ide-images-aliases"}}
 {{- $ := .root -}}
 {{- $gp := .gp -}}
@@ -25,6 +26,7 @@ code: {{ (include "stable-image-full" (dict "root" $ "gp" $gp "comp" $gp.compone
 code-latest: {{ (include "insider-image-full" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.codeImage)) }}
 {{ end }}
 
+# For backwards compability - remove me soon
 {{- define "desktop-ide-images-aliases"}}
 {{- $ := .root -}}
 {{- $gp := .gp -}}
@@ -32,6 +34,73 @@ code-desktop: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp"
 code-desktop-insiders: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.codeDesktopInsiders)) }}
 intellij: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.intellij)) }}
 goland: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.goland)) }}
+{{ end }}
+
+{{- define "ide-options" }}
+{{- $ := .root -}}
+{{- $gp := .gp -}}
+options:
+
+  # Browser IDEs
+  theia:
+    title: "Theia (legacy)"
+    tooltip: "This entry exists solely for legacy reasons."
+    type: "browser"
+    logo: "invalid"
+    hidden: true
+    image: {{ (include "stable-image-full" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.codeImage)) }}
+  code:
+    orderKey: "00"
+    title: "VS Code"
+    type: "browser"
+    logo: "vscode"
+    image: {{ (include "stable-image-full" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.codeImage)) }}
+  code-latest:
+    orderKey: "01"
+    title: "VS Code"
+    type: "browser"
+    logo: "vscode-insiders"
+    tooltip: "Early access version, still subject to testing."
+    label: "Insiders"
+    image: {{ (include "insider-image-full" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.codeImage)) }}
+    resolveImageDigest: true
+
+  # Desktop IDEs
+  code-desktop:
+    orderKey: "02"
+    title: "VS Code"
+    type: "desktop"
+    logo: "vscode"
+    image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.codeDesktop)) }}
+  code-desktop-insiders:
+    orderKey: "03"
+    title: "VS Code"
+    type: "desktop"
+    logo: "vscode-insiders"
+    tooltip: "Visual Studio Code Insiders for early adopters."
+    label: "Insiders"
+    image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.codeDesktopInsiders)) }}
+  intellij:
+    orderKey: "04"
+    title: "IntelliJ IDEA"
+    type: "desktop"
+    logo: "intellij-idea"
+    tooltip: "IntelliJ IDEA from the Early-Access-Programm (EAP)"
+    label: "EAP"
+    notes: ["While in beta, when you open a workspace with IntelliJ IDEA you will need to use the password “gitpod”."]
+    image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.intellij)) }}
+  goland:
+    orderKey: "05"
+    title: "GoLand"
+    type: "desktop"
+    logo: "goland"
+    tooltip: "GoLand from the Early-Access-Programm (EAP)"
+    label: "EAP"
+    notes: ["While in beta, when you open a workspace with GoLand you will need to use the password “gitpod”."]
+    image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.goland)) }}
+
+defaultIde: "code"
+defaultDesktopIde: "code-desktop"
 {{ end }}
 
 {{- if $comp.serverIdeConfigDeploy.enabled }}
@@ -45,12 +114,15 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
+  # ideVersion, ideImageRepo, ideImageAliases, and desktopIdeImageAliases -- For backwards compability - remove me soon
   config.json: |-
     {
         "ideVersion": "{{ .Values.components.workspace.codeImage.stableVersion }}",
         "ideImageRepo": "{{ template "gitpod.comp.imageRepo" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.codeImage) }}",
         "ideImageAliases": {{ (include "ide-images-aliases" (dict "root" . "gp" $.Values)) | fromYaml | toJson }},
         "desktopIdeImageAliases": {{ (include "desktop-ide-images-aliases" (dict "root" . "gp" $.Values)) | fromYaml | toJson }},
-        "supervisorImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}"
+
+        "supervisorImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.supervisor) }}",
+        "ideOptions": {{ (include "ide-options" (dict "root" . "gp" $.Values)) | fromYaml | toJson }}
     }
 {{- end }}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -29,6 +29,7 @@ import { AccountStatement, CreditAlert } from './accounting-protocol';
 import { GithubUpgradeURL, PlanCoupon } from './payment-protocol';
 import { TeamSubscription, TeamSubscriptionSlot, TeamSubscriptionSlotResolved } from './team-subscription-protocol';
 import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from './analytics';
+import { IDEServer } from './ide-protocol';
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -45,7 +46,7 @@ export interface GitpodClient {
 }
 
 export const GitpodServer = Symbol('GitpodServer');
-export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, LicenseService {
+export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, LicenseService, IDEServer {
     // User related API
     getLoggedInUser(): Promise<User>;
     getTerms(): Promise<Terms>;

--- a/components/gitpod-protocol/src/ide-protocol.ts
+++ b/components/gitpod-protocol/src/ide-protocol.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+/**
+ * `IDEServer` provides a list of available IDEs.
+ */
+export interface IDEServer {
+    /**
+     * Returns the IDE preferences.
+     */
+    getIDEOptions(): Promise<IDEOptions>;
+}
+
+export interface IDEOptions {
+    /**
+     * A list of available IDEs.
+     */
+    options: { [key: string]: IDEOption };
+
+    /**
+     * The default (browser) IDE when the user has not specified one.
+     */
+    defaultIde: string;
+
+    /**
+     * The default desktop IDE when the user has not specified one.
+     */
+    defaultDesktopIde: string;
+}
+
+export interface IDEOption {
+    /**
+     * To ensure a stable order one can set an `orderKey`.
+     */
+    orderKey?: string;
+
+    /**
+     * Human readable title text of the IDE (plain text only).
+     */
+    title: string;
+
+    /**
+     * The type of the IDE, currently 'browser' or 'desktop'.
+     */
+    type: 'browser' | 'desktop';
+
+    /**
+    * The logo for the IDE. That could be a key in (see
+    * components/dashboard/src/images/ideLogos.ts) or a URL.
+    */
+    logo: string;
+
+    /**
+     * Text of an optional tooltip (plain text only).
+     */
+    tooltip?: string;
+
+    /**
+     * Text of an optional label next to the IDE option like “Insiders” (plain
+     * text only).
+     */
+    label?: string;
+
+    /**
+     * Notes to the IDE option that are renderd in the preferences when a user
+     * chooses this IDE.
+     */
+    notes?: string[];
+
+    /**
+    * If `true` this IDE option is not visible in the IDE preferences.
+    */
+    hidden?: boolean;
+
+    /**
+     * The image ref to the IDE image.
+     */
+    image: string;
+
+    /**
+     * When this is `true`, the tag of this image is resolved to the latest
+     * image digest regularly.
+     *
+     * This is useful if this image points to a tag like `nightly` that will be
+     * updated regularly. When `resolveImageDigest` is `true`, we make sure that
+     * we resolve the tag regularly to the most recent image version.
+     */
+    resolveImageDigest?: boolean;
+}

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -169,7 +169,8 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "tsReassignSlot":  { group: "default", points: 1 },
         "trackEvent":  { group: "default", points: 1 },
         "trackLocation": { group: "default", points: 1},
-        "identifyUser": { group: "default", points: 1}
+        "identifyUser": { group: "default", points: 1},
+        "getIDEOptions": { group: "default", points: 1 },
     };
 
     return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -52,6 +52,8 @@ import { InvalidGitpodYMLError } from "./config-provider";
 import { ProjectsService } from "../projects/projects-service";
 import { LocalMessageBroker } from "../messaging/local-message-broker";
 import { CachingBlobServiceClientProvider } from '@gitpod/content-service/lib/sugar';
+import { IDEOptions } from '@gitpod/gitpod-protocol/lib/ide-protocol';
+import { IDEConfigService } from '../ide-config';
 
 @injectable()
 export class GitpodServerImpl<Client extends GitpodClient, Server extends GitpodServer> implements GitpodServer, Disposable {
@@ -96,6 +98,8 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     @inject(HeadlessLogService) protected readonly headlessLogService: HeadlessLogService;
 
     @inject(ProjectsService) protected readonly projectsService: ProjectsService;
+
+    @inject(IDEConfigService) protected readonly ideConfigService: IDEConfigService;
 
     /** Id the uniquely identifies this server instance */
     public readonly uuid: string = uuidv4();
@@ -2065,6 +2069,10 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         return this.termsProvider.getCurrent();
     }
 
+    async getIDEOptions(): Promise<IDEOptions> {
+        const ideConfig = await this.ideConfigService.config;
+        return ideConfig.ideOptions;
+    }
 
     //#region gitpod.io concerns
     //

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -307,16 +307,15 @@ export class WorkspaceStarter {
         // TODO(cw): once we allow changing the IDE in the workspace config (i.e. .gitpod.yml), we must
         //           give that value precedence over the default choice.
         const configuration: WorkspaceInstanceConfiguration = {
-            theiaVersion: ideConfig.ideVersion,
-            ideImage: ideConfig.ideImage,
+            ideImage: ideConfig.ideOptions.options[ideConfig.ideOptions.defaultIde].image,
             supervisorImage: ideConfig.supervisorImage,
         };
 
         const ideChoice = user.additionalData?.ideSettings?.defaultIde;
         if (!!ideChoice) {
-            const mappedImage = ideConfig.ideImageAliases[ideChoice];
-            if (!!mappedImage) {
-                configuration.ideImage = mappedImage;
+            const mappedImage = ideConfig.ideOptions.options[ideChoice];
+            if (!!mappedImage && mappedImage.image) {
+                configuration.ideImage = mappedImage.image;
             } else if (this.authService.hasPermission(user, "ide-settings")) {
                 // if the IDE choice isn't one of the preconfiured choices, we assume its the image name.
                 // For now, this feature requires special permissions.
@@ -328,9 +327,9 @@ export class WorkspaceStarter {
         if (useDesktopIdeChoice) {
             const desktopIdeChoice = user.additionalData?.ideSettings?.defaultDesktopIde;
             if (!!desktopIdeChoice) {
-                const mappedImage = ideConfig.desktopIdeImageAliases[desktopIdeChoice];
-                if (!!mappedImage) {
-                    configuration.desktopIdeImage = mappedImage;
+                const mappedImage = ideConfig.ideOptions.options[desktopIdeChoice];
+                if (!!mappedImage && mappedImage.image) {
+                    configuration.desktopIdeImage = mappedImage.image;
                 } else if (this.authService.hasPermission(user, "ide-settings")) {
                     // if the IDE choice isn't one of the preconfiured choices, we assume its the image name.
                     // For now, this feature requires special permissions.
@@ -606,7 +605,7 @@ export class WorkspaceStarter {
         });
 
         const ideAlias = user.additionalData?.ideSettings?.defaultIde;
-        if (ideAlias && ideConfig.ideImageAliases[ideAlias]) {
+        if (ideAlias && ideConfig.ideOptions.options[ideAlias]) {
             const ideAliasEnv = new EnvironmentVariable();
             ideAliasEnv.setName('GITPOD_IDE_ALIAS');
             ideAliasEnv.setValue(ideAlias);
@@ -734,7 +733,7 @@ export class WorkspaceStarter {
         if (!!instance.configuration?.ideImage) {
             ideImage = instance.configuration?.ideImage;
         } else {
-            ideImage = ideConfig.ideImage;
+            ideImage = ideConfig.ideOptions.options[ideConfig.ideOptions.defaultIde].image;
         }
 
         const spec = new StartWorkspaceSpec();

--- a/installer/pkg/components/server/types.go
+++ b/installer/pkg/components/server/types.go
@@ -10,11 +10,37 @@ import "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 
 // IDEConfig RawIDEConfig interface from components/server/src/ide-config.ts
 type IDEConfig struct {
-	IDEVersion             string            `json:"ideVersion"`
-	IDEImageRepo           string            `json:"ideImageRepo"`
-	IDEImageAliases        map[string]string `json:"ideImageAliases"`
-	DesktopIDEImageAliases map[string]string `json:"deskoptIdeImageAliases"`
+	// Deprecated
+	IDEVersion string `json:"ideVersion"`
+	// Deprecated
+	IDEImageRepo string `json:"ideImageRepo"`
+	// Deprecated
+	IDEImageAliases map[string]string `json:"ideImageAliases"`
+	// Deprecated
+	DesktopIDEImageAliases map[string]string `json:"desktopIdeImageAliases"`
 	SupervisorImage        string            `json:"supervisorImage"`
+	IDEOptions             IDEOptions        `json:"ideOptions"`
+}
+
+// IDEOptions interface from components/gitpod-protocol/src/ide-protocol.ts
+type IDEOptions struct {
+	Options           map[string]IDEOption `json:"options"`
+	DefaultIDE        string               `json:"defaultIde"`
+	DefaultDesktopIDE string               `json:"defaultDesktopIde"`
+}
+
+// IDEOption interface from components/gitpod-protocol/src/ide-protocol.ts
+type IDEOption struct {
+	OrderKey           *string  `json:"orderKey,omitempty"`
+	Title              string   `json:"title"`
+	Type               string   `json:"type"`
+	Logo               string   `json:"logo"`
+	Tooltip            *string  `json:"tooltip,omitempty"`
+	Label              *string  `json:"label,omitempty"`
+	Notes              []string `json:"notes,omitempty"`
+	Hidden             *bool    `json:"hidden,omitempty"`
+	Image              string   `json:"image"`
+	ResolveImageDigest *bool    `json:"resolveImageDigest,omitempty"`
 }
 
 // ConfigSerialized interface from components/server/src/config.ts

--- a/installer/pkg/components/workspace/constants.go
+++ b/installer/pkg/components/workspace/constants.go
@@ -9,7 +9,8 @@ const (
 	ContainerPort                = 23000
 	DefaultWorkspaceImage        = "gitpod/workspace-full"
 	DefaultWorkspaceImageVersion = "latest"
-	CodeIDEImage                 = "ide/code" // todo(sje): does this need to be config driven?
+	CodeIDEImage                 = "ide/code"
+	CodeIDEImageStableVersion    = "commit-d8477d484d00967a92686642b33541aed824cb63" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage          = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage  = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage      = "ide/intellij"

--- a/installer/pkg/components/ws-scheduler/configmap.go
+++ b/installer/pkg/components/ws-scheduler/configmap.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
@@ -40,8 +39,6 @@ type config struct {
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	// todo(sje): check this config
-
-	codeImageStableVersion := server.CodeImageStableVersion(ctx)
 
 	scaler := struct {
 		Enabled    bool                                        `json:"enabled"`
@@ -87,7 +84,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 			WorkspaceImage:     common.ImageName("", workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
-			IDEImage:           common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, codeImageStableVersion),
+			IDEImage:           common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, workspace.CodeIDEImageStableVersion),
 			SupervisorImage:    common.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
 			FeatureFlags:       nil,
 			MaxGhostWorkspaces: 10,

--- a/installer/pkg/config/versions/versions.go
+++ b/installer/pkg/config/versions/versions.go
@@ -36,7 +36,6 @@ type Components struct {
 	ServiceWaiter    Versioned `json:"serviceWaiter"`
 	Workspace        struct {
 		CodeImage        Versioned `json:"codeImage"`
-		CodeImageStable  Versioned `json:"codeImageStable"`
 		DockerUp         Versioned `json:"dockerUp"`
 		Supervisor       Versioned `json:"supervisor"`
 		DesktopIdeImages struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With this PR the IDE entries on the preferences page are served from the `server-ide-configmap`. This allows the IDE team to add new IDEs by just editing the configmap.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6601

## How to test
<!-- Provide steps to test this PR -->
- Make sure that changing the IDE still works.
- You can test the code by changing the server-ide-configmap (e.g. change name, set `hidden`, remove entires etc.) and verifying that the changes are propagated to the dashboard. Just change the configmap, no component restart is needed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

