### PR TITLE
[installer] Adjust mysql helm chart probes configuration

### DIFF
--- a/installer/pkg/components/database/incluster/helm.go
+++ b/installer/pkg/components/database/incluster/helm.go
@@ -39,6 +39,10 @@ var Helm = common.CompositeHelmFunc(
 					helm.KeyValue("mysql.metrics.image.registry", common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)),
 					helm.ImagePullSecrets("mysql.volumePermissions.image.pullSecrets", cfg),
 					helm.KeyValue("mysql.volumePermissions.image.registry", common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)),
+
+					// improve start time
+					helm.KeyValue("mysql.primary.startupProbe.enabled", "false"),
+					helm.KeyValue("mysql.primary.livenessProbe.initialDelaySeconds", "30"),
 				},
 				// This is too complex to be sent as a string
 				FileValues: []string{


### PR DESCRIPTION
## Description

Reduce the installation time by ~2 minutes adjusting the default values provided by the chart.

## How to test
- Install a cluster and verify there are no errors in the MySQL statefulset

## Release Notes
```release-note
[installer] Adjust mysql helm chart probes configuration
```
