### PR TITLE
Made tracing optional for preview environments

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -548,7 +548,9 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
         } else if (!!deploymentConfig.analytics) {
             flags += ` --set analytics.writer=${deploymentConfig.analytics!}`;
         }
-
+        if (deploymentConfig.withObservability) {
+            flags += ` -f ../.werft/values.tracing.yaml`;
+        }
         werft.log("helm", "extracting versions");
         try {
             exec(`docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${version} cat /versions.yaml | tee versions.yaml`);

--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -12,10 +12,6 @@ version: not-set
 imagePullPolicy: Always
 
 authProviders: []
-tracing:
-  endpoint: http://otel-collector:14268/api/traces
-  samplerType: const
-  samplerParam: "1"
 
 # we hit the "max. 110 pods/node" situation pretty often with our current core-dev setup.
 # the proper way to fix those would be to adjust the CIDR for workload NodePool which is a bit more work.

--- a/.werft/values.tracing.yaml
+++ b/.werft/values.tracing.yaml
@@ -1,0 +1,4 @@
+tracing:
+  endpoint: http://otel-collector:14268/api/traces
+  samplerType: const
+  samplerParam: "1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This makes tracing optional for preview-environments and binds its deployment to the observability stack.
- werft-job without observability: https://werft.gitpod-dev.com/job/gitpod-build-wth-tracing-optional.5/raw
- werft-job with observability: https://werft.gitpod-dev.com/job/gitpod-build-wth-tracing-optional.7/raw

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/334

## How to test
<!-- Provide steps to test this PR -->
Start a prev-environment without and `with-observability`.

## Release Notes
```release-notes
NONE
```