### PR TITLE
Use forked Minio charts

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   condition: docker-registry.enabled
 - name: minio
   version: 8.0.10
-  repository: https://helm.min.io/
+  repository: "file://dependencies/minio"
   condition: minio.enabled
 - name: mysql
   version: 8.6.2

--- a/chart/dependencies/minio/.helmignore
+++ b/chart/dependencies/minio/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/chart/dependencies/minio/Chart.yaml
+++ b/chart/dependencies/minio/Chart.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Minio https://min.io/
+
+apiVersion: v1
+appVersion: master
+description: High Performance, Kubernetes Native Object Storage
+home: https://min.io
+icon: https://min.io/resources/img/logo/MINIO_wordmark.png
+keywords:
+- storage
+- object-storage
+- S3
+maintainers:
+- email: dev@minio.io
+  name: MinIO, Inc
+name: minio
+sources:
+- https://github.com/minio/minio
+version: 8.0.10

--- a/chart/dependencies/minio/README.md
+++ b/chart/dependencies/minio/README.md
@@ -1,0 +1,416 @@
+> NOTE: This helm chart is in code freeze i.e we will only update MinIO releases occastionally by bumping up the version. For latest features you are advised to start using our [MinIO operator](https://github.com/minio/operator).
+
+MinIO
+=====
+
+[MinIO](https://min.io) is a High Performance Object Storage released under Apache License v2.0. It is API compatible with Amazon S3 cloud storage service. Use MinIO to build high performance infrastructure for machine learning, analytics and application data workloads.
+
+MinIO supports [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide). In distributed mode, you can pool multiple drives (even on different machines) into a single object storage server.
+
+For more detailed documentation please visit [here](https://docs.minio.io/)
+
+Introduction
+------------
+
+This chart bootstraps MinIO deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+
+- Kubernetes 1.4+ with Beta APIs enabled for default standalone mode.
+- Kubernetes 1.5+ with Beta APIs enabled to run MinIO in [distributed mode](#distributed-minio).
+- PV provisioner support in the underlying infrastructure.
+
+Configure MinIO Helm repo
+--------------------
+```bash
+$ helm repo add minio https://helm.min.io/
+```
+
+Installing the Chart
+--------------------
+
+Install this chart using:
+
+```bash
+$ helm install --namespace minio --generate-name minio/minio
+```
+
+The command deploys MinIO on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Release name
+
+An instance of a chart running in a Kubernetes cluster is called a release. Each release is identified by a unique name within the cluster. Helm automatically assigns a unique release name after installing the chart. You can also set your preferred name by:
+
+```bash
+$ helm install my-release minio/minio
+```
+
+### Access and Secret keys
+
+By default a pre-generated access and secret key will be used. To override the default keys, pass the access and secret keys as arguments to helm install.
+
+```bash
+$ helm install --set accessKey=myaccesskey,secretKey=mysecretkey --generate-name minio/minio
+```
+
+### Updating MinIO configuration via Helm
+
+[ConfigMap](https://kubernetes.io/docs/user-guide/configmap/) allows injecting containers with configuration data even while a Helm release is deployed.
+
+To update your MinIO server configuration while it is deployed in a release, you need to
+
+1. Check all the configurable values in the MinIO chart using `helm inspect values minio/minio`.
+2. Override the `minio_server_config` settings in a YAML formatted file, and then pass that file like this `helm upgrade -f config.yaml minio/minio`.
+3. Restart the MinIO server(s) for the changes to take effect.
+
+You can also check the history of upgrades to a release using `helm history my-release`. Replace `my-release` with the actual release name.
+
+### Installing certificates from third party CAs
+
+MinIO can connect to other servers, including MinIO nodes or other server types such as NATs and Redis. If these servers use certificates that were not registered with a known CA, add trust for these certificates to MinIO Server by bundling these certificates into a Kubernetes secret and providing it to Helm via the `trustedCertsSecret` value. If `.Values.tls.enabled` is `true` and you're installing certificates for third party CAs, remember to include Minio's own certificate with key `public.crt`, if it also needs to be trusted.
+
+For instance, given that TLS is enabled and you need to add trust for Minio's own CA and for the CA of a Keycloak server, a Kubernetes secret can be created from the certificate files using `kubectl`:
+
+```
+kubectl -n minio create secret generic minio-trusted-certs --from-file=public.crt --from-file=keycloak.crt
+```
+
+If TLS is not enabled, you would need only the third party CA:
+
+```
+kubectl -n minio create secret generic minio-trusted-certs --from-file=keycloak.crt
+```
+
+The name of the generated secret can then be passed to Helm using a values file or the `--set` parameter:
+
+```
+trustedCertsSecret: "minio-trusted-certs"
+
+or
+
+--set trustedCertsSecret=minio-trusted-certs
+```
+
+Uninstalling the Chart
+----------------------
+
+Assuming your release is named as `my-release`, delete it using the command:
+
+```bash
+$ helm delete my-release
+```
+
+or
+
+```bash
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+Upgrading the Chart
+-------------------
+
+You can use Helm to update MinIO version in a live release. Assuming your release is named as `my-release`, get the values using the command:
+
+```bash
+$ helm get values my-release > old_values.yaml
+```
+
+Then change the field `image.tag` in `old_values.yaml` file with MinIO image tag you want to use. Now update the chart using
+
+```bash
+$ helm upgrade -f old_values.yaml my-release minio/minio
+```
+
+Default upgrade strategies are specified in the `values.yaml` file. Update these fields if you'd like to use a different strategy.
+
+Configuration
+-------------
+
+The following table lists the configurable parameters of the MinIO chart and their default values.
+
+| Parameter                                        | Description                                                                                                                             | Default                          |
+|:-------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------|
+| `nameOverride`                                   | Provide a name in place of `minio`                                                                                                      | `""`                             |
+| `fullnameOverride`                               | Provide a name to substitute for the full names of resources                                                                            | `""`                             |
+| `image.repository`                               | Image repository                                                                                                                        | `minio/minio`                    |
+| `image.tag`                                      | MinIO image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).                                             | `RELEASE.2020-11-06T23-17-07Z`   |
+| `image.pullPolicy`                               | Image pull policy                                                                                                                       | `IfNotPresent`                   |
+| `imagePullSecrets`                               | List of container registry secrets                                                                                                      | `[]`                             |
+| `mcImage.repository`                             | Client image repository                                                                                                                 | `minio/mc`                       |
+| `mcImage.tag`                                    | mc image tag. Possible values listed [here](https://hub.docker.com/r/minio/mc/tags/).                                                   | `RELEASE.2020-10-03T02-54-56Z`   |
+| `mcImage.pullPolicy`                             | mc Image pull policy                                                                                                                    | `IfNotPresent`                   |
+| `ingress.enabled`                                | Enables Ingress                                                                                                                         | `false`                          |
+| `ingress.labels     `                            | Ingress labels                                                                                                                          | `{}`                             |
+| `ingress.annotations`                            | Ingress annotations                                                                                                                     | `{}`                             |
+| `ingress.hosts`                                  | Ingress accepted hostnames                                                                                                              | `[]`                             |
+| `ingress.tls`                                    | Ingress TLS configuration                                                                                                               | `[]`                             |
+| `trustedCertsSecret`                             | Kubernetes secret with trusted certificates to be mounted on `{{ .Values.certsPath }}/CAs`                                              | `""`                             |
+| `mode`                                           | MinIO server mode (`standalone` or `distributed`)                                                                                       | `standalone`                     |
+| `extraArgs`                                      | Additional command line arguments to pass to the MinIO server                                                                           | `[]`                             |
+| `replicas`                                       | Number of nodes (applicable only for MinIO distributed mode).                                                                           | `4`                              |
+| `zones`                                          | Number of zones (applicable only for MinIO distributed mode).                                                                           | `1`                              |
+| `drivesPerNode`                                  | Number of drives per node (applicable only for MinIO distributed mode).                                                                 | `1`                              |
+| `existingSecret`                                 | Name of existing secret with access and secret key.                                                                                     | `""`                             |
+| `accessKey`                                      | Default access key (5 to 20 characters)                                                                                                 | random 20 chars                  |
+| `secretKey`                                      | Default secret key (8 to 40 characters)                                                                                                 | random 40 chars                  |
+| `certsPath`                                      | Default certs path location                                                                                                             | `/etc/minio/certs`               |
+| `configPathmc`                                   | Default config file location for MinIO client - mc                                                                                      | `/etc/minio/mc`                  |
+| `mountPath`                                      | Default mount location for persistent drive                                                                                             | `/export`                        |
+| `bucketRoot`                                     | Directory from where minio should serve buckets.                                                                                        | Value of `.mountPath`            |
+| `clusterDomain`                                  | domain name of kubernetes cluster where pod is running.                                                                                 | `cluster.local`                  |
+| `service.type`                                   | Kubernetes service type                                                                                                                 | `ClusterIP`                      |
+| `service.port`                                   | Kubernetes port where service is exposed                                                                                                | `9000`                           |
+| `service.externalIPs`                            | service external IP addresses                                                                                                           | `nil`                            |
+| `service.annotations`                            | Service annotations                                                                                                                     | `{}`                             |
+| `serviceAccount.create`                          | Toggle creation of new service account                                                                                                  | `true`                           |
+| `serviceAccount.name`                            | Name of service account to create and/or use                                                                                            | `""`                             |
+| `persistence.enabled`                            | Use persistent volume to store data                                                                                                     | `true`                           |
+| `persistence.size`                               | Size of persistent volume claim                                                                                                         | `500Gi`                          |
+| `persistence.existingClaim`                      | Use an existing PVC to persist data                                                                                                     | `nil`                            |
+| `persistence.storageClass`                       | Storage class name of PVC                                                                                                               | `nil`                            |
+| `persistence.accessMode`                         | ReadWriteOnce or ReadOnly                                                                                                               | `ReadWriteOnce`                  |
+| `persistence.subPath`                            | Mount a sub directory of the persistent volume if set                                                                                   | `""`                             |
+| `resources.requests.memory`                      | Memory resource requests                                                                                                                | Memory: `4Gi`                    |
+| `priorityClassName`                              | Pod priority settings                                                                                                                   | `""`                             |
+| `securityContext.enabled`                        | Enable to run containers as non-root. NOTE: if `persistence.enabled=false` then securityContext will be automatically disabled          | `true`                           |
+| `securityContext.runAsUser`                      | User id of the user for the container                                                                                                   | `1000`                           |
+| `securityContext.runAsGroup`                     | Group id of the user for the container                                                                                                  | `1000`                           |
+| `securityContext.fsGroup`                        | Group id of the persistent volume mount for the container                                                                               | `1000`                           |
+| `nodeSelector`                                   | Node labels for pod assignment                                                                                                          | `{}`                             |
+| `affinity`                                       | Affinity settings for pod assignment                                                                                                    | `{}`                             |
+| `tolerations`                                    | Toleration labels for pod assignment                                                                                                    | `[]`                             |
+| `additionalLabels`                               | Additional labels for Deployment in standalone mode or StatefulSet in distributed mode                                                  | `[]`                             |
+| `additionalAnnotations`                          | Additional annotations for Deployment in standalone mode or StatefulSet in distributed mode                                             | `[]`                             |
+| `podAnnotations`                                 | Pod annotations                                                                                                                         | `{}`                             |
+| `podLabels`                                      | Pod Labels                                                                                                                              | `{}`                             |
+| `tls.enabled`                                    | Enable TLS for MinIO server                                                                                                             | `false`                          |
+| `tls.certSecret`                                 | Kubernetes Secret with `public.crt` and `private.key` files.                                                                            | `""`                             |
+| `defaultBucket.enabled`                          | If set to true, a bucket will be created after MinIO install                                                                            | `false`                          |
+| `defaultBucket.name`                             | Bucket name                                                                                                                             | `bucket`                         |
+| `defaultBucket.policy`                           | Bucket policy                                                                                                                           | `none`                           |
+| `defaultBucket.purge`                            | Purge the bucket if already exists                                                                                                      | `false`                          |
+| `defaultBucket.versioning`                       | Enable / Suspend versioning for bucket                                                                                                  | `nil`                            |
+| `buckets`                                        | List of buckets to create after MinIO install                                                                                           | `[]`                             |
+| `makeBucketJob.annotations`                      | Additional annotations for the Kubernetes Batch (make-bucket-job)                                                                       | `""`                             |
+| `makeBucketJob.podAnnotations`                   | Additional annotations for the pods of the Kubernetes Batch (make-bucket-job)                                                           | `""`                             |
+| `makeBucketJob.securityContext.enabled`          | Enable to run Kubernetes Batch (make-bucket-job) containers as non-root.                                                                | `false`                          |
+| `makeBucketJob.securityContext.runAsUser`        | User id of the user for the container                                                                                                   | `1000`                           |
+| `makeBucketJob.securityContext.runAsGroup`       | Group id of the user for the container                                                                                                  | `1000`                           |
+| `makeBucketJob.securityContext.fsGroup`          | Group id of the persistent volume mount for the container                                                                               | `1000`                           |
+| `makeBucketJob.resources.requests.memory`        | Memory resource requests for 'make bucket' job                                                                                          | `128Mi`                          |
+| `updatePrometheusJob.podAnnotations`             | Additional annotations for the pods of the Kubernetes Batch (update-prometheus-secret)                                                  | `""`                             |
+| `updatePrometheusJob.securityContext.enabled`    | Enable to run Kubernetes Batch (update-prometheus-secret) containers as non-root.                                                       | `false`                          |
+| `updatePrometheusJob.securityContext.runAsUser`  | User id of the user for the container                                                                                                   | `1000`                           |
+| `updatePrometheusJob.securityContext.runAsGroup` | Group id of the user for the container                                                                                                  | `1000`                           |
+| `updatePrometheusJob.securityContext.fsGroup`    | Group id of the persistent volume mount for the container                                                                               | `1000`                           |
+| `s3gateway.enabled`                              | Use MinIO as a [s3 gateway](https://github.com/minio/minio/blob/master/docs/gateway/s3.md)                                              | `false`                          |
+| `s3gateway.replicas`                             | Number of s3 gateway instances to run in parallel                                                                                       | `4`                              |
+| `s3gateway.serviceEndpoint`                      | Endpoint to the S3 compatible service                                                                                                   | `""`                             |
+| `s3gateway.accessKey`                            | Access key of S3 compatible service                                                                                                     | `""`                             |
+| `s3gateway.secretKey`                            | Secret key of S3 compatible service                                                                                                     | `""`                             |
+| `azuregateway.enabled`                           | Use MinIO as an [azure gateway](https://docs.minio.io/docs/minio-gateway-for-azure)                                                     | `false`                          |
+| `azuregateway.replicas`                          | Number of azure gateway instances to run in parallel                                                                                    | `4`                              |
+| `gcsgateway.enabled`                             | Use MinIO as a [Google Cloud Storage gateway](https://docs.minio.io/docs/minio-gateway-for-gcs)                                         | `false`                          |
+| `gcsgateway.gcsKeyJson`                          | credential json file of service account key                                                                                             | `""`                             |
+| `gcsgateway.projectId`                           | Google cloud project id                                                                                                                 | `""`                             |
+| `nasgateway.enabled`                             | Use MinIO as a [NAS gateway](https://docs.MinIO.io/docs/minio-gateway-for-nas)                                                          | `false`                          |
+| `nasgateway.replicas`                            | Number of NAS gateway instances to be run in parallel on a PV                                                                           | `4`                              |
+| `environment`                                    | Set MinIO server relevant environment variables in `values.yaml` file. MinIO containers will be passed these variables when they start. | `MINIO_STORAGE_CLASS_STANDARD: EC:4"` |
+| `metrics.serviceMonitor.enabled`                 | Set this to `true` to create ServiceMonitor for Prometheus operator                                                                     | `false`                          |
+| `metrics.serviceMonitor.additionalLabels`        | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                   | `{}`                             |
+| `metrics.serviceMonitor.namespace`               | Optional namespace in which to create ServiceMonitor                                                                                    | `nil`                            |
+| `metrics.serviceMonitor.interval`                | Scrape interval. If not set, the Prometheus default scrape interval is used                                                             | `nil`                            |
+| `metrics.serviceMonitor.scrapeTimeout`           | Scrape timeout. If not set, the Prometheus default scrape timeout is used                                                               | `nil`                            |
+| `metrics.serviceMonitor.relabelConfigs`          | Relabel configs that can be used on Endpoints                                                                                            | `{}`                             |
+| `etcd.endpoints`                                 | Endpoints of etcd                                                                                                                        | `[]`                             |
+| `etcd.pathPrefix`                                | Prefix for all etcd keys                                                                                                                | `""`                             |
+| `etcd.corednsPathPrefix`                         | Prefix for all CoreDNS etcd keys                                                                                                        | `""`                             |
+| `etcd.clientCert`                                | Certificate used for SSL/TLS connections to etcd [(etcd Security)](https://etcd.io/docs/latest/op-guide/security/)                      | `""`                             |
+| `etcd.clientCertKey`                             | Key for the certificate [(etcd Security)](https://etcd.io/docs/latest/op-guide/security/)                                               | `""`                             |
+
+Some of the parameters above map to the env variables defined in the [MinIO DockerHub image](https://hub.docker.com/r/minio/minio/).
+
+You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release --set persistence.size=1Ti minio/minio
+```
+
+The above command deploys MinIO server with a 1Ti backing persistent volume.
+
+Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml minio/minio
+```
+
+> **Tip**: You can use the default [values.yaml](minio/values.yaml)
+
+Distributed MinIO
+-----------
+
+This chart provisions a MinIO server in standalone mode, by default. To provision MinIO server in [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide), set the `mode` field to `distributed`,
+
+```bash
+$ helm install --set mode=distributed minio/minio
+```
+
+This provisions MinIO server in distributed mode with 4 nodes. To change the number of nodes in your distributed MinIO server, set the `replicas` field,
+
+```bash
+$ helm install --set mode=distributed,replicas=8 minio/minio
+```
+
+This provisions MinIO server in distributed mode with 8 nodes. Note that the `replicas` value should be a minimum value of 4, there is no limit on number of servers you can run.
+
+You can also expand an existing deployment by adding new zones, following command will create a total of 16 nodes with each zone running 8 nodes.
+
+```bash
+$ helm install --set mode=distributed,replicas=8,zones=2 minio/minio
+```
+
+### StatefulSet [limitations](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations) applicable to distributed MinIO
+
+1. StatefulSets need persistent storage, so the `persistence.enabled` flag is ignored when `mode` is set to `distributed`.
+2. When uninstalling a distributed MinIO release, you'll need to manually delete volumes associated with the StatefulSet.
+
+NAS Gateway
+-----------
+
+### Prerequisites
+
+MinIO in [NAS gateway mode](https://docs.minio.io/docs/minio-gateway-for-nas) can be used to create multiple MinIO instances backed by single PV in `ReadWriteMany` mode. Currently few [Kubernetes volume plugins](https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes) support `ReadWriteMany` mode. To deploy MinIO NAS gateway with Helm chart you'll need to have a Persistent Volume running with one of the supported volume plugins. [This document](https://kubernetes.io/docs/user-guide/volumes/#nfs)
+outlines steps to create a NFS PV in Kubernetes cluster.
+
+### Provision NAS Gateway MinIO instances
+
+To provision MinIO servers in [NAS gateway mode](https://docs.minio.io/docs/minio-gateway-for-nas), set the `nasgateway.enabled` field to `true`,
+
+```bash
+$ helm install --set nasgateway.enabled=true minio/minio
+```
+
+This provisions 4 MinIO NAS gateway instances backed by single storage. To change the number of instances in your MinIO deployment, set the `replicas` field,
+
+```bash
+$ helm install --set nasgateway.enabled=true,nasgateway.replicas=8 minio/minio
+```
+
+This provisions MinIO NAS gateway with 8 instances.
+
+Persistence
+-----------
+
+This chart provisions a PersistentVolumeClaim and mounts corresponding persistent volume to default location `/export`. You'll need physical storage available in the Kubernetes cluster for this to work. If you'd rather use `emptyDir`, disable PersistentVolumeClaim by:
+
+```bash
+$ helm install --set persistence.enabled=false minio/minio
+```
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+Existing PersistentVolumeClaim
+------------------------------
+
+If a Persistent Volume Claim already exists, specify it during installation.
+
+1. Create the PersistentVolume
+2. Create the PersistentVolumeClaim
+3. Install the chart
+
+```bash
+$ helm install --set persistence.existingClaim=PVC_NAME minio/minio
+```
+
+NetworkPolicy
+-------------
+
+To enable network policy for MinIO,
+install [a networking plugin that implements the Kubernetes
+NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin),
+and set `networkPolicy.enabled` to `true`.
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
+the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+
+    kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+
+With NetworkPolicy enabled, traffic will be limited to just port 9000.
+
+For more precise policy, set `networkPolicy.allowExternal=true`. This will
+only allow pods with the generated client label to connect to MinIO.
+This label will be displayed in the output of a successful install.
+
+Existing secret
+---------------
+
+Instead of having this chart create the secret for you, you can supply a preexisting secret, much
+like an existing PersistentVolumeClaim.
+
+First, create the secret:
+```bash
+$ kubectl create secret generic my-minio-secret --from-literal=accesskey=foobarbaz --from-literal=secretkey=foobarbazqux
+```
+
+Then install the chart, specifying that you want to use an existing secret:
+```bash
+$ helm install --set existingSecret=my-minio-secret minio/minio
+```
+
+The following fields are expected in the secret:
+
+| .data.<key> in Secret      | Corresponding variable  | Description                                                                       |
+|:---------------------------|:------------------------|:----------------------------------------------------------------------------------|
+| `accesskey`                | `accessKey`             | Access key ID. Mandatory.                                                         |
+| `secretkey`                | `secretKey`             | Secret key. Mandatory.                                                            |
+| `gcs_key.json`             | `gcsgateway.gcsKeyJson` | GCS key if you are using the GCS gateway feature. Optional                        |
+| `awsAccessKeyId`           | `s3gateway.accessKey`   | S3 access key if you are using the S3 gateway feature. Optional                   |
+| `awsSecretAccessKey`       | `s3gateway.secretKey`   | S3 secret key if you are using the S3 gateway feature. Optional                   |
+| `etcd_client_cert.pem`     | `etcd.clientCert`       | Certificate for SSL/TLS connections to etcd. Optional                             |
+| `etcd_client_cert_key.pem` | `etcd.clientCertKey`    | Corresponding key for certificate above. Mandatory when etcd certificate defined. |
+
+All corresponding variables will be ignored in values file.
+
+Configure TLS
+-------------
+
+To enable TLS for MinIO containers, acquire TLS certificates from a CA or create self-signed certificates. While creating / acquiring certificates ensure the corresponding domain names are set as per the standard [DNS naming conventions](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity) in a Kubernetes StatefulSet (for a distributed MinIO setup). Then create a secret using
+
+```bash
+$ kubectl create secret generic tls-ssl-minio --from-file=path/to/private.key --from-file=path/to/public.crt
+```
+
+Then install the chart, specifying that you want to use the TLS secret:
+
+```bash
+$ helm install --set tls.enabled=true,tls.certSecret=tls-ssl-minio minio/minio
+```
+
+Pass environment variables to MinIO containers
+----------------------------------------------
+
+To pass environment variables to MinIO containers when deploying via Helm chart, use the below command line format
+
+```bash
+$ helm install --set environment.MINIO_BROWSER=on,environment.MINIO_DOMAIN=domain-name minio/minio
+```
+
+You can add as many environment variables as required, using the above format. Just add `environment.<VARIABLE_NAME>=<value>` under `set` flag.
+
+Create buckets after install
+---------------------------
+
+Install the chart, specifying the buckets you want to create after install:
+
+```bash
+$ helm install --set buckets[0].name=bucket1,buckets[0].policy=none,buckets[0].purge=false minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `buckets[].name` - name of the bucket to create, must be a string with length > 0
+- `buckets[].policy` - can be one of none|download|upload|public
+- `buckets[].purge` - purge if bucket exists already

--- a/chart/dependencies/minio/ci/distributed-values.yaml
+++ b/chart/dependencies/minio/ci/distributed-values.yaml
@@ -1,0 +1,3 @@
+# Copyright (c) Minio https://min.io/
+
+mode: distributed

--- a/chart/dependencies/minio/templates/NOTES.txt
+++ b/chart/dependencies/minio/templates/NOTES.txt
@@ -1,0 +1,47 @@
+{{- if eq .Values.service.type "ClusterIP" "NodePort" }}
+Minio can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
+{{ template "minio.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Minio from localhost, run the below commands:
+
+  1. export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+
+  2. kubectl port-forward $POD_NAME 9000 --namespace {{ .Release.Namespace }}
+
+Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/
+
+You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. Get the ACCESS_KEY=$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.secretkey}" | base64 --decode)
+
+  3. mc alias set {{ template "minio.fullname" . }}-local http://localhost:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
+
+  4. mc ls {{ template "minio.fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}
+{{- if eq .Values.service.type "LoadBalancer" }}
+Minio can be accessed via port {{ .Values.service.port }} on an external IP address. Get the service external IP address by:
+kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "minio.fullname" . }}
+
+Note that the public IP may take a couple of minutes to be available.
+
+You can now access Minio server on http://<External-IP>:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. Get the ACCESS_KEY=$(kubectl get secret {{ template "minio.secretName" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret {{ template "minio.secretName" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.data.secretkey}" | base64 --decode)
+  3. mc alias set {{ template "minio.fullname" . }} http://<External-IP>:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
+
+  4. mc ls {{ template "minio.fullname" . }}
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}
+
+{{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+Note: Since NetworkPolicy is enabled, only pods with label
+{{ template "minio.fullname" . }}-client=true"
+will be able to connect to this minio cluster.
+{{- end }}

--- a/chart/dependencies/minio/templates/_helper_create_bucket.txt
+++ b/chart/dependencies/minio/templates/_helper_create_bucket.txt
@@ -1,0 +1,111 @@
+#!/bin/sh
+set -e ; # Have script exit in the event of a failed command.
+
+{{- if .Values.configPathmc }}
+MC_CONFIG_DIR="{{ .Values.configPathmc }}"
+MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+{{- else }}
+MC="/usr/bin/mc --insecure"
+{{- end }}
+
+# connectToMinio
+# Use a check-sleep-check loop to wait for Minio service to be available
+connectToMinio() {
+  SCHEME=$1
+  ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+  set -e ; # fail if we can't read the keys.
+  ACCESS=$(cat /config/accesskey) ; SECRET=$(cat /config/secretkey) ;
+  set +e ; # The connections to minio are allowed to fail.
+  echo "Connecting to Minio server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+  MC_COMMAND="${MC} config host add myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+  $MC_COMMAND ;
+  STATUS=$? ;
+  until [ $STATUS = 0 ]
+  do
+    ATTEMPTS=`expr $ATTEMPTS + 1` ;
+    echo \"Failed attempts: $ATTEMPTS\" ;
+    if [ $ATTEMPTS -gt $LIMIT ]; then
+      exit 1 ;
+    fi ;
+    sleep 2 ; # 1 second intervals between attempts
+    $MC_COMMAND ;
+    STATUS=$? ;
+  done ;
+  set -e ; # reset `e` as active
+  return 0
+}
+
+# checkBucketExists ($bucket)
+# Check if the bucket exists, by using the exit code of `mc ls`
+checkBucketExists() {
+  BUCKET=$1
+  CMD=$(${MC} ls myminio/$BUCKET > /dev/null 2>&1)
+  return $?
+}
+
+# createBucket ($bucket, $policy, $purge)
+# Ensure bucket exists, purging if asked to
+createBucket() {
+  BUCKET=$1
+  POLICY=$2
+  PURGE=$3
+  VERSIONING=$4
+
+  # Purge the bucket, if set & exists
+  # Since PURGE is user input, check explicitly for `true`
+  if [ $PURGE = true ]; then
+    if checkBucketExists $BUCKET ; then
+      echo "Purging bucket '$BUCKET'."
+      set +e ; # don't exit if this fails
+      ${MC} rm -r --force myminio/$BUCKET
+      set -e ; # reset `e` as active
+    else
+      echo "Bucket '$BUCKET' does not exist, skipping purge."
+    fi
+  fi
+
+  # Create the bucket if it does not exist
+  if ! checkBucketExists $BUCKET ; then
+    echo "Creating bucket '$BUCKET'"
+    ${MC} mb myminio/$BUCKET
+  else
+    echo "Bucket '$BUCKET' already exists."
+  fi
+
+
+  # set versioning for bucket
+  if [ ! -z $VERSIONING ] ; then
+    if [ $VERSIONING = true ] ; then
+        echo "Enabling versioning for '$BUCKET'"
+        ${MC} version enable myminio/$BUCKET
+    elif [ $VERSIONING = false ] ; then
+        echo "Suspending versioning for '$BUCKET'"
+        ${MC} version suspend myminio/$BUCKET
+    fi
+  else
+      echo "Bucket '$BUCKET' versioning unchanged."
+  fi
+
+  # At this point, the bucket should exist, skip checking for existence
+  # Set policy on the bucket
+  echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
+  ${MC} policy set $POLICY myminio/$BUCKET
+}
+
+# Try connecting to Minio instance
+{{- if .Values.tls.enabled }}
+scheme=https
+{{- else }}
+scheme=http
+{{- end }}
+connectToMinio $scheme
+
+{{- if or .Values.defaultBucket.enabled }}
+# Create the bucket
+createBucket {{ .Values.defaultBucket.name }} {{ .Values.defaultBucket.policy }} {{ .Values.defaultBucket.purge }} {{ .Values.defaultBucket.versioning }}
+{{ else if .Values.buckets }}
+# Create the buckets
+{{- range .Values.buckets }}
+createBucket {{ .name }} {{ .policy }} {{ .purge }} {{ .versioning }}
+{{- end }}
+{{- end }}

--- a/chart/dependencies/minio/templates/_helpers.tpl
+++ b/chart/dependencies/minio/templates/_helpers.tpl
@@ -1,0 +1,182 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "minio.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "minio.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "minio.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "minio.networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.Version -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "minio.deployment.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.Version -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "minio.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.16-0" .Capabilities.KubeVersion.Version -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "minio.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine secret name.
+*/}}
+{{- define "minio.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret }}
+{{- else -}}
+{{- include "minio.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine service account name for deployment or statefulset.
+*/}}
+{{- define "minio.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "minio.fullname" .) .Values.serviceAccount.name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine name for scc role and rolebinding
+*/}}
+{{- define "minio.sccRoleName" -}}
+{{- printf "%s-%s" "scc" (include "minio.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Properly format optional additional arguments to Minio binary
+*/}}
+{{- define "minio.extraArgs" -}}
+{{- range .Values.extraArgs -}}
+{{ " " }}{{ . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "minio.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+    {{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+    {{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Formats volumeMount for Minio tls keys and trusted certs
+*/}}
+{{- define "minio.tlsKeysVolumeMount" -}}
+{{- if .Values.tls.enabled }}
+- name: cert-secret-volume
+  mountPath: {{ .Values.certsPath }}
+{{- end }}
+{{- if or .Values.tls.enabled (ne .Values.trustedCertsSecret "") }}
+{{- $casPath := printf "%s/CAs" .Values.certsPath | clean }}
+- name: trusted-cert-secret-volume
+  mountPath: {{ $casPath }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Formats volume for Minio tls keys and trusted certs
+*/}}
+{{- define "minio.tlsKeysVolume" -}}
+{{- if .Values.tls.enabled }}
+- name: cert-secret-volume
+  secret:
+    secretName: {{ .Values.tls.certSecret }}
+    items:
+    - key: {{ .Values.tls.publicCrt }}
+      path: public.crt
+    - key: {{ .Values.tls.privateKey }}
+      path: private.key
+{{- end }}
+{{- if or .Values.tls.enabled (ne .Values.trustedCertsSecret "") }}
+{{- $certSecret := eq .Values.trustedCertsSecret "" | ternary .Values.tls.certSecret .Values.trustedCertsSecret }}
+{{- $publicCrt := eq .Values.trustedCertsSecret "" | ternary .Values.tls.publicCrt "" }}
+- name: trusted-cert-secret-volume
+  secret:
+    secretName: {{ $certSecret }}
+    {{- if ne $publicCrt "" }}
+    items:
+    - key: {{ $publicCrt }}
+      path: public.crt
+    {{- end }}
+{{- end }}
+{{- end -}}

--- a/chart/dependencies/minio/templates/clusterroles.yaml
+++ b/chart/dependencies/minio/templates/clusterroles.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "minio.serviceAccountName" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - {{ template "minio.fullname" . }}
+  verbs:
+  - use
+{{- end }}

--- a/chart/dependencies/minio/templates/configmap.yaml
+++ b/chart/dependencies/minio/templates/configmap.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) Minio https://min.io/
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  initialize: |-
+{{ include (print $.Template.BasePath "/_helper_create_bucket.txt") . | indent 4 }}

--- a/chart/dependencies/minio/templates/deployment.yaml
+++ b/chart/dependencies/minio/templates/deployment.yaml
@@ -1,0 +1,212 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if eq .Values.mode "standalone" }}
+{{ $scheme := "http" }}
+{{- if .Values.tls.enabled }}
+{{ $scheme = "https" }}
+{{ end }}
+{{ $bucketRoot := or ($.Values.bucketRoot) ($.Values.mountPath) }}
+apiVersion: {{ template "minio.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | trimSuffix "\n" | indent 4 }}
+{{- end }}
+{{- if .Values.additionalAnnotations }}
+  annotations:
+{{ toYaml .Values.additionalAnnotations | trimSuffix "\n" | indent 4 }}
+{{- end }}
+spec:
+  strategy:
+    type: {{ .Values.DeploymentUpdate.type }}
+    {{- if eq .Values.DeploymentUpdate.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.DeploymentUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.DeploymentUpdate.maxUnavailable }}
+    {{- end}}
+  {{- if .Values.nasgateway.enabled }}
+  replicas: {{ .Values.nasgateway.replicas }}
+  {{- end }}
+  {{- if .Values.s3gateway.enabled }}
+  replicas: {{ .Values.s3gateway.replicas }}
+  {{- end }}
+  {{- if .Values.azuregateway.enabled }}
+  replicas: {{ .Values.azuregateway.replicas }}
+  {{- end }}
+  {{- if .Values.gcsgateway.enabled }}
+  replicas: {{ .Values.gcsgateway.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "minio.fullname" . }}
+      labels:
+        app: {{ template "minio.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+{{- end }}
+    spec:
+  {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end }}
+      serviceAccountName: {{ include "minio.serviceAccountName" . | quote }}
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.s3gateway.enabled }}
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }} {{- template "minio.extraArgs" . }}"
+          {{- else }}
+          {{- if .Values.azuregateway.enabled }}
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{- template "minio.extraArgs" . }}"
+          {{- else }}
+          {{- if .Values.gcsgateway.enabled }}
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }} {{- template "minio.extraArgs" . }}"
+          {{- else }}
+          {{- if .Values.nasgateway.enabled }}
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }} {{- template "minio.extraArgs" . }}"
+          {{- else }}
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }} {{- template "minio.extraArgs" . }}"
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          volumeMounts:
+            {{- if and .Values.persistence.enabled (not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) }}
+            - name: export
+              mountPath: {{ .Values.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: "{{ .Values.persistence.subPath }}"
+              {{- end }}
+            {{- end }}
+            {{- if or .Values.gcsgateway.enabled .Values.etcd.clientCert .Values.etcd.clientCertKey }}
+            - name: minio-user
+              mountPath: "/etc/credentials"
+              readOnly: true
+            {{- end }}
+            {{- include "minio.tlsKeysVolumeMount" . | indent 12 }}
+          ports:
+            - name: {{ $scheme }}
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: secretkey
+            {{- if and .Values.gcsgateway.enabled .Values.gcsgateway.gcsKeyJson }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/credentials/gcs_key.json"
+            {{- end }}
+            {{- if .Values.etcd.endpoints }}
+            - name: MINIO_ETCD_ENDPOINTS
+              value: {{ join "," .Values.etcd.endpoints | quote }}
+            {{- if .Values.etcd.clientCert }}
+            - name: MINIO_ETCD_CLIENT_CERT
+              value: "/etc/credentials/etcd_client_cert.pem"
+            {{- end }}
+            {{- if .Values.etcd.clientCertKey }}
+            - name: MINIO_ETCD_CLIENT_CERT_KEY
+              value: "/etc/credentials/etcd_client_cert_key.pem"
+            {{- end }}
+            {{- if .Values.etcd.pathPrefix }}
+            - name: MINIO_ETCD_PATH_PREFIX
+              value: {{ .Values.etcd.pathPrefix }}
+            {{- end }}
+            {{- if .Values.etcd.corednsPathPrefix }}
+            - name: MINIO_ETCD_COREDNS_PATH
+              value: {{ .Values.etcd.corednsPathPrefix }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.s3gateway.enabled -}}
+            {{- if or .Values.s3gateway.accessKey .Values.existingSecret }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: awsAccessKeyId
+            {{- end }}
+            {{- if or .Values.s3gateway.secretKey .Values.existingSecret }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: awsSecretAccessKey
+            {{- end }}
+            {{- end }}
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        {{- if and (not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) }}
+        - name: export
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "minio.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- end }}
+        - name: minio-user
+          secret:
+            secretName: {{ template "minio.secretName" . }}
+        {{- include "minio.tlsKeysVolume" . | indent 8 }}
+{{- end }}

--- a/chart/dependencies/minio/templates/ingress.yaml
+++ b/chart/dependencies/minio/templates/ingress.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "minio.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: {{ template "minio.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+      {{- if . }}
+      host: {{ . | quote }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/dependencies/minio/templates/networkpolicy.yaml
+++ b/chart/dependencies/minio/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ template "minio.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+      release: {{ .Release.Name }}
+  ingress:
+    - ports:
+        - port: {{ .Values.service.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "minio.name" . }}-client: "true"
+      {{- end }}
+{{- end }}

--- a/chart/dependencies/minio/templates/poddisruptionbudget.yaml
+++ b/chart/dependencies/minio/templates/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: minio
+  labels:
+    app: {{ template "minio.name" . }}
+spec:
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+{{- end }}

--- a/chart/dependencies/minio/templates/post-install-create-bucket-job.yaml
+++ b/chart/dependencies/minio/templates/post-install-create-bucket-job.yaml
@@ -1,0 +1,89 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if or .Values.defaultBucket.enabled .Values.buckets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "minio.fullname" . }}-make-bucket-job
+  labels:
+    app: {{ template "minio.name" . }}-make-bucket-job
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- with .Values.makeBucketJob.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-job
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.makeBucketJob.podAnnotations }}
+      annotations:
+{{ toYaml .Values.makeBucketJob.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.makeBucketJob.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.makeBucketJob.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.makeBucketJob.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.makeBucketJob.securityContext.fsGroup }}
+{{- end }}
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: {{ template "minio.fullname" . }}
+            - secret:
+                name: {{ template "minio.secretName" . }}
+        {{- if .Values.tls.enabled }}
+        - name: cert-secret-volume-mc
+          secret:
+            secretName: {{ .Values.tls.certSecret }}
+            items:
+            - key: {{ .Values.tls.publicCrt }}
+              path: CAs/public.crt
+        {{ end }}
+      serviceAccountName: {{ include "minio.serviceAccountName" . | quote }}
+      containers:
+      - name: minio-mc
+        image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+        imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        command: ["/bin/sh", "/config/initialize"]
+        env:
+          - name: MINIO_ENDPOINT
+            value: {{ template "minio.fullname" . }}
+          - name: MINIO_PORT
+            value: {{ .Values.service.port | quote }}
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config
+          {{- if .Values.tls.enabled }}
+          - name: cert-secret-volume-mc
+            mountPath: {{ .Values.configPathmc }}certs
+          {{ end }}
+        resources:
+{{ toYaml .Values.makeBucketJob.resources | indent 10 }}
+{{- end }}

--- a/chart/dependencies/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/chart/dependencies/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -1,0 +1,137 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- $fullName := include "minio.fullname" . -}}
+{{ $scheme := "http" }}
+{{- if .Values.tls.enabled }}
+{{ $scheme = "https" }}
+{{ end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  {{ toYaml .Values.updatePrometheusJob.annotations | indent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-update-prometheus-secret
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.updatePrometheusJob.podAnnotations }}
+      annotations:
+{{ toYaml .Values.updatePrometheusJob.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ $fullName }}-update-prometheus-secret
+{{- end }}
+      restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.updatePrometheusJob.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.updatePrometheusJob.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.updatePrometheusJob.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.updatePrometheusJob.securityContext.fsGroup }}
+{{- end }}
+      volumes:
+        - name: workdir
+          emptyDir: {}
+      initContainers:
+        - name: minio-mc
+          image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+          imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            - mc --config-dir {{ .Values.configPathmc }} admin prometheus generate target --json --no-color -q > /workdir/mc.json
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: secretkey
+            #  mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
+            - name: MC_HOST_target
+              value: {{ $scheme }}://$(MINIO_ACCESS_KEY):$(MINIO_SECRET_KEY)@{{ $fullName }}:{{ .Values.service.port }}
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        # extract bearerToken from mc admin output
+        - name: jq
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            - jq -e -c -j -r .bearerToken < /workdir/mc.json > /workdir/token
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: kubectl-create
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            # The following script does:
+            # - get the servicemonitor that need this secret and copy some metadata and create the ownerreference for the secret file
+            # - create the secret
+            # - merge both json
+            - >
+              kubectl -n {{ .Release.Namespace }} get servicemonitor {{ $fullName }} -o json |
+                jq -c '{metadata: {name: "{{ $fullName }}-prometheus", namespace: .metadata.namespace, labels: {app: .metadata.labels.app, release: .metadata.labels.release}, ownerReferences: [{apiVersion: .apiVersion, kind: .kind, blockOwnerDeletion: true, controller: true, uid: .metadata.uid, name: .metadata.name}]}}' > /workdir/metadata.json &&
+              kubectl create secret generic {{ $fullName }}-prometheus --from-file=token=/workdir/token --dry-run -o json > /workdir/secret.json &&
+              cat /workdir/secret.json /workdir/metadata.json | jq -s add > /workdir/object.json
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      containers:
+        - name: kubectl-apply
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - kubectl
+            - apply
+            - "-f"
+            - /workdir/object.json
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/chart/dependencies/minio/templates/post-install-prometheus-metrics-role.yaml
+++ b/chart/dependencies/minio/templates/post-install-prometheus-metrics-role.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+    resourceNames:
+      - {{ $fullName }}-prometheus
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+    resourceNames:
+      - {{ $fullName }}
+{{- end -}}

--- a/chart/dependencies/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
+++ b/chart/dependencies/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-update-prometheus-secret
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-update-prometheus-secret
+    namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/chart/dependencies/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
+++ b/chart/dependencies/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/chart/dependencies/minio/templates/pvc.yaml
+++ b/chart/dependencies/minio/templates/pvc.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) Minio https://min.io/.
+
+{{- if eq .Values.mode "standalone" }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+{{- if and .Values.nasgateway.enabled .Values.nasgateway.pv }}
+  selector:
+    matchLabels:
+      pv: {{ .Values.nasgateway.pv | quote }}
+{{- end }}
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- if .Values.persistence.VolumeName }}
+  volumeName: "{{ .Values.persistence.VolumeName }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/chart/dependencies/minio/templates/rolebindings.yaml
+++ b/chart/dependencies/minio/templates/rolebindings.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "minio.serviceAccountName" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "minio.serviceAccountName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "minio.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/chart/dependencies/minio/templates/secrets.yaml
+++ b/chart/dependencies/minio/templates/secrets.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "minio.secretName" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  accesskey: {{ if .Values.accessKey }}{{ .Values.accessKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
+  secretkey: {{ if .Values.secretKey }}{{ .Values.secretKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
+{{- if and .Values.gcsgateway.enabled .Values.gcsgateway.gcsKeyJson }}
+  gcs_key.json: {{ .Values.gcsgateway.gcsKeyJson | toString | b64enc }}
+{{- end }}
+{{- if .Values.s3gateway.enabled -}}
+{{- if .Values.s3gateway.accessKey }}
+  awsAccessKeyId: {{ .Values.s3gateway.accessKey | toString | b64enc | quote }}
+{{- end }}
+{{- if .Values.s3gateway.secretKey }}
+  awsSecretAccessKey: {{ .Values.s3gateway.secretKey | toString | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.etcd.clientCert }}
+  etcd_client_cert.pem: {{ .Values.etcd.clientCert | toString | b64enc | quote }}
+{{- end }}
+{{- if .Values.etcd.clientCertKey }}
+  etcd_client_cert_key.pem: {{ .Values.etcd.clientCertKey | toString | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/chart/dependencies/minio/templates/securitycontextconstraints.yaml
+++ b/chart/dependencies/minio/templates/securitycontextconstraints.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: []
+readOnlyRootFilesystem: false
+defaultAddCapabilities: []
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+fsGroup:
+  type: MustRunAs
+  ranges:
+  - max: {{ .Values.securityContext.fsGroup }}
+    min: {{ .Values.securityContext.fsGroup }}
+runAsUser:
+  type: MustRunAs
+  uid: {{ .Values.securityContext.runAsUser }}
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{- end }}

--- a/chart/dependencies/minio/templates/service.yaml
+++ b/chart/dependencies/minio/templates/service.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) Minio https://min.io/
+
+{{ $scheme := "http" }}
+{{- if .Values.tls.enabled }}
+{{ $scheme = "https" }}
+{{ end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP" "") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if not (empty .Values.service.clusterIP) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+  ports:
+    - name: {{ $scheme }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+{{- if (and (eq .Values.service.type "NodePort") ( .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- else }}
+      targetPort: 9000
+{{- end}}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{- range $i , $ip := .Values.service.externalIPs }}
+  - {{ $ip }}
+{{- end }}
+{{- end }}
+  selector:
+    app: {{ template "minio.name" . }}
+    release: {{ .Release.Name }}

--- a/chart/dependencies/minio/templates/serviceaccount.yaml
+++ b/chart/dependencies/minio/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "minio.serviceAccountName" . | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: "{{ .Release.Name }}"
+{{- end -}}

--- a/chart/dependencies/minio/templates/servicemonitor.yaml
+++ b/chart/dependencies/minio/templates/servicemonitor.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{ $scheme := "http" }}
+{{- if .Values.tls.enabled }}
+{{ $scheme = "https" }}
+{{ end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "minio.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: {{ $scheme }}
+      path: /minio/prometheus/metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelConfigs }}
+{{ toYaml .Values.metrics.serviceMonitor.relabelConfigs | indent 6 }}
+      {{- end }}
+      bearerTokenSecret:
+        name: {{ template "minio.fullname" . }}-prometheus
+        key: token
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app: {{ include "minio.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/chart/dependencies/minio/templates/statefulset.yaml
+++ b/chart/dependencies/minio/templates/statefulset.yaml
@@ -1,0 +1,183 @@
+# Copyright (c) Minio https://min.io/
+
+{{- if eq .Values.mode "distributed" }}
+{{ $zoneCount := .Values.zones | int }}
+{{ $nodeCount := .Values.replicas | int }}
+{{ $drivesPerNode := .Values.drivesPerNode | int }}
+{{ $scheme := "http" }}
+{{- if .Values.tls.enabled }}
+{{ $scheme = "https" }}
+{{ end }}
+{{ $mountPath := .Values.mountPath }}
+{{ $bucketRoot := or ($.Values.bucketRoot) ($.Values.mountPath) }}
+{{ $subPath := .Values.persistence.subPath }}
+{{ $penabled := .Values.persistence.enabled }}
+{{ $accessMode := .Values.persistence.accessMode }}
+{{ $storageClass := .Values.persistence.storageClass }}
+{{ $psize := .Values.persistence.size }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "minio.fullname" . }}-svc
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  publishNotReadyAddresses: true
+  clusterIP: None
+  ports:
+    - name: {{ $scheme }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "minio.name" . }}
+    release: {{ .Release.Name }}
+---
+apiVersion: {{ template "minio.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | trimSuffix "\n" | indent 4 }}
+{{- end }}
+{{- if .Values.additionalAnnotations }}
+  annotations:
+{{ toYaml .Values.additionalAnnotations | trimSuffix "\n" | indent 4 }}
+{{- end }}
+spec:
+  updateStrategy:
+    type: {{ .Values.StatefulSetUpdate.updateStrategy }}
+  podManagementPolicy: "Parallel"
+  serviceName: {{ template "minio.fullname" . }}-svc
+  replicas: {{ mul $zoneCount $nodeCount }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "minio.fullname" . }}
+      labels:
+        app: {{ template "minio.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      serviceAccountName: {{ include "minio.serviceAccountName" . | quote }}
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          command: [ "/bin/sh",
+            "-ce",
+            "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{- range $i := until $zoneCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}}{{- template `minio.extraArgs` . }}" ]
+          volumeMounts:
+            {{- if $penabled }}
+            {{- if (gt $drivesPerNode 1) }}
+            {{- range $i := until $drivesPerNode }}
+            - name: export-{{ $i }}
+              mountPath: {{ $mountPath }}-{{ $i }}
+              {{- if and $penabled $subPath }}
+              subPath: {{ $subPath }}
+              {{- end }}
+            {{- end }}
+            {{- else }}
+            - name: export
+              mountPath: {{ $mountPath }}
+              {{- if and $penabled $subPath }}
+              subPath: {{ $subPath }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- include "minio.tlsKeysVolumeMount" . | indent 12 }}
+          ports:
+            - name: {{ $scheme }}
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: secretkey
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: minio-user
+          secret:
+            secretName: {{ template "minio.secretName" . }}
+        {{- include "minio.tlsKeysVolume" . | indent 8 }}
+{{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  {{- if gt $drivesPerNode 1 }}
+    {{- range $diskId := until $drivesPerNode}}
+    - metadata:
+        name: export-{{ $diskId }}
+      spec:
+        accessModes: [ {{ $accessMode | quote }} ]
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $psize }}
+    {{- end }}
+  {{- else }}
+    - metadata:
+        name: export
+      spec:
+        accessModes: [ {{ $accessMode | quote }} ]
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $psize }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/chart/dependencies/minio/values.yaml
+++ b/chart/dependencies/minio/values.yaml
@@ -1,0 +1,355 @@
+# Copyright (c) Minio https://min.io/
+
+## Provide a name in place of minio for `app:` labels
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources
+##
+fullnameOverride: ""
+
+## set kubernetes cluster domain where minio is running
+##
+clusterDomain: cluster.local
+
+## Set default image, imageTag, and imagePullPolicy. mode is used to indicate the
+##
+image:
+  repository: minio/minio
+  tag: RELEASE.2021-02-14T04-01-33Z
+  pullPolicy: IfNotPresent
+
+## Set default image, imageTag, and imagePullPolicy for the `mc` (the minio
+## client used to create a default bucket).
+##
+mcImage:
+  repository: minio/mc
+  tag: RELEASE.2021-02-14T04-28-06Z
+  pullPolicy: IfNotPresent
+
+## Set default image, imageTag, and imagePullPolicy for the `jq` (the JSON
+## process used to create secret for prometheus ServiceMonitor).
+##
+helmKubectlJqImage:
+  repository: bskim45/helm-kubectl-jq
+  tag: 3.1.0
+  pullPolicy: IfNotPresent
+
+## minio server mode, i.e. standalone or distributed.
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+mode: standalone
+
+## Additional labels to include with deployment or statefulset
+additionalLabels: []
+
+## Additional annotations to include with deployment or statefulset
+additionalAnnotations: []
+
+## Additional arguments to pass to minio binary
+extraArgs: []
+
+## Update strategy for Deployments
+DeploymentUpdate:
+  type: RollingUpdate
+  maxUnavailable: 0
+  maxSurge: 100%
+
+## Update strategy for StatefulSets
+StatefulSetUpdate:
+  updateStrategy: RollingUpdate
+
+## Pod priority settings
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+priorityClassName: ""
+
+## Set default accesskey, secretkey, Minio config file path, volume mount path and
+## number of nodes (only used for Minio distributed mode)
+## AccessKey and secretKey is generated when not set
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+accessKey: ""
+secretKey: ""
+certsPath: "/etc/minio/certs/"
+configPathmc: "/etc/minio/mc/"
+mountPath: "/export"
+
+## Use existing Secret that store following variables:
+##
+## | Chart var             | .data.<key> in Secret    |
+## |:----------------------|:-------------------------|
+## | accessKey             | accesskey                |
+## | secretKey             | secretkey                |
+## | gcsgateway.gcsKeyJson | gcs_key.json             |
+## | s3gateway.accessKey   | awsAccessKeyId           |
+## | s3gateway.secretKey   | awsSecretAccessKey       |
+## | etcd.clientCert       | etcd_client_cert.pem     |
+## | etcd.clientCertKey    | etcd_client_cert_key.pem |
+##
+## All mentioned variables will be ignored in values file.
+## .data.accesskey and .data.secretkey are mandatory,
+## others depend on enabled status of corresponding sections.
+existingSecret: ""
+
+## Override the root directory which the minio server should serve from.
+## If left empty, it defaults to the value of {{ .Values.mountPath }}
+## If defined, it must be a sub-directory of the path specified in {{ .Values.mountPath }}
+bucketRoot: ""
+
+# Number of drives attached to a node
+drivesPerNode: 1
+# Number of MinIO containers running
+replicas: 4
+# Number of expanded MinIO clusters
+zones: 1
+
+## TLS Settings for Minio
+tls:
+  enabled: false
+  ## Create a secret with private.key and public.crt files and pass that here. Ref: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+  certSecret: ""
+  publicCrt: public.crt
+  privateKey: private.key
+
+## Trusted Certificates Settings for Minio. Ref: https://docs.minio.io/docs/how-to-secure-access-to-minio-server-with-tls#install-certificates-from-third-party-cas
+## Bundle multiple trusted certificates into one secret and pass that here. Ref: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+## When using self-signed certificates, remember to include Minio's own certificate in the bundle with key public.crt.
+## If certSecret is left empty and tls is enabled, this chart installs the public certificate from .Values.tls.certSecret.
+trustedCertsSecret: ""
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  existingClaim: ""
+
+  ## minio data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  ## Storage class of PV to bind. By default it looks for standard storage class.
+  ## If the PV uses a different storage class, specify that here.
+  storageClass: ""
+  VolumeName: ""
+  accessMode: ReadWriteOnce
+  size: 500Gi
+
+  ## If subPath is set mount a sub folder of a volume instead of the root of the volume.
+  ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
+  ##
+  subPath: ""
+
+## Expose the Minio service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+
+service:
+  type: ClusterIP
+  clusterIP: ~
+  port: 9000
+  nodePort: 32000
+
+  ## List of IP addresses at which the Prometheus server service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+  #   - externalIp1
+
+  annotations: {}
+    # prometheus.io/scrape: 'true'
+    # prometheus.io/path:   '/minio/prometheus/metrics'
+    # prometheus.io/port:   '9000'
+
+## Configure Ingress based on the documentation here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+
+imagePullSecrets: []
+# - name: "image-pull-secret"
+
+ingress:
+  enabled: false
+  labels: {}
+    # node-role.kubernetes.io/ingress: platform
+
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.allow-http: "false"
+    # kubernetes.io/ingress.global-static-ip-name: ""
+    # nginx.ingress.kubernetes.io/secure-backends: "true"
+    # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    # nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+## Add stateful containers to have security context, if enabled MinIO will run as this
+## user and group NOTE: securityContext is only enabled if persistence.enabled=true
+securityContext:
+  enabled: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+# Additational pod annotations
+podAnnotations: {}
+
+# Additional pod labels
+podLabels: {}
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 4Gi
+
+## Create a bucket after minio install
+##
+defaultBucket:
+  enabled: false
+  ## If enabled, must be a string with length > 0
+  name: bucket
+  ## Can be one of none|download|upload|public
+  policy: none
+  ## Purge if bucket exists already
+  purge: false
+  ## set versioning for bucket true|false
+  # versioning: false
+
+## Create multiple buckets after minio install
+## Enabling `defaultBucket` will take priority over this list
+##
+buckets: []
+  # - name: bucket1
+  #   policy: none
+  #   purge: false
+  # - name: bucket2
+  #   policy: none
+  #   purge: false
+
+## Additional Annotations for the Kubernetes Batch (make-bucket-job)
+makeBucketJob:
+  podAnnotations:
+  annotations:
+  securityContext:
+    enabled: false
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  resources:
+    requests:
+      memory: 128Mi
+
+## Additional Annotations for the Kubernetes Batch (update-prometheus-secret)
+updatePrometheusJob:
+  podAnnotations:
+  annotations:
+  securityContext:
+    enabled: false
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+
+s3gateway:
+  enabled: false
+  replicas: 4
+  serviceEndpoint: ""
+  accessKey: ""
+  secretKey: ""
+
+## Use minio as an azure blob gateway, you should disable data persistence so no volume claim are created.
+## https://docs.minio.io/docs/minio-gateway-for-azure
+azuregateway:
+  enabled: false
+  # Number of parallel instances
+  replicas: 4
+
+## Use minio as GCS (Google Cloud Storage) gateway, you should disable data persistence so no volume claim are created.
+## https://docs.minio.io/docs/minio-gateway-for-gcs
+
+gcsgateway:
+  enabled: false
+  # Number of parallel instances
+  replicas: 4
+  # credential json file of service account key
+  gcsKeyJson: ""
+  # Google cloud project-id
+  projectId: ""
+
+## Use minio on NAS backend
+## https://docs.minio.io/docs/minio-gateway-for-nas
+
+nasgateway:
+  enabled: false
+  # Number of parallel instances
+  replicas: 4
+  # For NAS Gateway, you may want to bind the PVC to a specific PV. To ensure that happens, PV to bind to should have
+  # a label like "pv: <value>", use value here.
+  pv: ~
+
+## Use this field to add environment variables relevant to Minio server. These fields will be passed on to Minio container(s)
+## when Chart is deployed
+environment: {}
+  ## Please refer for comprehensive list https://docs.minio.io/docs/minio-server-configuration-guide.html
+  ## MINIO_DOMAIN: "chart-example.local"
+  ## MINIO_BROWSER: "off"
+
+networkPolicy:
+  enabled: false
+  allowExternal: true
+
+## PodDisruptionBudget settings
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+##
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1
+
+## Specify the service account to use for the Minio pods. If 'create' is set to 'false'
+## and 'name' is left unspecified, the account 'default' will be used.
+serviceAccount:
+  create: true
+  ## The name of the service account to use. If 'create' is 'true', a service account with that name
+  ## will be created. Otherwise, a name will be auto-generated.
+  name:
+
+metrics:
+  # Metrics can not be disabled yet: https://github.com/minio/minio/issues/7493
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    relabelConfigs: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+
+## ETCD settings: https://github.com/minio/minio/blob/master/docs/sts/etcd.md
+## Define endpoints to enable this section.
+etcd:
+  endpoints: []
+  pathPrefix: ""
+  corednsPathPrefix: ""
+  clientCert: ""
+  clientCertKey: ""


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Minio removed their chart overnight. This replaces it with a forked version of the chart.

Ideally, I would have changed to using the Bitnami Minio chart as has been done in the Installer. However, this requires a change of values from `minio.accessKey` and `minio.secretKey` to `minio.auth.rootUser` and `minio.auth.rootPassword`. From a testability/documentation/speed point of view, I took the view that this was too big a change and would require changes in Core Dev, Staging and Production. Using a fork at least keeps the change simple

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6876

## How to test
<!-- Provide steps to test this PR -->
Use Core Dev

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Change Minio to forked version
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
