### PR TITLE
Start VM in Harvester

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -33,6 +33,9 @@ pod:
     hostPath:
       path: /mnt/disks/ssd0/go-build-cache
       type: DirectoryOrCreate
+  - name: harvester-kubeconfig
+    secret:
+      secretName: harvester-kubeconfig
   # - name: deploy-key
   #   secret:
   #     secretName: deploy-key
@@ -77,6 +80,8 @@ pod:
     - name: go-build-cache
       mountPath: /go-build-cache
       readOnly: false
+    - name: harvester-kubeconfig
+      mountPath: /mnt/secrets/harvester-kubeconfig
     # - name: deploy-key
     #   mountPath: /mnt/secrets/deploy-key
     #   readOnly: true

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -50,10 +50,6 @@ spec:
           sockets: 1
           threads: 1
         devices:
-          inputs:
-            - bus: usb
-              name: tablet
-              type: tablet
           interfaces:
             - masquerade: {}
               model: virtio

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -1,0 +1,149 @@
+type NamespaceManifestOptions = {
+  namespace: string
+}
+
+export function NamespaceManifest({ namespace }: NamespaceManifestOptions) {
+  return `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+`
+}
+
+type VirtualMachineManifestArguments = {
+  vmName: string
+  namespace: string
+  claimName: string,
+  userDataSecretName: string
+}
+
+export function VirtualMachineManifest({ vmName, namespace, claimName, userDataSecretName }: VirtualMachineManifestArguments) {
+  return `
+apiVersion: kubevirt.io/v1
+type: kubevirt.io.virtualmachine
+kind: VirtualMachine
+metadata:
+  namespace: ${namespace}
+  annotations:
+    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"${claimName}","annotations":{"harvesterhci.io/imageId":"default/image-cjlm2"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"longhorn-image-cjlm2"}}]'
+    network.harvesterhci.io/ips: "[]"
+  labels:
+    harvesterhci.io/creator: harvester
+    harvesterhci.io/os: ubuntu
+  name: ${vmName}
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        harvesterhci.io/sshNames: "[]"
+      labels:
+        harvesterhci.io/vmName: ${vmName}
+    spec:
+      domain:
+        hostname: ${vmName}
+        machine:
+          type: q35
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
+        devices:
+          inputs:
+            - bus: usb
+              name: tablet
+              type: tablet
+          interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+          disks:
+            - name: system
+              bootOrder: 1
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+        resources:
+          limits:
+            memory: 2Gi
+            cpu: 1
+      evictionStrategy: LiveMigrate
+      networks:
+        - pod: {}
+          name: default
+      volumes:
+        - name: system
+          persistentVolumeClaim:
+            claimName: ${claimName}
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            networkDataSecretRef:
+              name: ${userDataSecretName}
+            secretRef:
+              name: ${userDataSecretName}
+`
+}
+
+type ServiceManifestOptions = {
+  vmName: string
+  namespace: string
+}
+
+export function ServiceManifest({ vmName, namespace }: ServiceManifestOptions) {
+  return `
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy
+  namespace: ${namespace}
+spec:
+  ports:
+    - name: ssh
+      protocol: TCP
+      port: 22
+      targetPort: 22
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+    - name: kube-api
+      protocol: TCP
+      port: 6443
+      targetPort: 6443
+  selector:
+    harvesterhci.io/vmName: ${vmName}
+  type: ClusterIP
+`
+}
+
+type UserDataSecretManifestOptions = {
+  namespace: string,
+  secretName: string
+}
+
+export function UserDataSecretManifest({ namespace, secretName }: UserDataSecretManifestOptions) {
+  const userdata = Buffer.from(`#cloud-config
+users:
+  - name: ubuntu
+    lock_passwd: false
+    sudo: "ALL=(ALL) NOPASSWD: ALL"
+    passwd: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"`).toString("base64")
+  return `
+apiVersion: v1
+type: secret
+kind: Secret
+data:
+  networkdata: ""
+  userdata: ${userdata}
+metadata:
+  name: ${secretName}
+  namespace: ${namespace}
+`
+}

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -1,0 +1,91 @@
+import { exec } from '../util/shell';
+
+import * as Manifests from './manifests'
+
+const KUBECONFIG_PATH = '/mnt/secrets/harvester-kubeconfig/harvester-kubeconfig.yml'
+
+/**
+ * Convenience function to kubectl apply a manifest from stdin.
+ */
+function kubectlApplyManifest(manifest: string, options?: { validate?: boolean }) {
+    exec(`
+        cat <<EOF | kubectl --kubeconfig ${KUBECONFIG_PATH} apply --validate=${!!options?.validate} -f -
+${manifest}
+EOF
+    `)
+}
+
+/**
+ * Start a VM
+ * Does not wait for the VM to be ready.
+ */
+export function startVM(options: { name: string }) {
+    const namespace = `preview-${options.name}`
+    const userDataSecretName = `userdata-${options.name}`
+
+    kubectlApplyManifest(
+        Manifests.NamespaceManifest({
+            namespace
+        })
+    )
+
+    kubectlApplyManifest(
+        Manifests.UserDataSecretManifest({
+            namespace,
+            secretName: userDataSecretName,
+        })
+    )
+
+    kubectlApplyManifest(
+        Manifests.VirtualMachineManifest({
+            namespace,
+            vmName: options.name,
+            claimName: `${options.name}-${Date.now()}`,
+            userDataSecretName
+        }),
+        { validate: false }
+    )
+
+    kubectlApplyManifest(
+        Manifests.ServiceManifest({
+            vmName: options.name,
+            namespace
+        })
+    )
+}
+
+/**
+ * Check if a VM with the given name already exists.
+ * @returns true if the VM already exists
+ */
+export function vmExists(options: { name: string }) {
+    const namespace = `preview-${options.name}`
+    const status = exec(`kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name}`, { dontCheckRc: true, silent: true })
+    return status.code == 0
+}
+
+/**
+ * Wait until the VM Instance reaches the Running status.
+ * If the VM Instance doesn't reach Running before the timeoutMS it will throw an Error.
+ */
+export function waitForVM(options: { name: string, timeoutMS: number }) {
+    const namespace = `preview-${options.name}`
+    const startTime = Date.now()
+    while (true) {
+
+        const status = exec(`kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name} -o jsonpath="{.status.phase}"`, { silent: true }).stdout.trim()
+
+        if (status == "Running") {
+            return
+        }
+
+        const elapsedTimeMs = Date.now() - startTime
+        if (elapsedTimeMs > options.timeoutMS) {
+            throw new Error("VM didn reach Running status before the timeout")
+        }
+
+        console.log(`VM is not yet running. Current status is ${status}. Sleeping 5 seconds`)
+        exec('sleep 5', { silent: true })
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is the initial step towards providing dedicated VMs for preview environments.

This introduces a new option with-vm for the build Werft job which will start a new VM in our Harvester cluster. This is a tiny step towards providing dedicated k3s clusters for preview environments.

For now it only boots a plain Ubuntu VM, so this is not useable by devs yet as it does not have Kubernetes running inside of it, but it gives us something to iterate on.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/harvester/issues/7

## How to test
<!-- Provide steps to test this PR -->

Run your job with `with-vm`, e.g

```sh
werft run github -f -a with-vm=true
```

Then in Harvester you should see the VM [here](https://harvester.gitpod-dev.com/dashboard/c/local/harvester/kubevirt.io.virtualmachine).

From Harvester you can get a Serial Console. You can use that to install NGINX

```sh
sudo apt-get install nginx
```

And then you should be able to reach it at `http://mads-communicate-with-harvester.preview.gitpod-dev.com/` where `mads-communicate-with-harvester` is the name of the branch.

The routing is configured in this [PR](https://github.com/gitpod-io/harvester/pull/8).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

/werft with-vm