### PR TITLE
supervisor analytics fixes

### DIFF
--- a/components/common-go/analytics/analytics.go
+++ b/components/common-go/analytics/analytics.go
@@ -81,24 +81,30 @@ type segmentAnalyticsWriter struct {
 func (s *segmentAnalyticsWriter) Identify(m IdentifyMessage) {
 	defer recover()
 
-	_ = s.Client.Enqueue(segment.Identify{
+	err := s.Client.Enqueue(segment.Identify{
 		AnonymousId: m.AnonymousID,
 		UserId:      m.UserID,
 		Timestamp:   m.Timestamp,
 		Traits:      m.Traits,
 	})
+	if err != nil {
+		log.WithError(err).Warn("analytics: identity failed")
+	}
 }
 
 func (s *segmentAnalyticsWriter) Track(m TrackMessage) {
 	defer recover()
 
-	_ = s.Client.Enqueue(segment.Track{
+	err := s.Client.Enqueue(segment.Track{
 		AnonymousId: m.AnonymousID,
 		UserId:      m.UserID,
 		Event:       m.Event,
 		Timestamp:   m.Timestamp,
 		Properties:  m.Properties,
 	})
+	if err != nil {
+		log.WithError(err).Warn("analytics: track failed")
+	}
 }
 
 func (s *segmentAnalyticsWriter) Close() error {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -825,6 +825,7 @@ func runIDEReadinessProbe(cfg *Config, ideConfig *IDEConfig, ide IDEKind) (deskt
 func isBlacklistedEnvvar(name string) bool {
 	// exclude blacklisted
 	prefixBlacklist := []string{
+		"GITPOD_ANALYTICS_",
 		"THEIA_SUPERVISOR_",
 		"GITPOD_TOKENS",
 		// The following vars are meant to filter out the kubernetes-injected env vars that we do not know how to turn of (yet)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`config-changed` seems to be only event which is delivered directly to Segment from supervisor. And we don't see it in production. This PR add error logging on calls to segment. It also hides analytics env vars from a user.

But maybe it is better to use Server API instead for it as well and remove analytics env var from workspace completely?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #6894

## How to test
<!-- Provide steps to test this PR -->

Start a workspace and check that you cannot get access to analytics env var from terminals.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
