### PR TITLE
[dashboard] Add analytics on IDE configurations

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -30,6 +30,14 @@ export default function Preferences() {
         const settings = additionalData.ideSettings || {};
         settings.defaultIde = value;
         additionalData.ideSettings = settings;
+        getGitpodService().server.trackEvent({
+            event: "ide_configuration_changed",
+            properties: {
+                useDesktopIde,
+                defaultIde: value,
+                defaultDesktopIde: useDesktopIde ? defaultDesktopIde : undefined
+            },
+        });
         await getGitpodService().server.updateLoggedInUser({ additionalData });
         setDefaultIde(value);
     }
@@ -40,6 +48,14 @@ export default function Preferences() {
         const settings = additionalData.ideSettings || {};
         settings.defaultDesktopIde = value;
         additionalData.ideSettings = settings;
+        getGitpodService().server.trackEvent({
+            event: "ide_configuration_changed",
+            properties: {
+                useDesktopIde,
+                defaultIde,
+                defaultDesktopIde: value
+            },
+        });
         await getGitpodService().server.updateLoggedInUser({ additionalData });
         setDefaultDesktopIde(value);
     }
@@ -52,6 +68,14 @@ export default function Preferences() {
         // Make sure that default desktop IDE is set even when the user did not explicitly select one.
         settings.defaultDesktopIde = defaultDesktopIde;
         additionalData.ideSettings = settings;
+        getGitpodService().server.trackEvent({
+            event: "ide_configuration_changed",
+            properties: {
+                useDesktopIde: value,
+                defaultIde,
+                defaultDesktopIde: value ? defaultDesktopIde : undefined
+            },
+        });
         await getGitpodService().server.updateLoggedInUser({ additionalData });
         setUseDesktopIde(value);
     }
@@ -129,7 +153,7 @@ export default function Preferences() {
                             </ul></InfoBox>
                         }
                         <p className="text-left w-full text-gray-500">
-                            The <strong>JetBrains desktop IDEs</strong> are currently in beta. <a href="https://github.com/gitpod-io/gitpod/issues/6576" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a> · <a href="https://www.gitpod.io/docs/integrations/jetbrains" target="_blank" rel="noopener" className="gp-link">Documentation</a>
+                            The <strong>JetBrains desktop IDEs</strong> are currently in beta. <a href="https://github.com/gitpod-io/gitpod/issues/6576" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a> · <a href="https://www.gitpod.io/docs/integrations/jetbrains" target="_blank" rel="noopener noreferrer" className="gp-link">Documentation</a>
                         </p>
                     </>}
                 </>}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add `ide_configuration_changed` event on user change IDE configuration

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6321

## How to test
<!-- Provide steps to test this PR -->
1. Open Preference in preview env https://pd-add-desk-ide-ana-6321.staging.gitpod-dev.com/preferences
2. change ide setting
3. you can see trackEvent in network

![image](https://user-images.githubusercontent.com/8299500/146143311-c6c76934-10ab-41cd-9a23-1583c90bf7ec.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
