### PR TITLE
[chart] Restore registry pullsecret

### DIFF
--- a/chart/templates/image-builder-registry-auth-secret.yaml
+++ b/chart/templates/image-builder-registry-auth-secret.yaml
@@ -1,0 +1,4 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+{{ include "gitpod.pull-secret" (dict "root" . "secret" .Values.components.imageBuilder.registry) }}


### PR DESCRIPTION
## Description
That secret got accidentally deleted in a cleanup PR: #7086

## Related Issue(s)
Context: #7086

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
