### PR TITLE
Fix JetBrains update GitHub action

### DIFF
--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -61,7 +61,7 @@ jobs:
           data=$(curl -sSL "https://data.services.jetbrains.com/products?code=GO&release.type=eap%2Crc&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000")
           link=$(echo "$data" | jq -r '.[0].releases[0].downloads.linux.link')
           build=$(echo "$data" | jq -r '.[0].releases[0].build')
-          build2=$(echo "$build" sed 's/\./-/g')
+          build2=$(echo "$build" | sed 's/\./-/g')
           echo "::set-output name=result::$link"
           echo "::set-output name=version::$build"
           echo "::set-output name=version2::$build2"


### PR DESCRIPTION
## Description
Fixes a tiny missing `|` in the GitHub action.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6804

## How to test
<!-- Provide steps to test this PR -->
Nothing to do.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

