### PR TITLE
.werft/observability: Follow refactor done in observability

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -800,7 +800,7 @@ export async function deployToDevWithHelm(deploymentConfig: DeploymentConfig, wo
 
     async function installMonitoring() {
         const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
-        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "v0.0.1";
+        installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "main";
         installMonitoringSatelliteParams.pathToKubeConfig = ""
         installMonitoringSatelliteParams.satelliteNamespace = namespace
         installMonitoringSatelliteParams.clusterName = namespace


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/observability/pull/45, we're doing a big refactor our the codebase aiming to be able to do backward-compatible changes in the future.

This PR adjusts our werft job with the changes done in that PR, and can also be used to test that very PR.

## How to test
<!-- Provide steps to test this PR -->
Run a new werft job with the following annotations:
```
/ werft run with-observability withObservabilityBranch=arthursens/find-a-way-to-introduce-34
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
