### PR TITLE
[server, db] Performance improvements to OAuthProvider sync

### DIFF
--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -192,6 +192,7 @@ const gitpodServiceMock = createServiceMock({
                 "clientId": "clientid-123",
                 "clientSecret": "redacted"
             },
+            "oauthRevision": "some-revision",
             "deleted": false
         }]
     },

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -28,6 +28,7 @@ packages:
       - "src/wait-for-db.ts"
       - "src/migrate-migrations.ts"
       - "src/user-db.ts"
+      - "src/auth-provider-entry-db.ts"
       - "package.json"
     deps:
       - components/gitpod-protocol:lib

--- a/components/gitpod-db/src/auth-provider-entry-db.ts
+++ b/components/gitpod-db/src/auth-provider-entry-db.ts
@@ -5,6 +5,7 @@
  */
 
 import { AuthProviderEntry as AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { createHash } from "crypto";
 
 export const AuthProviderEntryDB = Symbol('AuthProviderEntryDB');
 
@@ -13,7 +14,12 @@ export interface AuthProviderEntryDB {
 
     delete(ap: AuthProviderEntry): Promise<void>;
 
-    findAll(): Promise<AuthProviderEntry[]>;
+    findAll(exceptOAuthRevisions: string[]): Promise<AuthProviderEntry[]>;
+    findAllHosts(): Promise<string[]>;
     findByHost(host: string): Promise<AuthProviderEntry | undefined>;
     findByUserId(userId: string): Promise<AuthProviderEntry[]>;
+}
+
+export function hashOAuth(oauth: AuthProviderEntry["oauth"]): string {
+    return createHash('sha256').update(JSON.stringify(oauth)).digest('hex');
 }

--- a/components/gitpod-db/src/typeorm/entity/db-auth-provider-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-auth-provider-entry.ts
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { PrimaryColumn, Column, Entity } from "typeorm";
+import { PrimaryColumn, Column, Entity, Index } from "typeorm";
 import { TypeORM } from "../typeorm";
 import { AuthProviderEntry, OAuth2Config } from "@gitpod/gitpod-protocol";
 import { Transformer } from "../transformer";
@@ -36,6 +36,10 @@ export class DBAuthProviderEntry implements AuthProviderEntry {
         )
     })
     oauth: OAuth2Config;
+
+    @Index("ind_oauthRevision")
+    @Column()
+    oauthRevision: string;
 
     @Column()
     deleted?: boolean;

--- a/components/gitpod-db/src/typeorm/migration/1639584886082-OAuthRevision.ts
+++ b/components/gitpod-db/src/typeorm/migration/1639584886082-OAuthRevision.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { hashOAuth } from "../../auth-provider-entry-db";
+import { columnExists, indexExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_auth_provider_entry";
+const COLUMN_NAME: keyof AuthProviderEntry = "oauthRevision";
+const INDEX_NAME = "ind_oauthRevision";
+
+export class OAuthRevision1639584886082 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(`ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} varchar(128) NOT NULL DEFAULT ''`);
+        }
+        if (!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE_NAME} (${COLUMN_NAME})`);
+        }
+
+        const entries = await queryRunner.query(`SELECT id, oauth FROM ${TABLE_NAME}`) as Pick<AuthProviderEntry, "id" | "oauth">[];
+        console.log(JSON.stringify(entries));
+        console.log(`oauthRevision: calculating ${entries.length} hashes...`);
+        for (const entry of entries) {
+            const hash = hashOAuth(entry.oauth);
+            await queryRunner.query(`UPDATE ${TABLE_NAME} SET ${COLUMN_NAME} = ${hash} WHERE id = ${entry.id}`);
+        }
+        console.log(`oauthRevision: ${entries.length} hashes calculated.`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE ${TABLE_NAME} DROP INDEX ${INDEX_NAME}`);
+        await queryRunner.query(`ALTER TABLE ${TABLE_NAME} DROP COLUMN ${COLUMN_NAME}`);
+    }
+
+}

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1138,6 +1138,8 @@ export interface AuthProviderEntry {
     readonly status: AuthProviderEntry.Status;
 
     readonly oauth: OAuth2Config;
+    /** A random string that is guaranteed to change whenever oauth changes (enforced on service level) */
+    readonly oauthRevision: string;
 }
 
 export interface OAuth2Config {

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -31,14 +31,16 @@ export class AuthProviderService {
         const transformed = all.map(this.toAuthProviderParams.bind(this));
 
         // as a precaution, let's remove duplicates
-        const unique = transformed.reduce((prev, current) => {
-            const duplicate = prev.some(a => a.host === current.host);
+        const unique = new Map<string, AuthProviderParams>();
+        for (const current of transformed) {
+            const duplicate = unique.get(current.host);
             if (duplicate) {
                 log.warn(`Duplicate dynamic Auth Provider detected.`, { rawResult: all, duplicate: current.host });
+                continue;
             }
-            return duplicate ? prev : [...prev, current];
-        }, [] as AuthProviderParams[]);
-        return unique;
+            unique.set(current.host, current);
+        }
+        return Array.from(unique.values());
     }
 
     protected toAuthProviderParams = (oap: AuthProviderEntry) => <AuthProviderParams>{

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -238,8 +238,13 @@ export class GenericAuthProvider implements AuthProvider {
         }
     }
 
+    protected cachedAuthCallbackPath: string | undefined = undefined;
     get authCallbackPath() {
-        return new URL(this.oauthConfig.callBackUrl).pathname;
+        // This ends up being called quite often so we cache the URL constructor
+        if (this.cachedAuthCallbackPath === undefined) {
+            this.cachedAuthCallbackPath = new URL(this.oauthConfig.callBackUrl).pathname;
+        }
+        return this.cachedAuthCallbackPath;
     }
 
 


### PR DESCRIPTION
## Description
Three optimizations:
 - all requests to `/auth/...` need to check which host provider is the right one, by matching a string. This parsed a `URL` on the fly each time for each entry, making it rather expensive
 - we regularly (each 2s) poll the with `getAllAuthProviders` to sync with the in-memory state. This is expensive, because we need to materialize the (encrypted) oauth config, despite not using it 99.99% of cases. This change introduces a field `oauthRevision` besides the `oauth` field that is used to filter already known objects. As a result, the list of auth providers to sync should stay empty in most cases.
 - make sure to `dispose()` `setTimout` on websocket ping-pong in every case
 
@AlexTugarev Would love to discuss this before Christmas. No need to finish/merge this PR before, though.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: 7082

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
