### PR TITLE
Make analytic event casing consistent

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -212,7 +212,7 @@ export class WorkspaceStarter {
 
             this.analytics.track({
                 userId: user.id,
-                event: "workspace-started",
+                event: "workspace_started",
                 properties: {
                     workspaceId: workspace.id,
                     instanceId: instance.id,

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -208,7 +208,7 @@ export class WorkspaceManagerBridge implements Disposable {
                         instance.startedTime = new Date().toISOString();
                         this.prometheusExporter.observeWorkspaceStartupTime(instance);
                         this.analytics.track({
-                            event: "workspace-running",
+                            event: "workspace_running",
                             messageId: `bridge-wsrun-${instance.id}`,
                             properties: { instanceId: instance.id, workspaceId: workspaceId },
                             userId,
@@ -334,9 +334,9 @@ export class WorkspaceManagerBridge implements Disposable {
 
         try {
             await this.userDB.trace({span}).deleteGitpodTokensNamedLike(ownerUserID, `${instance.id}-%`);
-            await this.analytics.track({
+            this.analytics.track({
                 userId: ownerUserID,
-                event: "workspace-stopped",
+                event: "workspace_stopped",
                 messageId: `bridge-wsstopped-${instance.id}`,
                 properties: { "instanceId": instance.id, "workspaceId": instance.workspaceId }
             });


### PR DESCRIPTION
## Description
Most events are delimited with a `_`, but the workspace events are delimited by a `-`. This PR makes this more consistent. 

## Related Issue(s)
None at all!

## How to test
Probably overkill since it's just a string change but you can trigger some analytic events and inspect them in the Segment debugger. 

## Release Notes
```release-note
NONE
```

## Documentation
Nope, no docs updated.
