### PR TITLE
.werft/vm: Add readiness probe

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -322,7 +322,7 @@ export async function build(context, version) {
         }
 
         werft.log(vmSlices.BOOT_VM, 'Waiting for VM to be ready')
-        VM.waitForVM({ name: destname, timeoutMS: 1000 * 60 * 3, slice: vmSlices.BOOT_VM })
+        VM.waitForVM({ name: destname, timeoutSeconds: 60 * 10, slice: vmSlices.BOOT_VM })
 
         werft.log(vmSlices.START_KUBECTL_PORT_FORWARDS, 'Starting SSH port forwarding')
         VM.startSSHProxy({ name: destname, slice: vmSlices.START_KUBECTL_PORT_FORWARDS })

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -41,6 +41,14 @@ spec:
       labels:
         harvesterhci.io/vmName: ${vmName}
     spec:
+      readinessProbe:
+        tcpSocket:
+          port: 22
+        initialDelaySeconds: 120
+        periodSeconds: 20
+        timeoutSeconds: 10
+        failureThreshold: 10
+        successThreshold: 10
       domain:
         hostname: ${vmName}
         machine:

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -74,9 +74,11 @@ export function waitForVM(options: { name: string, timeoutSeconds: number, slice
     const werft = getGlobalWerftInstance()
     const namespace = `preview-${options.name}`
 
+    const startTime = Date.now()
     const ready = exec(`kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${namespace} wait --for=condition=ready --timeout=${options.timeoutSeconds}s pod -l kubevirt.io=virt-launcher -l harvesterhci.io/vmName=${options.name}`, { dontCheckRc: true, silent: true })
 
     if (ready.code == 0) {
+        werft.log(options.slice, `VM is ready after ${(Date.now() - startTime) / 1000} seconds`)
         return
     }
 

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -78,6 +78,8 @@ export function waitForVM(options: { name: string, timeoutMS: number, slice: str
 
         const status = exec(`kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name} -o jsonpath="{.status.phase}"`, { silent: true, slice: options.slice }).stdout.trim()
 
+        // This part needs to be changed
+        // We need to check for por readiness instead of just checking if it is running or not
         if (status == "Running") {
             return
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We fail to establish SSH connection because we try and also timeout before the SSH deamons starts to run.

This PR adds a readiness probe that checks the SSH port. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7471

## How to test
<!-- Provide steps to test this PR -->
* Make sure the namespace where de VM is deployed is deleted
* Start a new job
* Keep an eye on the job's log and Harvester UI at the same time
* Notice that we fail the SSH connection before the VM gets ready

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```