### PR TITLE
[installer]: set max ghost workspaces to 0

### DIFF
--- a/installer/pkg/components/ws-scheduler/configmap.go
+++ b/installer/pkg/components/ws-scheduler/configmap.go
@@ -90,7 +90,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			IDEImage:           common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, codeImageStableVersion),
 			SupervisorImage:    common.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
 			FeatureFlags:       nil,
-			MaxGhostWorkspaces: 10,
+			MaxGhostWorkspaces: 0,
 			SchedulerInterval:  util.Duration(time.Second * 5),
 			Renewal: struct {
 				Interval   util.Duration `json:"interval"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ghosts appear to be misconfigured. Setting to 0 solves the effect of this unblocking using the Installer in core-dev. Future work will be done to configure ghosts correctly

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
