### PR TITLE
Tweak WorkspaceConfig._origin docs

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -564,12 +564,12 @@ export interface WorkspaceConfig {
     /**
      * Where the config object originates from.
      *
-     * repo - from the repository
-     * project-db - from the "Project" stored in the database
-     * definitly-gp - from github.com/gitpod-io/definitely-gp
-     * derived - computed based on analyzing the repository
-     * additional-content - config comes from additional content, usually provided through the project's configuration
-     * default - our static catch-all default config
+     * - repo - from the repository
+     * - project-db - from the "Project" stored in the database
+     * - definitly-gp - from github.com/gitpod-io/definitely-gp
+     * - derived - computed based on analyzing the repository
+     * - additional-content - config comes from additional content, usually provided through the project's configuration
+     * - default - our static catch-all default config
      */
     _origin?: 'repo' | 'project-db' | 'definitely-gp' | 'derived' | 'additional-content' | 'default';
 


### PR DESCRIPTION
Apparently vscode finds those newlines very tasty,
so use markdown to actually mark this up as a list.

```release-note
NONE
```