### PR TITLE
Multiple append combined into a single call

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -165,8 +165,7 @@ func (c *Client) GitWithOutput(ctx context.Context, subcommand string, args ...s
 		if err != nil {
 			return nil, err
 		}
-		env = append(env, fmt.Sprintf("GIT_AUTH_USER=%s", user))
-		env = append(env, fmt.Sprintf("GIT_AUTH_PASSWORD=%s", pwd))
+		env = append(env, fmt.Sprintf("GIT_AUTH_USER=%s", user), fmt.Sprintf("GIT_AUTH_PASSWORD=%s", pwd))
 	}
 
 	fullArgs = append(fullArgs, subcommand)
@@ -267,8 +266,7 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 	args := []string{"--depth=1", "--no-single-branch", c.RemoteURI}
 
 	for key, value := range c.Config {
-		args = append(args, "--config")
-		args = append(args, strings.TrimSpace(key)+"="+strings.TrimSpace(value))
+		args = append(args, "--config", strings.TrimSpace(key)+"="+strings.TrimSpace(value))
 	}
 
 	args = append(args, ".")

--- a/components/ee/agent-smith/cmd/testbed/main.go
+++ b/components/ee/agent-smith/cmd/testbed/main.go
@@ -60,10 +60,7 @@ func run(args []string) error {
 				env[i] += e + ":" + cwd
 			}
 		}
-		env = append(env, "GITPOD_OWNER_ID=owner-id")
-		env = append(env, "GITPOD_WORKSPACE_ID=workspace-id")
-		env = append(env, "GITPOD_INSTANCE_ID=instance-id")
-		env = append(env, "GITPOD_WORKSPACE_CONTEXT_URL=https://github.com/gitpod-io/gitpod")
+		env = append(env, "GITPOD_OWNER_ID=owner-id", "GITPOD_WORKSPACE_ID=workspace-id", "GITPOD_INSTANCE_ID=instance-id", "GITPOD_WORKSPACE_CONTEXT_URL=https://github.com/gitpod-io/gitpod")
 
 		cmd := exec.Command("/proc/self/exe", "ring1")
 		cmd.Stdout = os.Stdout

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -769,8 +769,7 @@ func (gp *APIoverJSONRPC) StartWorkspace(ctx context.Context, id string, options
 	}
 	var _params []interface{}
 
-	_params = append(_params, id)
-	_params = append(_params, options)
+	_params = append(_params, id, options)
 
 	var result StartWorkspaceResult
 	err = gp.C.Call(ctx, "startWorkspace", _params, &result)
@@ -826,8 +825,7 @@ func (gp *APIoverJSONRPC) SetWorkspaceDescription(ctx context.Context, id string
 	}
 	var _params []interface{}
 
-	_params = append(_params, id)
-	_params = append(_params, desc)
+	_params = append(_params, id, desc)
 
 	err = gp.C.Call(ctx, "setWorkspaceDescription", _params, nil)
 	if err != nil {
@@ -845,8 +843,7 @@ func (gp *APIoverJSONRPC) ControlAdmission(ctx context.Context, id string, level
 	}
 	var _params []interface{}
 
-	_params = append(_params, id)
-	_params = append(_params, level)
+	_params = append(_params, id, level)
 
 	err = gp.C.Call(ctx, "controlAdmission", _params, nil)
 	if err != nil {
@@ -902,8 +899,7 @@ func (gp *APIoverJSONRPC) SetWorkspaceTimeout(ctx context.Context, workspaceID s
 	}
 	var _params []interface{}
 
-	_params = append(_params, workspaceID)
-	_params = append(_params, duration)
+	_params = append(_params, workspaceID, duration)
 
 	var result SetWorkspaceTimeoutResult
 	err = gp.C.Call(ctx, "setWorkspaceTimeout", _params, &result)
@@ -961,8 +957,7 @@ func (gp *APIoverJSONRPC) UpdateWorkspaceUserPin(ctx context.Context, id string,
 	}
 	var _params []interface{}
 
-	_params = append(_params, id)
-	_params = append(_params, action)
+	_params = append(_params, id, action)
 
 	err = gp.C.Call(ctx, "updateWorkspaceUserPin", _params, nil)
 	if err != nil {
@@ -1000,8 +995,7 @@ func (gp *APIoverJSONRPC) OpenPort(ctx context.Context, workspaceID string, port
 	}
 	var _params []interface{}
 
-	_params = append(_params, workspaceID)
-	_params = append(_params, port)
+	_params = append(_params, workspaceID, port)
 
 	var result WorkspaceInstancePort
 	err = gp.C.Call(ctx, "openPort", _params, &result)
@@ -1021,8 +1015,7 @@ func (gp *APIoverJSONRPC) ClosePort(ctx context.Context, workspaceID string, por
 	}
 	var _params []interface{}
 
-	_params = append(_params, workspaceID)
-	_params = append(_params, port)
+	_params = append(_params, workspaceID, port)
 
 	err = gp.C.Call(ctx, "closePort", _params, nil)
 	if err != nil {
@@ -1321,8 +1314,7 @@ func (gp *APIoverJSONRPC) StoreLayout(ctx context.Context, workspaceID string, l
 	}
 	var _params []interface{}
 
-	_params = append(_params, workspaceID)
-	_params = append(_params, layoutData)
+	_params = append(_params, workspaceID, layoutData)
 
 	err = gp.C.Call(ctx, "storeLayout", _params, nil)
 	if err != nil {
@@ -1380,8 +1372,7 @@ func (gp *APIoverJSONRPC) ResolvePlugins(ctx context.Context, workspaceID string
 	}
 	var _params []interface{}
 
-	_params = append(_params, workspaceID)
-	_params = append(_params, params)
+	_params = append(_params, workspaceID, params)
 
 	var result ResolvedPlugins
 	err = gp.C.Call(ctx, "resolvePlugins", _params, &result)

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -652,9 +652,7 @@ func prepareIDELaunch(cfg *Config, ideConfig *IDEConfig) *exec.Cmd {
 
 	// Add default args for IDE (not desktop IDE) to be backwards compatible
 	if ideConfig.Entrypoint == "/ide/startup.sh" && len(args) == 0 {
-		args = append(args, "{WORKSPACEROOT}")
-		args = append(args, "--port", "{IDEPORT}")
-		args = append(args, "--hostname", "{IDEHOSTNAME}")
+		args = append(args, "{WORKSPACEROOT}", "--port", "{IDEPORT}", "--hostname", "{IDEHOSTNAME}")
 	}
 
 	for i := range args {

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -187,8 +187,7 @@ func (d *Daemon) startReadinessSignal() {
 // cannot be started again.
 func (d *Daemon) Stop() error {
 	var errs []error
-	errs = append(errs, d.dispatch.Close())
-	errs = append(errs, d.content.Close())
+	errs = append(errs, d.dispatch.Close(), d.content.Close())
 	if d.hosts != nil {
 		errs = append(errs, d.hosts.Close())
 	}


### PR DESCRIPTION
## Description

Here little modifications to _simplify_ some `append` call. I have intentionally avoided certain file like [`components/ws-manager/pkg/manager/create.go`](https://github.com/gitpod-io/gitpod/blob/bdb1fb52d4c3d188b52276b0d71a3d946410ab0a/components/ws-manager/pkg/manager/create.go#L580) because I understand that it's for a need of readability. Even if by respecting the good practice until the end, it would be interesting to modify this file too.

_The append built-in function appends elements to the end of a slice. If it has sufficient capacity, the destination is resliced to accommodate the new elements, but if capacity is not enough, then append will allocate a new underlying array and return the updated slice._ 

- A single `append` call allocates memory once to accommodate all the elements to be appended 
- Multiple `append` calls introduce a lot of overhead

More infos [here](https://go.dev/blog/slices#TOC_9) & [here](https://pkg.go.dev/builtin#append)

Thank you

## Release Notes
```
NONE
```