### PR TITLE
[werft] delete migrations job before apply k8s resource

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -545,6 +545,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
 
     werft.log(installerSlices.APPLY_INSTALL_MANIFESTS, "Installing preview environment.");
     try {
+        exec(`kubectl delete -n ${deploymentConfig.namespace} job migrations | true`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
         // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
         exec(`kubectl apply -f k8s.yaml`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
         werft.done(installerSlices.APPLY_INSTALL_MANIFESTS);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Current preview env is using kubernetes v1.20, `TTLAfterFinished` feature gate is not enable by default

https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
This PR add delete migrations job before apply k8s resource to fixes this problem
![image](https://user-images.githubusercontent.com/8299500/147802355-d168431d-c1d2-4499-b5dd-5931913795c4.png)

another option is upgrade preview environment kubernetes version to v1.21 or above

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7402

## How to test
<!-- Provide steps to test this PR -->
rerun `werft run` and watch `migrations` job's create time

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
