### PR TITLE
[db] Remove dropped table d_b_payment_source_info from db-sync

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -180,11 +180,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: '_lastModified'
         },
         {
-            name: 'd_b_payment_source_info',
-            primaryKeys: ['id', 'resourceVersion'],
-            timeColumn: '_lastModified'
-        },
-        {
             name: 'd_b_gitpod_token',
             primaryKeys: ['tokenHash'],
             deletionColumn: 'deleted',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Follow-up to https://github.com/gitpod-io/gitpod/pull/7434. `d_b_payment_source_info` was removed. This change fixes a db-sync warning in prod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
