### PR TITLE
[workspacekit] Make independent of supervisor

### DIFF
--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -164,7 +164,7 @@ export function findFreeHostPorts(ranges: PortRange[], shellOpts: ExecOptions): 
     for (const port of hostPorts) {
         alreadyReservedPorts.add(port);
     }
-    werft.log(shellOpts.slice, `already reserved ports: ${Array.from(alreadyReservedPorts.values())}`);
+    werft.log(shellOpts.slice, `already reserved ports: ${Array.from(alreadyReservedPorts.values()).map(p => ""+p).join(", ")}`);
 
     const results: number[] = [];
     for (const range of ranges) {

--- a/chart/templates/registry-facade-configmap.yaml
+++ b/chart/templates/registry-facade-configmap.yaml
@@ -40,6 +40,10 @@ data:
                     "type": "image"
                 },
                 {
+                    "ref": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.workspacekit) }}",
+                    "type": "image"
+                },
+                {
                     "ref": "{{ template "gitpod.comp.imageFull" (dict "root" . "gp" $.Values "comp" .Values.components.workspace.dockerUp) }}",
                     "type": "image"
                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -398,6 +398,8 @@ components:
         imageName: "ide/phpstorm"
     supervisor:
       imageName: "supervisor"
+    workspacekit:
+      imageName: "workspacekit"
     dockerUp:
       imageName: "docker-up"
     pullSecret:

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -39,16 +39,16 @@ packages:
       - components/ee/payment-endpoint:docker
       - components/ee/ws-scheduler:docker
       - components/gitpod-db:docker
-      - components/ide/code:docker
       - components/ide/code-desktop:docker
       - components/ide/code-desktop:docker-insiders
-      - components/ide/jetbrains/image:intellij
+      - components/ide/code:docker
       - components/ide/jetbrains/image:goland
-      - components/ide/jetbrains/image:pycharm
+      - components/ide/jetbrains/image:intellij
       - components/ide/jetbrains/image:phpstorm
+      - components/ide/jetbrains/image:pycharm
       - components/ide/theia:docker
-      - components/image-builder-mk3:docker
       - components/image-builder-bob:docker
+      - components/image-builder-mk3:docker
       - components/local-app:docker
       - components/openvsx-proxy:docker
       - components/proxy:docker
@@ -57,6 +57,7 @@ packages:
       - components/server:docker
       - components/service-waiter:docker
       - components/supervisor:docker
+      - components/workspacekit:docker
       - components/ws-daemon:docker
       - components/ws-daemon/seccomp-profile-installer:docker
       - components/ws-daemon/shiftfs-module-loader:docker
@@ -97,6 +98,7 @@ packages:
       - components/service-waiter:app
       - components/supervisor:app
       - components/supervisor/frontend:app
+      - components/workspacekit:app
       - components/ws-daemon:app
       - components/ws-manager-bridge:app
       - components/ws-manager:app

--- a/components/supervisor/leeway.Dockerfile
+++ b/components/supervisor/leeway.Dockerfile
@@ -2,11 +2,6 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM alpine:3.15 as download
-ENV SLIRP4NETNS_VERSION=v1.1.12
-WORKDIR /download
-RUN wget https://github.com/rootless-containers/slirp4netns/releases/download/${SLIRP4NETNS_VERSION}/slirp4netns-x86_64 -O slirp4netns && chmod 755 slirp4netns
-
 FROM scratch
 
 # BEWARE: This must be the first layer in the image, s.t. that blobserve
@@ -17,11 +12,8 @@ COPY components-supervisor-frontend--app/node_modules/@gitpod/supervisor-fronten
 WORKDIR "/.supervisor"
 COPY components-supervisor--app/supervisor \
      supervisor-config.json \
-     components-workspacekit--app/workspacekit \
-     components-workspacekit--fuse-overlayfs/fuse-overlayfs \
      components-gitpod-cli--app/gitpod-cli \
      ./
-COPY --from=download /download/slirp4netns .
 
 WORKDIR "/.supervisor/ssh"
 COPY components-supervisor-openssh--app/usr/sbin/sshd .

--- a/components/workspacekit/BUILD.yaml
+++ b/components/workspacekit/BUILD.yaml
@@ -34,3 +34,19 @@ packages:
     config:
       packaging: library
       dontTest: true
+  - name: docker
+    type: docker
+    deps:
+      - :app
+      - :fuse-overlayfs
+    argdeps:
+      - imageRepoBase
+    config:
+      buildArgs:
+        VERSION: ${version}
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: workspace.workspacekit
+      image:
+        - ${imageRepoBase}/workspacekit:${version}
+        - ${imageRepoBase}/workspacekit:commit-${__git_commit}

--- a/components/workspacekit/leeway.Dockerfile
+++ b/components/workspacekit/leeway.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+FROM alpine:3.15 as download
+ENV SLIRP4NETNS_VERSION=v1.1.12
+WORKDIR /download
+RUN wget https://github.com/rootless-containers/slirp4netns/releases/download/${SLIRP4NETNS_VERSION}/slirp4netns-x86_64 -O slirp4netns && chmod 755 slirp4netns
+
+FROM scratch
+
+WORKDIR "/.supervisor"
+COPY components-workspacekit--app/workspacekit \
+     components-workspacekit--fuse-overlayfs/fuse-overlayfs \
+     ./
+COPY --from=download /download/slirp4netns .
+
+ARG __GIT_COMMIT
+ARG VERSION
+
+ENV GITPOD_BUILD_GIT_COMMIT=${__GIT_COMMIT}
+ENV GITPOD_BUILD_VERSION=${VERSION}
+

--- a/installer/pkg/components/registry-facade/configmap.go
+++ b/installer/pkg/components/registry-facade/configmap.go
@@ -40,13 +40,20 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			TLS:         &tls,
 			Store:       "/mnt/cache/registry",
 			RequireAuth: false,
-			StaticLayer: []regfac.StaticLayerCfg{{
-				Ref:  common.ImageName(ctx.Config.Repository, SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
-				Type: "image",
-			}, {
-				Ref:  common.ImageName(ctx.Config.Repository, DockerUpImage, ctx.VersionManifest.Components.Workspace.DockerUp.Version),
-				Type: "image",
-			}},
+			StaticLayer: []regfac.StaticLayerCfg{
+				{
+					Ref:  common.ImageName(ctx.Config.Repository, SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
+					Type: "image",
+				},
+				{
+					Ref:  common.ImageName(ctx.Config.Repository, WorkspacekitImage, ctx.VersionManifest.Components.Workspace.Workspacekit.Version),
+					Type: "image",
+				},
+				{
+					Ref:  common.ImageName(ctx.Config.Repository, DockerUpImage, ctx.VersionManifest.Components.Workspace.DockerUp.Version),
+					Type: "image",
+				},
+			},
 		},
 		AuthCfg:        "/mnt/pull-secret.json",
 		PProfAddr:      ":6060",

--- a/installer/pkg/components/registry-facade/constants.go
+++ b/installer/pkg/components/registry-facade/constants.go
@@ -16,4 +16,5 @@ const (
 	ServicePort       = common.RegistryFacadeServicePort
 	DockerUpImage     = workspace.DockerUpImage
 	SupervisorImage   = workspace.SupervisorImage
+	WorkspacekitImage = workspace.WorkspacekitImage
 )

--- a/installer/pkg/components/workspace/constants.go
+++ b/installer/pkg/components/workspace/constants.go
@@ -19,5 +19,6 @@ const (
 	PhpStormDesktopIdeImage      = "ide/phpstorm"
 	DockerUpImage                = "docker-up"
 	SupervisorImage              = "supervisor"
+	WorkspacekitImage            = "workspacekit"
 	SupervisorPort               = 22999
 )

--- a/installer/pkg/config/versions/versions.go
+++ b/installer/pkg/config/versions/versions.go
@@ -38,6 +38,7 @@ type Components struct {
 		CodeImage        Versioned `json:"codeImage"`
 		DockerUp         Versioned `json:"dockerUp"`
 		Supervisor       Versioned `json:"supervisor"`
+		Workspacekit     Versioned `json:"workspacekit"`
 		DesktopIdeImages struct {
 			CodeDesktopImage         Versioned `json:"codeDesktop"`
 			CodeDesktopImageInsiders Versioned `json:"codeDesktopInsiders"`


### PR DESCRIPTION
## Description
This PR makes workspacekit independent of supervisor, and binds it to the deployment cycle of workspace clusters rather than supervisor.

We needed to separate the two, because nowadays supervisor is deployed/chosen as part of the `StartWorkspace` request, and no longer bound to the registry-facade config. We've [shot ourselves in the foot](https://github.com/gitpod-io/gitpod/issues/7142#issuecomment-990253793) because of this.

## How to test
If workspaces start, all is well.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
