### PR TITLE
feat(dashboard): redirect /memes to the website

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -72,6 +72,7 @@ function isWebsiteSlug(pathName: string) {
         'gitpod-vs-github-codespaces',
         'imprint',
         'media-kit',
+        'memes',
         'pricing',
         'privacy',
         'security',


### PR DESCRIPTION

## Description

It turns out folks are starting to create Gitpod memes. Let's collect them!

## Related Issue(s)

Relates to https://github.com/gitpod-io/website/pull/1281
Relates to https://github.com/gitpod-io/gitpod/issues/6877

## How to test

/memes should head to our website once https://github.com/gitpod-io/website/pull/1281 is merged.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
