### PR TITLE
[installer]: correct the starts_with validation on the config

### DIFF
--- a/installer/pkg/config/validation.go
+++ b/installer/pkg/config/validation.go
@@ -46,7 +46,7 @@ func Validate(version ConfigVersion, cfg interface{}) (r *ValidationResult, err 
 					tag := strings.Replace(v.Tag(), "_", " ", -1)
 					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' is %s '%s'", v.Namespace(), tag, v.Param()))
 				case "startswith":
-					fmt.Printf("Field '%s' must start with '%s'", v.Namespace(), v.Param())
+					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' must start with '%s'", v.Namespace(), v.Param()))
 				default:
 					// General error message
 					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' failed %s validation", v.Namespace(), v.Tag()))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The validation was just being printed to terminal, not passed into the validation result. This corrects the mistake

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7205 

## How to test
<!-- Provide steps to test this PR -->
1. Generate a config `installer init > config.yaml`
2. Remove the `/` at the start of `workspace.runtime.containerdRuntimeDir`
3. Run `installer validate config -c config.yaml`

This should now bring the validation error out and exit with non-zero

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: correct the starts_with validation on the config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
