### PR TITLE
[image-builder] Workaround buildkit#2484

### DIFF
--- a/components/image-builder-bob/BUILD.yaml
+++ b/components/image-builder-bob/BUILD.yaml
@@ -2,15 +2,34 @@ packages:
 - name: app
   type: go
   srcs:
-  - "**/*.go"
+  - "cmd/*.go"
+  - "pkg/**/*.go"
+  - "main.go"
   - "go.mod"
   - "go.sum"
   env:
   - CGO_ENABLED=0
   - GOOS=linux
-  - GOPROXY=
   deps:
   - components/common-go:lib
+  prep:
+  - ["go", "mod", "tidy"]
+  config:
+    packaging: app
+- name: runc-facade
+  type: go
+  srcs:
+  - "cmd/runc-facade/*.go"
+  - "go.mod"
+  - "go.sum"
+  env:
+  - CGO_ENABLED=0
+  - GOOS=linux
+  deps:
+  - components/common-go:lib
+  prep:
+    - ["mv", "cmd/runc-facade/main.go", "main.go"]
+    - ["go", "mod", "tidy"]
   config:
     packaging: app
 - name: docker
@@ -20,6 +39,7 @@ packages:
   - ide-startup.sh
   deps:
   - :app
+  - :runc-facade
   config:
     argdeps:
         - imageRepoBase

--- a/components/image-builder-bob/cmd/runc-facade/main.go
+++ b/components/image-builder-bob/cmd/runc-facade/main.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/xerrors"
+)
+
+func main() {
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	var (
+		candidates = []string{"bob-runc", "runc"}
+		runcPath   string
+		bundle     string
+		err        error
+	)
+	for _, c := range candidates {
+		runcPath, err = exec.LookPath(c)
+		if runcPath != "" {
+			break
+		}
+	}
+	if err != nil {
+		log.WithError(err).Fatal("runc not found")
+	}
+
+	var useFacade bool
+	for i, arg := range os.Args {
+		if arg == "run" {
+			useFacade = true
+		}
+		if arg == "--bundle" && i+1 < len(os.Args) {
+			bundle = os.Args[i+1]
+		}
+	}
+
+	if useFacade && bundle != "" {
+		err = createAndRunc(runcPath, bundle)
+	} else {
+		err = syscall.Exec(runcPath, os.Args, os.Environ())
+	}
+	if err != nil {
+		log.WithError(err).Fatal("failed")
+	}
+}
+
+func createAndRunc(runcPath, bundle string) error {
+	fn := filepath.Join(bundle, "config.json")
+	fc, err := os.ReadFile(fn)
+	if err != nil {
+		return xerrors.Errorf("cannot read config.json: %w", err)
+	}
+
+	var cfg specs.Spec
+	err = json.Unmarshal(fc, &cfg)
+	if err != nil {
+		return xerrors.Errorf("cannot decode config.json: %w", err)
+	}
+
+	var hasSysMount bool
+	for _, m := range cfg.Mounts {
+		if m.Destination == "/sys" {
+			hasSysMount = true
+			break
+		}
+	}
+	if !hasSysMount {
+		cfg.Mounts = append(cfg.Mounts, specs.Mount{
+			Destination: "/sys",
+			Type:        "sysfs",
+			Source:      "sysfs",
+		})
+	}
+
+	fc, err = json.Marshal(cfg)
+	if err != nil {
+		return xerrors.Errorf("cannot encode config.json: %w", err)
+	}
+	for _, fn := range []string{fn, "/tmp/debug.json"} {
+		err = os.WriteFile(fn, fc, 0644)
+		if err != nil {
+			return xerrors.Errorf("cannot encode config.json: %w", err)
+		}
+	}
+
+	err = syscall.Exec(runcPath, os.Args, os.Environ())
+	if err != nil {
+		return xerrors.Errorf("exec %s: %w", runcPath, err)
+	}
+	return nil
+}

--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -11,6 +11,11 @@ RUN apk --no-cache add sudo bash \
     && echo "gitpod ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/gitpod \
     && chmod 0440 /etc/sudoers.d/gitpod
 
+COPY components-image-builder-bob--runc-facade/bob /app/runc-facade
+RUN chmod 4755 /app/runc-facade \
+    && mv /usr/bin/buildkit-runc /usr/bin/bob-runc \
+    && mv /app/runc-facade /usr/bin/buildkit-runc
+
 COPY components-image-builder-bob--app/bob /app/
 RUN chmod 4755 /app/bob
 


### PR DESCRIPTION
## Description
This PR works around https://github.com/moby/buildkit/issues/2484 by modifying the OCI runtime configuration produced by buildkit and adding the `/sys` mount back in.

This issue previously broke the OpenVSCode server build.

## How to test
1. Open a workspace on the OpenVS Code Server repo: https://cw-buidkit-runc.staging.gitpod-dev.com/#github.com/gitpod-io/openvscode-server
2. Open a workspace on the test repo which illustrated the issue: https://cw-buidkit-runc.staging.gitpod-dev.com/#github.com/csweichel/buildkit-udisks

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
