### PR TITLE
[installer]: set component owners

### DIFF
--- a/installer/pkg/components/agent-smith/OWNERS
+++ b/installer/pkg/components/agent-smith/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/blobserve/OWNERS
+++ b/installer/pkg/components/blobserve/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/content-service/OWNERS
+++ b/installer/pkg/components/content-service/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/dashboard/OWNERS
+++ b/installer/pkg/components/dashboard/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-meta
+
+labels:
+  - "team: meta"

--- a/installer/pkg/components/image-builder-mk3/OWNERS
+++ b/installer/pkg/components/image-builder-mk3/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/openvsx-proxy/OWNERS
+++ b/installer/pkg/components/openvsx-proxy/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/installer/pkg/components/proxy/OWNERS
+++ b/installer/pkg/components/proxy/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-meta
+
+labels:
+  - "team: meta"

--- a/installer/pkg/components/registry-facade/OWNERS
+++ b/installer/pkg/components/registry-facade/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/server/OWNERS
+++ b/installer/pkg/components/server/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-meta
+
+labels:
+  - "team: meta"

--- a/installer/pkg/components/ws-daemon/OWNERS
+++ b/installer/pkg/components/ws-daemon/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/ws-manager-bridge/OWNERS
+++ b/installer/pkg/components/ws-manager-bridge/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-meta
+
+labels:
+  - "team: meta"

--- a/installer/pkg/components/ws-manager/OWNERS
+++ b/installer/pkg/components/ws-manager/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/ws-proxy/OWNERS
+++ b/installer/pkg/components/ws-proxy/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/ws-scheduler/OWNERS
+++ b/installer/pkg/components/ws-scheduler/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set code owners in installer components as per `/components`. Where a component has a component and an API, the component owner file is used

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7039

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NODE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
