### PR TITLE
[ws-manager] Adjust probe InitialDelaySeconds

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -528,7 +528,7 @@ func (m *Manager) createWorkspaceContainer(startContext *startWorkspaceContext) 
 			PeriodSeconds:       1,
 			SuccessThreshold:    1,
 			TimeoutSeconds:      1,
-			InitialDelaySeconds: 4,
+			InitialDelaySeconds: 3,
 		}
 	)
 

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -166,7 +166,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -158,7 +158,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -160,7 +160,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -195,7 +195,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -163,7 +163,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -152,7 +152,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -184,7 +184,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -188,7 +188,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -160,7 +160,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -166,7 +166,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -170,7 +170,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -170,7 +170,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -166,7 +166,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -162,7 +162,7 @@
                                 "echo"
                             ]
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -166,7 +166,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -166,7 +166,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -167,7 +167,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -162,7 +162,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -181,7 +181,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -162,7 +162,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -184,7 +184,7 @@
                             "port": 22999,
                             "scheme": "HTTP"
                         },
-                        "initialDelaySeconds": 4,
+                        "initialDelaySeconds": 3,
                         "timeoutSeconds": 1,
                         "periodSeconds": 1,
                         "successThreshold": 1,


### PR DESCRIPTION
## Description

Reduce the initial delay to start checking the status of the workspace

## How to test
- Workspaces should start without issues

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] Adjust probe InitialDelaySeconds
```
