### PR TITLE
Restore page bottom margin

### DIFF
--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -40,7 +40,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                     })}
                 </ul>
             </div>
-            <div className='ml-32 w-full pt-1'>
+            <div className='ml-32 w-full pt-1 mb-40'>
                 {p.children}
             </div>
         </div>

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -167,7 +167,7 @@ export default function () {
                         </div>
                         <button onClick={showStartWSModal} className="ml-2">New Workspace</button>
                     </div>
-                    <ItemsList className="app-container">
+                    <ItemsList className="app-container pb-40">
                         <div className="border-t border-gray-200 dark:border-gray-800"></div>
                         {
                             teamsWorkspaceModel?.initialized && <ActiveTeamWorkspaces teams={teams} teamProjects={teamsProjects} teamWorkspaces={teamsActiveWorkspaces} />


### PR DESCRIPTION
## Description

Following the changes in https://github.com/gitpod-io/gitpod/pull/7065, this will :a: revert the change from https://github.com/gitpod-io/gitpod/pull/4417 and :b: add some extra margin at the bottom of each page provides better UX when navigating long lists or large sections that reach the bottom of the viewport when scrolling to the end of the lists or sections.

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/4634

### Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2021-12-30 at 12 00 02 AM (2)" src="https://user-images.githubusercontent.com/120486/147708499-f583f841-f209-4a29-ae85-af1018070310.png"> | <img width="1440" alt="Screenshot 2021-12-30 at 12 01 15 AM (2)" src="https://user-images.githubusercontent.com/120486/147708501-55a1664e-667b-4dbe-a380-8f54c90b9c13.png"> |
| <img width="1440" alt="Screenshot 2021-12-29 at 11 59 52 PM (2)" src="https://user-images.githubusercontent.com/120486/147708509-dd01bfc2-63e8-40f1-b3ab-1d914852ad79.png"> | <img width="1440" alt="Screenshot 2021-12-30 at 12 34 29 AM (2)" src="https://user-images.githubusercontent.com/120486/147708512-49984d3c-c7a1-48f8-bd0b-91db38e75b63.png"> |

## How to test

Try opening a few workspaces so that that list of worksspaces reaches the bottom of the viewport or going to user preferences on a viewport with a small height. Then, scroll down to the bottom of the page. Notice how this PR introduces some extra white space at the bottom of the page and lists or sections do not seem attached to the bottom of the viewport. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Restore page bottom margin
```