### PR TITLE
[wip][gitlab] URL encode project path

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -159,7 +159,7 @@ export default function NewProject() {
     }
 
     const createProject = async (teamOrUser: Team | User, selectedRepo: string) => {
-        if (!provider || isBitbucket()) {
+        if (!provider || isBitbucket()) {
             return;
         }
         const repo = reposInAccounts.find(r => r.account === selectedAccount && (r.path ? r.path === selectedRepo : r.name === selectedRepo));

--- a/components/server/BUILD.yaml
+++ b/components/server/BUILD.yaml
@@ -121,7 +121,7 @@ scripts:
       done
       cat >> $DST/run.sh <<EOF
       cd $PWD
-      su --pty - gitpod -c "source $DST/env; cd $PWD; TELEPRESENCE_USE_DEPLOYMENT=1 telepresence --swap-deployment server \
+      su --pty - gitpod -c "source $DST/env; cd $PWD; TELEPRESENCE_USE_DEPLOYMENT=1 telepresence --mount $DST/mounts --swap-deployment server \
                    --method inject-tcp \
                    --run yarn start-ee-inspect"
       EOF

--- a/components/server/ee/src/prebuilds/gitlab-service.ts
+++ b/components/server/ee/src/prebuilds/gitlab-service.ts
@@ -32,7 +32,7 @@ export class GitlabService extends RepositoryService {
             return false;
         }
         const api = await this.api.create(user);
-        const response = (await api.Projects.show(`${owner}/${repoName}`)) as unknown as GitLab.Project;
+        const response = (await api.Projects.show(`${owner}%2F${repoName}`)) as unknown as GitLab.Project;
         if (GitLab.ApiError.is(response)) {
             throw response;
         }


### PR DESCRIPTION
See https://docs.gitlab.com/ee/api/projects.html#get-single-project

## Description
URL paths passed as project IDs to the GitLab API must be URL encodedd.

## Related Issue(s)
Fixes #6743

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
