### PR TITLE
[server] Add generic tracing for API calls

### DIFF
--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -70,6 +70,22 @@ export namespace TraceContext {
             },
         });
     }
+
+    export function addJsonRPCParameters(ctx: TraceContext, method: string, args: any[]) {
+        if (!ctx.span) {
+            return;
+        }
+
+        ctx.span.addTags({
+            rpc: {
+                system: "jsonrpc",
+                method,
+                jsonrpc: {
+                    parameters: args.slice(),
+                },
+            },
+        });
+    }
 }
 
 @injectable()

--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -20,11 +20,16 @@ export type TraceContextWithSpan = TraceContext & {
 
 
 export namespace TraceContext {
-    export function startSpan(operation: string, ctx: TraceContext): opentracing.Span {
+    export function startSpan(operation: string, parentCtx: TraceContext): opentracing.Span {
         const options: opentracing.SpanOptions = {
-            childOf: ctx.span
+            childOf: parentCtx.span
         }
         return opentracing.globalTracer().startSpan(operation, options);
+    }
+
+    export function childContextWithSpan(operation: string, parentCtx: TraceContext): TraceContextWithSpan {
+        const span = startSpan(operation, parentCtx);
+        return { span };
     }
 
     export function startAsyncSpan(operation: string, ctx: TraceContext): opentracing.Span {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -43,7 +43,7 @@ import { SnapshotService, WaitForSnapshotOptions } from "./snapshot-service";
 import { SafePromise } from "@gitpod/gitpod-protocol/lib/util/safe-promise";
 
 @injectable()
-export class GitpodServerEEImpl extends GitpodServerImpl<GitpodClient, GitpodServer> {
+export class GitpodServerEEImpl extends GitpodServerImpl {
     @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
     @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
     @inject(LicenseDB) protected readonly licenseDB: LicenseDB;

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -47,7 +47,6 @@ import { TokenGarbageCollector } from './user/token-garbage-collector';
 import { WorkspaceDownloadService } from './workspace/workspace-download-service';
 import { WebsocketConnectionManager } from './websocket/websocket-connection-manager';
 import { OneTimeSecretServer } from './one-time-secret-server';
-import { GitpodServer, GitpodClient } from '@gitpod/gitpod-protocol';
 import { HostContainerMapping } from './auth/host-container-mapping';
 import { BlockedUserFilter, NoOneBlockedUserFilter } from './auth/blocked-user-filter';
 import { AuthProviderService } from './auth/auth-provider-service';
@@ -124,10 +123,10 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(GitpodServerImpl).toSelf();
     bind(WebsocketConnectionManager).toDynamicValue(ctx => {
-            const serverFactory = () => ctx.container.get<GitpodServerImpl<GitpodClient, GitpodServer>>(GitpodServerImpl);
+            const serverFactory = () => ctx.container.get<GitpodServerImpl>(GitpodServerImpl);
             const hostContextProvider = ctx.container.get<HostContextProvider>(HostContextProvider);
             const config = ctx.container.get<Config>(Config);
-            return new WebsocketConnectionManager<GitpodClient, GitpodServer>(serverFactory, hostContextProvider, config.rateLimiter);
+            return new WebsocketConnectionManager(serverFactory, hostContextProvider, config.rateLimiter);
         }
     ).inSingletonScope();
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -54,7 +54,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
     @inject(Authenticator) protected authenticator: Authenticator;
     @inject(UserController) protected readonly userController: UserController;
     @inject(EnforcementController) protected readonly enforcementController: EnforcementController;
-    @inject(WebsocketConnectionManager) protected websocketConnectionHandler: WebsocketConnectionManager<C, S>;
+    @inject(WebsocketConnectionManager) protected websocketConnectionHandler: WebsocketConnectionManager;
     @inject(MessageBusIntegration) protected readonly messagebus: MessageBusIntegration;
     @inject(LocalMessageBroker) protected readonly localMessageBroker: LocalMessageBroker;
     @inject(WorkspaceDownloadService) protected readonly workspaceDownloadService: WorkspaceDownloadService;

--- a/components/server/src/user/enforcement-endpoint.ts
+++ b/components/server/src/user/enforcement-endpoint.ts
@@ -7,7 +7,7 @@
 import * as express from 'express';
 import { injectable, inject } from "inversify";
 import { WorkspaceDB, UserDB } from '@gitpod/gitpod-db/lib';
-import { User, GitpodClient, GitpodServer } from '@gitpod/gitpod-protocol';
+import { User } from '@gitpod/gitpod-protocol';
 import { log, LogContext } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { Config } from '../config';
 import { UserDeletionService } from '../user/user-deletion-service';
@@ -19,7 +19,7 @@ import { GitpodServerImpl } from '../workspace/gitpod-server-impl';
 import { ResourceAccessGuard, OwnerResourceGuard } from '../auth/resource-access';
 
 export const EnforcementControllerServerFactory = Symbol('EnforcementControllerServerFactory');
-export type EnforcementControllerServerFactory = () => GitpodServerImpl<GitpodClient, GitpodServer>;
+export type EnforcementControllerServerFactory = () => GitpodServerImpl;
 
 @injectable()
 export class EnforcementController {

--- a/components/server/src/user/enforcement-endpoint.ts
+++ b/components/server/src/user/enforcement-endpoint.ts
@@ -101,7 +101,7 @@ export class EnforcementController {
             const targetUserID = req.params.userid;
             const server = this.createGitpodServer(callingUser, resourceAccessGuard);
             try {
-                await server.adminBlockUser({ id: targetUserID, blocked: true });
+                await server.adminBlockUser({}, { id: targetUserID, blocked: true });
                 res.sendStatus(200);
             } catch (e) {
                 if (e instanceof ResponseError && e.code === ErrorCodes.NOT_FOUND) {
@@ -145,7 +145,7 @@ export class EnforcementController {
             const targetWsID = req.params.wsid;
             const server = this.createGitpodServer(callingUser, resourceAccessGuard);
             try {
-                await server.adminForceStopWorkspace(targetWsID);
+                await server.adminForceStopWorkspace({}, targetWsID);
 
                 const target = (await this.workspaceDb.findById(targetWsID))!;
                 const owner = await this.userDB.findUserById(target!.ownerId);

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -30,7 +30,7 @@ const EVENT_CLIENT_CONTEXT_CREATED = "EVENT_CLIENT_CONTEXT_CREATED";
 const EVENT_CLIENT_CONTEXT_CLOSED = "EVENT_CLIENT_CONTEXT_CLOSED";
 
 /** TODO(gpl) Refine this list */
-export type WebsocketClientType = "browser" | "go-client";
+export type WebsocketClientType = "browser" | "go-client" | "vs-code";
 export namespace WebsocketClientType {
     export function getClientType(req: express.Request): WebsocketClientType | undefined {
         const userAgent = req.headers["user-agent"];
@@ -44,6 +44,10 @@ export namespace WebsocketClientType {
         if (userAgent.startsWith("Mozilla")) {
             return "browser";
         }
+        if (userAgent.startsWith("VS Code")) {
+            return "vs-code";
+        }
+        log.debug("API client without 'User-Agent'", { headers: req.headers });
         return undefined;
     }
 }

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -315,18 +315,19 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
 
         const span = opentracing.globalTracer().startSpan(method);
         const ctx = { span };
-
-        // some generic data
-        span.addTags({ client: this.clientMetadata });
-        if (this.userId) {
-            span.addTags({
-                user: {
-                    id: this.userId,
-                },
-            });
-        }
-
         try {
+            // generic tracing data
+            span.addTags({ client: this.clientMetadata });
+            if (this.userId) {
+                span.addTags({
+                    user: {
+                        id: this.userId,
+                    },
+                });
+            }
+            TraceContext.addJsonRPCParameters(ctx, method, args);
+
+            // actual call
             const result = await this.target[method](ctx, ...args);    // we can inject TraceContext here because of GitpodServerWithTracing
             increaseApiCallCounter(method, 200);
             return result;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -419,7 +419,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     public async getWorkspace(ctx: TraceContext, workspaceId: string): Promise<WorkspaceInfo> {
-        // TODO(gpl) Add all parameters as tags generically?
         ctx.span?.setTag("workspaceId", workspaceId);
 
         this.checkUser('getWorkspace');

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -6,7 +6,7 @@
 
 import { DownloadUrlRequest, DownloadUrlResponse, UploadUrlRequest, UploadUrlResponse } from '@gitpod/content-service/lib/blobs_pb';
 import { AppInstallationDB, UserDB, UserMessageViewsDB, WorkspaceDB, DBWithTracing, TracedWorkspaceDB, DBGitpodToken, DBUser, UserStorageResourcesDB, TeamDB } from '@gitpod/gitpod-db/lib';
-import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, Project, ProviderRepository, TeamMemberRole, WithDefaultConfig, FindPrebuildsParams, PrebuildWithStatus, StartPrebuildResult, ClientHeaderFields } from '@gitpod/gitpod-protocol';
+import { AuthProviderEntry, AuthProviderInfo, Branding, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient as GitpodApiClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, Project, ProviderRepository, TeamMemberRole, WithDefaultConfig, FindPrebuildsParams, PrebuildWithStatus, StartPrebuildResult, ClientHeaderFields } from '@gitpod/gitpod-protocol';
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { AdminBlockUserRequest, AdminGetListRequest, AdminGetListResult, AdminGetWorkspacesRequest, AdminModifyPermanentWorkspaceFeatureFlagRequest, AdminModifyRoleOrPermissionRequest, WorkspaceAndInstance } from '@gitpod/gitpod-protocol/lib/admin-protocol';
 import { GetLicenseInfoResult, LicenseFeature, LicenseValidationResult } from '@gitpod/gitpod-protocol/lib/license-protocol';
@@ -56,7 +56,7 @@ import { IDEOptions } from '@gitpod/gitpod-protocol/lib/ide-protocol';
 import { IDEConfigService } from '../ide-config';
 
 @injectable()
-export class GitpodServerImpl<Client extends GitpodClient, Server extends GitpodServer> implements GitpodServer, Disposable {
+export class GitpodServerImpl implements GitpodServer, Disposable {
 
     @inject(Config) protected readonly config: Config;
     @inject(TracedWorkspaceDB) protected readonly workspaceDb: DBWithTracing<WorkspaceDB>;
@@ -105,7 +105,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
     public readonly uuid: string = uuidv4();
     protected clientHeaderFields: ClientHeaderFields;
     protected resourceAccessGuard: ResourceAccessGuard;
-    protected client: Client | undefined;
+    protected client: GitpodApiClient | undefined;
 
     protected user: User | undefined;
 
@@ -115,7 +115,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
         this.disposables.dispose();
     }
 
-    initialize(client: Client | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientHeaderFields: ClientHeaderFields): void {
+    initialize(client: GitpodApiClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientHeaderFields: ClientHeaderFields): void {
         if (client) {
             this.disposables.push(Disposable.create(() => this.client = undefined));
         }
@@ -162,7 +162,7 @@ export class GitpodServerImpl<Client extends GitpodClient, Server extends Gitpod
 
     }
 
-    setClient(client: Client | undefined): void {
+    setClient(client: GitpodApiClient | undefined): void {
         throw new Error('Unsupported operation. Use initialize.')
     }
 


### PR DESCRIPTION
## Description
We have had tracing in `server` for quite some time now. But it was never but in a central place in the API, but always felt like "bolt-on", which showed in noisy patterns like this:
```
const span = TraceContext.startSpan("someMethod", ctx);
try {
    // actual method implementation
} catch (e) {
    TraceContext.logError({ span }, e);
    throw e;
} finally {
    span.finish();
}
```

This PR moves this into a [central place](https://github.com/gitpod-io/gitpod/commit/decd846ab4542470bb71ee479992142612e6a40e#diff-cad2793f0b559ff7502b9ec959208584f789b9e5df185b3ed5d425c5c3b5d9edR312-R338), resulting in:
 a) all API calls being traced instead only a few
 b) the code being more readable


Open questions:
 - [x] Do we want to generically add _all parameters_ to every trace? ([example](https://github.com/gitpod-io/gitpod/compare/gpl/api-telemetry?expand=1#diff-d6fdb9bb15400f4fbba00db81b2ce6cb7f7bb566dd97b93b9fd4e3fc9a79f479R421-R423))
       Pro: even less, cleaner code
       Con: big parameters might blow up our storage/tracing infra
       @mads-hartmann I'd be super keen on your opinion here! :slightly_smiling_face: 



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 1. start a workspace, work with it, stop it
 2. check server logs for no errors (ignore `Error: getaddrinfo ENOTFOUND otel-collector`) :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
