### PR TITLE
[werft] Conditional path to uninstall-gitpod.sh

### DIFF
--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -48,7 +48,15 @@ async function wipePreviewEnvironmentInstaller(namespace: string, shellOpts: Exe
     const hasGitpodConfigmap = (exec(`kubectl -n ${namespace} get configmap gitpod-app`, { slice, dontCheckRc: true })).code === 0;
     if (hasGitpodConfigmap) {
         werft.log(slice, `${namespace} has Gitpod configmap, proceeding with removal`);
-        exec(`./.werft/util/uninstall-gitpod.sh ${namespace}`, { slice });
+        const inWerftFolder = exec(`pwd`, { slice, dontCheckRc: true }).stdout.trim().endsWith(".werft");
+        if (inWerftFolder) {
+            // used in .werft/wipe-devstaging.yaml on preview environment clean-up
+            exec(`./util/uninstall-gitpod.sh ${namespace}`, { slice });
+        } else {
+            // used in .werft/build.yaml on 'with-clean-slate-deployment=true'
+            exec(`./.werft/util/uninstall-gitpod.sh ${namespace}`, { slice });
+        }
+
     } else {
         werft.log(slice, `There is no Gitpod configmap, moving on`);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set the path to `uninstall-gitpod.sh` conditionally

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7218

## How to test
<!-- Provide steps to test this PR -->
After a PR is merged back to main, sweeper tries to do clean-up, but it cannot clean-up environments provisioned with the Installer. This is because the werft job for `wipe-devstaging` uses a different presenting working directory than the `build` job.

Both of these jobs should work:
build: `werft run github -f -j ./.werft/build.yaml -a with-clean-slate-deployment=true`
wipe-devstaging: `werft run github -f -j ./.werft/wipe-devstaging.yaml -a namespace=staging-kyleb-fix-wipe-dev`


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
