### PR TITLE
Add git command analytics

### DIFF
--- a/components/gitpod-cli/BUILD.yaml
+++ b/components/gitpod-cli/BUILD.yaml
@@ -9,7 +9,20 @@ packages:
       - CGO_ENABLED=0
       - GOOS=linux
     deps:
+      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
+    argdeps:
+      - version
     config:
       packaging: app
+    prep:
+      - ["cp", "_deps/components-gitpod-cli--version/version.txt", "pkg/gitpod/version.txt"]
+  - name: version
+    type: generic
+    argdeps:
+      - version
+    config:
+      commands:
+        - ["sh", "-c", "echo '${version}' > version.txt"]
+        - ["echo", "Gitpod-CLI Version: ${version}"]

--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -57,6 +57,19 @@ var credentialHelper = &cobra.Command{
 		}()
 
 		repoURL, gitCommand := parseProcessTree()
+
+		// Starts another process which tracks the executed git event
+		gitCommandTracker := exec.Command("/proc/self/exe", "git-track-command", "--gitCommand", gitCommand)
+		err = gitCommandTracker.Start()
+		if err != nil {
+			log.WithError(err).Print("error spawning tracker")
+		} else {
+			err = gitCommandTracker.Process.Release()
+			if err != nil {
+				log.WithError(err).Print("error releasing tracker")
+			}
+		}
+
 		host := parseHostFromStdin()
 		if len(host) == 0 {
 			log.Println("'host' is missing")

--- a/components/gitpod-cli/cmd/git-track-command.go
+++ b/components/gitpod-cli/cmd/git-track-command.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
+)
+
+var gitTrackCommandOpts struct {
+	GitCommand string
+}
+
+var gitTrackCommand = &cobra.Command{
+	Use:    "git-track-command",
+	Short:  "Gitpod's Git command tracker",
+	Long:   "Sending anonymous statistics about the executed git commands inside a workspace",
+	Args:   cobra.ExactArgs(0),
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetOutput(io.Discard)
+		f, err := os.OpenFile(os.TempDir()+"/gitpod-git-credential-helper.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err == nil {
+			defer f.Close()
+			log.SetOutput(f)
+		}
+
+		log.Infof("gp git-track-command")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			fail(err.Error())
+		}
+
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{"function:trackEvent"})
+
+		if err != nil {
+			log.WithError(err).Fatal("error connecting to supervisor")
+		}
+
+		defer client.Close()
+
+		type GitEventParams struct {
+			Command             string `json:"command,omitempty"`
+			WorkspaceId         string `json:"workspaceId,omitempty"`
+			WorkspaceInstanceId string `json:"workspaceInstanceId,omitempty"`
+			Timestamp           int64  `json:"timestamp,omitempty"`
+		}
+
+		params := &GitEventParams{
+			Command:             gitTrackCommandOpts.GitCommand,
+			WorkspaceId:         wsInfo.WorkspaceId,
+			WorkspaceInstanceId: wsInfo.InstanceId,
+			Timestamp:           time.Now().Unix(),
+		}
+		event := &serverapi.RemoteTrackMessage{
+			Event:      "git_command",
+			Properties: *params,
+		}
+		log.WithField("command", gitTrackCommandOpts.GitCommand).
+			Info("tracking the GitCommand event")
+
+		err = client.TrackEvent(ctx, event)
+		if err != nil {
+			log.WithError(err).Fatal("error tracking git event")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(gitTrackCommand)
+	gitTrackCommand.Flags().StringVarP(&gitTrackCommandOpts.GitCommand, "gitCommand", "c", "", "The Git command to be recorded")
+	gitTrackCommand.MarkFlagRequired("gitCommand")
+}

--- a/components/gitpod-cli/cmd/version.go
+++ b/components/gitpod-cli/cmd/version.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	_ "embed"
+	"fmt"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+
+	"github.com/spf13/cobra"
+)
+
+// urlCmd represents the url command
+var versionCmd = &cobra.Command{
+	Use:    "version",
+	Hidden: false,
+	Short:  "Prints the version of the CLI",
+	Args:   cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(gitpod.Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/components/gitpod-cli/pkg/gitpod/server.go
+++ b/components/gitpod-cli/pkg/gitpod/server.go
@@ -6,13 +6,22 @@ package server
 
 import (
 	"context"
+	_ "embed"
 	"os"
+	"strings"
 
 	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+)
+
+var (
+	// Version : current version
+	Version string = strings.TrimSpace(version)
+	//go:embed version.txt
+	version string
 )
 
 func GetWSInfo(ctx context.Context) (*supervisor.WorkspaceInfoResponse, error) {
@@ -50,10 +59,15 @@ func ConnectToServer(ctx context.Context, wsInfo *supervisor.WorkspaceInfoRespon
 	if err != nil {
 		return nil, xerrors.Errorf("failed getting token from supervisor: %w", err)
 	}
+
 	client, err := serverapi.ConnectToServer(wsInfo.GitpodApi.Endpoint, serverapi.ConnectToServerOpts{
 		Token:   clientToken.Token,
 		Context: ctx,
 		Log:     log.NewEntry(log.StandardLogger()),
+		ExtraHeaders: map[string]string{
+			"User-Agent":       "gitpod/cli",
+			"X-Client-Version": Version,
+		},
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("failed connecting to server: %w", err)

--- a/components/gitpod-cli/pkg/gitpod/version.txt
+++ b/components/gitpod-cli/pkg/gitpod/version.txt
@@ -1,0 +1,1 @@
+set-during-build

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -82,6 +82,7 @@ type APIInterface interface {
 	InstallUserPlugins(ctx context.Context, params *InstallPluginsParams) (res bool, err error)
 	UninstallUserPlugin(ctx context.Context, params *UninstallPluginParams) (res bool, err error)
 	GuessGitTokenScopes(ctx context.Context, params *GuessGitTokenScopesParams) (res *GuessedGitTokenScopes, err error)
+	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
 
 	InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error)
 }
@@ -204,6 +205,8 @@ const (
 	FunctionUninstallUserPlugin FunctionName = "uninstallUserPlugin"
 	// FunctionGuessGitTokenScopes is the name of the guessGitTokenScopes function
 	FunctionGuessGitTokenScope FunctionName = "guessGitTokenScopes"
+	// FunctionTrackEvent is the name of the trackEvent function
+	FunctionTrackEvent FunctionName = "trackEvent"
 
 	// FunctionOnInstanceUpdate is the name of the onInstanceUpdate callback function
 	FunctionOnInstanceUpdate = "onInstanceUpdate"
@@ -1457,6 +1460,19 @@ func (gp *APIoverJSONRPC) GuessGitTokenScopes(ctx context.Context, params *Guess
 	return
 }
 
+// TrackEvent calls trackEvent on the server
+func (gp *APIoverJSONRPC) TrackEvent(ctx context.Context, params *RemoteTrackMessage) (err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	var _params []interface{}
+
+	_params = append(_params, params)
+	err = gp.C.Call(ctx, "trackEvent", _params, nil)
+	return
+}
+
 // PermissionName is the name of a permission
 type PermissionName string
 
@@ -2028,6 +2044,11 @@ type GitToken struct {
 type GuessedGitTokenScopes struct {
 	Scopes  []string `json:"scopes,omitempty"`
 	Message string   `json:"message,omitempty"`
+}
+
+type RemoteTrackMessage struct {
+	Event      string      `json:"event,omitempty"`
+	Properties interface{} `json:"properties,omitempty"`
 }
 
 // BrandingLink is the BrandingLink message type

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -540,6 +540,20 @@ func (mr *MockAPIInterfaceMockRecorder) GuessGitTokenScopes(ctx, params interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuessGitTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GuessGitTokenScopes), ctx, params)
 }
 
+// TrackEvent indicates an expected call of TrackEvent.
+func (m *MockAPIInterface) TrackEvent(ctx context.Context, params *RemoteTrackMessage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TrackEvent", ctx, params)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TrackEvent indicates an expected call of TrackEvent.
+func (mr *MockAPIInterfaceMockRecorder) TrackEvent(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuessGitTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).TrackEvent), ctx, params)
+}
+
 // HasPermission mocks base method.
 func (m *MockAPIInterface) HasPermission(ctx context.Context, permission *PermissionName) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description
Adds analytic tracking to git commands requiring the git credential manager (remote-facing commands), such as:
- `git clone` (for private repositories)
- `git fetch` (for private repositories)
- `git pull` (for private repositories)
- `git push` (for all repositories)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6896

## How to test
1. Open a repo in the preview environment: https://track-git-commands.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-python-flask
2. Open [Segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)
3. In the Gitpod workspace, open a terminal and execute a command requiring the cred manager, for instance `git clone https://github.com/filiptronicek/test /tmp/repo`- note that this will error out, but that doesn't matter, it should still register in the debugger
4. View the events in Segment, you should see a `git_command` there somewhere (if none is present, wait a couple of seconds)
4. Profit 💵 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Adds analytic tracking to git commands requiring the git credential manager (remote-facing commands)
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe