### PR TITLE
[chart] Change first disk for raid0

### DIFF
--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -162,7 +162,7 @@ spec:
                 exit 0
             fi
             # Discover how many disks there are
-            DISK_DEV_SUFFIX=(c d e f g h i j)
+            DISK_DEV_SUFFIX=(b c d e f g h i)
             MAX_NUM_DISKS=8
             NUM_DISKS=0
             declare -a DISKS


### PR DESCRIPTION
## Description

New k3s clusters do not use `/dev/sdb`.

## Release Notes
```release-note
NONE
```
