### PR TITLE
[server] When adding a project to a team, install the prebuild webhook as the adding user, not as a (random) team owner

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1535,7 +1535,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
             // Anyone who can read a team's information (i.e. any team member) can create a new project.
             await this.guardTeamOperation(params.teamId, "get");
         }
-        const project = this.projectsService.createProject(params);
+        const project = this.projectsService.createProject(params, user);
         this.analytics.track({
             userId: user.id,
             event: "project_created",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When adding a project to a team, install the prebuild webhook as the adding user, not as a (random) team owner

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6743#issuecomment-983454670

## How to test
<!-- Provide steps to test this PR -->

See steps in https://github.com/gitpod-io/gitpod/issues/6743#issue-1055948368

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] When adding a project to a team, install the prebuild webhook as the adding user, not as a (random) team owner
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc