### PR TITLE
[content-service] ignore error for DeleteUserContent if bucket does not exists

### DIFF
--- a/components/content-service/pkg/service/content-service.go
+++ b/components/content-service/pkg/service/content-service.go
@@ -43,8 +43,9 @@ func (cs *ContentService) DeleteUserContent(ctx context.Context, req *api.Delete
 
 	bucket := cs.s.Bucket(req.OwnerId)
 	err = cs.s.DeleteBucket(ctx, bucket)
+	// TODO
 	if err == storage.ErrNotFound {
-		log.WithFields(log.OWI(req.OwnerId, "", "")).WithError(err).Error("DeleteUserContent: NotFound")
+		log.WithFields(log.OWI(req.OwnerId, "", "")).Debug("DeleteUserContent: NotFound")
 		return &api.DeleteUserContentResponse{}, nil
 	}
 	if err != nil {

--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -952,6 +952,9 @@ func (p *PresignedGCPStorage) DeleteObject(ctx context.Context, bucket string, q
 		}
 		// if we get any error besides "done" the iterator is broken: make sure we don't use it again.
 		if err != nil {
+			if errors.Is(err, gcpstorage.ErrBucketNotExist) {
+				return ErrNotFound
+			}
 			log.WithField("bucket", bucket).WithError(err).Error("error iterating object")
 			break
 		}
@@ -962,10 +965,6 @@ func (p *PresignedGCPStorage) DeleteObject(ctx context.Context, bucket string, q
 			}
 			log.WithField("bucket", bucket).WithField("object", attrs.Name).WithError(err).Warn("cannot delete object, continue deleting objects")
 		}
-	}
-
-	if errors.Is(err, gcpstorage.ErrBucketNotExist) || errors.Is(err, gcpstorage.ErrObjectNotExist) {
-		return ErrNotFound
 	}
 	return err
 }
@@ -986,6 +985,11 @@ func (p *PresignedGCPStorage) DeleteBucket(ctx context.Context, bucket string) (
 
 	err = client.Bucket(bucket).Delete(ctx)
 	if err != nil {
+		if e, ok := err.(*googleapi.Error); ok {
+			if e.Code == http.StatusNotFound {
+				return ErrNotFound
+			}
+		}
 		if errors.Is(err, gcpstorage.ErrBucketNotExist) {
 			return ErrNotFound
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[content-service] ignore error for DeleteUserContent if bucket does not exists

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6626

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
