### PR TITLE
[Installer]: add license key to Installer config

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -53,7 +53,9 @@ export interface ConfigSerialized {
     insecureNoDomain: boolean;
     logLevel: LogrusLogLevel;
 
+    // Use one or other - licenseFile reads from a file and populates license
     license?: string;
+    licenseFile?: string;
 
     workspaceHeartbeat: {
         intervalSeconds: number;
@@ -178,6 +180,11 @@ export namespace ConfigFile {
         if (brandingConfig) {
             brandingConfig = BrandingParser.normalize(brandingConfig);
         }
+        let license = config.license
+        const licenseFile = config.licenseFile
+        if (licenseFile) {
+            license = fs.readFileSync(licenseFile, "utf-8")
+        }
         return {
             ...config,
             stage: translateLegacyStagename(config.stage),
@@ -186,6 +193,7 @@ export namespace ConfigFile {
             builtinAuthProvidersConfigured,
             brandingConfig,
             chargebeeProviderOptions,
+            license,
             workspaceGarbageCollection: {
                 ...config.workspaceGarbageCollection,
                 startDate: config.workspaceGarbageCollection.startDate ? new Date(config.workspaceGarbageCollection.startDate).getTime() : Date.now(),

--- a/installer/pkg/components/server/configmap.go
+++ b/installer/pkg/components/server/configmap.go
@@ -20,13 +20,18 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
+	license := ""
+	if ctx.Config.License != nil {
+		license = licenseFilePath
+	}
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
 		HostURL:               fmt.Sprintf("https://%s", ctx.Config.Domain),
 		InstallationShortname: ctx.Namespace, // todo(sje): is this needed?
 		Stage:                 "production",  // todo(sje): is this needed?
-		License:               "",            // todo(sje): how do we populate this?
+		LicenseFile:           license,
 		WorkspaceHeartbeat: WorkspaceHeartbeat{
 			IntervalSeconds: 60,
 			TimeoutSeconds:  300,

--- a/installer/pkg/components/server/constants.go
+++ b/installer/pkg/components/server/constants.go
@@ -12,6 +12,7 @@ const (
 	Component          = common.ServerComponent
 	ContainerPort      = 3000
 	ContainerPortName  = "http"
+	licenseFilePath    = "/gitpod/license"
 	PrometheusPort     = 9500
 	PrometheusPortName = "metrics"
 	ServicePort        = 3000

--- a/installer/pkg/components/server/types.go
+++ b/installer/pkg/components/server/types.go
@@ -52,6 +52,7 @@ type ConfigSerialized struct {
 	DevBranch                         string   `json:"devBranch"`
 	InsecureNoDomain                  bool     `json:"insecureNoDomain"`
 	License                           string   `json:"license"`
+	LicenseFile                       string   `json:"licenseFile"`
 	DefinitelyGpDisabled              bool     `json:"definitelyGpDisabled"`
 	EnableLocalApp                    bool     `json:"enableLocalApp"`
 	BuiltinAuthProvidersConfigured    bool     `json:"builtinAuthProvidersConfigured"`

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -83,6 +83,7 @@ type Config struct {
 
 	AuthProviders []AuthProviderConfigs `json:"authProviders" validate:"dive"`
 	BlockNewUsers BlockNewUsers         `json:"blockNewUsers"`
+	License       *ObjectRef            `json:"license,omitempty"`
 }
 
 type Metadata struct {

--- a/installer/pkg/config/v1/validation.go
+++ b/installer/pkg/config/v1/validation.go
@@ -102,5 +102,10 @@ func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
 		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("encryptionKeys", "host", "password", "port", "username")))
 	}
 
+	if cfg.License != nil {
+		secretName := cfg.License.Name
+		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("license")))
+	}
+
 	return res
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allows an enterprise license key to be added to the Installer config surface. This creates an optional Kubernetes secret from the volume and loads it into the server config. Also adds cluster validation to ensure that a license secret is set if included in the config YAML.

In the server, this adds `licenseFile` to the config interface and, if set, it loads it from that location and sets the value to `license`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6868

## How to test
<!-- Provide steps to test this PR -->
[Create a license](https://www.notion.so/gitpod/Create-a-Gitpod-Self-Hosted-License-fef6b0e3548b4676a9d782f6d5a3df9a), load it into a secret and deploy it to your cluster, adding the following block to your config YAML:

```yaml
license:
  kind: secret
  name: my-test-license
```

Happy to demo it to the approver(s) if required

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Installer]: add license key to config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
