### PR TITLE
[server] tracing: fix creation of "FOLLOWS_FROM" reference

### DIFF
--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -22,13 +22,14 @@ export type TraceContextWithSpan = TraceContext & {
 
 
 export namespace TraceContext {
-    export function startSpan(operation: string, parentCtx?: TraceContext, ...referencedSpans: (opentracing.Span | opentracing.SpanContext | undefined)[]): opentracing.Span {
+    export function startSpan(operation: string, parentCtx?: TraceContext, ...referencedSpans: (opentracing.Span | undefined)[]): opentracing.Span {
         const options: opentracing.SpanOptions = {};
         if (parentCtx) {
             options.childOf = parentCtx.span;
         }
         if (referencedSpans) {
-            options.references = referencedSpans.filter(s => s !== undefined).map(s => followsFrom(s!));
+            // note: allthough followsForm's type says it takes 'opentracing.Span | opentracing.SpanContext', it only works with SpanContext (typing mismatch)
+            options.references = referencedSpans.filter(s => s !== undefined).map(s => followsFrom(s!.context()));
         }
 
         return opentracing.globalTracer().startSpan(operation, options);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- wait for the [build](https://werft.gitpod-dev.com/job/gitpod-build-gpl-fix-server-tracing.12)
- go to https://gpl-fix-server-tracing.staging.gitpod-dev.com/projects and see that:
  - there is no error in console
  - you can successfully login

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
