### PR TITLE
[installer]: update docker-registry to allow for pod security policy application

### DIFF
--- a/installer/pkg/components/docker-registry/helm.go
+++ b/installer/pkg/components/docker-registry/helm.go
@@ -31,6 +31,7 @@ var Helm = common.CompositeHelmFunc(
 			helm.KeyValue("docker-registry.service.port", strconv.Itoa(common.ProxyContainerHTTPSPort)),
 			helm.KeyValue("docker-registry.tlsSecretName", BuiltInRegistryCerts),
 			helm.KeyValue("docker-registry.image.repository", repository),
+			helm.KeyValue("docker-registry.serviceAccount.name", Component),
 		}
 
 		if len(cfg.Config.ImagePullSecrets) > 0 {

--- a/installer/pkg/components/docker-registry/objects.go
+++ b/installer/pkg/components/docker-registry/objects.go
@@ -6,9 +6,19 @@ package dockerregistry
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 var Objects = common.CompositeRenderFunc(
 	certificate,
+	rolebinding,
 	secret,
+	func(ctx *common.RenderContext) ([]runtime.Object, error) {
+		if !pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
+			return nil, nil
+		}
+
+		return common.DefaultServiceAccount(Component)(ctx)
+	},
 )

--- a/installer/pkg/components/docker-registry/rolebinding.go
+++ b/installer/pkg/components/docker-registry/rolebinding.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dockerregistry
+
+import (
+	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if !pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
+		return nil, nil
+	}
+
+	return []runtime.Object{
+		&rbacv1.RoleBinding{
+			TypeMeta: common.TypeMetaRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    common.DefaultLabels(Component),
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind: "ServiceAccount",
+					Name: Component,
+				},
+			},
+		},
+	}, nil
+}

--- a/installer/third_party/charts/docker-registry/Chart.yaml
+++ b/installer/third_party/charts/docker-registry/Chart.yaml
@@ -8,5 +8,5 @@ name: docker-registry
 version: 1.0.0
 dependencies:
   - name: docker-registry
-    version: 1.14.0
+    version: 1.16.0
     repository: https://helm.twun.io


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the in-cluster Docker registry to latest version. This brings in two PRs important to us:
 - [42](https://github.com/twuni/docker-registry.helm/pull/42) - deploy registry to a specific namespace
 - [44](https://github.com/twuni/docker-registry.helm/pull/44) - create/use a service account for the deployment

This also creates a service account for the Docker registry and grants it the relevant pod security policies

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6728
Fixes #7139

## How to test
<!-- Provide steps to test this PR -->
Deploy a self-hosted instance with in-cluster container registry selected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: update docker-registry to allow for pod security policy application
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
