### PR TITLE
cleanup image builder mk2

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -137,8 +137,7 @@ components:
       # in preview envs, we want deployments to push scale-up early
       memory: 350Mi
 
-  imageBuilder:
-    hostDindData: "/mnt/disks/ssd0/builder"
+  imageBuilderMk3:
     # configure GCP registry
     registry:
       name: eu.gcr.io/gitpod-core-dev/registry

--- a/.werft/values.k3sWsCluster.yaml
+++ b/.werft/values.k3sWsCluster.yaml
@@ -130,9 +130,7 @@ components:
         containerPort: 8080
         servicePort: 80
 
-  imageBuilder:
-    disabled: true
-    hostDindData: "/mnt/disks/ssd0/builder"
+  imageBuilderMk3:
     # configure GCP registry
     registry:
       name: eu.gcr.io/gitpod-core-dev/registry

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -276,7 +276,7 @@ env:
 {{- end -}}
 
 {{- define "gitpod.builtinRegistry.name" -}}
-{{- if .Values.components.imageBuilder.registry.bypassProxy -}}
+{{- if .Values.components.imageBuilderMk3.registry.bypassProxy -}}
 {{ include "gitpod.builtinRegistry.internal_name" . }}
 {{- else -}}
 registry.{{ .Values.hostname }}

--- a/chart/templates/image-builder-mk3-configmap.yaml
+++ b/chart/templates/image-builder-mk3-configmap.yaml
@@ -2,17 +2,15 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ $comp := .Values.components.imageBuilderMk3 -}}
-{{ $compImgbldr := .Values.components.imageBuilder -}}
-{{- $this := dict "root" . "gp" $.Values "comp" $comp "compImgbldr" $compImgbldr -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 
 {{- define "registry-name" -}}
 {{- $comp := .comp -}}
-{{- $compImgbldr := .compImgbldr -}}
 {{- $ := .root -}}
-{{- if eq (default $comp.registry $compImgbldr.registry).name "builtin" -}}
+{{- if eq (default $comp.registry $comp.registry).name "builtin" -}}
 {{ template "gitpod.builtinRegistry.name" $ }}
 {{- else -}}
-{{ (default $comp.registry $compImgbldr.registry).name }}
+{{ (default $comp.registry $comp.registry).name }}
 {{- end -}}
 {{- end -}}
 
@@ -31,8 +29,8 @@ data:
     {
         "orchestrator": {
             "gitpodLayerLoc": "/app/workspace-image-layer.tar.gz",
-            "baseImageRepository": "{{ or (default $comp.registry $compImgbldr.registry).baseImageName (print (include "registry-name" $this) "/base-images") }}",
-            "workspaceImageRepository": "{{ or (default $comp.registry $compImgbldr.registry).workspaceImageName (print (include "registry-name" $this) "/workspace-images") }}",
+            "baseImageRepository": "{{ or (default $comp.registry $comp.registry).baseImageName (print (include "registry-name" $this) "/base-images") }}",
+            "workspaceImageRepository": "{{ or (default $comp.registry $comp.registry).workspaceImageName (print (include "registry-name" $this) "/workspace-images") }}",
             "imageBuildSalt": "{{ $comp.imageBuildSalt | default "" }}",
             {{- if $comp.wsman -}}
             {{ $comp.wsman | fromYaml | toJson }}
@@ -47,8 +45,8 @@ data:
             },
             {{- end -}}
             "builderImage": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" $comp.builderImage) }}",
-            {{- if (default $comp.registry $compImgbldr.registry).secretName -}}"pullSecretFile": "/config/pull-secret.json",{{- end -}}
-            "pullSecret": {{ (default $compImgbldr.registry).secretName | quote }}
+            {{- if (default $comp.registry $comp.registry).secretName -}}"pullSecretFile": "/config/pull-secret.json",{{- end -}}
+            "pullSecret": {{ (default $comp.registry).secretName | quote }}
         },
         "refCache": {
             "interval": "6h",

--- a/chart/templates/image-builder-mk3-deployment.yaml
+++ b/chart/templates/image-builder-mk3-deployment.yaml
@@ -2,8 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 {{ $comp := .Values.components.imageBuilderMk3 -}}
-{{ $compImgbldr := .Values.components.imageBuilder -}}
-{{- $this := dict "root" . "gp" $.Values "comp" $comp "compImgbldr" $compImgbldr -}}
+{{- $this := dict "root" . "gp" $.Values "comp" $comp -}}
 {{- if not $comp.disabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -47,12 +46,12 @@ spec:
       - name: configuration
         configMap:
           name: {{ template "gitpod.comp.configMap" $this }}
-      {{- if (default $compImgbldr.registry).secretName }}
+      {{- if (default $comp.registry).secretName }}
       - name: pull-secret
         secret:
-          secretName: {{ (default $compImgbldr.registry).secretName }}
+          secretName: {{ (default $comp.registry).secretName }}
       {{- end }}
-{{- range $idx, $sec := (default $comp.registryCerts $compImgbldr.registryCerts) }}
+{{- range $idx, $sec := (default $comp.registryCerts $comp.registryCerts) }}
       - name: docker-tls-certs-{{ $idx }}
         secret:
           secretName: {{ $sec.secret }}
@@ -79,8 +78,8 @@ spec:
         - mountPath: /wsman-certs
           name: wsman-tls-certs
           readOnly: true
-{{- if (default $comp $compImgbldr).registry }}
-{{- if (default $comp $compImgbldr).registry.secretName }}
+{{- if (default $comp $comp).registry }}
+{{- if (default $comp $comp).registry.secretName }}
         - mountPath: /config/pull-secret.json
           subPath: .dockerconfigjson
           name: pull-secret


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
From #7086 it remove image builder mk2, but not clean
The reason it works is that the values under werft have not been modified

Note that the `ops` may need to be modified before merging

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
