### PR TITLE
Add download button

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -5,6 +5,7 @@
  */
 
 import { User, WorkspaceAndInstance, ContextURL } from "@gitpod/gitpod-protocol";
+import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import moment from "moment";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -41,15 +42,20 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
             setActivity(false);
         }
     }
+
     const adminLinks = getAdminLinks(workspace);
-    const adminLink = (i: number) => <Property key={'admin-'+i} name={adminLinks[i]?.name || ''}><a className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400" href={adminLinks[i]?.url}>{adminLinks[i]?.title || ''}</a></Property>;
+    const adminLink = (i: number) => <Property key={'admin-' + i} name={adminLinks[i]?.name || ''}><a className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400" href={adminLinks[i]?.url}>{adminLinks[i]?.title || ''}</a></Property>;
     return <>
         <div className="flex">
             <div className="flex-1">
                 <div className="flex"><h3>{workspace.workspaceId}</h3><span className="my-auto ml-3"><WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(workspace)} /></span></div>
                 <p>{getProject(WorkspaceAndInstance.toWorkspace(workspace))}</p>
             </div>
-            <button className="secondary ml-3" disabled={activity} onClick={reload}>Reload Data</button>
+            <button className="secondary ml-3" onClick={() => {
+                window.location.href = new GitpodHostUrl(window.location.href).with({
+                    pathname: `/workspace-download/get/${workspace.workspaceId}`
+                }).toString();
+            }}>Download Workspace</button>
             <button className="danger ml-3" disabled={activity || workspace.phase === 'stopped'} onClick={stopWorkspace}>Stop Workspace</button>
         </div>
         <div className="flex mt-6">


### PR DESCRIPTION
## Description
- Adds download button to the admin dashboard
- Removes the reload button

<img width="731" alt="Screenshot 2021-11-29 at 13 26 43" src="https://user-images.githubusercontent.com/8015191/143868137-c1e27b84-9d18-49c4-ba89-c1dfbfb4a06b.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #6351

## How to test
When I test on staging, it gives me an error. Is there a way I can test this?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

