### PR TITLE
werft/VM: Install gitpod on k3s running in Haverster VMs

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -159,7 +159,6 @@ write_files:
           --write-kubeconfig-mode 444 \\
           --disable servicelb \\
           --disable traefik \\
-          --disable local-storage \\
           --disable metrics-server \\
           --flannel-backend=none \\
           --kubelet-arg config=/etc/kubernetes/kubelet-config.json \\

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -151,32 +151,32 @@ write_files:
       # Install k3s
       export INSTALL_K3S_SKIP_DOWNLOAD=true
 
-      /usr/local/bin/install-k3s.sh \
-          --token "1234" \
-          --node-ip "$(hostname -I | cut -d ' ' -f1)" \
-          --node-label "cloud.google.com/gke-nodepool=control-plane-pool" \
-          --container-runtime-endpoint=/var/run/containerd/containerd.sock \
-          --write-kubeconfig-mode 444 \
-          --disable servicelb \
-          --disable traefik \
-          --disable local-storage \
-          --disable metrics-server \
-          --flannel-backend=none \
-          --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
-          --kubelet-arg feature-gates=LocalStorageCapacityIsolation=true \
-          --kubelet-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \
-          --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolation=true \
-          --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \
+      /usr/local/bin/install-k3s.sh \\
+          --token "1234" \\
+          --node-ip "$(hostname -I | cut -d ' ' -f1)" \\
+          --node-label "cloud.google.com/gke-nodepool=control-plane-pool" \\
+          --container-runtime-endpoint=/var/run/containerd/containerd.sock \\
+          --write-kubeconfig-mode 444 \\
+          --disable servicelb \\
+          --disable traefik \\
+          --disable local-storage \\
+          --disable metrics-server \\
+          --flannel-backend=none \\
+          --kubelet-arg config=/etc/kubernetes/kubelet-config.json \\
+          --kubelet-arg feature-gates=LocalStorageCapacityIsolation=true \\
+          --kubelet-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \\
+          --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolation=true \\
+          --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \\
           --cluster-init
 
-      kubectl label nodes ${vmName} \
-          gitpod.io/workload_meta=true \
-          gitpod.io/workload_ide=true \
-          gitpod.io/workload_workspace_services=true \
-          gitpod.io/workload_workspace_regular=true \
-          gitpod.io/workload_workspace_headless=true \
-          gitpod.io/workspace_0=true \
-          gitpod.io/workspace_1=true \
+      kubectl label nodes ${vmName} \\
+          gitpod.io/workload_meta=true \\
+          gitpod.io/workload_ide=true \\
+          gitpod.io/workload_workspace_services=true \\
+          gitpod.io/workload_workspace_regular=true \\
+          gitpod.io/workload_workspace_headless=true \\
+          gitpod.io/workspace_0=true \\
+          gitpod.io/workspace_1=true \\
           gitpod.io/workspace_2=true
 
       kubectl apply -f /var/lib/gitpod/manifests/calico.yaml


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description (Iteration 1)
This PR points to Mo's branch `me/install_k3s` (See related PR: https://github.com/gitpod-io/gitpod/pull/7444).

It only increases the timeout for retrieving the kubeconfig from the VM. I'm doing that because, as mentioned in https://github.com/gitpod-io/gitpod/pull/7444, SSH is failing. The reason for the failure is just because SSH deamon is taking more than 3 minutes to start, running the job again is enough to retrieve the kubeconfig.

I'm opening this as a draft PR because this is still not enough to have gitpod installed in the k3s cluster. I'm now having problems with certificates created by terraform somewhere on our script.

```release-note
NONE
```

## Description (Iteration 2)
I (Moritz) continued the work on this PR. 

increasing the time out for SSH, unfortunately, did not solve the connection issues, thus I have removed the increase again. See https://github.com/gitpod-io/gitpod/issues/7471 for details. 

I enabled k3s' `local-storage` so that persistent volumes work.

I modified the job to download the docker-pull-secret from the core-dev-cluster before we change the kubectl-context to k3s.

## To test
1. run the job via `werft run github -a with-vm=true`
2.run the job again via `werft run github -a with-vm=true`  (workaround from https://github.com/gitpod-io/gitpod/issues/7471)
3. run `kubectl get pods` on the k3s cluster and see that all pods are in state "running".

