### PR TITLE
Auto focus on cancel on confirmation modal

### DIFF
--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -45,7 +45,7 @@ export default function ConfirmationModal(props: {
     }
 
     const buttons = [
-        <button className="secondary" onClick={props.onClose}>Cancel</button>,
+        <button className="secondary" onClick={props.onClose} autoFocus>Cancel</button>,
         <button className="ml-2 danger" onClick={props.onConfirm} disabled={props.buttonDisabled}>
             {props.buttonText || "Yes, I'm Sure"}
         </button>,

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -43,9 +43,10 @@ export default function ConfirmationModal(props: {
             child.push(props.children);
         }
     }
+    const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
     const buttons = [
-        <button className="secondary" onClick={props.onClose} autoFocus>Cancel</button>,
+        <button className="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>Cancel</button>,
         <button className="ml-2 danger" onClick={props.onConfirm} disabled={props.buttonDisabled}>
             {props.buttonText || "Yes, I'm Sure"}
         </button>,
@@ -63,6 +64,10 @@ export default function ConfirmationModal(props: {
             visible={props.visible === undefined ? true : props.visible}
             onClose={props.onClose}
             onEnter={() => {
+                if (cancelButtonRef?.current?.contains(document.activeElement)) {
+                    props.onClose();
+                    return false;
+                }
                 if (buttonDisabled.current) {
                     return false
                 }


### PR DESCRIPTION
## Description

This will add auto focus on the Cancel button for the confirmation modal to avoid leading users to accidentally performing destructive actions like removing a project or deleting a workspace.

## How to test
1. Add a new project or open a new workspace
2. Try removing a project or deleting a workspace

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2021-12-17 at 12 49 16 AM (2)" src="https://user-images.githubusercontent.com/120486/146460668-6d5445ce-b3c1-42a5-aca4-22b159bf16ad.png"> | <img width="1440" alt="Screenshot 2021-12-17 at 12 49 21 AM (2)" src="https://user-images.githubusercontent.com/120486/146460673-3b53ca59-deff-4857-bb5b-67dcd8ee2a32.png"> |
| <img width="1440" alt="Screenshot 2021-12-17 at 12 49 27 AM (2)" src="https://user-images.githubusercontent.com/120486/146460678-ec753b16-7e96-4750-87c5-f64477e683dc.png"> | <img width="1440" alt="Screenshot 2021-12-17 at 12 50 09 AM (2)" src="https://user-images.githubusercontent.com/120486/146460683-9e26c844-569a-41ef-89cc-2cb8be5da54e.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Auto focus on cance on confirmation modal
```