### PR TITLE
[server] use owner and repo name for workspace id

### DIFF
--- a/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
@@ -27,5 +27,19 @@ const expect = chai.expect
         expect(longestName.length <= 36, `"${longestName}" is longer than 36 chars (${longestName.length})`).to.be.true;
     }
 
+    @test public async testCustomName() {
+        const data = [
+            ['foo','bar','foo-bar-'],
+            ['f','bar','.{2,16}-bar-'],
+            ['gitpod-io','gitpod','gitpodio-gitpod-'],
+            ['this is rather long and has some "§$"% special chars','bar','thisisratherlong-bar-'],
+        ]
+        for (const d of data) {
+            const id = await generateWorkspaceID(d[0], d[1]);
+            expect(id).match(new RegExp("^"+d[2]));
+            expect(new GitpodHostUrl().withWorkspacePrefix(id, "eu").workspaceId).to.equal(id);
+        }
+    }
+
 }
 module.exports = new TestGenerateWorkspaceId()

--- a/components/gitpod-protocol/src/util/generate-workspace-id.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.ts
@@ -5,8 +5,25 @@
  */
 import randomNumber = require("random-number-csprng");
 
-export async function generateWorkspaceID(): Promise<string> {
-    return (await random(colors))+'-'+(await random(animals))+'-'+(await random(characters, 8));
+export async function generateWorkspaceID(firstSegment?: string, secondSegment?: string): Promise<string> {
+    const firstSeg = clean(firstSegment) || await random(colors);
+    const secSeg = clean(secondSegment) || await random(animals);
+    return firstSeg+'-'+secSeg+'-'+(await random(characters, 8));
+}
+
+function clean(segment?: string) {
+  if (segment) {
+    let result = '';
+    for (let i =0; i < segment.length; i++) {
+      if (characters.indexOf(segment[i]) !== -1) {
+        result += segment[i];
+      }
+    }
+    if (result.length >= 2) {
+      return result.substring(0, 16);
+    }
+  }
+  return undefined;
 }
 
 async function random(array: string[], length: number = 1): Promise<string> {

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -12,13 +12,13 @@ export interface UrlChange {
 }
 export type UrlUpdate = UrlChange | Partial<URL>;
 
-const basewoWkspaceIDRegex = "(([a-f][0-9a-f]{7}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|([0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8}))";
+const baseWorkspaceIDRegex = "(([a-f][0-9a-f]{7}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|([0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8}))";
 
 // this pattern matches v4 UUIDs as well as the new generated workspace ids (e.g. pink-panda-ns35kd21)
-const workspaceIDRegex = RegExp(`^${basewoWkspaceIDRegex}$`);
+const workspaceIDRegex = RegExp(`^${baseWorkspaceIDRegex}$`);
 
 // this pattern matches URL prefixes of workspaces
-const workspaceUrlPrefixRegex = RegExp(`^([0-9]{4,6}-)?${basewoWkspaceIDRegex}\\.`);
+const workspaceUrlPrefixRegex = RegExp(`^([0-9]{4,6}-)?${baseWorkspaceIDRegex}\\.`);
 
 export class GitpodHostUrl {
     readonly url: URL;

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -14,7 +14,6 @@ import { LicenseEvaluator } from '@gitpod/licensor/lib';
 import { Feature } from '@gitpod/licensor/lib/api';
 import { ResponseError } from 'vscode-jsonrpc';
 import { ErrorCodes } from '@gitpod/gitpod-protocol/lib/messaging/error';
-import { generateWorkspaceID } from '@gitpod/gitpod-protocol/lib/util/generate-workspace-id';
 import { HostContextProvider } from '../../../src/auth/host-context-provider';
 import { RepoURL } from '../../../src/repohost';
 
@@ -220,7 +219,7 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                 }
             }
 
-            const id = await generateWorkspaceID();
+            const id = await this.generateWorkspaceID(context);
             const newWs: Workspace = {
                 id,
                 type: "regular",


### PR DESCRIPTION
This change introduces optional arguments in `generateWorkspaceId`
for the first two segments. And makes use of it in workspace factory
using the repos org/group and name.

fixes https://github.com/gitpod-io/gitpod/issues/4129

### Testing

Start a workspace on GitHub and GitLab repos (try with nested groups on GitLab) and find the repo names and orgs reflected in the workspace id.

## Release Notes
```release-note
Use repository org and name for workspace ids.
```