### PR TITLE
werft/observability: Pin default observability branch to v0.0.1

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -608,7 +608,7 @@ export async function deployToDev(deploymentConfig: DeploymentConfig, workspaceF
 
     async function installMonitoring() {
         const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
-        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "main";
+        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "v0.0.1";
         installMonitoringSatelliteParams.pathToKubeConfig = ""
         installMonitoringSatelliteParams.satelliteNamespace = namespace
         installMonitoringSatelliteParams.clusterName = namespace


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We're doing a [major refactoring of the observability repo](https://github.com/gitpod-io/observability/pull/45). This PR pins the default branch used to clone the observability repo so we can safely merge breaking changes to main

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
