### PR TITLE
[dashboard] Fix UI experiments

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -47,7 +47,7 @@ interface TrackPathChanged {
 }
 
 interface TrackUIExperiments {
-  ui_experiments?: string[],
+  ui_experiments?: {},
 }
 
 //call this to track all events outside of button and anchor clicks
@@ -56,7 +56,7 @@ export const trackEvent = (event: Event, properties: EventProperties) => {
 }
 
 const trackEventInternal = (event: InternalEvent, properties: InternalEventProperties, userKnown?: boolean) => {
-  properties.ui_experiments = Experiment.getAsArray();
+  properties.ui_experiments = Experiment.get();
 
   getGitpodService().server.trackEvent({
     //if the user is authenticated, let server determine the id. else, pass anonymousId explicitly.
@@ -141,7 +141,7 @@ export const trackLocation = async (userKnown: boolean) => {
     path: window.location.pathname,
     host: window.location.hostname,
     url: window.location.href,
-    ui_experiments: Experiment.getAsArray(),
+    ui_experiments: Experiment.get(),
   };
 
   getGitpodService().server.trackLocation({


### PR DESCRIPTION
## Description
Fixes #7081 by:
 - properly `JSON.parse` :see_no_evil: 
 - persists non-participation in an experiments (by using a shape `{ [e in Experiment]: boolean }` instead of `Experiment[]` to allow for a random distribution (instead of slowly converging to participation in all experiments with every page load)
 - make `Experiment` methods more robust (and handle all failure cases)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #7081

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
