### PR TITLE
Enable projects of self-managed GitLab instances

### DIFF
--- a/components/dashboard/src/projects/render-utils.test.ts
+++ b/components/dashboard/src/projects/render-utils.test.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { toRemoteURL } from './render-utils'
+
+test('parse clone URL', () => {
+    expect(toRemoteURL("https://gitlab.com/laushinka/my-node-project")).toEqual("gitlab.com/laushinka/my-node-project");
+    expect(toRemoteURL("https://gitlab.gitlab.gitpod.io/test-group/test-project")).toEqual("gitlab.gitlab.gitpod.io/test-group/test-project");
+});

--- a/components/dashboard/src/projects/render-utils.tsx
+++ b/components/dashboard/src/projects/render-utils.tsx
@@ -6,7 +6,7 @@
 
 
 export function toRemoteURL(cloneURL: string) {
-    return cloneURL.replace("https://", "").replace(".git", "");
+    return cloneURL.replace(/(^https:\/\/)|(\.git$)/g, "");
 }
 
 export function shortCommitMessage(message: string) {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1423,10 +1423,13 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const user = this.checkAndBlockUser("getProviderRepositoriesForUser");
 
         const repositories: ProviderRepository[] = [];
-        if (params.provider === "github.com") {
+        const providerHost = params.provider;
+        const provider = (await this.getAuthProviders(ctx)).find(ap => ap.host === providerHost);
+
+        if (providerHost === "github.com") {
             repositories.push(...(await this.githubAppSupport.getProviderRepositoriesForUser({ user, ...params })));
-        } else if (params.provider === "gitlab.com") {
-            repositories.push(...(await this.gitLabAppSupport.getProviderRepositoriesForUser({ user, ...params })));
+        } else if (provider?.authProviderType === "GitLab") {
+            repositories.push(...(await this.gitLabAppSupport.getProviderRepositoriesForUser({ user, provider })));
         } else {
             log.info({ userId: user.id }, `Unsupported provider: "${params.provider}"`, { params });
         }


### PR DESCRIPTION
This change allows to create projects based on repositories of self-managed GitLab instances. 

### how to test
0. setup a team; setup an application on a self-managed GitLab (internal: gitlab.gitlab.gitpod.io); setup a [Git Integration](https://at-gitlab-self-hosted.staging.gitpod-dev.com/integrations) and authorize.
1. create a new project: go to the [wizard](https://at-gitlab-self-hosted.staging.gitpod-dev.com/new), hit `Select Git Provider`, select the authorized GitLab provider, choose repository (from a group, otherwise it always lands in your account, but we want to have it in the team), and create a project.
  <img width="571" alt="Screen Shot 2021-12-08 at 15 39 44" src="https://user-images.githubusercontent.com/914497/145230165-fc60df11-5d75-4dfd-bd46-8d1814ced69e.png">
2. using another team member's account, navigate to the created project and see the option to authorize with the provider of the self-managed GitLab instance.
  <img width="1774" alt="Screen Shot 2021-12-08 at 15 46 11" src="https://user-images.githubusercontent.com/914497/145230175-7fceaafb-d27d-40c1-80f2-f7e3823b8865.png">



Resolves https://github.com/gitpod-io/gitpod/issues/5115





```release-note
Enable self-managed GitLab instances for Teams & Projects
```