### PR TITLE
[dashboard] Fix PageWithSubMenu selection state by URL-encoding all links

### DIFF
--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -27,7 +27,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                 <ul className="flex flex-col text tracking-wide text-gray-500 pt-4 lg:pt-0 w-48 space-y-2">
                     {p.subMenu.map(e => {
                         let classes = "flex block py-2 px-4 rounded-md";
-                        if (e.link.some(l => l.toLocaleLowerCase() === location.pathname)) {
+                        if (e.link.some(l => l === location.pathname)) {
                             classes += " bg-gray-800 text-gray-50";
                         } else {
                             classes += " hover:bg-gray-100 dark:hover:bg-gray-800";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes PageWithSubMenu selection state when sub-menu links contain special characters (e.g. a space).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7231

## How to test
<!-- Provide steps to test this PR -->

1. Log in to the preview
2. Add a repository with a space in its name as a new Project (e.g. `Gitpod Test`)
3. Open this PR in Gitpod and run this:

```
$ kubectl port-forward mysql-0 3306 &
$ mysql -h 127.0.0.1 -pjBzVMe2w4Yi7GagadsyB gitpod
mysql> update d_b_project set slug = NULL;
```

4. Refresh the preview tab
5. Visit the Project Settings for your Project added in 2.

Expected: The current Project Settings subsection should have a different background in the left menu (without needing to hover):

<table><tr><td>
<img width="236" alt="Screenshot 2021-12-16 at 10 20 20" src="https://user-images.githubusercontent.com/599268/146343737-d5645e27-e3ac-49f5-a554-3c9b0a887a0d.png">
</td><td>
<img width="216" alt="Screenshot 2021-12-16 at 10 20 54" src="https://user-images.githubusercontent.com/599268/146343739-57e5614c-3b58-41ee-920a-18294d1a271e.png">
</td></tr></table>

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc