### PR TITLE
[ops] Add dashboard "Meta Services"

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/meta-services.json
+++ b/operations/observability/mixins/meta/dashboards/components/meta-services.json
@@ -1,0 +1,489 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1637673525850,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "repeat": "cluster",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": "VictoriaMetrics",
+          "exemplar": true,
+          "expr": "sum(\n    rate(container_cpu_usage_seconds_total{container!=\"POD\", cluster=~\"$cluster\", node=~\"$node\", pod=~\"$component-.*\"}[5m])\n) by (pod, cluster, node)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{ pod }} - {{ node }}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "$cluster: CPU per Pod (# of vCores)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "repeat": "cluster",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(container_memory_working_set_bytes{container!=\"POD\", cluster=~\"$cluster\", node=~\"$node\", pod=~\"$component-.*\"}) by (pod, cluster, node)",
+          "interval": "",
+          "legendFormat": "{{ pod }} - {{ node }}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "$cluster: RAM usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "repeat": "cluster",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum (\n  rate(container_network_receive_bytes_total{container!=\"POD\", cluster=~\"$cluster\", node=~\"$node\", pod=~\"$component-.*\"}[5m])\n) by (pod, cluster, node)",
+          "interval": "",
+          "legendFormat": "{{ pod }} - {{ node }}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "$cluster: Network Utilization",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 31,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "VictoriaMetrics",
+        "definition": "label_values(up{job=\"messagebus\"}, cluster)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(up{job=\"messagebus\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "VictoriaMetrics",
+        "definition": "label_values(kube_node_info{cluster=~\"$cluster\", node=~\".*-services-.*\"}, node)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "node",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_node_info{cluster=~\"$cluster\", node=~\".*-services-.*\"}, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": false,
+          "text": [
+            "content-service",
+            "dashboard",
+            "db",
+            "db-sync",
+            "messagebus",
+            "kedge",
+            "payment-endpoint",
+            "proxy",
+            "server",
+            "ws-manager-bridge"
+          ],
+          "value": [
+            "content-service",
+            "dashboard",
+            "db",
+            "db-sync",
+            "messagebus",
+            "kedge",
+            "payment-endpoint",
+            "proxy",
+            "server",
+            "ws-manager-bridge"
+          ]
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "component",
+        "multi": true,
+        "name": "component",
+        "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": true,
+            "text": "content-service",
+            "value": "content-service"
+          },
+          {
+            "selected": true,
+            "text": "dashboard",
+            "value": "dashboard"
+          },
+          {
+            "selected": true,
+            "text": "db",
+            "value": "db"
+          },
+          {
+            "selected": true,
+            "text": "db-sync",
+            "value": "db-sync"
+          },
+          {
+            "selected": true,
+            "text": "messagebus",
+            "value": "messagebus"
+          },
+          {
+            "selected": true,
+            "text": "kedge",
+            "value": "kedge"
+          },
+          {
+            "selected": true,
+            "text": "payment-endpoint",
+            "value": "payment-endpoint"
+          },
+          {
+            "selected": true,
+            "text": "proxy",
+            "value": "proxy"
+          },
+          {
+            "selected": true,
+            "text": "server",
+            "value": "server"
+          },
+          {
+            "selected": true,
+            "text": "ws-manager-bridge",
+            "value": "ws-manager-bridge"
+          },
+          {
+            "selected": false,
+            "text": "image-builder",
+            "value": "image-builder"
+          },
+          {
+            "selected": false,
+            "text": "image-builder-mk3",
+            "value": "image-builder-mk3"
+          }
+        ],
+        "query": "content-service, dashboard, db, db-sync, messagebus, kedge, payment-endpoint, proxy, server, ws-manager-bridge, image-builder, image-builder-mk3",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Meta Services",
+  "uid": "gitpod-services",
+  "version": 28
+}


### PR DESCRIPTION
## Description
Adds a separate "Meta Services" dashboard which shows aggregated resource usage for all meta-services.
[Link](https://grafana.gitpod.io/d/gitpod-services/meta-services?orgId=1&var-cluster=All&from=now-3h&to=now&var-node=All&var-pod=All&var-service=content-service&var-service=dashboard&var-service=db&var-service=db-sync&var-service=messagebus&var-service=kedge&var-service=payment-endpoint&var-service=proxy&var-service=server&var-service=ws-manager-bridge&var-component=content-service&var-component=dashboard&var-component=db&var-component=db-sync&var-component=messagebus&var-component=kedge&var-component=payment-endpoint&var-component=proxy&var-component=server&var-component=ws-manager-bridge)

![image](https://user-images.githubusercontent.com/32448529/143031537-947d7359-e6ef-4a60-991f-a2ce189348d6.png)

A note on the `service` variable:
 - it would be nice if we could generate the list of values (using `label_values(kube_pod_labels{cluster="prod-meta-eu01", namespace="default"}, component)`, for instance), but that's currently too polluted with workspace components - and we have no label to tell them apart
 - also, I added `image-builder`/`image-builder-mk3` (albeit as opt-in) for now so we can have an eye on those as well

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #6785 

## How to test
- check [this link](https://grafana.gitpod.io/d/gitpod-services/meta-services?orgId=1&var-cluster=All&from=now-3h&to=now&var-node=All&var-pod=All&var-service=content-service&var-service=dashboard&var-service=db&var-service=db-sync&var-service=messagebus&var-service=kedge&var-service=payment-endpoint&var-service=proxy&var-service=server&var-service=ws-manager-bridge&var-component=content-service&var-component=dashboard&var-component=db&var-component=db-sync&var-component=messagebus&var-component=kedge&var-component=payment-endpoint&var-component=proxy&var-component=server&var-component=ws-manager-bridge) and play around
- note that the branch-deployment may look different/not work due differences in metric setup/labelling

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-observability