### PR TITLE
[Analytics] Fix path prop of dashboard_clicked event

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -189,7 +189,7 @@ function App() {
                 curr = curr.parentNode as HTMLElement;
             }
         }
-        window.addEventListener("click", handleButtonOrAnchorTracking);
+        window.addEventListener("click", handleButtonOrAnchorTracking, true);
         return () => window.removeEventListener("click", handleButtonOrAnchorTracking, true);
     }, []);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes an Analytics bug in the tracking of clicks in the dashboard where the path an anchor redirects to is passed to `path` of the `dashboard_clicked` track call instead of the path from which the anchor was clicked by moving the activation of the event handler to the capturing phase.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
- open `/project` in the preview environment
- click on Branches or Prebuild of any project
- check in Segment's staging untrusted source that the path for the fired `dashboard_clicked` is `/project`, not `/project/<name_of_project_the_link_redirects_to>[/prebuilds]`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe