### PR TITLE
[installer]: separate out the rendering to two calls

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -126,7 +126,8 @@ A config file is required which can be generated with the init command.`,
 
 		// output the YAML to stdout
 		for _, c := range sortedObjs {
-			fmt.Printf("---\n# %s/%s %s\n%s\n", c.TypeMeta.APIVersion, c.TypeMeta.Kind, c.Metadata.Name, c.Content)
+			fmt.Printf("---\n# %s/%s %s\n", c.TypeMeta.APIVersion, c.TypeMeta.Kind, c.Metadata.Name)
+			fmt.Println(c.Content)
 		}
 
 		return nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Exporting the content via `fmt.Printf` appears to intermittently change strings prepended with `%`. In the `db-init-scripts` configmap, this was setting the value `GRANT ALL ON `gitpod-sessions`.* TO "gitpod"@"%";` to `GRANT ALL ON `gitpod-sessions`.* TO "gitpod"@"%!"(MISSING);`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
