### PR TITLE
[image-builder] Don't re-use authentication across requests

### DIFF
--- a/components/image-builder-bob/OWNERS
+++ b/components/image-builder-bob/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/components/image-builder-bob/cmd/proxy.go
+++ b/components/image-builder-bob/cmd/proxy.go
@@ -52,7 +52,7 @@ var proxyCmd = &cobra.Command{
 			targettag = r.Tag()
 		}
 
-		auth := docker.NewDockerAuthorizer(docker.WithAuthCreds(authP.Authorize))
+		auth := func() docker.Authorizer { return docker.NewDockerAuthorizer(docker.WithAuthCreds(authP.Authorize)) }
 		prx, err := proxy.NewProxy(&url.URL{Host: "localhost:8080", Scheme: "http"}, map[string]proxy.Repo{
 			"base": {
 				Host: reference.Domain(baseref),

--- a/components/image-builder-mk3/OWNERS
+++ b/components/image-builder-mk3/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"


### PR DESCRIPTION
## Description
This PR fixes authentication issues with bob proxy caused by invalid re-use of the Docker authorizer.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6849

## How to test
Try to push an image to a private Azure registry through bob proxy.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[image-builder] Fix authentication issues with external registries
```
