### PR TITLE
[server] Pin oci-tool to 0.1.1

### DIFF
--- a/components/server/leeway.Dockerfile
+++ b/components/server/leeway.Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN /installer/install.sh
 
 FROM golang:1.17.2 as oci-tool-builder
-RUN go install github.com/csweichel/oci-tool@latest
+RUN go install github.com/csweichel/oci-tool@v0.1.1
 
 FROM node:16.13.0-slim
 ENV NODE_OPTIONS="--unhandled-rejections=warn --max_old_space_size=2048"


### PR DESCRIPTION
## Description

/cc @csweichel 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7174

## How to test
 - opne workspace on this branch
 - `kubectl logs server-... -f`
 - note that there are now `oci-tool` related errors anymore:
 ```
{"component":"server","severity":"INFO","time":"2021-12-13T11:34:31.122Z","environment":"devstaging","message":"ide config: successfully resolved image digest","payload":{"ide":"code-latest","image":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-4cf15538da2ecff8bae9245f18aa3ac6f3b90c3f","resolvedImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-4cf15538da2ecff8bae9245f18aa3ac6f3b90c3f@sha256:d649fa6f7726ea1841928d738b8b5bece0ea516caba11ee31a811f8dacf2500b","trigger":"file changed"}}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

