### PR TITLE
[werft] Consider migrations delete successful

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -545,7 +545,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
 
     werft.log(installerSlices.APPLY_INSTALL_MANIFESTS, "Installing preview environment.");
     try {
-        exec(`kubectl delete -n ${deploymentConfig.namespace} job migrations | true`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
+        exec(`kubectl delete -n ${deploymentConfig.namespace} job migrations || true`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
         // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
         exec(`kubectl apply -f k8s.yaml`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
         werft.done(installerSlices.APPLY_INSTALL_MANIFESTS);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Werft build jobs fail if the migrations job doesn't exist because we used pipe instead of an OR in #7403 

[Werft build jobs](https://werft.gitpod-dev.com/job/gitpod-build-main.2098) can fail with `Error from server (NotFound): error when deleting "STDIN": jobs.batch "migrations" not found`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->
[Builds for main must pass when the migrations job is not present and cannot be deleted](https://werft.gitpod-dev.com/job/gitpod-build-main.2098)
or
1. Create a new branch and push code to it, that'll create your preview environment
2. Wait till the mirgations job has run and been removed, or delete it
3. Do a `/werft run` for your environment, it should not fail when trying to delete the migrations job when the job doesn't exist

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```