### PR TITLE
Make Gitpod SLSA Level 1 compliant by providing in-toto provenance

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -56,7 +56,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-dev-tools.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,6 +7,10 @@ defaultArgs:
   localAppVersion: unknown
   codeCommit: 6fa6863137230f9daf7ef10c2f379cb2ec21fcb2
 
+provenance:
+  enabled: true
+  slsa: true
+
 defaultVariant:
   srcs:
     exclude:

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -79,6 +79,8 @@ packages:
         - ["yarn", "--cwd", "mig/node_modules/@gitpod/gitpod-db", "run", "migrate-migrations"]
         # Run actual migrations
         - ["yarn", "--cwd", "mig/node_modules/@gitpod/gitpod-db", "typeorm", "migrations:run"]
+        # Clean out package to not bload the build artifact
+        - ["rm", "-rf", "mig"]
   - name: docker
     type: docker
     srcs:

--- a/components/leeway.Dockerfile
+++ b/components/leeway.Dockerfile
@@ -3,4 +3,4 @@
 # See License-AGPL.txt in the project root for license information.
 
 FROM alpine:3.15
-COPY components--all-docker/versions.yaml /
+COPY components--all-docker/versions.yaml components--all-docker/provenance-bundle.jsonl /

--- a/components/supervisor/openssh/BUILD.yaml
+++ b/components/supervisor/openssh/BUILD.yaml
@@ -5,7 +5,7 @@ packages:
       - :docker-build
     config:
       commands:
-        - ["sh", "-c", "find . | grep layer.tar | xargs tar xfv"]
+        - ["sh", "-c", "find . | grep layer.tar | while read f; do tar xfv $f; done"]
         - ["rm", "-rf", "components-supervisor-openssh--docker-build"]
   - name: docker-build
     type: docker

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -55,8 +55,8 @@ RUN cd /usr/local && curl -fsSL https://install.goreleaser.com/github.com/golang
 RUN cd /usr/bin && curl -L https://github.com/praetorian-inc/gokart/releases/download/v0.3.0/gokart_0.3.0_linux_x86_64.tar.gz | tar xzv gokart
 
 # leeway
-ENV LEEWAY_NESTED_WORKSPACE=true
-RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.9/leeway_0.2.9_Linux_x86_64.tar.gz | tar xz
+ENV LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE=8388608
+RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.16/leeway_0.2.16_Linux_x86_64.tar.gz | tar xz
 
 # dazzle
 RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.4/dazzle_0.1.4_Darwin_x86_64.tar.gz| tar xz

--- a/installer/leeway.Dockerfile
+++ b/installer/leeway.Dockerfile
@@ -3,6 +3,6 @@
 # See License-AGPL.txt in the project root for license information.
 
 FROM alpine:3.15
-COPY installer--app/installer /app/installer
+COPY installer--app/installer installer--app/provenance-bundle.jsonl /app/
 ENTRYPOINT [ "/app/installer" ]
 CMD [ "help" ]


### PR DESCRIPTION
## Description
This PR updates leeway to the [latest release](https://github.com/gitpod-io/leeway/releases/tag/v0.2.16) which supports generating [SLSA provenance](https://slsa.dev/) as part of the build. With this [change](https://github.com/gitpod-io/leeway/compare/1d0912e3ab05a3bfd44c347197d51e00d5d17ca4...main), for every subsequent build, we find out what went into this build. In the future, with the addition of signatures (already supported by leeway), we can find out if the build - or the leeway cache - has been tampered with.

Use-cases for this change:
- leeway relies heavily on caching, and prior to this change modifications of the cache were undetectable. This change makes the entire chain traceable.
- when we deploy code to production, or release new self-hosted versions, we want to make sure we're actually shipping what we believe we're shipping. With this change we can make assertions against the collected provenance to ensure that e.g. all code was built from a clean working copy (i.e. actually came out of the Git repo). In benign cases someone accidentally modified the build cache or pushed an image under a false tag.
- we've had instances in the past where we did not fully trust the build cache or did not understand where a build was coming from. Although those cases have become exceedingly rare now that leeway has become much more stable, we might still see those kind of issues.
- once this PR is merged, imho Gitpod is [SALSA level 1](https://slsa.dev/spec/v0.1/levels) compliant, which is something more and more organisations care about.

<a href="https://www.loom.com/share/200a7a5a7ace4be6a23c592777da91e5">
    <p>See below's Loom video for more detail.</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/200a7a5a7ace4be6a23c592777da91e5-with-play.gif">
  </a>

### Caveats
- our CI builds do not run from a clean working copy, but have e.g. `.gradle/` or `go/` directories. leeway has a fallback mode where if the working copy is dirty, it collects the [materials](https://slsa.dev/provenance/v0.1) from the package sources directly. We want to get to a state where build from a clean working copy, to ensure that we're truly building directly from Git.
- we're not signing the provenance just yet, and it's not quite clear how to do that in a way that makes sense. We'd need to make the private key available during the CI builds which all but places it in the open. I'm wondering how other organisations handle this.
- this is super early days, and closer to a PoC than to production ready code. There aren't a whole lot of tools out there that produce SLSA provenance, neither are there too many consumers just yet.
- we don't have a good way to distribute the provenance ([attestation bundles](https://github.com/in-toto/attestation/blob/main/spec/bundle.md)) we produce. All cached leeway build artefacts carry their attestation bundle, but that's not really accessible. We also place the bundle in the version and installer Docker images that come out of the build.

## How to test
Best way is to inspect the provenance generated for the build:
```YAML
# get the provenance of a build from the version image
docker run --rm -it eu.gcr.io/gitpod-core-dev/build/versions:cw-bump-leeway.30 cat /provenance-bundle.jsonl > prov.jsonl

# decode the envelope payloads
cat prov.json | jq -r .payload | base64 -d > prov-decode.jsonl

# ensure that everything was built using leeway (requires a [recent leeway version](https://github.com/gitpod-io/leeway/releases/tag/v0.2.16))
leeway provenance assert --built-with-leeway file://prov.jsonl

# ensure that everything was built directly from Git (will fail)
leeway provenance assert --git-only file://prov.jsonl
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Provide SLSA/in-toto provenance for the build
```
