### PR TITLE
Add Harvester to workspace kubeconfig

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,6 +25,10 @@ ports:
 # Dev Theia
   - port: 13444
 tasks:
+  - name: Add Harvester kubeconfig
+    command: |
+      ./dev/preview/download-and-merge-harvester-kubeconfig.sh
+      exit 0
   - name: Java
     init: |
       leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build

--- a/dev/preview/download-and-merge-harvester-kubeconfig.sh
+++ b/dev/preview/download-and-merge-harvester-kubeconfig.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function log {
+    echo "[$(date)] $*"
+}
+
+function has-dev-access {
+    kubectl --context=dev auth can-i get secrets > /dev/null 2>&1 || false
+}
+
+if ! has-dev-access; then
+    log "The workspace isn't configured to have core-dev access. Exiting."
+    exit 0
+fi
+
+KUBECONFIG_PATH="/home/gitpod/.kube/config"
+HARVESTER_KUBECONFIG_PATH="$(mktemp)"
+MERGED_KUBECONFIG_PATH="$(mktemp)"
+
+log "Downloading and preparing Harvester kubeconfig"
+kubectl -n werft get secret harvester-kubeconfig -o jsonpath='{.data}' \
+| jq -r '.["harvester-kubeconfig.yml"]' \
+| base64 -d \
+| sed 's/default/harvester/g' \
+> "${HARVESTER_KUBECONFIG_PATH}"
+
+# Order of files is important, we have the original config first so we preserve
+# the value of current-context
+log "Merging kubeconfig files ${KUBECONFIG_PATH} ${HARVESTER_KUBECONFIG_PATH} into ${MERGED_KUBECONFIG_PATH}"
+KUBECONFIG="${KUBECONFIG_PATH}:${HARVESTER_KUBECONFIG_PATH}" \
+    kubectl config view --flatten --merge > "${MERGED_KUBECONFIG_PATH}"
+
+log "Overwriting ${KUBECONFIG_PATH}"
+mv "${MERGED_KUBECONFIG_PATH}" "${KUBECONFIG_PATH}"
+
+log "Cleaning up temporay Harveter kubeconfig"
+rm "${HARVESTER_KUBECONFIG_PATH}"
+
+log "Done"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This extends our workspace tasks to updates the workspace kubeconfig to also include a context for Harvester. This will give all Gitpod developers easy access to the Harvester clusters through `kubectx`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Fixes https://github.com/gitpod-io/gitpod/issues/7469

## How to test
<!-- Provide steps to test this PR -->

Unfortunately testing this is a bit manual right now due to a bug in our incremental prebuild (see https://github.com/gitpod-io/gitpod/issues/7475). So the best you can do is start a workspace and run the script and verify that kubectx shows harvester as well as dev:

```sh
dev/preview/download-and-merge-harvester-kubeconfig.sh
kubectx
# should show dev and harvester
kubectl get ns 
# should show a bunch of preview-* namespaces
```

I tested the behaviour of the script for users who don't have core-dev access by creating another GitHub user and running the script. I got the following output:

```
gitpod /workspace/gitpod $ ./dev/preview/download-and-merge-harvester-kubeconfig.sh 
[Thu 06 Jan 2022 01:43:54 PM UTC] The workspace isn't configured to have core-dev access. Exiting.
```
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A
