### PR TITLE
add --ignore-not-found=true for wipe dev cluster

### DIFF
--- a/.werft/util/uninstall-gitpod.sh
+++ b/.werft/util/uninstall-gitpod.sh
@@ -10,7 +10,7 @@ if [[ -z ${NAMESPACE} ]]; then
 fi
 
 echo "Removing Gitpod in namespace ${NAMESPACE}"
-kubectl get configmap gitpod-app -n "${NAMESPACE}" -o jsonpath='{.data.app\.yaml}' | kubectl delete -f -
+kubectl get configmap gitpod-app -n "${NAMESPACE}" -o jsonpath='{.data.app\.yaml}' | kubectl delete --ignore-not-found=true -f -
 
 echo "Removing Gitpod storage from ${NAMESPACE}"
 kubectl -n "${NAMESPACE}" delete pvc data-mysql-0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
fixes `Error from server (NotFound): error when deleting "STDIN": jobs.batch "migrations" not found` in preview env
![image](https://user-images.githubusercontent.com/8299500/147920879-42d8e3cb-3fe2-4d6c-bd1d-0b7d514b94b2.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
run with  /werft run with-clean-slate-deployment

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
