### PR TITLE
Update VM image

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -25,7 +25,7 @@ kind: VirtualMachine
 metadata:
   namespace: ${namespace}
   annotations:
-    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"${claimName}","annotations":{"harvesterhci.io/imageId":"default/image-cjlm2"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"longhorn-image-cjlm2"}}]'
+    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"${claimName}","annotations":{"harvesterhci.io/imageId":"default/image-4vm9w"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"50Gi"}},"volumeMode":"Block","storageClassName":"longhorn-image-4vm9w"}}]'
     network.harvesterhci.io/ips: "[]"
   labels:
     harvesterhci.io/creator: harvester
@@ -57,7 +57,7 @@ spec:
             - name: system
               bootOrder: 1
               disk:
-                bus: virtio
+                bus: scsi
             - name: cloudinitdisk
               disk:
                 bus: virtio


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a single commit to the `mads/harvester-k3s` branch (See related PR: https://github.com/gitpod-io/gitpod/pull/7272)

It updates the VM image, while changing the VM disk size and type.

We can see that the VM was started from the preview environment, and it has a functional VNC and serial console 🙂 
https://harvester.gitpod-dev.com/dashboard/c/local/harvester/kubevirt.io.virtualmachine/preview-as-preview-k3s-img/as-preview-k3s-img#basics

```release-note
NONE
```