### PR TITLE
[workspacekit] Don't shadow /.supervisor

### DIFF
--- a/components/supervisor/BUILD.yaml
+++ b/components/supervisor/BUILD.yaml
@@ -25,8 +25,6 @@ packages:
       - :app
       - components/supervisor/frontend:app
       - components/supervisor/openssh:app
-      - components/workspacekit:app
-      - components/workspacekit:fuse-overlayfs
       - components/gitpod-cli:app
     argdeps:
       - imageRepoBase

--- a/components/workspacekit/leeway.Dockerfile
+++ b/components/workspacekit/leeway.Dockerfile
@@ -9,11 +9,10 @@ RUN wget https://github.com/rootless-containers/slirp4netns/releases/download/${
 
 FROM scratch
 
-WORKDIR "/.supervisor"
 COPY components-workspacekit--app/workspacekit \
      components-workspacekit--fuse-overlayfs/fuse-overlayfs \
-     ./
-COPY --from=download /download/slirp4netns .
+     /.supervisor/
+COPY --from=download /download/slirp4netns /.supervisor/
 
 ARG __GIT_COMMIT
 ARG VERSION


### PR DESCRIPTION
## Description
This PR ensures that the new workspacekit image never shadows/"tombstones" the `/.supervisor`, which breaks workspaces which do have an explicit `supervisorImage` set as part of their `imageSpec` (e.g. image-builds).

## How to test
Run an image-build on this branch

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
