### PR TITLE
[payment-endpoint] GitHub: fix reconcilePlan

### DIFF
--- a/components/ee/payment-endpoint/package.json
+++ b/components/ee/payment-endpoint/package.json
@@ -42,7 +42,7 @@
     "build:clean": "yarn clean && yarn build",
     "rebuild": "yarn build:clean",
     "build:watch": "watch 'yarn build' .",
-    "watch": "yarn tsc -w",
+    "watch": "leeway exec --package .:app --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
     "clean": "yarn run rimraf lib",
     "clean:node": "yarn run rimraf node_modules",
     "purge": "yarn clean && yarn clean:node && yarn run rimraf yarn.lock",

--- a/components/gitpod-db/src/accounting-db.ts
+++ b/components/gitpod-db/src/accounting-db.ts
@@ -6,7 +6,12 @@
 
 import { AccountEntry, Subscription, SubscriptionAndUser, Credit } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { DBSubscriptionAdditionalData, DBPaymentSourceInfo } from "./typeorm/entity/db-subscription";
-import { DeepPartial } from "typeorm";
+import { DeepPartial, EntityManager } from "typeorm";
+
+export const TransactionalAccountingDBFactory = Symbol('TransactionalAccountingDBFactory');
+export interface TransactionalAccountingDBFactory {
+    (manager: EntityManager): AccountingDB;
+}
 
 export const AccountingDB = Symbol('AccountingDB');
 
@@ -33,7 +38,7 @@ export interface AccountingDB {
     hadSubscriptionCreatedWithCoupon(userId: string, coupon: string): Promise<boolean>;
     findSubscriptionAdditionalData(paymentReference: string): Promise<DBSubscriptionAdditionalData | undefined>;
 
-    transaction<T>(code: (db: AccountingDB)=>Promise<T>): Promise<T>;
+    transaction<T>(closure: (db: AccountingDB)=>Promise<T>, closures?: ((manager: EntityManager) => Promise<any>)[]): Promise<T>;
 
     storeSubscriptionAdditionalData(subscriptionData: DBSubscriptionAdditionalData): Promise<DBSubscriptionAdditionalData>;
     storePaymentSourceInfo(cardInfo: DBPaymentSourceInfo): Promise<DBPaymentSourceInfo>;

--- a/components/gitpod-db/src/pending-github-event-db.ts
+++ b/components/gitpod-db/src/pending-github-event-db.ts
@@ -5,8 +5,14 @@
  */
 
 import { PendingGithubEvent, User, Identity } from "@gitpod/gitpod-protocol";
+import { EntityManager } from "typeorm";
 
 export type PendingGithubEventWithUser = PendingGithubEvent & { identity: Identity & { user: User } };
+
+export const TransactionalPendingGithubEventDBFactory = Symbol('TransactionalPendingGithubEventDBFactory');
+export interface TransactionalPendingGithubEventDBFactory {
+    (manager: EntityManager): PendingGithubEventDB;
+}
 
 export const PendingGithubEventDB = Symbol('PendingGithubEventDB');
 export interface PendingGithubEventDB {
@@ -19,4 +25,7 @@ export interface PendingGithubEventDB {
      * when the event arrived. This function finds all pending events for which a user exists now.
      */
     findWithUser(type: string): Promise<PendingGithubEventWithUser[]>;
+
+
+    transaction<T>(code: (db: PendingGithubEventDB) => Promise<T>): Promise<T>;
 }

--- a/components/gitpod-db/src/typeorm/pending-github-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/pending-github-event-db-impl.ts
@@ -38,7 +38,7 @@ export class TypeORMPendingGithubEventDBImpl implements PendingGithubEventDB {
 
     public async delete(evt: PendingGithubEvent) {
         // pending events is not synchronized via DB sync so we can delete it
-        (await this.getRepo()).delete(evt);
+        (await this.getRepo()).delete(evt.id);
     }
 
     public async findWithUser(type: string): Promise<PendingGithubEventWithUser[]> {

--- a/components/gitpod-db/src/typeorm/pending-github-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/pending-github-event-db-impl.ts
@@ -8,13 +8,14 @@ import { inject, injectable } from "inversify";
 import { PendingGithubEvent } from "@gitpod/gitpod-protocol";
 import { EntityManager, Repository } from "typeorm";
 import { TypeORM } from './typeorm';
-import { PendingGithubEventDB, PendingGithubEventWithUser } from "../pending-github-event-db";
+import { PendingGithubEventDB, PendingGithubEventWithUser, TransactionalPendingGithubEventDBFactory } from "../pending-github-event-db";
 import { DBPendingGithubEvent } from "./entity/db-pending-github-event";
 import { DBIdentity } from "./entity/db-identity";
 
 @injectable()
 export class TypeORMPendingGithubEventDBImpl implements PendingGithubEventDB {
     @inject(TypeORM) protected readonly typeorm: TypeORM;
+    @inject(TransactionalPendingGithubEventDBFactory) protected readonly transactionalFactory: TransactionalPendingGithubEventDBFactory;
 
     protected async getManager(): Promise<EntityManager> {
         return (await this.typeorm.getConnection()).manager;
@@ -55,4 +56,27 @@ export class TypeORMPendingGithubEventDBImpl implements PendingGithubEventDB {
         return res as PendingGithubEventWithUser[];
     }
 
+    async transaction<T>(code: (db: PendingGithubEventDB) => Promise<T>): Promise<T> {
+        const manager = await this.getManager();
+        return await manager.transaction(async manager => {
+            const transactionalDB = this.transactionalFactory(manager);
+            return await code(transactionalDB);
+        });
+    }
+}
+
+export class TransactionalPendingGithubEventDBImpl extends TypeORMPendingGithubEventDBImpl {
+
+    constructor(
+        protected readonly manager: EntityManager) {
+        super();
+    }
+
+    protected async getManager() {
+        return this.manager;
+    }
+
+    public async transaction<T>(code: (sb: PendingGithubEventDB) => Promise<T>): Promise<T> {
+        return await code(this);
+    }
 }


### PR DESCRIPTION
## Description
This PR fixes two issues that in combination caused https://github.com/gitpod-io/ops/issues/339:
 - [0b72f48](https://github.com/gitpod-io/gitpod/commit/0b72f4851dba42fda8c6927af3a3142fa6388976): reference `PendingGitHubEvents` by id and not by full shape for deletion: This ensures typeorm does not choke on unexpected fields ([identity](https://console.cloud.google.com/logs/query;cursorTimestamp=2021-11-25T14:05:29.182Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.pod_name:%22payment-endpoint-%22%0Atimestamp%3D%222021-11-25T14:05:26.842Z%22%0AinsertId%3D%22h89m9xljfvzh70c6%22?project=gitpod-191109))
 - [8bbb5fc](https://github.com/gitpod-io/gitpod/commit/8bbb5fc4117e3766f61bba8cc6a3a473ec601b23) and [ede2412](https://github.com/gitpod-io/gitpod/commit/ede241292cae98807fbed920c2b2a159cc26081f): Ensure that event reconciliation and bookkeeping are running inside the same transaction. This required a bit more code in `gitpod-db` as we so far had no interface to do so. The current solution is not perfect (too much code per DB) but IMO a reasonable compromise.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/339

## How to test
I'm not sure how to test this in devstaging :confused: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
