### PR TITLE
.werft/observability: Align rendering cmd with latest changes

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -51,6 +51,7 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
     --ext-str tracing_enabled="true" \
     --ext-str honeycomb_api_key="${process.env.HONEYCOMB_API_KEY}" \
     --ext-str honeycomb_dataset="preview-environments" \
+    --ext-str jaeger_endpoint="" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
To align with https://github.com/gitpod-io/observability/pull/30. If `tracing_enabled` is set to true, `jaeger_endpoint` also needs to be set, even if it is an empty string

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
