### PR TITLE
Remove experiments from Login page

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -11,7 +11,6 @@ import { UserContext } from "./user-context";
 import { TeamsContext } from "./teams/teams-context";
 import { getGitpodService } from "./service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName, getSafeURLRedirect } from "./provider-utils";
-import { Experiment } from './experiments';
 import gitpod from './images/gitpod.svg';
 import gitpodDark from './images/gitpod-dark.svg';
 import gitpodIcon from './icons/gitpod.svg';
@@ -67,10 +66,7 @@ export function Login() {
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
     const [providerFromContext, setProviderFromContext] = useState<AuthProviderInfo>();
 
-    const showWelcome = Experiment.has("login-from-context-6826") ?
-        (!hasLoggedInBefore() && !hasVisitedMarketingWebsiteBefore() && !urlHash.startsWith("https://"))
-        : (!hasLoggedInBefore() && !hasVisitedMarketingWebsiteBefore())
-        ;
+    const showWelcome = !hasLoggedInBefore() && !hasVisitedMarketingWebsiteBefore() && !urlHash.startsWith("https://");
 
     useEffect(() => {
         (async () => {
@@ -79,9 +75,6 @@ export function Login() {
     }, [])
 
     useEffect(() => {
-        if (!Experiment.has("login-from-context-6826")) {
-            return;
-        }
         if (hostFromContext && authProviders) {
             const providerFromContext = authProviders.find(provider => provider.host === hostFromContext);
             setProviderFromContext(providerFromContext);

--- a/components/dashboard/src/experiments.ts
+++ b/components/dashboard/src/experiments.ts
@@ -27,8 +27,7 @@ const Experiments = {
     /**
      * Experiment "example" will be activate on login for 10% of all clients.
      */
-    // "example": 0.1,
-    "login-from-context-6826": 0, // https://github.com/gitpod-io/gitpod/issues/6826
+    "example": 0.1,
 };
 type Experiments = Partial<{ [e in Experiment]: boolean }>;
 export type Experiment = keyof (typeof Experiments);

--- a/components/dashboard/src/experiments.ts
+++ b/components/dashboard/src/experiments.ts
@@ -28,7 +28,7 @@ const Experiments = {
      * Experiment "example" will be activate on login for 10% of all clients.
      */
     // "example": 0.1,
-    "login-from-context-6826": 0.5, // https://github.com/gitpod-io/gitpod/issues/6826
+    "login-from-context-6826": 0, // https://github.com/gitpod-io/gitpod/issues/6826
 };
 type Experiments = Partial<{ [e in Experiment]: boolean }>;
 export type Experiment = keyof (typeof Experiments);


### PR DESCRIPTION
## Description
Removes the experiment from the Login page.

## Related Issue(s)
Fixes #7329

## How to test
Append a Git repo link to `https://laushinka-remove-ui-experiment-7329.staging.gitpod-dev.com/#`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Every user sees the new Login page.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
