### PR TITLE
[server, db] Fix wrong tablename

### DIFF
--- a/components/ee/payment-endpoint/src/accounting/subscription-service.ts
+++ b/components/ee/payment-endpoint/src/accounting/subscription-service.ts
@@ -97,10 +97,12 @@ export class SubscriptionService {
         const subs = await this.getNotYetCancelledSubscriptions(user, now.toISOString());
         const uncancelledOssSub = subs.find(s => s.planId === Plans.FREE_OPEN_SOURCE.chargebeeId && !s.cancellationDate);
         if (uncancelledOssSub) {
+            log.debug({ userId: userId }, "already has professional OSS subscription");
             return;
         }
 
-        await this.subscribe(userId, Plans.FREE_OPEN_SOURCE, undefined, now.toISOString());
+        const subscription = await this.subscribe(userId, Plans.FREE_OPEN_SOURCE, undefined, now.toISOString());
+        log.debug({ userId: userId }, "create new OSS subscription", { subscription });
         return;
     }
 

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -245,7 +245,7 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: '_lastModified',
         },
         {
-            name: 'd_b_oss_allowlist',
+            name: 'd_b_oss_allow_list',
             primaryKeys: ['identity'],
             deletionColumn: 'deleted',
             timeColumn: '_lastModified',

--- a/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
+++ b/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
@@ -57,7 +57,7 @@ const tables: TableWithDeletion[] = [
     { deletionColumn: "deleted", name: "d_b_team_membership_invite" },
     { deletionColumn: "deleted", name: "d_b_project" },
     { deletionColumn: "deleted", name: "d_b_prebuild_info" },
-    { deletionColumn: "deleted", name: "d_b_oss_allowlist" },
+    { deletionColumn: "deleted", name: "d_b_oss_allow_list" },
 ];
 
 interface TableWithDeletion {

--- a/components/gitpod-db/src/typeorm/migration/1638973332787-OssAllowlist.ts
+++ b/components/gitpod-db/src/typeorm/migration/1638973332787-OssAllowlist.ts
@@ -10,12 +10,12 @@ import { tableExists } from "./helper/helper";
 export class OssAllowList1638973332787 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query("CREATE TABLE IF NOT EXISTS `d_b_oss_allowlist` (`identity` char(128) NOT NULL, `deleted` tinyint(4) NOT NULL DEFAULT 0, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY(`identity`)) ENGINE=InnoDB");
+        await queryRunner.query("CREATE TABLE IF NOT EXISTS `d_b_oss_allow_list` (`identity` char(128) NOT NULL, `deleted` tinyint(4) NOT NULL DEFAULT 0, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY(`identity`)) ENGINE=InnoDB");
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {
-        if (await tableExists(queryRunner, "d_b_oss_allowlist")) {
-            await queryRunner.query("DROP TABLE `d_b_oss_allowlist`");
+        if (await tableExists(queryRunner, "d_b_oss_allow_list")) {
+            await queryRunner.query("DROP TABLE `d_b_oss_allow_list`");
         }
     }
 

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -109,6 +109,7 @@ export class LoginCompletionHandler {
 
     protected async checkForAndSubscribeToProfessionalOss(user: User) {
         const eligible = await this.userService.checkAutomaticOssEligibility(user);
+        log.debug({ userId: user.id }, "user eligible for OSS subscription?", { eligible });
         if (!eligible) {
             return;
         }


### PR DESCRIPTION
## Description
Fixes wrong table name! `d_b_oss_allowlist` vs `d_b_oss_allow_list` :grimacing: 

Will adjust this in staging once this got merged by:
 1. re-running the migration (pop last entry from `migrations` table)
 2. manually deleting the old table

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
