### PR TITLE
Launch k3s on VM on Harvester

### DIFF
--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -22,6 +22,7 @@ EOF
  */
 export function startVM(options: { name: string }) {
     const namespace = `preview-${options.name}`
+    const userDataSecretName = `userdata-${options.name}`
 
     kubectlApplyManifest(
         Manifests.NamespaceManifest({
@@ -30,10 +31,19 @@ export function startVM(options: { name: string }) {
     )
 
     kubectlApplyManifest(
+        Manifests.UserDataSecretManifest({
+            vmName: options.name,
+            namespace,
+            secretName: userDataSecretName,
+        })
+    )
+
+    kubectlApplyManifest(
         Manifests.VirtualMachineManifest({
             namespace,
             vmName: options.name,
-            claimName: `${options.name}-${Date.now()}`
+            claimName: `${options.name}-${Date.now()}`,
+            userDataSecretName
         }),
         { validate: false }
     )


### PR DESCRIPTION
## Description
Launch k3s in VM on Harvester.

## Related Issue(s)
Fixes #

## How to test
1. Run build with `with-vm` annotation:
```
werft run github -a with-vm=true
```

2. Log into the VM and confirm that k3s is running:
```
# Grab the Harvester kubeconfig
kubectl -n werft get secret harvester-kubeconfig -o jsonpath='{.data}' | jq -r '.["harvester-kubeconfig.yml"]' | base64 -d > harvester-kubeconfig.yml
kubectl -n werft get secret harvester-vm-ssh-keys -o jsonpath='{.data}' | jq -r '.["id_rsa"]' | base64 -d > /home/gitpod/.ssh/id_rsa
kubectl -n werft get secret harvester-vm-ssh-keys -o jsonpath='{.data}' | jq -r '.["id_rsa.pub"]' | base64 -d > /home/gitpod/.ssh/id_rsa.pub

chmod 600 /home/gitpod/.ssh/id_rsa
chmod 644 /home/gitpod/.ssh/id_rsa.pub

# Workspace: Start SSH proxy
sudo kubectl \
	--kubeconfig=harvester-kubeconfig.yml \
	-n preview-mads-harvester-k3s \
	port-forward service/proxy 22:22

# Workspace: In a new shell SSH to the VM
ssh ubuntu@127.0.0.1
```

3. Run `kubectl get pods -A ` and confirm k3s is running:
```
NAMESPACE      NAME                                       READY   STATUS      RESTARTS   AGE
cert-manager   cert-manager-57d89b9548-fpwfh              1/1     Running     0          22m
cert-manager   cert-manager-cainjector-5bcf77b697-c4vkg   1/1     Running     0          22m
cert-manager   cert-manager-startupapicheck--1-kwctf      0/1     Completed   0          22m
cert-manager   cert-manager-webhook-5f99d6f7c6-cqp8b      1/1     Running     0          22m
kube-system    calico-kube-controllers-6b9fbfff44-4h25f   1/1     Running     0          22m
kube-system    calico-node-dscxx                          1/1     Running     0          22m
kube-system    coredns-85cb69466-hq6df                    1/1     Running     0          22m
kube-system    metrics-server-5479b7cb8d-chtmc            1/1     Running     0          22m
```

This PR is the result of @ArthurSens and me pair-debugging / programming.

There is a known issue that in the Werft job, copying the k3s.yaml into the job fails because the ssh connection can not be established. See https://werft.gitpod-dev.com/job/gitpod-build-me-install-k3s.7/raw for example.  From my Gitpod workspace, I can connect via ssh to the VM without problems. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
