### PR TITLE
[dashboard] When creating a new Project in your personal account, don't ask under which team to create it

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -59,6 +59,10 @@ export default function NewProject() {
             const team = teams?.find(t => t.slug === teamParam);
             setSelectedTeamOrUser(team);
         }
+        if (params.get("user")) {
+            window.history.replaceState({}, '', window.location.pathname);
+            setSelectedTeamOrUser(user);
+        }
     }, []);
 
     useEffect(() => {

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -63,7 +63,7 @@ export default function () {
         setLastPrebuilds(map);
     }
 
-    const newProjectUrl = !!team ? `/new?team=${team.slug}` : '/new';
+    const newProjectUrl = !!team ? `/new?team=${team.slug}` : '/new?user=1';
     const onNewProject = () => {
         history.push(newProjectUrl);
     }

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -45,7 +45,7 @@ export default function () {
     const [teamsWorkspaceModel, setTeamsWorkspaceModel] = useState<WorkspaceModel|undefined>();
     const [teamsActiveWorkspaces, setTeamsActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
 
-    const newProjectUrl = !!team ? `/new?team=${team.slug}` : '/new';
+    const newProjectUrl = !!team ? `/new?team=${team.slug}` : '/new?user=1';
     const onNewProject = () => {
         history.push(newProjectUrl);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Current situation:

1. When visiting `/new` directly, we ask under which team (or personal account) to create the Project
2. When going to a specific team and clicking on the `New Project` button, we don't ask
3. When going to your personal account and clicking on the `New Project` button, we ask where to put the new Project

Both 1. and 2. are fine, but for 3., we already know the user intended to create a new Project for their personal account, so we don't really need to ask.

In fact, we've purposefully decided to still ask here, in order to encourage users to create new teams, but maybe this isn't actually a good idea (e.g. we've seen users get confused at this point about what a team was, and creating one "by accident").

This PR fixes it: When clicking on `New Project` in your personal account, the project is now created in your personal account by default (and we don't ask for team selection).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Minimum viable change for https://github.com/gitpod-io/gitpod/issues/6686

## How to test
<!-- Provide steps to test this PR -->

1. Go to your personal account
2. Click on `New Project`
3. Select a repository
4. You should not see the team selection screen -- instead the flow should go straight to the Configuration screen

Notes:
- When creating a new project from a specific team, Gitpod remembers which team to use thanks to a query parameter (`/new?team=<ID>`)
- This PR implements something similar for when you create a new project from your personal account (i.e. `/new?user=<any value>`)
- Visiting `/new` without context still asks under which team (or personal account) you want to create the Project

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] When creating a new Project in your personal account, don't ask under which team to create it
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc