### PR TITLE
[gitpod-protocol] Remove HTTP headers from logs

### DIFF
--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -218,7 +218,7 @@ func (rc *ReconnectingWebsocket) connect(ctx context.Context) *WebsocketConnecti
 		if resp != nil {
 			statusCode = resp.StatusCode
 		}
-		rc.log.WithField("url", rc.url).WithField("headers", rc.reqHeader).Info("websocket handshake")
+		rc.log.WithField("url", rc.url).Info("websocket handshake")
 
 		rc.log.WithError(err).
 			WithField("url", rc.url).


### PR DESCRIPTION
## Description
This is to avoid leaking bearer tokens in the logs.

/werft no-preview

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6919

## How to test
<!-- Provide steps to test this PR -->
Just check the code changes. Nothing else to do.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

