### PR TITLE
[ws-daemon] Retry /dev/fuse setup

### DIFF
--- a/components/ws-daemon/pkg/daemon/cgroup_customizer.go
+++ b/components/ws-daemon/pkg/daemon/cgroup_customizer.go
@@ -6,8 +6,10 @@ package daemon
 
 import (
 	"context"
+	"time"
 
 	"github.com/containerd/cgroups"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/dispatch"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/xerrors"
@@ -32,34 +34,58 @@ func (c *CgroupCustomizer) WorkspaceAdded(ctx context.Context, ws *dispatch.Work
 	if disp == nil {
 		return xerrors.Errorf("no dispatch available")
 	}
-
 	cgroupPath, err := disp.Runtime.ContainerCGroupPath(context.Background(), ws.ContainerID)
 	if err != nil {
-		return xerrors.Errorf("cannot start governer: %w", err)
+		return xerrors.Errorf("cannot get container (%s) cgroup path: %w", ws.ContainerID, err)
 	}
 
-	control, err := cgroups.Load(c.customV1, cgroups.StaticPath(cgroupPath))
+	enableDevFus := func() error {
+		control, err := cgroups.Load(c.customV1, cgroups.StaticPath(cgroupPath))
+		if err != nil {
+			return err
+		}
 
-	if err != nil {
-		return xerrors.Errorf("error loading cgroup at path: %s %w", cgroupPath, err)
-	}
-
-	res := &specs.LinuxResources{
-		Devices: []specs.LinuxDeviceCgroup{
-			// /dev/fuse
-			{
-				Type:   "c",
-				Minor:  &fuseDeviceMinor,
-				Major:  &fuseDeviceMajor,
-				Access: "rwm",
-				Allow:  true,
+		err = control.Update(&specs.LinuxResources{
+			Devices: []specs.LinuxDeviceCgroup{
+				// /dev/fuse
+				{
+					Type:   "c",
+					Minor:  &fuseDeviceMinor,
+					Major:  &fuseDeviceMajor,
+					Access: "rwm",
+					Allow:  true,
+				},
 			},
-		},
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 
-	if err := control.Update(res); err != nil {
-		return xerrors.Errorf("cgroup update failed: %w", err)
-	}
+	// We'll try for some time to modify the cgroup. On some systems the cgroup is not fully present
+	// by the time this function gets called. A future CRI-based container integration would benefit
+	// from containerd internal synchronisation. We don't have that synchronisation today though, hence
+	// need to supendously retry.
+	go func() {
+		t := time.NewTicker(500 * time.Millisecond)
+		defer t.Stop()
+
+		for range t.C {
+			if ctx.Err() != nil {
+				return
+			}
+
+			err := enableDevFus()
+			if err != nil {
+				log.WithField("cgroup", cgroupPath).WithFields(ws.OWI()).WithError(err).Debug("cannot enable /dev/fuse in cgroup")
+				continue
+			}
+
+			return
+		}
+	}()
 
 	return nil
 }


### PR DESCRIPTION
## Description
This PR fixes the `/dev/fuse` preparation in some environments where the cgroup does not exist by the time the container is added to the ws-daemon dispatch.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6999

## How to test
- Start a workspace on a k3s cluster
- Try to use /dev/fuse

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
