### PR TITLE
[dashboard] show repo name when workspace creation fails

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -233,9 +233,11 @@ function LimitReachedOutOfHours() {
 
 function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
   const [statusMessage, setStatusMessage] = useState<React.ReactNode>();
+  const { host, owner, repoName, userIsOwner, userScopes, lastUpdate } = p.error.data;
+  const repoFullName = (owner && repoName) ? `${owner}/${repoName}` : '';
+
   useEffect(() => {
     (async () => {
-      const { host, owner, repoName, userIsOwner, userScopes, lastUpdate } = p.error.data;
       console.log('host', host);
       console.log('owner', owner);
       console.log('repoName', repoName);
@@ -247,8 +249,6 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
       if (!authProvider) {
         return;
       }
-
-      const repoFullName = (owner && repoName) ? `${owner}/${repoName}` : '';
 
       // TODO: this should be aware of already granted permissions
       const missingScope = authProvider.host === 'github.com' ? 'repo' : 'read_repository';
@@ -297,9 +297,14 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
     })();
   }, []);
 
-  return <StartPage phase={StartPhase.Checking} error={p.error}>
-    {statusMessage}
-  </StartPage>;
+  return (
+    <StartPage phase={StartPhase.Checking} error={p.error}>
+      <p className="text-base text-gitpod-red mt-2">
+        <code>{repoFullName}</code>
+      </p>
+      {statusMessage}
+    </StartPage>
+  );
 }
 
 interface RunningPrebuildViewProps {


### PR DESCRIPTION
## Description

When the creation of a workspace fails because the repo wasn't found, also display the repository name near the error messages so that in the scenario described by #7191 it becomes easier to understand what's actually going on.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7191 

## How to test
<!-- Provide steps to test this PR -->

- Run the dashboard app
- Try to create a workspace from a non-existent repository. E.g. https://3000-teal-earthworm-ch85f047.ws-eu23.gitpod.io/#https://github.com/gitpod-io/gitpoddenz
- Look for the updated error message (See screenshot below)

![image](https://user-images.githubusercontent.com/462705/146616508-ba45178a-aded-43ca-8b8e-bd2380d94af3.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Error messages on workspace creation when the repository is not found, will now also display the name of the repository
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
