### PR TITLE
[dashboard] Fix possible race condition when creating a new project

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -96,12 +96,12 @@ export default function NewProject() {
                     if (repoConfigString) {
                         setSourceOfConfig("repo");
                     } else {
-                        setSourceOfConfig("db");
                         setGuessedConfigString(await guessedConfigStringPromise || `tasks:
   - init: |
       echo 'TODO: build project'
     command: |
       echo 'TODO: start app'`);
+                        setSourceOfConfig("db");
                     }
                 } catch (error) {
                     console.error('Getting project configuration failed', error);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes a race condition where `guessedConfiguration` can be set to `undefined` (if guessing it takes longer than getting the repo `.gitpod.yml`).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up to https://github.com/gitpod-io/gitpod/pull/7102#pullrequestreview-826642114

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc