### PR TITLE
[supervisor] Add desktop IDE port to supervisor internal ports

### DIFF
--- a/components/ide/code-desktop/startup.sh
+++ b/components/ide/code-desktop/startup.sh
@@ -8,6 +8,6 @@ set -euo pipefail
 # kill background jobs when the script exits
 trap "jobs -p | xargs -r kill" SIGINT SIGTERM EXIT
 
-/ide-desktop/status 24000 "$1" "$2"
+/ide-desktop/status "$1" "$2" "$3"
 
 echo "Desktop IDE startup script exited"

--- a/components/ide/code-desktop/supervisor-ide-config_insiders.json
+++ b/components/ide/code-desktop/supervisor-ide-config_insiders.json
@@ -1,10 +1,9 @@
 {
     "entrypoint": "/ide-desktop/startup.sh",
-    "entrypointArgs": [ "Open in VS Code Insiders on Desktop", "vscode-insiders" ],
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in VS Code Insiders on Desktop", "vscode-insiders" ],
     "readinessProbe": {
         "type": "http",
         "http": {
-            "port": 24000,
             "path": "/status"
         }
       }

--- a/components/ide/code-desktop/supervisor-ide-config_stable.json
+++ b/components/ide/code-desktop/supervisor-ide-config_stable.json
@@ -1,10 +1,9 @@
 {
     "entrypoint": "/ide-desktop/startup.sh",
-    "entrypointArgs": [ "Open in VS Code on Desktop", "vscode" ],
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in VS Code on Desktop", "vscode" ],
     "readinessProbe": {
         "type": "http",
         "http": {
-            "port": 24000,
             "path": "/status"
         }
       }

--- a/components/ide/jetbrains/image/startup.sh
+++ b/components/ide/jetbrains/image/startup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # kill background jobs when the script exits
 trap "jobs -p | xargs -r kill" SIGINT SIGTERM EXIT
 
-/ide-desktop/status 24000 "$1" &
+/ide-desktop/status "$1" "$2" &
 
 echo "Desktop IDE: Waiting for the content initializer ..."
 until curl -sS "$SUPERVISOR_ADDR"/_supervisor/v1/status/content/wait/true | grep '"available":true' > /dev/null; do

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland.json
@@ -1,10 +1,9 @@
 {
     "entrypoint": "/ide-desktop/startup.sh",
-    "entrypointArgs": [ "Open in GoLand" ],
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in GoLand" ],
     "readinessProbe": {
         "type": "http",
         "http": {
-            "port": 24000,
             "path": "/status"
         }
       }

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
@@ -1,10 +1,9 @@
 {
     "entrypoint": "/ide-desktop/startup.sh",
-    "entrypointArgs": [ "Open in IntelliJ IDEA" ],
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in IntelliJ IDEA" ],
     "readinessProbe": {
         "type": "http",
         "http": {
-            "port": 24000,
             "path": "/status"
         }
       }

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
@@ -1,10 +1,9 @@
 {
     "entrypoint": "/ide-desktop/startup.sh",
-    "entrypointArgs": [ "Open in PhpStorm" ],
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in PhpStorm" ],
     "readinessProbe": {
         "type": "http",
         "http": {
-            "port": 24000,
             "path": "/status"
         }
       }

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
@@ -1,10 +1,9 @@
 {
     "entrypoint": "/ide-desktop/startup.sh",
-    "entrypointArgs": [ "Open in PyCharm" ],
+    "entrypointArgs": [ "{DESKTOPIDEPORT}", "Open in PyCharm" ],
     "readinessProbe": {
         "type": "http",
         "http": {
-            "port": 24000,
             "path": "/status"
         }
       }

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -190,6 +190,13 @@ func Run(options ...RunOption) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	internalPorts := []uint32{uint32(cfg.IDEPort), uint32(cfg.APIEndpointPort), uint32(cfg.SSHPort)}
+	desktopIDEPort := uint32(24000)
+	if cfg.DesktopIDE != nil {
+		internalPorts = append(internalPorts, desktopIDEPort)
+	}
+
 	var (
 		shutdown                           = make(chan ShutdownReason, 1)
 		ideReady                           = &ideReadyState{cond: sync.NewCond(&sync.Mutex{})}
@@ -205,9 +212,7 @@ func Run(options ...RunOption) {
 			ports.NewConfigService(cfg.WorkspaceID, gitpodConfigService, gitpodService),
 			tunneledPortsService,
 			slirp,
-			uint32(cfg.IDEPort),
-			uint32(cfg.APIEndpointPort),
-			uint32(cfg.SSHPort),
+			internalPorts...,
 		)
 		termMux             = terminal.NewMux()
 		termMuxSrv          = terminal.NewMuxTerminalService(termMux)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. Add desktop IDE port to supervisor internal ports
2. Pass desktopIDEPort  to desktop IDEs
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6928

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace, check everything like before
2. Select a DesktopIDE, and open another workspace
3. Check port view, it should not contain 24000 and check everything like before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
