### PR TITLE
community: route users to Discord for support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ labels: "bug"
 body:
 - type: markdown
   attributes:
-    value: Before raising an issue, please search for existing issues to avoid creating duplicates. For questions and support please use the [community forum](https://community.gitpod.io/).
+    value: Before raising an issue, please search for existing issues to avoid creating duplicates. For questions and support please use [Discord](https://www.gitpod.io/chat).
 - type: textarea
   id: bug-description
   attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Community
-    url: https://community.gitpod.io
+    url: https://www.gitpod.io/chat
     about: Please ask and answer usage questions here.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For example, see [Introduction](https://www.gitpod.io/docs) and [Getting Started
 
 ## Questions
 
-For questions and support please use the [community forum](http://community.gitpod.io) or the [community discord server](https://www.gitpod.io/chat).
+For questions and support please use [Discord](https://www.gitpod.io/chat).
 Join the conversation, and connect with other community members. 💬
 
 You can also follow [`@gitpod`](https://twitter.com/gitpod) for announcements and updates from our team.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Route users to Discord for questions and support

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7240 

[Related conversation](https://gitpod.slack.com/archives/C01KPEPLLRY/p1639519263122900)

## How to test
<!-- Provide steps to test this PR -->
Github links mentioned in the issue (bug report, issue template, and readme) route to Discord. We won't be able to test until we merge, I believe.

Also, @gitpod-io/engineering-meta there are a couple social links [[1](https://github.com/gitpod-io/gitpod/pull/7241/files#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4R123-R124)] [[2](https://github.com/gitpod-io/gitpod/pull/7241/files#diff-001cc9444a98994948112e6868bc448d73251cc4595f816f43c0a36b36f616efR93-R94)], which I updated from Discourse to Discord. I couldn't find where they're being used, and am unsure how to test. I am unsure how to test the social type link for the configmap used by server...can you help :question: :pray: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Route users to Discord for support
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
