### PR TITLE
[server] dispose pingpong timer when ws is closing/closed

### DIFF
--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -24,7 +24,7 @@ export const pingPong: WsRequestHandler = (ws, req, next) => {
         if (ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
             danglingTimeoutCounter++;
             log.warn("websocket ping-pong: dangling timer!", { readyState: ws.readyState, counter: danglingTimeoutCounter, globalPingPongCounter });
-            // disposable.dispose(); if this happens very often we should uncomment this line!
+            disposable.dispose();
             return;
         }
         danglingTimeoutCounter = 0;


### PR DESCRIPTION
## Description
We're  apparently leaking the ping-pong timer. This could be the major source of the server event-loop lg.

## Related Issue(s)
Fixes #7082

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
