### PR TITLE
[installer]: refactor the workspace component with ide ownership

### DIFF
--- a/installer/pkg/components/blobserve/configmap.go
+++ b/installer/pkg/components/blobserve/configmap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace/ide"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Port:    ContainerPort,
 			Timeout: util.Duration(time.Second * 5),
 			Repos: map[string]blobserve.Repo{
-				common.RepoName(ctx.Config.Repository, workspace.CodeIDEImage): {
+				common.RepoName(ctx.Config.Repository, ide.CodeIDEImage): {
 					PrePull: []string{},
 					Workdir: "/ide",
 					Replacements: []blobserve.StringReplacement{{

--- a/installer/pkg/components/server/ide/configmap.go
+++ b/installer/pkg/components/server/ide/configmap.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace/ide"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,14 +31,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:    typeBrowser,
 					Logo:    "invalid",
 					Hidden:  pointer.Bool(true),
-					Image:   common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, workspace.CodeIDEImageStableVersion),
+					Image:   common.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ide.CodeIDEImageStableVersion),
 				},
 				"code": {
 					OrderKey: pointer.String("00"),
 					Title:    "VS Code",
 					Type:     typeBrowser,
 					Logo:     "vscode",
-					Image:    common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, workspace.CodeIDEImageStableVersion),
+					Image:    common.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ide.CodeIDEImageStableVersion),
 				},
 				"code-latest": {
 					OrderKey:           pointer.String("01"),
@@ -46,7 +47,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Logo:               "vscode-insiders",
 					Tooltip:            pointer.String("Early access version, still subject to testing."),
 					Label:              pointer.String("Insiders"),
-					Image:              common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
+					Image:              common.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ctx.VersionManifest.Components.Workspace.CodeImage.Version),
 					ResolveImageDigest: pointer.Bool(true),
 				},
 				"code-desktop": {
@@ -54,7 +55,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Title:    "VS Code",
 					Type:     typeDesktop,
 					Logo:     "vscode",
-					Image:    common.ImageName(ctx.Config.Repository, workspace.CodeDesktopIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CodeDesktopImage.Version),
+					Image:    common.ImageName(ctx.Config.Repository, ide.CodeDesktopIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CodeDesktopImage.Version),
 				},
 				"code-desktop-insiders": {
 					OrderKey: pointer.String("03"),
@@ -63,7 +64,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Logo:     "vscode-insiders",
 					Tooltip:  pointer.String("Visual Studio Code Insiders for early adopters."),
 					Label:    pointer.String("Insiders"),
-					Image:    common.ImageName(ctx.Config.Repository, workspace.CodeDesktopInsidersIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CodeDesktopImageInsiders.Version),
+					Image:    common.ImageName(ctx.Config.Repository, ide.CodeDesktopInsidersIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.CodeDesktopImageInsiders.Version),
 				},
 				"intellij": {
 					OrderKey: pointer.String("04"),
@@ -71,7 +72,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:     typeDesktop,
 					Logo:     "intellij-idea",
 					Notes:    []string{"While in beta, when you open a workspace with IntelliJ IDEA you will need to use the password “gitpod”."},
-					Image:    common.ImageName(ctx.Config.Repository, workspace.IntelliJDesktopIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.IntelliJImage.Version),
+					Image:    common.ImageName(ctx.Config.Repository, ide.IntelliJDesktopIDEImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.IntelliJImage.Version),
 				},
 				"goland": {
 					OrderKey: pointer.String("05"),
@@ -79,7 +80,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:     typeDesktop,
 					Logo:     "goland",
 					Notes:    []string{"While in beta, when you open a workspace with GoLand you will need to use the password “gitpod”."},
-					Image:    common.ImageName(ctx.Config.Repository, workspace.GoLandDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.GoLandImage.Version),
+					Image:    common.ImageName(ctx.Config.Repository, ide.GoLandDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.GoLandImage.Version),
 				},
 				"pycharm": {
 					OrderKey: pointer.String("06"),
@@ -87,7 +88,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:     typeDesktop,
 					Logo:     "https://upload.wikimedia.org/wikipedia/commons/1/1d/PyCharm_Icon.svg", // TODO(clu): Serve logo from our own components instead of using this wikimedia URL.
 					Notes:    []string{"While in beta, when you open a workspace with PyCharm you will need to use the password “gitpod”."},
-					Image:    common.ImageName(ctx.Config.Repository, workspace.PyCharmDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PyCharmImage.Version),
+					Image:    common.ImageName(ctx.Config.Repository, ide.PyCharmDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PyCharmImage.Version),
 				},
 				"phpstorm": {
 					OrderKey: pointer.String("07"),
@@ -95,7 +96,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Type:     typeDesktop,
 					Logo:     "https://upload.wikimedia.org/wikipedia/commons/c/c9/PhpStorm_Icon.svg", // TODO(clu): Serve logo from our own components instead of using this wikimedia URL.
 					Notes:    []string{"While in beta, when you open a workspace with PhpStorm you will need to use the password “gitpod”."},
-					Image:    common.ImageName(ctx.Config.Repository, workspace.PhpStormDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PhpStormImage.Version),
+					Image:    common.ImageName(ctx.Config.Repository, ide.PhpStormDesktopIdeImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.PhpStormImage.Version),
 				},
 			},
 			DefaultIDE:        "code",

--- a/installer/pkg/components/workspace/OWNERS
+++ b/installer/pkg/components/workspace/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/workspace/constants.go
+++ b/installer/pkg/components/workspace/constants.go
@@ -9,14 +9,6 @@ const (
 	ContainerPort                = 23000
 	DefaultWorkspaceImage        = "gitpod/workspace-full"
 	DefaultWorkspaceImageVersion = "latest"
-	CodeIDEImage                 = "ide/code"
-	CodeIDEImageStableVersion    = "commit-0d1e8cc5dcc8ccb38efcc2cd6404316b6e7bf4e9" // stable version that will be updated manually on demand
-	CodeDesktopIDEImage          = "ide/code-desktop"
-	CodeDesktopInsidersIDEImage  = "ide/code-desktop-insiders"
-	IntelliJDesktopIDEImage      = "ide/intellij"
-	GoLandDesktopIdeImage        = "ide/goland"
-	PyCharmDesktopIdeImage       = "ide/pycharm"
-	PhpStormDesktopIdeImage      = "ide/phpstorm"
 	DockerUpImage                = "docker-up"
 	SupervisorImage              = "supervisor"
 	WorkspacekitImage            = "workspacekit"

--- a/installer/pkg/components/workspace/ide/OWNERS
+++ b/installer/pkg/components/workspace/ide/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-ide
+
+labels:
+  - "team: IDE"

--- a/installer/pkg/components/workspace/ide/constants.go
+++ b/installer/pkg/components/workspace/ide/constants.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package ide
+
+const (
+	CodeIDEImage                = "ide/code"
+	CodeIDEImageStableVersion   = "commit-0d1e8cc5dcc8ccb38efcc2cd6404316b6e7bf4e9" // stable version that will be updated manually on demand
+	CodeDesktopIDEImage         = "ide/code-desktop"
+	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
+	IntelliJDesktopIDEImage     = "ide/intellij"
+	GoLandDesktopIdeImage       = "ide/goland"
+	PyCharmDesktopIdeImage      = "ide/pycharm"
+	PhpStormDesktopIdeImage     = "ide/phpstorm"
+)

--- a/installer/pkg/components/ws-scheduler/configmap.go
+++ b/installer/pkg/components/ws-scheduler/configmap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace/ide"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scaler"
 	"github.com/gitpod-io/gitpod/ws-scheduler/pkg/scheduler"
@@ -84,7 +85,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 			WorkspaceImage:     common.ImageName("", workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
-			IDEImage:           common.ImageName(ctx.Config.Repository, workspace.CodeIDEImage, workspace.CodeIDEImageStableVersion),
+			IDEImage:           common.ImageName(ctx.Config.Repository, ide.CodeIDEImage, ide.CodeIDEImageStableVersion),
 			SupervisorImage:    common.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
 			FeatureFlags:       nil,
 			MaxGhostWorkspaces: 0,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
From [suggestion by Chris](https://github.com/gitpod-io/gitpod/pull/7296/files#r772141867), this moves the IDE constants in the workspace component under @gitpod-io/engineering-ide ownership

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
