### PR TITLE
[server] set default branch for BitBucket provider

### DIFF
--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -29,7 +29,8 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
         const description = repo.description;
         const avatarUrl = repo.owner!.links!.avatar!.href;
         const webUrl = repo.links!.html!.href;
-        return { host, owner, name, cloneUrl, description, avatarUrl, webUrl };
+        const defaultBranch = repo.mainbranch?.name;
+        return { host, owner, name, cloneUrl, description, avatarUrl, webUrl, defaultBranch };
     }
 
     async getBranch(user: User, owner: string, repo: string, branchName: string): Promise<Branch> {


### PR DESCRIPTION
## Description

I found `mainbranch` in the BitBucket API. Here's hoping it is our missing default branch. 

I wasn't able to test it because I couldn't figure out how to rebuild the server app 😬 (whereas with Nx I would have known to run `nx build server` because the commands are always the same for every single project in the repo, no matter the language or framework - see https://github.com/gitpod-io/gitpod/pull/7334 😇🍊🦄)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7325 
Fixes #7366

## How to test

If anybody's willing to comment here and explain how to rebuild / relaunch the server project to test this, I'll be adding instructions to the README for future reference 🙏 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] add default branch to BitBucket provider
```
