### PR TITLE
change ide-proxy network policy

### DIFF
--- a/chart/templates/ide-proxy-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/ide-proxy-deny-all-allow-explicit-networkpolicy.yaml
@@ -22,10 +22,4 @@ spec:
   - ports:
     - protocol: TCP
       port: 80
-    from:
-    # Allow ingress on port 80 from component:
-    - podSelector:
-        matchLabels:
-          app: {{ template "gitpod.fullname" . }}
-          component: proxy
 {{- end -}}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change ide-proxy network policy to adjust GCP

background:
in https://github.com/gitpod-io/gitpod/pull/7141, we added a network policy to `ide-proxy` that only allows access from the `proxy` component, which is fine for preview environments and self-hosted clusters, but for staging and prod clusters, which require direct GLB access, this PR removes that restriction

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
only affect staging and prod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
