### PR TITLE
[jetbrains] Remove werft secret

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -174,8 +174,7 @@ export async function build(context, version) {
     if (withContrib || publishRelease) {
         exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} -Dversion=${version} -DimageRepoBase=${imageRepo} contrib:all`);
     }
-    const jetbrainsArgs = `-DINTELLIJ_PLUGIN_PLATFORM_VERSION=${process.env.INTELLIJ_PLUGIN_PLATFORM_VERSION} -DINTELLIJ_BACKEND_URL=${process.env.INTELLIJ_BACKEND_URL} -DGOLAND_BACKEND_URL=${process.env.GOLAND_BACKEND_URL}`;
-    exec(`leeway build --docker-build-options network=host --werft=true -c remote ${retag} --coverage-output-path=${coverageOutput} -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo} -DlocalAppVersion=${localAppVersion} ${jetbrainsArgs} -DnpmPublishTrigger=${publishToNpm ? Date.now() : 'false'}`);
+    exec(`leeway build --docker-build-options network=host --werft=true -c remote ${retag} --coverage-output-path=${coverageOutput} -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo} -DlocalAppVersion=${localAppVersion} -DnpmPublishTrigger=${publishToNpm ? Date.now() : 'false'}`);
     if (publishRelease) {
         try {
             werft.phase("publish", "checking version semver compliance...");

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -145,9 +145,6 @@ pod:
         secretKeyRef:
           name: honeycomb-api-key
           key: apikey
-    envFrom:
-    - secretRef:
-        name: jetbrains-secrets
     command:
       - bash
       - -c

--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -12,11 +12,8 @@ packages:
       - "gradlew"
       - "settings.gradle.kts"
       - "src/main/resources/*"
-    argdeps:
-      - INTELLIJ_PLUGIN_PLATFORM_VERSION
     env:
       - JAVA_HOME=/home/gitpod/.sdkman/candidates/java/current
-      - INTELLIJ_PLUGIN_PLATFORM_VERSION=${INTELLIJ_PLUGIN_PLATFORM_VERSION}
     config:
       commands:
         - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "buildPlugin"]

--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
     pluginName.set(properties("pluginName"))
-    version.set(System.getenv("INTELLIJ_PLUGIN_PLATFORM_VERSION"))
+    version.set(properties("platformVersion"))
     type.set(properties("platformType"))
     instrumentCode.set(false)
     downloadSources.set(properties("platformDownloadSources").toBoolean())

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -15,7 +15,9 @@ pluginUntilBuild = 213.*
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions = 2021.3.1
 
+# IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
+platformVersion = 213-EAP-SNAPSHOT
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -38,7 +38,6 @@ packages:
       - components/ide/jetbrains/backend-plugin:plugin
     argdeps:
       - imageRepoBase
-      - GOLAND_BACKEND_URL
     config:
       dockerfile: leeway.Dockerfile
       metadata:


### PR DESCRIPTION
## Description
Initially, we should not publish the download URLs. In the meantime, they are publicly available. For this reason, we don't need to hide them in a secret anymore.

This PR removes the usage of the secret.


_When the PR has been merged (and ideally all branches has been rebased) the secret in the `werft` namespace can be removed as well._

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6787

## How to test
<!-- Provide steps to test this PR -->
It can not hurt to make sure the JetBrains images still work (go to the preferences and switch to the JetBrains IDEs, start a workspace, ...). However, nothing should have changed in the images.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

