### PR TITLE
[installer]: separate server and IDE components

### DIFF
--- a/installer/pkg/components/server/ide/OWNERS
+++ b/installer/pkg/components/server/ide/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/installer/pkg/components/server/ide/configmap.go
+++ b/installer/pkg/components/server/ide/configmap.go
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package server
+package ide
 
 import (
 	"encoding/json"
@@ -17,7 +17,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func ideconfigmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	typeBrowser := "browser"
 	typeDesktop := "desktop"
 	idecfg := IDEConfig{

--- a/installer/pkg/components/server/ide/constants.go
+++ b/installer/pkg/components/server/ide/constants.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package ide
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+)
+
+const (
+	Component = common.ServerComponent
+)

--- a/installer/pkg/components/server/ide/objects.go
+++ b/installer/pkg/components/server/ide/objects.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+// Logically, this package belongs to the server component. However,
+// from an ownership sense, this package belongs to a different team
+// to the server so it's separated out
+
+package ide
+
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
+var Objects = common.CompositeRenderFunc(
+	configmap,
+)

--- a/installer/pkg/components/server/ide/types.go
+++ b/installer/pkg/components/server/ide/types.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package ide
+
+// These types are from TypeScript files
+
+// IDEConfig RawIDEConfig interface from components/server/src/ide-config.ts
+type IDEConfig struct {
+	// Deprecated
+	IDEVersion string `json:"ideVersion"`
+	// Deprecated
+	IDEImageRepo string `json:"ideImageRepo"`
+	// Deprecated
+	IDEImageAliases map[string]string `json:"ideImageAliases"`
+	// Deprecated
+	DesktopIDEImageAliases map[string]string `json:"desktopIdeImageAliases"`
+	SupervisorImage        string            `json:"supervisorImage"`
+	IDEOptions             IDEOptions        `json:"ideOptions"`
+}
+
+// IDEOptions interface from components/gitpod-protocol/src/ide-protocol.ts
+type IDEOptions struct {
+	Options           map[string]IDEOption `json:"options"`
+	DefaultIDE        string               `json:"defaultIde"`
+	DefaultDesktopIDE string               `json:"defaultDesktopIde"`
+}
+
+// IDEOption interface from components/gitpod-protocol/src/ide-protocol.ts
+type IDEOption struct {
+	OrderKey           *string  `json:"orderKey,omitempty"`
+	Title              string   `json:"title"`
+	Type               string   `json:"type"`
+	Logo               string   `json:"logo"`
+	Tooltip            *string  `json:"tooltip,omitempty"`
+	Label              *string  `json:"label,omitempty"`
+	Notes              []string `json:"notes,omitempty"`
+	Hidden             *bool    `json:"hidden,omitempty"`
+	Image              string   `json:"image"`
+	ResolveImageDigest *bool    `json:"resolveImageDigest,omitempty"`
+}

--- a/installer/pkg/components/server/objects.go
+++ b/installer/pkg/components/server/objects.go
@@ -6,12 +6,13 @@ package server
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/server/ide"
 )
 
 var Objects = common.CompositeRenderFunc(
 	configmap,
 	deployment,
-	ideconfigmap,
+	ide.Objects,
 	networkpolicy,
 	role,
 	rolebinding,

--- a/installer/pkg/components/server/types.go
+++ b/installer/pkg/components/server/types.go
@@ -8,41 +8,6 @@ import "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 
 // These types are from TypeScript files
 
-// IDEConfig RawIDEConfig interface from components/server/src/ide-config.ts
-type IDEConfig struct {
-	// Deprecated
-	IDEVersion string `json:"ideVersion"`
-	// Deprecated
-	IDEImageRepo string `json:"ideImageRepo"`
-	// Deprecated
-	IDEImageAliases map[string]string `json:"ideImageAliases"`
-	// Deprecated
-	DesktopIDEImageAliases map[string]string `json:"desktopIdeImageAliases"`
-	SupervisorImage        string            `json:"supervisorImage"`
-	IDEOptions             IDEOptions        `json:"ideOptions"`
-}
-
-// IDEOptions interface from components/gitpod-protocol/src/ide-protocol.ts
-type IDEOptions struct {
-	Options           map[string]IDEOption `json:"options"`
-	DefaultIDE        string               `json:"defaultIde"`
-	DefaultDesktopIDE string               `json:"defaultDesktopIde"`
-}
-
-// IDEOption interface from components/gitpod-protocol/src/ide-protocol.ts
-type IDEOption struct {
-	OrderKey           *string  `json:"orderKey,omitempty"`
-	Title              string   `json:"title"`
-	Type               string   `json:"type"`
-	Logo               string   `json:"logo"`
-	Tooltip            *string  `json:"tooltip,omitempty"`
-	Label              *string  `json:"label,omitempty"`
-	Notes              []string `json:"notes,omitempty"`
-	Hidden             *bool    `json:"hidden,omitempty"`
-	Image              string   `json:"image"`
-	ResolveImageDigest *bool    `json:"resolveImageDigest,omitempty"`
-}
-
 // ConfigSerialized interface from components/server/src/config.ts
 type ConfigSerialized struct {
 	Version                           string   `json:"version"`

--- a/installer/pkg/config/versions/OWNERS
+++ b/installer/pkg/config/versions/OWNERS
@@ -1,0 +1,15 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-ide
+  - engineering-meta
+  - engineering-self-hosted
+  - engineering-workspace
+
+labels:
+  - "team: IDE"
+  - "team: meta"
+  - "team: self-hosted"
+  - "team: workspace"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As the `server` component is currently structured, it doesn't accurately reflect the team ownership. The `server` component is owned by @gitpod-io/engineering-meta and the `ide-configmap` is owned by the @gitpod-io/engineering-ide team.

This separates out the `ide-configmap` into it's own package underneath `server` with the corrected ownership

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7060

## How to test
<!-- Provide steps to test this PR -->
Run a deployment via the Installer as normal. There are no changes to the way the Installer behaves, just code structure changes

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: separate server and IDE components
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
