### PR TITLE
[helm] Add missing condition for ide-proxy heml chart

### DIFF
--- a/chart/templates/ide-proxy-deny-all-allow-explicit-networkpolicy.yaml
+++ b/chart/templates/ide-proxy-deny-all-allow-explicit-networkpolicy.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-{{ if .Values.installNetworkPolicies -}}
+{{ if and (not .Values.components.ideProxy.disabled) (.Values.installNetworkPolicies) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/ide-proxy-rolebinding.yaml
+++ b/chart/templates/ide-proxy-rolebinding.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if not .Values.components.ideProxy.disabled -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -17,3 +18,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Namespace }}-ns-psp:restricted-root-user
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/chart/templates/ide-proxy-serviceaccount.yaml
+++ b/chart/templates/ide-proxy-serviceaccount.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
+{{ if not .Values.components.ideProxy.disabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,3 +12,4 @@ metadata:
     kind: service-account
     stage: {{ .Values.installation.stage }}
 automountServiceAccountToken: false
+{{- end -}}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[helm] Add missing condition for ide-proxy heml chart

Previously, ide-proxy's RoleBinding, ServiceAccount, and NetworkPolicy were not controlled by ideProxy.disabled, this PR fixes it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
no need to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
