### PR TITLE
Remove Theia references from the CLI component

### DIFF
--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -22,7 +21,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
-	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/theialib"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 )
 
@@ -62,27 +60,6 @@ var credentialHelper = &cobra.Command{
 			log.Println("'host' is missing")
 		}
 
-		if isTheiaIDE() {
-			service, err := theialib.NewServiceFromEnv()
-			if err != nil {
-				log.WithError(err).Print("cannot connect to Theia")
-				return
-			}
-			if action == "get" {
-				resp, err := service.GetGitToken(theialib.GetGitTokenRequest{
-					Command: gitCommand,
-					Host:    host,
-					RepoURL: repoURL,
-				})
-				if err != nil {
-					log.WithError(err).Print("cannot get token")
-					return
-				}
-				user = resp.User
-				token = resp.Token
-			}
-			return
-		}
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
 		supervisorAddr := os.Getenv("SUPERVISOR_ADDR")
@@ -119,11 +96,6 @@ var credentialHelper = &cobra.Command{
 		user = resp.User
 		token = resp.Token
 	},
-}
-
-func isTheiaIDE() bool {
-	stat, err := os.Stat("/theia")
-	return !errors.Is(os.ErrNotExist, err) && stat != nil && stat.IsDir()
 }
 
 func parseHostFromStdin() string {

--- a/components/gitpod-cli/cmd/preview.go
+++ b/components/gitpod-cli/cmd/preview.go
@@ -15,8 +15,6 @@ import (
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-
-	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/theialib"
 )
 
 var regexLocalhost = regexp.MustCompile(`((^(localhost|127\.0\.0\.1))|(https?://(localhost|127\.0\.0\.1)))(:[0-9]+)?`)
@@ -38,15 +36,6 @@ var previewCmd = &cobra.Command{
 			}
 			openPreview("GP_EXTERNAL_BROWSER", url)
 			return
-		}
-		if isTheiaIDE() {
-			if service, err := theialib.NewServiceFromEnv(); err == nil {
-				_, err = service.OpenPreview(theialib.OpenPreviewRequest{URL: url})
-				if err == nil {
-					// we've opened the preview. All is well.
-					return
-				}
-			}
 		}
 		openPreview("GP_PREVIEW_BROWSER", url)
 	},


### PR DESCRIPTION
## Description
Removes some references to the now removed [Theia IDE](https://theia-ide.org/).

## Related Issue(s)
See https://github.com/gitpod-io/gitpod/pull/5511 & https://github.com/gitpod-io/gitpod/pull/7395

## How to test
1. Open the preview environment
2. Try using the `gp env` and `gp preview`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

