### PR TITLE
Add domain to previewEnvironment config

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -47,6 +47,7 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
             honeycombDataset: 'preview-environments',
         },
         previewEnvironment: {
+            domain: '${params.previewDomain}',
             nodeExporterPort: ${params.nodeExporterPort},
             prometheusDNS: 'prometheus-${params.previewDomain}',
             grafanaDNS: 'grafana-${params.previewDomain}',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This passes the preview domain to the monitoring-satellite configuration so that we can use it to attach it to all spans that go through the OpenTelemetry Collector. See this https://github.com/gitpod-io/observability/pull/47 for the changes to monitoring-satellite.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes gitpod-io/ops/issues/401

## How to test

From a gitpod-io/gitpod workspace deploy the observability stack using this branch:

```
werft run github -f \
  -a with-observability="" \
  -a with-helm="" \
  -a withObservabilityBranch="mads/add-preview-environment" \
  -a with-clean-slate-deployment=""
```

Here's a [query](https://ui.honeycomb.io/gitpod/datasets/preview-environments/result/8kMJQ8FRaah) showing the preview environment being set (for my preview environment)

<img width="1094" alt="Screenshot 2021-12-14 at 15 09 22" src="https://user-images.githubusercontent.com/83561/146014173-691d11b4-20bf-4dc7-87d8-71ea4e0c1576.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A