### PR TITLE
[installer]: remove jaeger operator external

### DIFF
--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -170,12 +170,7 @@ type ContainerRegistryExternal struct {
 }
 
 type Jaeger struct {
-	InCluster *bool                   `json:"inCluster,omitempty" validate:"required"`
-	External  *JaegerOperatorExternal `json:"external,omitempty" validate:"required_if=InCluster false"`
-}
-
-type JaegerOperatorExternal struct {
-	Certificate ObjectRef `json:"certificate" validate:"required"`
+	InCluster *bool `json:"inCluster,omitempty" validate:"required"`
 }
 
 type LogLevel string


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The `jaegerOperator` external object doesn't make any sense in it's current form. The Jaeger operators are all about installing Custom Resource Definitions and are not a resource that can be communicated with, which is what the `external` objects have been used for

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove jaeger operator external
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
