### PR TITLE
[ide] add user-agent header to ws connection to server

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -218,6 +218,7 @@ type ConnectToServerOpts struct {
 	Log                 *logrus.Entry
 	ReconnectionHandler func()
 	CloseHandler        func(error)
+	ExtraHeaders        map[string]string
 }
 
 // ConnectToServer establishes a new websocket connection to the server
@@ -241,6 +242,9 @@ func ConnectToServer(endpoint string, opts ConnectToServerOpts) (*APIoverJSONRPC
 
 	reqHeader := http.Header{}
 	reqHeader.Set("Origin", origin)
+	for k, v := range opts.ExtraHeaders {
+		reqHeader.Set(k, v)
+	}
 	if opts.Token != "" {
 		reqHeader.Set("Authorization", "Bearer "+opts.Token)
 	}

--- a/components/local-app/main.go
+++ b/components/local-app/main.go
@@ -261,6 +261,10 @@ func tryConnectToServer(gitpodUrl string, tkn string, reconnectionHandler func()
 		Log:                 logrus.NewEntry(logrus.StandardLogger()),
 		ReconnectionHandler: reconnectionHandler,
 		CloseHandler:        closeHandler,
+		ExtraHeaders: map[string]string{
+			"User-Agent":       "gitpod/local-companion",
+			"X-Client-Version": Version,
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -30,7 +30,7 @@ const EVENT_CLIENT_CONTEXT_CREATED = "EVENT_CLIENT_CONTEXT_CREATED";
 const EVENT_CLIENT_CONTEXT_CLOSED = "EVENT_CLIENT_CONTEXT_CLOSED";
 
 /** TODO(gpl) Refine this list */
-export type WebsocketClientType = "browser" | "go-client" | "vs-code";
+export type WebsocketClientType = "browser" | "go-client" | "vs-code" | "supervisor" | "local-companion";
 namespace WebsocketClientType {
     export function getClientType(req: express.Request): WebsocketClientType | undefined {
         const userAgent = req.headers["user-agent"];
@@ -47,7 +47,13 @@ namespace WebsocketClientType {
         if (userAgent.startsWith("VS Code")) {
             return "vs-code";
         }
-        log.debug("API client without 'User-Agent'", { headers: req.headers });
+        if (userAgent.startsWith("gitpod/supervisor")) {
+            return "supervisor";
+        }
+        if (userAgent.startsWith("gitpod/local-companion")) {
+            return "local-companion";
+        }
+        log.debug("API client with unknown 'User-Agent'", userAgent);
         return undefined;
     }
 }

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -19,6 +19,7 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, true, false)
 		common_grpc.SetupLogging()
+		supervisor.Version = Version
 		supervisor.Run()
 	},
 }

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -64,6 +64,7 @@ const (
 var (
 	additionalServices []RegisterableService
 	apiEndpointOpts    []grpc.ServerOption
+	Version            = ""
 )
 
 // RegisterAdditionalService registers additional services for the API endpoint
@@ -382,6 +383,11 @@ func createGitpodService(cfg *Config, tknsrv api.TokenServiceServer) *gitpod.API
 	gitpodService, err := gitpod.ConnectToServer(endpoint, gitpod.ConnectToServerOpts{
 		Token: tknres.Token,
 		Log:   log.Log,
+		ExtraHeaders: map[string]string{
+			"User-Agent":              "gitpod/supervisor",
+			"X-Workspace-Instance-Id": cfg.WorkspaceInstanceID,
+			"X-Client-Version":        Version,
+		},
 	})
 	if err != nil {
 		log.WithError(err).Error("cannot connect to Gitpod API")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ide] add user-agent header to ws connection to server

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7166

## How to test
<!-- Provide steps to test this PR -->
I add a debug commit (will revert after test)
1. Open a workspace
2. see server log (you can find it by `new connection for supervisor `) and check `full headers` in log
3. open workspace with local vscode
4. see server log (you can find it by `new connection for local-companion`)  and check `full headers` in log

```
{"component":"server",..."message":"new connection for supervisor full headers: {...\"x-workspace-instance-id\":\"5709005b-e617-4ab5..."}
...
{"component":"server",..."message":"new connection for local-companion full headers: {...\"x-client-version\":\"pd-ide-add-header-7166.4\....}"}

```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft with-localapp-version=special-test