### PR TITLE
[installer]: use a pointer deref if the ssh gateway secret does not exist

### DIFF
--- a/installer/pkg/components/ws-proxy/deployment.go
+++ b/installer/pkg/components/ws-proxy/deployment.go
@@ -44,7 +44,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MountPath: "/mnt/certificates",
 		})
 	}
-	if ctx.Config.SSHGatewayHostKey.Name != "" {
+	if ctx.Config.SSHGatewayHostKey != nil {
 		volumes = append(volumes, corev1.Volume{
 			Name: "host-key",
 			VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If no `SSHGatewayHostKey` is provided, the `ws-proxy.deployment` errored as was referencing the `Name != ""`. To keep with the existing convention, this has been changed to `SSHGatewayHostKey != nil` as the validation ensures that the `Name` is populated

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
[Fixes issue raised in Discord](https://discord.com/channels/816244985187008514/879915120510267412/929089332277547079)

## How to test
<!-- Provide steps to test this PR -->
Render a k8s object with not `SSHGatewayHostKey` secret set

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: use a pointer deref if the ssh gateway secret does not exist
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
