### PR TITLE
Cleanup no child processes running errors

### DIFF
--- a/components/common-go/process/process.go
+++ b/components/common-go/process/process.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package process
+
+// IsNotChildProcess checks if an error returned by a command
+// execution is an error related to no child processes running
+// This can be seen, for instance, in short lived commands.
+func IsNotChildProcess(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return (err.Error() == "wait: no child processes" || err.Error() == "waitid: no child processes")
+}

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/process"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
@@ -103,7 +104,7 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		args := []string{"-R", "-L", "gitpod", ws.Location}
 		cmd := exec.Command("chown", args...)
 		res, cerr := cmd.CombinedOutput()
-		if cerr != nil && !(cerr.Error() == "wait: no child processes" || cerr.Error() == "waitid: no child processes") {
+		if cerr != nil && !process.IsNotChildProcess(cerr) {
 			err = git.OpFailedError{
 				Args:       args,
 				ExecErr:    cerr,

--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/process"
 )
 
 func newSSHServer(ctx context.Context, cfg *Config) (*sshServer, error) {
@@ -177,7 +178,7 @@ func prepareSSHKey(ctx context.Context, sshkey string) error {
 	}()
 
 	_, err = keycmd.CombinedOutput()
-	if err != nil && !(err.Error() == "wait: no child processes" || err.Error() == "waitid: no child processes") {
+	if err != nil && !process.IsNotChildProcess(err) {
 		return xerrors.Errorf("cannot create SSH hostkey file: %w", err)
 	}
 

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/analytics"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
+	"github.com/gitpod-io/gitpod/common-go/process"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/executor"
 	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
@@ -325,7 +326,7 @@ func Run(options ...RunOption) {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			err := cmd.Run()
-			if err != nil && !(err.Error() == "wait: no child processes" || err.Error() == "waitid: no child processes") {
+			if err != nil && !process.IsNotChildProcess(err) {
 				log.WithError(err).Error("git fetch error")
 			}
 		}()

--- a/components/supervisor/pkg/terminal/terminal.go
+++ b/components/supervisor/pkg/terminal/terminal.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/process"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 )
 
@@ -170,7 +171,9 @@ func (term *Term) gracefullyShutdownProcess(gracePeriod time.Duration) error {
 			// process is gone now - we're good
 			return nil
 		}
-		log.WithError(err).Warn("unexpected terminal error")
+		if !process.IsNotChildProcess(err) {
+			log.WithError(err).Warn("unexpected terminal error")
+		}
 	case <-time.After(gracePeriod):
 	}
 


### PR DESCRIPTION
## Description

Cleanup `"waitid: no child processes"` errors

Internal link: https://cloudlogging.app.goo.gl/RYLcPrqsbKGzC2rZ6

## Release Notes
```release-note
NONE
```
