### PR TITLE
[server] Switch to per-server heartbeating for websockets

### DIFF
--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -71,13 +71,13 @@ export namespace TraceContext {
         addNestedTags(ctx, tags);
     }
 
-    export function setJsonRPCError(ctx: TraceContext, method: string, err: ResponseError<any>) {
+    export function setJsonRPCError(ctx: TraceContext, method: string, err: ResponseError<any>, withStatusCode: boolean = false) {
         if (!ctx.span) {
             return;
         }
         // not use setError bc this is (most likely) a working operation
 
-        setJsonRPCMetadata(ctx);
+        setJsonRPCMetadata(ctx, method);
         // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md#json-rpc
         addNestedTags(ctx, {
             rpc: {
@@ -87,6 +87,11 @@ export namespace TraceContext {
                 },
             },
         });
+
+        // the field "status_code" is used by honeycomb to derive insights like success rate, etc. Defaults to "0".
+        if (withStatusCode) {
+            ctx.span.setTag("status_code", err.code);
+        }
     }
 
     export function addJsonRPCParameters(ctx: TraceContext, params: { [key: string]: any }) {

--- a/components/server/src/express/ws-handler.ts
+++ b/components/server/src/express/ws-handler.ts
@@ -82,7 +82,7 @@ export class WsExpressHandler {
         });
     }
 
-    protected matches(route: Route, pathname: string | undefined | null): boolean {
+    protected matches(route: Route, pathname: string | undefined | null): boolean {
         if (route instanceof RegExp) {
             return !!pathname && route.test(pathname);
         }

--- a/components/server/src/express/ws-ping-pong-handler.ts
+++ b/components/server/src/express/ws-ping-pong-handler.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+ import * as express from 'express';
+ import * as websocket from 'ws';
+import { Disposable, DisposableCollection } from "@gitpod/gitpod-protocol";
+import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
+import { WsNextFunction, WsRequestHandler } from './ws-handler';
+
+/**
+ * This class provides a websocket handler that manages ping-pong behavior for all incoming websocket requests.
+ * Clients that to not respond in time are terminated.
+ */
+export class WsPingPongHandler implements Disposable {
+
+    protected readonly disposables: DisposableCollection = new DisposableCollection();
+    protected readonly clients: Set<websocket> = new Set();
+
+    start(): void {
+        // implement heartbeating closely following https://www.npmjs.com/package/ws#how-to-detect-and-close-broken-connections
+        const INTERVAL = 30000;
+        const TIMEOUT = INTERVAL;
+        const CLOSING_TIMEOUT = INTERVAL;
+        const timer = repeat(async () => {
+            this.clients.forEach((ws) => {
+                try {
+                    switch (ws.readyState) {
+                        case websocket.CLOSED:
+                            // ws should not be in the clients list anymore
+                            log.warn("websocket in strange state", { readyState: ws.readyState });
+                            return
+                        case websocket.CONNECTING:
+                            // ws should not be in the clients list, yet
+                            log.warn("websocket in strange state", { readyState: ws.readyState });
+                            return;
+                        case websocket.CLOSING:
+                            const closingTimestamp = getOrSetClosingTimestamp(ws);
+                            if (closingTimestamp + CLOSING_TIMEOUT <= Date.now()) {
+                                log.warn("websocket in CLOSING state for too long, terminating.");
+                                ws.terminate();
+                                return;
+                            }
+                            log.warn("websocket in CLOSING state, giving it a last chance...");
+                            return;
+                    }
+
+                    const heartbeat = getHeartbeat(ws);
+                    if (!heartbeat) {
+                        log.warn("websocket without heartbeat!");
+                        return;
+                    }
+
+                    if (heartbeat + TIMEOUT <= Date.now()) {
+                        ws.terminate();
+                        return;
+                    }
+                    ws.ping();
+                } catch (err) {
+                    log.error("websocket ping-pong error", err);
+                }
+            });
+        }, INTERVAL);
+        this.disposables.push(timer);
+    }
+
+    handler(): WsRequestHandler {
+        return (ws: websocket, req: express.Request, next: WsNextFunction) => {
+            // maintain set of clients
+            this.clients.add(ws);
+            ws.on('close', () => this.clients.delete(ws));
+
+            // setup heartbeating
+            setHeartbeat(ws);   // first "artificial" heartbeat
+            ws.on('pong', () => {
+                setHeartbeat(ws, Date.now());
+            });
+            ws.on('ping', (data: any) => {
+                // answer browser-side ping to conform RFC6455 (https://tools.ietf.org/html/rfc6455#section-5.5.2)
+                ws.pong(data);
+            });
+
+            next();
+        };
+    }
+
+    dispose(): void {
+        this.disposables.dispose();
+    }
+}
+
+function setHeartbeat(ws: websocket, timestamp: number = Date.now()) {
+    (ws as any).lastHeartbeat = timestamp;
+}
+
+function getHeartbeat(ws: websocket): number | undefined {
+    return (ws as any).lastHeartbeat;
+}
+
+function getOrSetClosingTimestamp(ws: websocket, timestamp: number = Date.now()): number {
+    return (ws as any).closingTimestamp = (ws as any).closingTimestamp || timestamp;
+}

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -204,6 +204,12 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
             }, handleError, wsPingPongHandler.handler(), (ws: ws, req: express.Request) => {
                 websocketConnectionHandler.onConnection((req as any).wsConnection, req);
             });
+            wsHandler.ws(/.*/, (ws, request) => {
+                // fallthrough case
+                // note: this is suboptimal as we upgrade and than terminate the request. But we're not sure this is a problem at all, so we start out with this
+                log.warn("websocket path not matching", { path: request.path })
+                ws.terminate();
+            });
 
             // start ws heartbeat/ping-pong
             wsPingPongHandler.start();

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -17,7 +17,7 @@ import { UserController } from './user/user-controller';
 import { EventEmitter } from 'events';
 import { toIWebSocket } from '@gitpod/gitpod-protocol/lib/messaging/node/connection';
 import { WsExpressHandler, WsRequestHandler } from './express/ws-handler';
-import { pingPong, handleError, isAllowedWebsocketDomain, bottomErrorHandler, unhandledToError } from './express-util';
+import { handleError, isAllowedWebsocketDomain, bottomErrorHandler, unhandledToError } from './express-util';
 import { createWebSocketConnection } from 'vscode-ws-jsonrpc/lib';
 import { MessageBusIntegration } from './workspace/messagebus-integration';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
@@ -43,6 +43,7 @@ import { NewsletterSubscriptionController } from './user/newsletter-subscription
 import { Config } from './config';
 import { DebugApp } from './debug-app';
 import { LocalMessageBroker } from './messaging/local-message-broker';
+import { WsPingPongHandler } from './express/ws-ping-pong-handler';
 
 @injectable()
 export class Server<C extends GitpodClient, S extends GitpodServer> {
@@ -189,19 +190,24 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
                 }
             );
 
+            const wsPingPongHandler = new WsPingPongHandler();
             const wsHandler = new WsExpressHandler(httpServer, verifyClient);
             wsHandler.ws(websocketConnectionHandler.path, (ws, request) => {
                 const websocket = toIWebSocket(ws);
                 (request as any).wsConnection = createWebSocketConnection(websocket, console);
-            }, handleSession, ...initSessionHandlers, handleError, pingPong, (ws: ws, req: express.Request) => {
+            }, handleSession, ...initSessionHandlers, handleError, wsPingPongHandler.handler(), (ws: ws, req: express.Request) => {
                 websocketConnectionHandler.onConnection((req as any).wsConnection, req);
             });
             wsHandler.ws("/v1", (ws, request) => {
                 const websocket = toIWebSocket(ws);
                 (request as any).wsConnection = createWebSocketConnection(websocket, console);
-            }, handleError, pingPong, (ws: ws, req: express.Request) => {
+            }, handleError, wsPingPongHandler.handler(), (ws: ws, req: express.Request) => {
                 websocketConnectionHandler.onConnection((req as any).wsConnection, req);
             });
+
+            // start ws heartbeat/ping-pong
+            wsPingPongHandler.start();
+            this.disposables.push(wsPingPongHandler);
         })
 
         // register routers

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -346,7 +346,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
 
                 const err = new ResponseError(500, "internal server error");
                 increaseApiCallCounter(method, err.code);
-                TraceContext.setJsonRPCError(ctx, method, err);
+                TraceContext.setJsonRPCError(ctx, method, err, true);
 
                 log.error({ userId }, `Request ${method} failed with internal server error`, e, { method, args });
             }


### PR DESCRIPTION
## Description
This PR attempts to rule-out websocket ping-pong timeouts as the root cause for accumulating event-loop lag (#7082). It contains three changes:
 - replace the per-websocket ping-pong timer/mechanism with a global timer + list of active websockets ([link](https://github.com/gitpod-io/gitpod/pull/7442/files#diff-35d07906ffc4e8fa6ead8b22b1083d93f4952dd5f1feb4607cf72a81a60c722bR18-R93))
 - ensure that websockets are not danling in state `CLOSING` ([link](https://github.com/gitpod-io/gitpod/pull/7442/files#diff-35d07906ffc4e8fa6ead8b22b1083d93f4952dd5f1feb4607cf72a81a60c722bR40-R48))
 - add a catch-all-route for websocket connections that `.terminate()` all incoming websockets on different routes ([link](https://github.com/gitpod-io/gitpod/pull/7442/files#diff-bd6f821f67d3f4ea170ed2d0e38f54fd9094bf17aaaa5cbdba1dd8179adbaa35R207-R212))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7082

## How to test
- go to the preview env: https://gpl-7082-ws-terminate.staging.gitpod-dev.com/workspaces
- open dev tools, and observe the websocket messages while interacting with the dashboard
- note how the ping-pong messages happen every 30s

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
