### PR TITLE
Link to user profile

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -274,6 +274,10 @@ export default function NewProject() {
 
         const showSearchInput = !!repoSearchFilter || filteredRepos.length > 0;
 
+        const userLink = (r: ProviderRepository) => {
+            return `https://${new URL(r.cloneUrl).host}/${r.inUse?.userName}`
+        }
+
         const projectText = () => {
             return <p className="text-gray-500 text-center text-base">Projects allow you to manage prebuilds and workspaces for your repository. <a href="https://www.gitpod.io/docs/teams-and-projects" rel="noopener" className="gp-link">Learn more</a></p>
         }
@@ -324,7 +328,7 @@ export default function NewProject() {
                                                 <button className="primary" onClick={() => setSelectedRepo(r)}>Select</button>
                                             ) : (
                                                 <p className="text-gray-500 font-medium">
-                                                    @{r.inUse.userName} already<br/>added this repo
+                                                    <a rel="noopener" className="gp-link" href={userLink(r)}>@{r.inUse.userName}</a> already<br/>added this repo
                                                 </p>
                                             )}
                                         </div>


### PR DESCRIPTION
## Description
Links the profile of the user who already added a project. 
The profile provider should match the repo provider. 
| UPDATED |
|-|
|<img width="331" alt="Screenshot 2021-12-20 at 15 27 03" src="https://user-images.githubusercontent.com/8015191/146783023-c659038a-8d1c-4310-8389-e7946ae31475.png">|


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7310

## How to test
1. Have two different accounts using the same Git provider.
2. Account A create a group/org and add projects/repos, and invite account B as member with write access.
3. Account A adds project to Gitpod.
4. Account B tries to add the project and should be shown the username of account A. This username should link to account A's profile on the Git provider website.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Profile of the user who already added a project is linked.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
