### PR TITLE
[jetbrains] Add PyCharm IDE

### DIFF
--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -98,6 +98,13 @@ options:
     label: "EAP"
     notes: ["While in beta, when you open a workspace with GoLand you will need to use the password “gitpod”."]
     image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.goland)) }}
+  pycharm:
+    orderKey: "06"
+    title: "PyCharm"
+    type: "desktop"
+    logo: "https://upload.wikimedia.org/wikipedia/commons/1/1d/PyCharm_Icon.svg"
+    notes: ["While in beta, when you open a workspace with PyCharm you will need to use the password “gitpod”."]
+    image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.pycharm)) }}
 
 defaultIde: "code"
 defaultDesktopIde: "code-desktop"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -410,6 +410,8 @@ components:
         imageName: "ide/intellij"
       goland:
         imageName: "ide/goland"
+      pycharm:
+        imageName: "ide/pycharm"
     supervisor:
       imageName: "supervisor"
     dockerUp:

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -44,6 +44,7 @@ packages:
       - components/ide/code-desktop:docker-insiders
       - components/ide/jetbrains/image:intellij
       - components/ide/jetbrains/image:goland
+      - components/ide/jetbrains/image:pycharm
       - components/ide/theia:docker
       - components/image-builder:docker
       - components/image-builder-mk3:docker

--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -6,6 +6,7 @@ packages:
     deps:
       - :intellij
       - :goland
+      - :pycharm
   - name: intellij
     type: docker
     srcs:
@@ -48,3 +49,24 @@ packages:
       image:
         - ${imageRepoBase}/ide/goland:${version}
         - ${imageRepoBase}/ide/goland:commit-${__git_commit}
+  - name: pycharm
+    type: docker
+    srcs:
+      - "startup.sh"
+      - "supervisor-ide-config_pycharm.json"
+      - "status/go.mod"
+      - "status/main.go"
+    deps:
+      - components/ide/jetbrains/backend-plugin:plugin
+    argdeps:
+      - imageRepoBase
+    config:
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: workspace.desktopIdeImages.pycharm
+      buildArgs:
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/python/pycharm-professional-2021.3.tar.gz"
+        SUPERVISOR_IDE_CONFIG: supervisor-ide-config_pycharm.json
+      image:
+        - ${imageRepoBase}/ide/pycharm:${version}
+        - ${imageRepoBase}/ide/pycharm:commit-${__git_commit}

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
@@ -1,0 +1,11 @@
+{
+    "entrypoint": "/ide-desktop/startup.sh",
+    "entrypointArgs": [ "Open in PyCharm" ],
+    "readinessProbe": {
+        "type": "http",
+        "http": {
+            "port": 24000,
+            "path": "/status"
+        }
+      }
+}

--- a/installer/pkg/components/server/ide-configmap.go
+++ b/installer/pkg/components/server/ide-configmap.go
@@ -97,6 +97,14 @@ func ideconfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Notes:    []string{"While in beta, when you open a workspace with GoLand you will need to use the password “gitpod”."},
 					Image:    common.ImageName(ctx.Config.Repository, workspace.GoLandDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.GoLandImage.Version),
 				},
+				"pycharm": {
+					OrderKey: pointer.String("06"),
+					Title:    "PyCharm",
+					Type:     typeDesktop,
+					Logo:     "https://upload.wikimedia.org/wikipedia/commons/1/1d/PyCharm_Icon.svg", // TODO(clu): Serve logo from our own components instead of using this wikimedia URL.
+					Notes:    []string{"While in beta, when you open a workspace with PyCharm you will need to use the password “gitpod”."},
+					Image:    common.ImageName(ctx.Config.Repository, workspace.PyCharmDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.GoLandImage.Version),
+				},
 			},
 			DefaultIDE:        "code",
 			DefaultDesktopIDE: "code-desktop",

--- a/installer/pkg/components/workspace/constants.go
+++ b/installer/pkg/components/workspace/constants.go
@@ -15,6 +15,7 @@ const (
 	CodeDesktopInsidersIDEImage  = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage      = "ide/intellij"
 	GoLandDesktopIdeImage        = "ide/goland"
+	PyCharmDesktopIdeImage       = "ide/pycharm"
 	DockerUpImage                = "docker-up"
 	SupervisorImage              = "supervisor"
 	SupervisorPort               = 22999

--- a/installer/pkg/config/versions/versions.go
+++ b/installer/pkg/config/versions/versions.go
@@ -43,6 +43,7 @@ type Components struct {
 			CodeDesktopImageInsiders Versioned `json:"codeDesktopInsiders"`
 			IntelliJImage            Versioned `json:"intellij"`
 			GoLandImage              Versioned `json:"goland"`
+			PyCharmImage             Versioned `json:"pycharm"`
 		} `json:"desktopIdeImages"`
 	} `json:"workspace"`
 	WSDaemon struct {


### PR DESCRIPTION
## Description
This PR adds the desktop IDE PyCharm.

![image](https://user-images.githubusercontent.com/24960040/144317172-692b31a5-dcf0-4a2c-97cb-c4194f034c3e.png)

## What's not included

- This PR does not include an update of the GitHub action that checks for image updates. Since I'm working on improving this currently anyways, it does not make sense to add this now.
- This PR re-uses the PyCharm logo from Wikimedia. That allows us to deploy this without a meta update. We should add the logo soon as well (this is planned to serve from IDE components as well in the near future).

## How to test
Go to the preferences page and select PyCharm. Start a workspace and make sure you are able to run the Code With Me command.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add PyCharm desktop IDE.
```
