### PR TITLE
Install Gitpod in Harvester-based k3s cluster for preview environments (opt-in)

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -36,6 +36,9 @@ pod:
   - name: harvester-kubeconfig
     secret:
       secretName: harvester-kubeconfig
+  - name: harvester-vm-ssh-keys
+    secret:
+      secretName: harvester-vm-ssh-keys
   # - name: deploy-key
   #   secret:
   #     secretName: deploy-key
@@ -82,6 +85,8 @@ pod:
       readOnly: false
     - name: harvester-kubeconfig
       mountPath: /mnt/secrets/harvester-kubeconfig
+    - name: harvester-vm-ssh-keys
+      mountPath: /mnt/secrets/harvester-vm-ssh-keys
     # - name: deploy-key
     #   mountPath: /mnt/secrets/deploy-key
     #   readOnly: true
@@ -162,6 +167,12 @@ pod:
 
         export DOCKER_HOST=tcp://$NODENAME:2475
         sudo chown -R gitpod:gitpod /workspace
+
+        mkdir /workspace/.ssh
+        cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa /workspace/.ssh/id_rsa_harvester_vm
+        cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa.pub /workspace/.ssh/id_rsa_harvester_vm.pub
+        sudo chmod 600 /workspace/.ssh/id_rsa_harvester_vm
+        sudo chmod 644 /workspace/.ssh/id_rsa_harvester_vm.pub
 
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
         printf '{{ toJson . }}' > context.json

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -1,4 +1,5 @@
 import { exec } from '../util/shell';
+import { getGlobalWerftInstance } from '../util/werft';
 
 import * as Manifests from './manifests'
 
@@ -21,7 +22,6 @@ EOF
  */
 export function startVM(options: { name: string }) {
     const namespace = `preview-${options.name}`
-    const userDataSecretName = `userdata-${options.name}`
 
     kubectlApplyManifest(
         Manifests.NamespaceManifest({
@@ -30,18 +30,10 @@ export function startVM(options: { name: string }) {
     )
 
     kubectlApplyManifest(
-        Manifests.UserDataSecretManifest({
-            namespace,
-            secretName: userDataSecretName,
-        })
-    )
-
-    kubectlApplyManifest(
         Manifests.VirtualMachineManifest({
             namespace,
             vmName: options.name,
-            claimName: `${options.name}-${Date.now()}`,
-            userDataSecretName
+            claimName: `${options.name}-${Date.now()}`
         }),
         { validate: false }
     )
@@ -68,12 +60,13 @@ export function vmExists(options: { name: string }) {
  * Wait until the VM Instance reaches the Running status.
  * If the VM Instance doesn't reach Running before the timeoutMS it will throw an Error.
  */
-export function waitForVM(options: { name: string, timeoutMS: number }) {
+export function waitForVM(options: { name: string, timeoutMS: number, slice: string }) {
+    const werft = getGlobalWerftInstance()
     const namespace = `preview-${options.name}`
     const startTime = Date.now()
     while (true) {
 
-        const status = exec(`kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name} -o jsonpath="{.status.phase}"`, { silent: true }).stdout.trim()
+        const status = exec(`kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name} -o jsonpath="{.status.phase}"`, { silent: true, slice: options.slice }).stdout.trim()
 
         if (status == "Running") {
             return
@@ -84,8 +77,55 @@ export function waitForVM(options: { name: string, timeoutMS: number }) {
             throw new Error("VM didn reach Running status before the timeout")
         }
 
-        console.log(`VM is not yet running. Current status is ${status}. Sleeping 5 seconds`)
-        exec('sleep 5', { silent: true })
+        werft.log(options.slice, `VM is not yet running. Current status is ${status}. Sleeping 5 seconds`)
+        exec('sleep 5', { silent: true, slice: options.slice })
     }
+}
 
+/**
+ * Copies the k3s kubeconfig out of the VM and places it at `path`
+ * If it doesn't manage to do so before the timeout it will throw an Error
+ */
+export function copyk3sKubeconfig(options: { path: string, timeoutMS: number, slice: string }) {
+    const werft = getGlobalWerftInstance()
+    const startTime = Date.now()
+    while (true) {
+
+        const status = exec(`ssh -i /workspace/.ssh/id_rsa_harvester_vm ubuntu@127.0.0.1 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no 'sudo cat /etc/rancher/k3s/k3s.yaml' > ${options.path}`, { silent: true, dontCheckRc: true, slice: options.slice })
+
+        if (status.code == 0) {
+            return
+        }
+
+        const elapsedTimeMs = Date.now() - startTime
+        if (elapsedTimeMs > options.timeoutMS) {
+            throw new Error(`Wasn't able to copy out the kubeconfig before the timeout. Exit code ${status.code}. Stderr: ${status.stderr}. Stdout: ${status.stdout}`)
+        }
+
+        werft.log(options.slice, `Wasn't able to copy out kubeconfig yet. Sleeping 5 seconds`)
+        exec('sleep 5', { silent: true, slice: options.slice })
+    }
+}
+
+/**
+ * Proxy 127.0.0.1:22 to :22 in the VM through the k8s service
+ */
+export function startSSHProxy(options: { name: string, slice: string }) {
+    const namespace = `preview-${options.name}`
+    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 22:22`, { async: true, silent: true, slice: options.slice })
+}
+
+/**
+ * Proxy 127.0.0.1:6443 to :6443 in the VM through the k8s service
+ */
+export function startKubeAPIProxy(options: { name: string, slice: string }) {
+    const namespace = `preview-${options.name}`
+    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 6443:6443`, { async: true, silent: true, slice: options.slice })
+}
+
+/**
+ * Terminates all running kubectl proxies
+ */
+export function stopKubectlPortForwards() {
+    exec(`sudo killall kubectl || true`)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This provides Werft with kubectl access to the k3s cluster running inside of the Harvester-managed VM based preview environment so that we can install Gitpod.

**It is outside of the scope of this PR to get the Gitpod installation working. This PR is an step towards getting there, but we'll focus on getting the Gitpod installation working properly in follow up PRs; this gives us something to iterate on**

It currently achieves it by adding the dev@gitpod.io SSH key to the VM. The keys are also stored in core-dev in the `harvester-vm-ssh-keys` secret. The keys are used in the Werft job to copy out the `kubeconfig` file for the k3s cluster.

SSH and Kube API access to the VM is achieved by port-forwarding. In a follow up PR we're hoping to have the Harvester ingress take care of the proxying so we don't have to do that in the Werft job.

The cloudinit has been extended to install k3s, CertManager, and create the certs namespace.

Addiotionally, instead of using a secret for the cloudinit this just has it inline. I found that easier to work with, and given the Secret was public anyway (plaintext in this repository) there wasn't a lot of reason to use the Secret.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/harvester/issues/7

## How to test
<!-- Provide steps to test this PR -->

Trigger the job with the `with-vm` option:

```sh
werft run github -a with-vm=true
```

This will boot the VM and try to install Gitpod. it won't be able to install Gitpod properly yet, but getting Gitpod fully operational is outside the scope of this PR.

I have added a few debug tips below.

### Get a shell in the Werft job pod to debug

If you want do debug it might use useful to get a shell inside of the the Werft job so you can poke around:

``` sh
# From a workspace
# Find your job pod
kubectl -n werft get pods 
# Exec into it
kubectl -n werft exec -it -c build gitpod-build-mads-harvester-k3s.23 -- sh
```

If you want to delete the pod:

```sh
# From a workspace
kubectl -n werft delete pod gitpod-build-mads-harvester-k3s.25
```

### Deleting the VM so you get a new one in the next job

If you're modifying the cloudinit or for whatever reason want to start a fresh VM then you can delete your VM and all related resources by deleting the namespace in Harvester

```sh
# From a workspace

# Grab the Harvester kubeconfig
kubectl -n werft get secret harvester-kubeconfig -o jsonpath='{.data}' | jq -r '.["harvester-kubeconfig.yml"]' | base64 -d > harvester-kubeconfig.yml

# Find your namespace
kubectl --kubeconfig=harvester-kubeconfig.yml get ns

# Delete your namespace
kubectl --kubeconfig=harvester-kubeconfig.yml delete ns preview-mads-harvester-k3s
```

### SSHing to the VM from a workspace

If you want to SSH to the VM you can grab the SSH keys and start the proxy manually and then SSH into the VM

```sh
kubectl -n werft get secret harvester-vm-ssh-keys -o jsonpath='{.data}' | jq -r '.["id_rsa"]' | base64 -d > /home/gitpod/.ssh/id_rsa
kubectl -n werft get secret harvester-vm-ssh-keys -o jsonpath='{.data}' | jq -r '.["id_rsa.pub"]' | base64 -d > /home/gitpod/.ssh/id_rsa.pub

chmod 600 /home/gitpod/.ssh/id_rsa
chmod 644 /home/gitpod/.ssh/id_rsa.pub

# Workspace: Start SSH proxy
sudo kubectl \
	--kubeconfig=harvester-kubeconfig.yml \
	-n preview-mads-harvester-k3s \
	port-forward service/proxy 22:22

# Workspace: In a new shell SSH to the VM
ssh ubuntu@127.0.0.1
```

### Getting kubectl access to k3s in VM

This assume you have SSH access to the VM as described above

```sh
# Workspace: Copy out kubeconfig
ssh ubuntu@127.0.0.1 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no 'sudo cat /etc/rancher/k3s/k3s.yaml' > k3s-kubeconfig.yaml

# Workspace: Start kube API proxy
sudo kubectl \
	--kubeconfig=harvester-kubeconfig.yml \
	-n preview-mads-harvester-k3s \
	port-forward service/proxy 6443:6443

kubectl --kubeconfig=./k3s-kubeconfig.yaml get ns
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->