### PR TITLE
[installer] Add option to use S3 as docker-registry backend

### DIFF
--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -162,6 +162,7 @@ const (
 type ContainerRegistry struct {
 	InCluster *bool                      `json:"inCluster,omitempty" validate:"required"`
 	External  *ContainerRegistryExternal `json:"external,omitempty" validate:"required_if=InCluster false"`
+	S3Storage *S3Storage                 `json:"s3storage"`
 }
 
 type ContainerRegistryExternal struct {
@@ -169,6 +170,10 @@ type ContainerRegistryExternal struct {
 	Certificate ObjectRef `json:"certificate" validate:"required"`
 }
 
+type S3Storage struct {
+	Bucket      string    `json:"bucket" validate:"required"`
+	Certificate ObjectRef `json:"certificate" validate:"required"`
+}
 type Jaeger struct {
 	InCluster *bool                   `json:"inCluster,omitempty" validate:"required"`
 	External  *JaegerOperatorExternal `json:"external,omitempty" validate:"required_if=InCluster false"`

--- a/installer/third_party/charts/docker-registry/Chart.yaml
+++ b/installer/third_party/charts/docker-registry/Chart.yaml
@@ -8,5 +8,5 @@ name: docker-registry
 version: 1.0.0
 dependencies:
   - name: docker-registry
-    version: 1.11.0
+    version: 1.14.0
     repository: https://helm.twun.io


### PR DESCRIPTION
## Description

Enable S3 as backend storage for `inCluster` `docker-registry`.
This is useful in  at least two scenarios:
- In EKS, where ECR requires the creation of repositories
- self-hosted using S3 compatible storage (like Minio) instead of in cluster storage.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Add option to use S3 as docker-registry backend
```
