### PR TITLE
[image-builder-mk3] fix image tag and digest conflict

### DIFF
--- a/components/image-builder-mk3/pkg/resolve/resolve.go
+++ b/components/image-builder-mk3/pkg/resolve/resolve.go
@@ -70,7 +70,15 @@ func (sr *StandaloneRefResolver) Resolve(ctx context.Context, ref string, opts .
 	}
 
 	// The reference is already in digest form we don't have to do anything
-	if _, ok := pref.(reference.Canonical); ok {
+	if cref, ok := pref.(reference.Canonical); ok {
+		// if reference contain tag, we should remove it to avoid tag and digest conflict
+		if _, ok := pref.(reference.Tagged); ok {
+			dref, err := reference.WithDigest(reference.TrimNamed(pref), cref.Digest())
+			if err != nil {
+				return "", err
+			}
+			ref = dref.String()
+		}
 		span.LogKV("result", ref)
 		return ref, nil
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[image-builder-mk3] fix image tag and digest conflict
If image name contain tag and digest both, and tag's latest digest is not same with provider digest image-builder will reject it
This PR remove tag while tag and digest both exist

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7285

## How to test
<!-- Provide steps to test this PR -->
start with repo 
https://pd-fix-7285.staging.gitpod-dev.com/#/https://github.com/jldec/test-image
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
