### PR TITLE
Fix Gitpod casing in proc tests

### DIFF
--- a/components/ee/agent-smith/pkg/detector/proc.go
+++ b/components/ee/agent-smith/pkg/detector/proc.go
@@ -171,7 +171,7 @@ func (p realProcfs) Environ(pid int) ([]string, error) {
 }
 
 func parseGitpodEnviron(r io.Reader) ([]string, error) {
-	// Note: this function is benchmarked in BenchmarkParseGitPodEnviron.
+	// Note: this function is benchmarked in BenchmarkParseGitpodEnviron.
 	//       At the time of this wriging it consumed 3+N allocs where N is the number of
 	//       env vars starting with GITPOD_.
 	//

--- a/components/ee/agent-smith/pkg/detector/proc_test.go
+++ b/components/ee/agent-smith/pkg/detector/proc_test.go
@@ -345,7 +345,7 @@ func TestParseGitpodEnviron(t *testing.T) {
 	}
 }
 
-func benchmarkParseGitPodEnviron(content string, b *testing.B) {
+func benchmarkParseGitpodEnviron(content string, b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -353,28 +353,28 @@ func benchmarkParseGitPodEnviron(content string, b *testing.B) {
 	}
 }
 
-func BenchmarkParseGitPodEnvironP0(b *testing.B) { benchmarkParseGitPodEnviron("", b) }
-func BenchmarkParseGitPodEnvironP1(b *testing.B) {
-	benchmarkParseGitPodEnviron("GITPOD_INSTANCE_ID=foobar\000", b)
+func BenchmarkParseGitpodEnvironP0(b *testing.B) { benchmarkParseGitpodEnviron("", b) }
+func BenchmarkParseGitpodEnvironP1(b *testing.B) {
+	benchmarkParseGitpodEnviron("GITPOD_INSTANCE_ID=foobar\000", b)
 }
-func BenchmarkParseGitPodEnvironP2(b *testing.B) {
-	benchmarkParseGitPodEnviron("GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000", b)
+func BenchmarkParseGitpodEnvironP2(b *testing.B) {
+	benchmarkParseGitpodEnviron("GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000", b)
 }
 func BenchmarkParseGitPodEnvironP4(b *testing.B) {
-	benchmarkParseGitPodEnviron("GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000", b)
+	benchmarkParseGitpodEnviron("GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000", b)
 }
-func BenchmarkParseGitPodEnvironP8(b *testing.B) {
-	benchmarkParseGitPodEnviron("GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000", b)
+func BenchmarkParseGitpodEnvironP8(b *testing.B) {
+	benchmarkParseGitpodEnviron("GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000GITPOD_INSTANCE_ID=foobar\000", b)
 }
-func BenchmarkParseGitPodEnvironN1(b *testing.B) { benchmarkParseGitPodEnviron("NOT_ME\000", b) }
-func BenchmarkParseGitPodEnvironN2(b *testing.B) {
-	benchmarkParseGitPodEnviron("NOT_ME\000NOT_ME\000", b)
+func BenchmarkParseGitpodEnvironN1(b *testing.B) { benchmarkParseGitpodEnviron("NOT_ME\000", b) }
+func BenchmarkParseGitpodEnvironN2(b *testing.B) {
+	benchmarkParseGitpodEnviron("NOT_ME\000NOT_ME\000", b)
 }
-func BenchmarkParseGitPodEnvironN4(b *testing.B) {
-	benchmarkParseGitPodEnviron("NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000", b)
+func BenchmarkParseGitpodEnvironN4(b *testing.B) {
+	benchmarkParseGitpodEnviron("NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000", b)
 }
-func BenchmarkParseGitPodEnvironN8(b *testing.B) {
-	benchmarkParseGitPodEnviron("NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000", b)
+func BenchmarkParseGitpodEnvironN8(b *testing.B) {
+	benchmarkParseGitpodEnviron("NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000NOT_ME\000", b)
 }
 
 func TestParseStat(t *testing.T) {


### PR DESCRIPTION
## Description

Make `GitPod` `Gitpod` again!

These should be the last incorrectly-spelled Gitpods in the repo. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```