### PR TITLE
[local-app] timeout the local app after special time of inactivity

### DIFF
--- a/components/local-app/main.go
+++ b/components/local-app/main.go
@@ -108,6 +108,14 @@ func main() {
 				},
 				Value: 30,
 			},
+			&cli.StringFlag{
+				Name:  "timeout",
+				Usage: "How long the local app can run if last workspace was stopped",
+				EnvVars: []string{
+					"GITPOD_LCA_TIMEOUT",
+				},
+				Value: "0",
+			},
 		},
 		Commands: []*cli.Command{
 			{
@@ -117,7 +125,7 @@ func main() {
 						keyring.MockInit()
 					}
 					return run(c.String("gitpod-host"), c.String("ssh_config"), c.Int("api-port"), c.Bool("allow-cors-from-port"),
-						c.Bool("auto-tunnel"), c.String("auth-redirect-url"), c.Bool("verbose"), c.Duration("auth-timeout"))
+						c.Bool("auto-tunnel"), c.String("auth-redirect-url"), c.Bool("verbose"), c.Duration("auth-timeout"), c.Duration("timeout"))
 				},
 				Flags: []cli.Flag{
 					&cli.PathFlag{
@@ -141,7 +149,7 @@ func DefaultCommand(name string) cli.ActionFunc {
 	}
 }
 
-func run(origin, sshConfig string, apiPort int, allowCORSFromPort bool, autoTunnel bool, authRedirectUrl string, verbose bool, authTimeout time.Duration) error {
+func run(origin, sshConfig string, apiPort int, allowCORSFromPort bool, autoTunnel bool, authRedirectUrl string, verbose bool, authTimeout time.Duration, localAppTimeout time.Duration) error {
 	if verbose {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
@@ -185,7 +193,7 @@ func run(origin, sshConfig string, apiPort int, allowCORSFromPort bool, autoTunn
 		cb = append(cb, s)
 	}
 
-	b = bastion.New(client, cb)
+	b = bastion.New(client, localAppTimeout, cb)
 	b.EnableAutoTunnel = autoTunnel
 	grpcServer := grpc.NewServer()
 	appapi.RegisterLocalAppServer(grpcServer, bastion.NewLocalAppService(b, s))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add a new flag timeout controlling for how long the local app can run if last workspace was stopped

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7074

## How to test
<!-- Provide steps to test this PR -->
```bash
# build and run local-app
go build
./local-app --timeout 1m --verbose
```
without any alive workspace, local-app will exit in 1 minute
once we open a workspace `timeout` timer will be stopped
after all workspaces stopped, local-app will terminate after 1 minute

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
