### PR TITLE
Laushinka/login 6826

### DIFF
--- a/components/dashboard/src/App.test.ts
+++ b/components/dashboard/src/App.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { getURLHash } from './App'
+
+test('urlHash', () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+        value: {
+            hash: '#https://example.org/user/repo'
+        }
+    });
+
+    expect(getURLHash()).toBe('https://example.org/user/repo');
+});

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -86,7 +86,7 @@ function isWebsiteSlug(pathName: string) {
     return slugs.some(slug => pathName.startsWith('/' + slug + '/') || pathName === ('/' + slug));
 }
 
-function getURLHash() {
+export function getURLHash() {
     return window.location.hash.replace(/^[#/]+/, '');
 }
 

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -169,7 +169,7 @@ export function Login() {
                     <div className="rounded-xl px-10 py-10 mx-auto">
                         <div className="mx-auto pb-8">
                             <img src={providerFromContext ? gitpod : gitpodIcon} className="h-14 mx-auto block dark:hidden" alt="Gitpod's logo" />
-                            <img src={gitpodDark} className="h-14 hidden mx-auto dark:block" alt="Gitpod dark theme logo" />
+                            <img src={providerFromContext ? gitpodDark : gitpodIcon} className="h-14 hidden mx-auto dark:block" alt="Gitpod dark theme logo" />
                         </div>
 
                         <div className="mx-auto text-center pb-8 space-y-2">

--- a/components/dashboard/src/experiments.ts
+++ b/components/dashboard/src/experiments.ts
@@ -73,7 +73,7 @@ export namespace Experiment {
         if (arr === null) {
             return undefined;
         }
-        return new Set(arr) as Set<Experiment>;
+        return new Set(JSON.parse(arr)) as Set<Experiment>;
     }
 
     export function getAsArray(): Experiment[] {

--- a/components/dashboard/src/experiments.ts
+++ b/components/dashboard/src/experiments.ts
@@ -28,6 +28,7 @@ const Experiments = {
      * Experiment "example" will be activate on login for 10% of all clients.
      */
     // "example": 0.1,
+    "login-from-context-6826": 0.5, // https://github.com/gitpod-io/gitpod/issues/6826
 };
 const ExperimentsSet = new Set(Object.keys(Experiments)) as Set<Experiment>;
 export type Experiment = keyof (typeof Experiments);


### PR DESCRIPTION
## Description
Unlogged visitors using a prefix are shown:
1. No welcome section
2. More relevant text
3. A button to continue only with the corresponding Git provider


<img width="433" alt="Screenshot 2021-12-06 at 11 37 35" src="https://user-images.githubusercontent.com/8015191/144831717-8293145d-58f9-461d-baf1-1ba520835af6.png">

<img width="333" alt="Screenshot 2021-12-07 at 09 24 29" src="https://user-images.githubusercontent.com/8015191/144993585-44adef72-b06b-44cb-9c33-e7f231ab5e98.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6826 
Depends on #7081 

## How to test
1. Append a repo URL to `https://laushinka-login-6826.staging.gitpod-dev.com/#`
2. See the changed page

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Unlogged visitors using a prefix will be shown a more direct login page.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
