### PR TITLE
Fix ws-proxy helm chart syntax error

### DIFF
--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -52,10 +52,10 @@ spec:
         secret:
           secretName: {{ $.Values.certificatesSecret.secretName }}
 {{- end }}
-{{- if $.comp.hostKeySecretName }}
+{{- if $comp.hostKeySecretName }}
       - name: host-key
         secret:
-          secretName: {{ $.comp.hostKeySecretName }}
+          secretName: {{ $comp.hostKeySecretName }}
 {{- end }}
       enableServiceLinks: false
       containers:
@@ -90,7 +90,7 @@ spec:
         - name: config-certificates
           mountPath: "/mnt/certificates"
 {{- end }}
-{{- if $.comp.hostKeySecretName }}
+{{- if $comp.hostKeySecretName }}
         - name: host-key
           mountPath: "/mnt/host-key"
 {{- end }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix ws-proxy helm chart syntax error, after #7412 

![image](https://user-images.githubusercontent.com/8299500/148425826-0fb078ea-dd0b-49fc-9b7d-ef4aaf08c78b.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
