### PR TITLE
[dashboard] show repo name when workspace creation fails

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -285,14 +285,14 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
 
       if (!updatedRecently) {
         setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
-          <p className="text-base text-gray-400 w-96">Permission to access private repositories has been granted. If you are a member of '{owner}', please try to request access for Gitpod.</p>
+          <p className="text-base text-gray-400 w-96">Permission to access private repositories has been granted. If you are a member of <CodeText>{owner}</CodeText>, please try to request access for Gitpod.</p>
           <a className="mx-auto" href={authorizeURL}><button className="secondary">Request Access for Gitpod</button></a>
         </div>);
         return;
       }
 
       setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
-        <p className="text-base text-gray-400 w-96">Your access token was updated recently. Please try again if the repository exists and Gitpod was approved for '{owner}'.</p>
+        <p className="text-base text-gray-400 w-96">Your access token was updated recently. Please try again if the repository exists and Gitpod was approved for <CodeText>{owner}</CodeText>.</p>
         <a className="mx-auto" href={authorizeURL}><button className="secondary">Try Again</button></a>
       </div>);
     })();

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -261,7 +261,7 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
       if (!userScopes.includes(missingScope)) {
         setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
           <p className="text-base text-gray-400 w-96">The repository may be private. Please authorize Gitpod to access to private repositories.</p>
-          <a className="mx-auto" href={authorizeURL}><button className="secondary">Grant Access</button></a>
+          <a className="mx-auto" href={authorizeURL}><button>Grant Access</button></a>
         </div>);
         return;
       }
@@ -286,14 +286,14 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
       if (!updatedRecently) {
         setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
           <p className="text-base text-gray-400 w-96">Permission to access private repositories has been granted. If you are a member of <CodeText>{owner}</CodeText>, please try to request access for Gitpod.</p>
-          <a className="mx-auto" href={authorizeURL}><button className="secondary">Request Access for Gitpod</button></a>
+          <a className="mx-auto" href={authorizeURL}><button>Request Access for Gitpod</button></a>
         </div>);
         return;
       }
 
       setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
         <p className="text-base text-gray-400 w-96">Your access token was updated recently. Please try again if the repository exists and Gitpod was approved for <CodeText>{owner}</CodeText>.</p>
-        <a className="mx-auto" href={authorizeURL}><button className="secondary">Try Again</button></a>
+        <a className="mx-auto" href={authorizeURL}><button>Try Again</button></a>
       </div>);
     })();
   }, []);


### PR DESCRIPTION
## Description

When the creation of a workspace fails because the repo wasn't found, also display the repository name near the error messages so that in the scenario described by #7191 it becomes easier to understand what's actually going on.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7191 

## How to test
<!-- Provide steps to test this PR -->

- Run the dashboard app
- Try to create a workspace from a non-existent repository. E.g. https://3000-teal-earthworm-ch85f047.ws-eu23.gitpod.io/#https://github.com/gitpod-io/gitpoddenz
- Look for the updated error message (See screenshot below)

![image](https://user-images.githubusercontent.com/462705/146616508-ba45178a-aded-43ca-8b8e-bd2380d94af3.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Error messages on workspace creation when the repository is not found, will now also display the name of the repository
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
