### PR TITLE
[installer]: grant option for disabling proxy load balancer

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -476,6 +476,21 @@ Kubernetes objects, such as your TLS certificate or connection secrets.
 kubectl create namespace gitpod
 ```
 
+# I need to add additional configuration to my load balancer - what do I do?
+
+By default, this will create a `proxy` service with `ServiceType: LoadBalancer`.
+If you want to specify your own ingress, you can do this easily by changing
+your Installer configuration:
+
+```yaml
+components:
+  proxy:
+    serviceType: ClusterIP
+```
+
+This will set the `ServiceType` to `ClusterIP` allowing you to create your own
+ingress controller.
+
 # Todo
 
 PRs/comments welcome

--- a/installer/pkg/components/proxy/objects.go
+++ b/installer/pkg/components/proxy/objects.go
@@ -32,7 +32,7 @@ var Objects = common.CompositeRenderFunc(
 				ServicePort:   PrometheusPort,
 			},
 		}, func(service *corev1.Service) {
-			service.Spec.Type = corev1.ServiceTypeLoadBalancer
+			service.Spec.Type = cfg.Config.Components.Proxy.ServiceType
 			service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", cfg.Config.Domain, cfg.Config.Domain, cfg.Config.Domain)
 			service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
 		})(cfg)

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -26,6 +26,11 @@ func (v version) Factory() interface{} {
 			Enabled:  false,
 			Passlist: []string{},
 		},
+		Components: &Components{
+			Proxy: &ProxyComponent{
+				ServiceType: corev1.ServiceTypeLoadBalancer,
+			},
+		},
 	}
 }
 func (v version) Defaults(in interface{}) error {
@@ -78,6 +83,8 @@ type Config struct {
 	Certificate ObjectRef `json:"certificate" validate:"required"`
 
 	ImagePullSecrets []ObjectRef `json:"imagePullSecrets"`
+
+	Components *Components `json:"components,omitempty"`
 
 	Workspace Workspace `json:"workspace" validate:"required"`
 
@@ -163,7 +170,7 @@ const (
 type ContainerRegistry struct {
 	InCluster *bool                      `json:"inCluster,omitempty" validate:"required"`
 	External  *ContainerRegistryExternal `json:"external,omitempty" validate:"required_if=InCluster false"`
-	S3Storage *S3Storage                 `json:"s3storage"`
+	S3Storage *S3Storage                 `json:"s3storage,omitempty"`
 }
 
 type ContainerRegistryExternal struct {
@@ -220,6 +227,14 @@ type Workspace struct {
 	Runtime   WorkspaceRuntime    `json:"runtime" validate:"required"`
 	Resources Resources           `json:"resources" validate:"required"`
 	Templates *WorkspaceTemplates `json:"templates,omitempty"`
+}
+
+type Components struct {
+	Proxy *ProxyComponent `json:"proxy,omitempty"`
+}
+
+type ProxyComponent struct {
+	ServiceType corev1.ServiceType `json:"serviceType,omitempty" validate:"k8s_service_type"`
 }
 
 type FSShiftMethod string

--- a/installer/pkg/config/v1/validation.go
+++ b/installer/pkg/config/v1/validation.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
-	"sigs.k8s.io/yaml"
-
 	"github.com/go-playground/validator/v10"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 var InstallationKindList = map[InstallationKind]struct{}{
@@ -39,6 +38,13 @@ var FSShiftMethodList = map[FSShiftMethod]struct{}{
 	FSShiftShiftFS: {},
 }
 
+var KubernetesServiceTypeList = map[corev1.ServiceType]struct{}{
+	corev1.ServiceTypeClusterIP:    {},
+	corev1.ServiceTypeNodePort:     {},
+	corev1.ServiceTypeLoadBalancer: {},
+	corev1.ServiceTypeExternalName: {},
+}
+
 // LoadValidationFuncs load custom validation functions for this version of the config API
 func (v version) LoadValidationFuncs(validate *validator.Validate) error {
 	funcs := map[string]validator.Func{
@@ -52,6 +58,10 @@ func (v version) LoadValidationFuncs(validate *validator.Validate) error {
 		},
 		"installation_kind": func(fl validator.FieldLevel) bool {
 			_, ok := InstallationKindList[InstallationKind(fl.Field().String())]
+			return ok
+		},
+		"k8s_service_type": func(fl validator.FieldLevel) bool {
+			_, ok := KubernetesServiceTypeList[corev1.ServiceType(fl.Field().String())]
 			return ok
 		},
 		"log_level": func(fl validator.FieldLevel) bool {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This will allow users to create their own ingress controller. An example for NGINX Ingress is shown.

The thinking behind this is due to the number of corporate users who have said that using `ServiceType: LoadBalancer` is not possible for them. If the ingress is disabled, the `ServiceType: ClusterIP` is used and the expectation is that the user will configure their own ingress controller

An example for NGINX Ingress is provided (in a gist)

This introduced the `meta` config object (similar to `workspace`) and `ingress.serviceType`, which defaults to `LoadBalancer`

## How to test
<!-- Provide steps to test this PR -->
Create a deployment and set the config:

```yaml
components:
  proxy:
    serviceType: ClusterIP
```

Deploy your installation of Gitpod

Install ingress-nginx:

```shell
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/docs/examples/psp/psp.yaml
helm upgrade \
    --atomic \
    --cleanup-on-fail \
    --create-namespace \
    --install \
    --namespace ingress-nginx \
    --reset-values \
    --repo https://kubernetes.github.io/ingress-nginx \
    --set defaultBackend.enabled=false \
    --set controller.extraArgs.enable-ssl-passthrough=true \
    --wait \
    ingress-nginx \
    ingress-nginx
```

Create your ingress controller:

```yaml
# Replace $DOMAIN with your domain

apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: gitpod
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
spec:
  tls:
    - hosts:
        - "$DOMAIN"
        - "*.$DOMAIN"
        - "*.ws.$DOMAIN"
      secretName: https-certificates
  rules:
    - host: "$DOMAIN"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: proxy
                port:
                  number: 443
    - host: "*.$DOMAIN"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: proxy
                port:
                  number: 443
    - host: "*.ws.$DOMAIN"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: proxy
                port:
                  number: 443
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: grant option for disabling proxy load balancer 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
