### PR TITLE
Truncate projects with long path

### DIFF
--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -179,7 +179,7 @@ export default function () {
                                     </div>
                                 </div>
                                 <a href={p.cloneUrl.replace(/\.git$/, '')}>
-                                    <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500">{toRemoteURL(p.cloneUrl)}</p>
+                                    <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500 pr-10 truncate">{toRemoteURL(p.cloneUrl)}</p>
                                 </a>
                             </div>
                             <div className="h-10 px-6 py-1 text-gray-400 text-sm">


### PR DESCRIPTION
## Description

This will trucnate project URL when project path is overflowing the project card.

## How to test
1. Add a new project overflowing the project card.

| BEFORE | AFTER | 
|-|-|
| <img width="771" alt="card-before" src="https://user-images.githubusercontent.com/120486/148474830-f56fa5a2-940a-4a75-8b87-dcc2dd046847.png"> | <img width="771" alt="card-after" src="https://user-images.githubusercontent.com/120486/148474833-f1d02179-46f1-4330-90fd-d39da6fe8977.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```