### PR TITLE
[installer]: bump rabbitmq chart to remove deprecated kube api

### DIFF
--- a/installer/third_party/charts/rabbitmq/Chart.yaml
+++ b/installer/third_party/charts/rabbitmq/Chart.yaml
@@ -8,5 +8,5 @@ name: rabbitmq
 version: 1.0.0
 dependencies:
   - name: rabbitmq
-    version: 8.16.0
+    version: 8.24.6
     repository: https://charts.bitnami.com/bitnami

--- a/installer/third_party/charts/rabbitmq/values.yaml
+++ b/installer/third_party/charts/rabbitmq/values.yaml
@@ -2,6 +2,9 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+global:
+  kubeVersion: 1.21.0
+
 rabbitmq:
   enabled: true
   fullnameOverride: "messagebus"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
RabbitMQ used the deprecated pod disruption budget API. This has been upgraded in the latest version of the chart.

As we use `helm template` to generate the YAML, this [fakes the Kubernetes version](https://github.com/helm/helm/issues/7991). There, we have to set the `kubeVersion` global in the RabbitMQ template

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6829

## How to test
<!-- Provide steps to test this PR -->
Deploy an instance with the Installer.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Installer]: Update RabbitMQ chart
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
