### PR TITLE
[chart] Fix values yaml after ephemeral storage change

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -34,7 +34,7 @@ workspaceSizing:
   requests:
     cpu: "1m"
     memory: "2.25Gi"
-    storage: "5Gi"
+    ephemeral-storage: "5Gi"
   limits:
     cpu: "5"
     memory: "12Gi"


### PR DESCRIPTION
## Description
This PR fixes the ws-manager config after the recent ephemeral storage change.

## How to test
If ws-manager starts we're good

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
