### PR TITLE
[code] update stable to 1.63

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -381,7 +381,7 @@ components:
       imageName: "ide/theia"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-d8477d484d00967a92686642b33541aed824cb63"
+      stableVersion: "commit-4cf15538da2ecff8bae9245f18aa3ac6f3b90c3f"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

## Description
<!-- Describe your changes in detail -->
Updates stable VS Code Web to 1.63

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Select vscode stable in dashboard settings
- Start a workspace.
- Use about dialog to check that version is `1.63`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update VS Code Web to 1.63
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
