### PR TITLE
[dashboard] Add more actions to workspace ready page

### DIFF
--- a/components/dashboard/src/components/Arrow.tsx
+++ b/components/dashboard/src/components/Arrow.tsx
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+function Arrow(props: { up: boolean }) {
+    return <span className="mx-2 border-gray-400 dark:border-gray-600 group-hover:border-gray-600 dark:group-hover:border-gray-400" style={{ marginTop: 2, marginBottom: 2, padding: 3, borderWidth: '0 2px 2px 0', display: 'inline-block', transform: `rotate(${props.up ? '-135deg' : '45deg'})` }}></span>
+}
+
+export default Arrow;

--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import React from 'react';
+import React, { HTMLAttributeAnchorTarget } from 'react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -26,6 +26,7 @@ export interface ContextMenuEntry {
     onClick?: (event: React.MouseEvent) => void;
     href?: string;
     link?: string;
+    target?: HTMLAttributeAnchorTarget;
 }
 
 function ContextMenu(props: ContextMenuProps) {
@@ -91,11 +92,11 @@ function ContextMenu(props: ContextMenuProps) {
                             </div>
                             const key = `entry-${menuId}-${index}-${e.title}`;
                             if (e.link) {
-                                return <Link key={key} to={e.link} onClick={e.onClick}>
+                                return <Link key={key} to={e.link} onClick={e.onClick} target={e.target}>
                                     {entry}
                                 </Link>;
                             } else if (e.href) {
-                                return <a key={key} href={e.href} onClick={e.onClick}>
+                                return <a key={key} href={e.href} onClick={e.onClick} target={e.target}>
                                     {entry}
                                 </a>;
                             } else {

--- a/components/dashboard/src/components/DropDown.tsx
+++ b/components/dashboard/src/components/DropDown.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import Arrow from './Arrow';
 import ContextMenu from './ContextMenu';
 
 export interface DropDownProps {
@@ -17,10 +18,6 @@ export interface DropDownProps {
 export interface DropDownEntry {
     title: string,
     onClick: ()=>void
-}
-
-function Arrow(props: {up: boolean}) {
-    return <span className="mx-2 border-gray-400 dark:border-gray-600 group-hover:border-gray-600 dark:group-hover:border-gray-400" style={{ marginTop: 2, marginBottom: 2, padding: 3, borderWidth: '0 2px 2px 0', display: 'inline-block', transform: `rotate(${props.up ? '-135deg' : '45deg'})`}}></span>
 }
 
 function DropDown(props: DropDownProps) {

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -4,15 +4,17 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import EventEmitter from "events";
-import React, { useEffect, Suspense } from "react";
-import { DisposableCollection, WorkspaceInstance, WorkspaceImageBuild, Workspace, WithPrebuild, ContextURL } from "@gitpod/gitpod-protocol";
+import { ContextURL, DisposableCollection, WithPrebuild, Workspace, WorkspaceImageBuild, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import EventEmitter from "events";
+import React, { Suspense, useEffect } from "react";
+import { v4 } from 'uuid';
+import Arrow from "../components/Arrow";
+import ContextMenu from "../components/ContextMenu";
 import PendingChangesDropdown from "../components/PendingChangesDropdown";
+import { watchHeadlessLogs } from "../components/PrebuildLogs";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
-import { watchHeadlessLogs } from "../components/PrebuildLogs";
-import { v4 } from 'uuid';
 const sessionId = v4();
 
 const WorkspaceLogs = React.lazy(() => import('../components/WorkspaceLogs'));
@@ -291,7 +293,23 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
               </div>
             </div>
             <div className="mt-10 justify-center flex space-x-2">
-              <button className="secondary" onClick={() => window.parent.postMessage({ type: 'openBrowserIde' }, '*')}>Open VS Code in Browser</button>
+              <ContextMenu menuEntries={[
+                {
+                  title: 'Open in Browser',
+                  onClick: () => window.parent.postMessage({ type: 'openBrowserIde' }, '*'),
+                },
+                {
+                  title: 'Stop Workspace',
+                  onClick: () => getGitpodService().server.stopWorkspace(this.props.workspaceId),
+                },
+                {
+                  title: 'Go to Dashboard',
+                  href: gitpodHostUrl.asDashboard().toString(),
+                  target: "_parent",
+                },
+              ]} >
+                <button className="secondary">More Actions...<Arrow up={false} /></button>
+              </ContextMenu>
               <a target="_blank" href={this.state.desktopIde.link}><button>{this.state.desktopIde.label}</button></a>
             </div>
           </div>;

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -312,6 +312,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
               </ContextMenu>
               <a target="_blank" href={this.state.desktopIde.link}><button>{this.state.desktopIde.label}</button></a>
             </div>
+            <div className="text-sm text-gray-400 dark:text-gray-500 mt-5">These IDE options are based on <a className="gp-link" href={gitpodHostUrl.asPreferences().toString()} target="_parent">your user preferences</a>.</div>
           </div>;
         }
 

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -104,6 +104,10 @@ export class GitpodHostUrl {
         return this.with(url => ({ pathname: '/settings' }));
     }
 
+    asPreferences(): GitpodHostUrl {
+        return this.with(url => ({ pathname: '/preferences' }));
+    }
+
     asGraphQLApi(): GitpodHostUrl {
         return this.with(url => ({ pathname: '/graphql/' }));
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds more actions to the “Your Workspace is Ready” page and adds a hint to the preferences [proposed by Lou](https://github.com/gitpod-io/gitpod/issues/6769#issuecomment-975317543).

![image](https://user-images.githubusercontent.com/24960040/143000658-70bdbae1-cb53-4b1c-915c-dd8a3d541542.png)

![image](https://user-images.githubusercontent.com/24960040/143000689-37dbfe34-dd6e-4f8f-a15c-2dcdc71ede97.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6769 and fixes #6841

## How to test
<!-- Provide steps to test this PR -->
Open a workspace with a desktop IDE enabled in the preferences and check that all links are working.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The “Your Workspace is Ready” page for desktop IDEs now has “Stop Workspace” and “Go to Dashboard” actions.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

@loujaybee Any docs updates needed?
