### PR TITLE
[server] Prevent blocked users from starting new prebuilds

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -65,6 +65,9 @@ export class PrebuildManager {
         span.setTag("cloneURL", cloneURL);
         span.setTag("commit", commit);
         try {
+            if (user.blocked) {
+                throw new Error("Blocked users cannot start prebuilds.");
+            }
             const existingPB = await this.workspaceDB.trace({ span }).findPrebuiltWorkspaceByCommit(cloneURL, commit);
             // If the existing prebuild is failed, we want to retrigger it.
             if (!!existingPB && existingPB.state !== 'aborted' && existingPB.state !== 'timeout' && !existingPB.error) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Before starting new prebuilds, check if the user is blocked. If they are, don't start the prebuild.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/371 (internal)

## How to test
<!-- Provide steps to test this PR -->

1. Set up Prebuilds for a repository
2. Become blocked (e.g. block yourself via Admin)
3. Changes to your repository shouldn't trigger new prebuilds

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc