### PR TITLE
[gp-cli] allow to create snapshot

### DIFF
--- a/components/gitpod-cli/cmd/snapshot.go
+++ b/components/gitpod-cli/cmd/snapshot.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/spf13/cobra"
+)
+
+const (
+	ErrorCodeSnapshotNotFound = 404
+	ErrorCodeSnapshotError    = 630
+)
+
+// snapshotCmd represents the snapshotCmd command
+var snapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Take a snapshot of the current workspace",
+	Args:  cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			cancel()
+		}()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			fail(err.Error())
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:takeSnapshot",
+			"function:waitForSnapshot",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+		snapshotId, err := client.TakeSnapshot(ctx, &protocol.TakeSnapshotOptions{
+			WorkspaceID: wsInfo.WorkspaceId,
+			DontWait:    true,
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+		for ctx.Err() == nil {
+			err := client.WaitForSnapshot(ctx, snapshotId)
+			if err != nil {
+				var responseErr *jsonrpc2.Error
+				if errors.As(err, &responseErr) && (responseErr.Code == ErrorCodeSnapshotNotFound || responseErr.Code == ErrorCodeSnapshotError) {
+					panic(err)
+				}
+				time.Sleep(time.Second * 3)
+			} else {
+				break
+			}
+		}
+		url := fmt.Sprintf("%s/#snapshot/%s", wsInfo.GitpodHost, snapshotId)
+		fmt.Println(url)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(snapshotCmd)
+}

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -73,7 +73,7 @@ type APIInterface interface {
 	SendFeedback(ctx context.Context, feedback string) (res string, err error)
 	RegisterGithubApp(ctx context.Context, installationID string) (err error)
 	TakeSnapshot(ctx context.Context, options *TakeSnapshotOptions) (res string, err error)
-	WaitForSnapshot(ctx context.Context, options *WaitForSnapshotOptions) (err error)
+	WaitForSnapshot(ctx context.Context, snapshotId string) (err error)
 	GetSnapshots(ctx context.Context, workspaceID string) (res []*string, err error)
 	StoreLayout(ctx context.Context, workspaceID string, layoutData string) (err error)
 	GetLayout(ctx context.Context, workspaceID string) (res string, err error)
@@ -1279,14 +1279,14 @@ func (gp *APIoverJSONRPC) TakeSnapshot(ctx context.Context, options *TakeSnapsho
 }
 
 // WaitForSnapshot calls waitForSnapshot on the server
-func (gp *APIoverJSONRPC) WaitForSnapshot(ctx context.Context, options *WaitForSnapshotOptions) (err error) {
+func (gp *APIoverJSONRPC) WaitForSnapshot(ctx context.Context, snapshotId string) (err error) {
 	if gp == nil {
 		err = errNotConnected
 		return
 	}
 	var _params []interface{}
 
-	_params = append(_params, options)
+	_params = append(_params, snapshotId)
 
 	var result string
 	err = gp.C.Call(ctx, "waitForSnapshot", _params, &result)
@@ -1939,11 +1939,7 @@ type GenerateNewGitpodTokenOptions struct {
 type TakeSnapshotOptions struct {
 	LayoutData  string `json:"layoutData,omitempty"`
 	WorkspaceID string `json:"workspaceId,omitempty"`
-}
-
-// WaitForSnapshotOptions is the WaitForSnapshotOptions message type
-type WaitForSnapshotOptions struct {
-	SnapshotID string `json:"snapshotID,omitempty"`
+	DontWait    bool   `json:"dontWait",omitempty`
 }
 
 // PreparePluginUploadParams is the PreparePluginUploadParams message type

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -805,9 +805,9 @@ func (mr *MockAPIInterfaceMockRecorder) TakeSnapshot(ctx, options interface{}) *
 }
 
 // WaitForSnapshot mocks base method.
-func (m *MockAPIInterface) WaitForSnapshot(ctx context.Context, options *WaitForSnapshotOptions) error {
+func (m *MockAPIInterface) WaitForSnapshot(ctx context.Context, snapshotId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForSnapshot", ctx, options)
+	ret := m.ctrl.Call(m, "WaitForSnapshot", ctx, snapshotId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[gp-cli] allow to create snapshot

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7076 

## How to test
<!-- Provide steps to test this PR -->
run `gp snapshot`
![image](https://user-images.githubusercontent.com/8299500/144881362-5140535e-8966-476b-b310-23b8c9b7a7ce.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow to create a workspace snapshot from Gitpod CLI.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
