### PR TITLE
[installer] Remove Jobs after a minute of completion

### DIFF
--- a/installer/pkg/components/database/init/job.go
+++ b/installer/pkg/components/database/init/job.go
@@ -8,6 +8,7 @@ package init
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 		TypeMeta:   common.TypeMetaBatchJob,
 		ObjectMeta: objectMeta,
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: pointer.Int32(60),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: objectMeta,
 				Spec: corev1.PodSpec{

--- a/installer/pkg/components/migrations/job.go
+++ b/installer/pkg/components/migrations/job.go
@@ -24,6 +24,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 		TypeMeta:   common.TypeMetaBatchJob,
 		ObjectMeta: objectMeta,
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: pointer.Int32(60),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: objectMeta,
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
## Description

Remove finished Jobs to allow reuse of same manifests

Fixes #6573

## How to test

Check `migration` pod is removed after a minute of running the installer

```release-note
NONE
```
