### PR TITLE
[supervisor] Add log for exposed port instance update

### DIFF
--- a/components/supervisor/pkg/ports/exposed-ports.go
+++ b/components/supervisor/pkg/ports/exposed-ports.go
@@ -109,8 +109,11 @@ func (g *GitpodExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
 			select {
 			case u := <-updates:
 				if u == nil {
+					log.WithFields(log.OWI("", g.WorkspaceID, g.InstanceID)).Info("GitpodExposedPorts: instance update is nil")
 					return
 				}
+
+				log.WithFields(log.OWI("", g.WorkspaceID, g.InstanceID)).WithField("instance", u).Info("GitpodExposedPorts: new instance update")
 
 				res := make([]ExposedPort, len(u.Status.ExposedPorts))
 				for i, p := range u.Status.ExposedPorts {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This change is meant to be able to better debug #6778. This change will probably be rolled back later.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
#6778

## How to test
<!-- Provide steps to test this PR -->
Start a workspace and see the log messages

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
