### PR TITLE
Rename editor preference section heading

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -112,7 +112,7 @@ export default function Preferences() {
     return <div>
         <PageWithSubMenu subMenu={settingsMenu} title='Preferences' subtitle='Configure user preferences.'>
             {ideOptions && browserIdeOptions && <>
-                <h3>Default IDE</h3>
+                <h3>Editor</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Choose which IDE you want to use.</p>
                 <div className="my-4 space-x-4 flex">
                     {

--- a/components/dashboard/src/whatsnew/WhatsNew-2021-04.tsx
+++ b/components/dashboard/src/whatsnew/WhatsNew-2021-04.tsx
@@ -10,7 +10,7 @@ import { WhatsNewEntry } from "./WhatsNew";
 
 export const switchToVSCodeAction = async (user: User) => {
     const additionalData = user.additionalData = user.additionalData || {};
-    // make sure code is set as the default IDE
+    // make sure code is set as the editor preference
     const ideSettings = additionalData.ideSettings = additionalData.ideSettings || {};
     ideSettings.defaultIde = 'code';
     user = await getGitpodService().server.updateLoggedInUser({

--- a/components/server/src/ide-config.ts
+++ b/components/server/src/ide-config.ts
@@ -131,16 +131,16 @@ export class IDEConfigService {
                 }
 
                 if (!(newValue.ideOptions.defaultIde in newValue.ideOptions.options)) {
-                    throw new Error(`invalid: There is no IDEOption entry for default IDE '${newValue.ideOptions.defaultIde}'.`);
+                    throw new Error(`invalid: There is no IDEOption entry for editor '${newValue.ideOptions.defaultIde}'.`);
                 }
                 if (!(newValue.ideOptions.defaultDesktopIde in newValue.ideOptions.options)) {
                     throw new Error(`invalid: There is no IDEOption entry for default desktop IDE '${newValue.ideOptions.defaultDesktopIde}'.`);
                 }
                 if (newValue.ideOptions.options[newValue.ideOptions.defaultIde].type != "browser") {
-                    throw new Error(`invalid: Default IDE '${newValue.ideOptions.defaultIde}' needs to be of type 'browser' but is '${newValue.ideOptions.options[newValue.ideOptions.defaultIde].type}'.`);
+                    throw new Error(`invalid: Editor '${newValue.ideOptions.defaultIde}' needs to be of type 'browser' but is '${newValue.ideOptions.options[newValue.ideOptions.defaultIde].type}'.`);
                 }
                 if (newValue.ideOptions.options[newValue.ideOptions.defaultDesktopIde].type != "desktop") {
-                    throw new Error(`invalid: Default desktop IDE '${newValue.ideOptions.defaultDesktopIde}' needs to be of type 'desktop' but is '${newValue.ideOptions.options[newValue.ideOptions.defaultIde].type}'.`);
+                    throw new Error(`invalid: Editor (desktop), '${newValue.ideOptions.defaultDesktopIde}' needs to be of type 'desktop' but is '${newValue.ideOptions.options[newValue.ideOptions.defaultIde].type}'.`);
                 }
 
                 value = newValue;

--- a/installer/pkg/components/server/ide/configmap.go
+++ b/installer/pkg/components/server/ide/configmap.go
@@ -97,7 +97,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	if idecfg.IDEOptions.Options[idecfg.IDEOptions.DefaultIDE].Type != typeBrowser {
-		return nil, fmt.Errorf("default IDE '%s' does not point to a browser IDE option", idecfg.IDEOptions.DefaultIDE)
+		return nil, fmt.Errorf("editor '%s' does not point to a browser IDE option", idecfg.IDEOptions.DefaultIDE)
 	}
 
 	if idecfg.IDEOptions.Options[idecfg.IDEOptions.DefaultDesktopIDE].Type != typeDesktop {


### PR DESCRIPTION
## Description

This will update the IDE (Editor) preference section heading from _Default IDE_ to _Editor_.

This can probably be further improved in https://github.com/gitpod-io/gitpod/issues/6602.

See [relevant discussion](https://gitpod.slack.com/archives/C01KGM9BH54/p1641237326485600) (internal).

## How to test

Go to [`/preferences`](https://gitpod.io/preferences).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Rename editor preference section heading
```