### PR TITLE
.werft/VM: Fixes to improve VM stability

### DIFF
--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -116,7 +116,7 @@ export function copyk3sKubeconfig(options: { path: string, timeoutMS: number, sl
  */
 export function startSSHProxy(options: { name: string, slice: string }) {
     const namespace = `preview-${options.name}`
-    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 22:22`, { async: true, silent: true, slice: options.slice })
+    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 22:22`, { async: true, silent: true, slice: options.slice, dontCheckRc: true })
 }
 
 /**
@@ -124,7 +124,7 @@ export function startSSHProxy(options: { name: string, slice: string }) {
  */
 export function startKubeAPIProxy(options: { name: string, slice: string }) {
     const namespace = `preview-${options.name}`
-    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 6443:6443`, { async: true, silent: true, slice: options.slice })
+    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 6443:6443`, { async: true, silent: true, slice: options.slice, dontCheckRc: true })
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
#### 1
For some unknown reason, the kubectl context is set to `werft` inside out jobs. @meysholdt and I tried to debug but could find any trace of it written in kubeconfig files.

To make sure we don't use this namespace, were explicitly setting the namespace when checking for the rollout of server component.

#### 2

Also, sweeper is not implemented in a way that works for Harvester VMs, so we're skipping its deployment since it runs in the namespace werft, which doesn't exist and causes the job to fail.

#### 3

Logs are still telling us that `kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 6443:6443` fails at the end of the job.

`killall` abruptly kills all kubectl commands running asynchronously inside our job, I've added the `dontCheckRc` option so the job doesn't fail after they get killed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
