### PR TITLE
Make certs for Gitpod installation on harvester available 

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -336,9 +336,7 @@ export async function build(context, version) {
         //       We might want to keep both kubeconfigs around and be explicit about which one we're using.s
         exec(`mv k3s.yml /home/gitpod/.kube/config`)
 
-        if (!existingVM) {
-            exec(`kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`, { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true })
-        }
+        exec(`kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`, { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true })
     }
 
     werft.phase(phases.PREDEPLOY, "Checking for existing installations...");


### PR DESCRIPTION
## Description
This fixes two issues:
* the issuer and dns-sa for Certmanger were not installed when the VM existed already but did not have them yet. 
* the gitpod installation did not yet get a certificate. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # NONE

## How to test
1. run ` werft run github -a with-vm=true`
2. get a kubectx for k3s
3. confirm that all pods the gitpod installation came up. they only do that if all needed certs are present.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
