### PR TITLE
[installer] Update policy api to v1

### DIFF
--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -470,7 +470,7 @@ var (
 		Kind:       "Secret",
 	}
 	TypeMetaPodSecurityPolicy = metav1.TypeMeta{
-		APIVersion: "policy/v1beta1",
+		APIVersion: "policy/v1",
 		Kind:       "PodSecurityPolicy",
 	}
 	TypeMetaResourceQuota = metav1.TypeMeta{

--- a/installer/pkg/components/cluster/podsecuritypolicies.go
+++ b/installer/pkg/components/cluster/podsecuritypolicies.go
@@ -6,9 +6,10 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -16,7 +17,7 @@ import (
 
 func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{
-		&v1beta1.PodSecurityPolicy{
+		&policyv1.PodSecurityPolicy{
 			TypeMeta: common.TypeMetaPodSecurityPolicy,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-ns-privileged", ctx.Namespace),
@@ -28,25 +29,25 @@ func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
 				},
 			},
-			Spec: v1beta1.PodSecurityPolicySpec{
+			Spec: policyv1.PodSecurityPolicySpec{
 				Privileged:               true,
 				AllowPrivilegeEscalation: pointer.Bool(true),
 				AllowedCapabilities:      []corev1.Capability{"*"},
-				Volumes:                  []v1beta1.FSType{v1beta1.All},
+				Volumes:                  []policyv1.FSType{policyv1.All},
 				HostNetwork:              true,
-				HostPorts: []v1beta1.HostPortRange{{
+				HostPorts: []policyv1.HostPortRange{{
 					Min: 0,
 					Max: 65535,
 				}},
 				HostIPC:            true,
 				HostPID:            true,
-				RunAsUser:          v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
-				SELinux:            v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
-				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{Rule: v1beta1.SupplementalGroupsStrategyRunAsAny},
-				FSGroup:            v1beta1.FSGroupStrategyOptions{Rule: v1beta1.FSGroupStrategyRunAsAny},
+				RunAsUser:          policyv1.RunAsUserStrategyOptions{Rule: policyv1.RunAsUserStrategyRunAsAny},
+				SELinux:            policyv1.SELinuxStrategyOptions{Rule: policyv1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{Rule: policyv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:            policyv1.FSGroupStrategyOptions{Rule: policyv1.FSGroupStrategyRunAsAny},
 			},
 		},
-		&v1beta1.PodSecurityPolicy{
+		&policyv1.PodSecurityPolicy{
 			TypeMeta: common.TypeMetaPodSecurityPolicy,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace),
@@ -58,25 +59,25 @@ func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
 				},
 			},
-			Spec: v1beta1.PodSecurityPolicySpec{
+			Spec: policyv1.PodSecurityPolicySpec{
 				Privileged:               true,
 				AllowPrivilegeEscalation: pointer.Bool(true),
 				AllowedCapabilities:      []corev1.Capability{"*"},
-				Volumes:                  []v1beta1.FSType{v1beta1.All},
+				Volumes:                  []policyv1.FSType{policyv1.All},
 				HostNetwork:              false,
-				HostPorts: []v1beta1.HostPortRange{{
+				HostPorts: []policyv1.HostPortRange{{
 					Min: 0,
 					Max: 65535,
 				}},
 				HostIPC:            false,
 				HostPID:            true,
-				RunAsUser:          v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
-				SELinux:            v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
-				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{Rule: v1beta1.SupplementalGroupsStrategyRunAsAny},
-				FSGroup:            v1beta1.FSGroupStrategyOptions{Rule: v1beta1.FSGroupStrategyRunAsAny},
+				RunAsUser:          policyv1.RunAsUserStrategyOptions{Rule: policyv1.RunAsUserStrategyRunAsAny},
+				SELinux:            policyv1.SELinuxStrategyOptions{Rule: policyv1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{Rule: policyv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:            policyv1.FSGroupStrategyOptions{Rule: policyv1.FSGroupStrategyRunAsAny},
 			},
 		},
-		&v1beta1.PodSecurityPolicy{
+		&policyv1.PodSecurityPolicy{
 			TypeMeta: common.TypeMetaPodSecurityPolicy,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-ns-restricted-root-user", ctx.Namespace),
@@ -88,35 +89,35 @@ func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
 				},
 			},
-			Spec: v1beta1.PodSecurityPolicySpec{
+			Spec: policyv1.PodSecurityPolicySpec{
 				Privileged: true,
-				Volumes: []v1beta1.FSType{
-					v1beta1.ConfigMap,
-					v1beta1.Projected,
-					v1beta1.Secret,
-					v1beta1.EmptyDir,
-					v1beta1.PersistentVolumeClaim,
-					v1beta1.HostPath,
+				Volumes: []policyv1.FSType{
+					policyv1.ConfigMap,
+					policyv1.Projected,
+					policyv1.Secret,
+					policyv1.EmptyDir,
+					policyv1.PersistentVolumeClaim,
+					policyv1.HostPath,
 				},
 				HostNetwork: true,
-				HostPorts: []v1beta1.HostPortRange{{
+				HostPorts: []policyv1.HostPortRange{{
 					Min: 30000,
 					Max: 33000,
 				}},
 				HostIPC:   false,
 				HostPID:   false,
-				RunAsUser: v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
-				SELinux:   v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
-				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
-					Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
-					Ranges: []v1beta1.IDRange{{
+				RunAsUser: policyv1.RunAsUserStrategyOptions{Rule: policyv1.RunAsUserStrategyRunAsAny},
+				SELinux:   policyv1.SELinuxStrategyOptions{Rule: policyv1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{
+					Rule: policyv1.SupplementalGroupsStrategyMustRunAs,
+					Ranges: []policyv1.IDRange{{
 						Min: 1,
 						Max: 65535,
 					}},
 				},
-				FSGroup: v1beta1.FSGroupStrategyOptions{
-					Rule: v1beta1.FSGroupStrategyMustRunAs,
-					Ranges: []v1beta1.IDRange{{
+				FSGroup: policyv1.FSGroupStrategyOptions{
+					Rule: policyv1.FSGroupStrategyMustRunAs,
+					Ranges: []policyv1.IDRange{{
 						Min: 1,
 						Max: 65535,
 					}},
@@ -124,7 +125,7 @@ func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 				ReadOnlyRootFilesystem: false,
 			},
 		},
-		&v1beta1.PodSecurityPolicy{
+		&policyv1.PodSecurityPolicy{
 			TypeMeta: common.TypeMetaPodSecurityPolicy,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-ns-unprivileged", ctx.Namespace),
@@ -136,32 +137,32 @@ func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
 				},
 			},
-			Spec: v1beta1.PodSecurityPolicySpec{
+			Spec: policyv1.PodSecurityPolicySpec{
 				Privileged:               false,
 				AllowPrivilegeEscalation: pointer.Bool(false),
 				RequiredDropCapabilities: []corev1.Capability{"ALL"},
-				Volumes: []v1beta1.FSType{
-					v1beta1.ConfigMap,
-					v1beta1.EmptyDir,
-					v1beta1.Projected,
-					v1beta1.Secret,
-					v1beta1.PersistentVolumeClaim,
+				Volumes: []policyv1.FSType{
+					policyv1.ConfigMap,
+					policyv1.EmptyDir,
+					policyv1.Projected,
+					policyv1.Secret,
+					policyv1.PersistentVolumeClaim,
 				},
 				HostNetwork: false,
 				HostIPC:     false,
 				HostPID:     false,
-				RunAsUser:   v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyMustRunAsNonRoot},
-				SELinux:     v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
-				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
-					Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
-					Ranges: []v1beta1.IDRange{{
+				RunAsUser:   policyv1.RunAsUserStrategyOptions{Rule: policyv1.RunAsUserStrategyMustRunAsNonRoot},
+				SELinux:     policyv1.SELinuxStrategyOptions{Rule: policyv1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{
+					Rule: policyv1.SupplementalGroupsStrategyMustRunAs,
+					Ranges: []policyv1.IDRange{{
 						Min: 1,
 						Max: 65535,
 					}},
 				},
-				FSGroup: v1beta1.FSGroupStrategyOptions{
-					Rule: v1beta1.FSGroupStrategyMustRunAs,
-					Ranges: []v1beta1.IDRange{{
+				FSGroup: policyv1.FSGroupStrategyOptions{
+					Rule: policyv1.FSGroupStrategyMustRunAs,
+					Ranges: []policyv1.IDRange{{
 						Min: 1,
 						Max: 65535,
 					}},

--- a/installer/pkg/components/registry-facade/podsecuritypolicy.go
+++ b/installer/pkg/components/registry-facade/podsecuritypolicy.go
@@ -6,15 +6,16 @@ package registryfacade
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func podsecuritypolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return []runtime.Object{&v1beta1.PodSecurityPolicy{
+	return []runtime.Object{&policyv1.PodSecurityPolicy{
 		TypeMeta: common.TypeMetaPodSecurityPolicy,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
@@ -27,36 +28,36 @@ func podsecuritypolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 				"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
 			},
 		},
-		Spec: v1beta1.PodSecurityPolicySpec{
-			Volumes: []v1beta1.FSType{
-				v1beta1.ConfigMap,
-				v1beta1.Secret,
-				v1beta1.EmptyDir,
-				v1beta1.HostPath,
+		Spec: policyv1.PodSecurityPolicySpec{
+			Volumes: []policyv1.FSType{
+				policyv1.ConfigMap,
+				policyv1.Secret,
+				policyv1.EmptyDir,
+				policyv1.HostPath,
 			},
 			HostNetwork: true,
 			HostIPC:     false,
 			HostPID:     false,
-			HostPorts: []v1beta1.HostPortRange{{
+			HostPorts: []policyv1.HostPortRange{{
 				Min: 30000,
 				Max: 33000,
 			}},
-			RunAsUser: v1beta1.RunAsUserStrategyOptions{
-				Rule: v1beta1.RunAsUserStrategyRunAsAny,
+			RunAsUser: policyv1.RunAsUserStrategyOptions{
+				Rule: policyv1.RunAsUserStrategyRunAsAny,
 			},
-			SELinux: v1beta1.SELinuxStrategyOptions{
-				Rule: v1beta1.SELinuxStrategyRunAsAny,
+			SELinux: policyv1.SELinuxStrategyOptions{
+				Rule: policyv1.SELinuxStrategyRunAsAny,
 			},
-			SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
-				Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
-				Ranges: []v1beta1.IDRange{{
+			SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{
+				Rule: policyv1.SupplementalGroupsStrategyMustRunAs,
+				Ranges: []policyv1.IDRange{{
 					Min: 1,
 					Max: 65535,
 				}},
 			},
-			FSGroup: v1beta1.FSGroupStrategyOptions{
-				Rule: v1beta1.FSGroupStrategyMustRunAs,
-				Ranges: []v1beta1.IDRange{{
+			FSGroup: policyv1.FSGroupStrategyOptions{
+				Rule: policyv1.FSGroupStrategyMustRunAs,
+				Ranges: []policyv1.IDRange{{
 					Min: 1,
 					Max: 65535,
 				}},

--- a/installer/pkg/components/workspace/podsecuritypolicies.go
+++ b/installer/pkg/components/workspace/podsecuritypolicies.go
@@ -6,9 +6,10 @@ package workspace
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -16,7 +17,7 @@ import (
 
 func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{
-		&v1beta1.PodSecurityPolicy{
+		&policyv1.PodSecurityPolicy{
 			TypeMeta: common.TypeMetaPodSecurityPolicy,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-ns-workspace", ctx.Namespace),
@@ -28,26 +29,26 @@ func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
 				},
 			},
-			Spec: v1beta1.PodSecurityPolicySpec{
+			Spec: policyv1.PodSecurityPolicySpec{
 				Privileged:               false,
 				AllowPrivilegeEscalation: pointer.Bool(true),
 				AllowedCapabilities:      []corev1.Capability{"AUDIT_WRITE", "FSETID", "KILL", "NET_BIND_SERVICE", "SYS_PTRACE"},
-				Volumes:                  []v1beta1.FSType{v1beta1.ConfigMap, v1beta1.Projected, v1beta1.Secret, v1beta1.HostPath},
+				Volumes:                  []policyv1.FSType{policyv1.ConfigMap, policyv1.Projected, policyv1.Secret, policyv1.HostPath},
 				HostNetwork:              false,
 				HostIPC:                  false,
 				HostPID:                  false,
-				RunAsUser:                v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
-				SELinux:                  v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
-				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
-					Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
-					Ranges: []v1beta1.IDRange{{
+				RunAsUser:                policyv1.RunAsUserStrategyOptions{Rule: policyv1.RunAsUserStrategyRunAsAny},
+				SELinux:                  policyv1.SELinuxStrategyOptions{Rule: policyv1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{
+					Rule: policyv1.SupplementalGroupsStrategyMustRunAs,
+					Ranges: []policyv1.IDRange{{
 						Min: 1,
 						Max: 65535,
 					}},
 				},
-				FSGroup: v1beta1.FSGroupStrategyOptions{
-					Rule: v1beta1.FSGroupStrategyMustRunAs,
-					Ranges: []v1beta1.IDRange{{
+				FSGroup: policyv1.FSGroupStrategyOptions{
+					Rule: policyv1.FSGroupStrategyMustRunAs,
+					Ranges: []policyv1.IDRange{{
 						Min: 1,
 						Max: 65535,
 					}},


### PR DESCRIPTION
## Description

Fixes `Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Update policy api to v1
```
