### PR TITLE
[jetbrains] Add PhpStorm IDE

### DIFF
--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -27,3 +27,10 @@ jobs:
       productId: pycharm
       productCode: PCP
       productType: release
+  phpstorm:
+    uses: gitpod-io/gitpod/.github/workflows/jetbrains-updates-template.yml@main
+    with:
+      productName: PhpStorm
+      productId: phpstorm
+      productCode: PS
+      productType: release

--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -101,6 +101,13 @@ options:
     logo: "https://upload.wikimedia.org/wikipedia/commons/1/1d/PyCharm_Icon.svg"
     notes: ["While in beta, when you open a workspace with PyCharm you will need to use the password “gitpod”."]
     image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.pycharm)) }}
+  phpstorm:
+    orderKey: "07"
+    title: "PhpStorm"
+    type: "desktop"
+    logo: "https://upload.wikimedia.org/wikipedia/commons/c/c9/PhpStorm_Icon.svg"
+    notes: ["While in beta, when you open a workspace with PhpStorm you will need to use the password “gitpod”."]
+    image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.phpstorm)) }}
 
 defaultIde: "code"
 defaultDesktopIde: "code-desktop"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -412,6 +412,8 @@ components:
         imageName: "ide/goland"
       pycharm:
         imageName: "ide/pycharm"
+      phpstorm:
+        imageName: "ide/phpstorm"
     supervisor:
       imageName: "supervisor"
     dockerUp:

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -45,6 +45,7 @@ packages:
       - components/ide/jetbrains/image:intellij
       - components/ide/jetbrains/image:goland
       - components/ide/jetbrains/image:pycharm
+      - components/ide/jetbrains/image:phpstorm
       - components/ide/theia:docker
       - components/image-builder:docker
       - components/image-builder-mk3:docker

--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -7,6 +7,8 @@ packages:
       - :intellij
       - :goland
       - :pycharm
+      - :phpstorm
+
   - name: intellij
     type: docker
     srcs:
@@ -28,6 +30,7 @@ packages:
       image:
         - ${imageRepoBase}/ide/intellij:${version}
         - ${imageRepoBase}/ide/intellij:commit-${__git_commit}
+
   - name: goland
     type: docker
     srcs:
@@ -49,6 +52,7 @@ packages:
       image:
         - ${imageRepoBase}/ide/goland:${version}
         - ${imageRepoBase}/ide/goland:commit-${__git_commit}
+
   - name: pycharm
     type: docker
     srcs:
@@ -70,3 +74,25 @@ packages:
       image:
         - ${imageRepoBase}/ide/pycharm:${version}
         - ${imageRepoBase}/ide/pycharm:commit-${__git_commit}
+
+  - name: phpstorm
+    type: docker
+    srcs:
+      - "startup.sh"
+      - "supervisor-ide-config_phpstorm.json"
+      - "status/go.mod"
+      - "status/main.go"
+    deps:
+      - components/ide/jetbrains/backend-plugin:plugin
+    argdeps:
+      - imageRepoBase
+    config:
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: workspace.desktopIdeImages.phpstorm
+      buildArgs:
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/webide/PhpStorm-2021.3.tar.gz"
+        SUPERVISOR_IDE_CONFIG: supervisor-ide-config_phpstorm.json
+      image:
+        - ${imageRepoBase}/ide/phpstorm:${version}
+        - ${imageRepoBase}/ide/phpstorm:commit-${__git_commit}

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
@@ -1,0 +1,11 @@
+{
+    "entrypoint": "/ide-desktop/startup.sh",
+    "entrypointArgs": [ "Open in PhpStorm" ],
+    "readinessProbe": {
+        "type": "http",
+        "http": {
+            "port": 24000,
+            "path": "/status"
+        }
+      }
+}

--- a/installer/pkg/components/server/ide-configmap.go
+++ b/installer/pkg/components/server/ide-configmap.go
@@ -99,7 +99,15 @@ func ideconfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:     typeDesktop,
 					Logo:     "https://upload.wikimedia.org/wikipedia/commons/1/1d/PyCharm_Icon.svg", // TODO(clu): Serve logo from our own components instead of using this wikimedia URL.
 					Notes:    []string{"While in beta, when you open a workspace with PyCharm you will need to use the password “gitpod”."},
-					Image:    common.ImageName(ctx.Config.Repository, workspace.PyCharmDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.GoLandImage.Version),
+					Image:    common.ImageName(ctx.Config.Repository, workspace.PyCharmDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PyCharmImage.Version),
+				},
+				"phpstorm": {
+					OrderKey: pointer.String("07"),
+					Title:    "PhpStorm",
+					Type:     typeDesktop,
+					Logo:     "https://upload.wikimedia.org/wikipedia/commons/c/c9/PhpStorm_Icon.svg", // TODO(clu): Serve logo from our own components instead of using this wikimedia URL.
+					Notes:    []string{"While in beta, when you open a workspace with PhpStorm you will need to use the password “gitpod”."},
+					Image:    common.ImageName(ctx.Config.Repository, workspace.PhpStormDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PhpStormImage.Version),
 				},
 			},
 			DefaultIDE:        "code",

--- a/installer/pkg/components/workspace/constants.go
+++ b/installer/pkg/components/workspace/constants.go
@@ -16,6 +16,7 @@ const (
 	IntelliJDesktopIDEImage      = "ide/intellij"
 	GoLandDesktopIdeImage        = "ide/goland"
 	PyCharmDesktopIdeImage       = "ide/pycharm"
+	PhpStormDesktopIdeImage      = "ide/phpstorm"
 	DockerUpImage                = "docker-up"
 	SupervisorImage              = "supervisor"
 	SupervisorPort               = 22999

--- a/installer/pkg/config/versions/versions.go
+++ b/installer/pkg/config/versions/versions.go
@@ -44,6 +44,7 @@ type Components struct {
 			IntelliJImage            Versioned `json:"intellij"`
 			GoLandImage              Versioned `json:"goland"`
 			PyCharmImage             Versioned `json:"pycharm"`
+			PhpStormImage            Versioned `json:"phpstorm"`
 		} `json:"desktopIdeImages"`
 	} `json:"workspace"`
 	WSDaemon struct {


### PR DESCRIPTION
## Description
Another day, another IDE. I just had a few minutes and added PhpStorm. Short smoke test looked good so far.

## How to test
<!-- Provide steps to test this PR -->
Go to preferences and choose PhpStorm.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add PhpStorm desktop IDE.
```

## Documentation
Docs need to be updated. Issue follows soon.