### PR TITLE
[installer] Adjust default MySQL value

### DIFF
--- a/installer/pkg/components/database/incluster/configmap.go
+++ b/installer/pkg/components/database/incluster/configmap.go
@@ -7,12 +7,13 @@ package incluster
 import (
 	"embed"
 	"fmt"
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"io/fs"
+	"strings"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"strings"
 )
 
 //go:embed init/*.sql
@@ -51,7 +52,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.DefaultLabels(Component),
 			},
 			Data: map[string]string{
-				"init.sql": initScriptData,
+				"init.sql":      initScriptData,
+				"tuneMysql.sql": `SET GLOBAL innodb_lru_scan_depth=256;`,
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Description

The default value 1024 is too high.

http://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_lru_scan_depth

## Related Issue(s)

Using the installer and the in-cluster database I see this error in the MySQL statefulset

`2022-01-07T19:32:58.602740Z 0 [Note] InnoDB: page_cleaner: 1000ms intended loop took 8984ms. The settings might not be optimal. (flushed=11 and evicted=0, during the time.)
`

## How to test

- Install a cluster and check the page_cleaner message is not present.

## Release Notes

```release-note
[installer] Adjust default MySQL value
```
