### PR TITLE
[workspacekit] Make the enclave join ring2 netns

### DIFF
--- a/components/image-builder-mk3/pkg/resolve/resolve.go
+++ b/components/image-builder-mk3/pkg/resolve/resolve.go
@@ -114,7 +114,7 @@ func (sr *StandaloneRefResolver) Resolve(ctx context.Context, ref string, opts .
 	}
 
 	if mf.Config.Size != 0 {
-		pref, err = reference.WithDigest(pref, mf.Config.Digest)
+		pref, err = reference.WithDigest(pref, desc.Digest)
 		if err != nil {
 			return
 		}

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -530,7 +530,7 @@ var ring1Cmd = &cobra.Command{
 		}
 
 		if enclave := os.Getenv("WORKSPACEKIT_RING2_ENCLAVE"); enclave != "" {
-			ecmd := exec.Command("/proc/self/exe", append([]string{"nsenter", "--target", strconv.Itoa(cmd.Process.Pid), "--mount"}, strings.Fields(enclave)...)...)
+			ecmd := exec.Command("/proc/self/exe", append([]string{"nsenter", "--target", strconv.Itoa(cmd.Process.Pid), "--mount", "--net"}, strings.Fields(enclave)...)...)
 			ecmd.Stdout = os.Stdout
 			ecmd.Stderr = os.Stderr
 


### PR DESCRIPTION
## Description
Fixes the recent image-builder issues produced by #7063. That former change failed to include the ring2 enclave in which the bob proxy runs in the network namespace of ring2. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7114

## How to test
Open a workspace which requires an image build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
