### PR TITLE
[installer]: set all internal certs to 90 days duration

### DIFF
--- a/installer/pkg/common/constants.go
+++ b/installer/pkg/common/constants.go
@@ -4,6 +4,11 @@
 
 package common
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
 // This file exists to break cyclic-dependency errors
 
 const (
@@ -34,4 +39,8 @@ const (
 	WSSchedulerComponent        = "ws-scheduler"
 
 	AnnotationConfigChecksum = "gitpod.io/checksum_config"
+)
+
+var (
+	InternalCertDuration = &metav1.Duration{Duration: time.Hour * 24 * 90}
 )

--- a/installer/pkg/components/cluster/certmanager.go
+++ b/installer/pkg/components/cluster/certmanager.go
@@ -39,6 +39,7 @@ func certmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: v1.CertificateSpec{
 				IsCA:       true,
+				Duration:   common.InternalCertDuration,
 				CommonName: caName,
 				SecretName: caName,
 				PrivateKey: &v1.CertificatePrivateKey{

--- a/installer/pkg/components/docker-registry/certificate.go
+++ b/installer/pkg/components/docker-registry/certificate.go
@@ -6,11 +6,9 @@ package dockerregistry
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"time"
-
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -21,8 +19,6 @@ func certificate(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, nil
 	}
 
-	oneYear := &metav1.Duration{Duration: time.Hour * 24 * 365}
-
 	return []runtime.Object{&certmanagerv1.Certificate{
 		TypeMeta: common.TypeMetaCertificate,
 		ObjectMeta: metav1.ObjectMeta{
@@ -31,7 +27,7 @@ func certificate(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Labels:    common.DefaultLabels(Component),
 		},
 		Spec: certmanagerv1.CertificateSpec{
-			Duration:   oneYear,
+			Duration:   common.InternalCertDuration,
 			SecretName: BuiltInRegistryCerts,
 			IssuerRef: cmmeta.ObjectReference{
 				Name:  common.CertManagerCAIssuer,

--- a/installer/pkg/components/registry-facade/certificate.go
+++ b/installer/pkg/components/registry-facade/certificate.go
@@ -6,8 +6,6 @@ package registryfacade
 
 import (
 	"fmt"
-	"time"
-
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 
@@ -17,8 +15,6 @@ import (
 )
 
 func certificate(ctx *common.RenderContext) ([]runtime.Object, error) {
-	oneYear := &metav1.Duration{Duration: time.Hour * 24 * 365}
-
 	return []runtime.Object{&certmanagerv1.Certificate{
 		TypeMeta: common.TypeMetaCertificate,
 		ObjectMeta: metav1.ObjectMeta{
@@ -27,7 +23,7 @@ func certificate(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Labels:    common.DefaultLabels(Component),
 		},
 		Spec: certmanagerv1.CertificateSpec{
-			Duration:   oneYear,
+			Duration:   common.InternalCertDuration,
 			SecretName: common.RegistryFacadeTLSCertSecret,
 			IssuerRef: cmmeta.ObjectReference{
 				Name:  common.CertManagerCAIssuer,

--- a/installer/pkg/components/ws-daemon/tlssecret.go
+++ b/installer/pkg/components/ws-daemon/tlssecret.go
@@ -10,14 +10,10 @@ import (
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
-
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
-	oneYear := &metav1.Duration{Duration: time.Hour * 24 * 365}
-
 	return []runtime.Object{
 		&certmanagerv1.Certificate{
 			TypeMeta: common.TypeMetaCertificate,
@@ -27,7 +23,7 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.DefaultLabels(Component),
 			},
 			Spec: certmanagerv1.CertificateSpec{
-				Duration:   oneYear,
+				Duration:   common.InternalCertDuration,
 				SecretName: TLSSecretName,
 				DNSNames: []string{
 					fmt.Sprintf("gitpod.%s", ctx.Namespace),

--- a/installer/pkg/components/ws-manager/tlssecret.go
+++ b/installer/pkg/components/ws-manager/tlssecret.go
@@ -6,8 +6,6 @@ package wsmanager
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -32,7 +30,6 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Component,
 	}
 
-	sixMonths := &metav1.Duration{Duration: time.Hour * 4380}
 	issuer := common.CertManagerCAIssuer
 
 	return []runtime.Object{
@@ -44,7 +41,7 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.DefaultLabels(Component),
 			},
 			Spec: certmanagerv1.CertificateSpec{
-				Duration:   sixMonths,
+				Duration:   common.InternalCertDuration,
 				SecretName: TLSSecretNameSecret,
 				DNSNames:   serverAltNames,
 				IssuerRef: cmmeta.ObjectReference{
@@ -62,7 +59,7 @@ func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.DefaultLabels(Component),
 			},
 			Spec: certmanagerv1.CertificateSpec{
-				Duration:   sixMonths,
+				Duration:   common.InternalCertDuration,
 				SecretName: TLSSecretNameClient,
 				DNSNames:   clientAltNames,
 				IssuerRef: cmmeta.ObjectReference{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Give all internal certs a consistent 90 day duration (I chose this figure as it's what LetsEncrypt does - happy to change if necessary).

Did this after setting all certs to a duration of 1 hour to prove that they auto-renew, which they do.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6820

## How to test
<!-- Provide steps to test this PR -->
Deploy the installer

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Set internal certs to 90 day duration
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
