### PR TITLE
Enable experimentalNetwork by default

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -209,7 +209,7 @@
         },
         "experimentalNetwork": {
             "type": "boolean",
-            "description": "Experimental network configuration in workspaces"
+            "description": "Experimental network configuration in workspaces (deprecated). Enabled by default"
         }
     },
     "additionalProperties": false

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -558,7 +558,7 @@ export interface WorkspaceConfig {
     github?: GithubAppConfig;
     vscode?: VSCodeConfig;
 
-    /** tailscale demo */
+    /** deprecated. Enabled by default **/
     experimentalNetwork?: boolean;
 
     /**

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -654,13 +654,6 @@ export class WorkspaceStarter {
         vsxRegistryUrl.setValue(this.config.vsxRegistryUrl);
         envvars.push(vsxRegistryUrl);
 
-        if (workspace.config.experimentalNetwork) {
-            const useNetnsVar = new EnvironmentVariable();
-            useNetnsVar.setName("WORKSPACEKIT_USE_NETNS");
-            useNetnsVar.setValue("true");
-            envvars.push(useNetnsVar);
-        }
-
         const createGitpodTokenPromise = (async () => {
             const scopes = this.createDefaultGitpodAPITokenScopes(workspace, instance);
             const token = crypto.randomBytes(30).toString('hex');

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -250,7 +250,6 @@ var ring1Cmd = &cobra.Command{
 		}
 
 		var (
-			wrapNetns         = os.Getenv("WORKSPACEKIT_USE_NETNS") == "true"
 			slirp4netnsSocket string
 		)
 
@@ -308,16 +307,14 @@ var ring1Cmd = &cobra.Command{
 			)
 		}
 
-		if wrapNetns {
-			f, err := ioutil.TempDir("", "wskit-slirp4netns")
-			if err != nil {
-				log.WithError(err).Error("cannot create slirp4netns socket tempdir")
-				return
-			}
-
-			slirp4netnsSocket = filepath.Join(f, "slirp4netns.sock")
-			mnts = append(mnts, mnte{Target: "/.supervisor/slirp4netns.sock", Source: f, Flags: unix.MS_BIND | unix.MS_REC})
+		f, err := ioutil.TempDir("", "wskit-slirp4netns")
+		if err != nil {
+			log.WithError(err).Error("cannot create slirp4netns socket tempdir")
+			return
 		}
+
+		slirp4netnsSocket = filepath.Join(f, "slirp4netns.sock")
+		mnts = append(mnts, mnte{Target: "/.supervisor/slirp4netns.sock", Source: f, Flags: unix.MS_BIND | unix.MS_REC})
 
 		for _, m := range mnts {
 			dst := filepath.Join(ring2Root, m.Target)
@@ -358,9 +355,8 @@ var ring1Cmd = &cobra.Command{
 			}
 			env = append(env, e)
 		}
-		if wrapNetns {
-			env = append(env, "WORKSPACEKIT_WRAP_NETNS=true")
-		}
+
+		env = append(env, "WORKSPACEKIT_WRAP_NETNS=true")
 
 		socketFN := filepath.Join(os.TempDir(), fmt.Sprintf("workspacekit-ring1-%d.unix", time.Now().UnixNano()))
 		skt, err := net.Listen("unix", socketFN)
@@ -371,11 +367,8 @@ var ring1Cmd = &cobra.Command{
 		defer skt.Close()
 
 		var (
-			cloneFlags uintptr = syscall.CLONE_NEWNS | syscall.CLONE_NEWPID
+			cloneFlags uintptr = syscall.CLONE_NEWNS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET
 		)
-		if wrapNetns {
-			cloneFlags = cloneFlags | syscall.CLONE_NEWNET
-		}
 
 		cmd := exec.Command("/proc/self/exe", "ring2", socketFN)
 		cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -463,30 +456,28 @@ var ring1Cmd = &cobra.Command{
 			return
 		}
 
-		if wrapNetns {
-			slirpCmd := exec.Command(filepath.Join(filepath.Dir(ring2Opts.SupervisorPath), "slirp4netns"),
-				"--configure",
-				"--mtu=65520",
-				"--disable-host-loopback",
-				"--api-socket", slirp4netnsSocket,
-				strconv.Itoa(cmd.Process.Pid),
-				"tap0",
-			)
-			slirpCmd.SysProcAttr = &syscall.SysProcAttr{
-				Pdeathsig: syscall.SIGKILL,
-			}
-			slirpCmd.Stdin = os.Stdin
-			slirpCmd.Stdout = os.Stdout
-			slirpCmd.Stderr = os.Stderr
-
-			err = slirpCmd.Start()
-			if err != nil {
-				log.WithError(err).Error("cannot start slirp4netns")
-				return
-			}
-			//nolint:errcheck
-			defer slirpCmd.Process.Kill()
+		slirpCmd := exec.Command(filepath.Join(filepath.Dir(ring2Opts.SupervisorPath), "slirp4netns"),
+			"--configure",
+			"--mtu=65520",
+			"--disable-host-loopback",
+			"--api-socket", slirp4netnsSocket,
+			strconv.Itoa(cmd.Process.Pid),
+			"tap0",
+		)
+		slirpCmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGKILL,
 		}
+		slirpCmd.Stdin = os.Stdin
+		slirpCmd.Stdout = os.Stdout
+		slirpCmd.Stderr = os.Stderr
+
+		err = slirpCmd.Start()
+		if err != nil {
+			log.WithError(err).Error("cannot start slirp4netns")
+			return
+		}
+		//nolint:errcheck
+		defer slirpCmd.Process.Kill()
 
 		log.Info("signaling to child process")
 		_, err = msgutil.MarshalToWriter(ring2Conn, ringSyncMsg{


### PR DESCRIPTION
## Description

Now that we use a more recent kernel we can enable this feature by default

## Release Notes
```release-note
Enable experimentalNetwork by default
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
