### PR TITLE
[supervisor] Trigger instance update if missing after port exposure

### DIFF
--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -603,6 +603,10 @@ func (tep *testExposedPorts) Expose(ctx context.Context, local uint32, public bo
 	return nil
 }
 
+func (*testExposedPorts) TriggerUpdate(ctx context.Context) error {
+	return nil
+}
+
 type testServedPorts struct {
 	Changes chan []ServedPort
 	Error   chan error


### PR DESCRIPTION
## Description
When for some reason the server stops sending instance updates ports are getting stuck in `detecting`. This PR checks 1 minute after port exposure if we got the port exposure information from the server and if not it asks actively for an instance update.

@akosyakov @csweichel After implementing this, I'm not sure if this is 100 % that was you had in mind. I'm very open to any suggestions for other implementations.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Mitigate/Fixes https://github.com/gitpod-io/gitpod/issues/6778

See also: https://github.com/gitpod-io/gitpod/issues/7054

## How to test
<!-- Provide steps to test this PR -->
I tested this PR by adding this change:
```diff
diff --git a/components/supervisor/pkg/ports/exposed-ports.go b/components/supervisor/pkg/ports/exposed-ports.go
index 5408a5b3..001cbcbc 100644
--- a/components/supervisor/pkg/ports/exposed-ports.go
+++ b/components/supervisor/pkg/ports/exposed-ports.go
@@ -120,6 +120,13 @@ func (g *GitpodExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
                for {
                        select {
                        case u := <-updates:
+
+                               // TODO: ignoring all updates just for testing purposes
+                               // remove the following block before merging
+                               if u != nil {
+                                       break
+                               }
+
                                res := getExposedPorts(u)
                                if res == nil {
                                        return
```
This change ignores all instance updates from `server`. With this we see the same as we see in prod: The ports get stuck in “detecting”. After 1 minute, `supervisor` logs “we haven't seen an instance update with port exposure info after 1 minute” and “detecting” disappears.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Mitigate ports getting stuck in detecting
```
