### PR TITLE
[ws-scheduler] Pace GetWorkspace calls

### DIFF
--- a/components/ee/ws-scheduler/pkg/scaler/driver.go
+++ b/components/ee/ws-scheduler/pkg/scaler/driver.go
@@ -152,8 +152,10 @@ func (wspd *WorkspaceManagerPrescaleDriver) Run() {
 			} else if err != nil {
 				log.WithError(err).Error("cannot maintain workspace count")
 			}
-			// we don't have to wait here until we retry, because the RPC calls
-			// in maintainWorkspaceStatus will wait for us.
+
+			// We want to wait here because otherwise we might bombard ws-manager with
+			// GetWorkspace calls.
+			time.Sleep(10 * time.Second)
 		}
 	}()
 


### PR DESCRIPTION
## Description
ws-scheduler can produce a lot of `GetWorkspace` when the connection to ws-manager is broken. This PR paces the call rate in such cases.

## How to test
1. Scale down ws-manager. `cannot maintain workspace count` should show at a 10s pace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
