### PR TITLE
[dev/kubecdl] A tool for downloading kubeconfig files from k3s servers on GCP

### DIFF
--- a/dev/kubecdl/go.mod
+++ b/dev/kubecdl/go.mod
@@ -1,0 +1,10 @@
+module github.com/gitpod-io/gitpod/kubecdl
+
+go 1.17
+
+require (
+	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/pflag v1.0.5
+)
+
+require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect

--- a/dev/kubecdl/go.sum
+++ b/dev/kubecdl/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/dev/kubecdl/main.go
+++ b/dev/kubecdl/main.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+)
+
+var (
+	project    = pflag.StringP("project", "p", "", "name of the Google project - defaults to what's configured in gcloud")
+	kubeconfig = pflag.StringP("kubeconfig", "k", os.Getenv("KUBECONFIG"), "kubeconfig filepath")
+)
+
+func main() {
+	pflag.Parse()
+
+	node := pflag.Arg(0)
+	if node == "" {
+		logrus.Fatalf("usage: %s [--project|-p GoogleProject] [--kubeconfig|-k ~/.kube/config] <nodeName>", os.Args[0])
+	}
+
+	_, err := exec.LookPath("gcloud")
+	if err != nil {
+		logrus.WithError(err).Fatal("gcloud is not available")
+	}
+
+	prj := *project
+	if prj == "" {
+		out, err := exec.Command("gcloud", "config", "get-value", "project").CombinedOutput()
+		if err != nil {
+			logrus.WithError(err).Fatal("cannot get configured project. Use --project to explicitly set one.")
+		}
+		prj = strings.TrimSpace(string(out))
+	}
+	kubecfgfn := *kubeconfig
+	if kubecfgfn == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		kubecfgfn = filepath.Join(home, ".kube", "config")
+	}
+
+	serverIP, err := getServerIP(node, prj)
+	if err != nil {
+		logrus.WithError(err).Fatal("cannot get node IP")
+	}
+
+	kubecfg, err := getK3sKubeconfig(node, prj)
+	if err != nil {
+		logrus.WithError(err).Fatal("cannot get kubeconfig")
+	}
+
+	kubecfg = bytes.ReplaceAll(kubecfg, []byte("127.0.0.1"), []byte(serverIP))
+	kubecfg = bytes.ReplaceAll(kubecfg, []byte("default"), []byte(node))
+
+	tmpfile, err := os.CreateTemp("", "kubecfg-*.yaml")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	_, err = tmpfile.Write(kubecfg)
+	if err != nil {
+		logrus.WithError(err).Fatal("cannot write temporary kubeconfig")
+	}
+	tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+
+	cmd := exec.Command("kubectl", "config", "view", "--flatten", "--merge")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s:%s", kubecfgfn, tmpfile.Name()))
+	res, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.WithError(err).Error("cannot merge kubeconfig")
+		return
+	}
+
+	err = ioutil.WriteFile(kubecfgfn, res, 0644)
+	if err != nil {
+		logrus.WithError(err).WithField("path", kubecfgfn).Error("cannot write kubeconfig. Dumping combined result:")
+		fmt.Println(string(res))
+		return
+	}
+}
+
+func getServerIP(nodeName, project string) (sererIP string, err error) {
+	var nfo struct {
+		NetworkInterfaces []struct {
+			AccessConfigs []struct {
+				NatIP string `json:"natIP"`
+			} `json:"accessConfigs"`
+		} `json:"networkInterfaces"`
+	}
+
+	out, err := exec.Command("gcloud", "compute", "instances", "describe", "--format=json", "--project", project, nodeName).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to describe node: %s: %w", string(out), err)
+	}
+
+	err = json.Unmarshal(out, &nfo)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal node description: %s: %w", string(out), err)
+	}
+
+	for _, iff := range nfo.NetworkInterfaces {
+		for _, n := range iff.AccessConfigs {
+			if n.NatIP == "" {
+				continue
+			}
+
+			return n.NatIP, nil
+		}
+	}
+
+	return "", fmt.Errorf("did not find public IP for node")
+}
+
+func getK3sKubeconfig(nodeName, project string) ([]byte, error) {
+	res, err := exec.Command("gcloud", "compute", "ssh", "--project", project, "--command", "sudo cat /etc/rancher/k3s/k3s.yaml", nodeName).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("cannot ssh into node: %s: %w", string(res), err)
+	}
+
+	// we may have had to login first, i.e. the output might not be the pure kubeconfig file
+	idx := bytes.Index(res, []byte("apiVersion:"))
+	if idx == -1 {
+		return nil, fmt.Errorf("did not find kubeconfig")
+	}
+
+	return res[idx:], nil
+}


### PR DESCRIPTION
## Description
This change adds a script/tool which downloads the kubeconfig file from a k3s server running on GCP. 

## How to test
```
cd dev/kubecdl
go run main.go -p <some-gcp-project> <some-k3s-node-name>
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
