### PR TITLE
Update dotfiles input help text design

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -190,7 +190,9 @@ export default function Preferences() {
             <div className="mt-4 max-w-md">
                 <h4>Repository URL</h4>
                 <input type="text" value={dotfileRepo} className="w-full" placeholder="e.g. https://github.com/username/dotfiles" onChange={(e) => setDotfileRepo(e.target.value)} />
-                <p className="text-base text-gray-500 dark:text-gray-400">Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for every new workspace.</p>
+                <div className="mt-1">
+                    <p className="text-gray-500 dark:text-gray-400">Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for every new workspace.</p>
+                </div>
                 <div className="mt-4 max-w-md">
                     <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
                 </div>


### PR DESCRIPTION
## Description

Following the changes in https://github.com/gitpod-io/gitpod/pull/7337, this will update dotfiles input help text design to match the design of other help text instances accross the product.

## How to test
1. Go to [`/preferences`](https://gitpod.io/preferences)
2. Notice how the dotfiles input help text matches the design of other help text instances accross the product. For example, check the help text when adding a new environment variable in [`/variables`](https://gitpod.io/variables).

| BEFORE | AFTER |
|-|-|
| <img width="577" alt="dotfiles-before" src="https://user-images.githubusercontent.com/120486/148469356-156ee5ed-2893-419a-8dfe-07478bed5195.png"> | <img width="577" alt="dotfiles-after" src="https://user-images.githubusercontent.com/120486/148469357-b4175a7a-0925-4fdb-a964-70b794a21ac4.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```