### PR TITLE
[server] Fix grpc client leak

### DIFF
--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -7,7 +7,7 @@
     "build": "mkdir -p lib; tsc && cp -f src/*.js src/*d.ts lib"
   },
   "files": [
-    ".",
+    "src",
     "lib"
   ],
   "dependencies": {

--- a/components/content-service-api/typescript/src/sugar.ts
+++ b/components/content-service-api/typescript/src/sugar.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable, interfaces, optional } from "inversify";
+import * as grpc from "@grpc/grpc-js";
+import { createClientCallMetricsInterceptor, IClientCallMetrics } from "./client-call-metrics";
+import { IDEPluginServiceClient } from "./ideplugin_grpc_pb";
+import { ContentServiceClient } from "./content_grpc_pb";
+import { BlobServiceClient } from "./blobs_grpc_pb";
+import { WorkspaceServiceClient } from "./workspace_grpc_pb";
+import { HeadlessLogServiceClient } from "./headless-log_grpc_pb";
+
+export const ContentServiceClientConfig = Symbol("ContentServiceClientConfig");
+export const ContentServiceClientCallMetrics = Symbol("ContentServiceClientCallMetrics");
+
+export const contentServiceBinder = (config: (ctx: interfaces.Context) => ContentServiceClientConfig, clientCallMetrics?: IClientCallMetrics): interfaces.ContainerModuleCallBack => {
+    return (bind, unbind, isBound, rebind) => {
+        bind(ContentServiceClientConfig).toDynamicValue(config).inSingletonScope();
+        if (clientCallMetrics) {
+            bind(ContentServiceClientCallMetrics).toConstantValue(clientCallMetrics);
+        }
+
+        bind(CachingContentServiceClientProvider).toSelf().inSingletonScope();
+        bind(CachingBlobServiceClientProvider).toSelf().inSingletonScope();
+        bind(CachingWorkspaceServiceClientProvider).toSelf().inSingletonScope();
+        bind(CachingIDEPluginClientProvider).toSelf().inSingletonScope();
+        bind(CachingHeadlessLogServiceClientProvider).toSelf().inSingletonScope();
+    };
+};
+
+export interface ContentServiceClientConfig {
+    address: string;
+    credentials: grpc.ChannelCredentials;
+    options?: Partial<grpc.ClientOptions>;
+}
+
+type Client<T> = T & grpc.Client;
+
+/**
+ * ContentServiceClientProvider caches content service client
+ */
+export interface ContentServiceClientProvider<T> {
+    getDefault(): Client<T>;
+}
+
+@injectable()
+abstract class CachingClientProvider<T> implements ContentServiceClientProvider<T> {
+    @inject(ContentServiceClientConfig) protected readonly clientConfig: ContentServiceClientConfig;
+
+    @inject(ContentServiceClientCallMetrics) @optional()
+    protected readonly clientCallMetrics: IClientCallMetrics;
+
+    protected readonly interceptors: grpc.Interceptor[] = [];
+
+    // gRPC connections can be used concurrently, even across services.
+    // Thus it makes sense to cache them rather than create a new connection for each request.
+    protected client: Client<T> | undefined;
+
+    constructor(
+        protected readonly createClient: (config: ContentServiceClientConfig) => Client<T>,
+    ) {
+        if (this.clientCallMetrics) {
+            this.interceptors.push(createClientCallMetricsInterceptor(this.clientCallMetrics));
+        }
+    }
+
+    getDefault(): Client<T> {
+        let client = this.client;
+        if (!client) {
+            client = this.createClient(this.getConfig());
+        } else if (!isConnectionAlive(client)) {
+            client.close();
+
+            client = this.createClient(this.getConfig());
+        }
+
+        this.client = client;
+        return client;
+    }
+
+    protected getConfig(): ContentServiceClientConfig {
+        const config = this.clientConfig;
+        if (this.interceptors) {
+            return {
+                ...config,
+                options: {
+                    ...(config.options || {}),
+                    interceptors: [...(config.options?.interceptors || []), ...this.interceptors],
+                }
+            }
+        }
+        return config;
+    }
+}
+
+@injectable()
+export class CachingContentServiceClientProvider extends CachingClientProvider<ContentServiceClient> {
+    constructor() {
+        super((config) => {
+            return new ContentServiceClient(config.address, config.credentials, config.options);
+        })
+    }
+}
+
+@injectable()
+export class CachingBlobServiceClientProvider extends CachingClientProvider<BlobServiceClient> {
+    constructor() {
+        super((config) => {
+            return new BlobServiceClient(config.address, config.credentials, config.options);
+        })
+    }
+}
+
+@injectable()
+export class CachingWorkspaceServiceClientProvider extends CachingClientProvider<WorkspaceServiceClient> {
+    constructor() {
+        super((config) => {
+            return new WorkspaceServiceClient(config.address, config.credentials, config.options);
+        })
+    }
+}
+
+@injectable()
+export class CachingIDEPluginClientProvider extends CachingClientProvider<IDEPluginServiceClient> {
+    constructor() {
+        super((config) => {
+            return new IDEPluginServiceClient(config.address, config.credentials, config.options);
+        })
+    }
+}
+
+@injectable()
+export class CachingHeadlessLogServiceClientProvider extends CachingClientProvider<HeadlessLogServiceClient> {
+    constructor() {
+        super((config) => {
+            return new HeadlessLogServiceClient(config.address, config.credentials, config.options);
+        })
+    }
+}
+
+function isConnectionAlive(client: grpc.Client) {
+    const cs = client.getChannel().getConnectivityState(false);
+    return cs == grpc.connectivityState.CONNECTING || cs == grpc.connectivityState.IDLE || cs == grpc.connectivityState.READY;
+}


### PR DESCRIPTION
## Description
This PR fixes two of the issues identified in #6852:
 - [image-builder client is never explicitly closed](https://github.com/gitpod-io/gitpod/commit/c2c677eb9cd0835fda1957e194e0c0041133a123)
 - we create a lot of ContentService clients without making sure they re-connect or are properly `close`d [3c10694](https://github.com/gitpod-io/gitpod/commit/3c10694a6040e111c019ac809f959da64e2d2472)

Both issues are triggered/got worse by our version upgrade to `@grpc/grpc-js: 1.4.2` it seems.

As a side effect we now re-establish connections from websocket endpoints to `content-service`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6852.

## How to test

### Test that code-sync works
 1. open a fresh workspace: https://gpl-server-ram-leak.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-typescript-node
 2. open sync log (F1 -> Sync: log)
 3. install any extension (Gitlens for instance), and note how it shows up in the sync log
 4. open another fresh workspace: https://gpl-server-ram-leak.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-typescript-node
 5. open sync log (F1 -> Sync: log), and note how GitLens is synced and installed :heavy_check_mark: 

### Test that image builds work

 1. find a context with an not-yet-built dockerimage

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
