### PR TITLE
[dev-env] Add gpctl and kubecdl to dev-environment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/BUILD.yaml
+++ b/dev/image/BUILD.yaml
@@ -1,6 +1,9 @@
 packages:
   - name: docker
     type: docker
+    deps:
+      - dev/gpctl:app
+      - dev/kubecdl:app
     argdeps:
       - imageRepoBase
     srcs:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -212,3 +212,6 @@ ARG GOJSONTOYAML_VERSION="0.1.0"
 RUN curl -LO https://github.com/brancz/gojsontoyaml/releases/download/v${GOJSONTOYAML_VERSION}/gojsontoyaml_${GOJSONTOYAML_VERSION}_linux_amd64.tar.gz && \
     tar -xzvf gojsontoyaml_${GOJSONTOYAML_VERSION}_linux_amd64.tar.gz && \
     sudo mv gojsontoyaml /usr/local/bin/gojsontoyaml
+
+# Copy our own tools
+COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl /usr/bin/

--- a/dev/kubecdl/BUILD.yaml
+++ b/dev/kubecdl/BUILD.yaml
@@ -1,0 +1,13 @@
+packages:
+  - name: app
+    type: go
+    srcs:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+    env:
+      - CGO_ENABLED=0
+    config:
+      packaging: app
+      dontTest: true
+


### PR DESCRIPTION
## Description
This PR adds `gpctl` and `kubecdl` to the workspace image of this repo. This way using those tools becomes easier.

## How to test
1. Open a workspace on this branch
2. Try to use `gpctl` or `kubecdl`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
