### PR TITLE
[ws-manager] Improve workspaces PodAffinity

### DIFF
--- a/components/registry-facade/leeway.Dockerfile
+++ b/components/registry-facade/leeway.Dockerfile
@@ -6,7 +6,9 @@ FROM alpine:3.15
 
 # Ensure latest packages are present, like security updates.
 RUN  apk upgrade --no-cache \
-  && apk add --no-cache ca-certificates
+  && apk add --no-cache ca-certificates bash
+
+RUN apk add --no-cache kubectl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 RUN adduser -S -D -H -h /app -u 1000 appuser
 COPY components-registry-facade--app/registry-facade /app/registry-facade

--- a/components/ws-daemon/debug.Dockerfile
+++ b/components/ws-daemon/debug.Dockerfile
@@ -8,6 +8,8 @@ FROM alpine:3.15
 RUN  apk upgrade --no-cache \
   && apk add --no-cache git bash openssh-client lz4 e2fsprogs
 
+RUN apk add --no-cache kubectl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
 # Add gitpod user for operations (e.g. checkout because of the post-checkout hook!)
 # RUN addgroup -g 33333 gitpod \
 #     && adduser -D -h /home/gitpod -s /bin/sh -u 33333 -G gitpod gitpod \

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -15,6 +15,9 @@ RUN apk upgrade \
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
 RUN apk add --no-cache git bash openssh-client lz4 e2fsprogs coreutils tar strace xfsprogs-extra
+
+RUN apk add --no-cache kubectl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
 COPY --from=dl /dl/runc.amd64 /usr/bin/runc
 
 # Add gitpod user for operations (e.g. checkout because of the post-checkout hook!)

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -361,6 +361,14 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 									Key:      "gitpod.io/workload_workspace_" + workloadType,
 									Operator: corev1.NodeSelectorOpExists,
 								},
+								{
+									Key:      "gitpod.io/ws-daemon_ready_ns_" + m.Config.Namespace,
+									Operator: corev1.NodeSelectorOpExists,
+								},
+								{
+									Key:      "gitpod.io/registry-facade_ready_ns_" + m.Config.Namespace,
+									Operator: corev1.NodeSelectorOpExists,
+								},
 							},
 						},
 					},

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -211,6 +211,14 @@
                                         "operator": "Exists"
                                     },
                                     {
+                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
+                                        "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/registry-facade_ready_ns_default",
+                                        "operator": "Exists"
+                                    },
+                                    {
                                         "key": "foobar",
                                         "operator": "Exists"
                                     }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -213,6 +213,14 @@
                                     {
                                         "key": "gitpod.io/workload_workspace_regular",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
+                                        "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/registry-facade_ready_ns_default",
+                                        "operator": "Exists"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -235,6 +235,14 @@
                                     {
                                         "key": "gitpod.io/workload_workspace_headless",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
+                                        "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/registry-facade_ready_ns_default",
+                                        "operator": "Exists"
                                     }
                                 ]
                             }

--- a/installer/pkg/common/constants.go
+++ b/installer/pkg/common/constants.go
@@ -5,8 +5,9 @@
 package common
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // This file exists to break cyclic-dependency errors

--- a/installer/pkg/components/registry-facade/clusterrole.go
+++ b/installer/pkg/components/registry-facade/clusterrole.go
@@ -22,12 +22,18 @@ func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Name:   fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
 				Labels: common.DefaultLabels(Component),
 			},
-			Rules: []rbacv1.PolicyRule{{
-				APIGroups:     []string{"policy"},
-				Resources:     []string{"podsecuritypolicies"},
-				Verbs:         []string{"use"},
-				ResourceNames: []string{fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component)},
-			}},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups:     []string{"policy"},
+					Resources:     []string{"podsecuritypolicies"},
+					Verbs:         []string{"use"},
+					ResourceNames: []string{fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component)},
+				}, {
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"update"},
+				},
+			},
 		},
 	}, nil
 }

--- a/installer/pkg/components/registry-facade/clusterrole.go
+++ b/installer/pkg/components/registry-facade/clusterrole.go
@@ -31,7 +31,7 @@ func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
 				}, {
 					APIGroups: []string{""},
 					Resources: []string{"nodes"},
-					Verbs:     []string{"update"},
+					Verbs:     []string{"get", "patch"},
 				},
 			},
 		},

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -174,6 +174,22 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 							*common.InternalCAVolumeMount(),
 						}, volumeMounts...),
+						Lifecycle: &corev1.Lifecycle{
+							PostStart: &corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: []string{
+										"/bin/bash", "-c", `kubectl label nodes ${NODENAME} gitpod.io/registry-facade_ready_ns_${KUBE_NAMESPACE}=true`,
+									},
+								},
+							},
+							PreStop: &corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: []string{
+										"/bin/bash", "-c", `kubectl label nodes ${NODENAME} gitpod.io/registry-facade_ready_ns_${KUBE_NAMESPACE}-`,
+									},
+								},
+							},
+						},
 					},
 
 						*common.KubeRBACProxyContainer(ctx),

--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -154,6 +154,13 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							[]corev1.EnvVar{{
 								Name:  "GRPC_GO_RETRY",
 								Value: "on",
+							}, {
+								Name: "NODENAME",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "spec.nodeName",
+									},
+								},
 							}},
 						),
 						VolumeMounts: append([]corev1.VolumeMount{{

--- a/installer/pkg/components/registry-facade/rolebinding.go
+++ b/installer/pkg/components/registry-facade/rolebinding.go
@@ -18,12 +18,11 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{
-		&rbacv1.RoleBinding{
-			TypeMeta: common.TypeMetaRoleBinding,
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: common.TypeMetaClusterRoleBinding,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:   Component,
+				Labels: labels,
 			},
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "ClusterRole",
@@ -31,8 +30,9 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 			Subjects: []rbacv1.Subject{{
-				Kind: "ServiceAccount",
-				Name: Component,
+				Kind:      "ServiceAccount",
+				Name:      Component,
+				Namespace: ctx.Namespace,
 			}},
 		},
 		&rbacv1.ClusterRoleBinding{

--- a/installer/pkg/components/ws-daemon/rolebinding.go
+++ b/installer/pkg/components/ws-daemon/rolebinding.go
@@ -37,22 +37,22 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
-		&rbacv1.RoleBinding{
-			TypeMeta: common.TypeMetaRoleBinding,
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: common.TypeMetaClusterRoleBinding,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-rb", Component),
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:   fmt.Sprintf("%s-%s-rb", ctx.Namespace, Component),
+				Labels: labels,
 			},
-			Subjects: []rbacv1.Subject{{
-				Kind: "ServiceAccount",
-				Name: Component,
-			}},
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "ClusterRole",
 				Name:     fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
 				APIGroup: "rbac.authorization.k8s.io",
 			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      Component,
+				Namespace: ctx.Namespace,
+			}},
 		},
 	}, nil
 }


### PR DESCRIPTION
## Description

If `EnforceWorkspaceNodeAffinity` is configured, ensure the workspaces are scheduled in nodes where `ws-daemon` and `registry-facade` are running.

## Release Notes
```release-note
[ws-manager] Improve workspaces PodAffinity
```

## How to test

- scale down ws-scheduler replicas to 0
- change ws-manager configmap and remove `schedulerName`
- restart ws-manager
- start a workspace
- check the workspace contains the affinity
```
nodeSelectorTerms:
- matchExpressions:
  - key: gitpod.io/ws-daemon_ready_ns_<namespace>
    operator: Exists
  - key: gitpod.io/registry-facade_ready_ns_<namespace>
    operator: Exists
``` 

/werft with-clean-slate-deployment