### PR TITLE
Add dotfile repo support

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -85,6 +85,13 @@ export default function Preferences() {
     const browserIdeOptions = ideOptions && orderedIdeOptions(ideOptions, "browser");
     const desktopIdeOptions = ideOptions && orderedIdeOptions(ideOptions, "desktop");
 
+    const [dotfileRepo, setDotfileRepo] = useState<string>(user?.additionalData?.dotfileRepo || "");
+    const actuallySetDotfileRepo = async (value: string) => {
+        const additionalData = user?.additionalData || {};
+        additionalData.dotfileRepo = value;
+        await getGitpodService().server.updateLoggedInUser({ additionalData });
+    };
+
     return <div>
         <PageWithSubMenu subMenu={settingsMenu} title='Preferences' subtitle='Configure user preferences.'>
             {ideOptions && browserIdeOptions && <>
@@ -152,6 +159,17 @@ export default function Preferences() {
                         <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" /><path fill="#737373" d="M74.111 3.412A8 8 0 0180.665 0H100a8 8 0 018 8v24a8 8 0 01-8 8H48.5L74.111 3.412z" /><rect width="32" height="16" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="24" fill="#737373" rx="8" /><rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" /></svg>
                     </div>
                 </SelectableCard>
+            </div>
+
+            <h3 className="mt-12">Dotfiles <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel></h3>
+            <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
+            <div className="mt-4 max-w-md">
+                <h4>Repository URL</h4>
+                <input type="text" value={dotfileRepo} className="w-full" placeholder="e.g. https://github.com/username/dotfiles" onChange={(e) => setDotfileRepo(e.target.value)} />
+                <p className="text-base text-gray-500 dark:text-gray-400">Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for every new workspace.</p>
+                <div className="mt-4 max-w-md">
+                    <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
+                </div>
             </div>
         </PageWithSubMenu>
     </div>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -104,6 +104,9 @@ export interface AdditionalUserData {
     oauthClientsApproved?: { [key: string]: string }
     // to remember GH Orgs the user installed/updated the GH App for
     knownGitHubOrgs?: string[];
+
+    // Git clone URL pointing to the user's dotfile repo
+    dotfileRepo?: string;
 }
 
 export interface EmailNotificationSettings {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -653,6 +653,12 @@ export class WorkspaceStarter {
         vsxRegistryUrl.setValue(this.config.vsxRegistryUrl);
         envvars.push(vsxRegistryUrl);
 
+        // supervisor ensures dotfiles are only used if the workspace is a regular workspace
+        const dotfileEnv = new EnvironmentVariable();
+        dotfileEnv.setName("SUPERVISOR_DOTFILE_REPO");
+        dotfileEnv.setValue(user.additionalData?.dotfileRepo || "");
+        envvars.push(dotfileEnv);
+
         const createGitpodTokenPromise = (async () => {
             const scopes = this.createDefaultGitpodAPITokenScopes(workspace, instance);
             const token = crypto.randomBytes(30).toString('hex');

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -236,6 +236,10 @@ type WorkspaceConfig struct {
 
 	// WorkspaceClusterHost is a host under which this workspace is served, e.g. ws-eu11.gitpod.io
 	WorkspaceClusterHost string `env:"GITPOD_WORKSPACE_CLUSTER_HOST"`
+
+	// DotfileRepo is a user-configurable repository which contains their dotfiles to customise
+	// the in-workspace epxerience.
+	DotfileRepo string `env:"SUPERVISOR_DOTFILE_REPO"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service.


### PR DESCRIPTION
## Description
This PR implements dotfile support, whereby a user can provide a "dotfile repo" which gets cloned during workspace startup. We implement exactly what's described in the [dotfile RFC](https://github.com/gitpod-io/gitpod/issues/5198).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #5198

## How to test
1. Go to the [preferences](https://cw-dotfiles.staging.gitpod-dev.com/preferences) and enter a dotfile repo (e.g. `https://github.com/Bash-it/bash-it.git`)
2. Start any workspace and notice how the terminal looks different than what you're used to
3. Inspect `$HOME/.dotfiles`
4. Check out the logs of the dotfile installation process: `cat ~/.dotfiles.log`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add dotfile repo support
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
Will add an issue once it's clear how this feature will work and if it should land.