### PR TITLE
Move .vscode-remote location to /workspace folder

### DIFF
--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -22,6 +22,7 @@
 
 export SHELL=/bin/bash
 export USER=gitpod
+export VSCODE_AGENT_FOLDER=/workspace/.vscode-remote
 
 # TODO ENVVAR CLEANUP: This stays here until we moved it to a central location, ideally workspace-full
 # (+ compatibility period)


### PR DESCRIPTION
## Description
Moves ` .vscode-remote` folder location from `/home/gitpod` to `/workspace` folder

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/3342 and https://github.com/gitpod-io/openvscode-server/pull/272

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace
2. Check `.vscode-remote` folder is inside `/workspace` folder
3. Install some extensions manually and check they have sync enabled
4. Restart workspace and check the extensions are installed properly

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
