### PR TITLE
[server] Improve tracing around websocket connections

### DIFF
--- a/components/gitpod-messagebus/src/messagebus.ts
+++ b/components/gitpod-messagebus/src/messagebus.ts
@@ -520,6 +520,10 @@ export abstract class AbstractTopicListener<T> implements MessagebusListener {
                 this.listener({ span }, msg, message.fields.routingKey);
             } catch (e) {
                 log.error('Error while executing message handler', e, { message });
+            } finally {
+                if (span) {
+                    span.finish();
+                }
             }
         }
     }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -40,6 +40,7 @@ import { GitLabAppSupport } from "../gitlab/gitlab-app-support";
 import { Config } from "../../../src/config";
 import { SnapshotService, WaitForSnapshotOptions } from "./snapshot-service";
 import { SafePromise } from "@gitpod/gitpod-protocol/lib/util/safe-promise";
+import { ClientMetadata } from "../../../src/websocket/websocket-connection-manager";
 
 @injectable()
 export class GitpodServerEEImpl extends GitpodServerImpl {
@@ -72,8 +73,8 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
     @inject(SnapshotService) protected readonly snapshotService: SnapshotService;
 
-    initialize(client: GitpodClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientHeaderFields: ClientHeaderFields): void {
-        super.initialize(client, user, accessGuard, clientHeaderFields);
+    initialize(client: GitpodClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientMetadata: ClientMetadata, clientHeaderFields: ClientHeaderFields): void {
+        super.initialize(client, user, accessGuard, clientMetadata, clientHeaderFields);
 
         this.listenToCreditAlerts();
         this.listenForPrebuildUpdates();

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -29,7 +29,7 @@ import { RabbitMQConsensusLeaderMessenger } from './consensus/rabbitmq-consensus
 import { WorkspaceGarbageCollector } from './workspace/garbage-collector';
 import { WorkspaceDownloadService } from './workspace/workspace-download-service';
 import { MonitoringEndpointsApp } from './monitoring-endpoints';
-import { WebsocketClientType, WebsocketConnectionManager } from './websocket/websocket-connection-manager';
+import { WebsocketConnectionManager } from './websocket/websocket-connection-manager';
 import { DeletedEntryGC, PeriodicDbDeleter, TypeORM } from '@gitpod/gitpod-db/lib';
 import { OneTimeSecretServer } from './one-time-secret-server';
 import { Disposable, DisposableCollection, GitpodClient, GitpodServer } from '@gitpod/gitpod-protocol';
@@ -164,7 +164,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                 if (info.req.url === '/v1') {
                     try {
                         await this.bearerAuth.auth(info.req as express.Request)
-                    } catch (e) {
+                    } catch (e) {
                         if (isBearerAuthError(e)) {
                             return callback(false, 401, e.message);
                         }
@@ -319,8 +319,8 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
             help: 'Currently served websocket connections',
             labelNames: ["clientType"],
         });
-        this.websocketConnectionHandler.onConnectionCreated((_, req) => gauge.inc({ clientType: WebsocketClientType.getClientType(req) || "undefined" }));
-        this.websocketConnectionHandler.onConnectionClosed((_, req) => gauge.dec({ clientType: WebsocketClientType.getClientType(req) || "undefined" }));
+        this.websocketConnectionHandler.onConnectionCreated((s, _) => gauge.inc({ clientType: s.clientMetadata.type || "undefined" }));
+        this.websocketConnectionHandler.onConnectionClosed((s, _) => gauge.dec({ clientType: s.clientMetadata.type || "undefined" }));
     }
 
     protected installWebsocketClientContextGauge() {
@@ -329,7 +329,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
             help: 'Currently served client contexts',
             labelNames: ["authLevel"],
         });
-        this.websocketConnectionHandler.onClientContextCreated((ctx) => gauge.inc({ authLevel: ctx.authLevel }));
-        this.websocketConnectionHandler.onClientContextClosed((ctx) => gauge.dec({ authLevel: ctx.authLevel }));
+        this.websocketConnectionHandler.onClientContextCreated((ctx) => gauge.inc({ authLevel: ctx.clientMetadata.authLevel }));
+        this.websocketConnectionHandler.onClientContextClosed((ctx) => gauge.dec({ authLevel: ctx.clientMetadata.authLevel }));
     }
 }

--- a/components/server/src/user/enforcement-endpoint.ts
+++ b/components/server/src/user/enforcement-endpoint.ts
@@ -17,6 +17,7 @@ import { ResponseError } from 'vscode-jsonrpc';
 import { ErrorCodes } from '@gitpod/gitpod-protocol/lib/messaging/error';
 import { GitpodServerImpl } from '../workspace/gitpod-server-impl';
 import { ResourceAccessGuard, OwnerResourceGuard } from '../auth/resource-access';
+import { ClientMetadata } from '../websocket/websocket-connection-manager';
 
 export const EnforcementControllerServerFactory = Symbol('EnforcementControllerServerFactory');
 export type EnforcementControllerServerFactory = () => GitpodServerImpl;
@@ -47,7 +48,7 @@ export class EnforcementController {
             another architecture is not necessary.
         */
         const server = this.serverFactory()
-        server.initialize(undefined, user, resourceAccessGuard, {});
+        server.initialize(undefined, user, resourceAccessGuard, ClientMetadata.from(user.id), {});
         return server;
     }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -54,6 +54,7 @@ import { CachingBlobServiceClientProvider } from '@gitpod/content-service/lib/su
 import { IDEOptions } from '@gitpod/gitpod-protocol/lib/ide-protocol';
 import { IDEConfigService } from '../ide-config';
 import { PartialProject } from '@gitpod/gitpod-protocol/src/teams-projects-protocol';
+import { ClientMetadata } from '../websocket/websocket-connection-manager';
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi);    // userId is already taken care of in WebsocketConnectionManager
@@ -111,6 +112,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     /** Id the uniquely identifies this server instance */
     public readonly uuid: string = uuidv4();
+    public readonly clientMetadata: ClientMetadata;
     protected clientHeaderFields: ClientHeaderFields;
     protected resourceAccessGuard: ResourceAccessGuard;
     protected client: GitpodApiClient | undefined;
@@ -123,7 +125,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         this.disposables.dispose();
     }
 
-    initialize(client: GitpodApiClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientHeaderFields: ClientHeaderFields): void {
+    initialize(client: GitpodApiClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientMetadata: ClientMetadata, clientHeaderFields: ClientHeaderFields): void {
         if (client) {
             this.disposables.push(Disposable.create(() => this.client = undefined));
         }
@@ -131,6 +133,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         this.user = user;
         this.resourceAccessGuard = accessGuard;
         this.clientHeaderFields = clientHeaderFields;
+        (this.clientMetadata as any) = clientMetadata;
 
         log.debug({ userId: this.user?.id }, `clientRegion: ${clientHeaderFields.clientRegion}`);
         log.debug({ userId: this.user?.id }, 'initializeClient');

--- a/components/server/src/workspace/messagebus-integration.ts
+++ b/components/server/src/workspace/messagebus-integration.ts
@@ -94,6 +94,10 @@ export class PrebuildUpdatableQueueListener implements MessagebusListener {
                 this.callback({ span }, msg);
             } catch (e) {
                 log.error('Error while executing message handler', e, { message });
+            } finally {
+                if (span) {
+                    span.finish();
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
This PR contains 4 tracing improvements around websockets (in order of commits, can be reviewed commit-by-commit):
 - `finish()` spans that we create from messagebus messages/updates so they don't end up as "missing" in jaeger/honeycomb
 - set owner-workspace-instance on messagebus messages (if possible)
 - trace ratelimiting and access guards for JsonRPC API calls
 - add tracing for websocket connections (parentCtx of individual calls) + minor refactoring

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #7054

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
