### PR TITLE
[installer]: set affinities for pods and jobs

### DIFF
--- a/installer/pkg/components/blobserve/deployment.go
+++ b/installer/pkg/components/blobserve/deployment.go
@@ -6,6 +6,7 @@ package blobserve
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	dockerregistry "github.com/gitpod-io/gitpod/installer/pkg/components/docker-registry"
 	appsv1 "k8s.io/api/apps/v1"
@@ -69,7 +70,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           &corev1.Affinity{},
+						Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),
 						Volumes: []corev1.Volume{{

--- a/installer/pkg/components/content-service/deployment.go
+++ b/installer/pkg/components/content-service/deployment.go
@@ -5,6 +5,7 @@
 package content_service
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	v1 "k8s.io/api/apps/v1"
@@ -24,7 +25,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	podSpec := corev1.PodSpec{
-		Affinity:                      &corev1.Affinity{},
+		Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
 		ServiceAccountName:            Component,
 		EnableServiceLinks:            pointer.Bool(false),
 		DNSPolicy:                     "ClusterFirst",

--- a/installer/pkg/components/dashboard/deployment.go
+++ b/installer/pkg/components/dashboard/deployment.go
@@ -5,6 +5,7 @@
 package dashboard
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,7 +40,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Labels:    labels,
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      &corev1.Affinity{},
+						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
 						ServiceAccountName:            Component,
 						EnableServiceLinks:            pointer.Bool(false),
 						DNSPolicy:                     "ClusterFirst",

--- a/installer/pkg/components/database/init/job.go
+++ b/installer/pkg/components/database/init/job.go
@@ -8,6 +8,7 @@ package init
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,7 +33,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: objectMeta,
 				Spec: corev1.PodSpec{
-					Affinity:           &corev1.Affinity{},
+					Affinity:           common.Affinity(cluster.AffinityLabelMeta),
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: Component,
 					EnableServiceLinks: pointer.Bool(false),

--- a/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/installer/pkg/components/image-builder-mk3/deployment.go
@@ -6,6 +6,7 @@ package image_builder_mk3
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	dockerregistry "github.com/gitpod-io/gitpod/installer/pkg/components/docker-registry"
@@ -78,7 +79,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Spec: corev1.PodSpec{
-					Affinity:                      &corev1.Affinity{},
+					Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/installer/pkg/components/migrations/job.go
+++ b/installer/pkg/components/migrations/job.go
@@ -5,6 +5,7 @@
 package migrations
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +29,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: objectMeta,
 				Spec: corev1.PodSpec{
-					Affinity:           &corev1.Affinity{},
+					Affinity:           common.Affinity(cluster.AffinityLabelMeta),
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: Component,
 					EnableServiceLinks: pointer.Bool(false),

--- a/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -6,6 +6,7 @@ package openvsx_proxy
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
@@ -50,7 +51,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Spec: v1.PodSpec{
-					Affinity:                      &v1.Affinity{},
+					Affinity:                      common.Affinity(cluster.AffinityLabelIDE),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/installer/pkg/components/proxy/deployment.go
+++ b/installer/pkg/components/proxy/deployment.go
@@ -6,6 +6,7 @@ package proxy
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
@@ -115,7 +116,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      &corev1.Affinity{},
+						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
 						PriorityClassName:             common.SystemNodeCritical,
 						ServiceAccountName:            Component,
 						EnableServiceLinks:            pointer.Bool(false),

--- a/installer/pkg/components/rabbitmq/helm.go
+++ b/installer/pkg/components/rabbitmq/helm.go
@@ -7,6 +7,7 @@ package rabbitmq
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/helm"
 	"github.com/gitpod-io/gitpod/installer/third_party/charts"
@@ -258,6 +259,16 @@ var Helm = common.CompositeHelmFunc(
 			return nil, err
 		}
 
+		affinity, err := helm.AffinityYaml(cluster.AffinityLabelMeta)
+		if err != nil {
+			return nil, err
+		}
+
+		affinityTemplate, err := helm.KeyFileValue("rabbitmq.affinity", affinity)
+		if err != nil {
+			return nil, err
+		}
+
 		return &common.HelmConfig{
 			Enabled: true,
 			Values: &values.Options{
@@ -271,6 +282,7 @@ var Helm = common.CompositeHelmFunc(
 				},
 				// This is too complex to be sent as a string
 				FileValues: []string{
+					affinityTemplate,
 					loadDefinitionFilename,
 					shovelsTemplateFileName,
 				},

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -88,8 +88,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Spec: corev1.PodSpec{
-					PriorityClassName: common.SystemNodeCritical,
-					// todo(sje): do we need affinity?
+					PriorityClassName:             common.SystemNodeCritical,
 					Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),

--- a/installer/pkg/components/server/deployment.go
+++ b/installer/pkg/components/server/deployment.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
@@ -59,7 +60,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           &corev1.Affinity{},
+						Affinity:           common.Affinity(cluster.AffinityLabelMeta),
 						PriorityClassName:  common.SystemNodeCritical,
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),

--- a/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -6,6 +6,7 @@ package wsmanagerbridge
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 
@@ -63,7 +64,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      &corev1.Affinity{},
+						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
 						ServiceAccountName:            Component,
 						PriorityClassName:             common.SystemNodeCritical,
 						EnableServiceLinks:            pointer.Bool(false),

--- a/installer/pkg/components/ws-manager/deployment.go
+++ b/installer/pkg/components/ws-manager/deployment.go
@@ -5,6 +5,7 @@
 package wsmanager
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,7 +26,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	podSpec := corev1.PodSpec{
 		PriorityClassName:  common.SystemNodeCritical,
-		Affinity:           &corev1.Affinity{},
+		Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
 		EnableServiceLinks: pointer.Bool(false),
 		ServiceAccountName: Component,
 		SecurityContext: &corev1.PodSecurityContext{

--- a/installer/pkg/components/ws-proxy/deployment.go
+++ b/installer/pkg/components/ws-proxy/deployment.go
@@ -5,6 +5,7 @@
 package wsproxy
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
@@ -68,7 +69,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 					Spec: corev1.PodSpec{
 						PriorityClassName:  common.SystemNodeCritical,
-						Affinity:           &corev1.Affinity{},
+						Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
 						EnableServiceLinks: pointer.Bool(false),
 						ServiceAccountName: Component,
 						SecurityContext: &corev1.PodSecurityContext{

--- a/installer/pkg/components/ws-scheduler/deployment.go
+++ b/installer/pkg/components/ws-scheduler/deployment.go
@@ -5,6 +5,7 @@
 package wsscheduler
 
 import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
@@ -47,7 +48,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 				Spec: corev1.PodSpec{
 					PriorityClassName:  common.SystemNodeCritical,
-					Affinity:           &corev1.Affinity{},
+					Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
 					EnableServiceLinks: pointer.Bool(false),
 					ServiceAccountName: Component,
 					SecurityContext: &corev1.PodSecurityContext{

--- a/installer/pkg/helm/helm.go
+++ b/installer/pkg/helm/helm.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sigs.k8s.io/yaml"
 	"syscall"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -106,6 +107,18 @@ func writeCharts(chart *charts.Chart) (string, error) {
 	}
 
 	return dir, nil
+}
+
+// AffinityYaml convert an affinity into a YAML byte array
+func AffinityYaml(orLabels ...string) ([]byte, error) {
+	affinities := common.Affinity(orLabels...)
+
+	marshal, err := yaml.Marshal(affinities)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal, nil
 }
 
 // ImportTemplate allows for Helm charts to be imported into the installer manifest


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Applied the node affinities as specified in #6842. Have also given Jobs the same affinities as their associated Deployments

The only question is what, if any, affinities to put on the in-cluster Docker registry and the Jaeger operators

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6842

## How to test
<!-- Provide steps to test this PR -->
Deploy a self-hosted instance

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Apply node affinities to components
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
