### PR TITLE
Adjust success criteria dashboard grouping period

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/success-criteria.json
+++ b/operations/observability/mixins/workspace/dashboards/success-criteria.json
@@ -101,7 +101,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "1-((\n  (\n    sum(rate(gitpod_ws_manager_workspace_stops_total{reason=\"failed\",type!~\"GHOST|PREBUILD\"}[30d]))\n    /\n    sum(rate(gitpod_ws_manager_workspace_stops_total{type!~\"GHOST|PREBUILD\"}[30d]))\n  )\n) + (\n  (\n    sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\",grpc_code!~\"OK|ResourceExhausted\"}[30d]))\n    /\n    sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\"}[30d]))\n  )\n))",
+          "expr": "1-((\n  (\n    sum(rate(gitpod_ws_manager_workspace_stops_total{reason=\"failed\",type!~\"GHOST|PREBUILD\"}[1d]))\n    /\n    sum(rate(gitpod_ws_manager_workspace_stops_total{type!~\"GHOST|PREBUILD\"}[1d]))\n  )\n) + (\n  (\n    sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\",grpc_code!~\"OK|ResourceExhausted\"}[1d]))\n    /\n    sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\"}[1d]))\n  )\n))",
           "interval": "",
           "legendFormat": "Success Rate",
           "refId": "A"


### PR DESCRIPTION
## Description

Grouping by a period of 30 days means we don't see anything any meaningful trend in case of an incident.

## Release Notes
```release-note
Adjust success criteria dashboard grouping period
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
