### PR TITLE
[dashboard] enable UI experiments only for Gitpod SaaS

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -170,8 +170,10 @@ function App() {
 
     // listen and notify Segment of client-side path updates
     useEffect(() => {
-        // Choose which experiments to run for this session/user
-        Experiment.set(Experiment.seed(true));
+        if (isGitpodIo()) {
+            // Choose which experiments to run for this session/user
+            Experiment.set(Experiment.seed(true));
+        }
     })
 
     useEffect(() => {


### PR DESCRIPTION
## Description
UI experiments should only be done on our own installations. 

## Related Issue(s)
Fixes #7167

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
