### PR TITLE
[image-builder] Accept "familiar" base image refs

### DIFF
--- a/components/image-builder-bob/cmd/proxy.go
+++ b/components/image-builder-bob/cmd/proxy.go
@@ -35,7 +35,7 @@ var proxyCmd = &cobra.Command{
 			log.WithError(err).WithField("auth", proxyOpts.Auth).Fatal("cannot unmarshal auth")
 		}
 
-		baseref, err := reference.ParseNamed(proxyOpts.BaseRef)
+		baseref, err := reference.ParseNormalizedNamed(proxyOpts.BaseRef)
 		if err != nil {
 			log.WithError(err).Fatal("cannot parse base ref")
 		}
@@ -43,7 +43,7 @@ var proxyCmd = &cobra.Command{
 		if r, ok := baseref.(reference.NamedTagged); ok {
 			basetag = r.Tag()
 		}
-		targetref, err := reference.ParseNamed(proxyOpts.TargetRef)
+		targetref, err := reference.ParseNormalizedNamed(proxyOpts.TargetRef)
 		if err != nil {
 			log.WithError(err).Fatal("cannot parse target ref")
 		}


### PR DESCRIPTION
## Description
This PR makes workspaces work again which use a digested familiar reference as base image, e.g. `jelaniwoods/appdev2021-base-rails@sha256:91427ecf043c8cdd8040bbd3626eb9bbbf3bee99d44ed3d1281504f71681d661`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7043

## How to test
Open https://github.com/appdev-projects/base-rails/tree/5e42ef0d03bcc267baf7f13b47f3b7f3ad71dc32 in a workspace. If it opens we're good.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[image-builder] Fix bug with familiar digested base image references
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
