### PR TITLE
Add GitHubApp to installer config and create mounts

### DIFF
--- a/installer/pkg/components/server/configmap.go
+++ b/installer/pkg/components/server/configmap.go
@@ -140,6 +140,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		EnablePayment:                false,
 		InsecureNoDomain:             false,
 		ChargebeeProviderOptionsFile: "/chargebee/providerOptions",
+		GitHubApp: GitHubApp{
+			Enabled:         ctx.Config.GitHubApp.Enabled,
+			AppId:           ctx.Config.GitHubApp.AppId,
+			BaseUrl:         ctx.Config.GitHubApp.BaseUrl,
+			WebhookSecret:   ctx.Config.GitHubApp.WebhookSecret,
+			AuthProviderId:  ctx.Config.GitHubApp.AuthProviderId,
+			CertPath:        "/githubapp/githubapp-private-key.pem",
+			MarketplaceName: ctx.Config.GitHubApp.MarketplaceName,
+			LogLevel:        string(ctx.Config.GitHubApp.LogLevel),
+		},
 	}
 
 	fc, err := json.MarshalIndent(scfg, "", " ")

--- a/installer/pkg/components/server/deployment.go
+++ b/installer/pkg/components/server/deployment.go
@@ -57,6 +57,22 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		})
 	}
 
+	if ctx.Config.GitHubApp.Enabled {
+		volumes = append(volumes, corev1.Volume{
+			Name: "githubapp-private-key",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: ctx.Config.GitHubApp.PrivateKey.Name,
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "githubapp-private-key",
+			MountPath: "/githubapp",
+			ReadOnly:  true,
+		})
+	}
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -55,6 +55,11 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
 
+	cfg.GitHubApp = GitHubApp{
+		Enabled:  false,
+		LogLevel: LogLevelInfo,
+	}
+
 	return nil
 }
 
@@ -84,6 +89,8 @@ type Config struct {
 	AuthProviders []AuthProviderConfigs `json:"authProviders" validate:"dive"`
 	BlockNewUsers BlockNewUsers         `json:"blockNewUsers"`
 	License       *ObjectRef            `json:"license,omitempty"`
+
+	GitHubApp GitHubApp `json:"gitHubApp"`
 }
 
 type Metadata struct {
@@ -263,4 +270,15 @@ type OAuth struct {
 	AuthorizationParams map[string]string `json:"authorizationParams"`
 	ConfigURL           string            `json:"configURL"`
 	ConfigFn            string            `json:"configFn"`
+}
+
+type GitHubApp struct {
+	Enabled         bool       `json:"enabled"`
+	AppId           int32      `json:"appId"`
+	BaseUrl         string     `json:"baseUrl"`
+	WebhookSecret   string     `json:"webhookSecret"`
+	AuthProviderId  string     `json:"authProviderId"`
+	PrivateKey      *ObjectRef `json:"privateKey"`
+	MarketplaceName string     `json:"marketplaceName"`
+	LogLevel        LogLevel   `json:"logLevel"`
 }


### PR DESCRIPTION
## Description
This adds a new struct for configuring the GitHubApp in the installer
config. It uses the ObjectRef to allow a user to configure a secret
containing the GitHubApp's private key. The server deployment mounts
this as a volume.

## Related Issue(s)
WIP: #7145

## How to test
This requires a Github App:
1. Create an app at: https://github.com/settings/apps/new
2. As for permissions, I guessed these by looking at the current gitpod app on github:
- Metadata: read-only
- Pull requests:  read & write
- Commit statuses: read & write
Events:
- Meta
- Pull request
- Push
- Repository
Then continue filling out webhook secret and creating a private key

It also requires the creating of a Kubernetes secret with the private key content. Here's a helper sh script:
```bash
#!/bin/env bash

PRIVATE_KEY=$(base64 --wrap=0 < $1)

cat << EOF > githubapp-private-key.yaml
apiVersion: v1
kind: Secret
metadata:
  name: githubapp-private-key
  labels:
    app: gitpod
data:
  githubapp-private-key.pem: $PRIVATE_KEY
EOF
```

You can run this script as: `./generate.sh <github_app_private_key.pem>`

Run the installer, with new config:
```yaml
gitHubApp:
  enabled: true
  appId: 
  baseUrl: ""
  webhookSecret:
  authProviderId: 1
  privateKey:
    kind: secret
    name: githubapp-private-key
  marketplaceName: 
  logLevel: info
```
Not sure where the `authProviderId` and `marketplaceName` are used for though.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
