### PR TITLE
[dashboard][server] Make all project slugs unique within a team or user account by adding a unique suffix

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -171,7 +171,7 @@ export default function NewProject() {
         const repoSlug = repo.path || repo.name;
 
         try {
-            await getGitpodService().server.createProject({
+            const project = await getGitpodService().server.createProject({
                 name: repo.name,
                 slug: repoSlug,
                 cloneUrl: repo.cloneUrl,
@@ -181,7 +181,7 @@ export default function NewProject() {
                 appInstallationId: String(repo.installationId),
             });
 
-            history.push(`/${User.is(teamOrUser) ? 'projects' : 't/'+teamOrUser.slug}/${repoSlug}/configure`);
+            history.push(`/${User.is(teamOrUser) ? 'projects' : 't/'+teamOrUser.slug}/${project.slug}/configure`);
         } catch (error) {
             const message = (error && error?.message) || "Failed to create new project."
             window.alert(message);

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -95,9 +95,17 @@ export class ProjectsService {
         if (projects.length > 0) {
             throw new Error("Project for repository already exists.");
         }
+        // If the desired project slug already exists in this team or user account, add a unique suffix to avoid collisions.
+        let uniqueSlug = slug;
+        let uniqueSuffix = 0;
+        const existingProjects = await (!!userId ? this.getUserProjects(userId) : this.getTeamProjects(teamId!));
+        while (existingProjects.some(p => p.slug === uniqueSlug)) {
+            uniqueSuffix++;
+            uniqueSlug = `${slug}-${uniqueSuffix}`;
+        }
         const project = Project.create({
             name,
-            slug,
+            slug: uniqueSlug,
             cloneUrl,
             ...(!!userId ? { userId } : { teamId }),
             appInstallationId


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make all project slugs unique within a team or user account by adding a unique suffix.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6600

## How to test
<!-- Provide steps to test this PR -->

1. Create two repositories with the same name, but under different owners (or Git providers), e.g. `username/test` and `org/test`
2. Add the two repos as Projects (either under your personal account, or a team, but both Projects should be in the same location)
3. Verify the two Projects have different slugs (e.g. the first added should have the slug `test`, and the second one `test-1`)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard][server] Make all project slugs unique within a team or user account by adding a unique suffix
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc