### PR TITLE
[installer]: set the server cookie secret as random string

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -67,6 +67,7 @@ export interface ConfigSerialized {
     session: {
         maxAgeMs: number;
         secret: string;
+        secretFile?: string;
     };
 
     githubApp?: {
@@ -184,6 +185,10 @@ export namespace ConfigFile {
         const licenseFile = config.licenseFile
         if (licenseFile) {
             license = fs.readFileSync(licenseFile, "utf-8")
+        }
+        const sessionSecretFile = config.session.secretFile
+        if (sessionSecretFile) {
+            config.session.secret = fs.readFileSync(sessionSecretFile, "utf-8")
         }
         return {
             ...config,

--- a/installer/pkg/components/server/configmap.go
+++ b/installer/pkg/components/server/configmap.go
@@ -7,6 +7,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
@@ -26,6 +27,17 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		license = licenseFilePath
 	}
 
+	sessionCfg := Session{
+		MaxAgeMs:   int32((time.Hour * 24 * 3).Milliseconds()),
+	}
+
+	componentCfg := getComponentConfig(ctx)
+	if componentCfg != nil && componentCfg.CookieSecret != nil {
+		sessionCfg.SecretFile = fmt.Sprintf("%s/server-session-secret", secretFilePath)
+	} else {
+		sessionCfg.Secret = "Important!Really-Change-This-Key!"
+	}
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -42,10 +54,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			PreviewFeatureFlags: []NamedWorkspaceFeatureFlag{},
 			DefaultFeatureFlags: []NamedWorkspaceFeatureFlag{},
 		},
-		Session: Session{
-			MaxAgeMs: 259200000,
-			Secret:   "Important!Really-Change-This-Key!", // todo(sje): how best to do this?
-		},
+		Session:              sessionCfg,
 		DefinitelyGpDisabled: false,
 		WorkspaceGarbageCollection: WorkspaceGarbageCollection{
 			ChunkLimit:                 1000,
@@ -63,49 +72,66 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Logo:     "/images/gitpod-ddd.svg",
 			Homepage: fmt.Sprintf("https://%s/", ctx.Config.Domain),
 			Links: BrandingLinks{
-				Header: []Link{{
-					Name: "Workspaces",
-					URL:  "/workspaces/",
-				}, {
-					Name: "Docs",
-					URL:  "https://www.gitpod.io/docs/",
-				}, {
-					Name: "Blog",
-					URL:  "https://www.gitpod.io/blog/",
-				}, {
-					Name: "Community",
-					URL:  "https://community.gitpod.io/",
-				}},
-				Footer: []Link{{
-					Name: "Docs",
-					URL:  "https://www.gitpod.io/docs/",
-				}, {
-					Name: "Blog",
-					URL:  "https://www.gitpod.io/blog/",
-				}, {
-					Name: "Status",
-					URL:  "https://status.gitpod.io/",
-				}},
-				Social: []SocialLink{{
-					Type: "GitHub",
-					URL:  "https://github.com/gitpod-io/gitpod",
-				}, {
-					Type: "Discourse",
-					URL:  "https://community.gitpod.io/",
-				}, {
-					Type: "Twitter",
-					URL:  "https://twitter.com/gitpod",
-				}},
-				Legal: []Link{{
-					Name: "Imprint",
-					URL:  "https://www.gitpod.io/imprint/",
-				}, {
-					Name: "Privacy Policy",
-					URL:  "https://www.gitpod.io/privacy/",
-				}, {
-					Name: "Terms of Service",
-					URL:  "https://www.gitpod.io/terms/",
-				}},
+				Header: []Link{
+					{
+						Name: "Workspaces",
+						URL:  "/workspaces/",
+					},
+					{
+						Name: "Docs",
+						URL:  "https://www.gitpod.io/docs/",
+					},
+					{
+						Name: "Blog",
+						URL:  "https://www.gitpod.io/blog/",
+					},
+					{
+						Name: "Community",
+						URL:  "https://community.gitpod.io/",
+					},
+				},
+				Footer: []Link{
+					{
+						Name: "Docs",
+						URL:  "https://www.gitpod.io/docs/",
+					},
+					{
+						Name: "Blog",
+						URL:  "https://www.gitpod.io/blog/",
+					},
+					{
+						Name: "Status",
+						URL:  "https://status.gitpod.io/",
+					},
+				},
+				Social: []SocialLink{
+					{
+						Type: "GitHub",
+						URL:  "https://github.com/gitpod-io/gitpod",
+					},
+					{
+						Type: "Discourse",
+						URL:  "https://community.gitpod.io/",
+					},
+					{
+						Type: "Twitter",
+						URL:  "https://twitter.com/gitpod",
+					},
+				},
+				Legal: []Link{
+					{
+						Name: "Imprint",
+						URL:  "https://www.gitpod.io/imprint/",
+					},
+					{
+						Name: "Privacy Policy",
+						URL:  "https://www.gitpod.io/privacy/",
+					},
+					{
+						Name: "Terms of Service",
+						URL:  "https://www.gitpod.io/terms/",
+					},
+				},
 			},
 		},
 		MaxEnvvarPerUserCount:             4048,

--- a/installer/pkg/components/server/constants.go
+++ b/installer/pkg/components/server/constants.go
@@ -13,6 +13,7 @@ const (
 	ContainerPort      = 3000
 	ContainerPortName  = "http"
 	licenseFilePath    = "/gitpod/license"
+	secretFilePath     = "/gitpod/session"
 	PrometheusPort     = 9500
 	PrometheusPortName = "metrics"
 	ServicePort        = 3000

--- a/installer/pkg/components/server/objects.go
+++ b/installer/pkg/components/server/objects.go
@@ -7,7 +7,16 @@ package server
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/server/ide"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 )
+
+func getComponentConfig(ctx *common.RenderContext) *config.ServerComponent {
+	if ctx.Config.Components != nil && ctx.Config.Components.Server != nil {
+		return ctx.Config.Components.Server
+	}
+
+	return nil
+}
 
 var Objects = common.CompositeRenderFunc(
 	configmap,

--- a/installer/pkg/components/server/types.go
+++ b/installer/pkg/components/server/types.go
@@ -141,8 +141,9 @@ type GitHubApp struct {
 }
 
 type Session struct {
-	MaxAgeMs int32  `json:"maxAgeMs"`
-	Secret   string `json:"secret"`
+	MaxAgeMs   int32  `json:"maxAgeMs"`
+	Secret     string `json:"secret"`
+	SecretFile string `json:"secretFile"`
 }
 
 type WorkspaceHeartbeat struct {

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -79,6 +79,8 @@ type Config struct {
 
 	ImagePullSecrets []ObjectRef `json:"imagePullSecrets"`
 
+	Components *Components `json:"components,omitempty"`
+
 	Workspace Workspace `json:"workspace" validate:"required"`
 
 	AuthProviders []AuthProviderConfigs `json:"authProviders" validate:"dive"`
@@ -220,6 +222,14 @@ type Workspace struct {
 	Runtime   WorkspaceRuntime    `json:"runtime" validate:"required"`
 	Resources Resources           `json:"resources" validate:"required"`
 	Templates *WorkspaceTemplates `json:"templates,omitempty"`
+}
+
+type Components struct {
+	Server *ServerComponent `json:"server,omitempty"`
+}
+
+type ServerComponent struct {
+	CookieSecret *ObjectRef `json:"cookieSecret,omitempty"`
 }
 
 type FSShiftMethod string


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This also includes a couple of tidy ups of the config map code. I've selected option 1 (random secret generated)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7210

## How to test
<!-- Provide steps to test this PR -->
Render as normal

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: set the server cookie secret as random string
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
