### PR TITLE
[messagebus, bridge] Remove messagebus cross-cluster dependency

### DIFF
--- a/.werft/values.dev.yaml
+++ b/.werft/values.dev.yaml
@@ -218,10 +218,6 @@ mysql:
         memory: 350Mi
 
 rabbitmq:
-  # ensure shovels are configured on boot
-  shovels:
-    - name: messagebus-0
-      srcUri: "amqp://$USERNAME:$PASSWORD@messagebus-0"
   auth:
     username: override-me
     password: override-me

--- a/chart/templates/ws-manager-bridge-configmap.yaml
+++ b/chart/templates/ws-manager-bridge-configmap.yaml
@@ -31,6 +31,7 @@ data:
           "stoppingPhaseSeconds": 3600,
           "unknownPhaseSeconds": 600
         },
+        "emulatePreparingIntervalSeconds": "10",
         "staticBridges": {{ index (include "ws-manager-list" (dict "root" . "gp" $.Values "comp" .Values.components.server) | fromYaml) "manager" | default list | toJson }}
     }
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -580,9 +580,6 @@ mysql:
 rabbitmq:
   enabled: true
   fullnameOverride: "messagebus"
-  # non-standard configuration
-  # defined by gitpod.io
-  shovels: []
   persistence:
     enabled: false
   replicaCount: 1
@@ -605,7 +602,7 @@ rabbitmq:
     enabled: true
     allowExternal: true
   plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
-  extraPlugins: "rabbitmq_shovel rabbitmq_shovel_management"
+  extraPlugins: ""
   extraSecrets:
     load-definition:
       load_definition.json: |
@@ -618,7 +615,7 @@ rabbitmq:
           "vhosts": [{
             "name": "/"
           }],
-          "parameters": {{ tpl (.Values.shovelsTemplate) . | fromYamlArray | toJson }},
+          "parameters": [],
           "permissions": [{
             "user": {{ .Values.auth.username | quote }},
             "vhost": "/",
@@ -627,22 +624,10 @@ rabbitmq:
             "read": ".*"
           }],
           "exchanges": [{
-            "name": "gitpod.ws",
-            "vhost": "/",
-            "type": "topic",
-            "durable": true,
-            "auto_delete": false
-          }, {
             "name": "gitpod.ws.local",
             "vhost": "/",
             "type": "topic",
             "durable": true,
-            "auto_delete": false
-          }, {
-            "name": "wsman",
-            "vhost": "/",
-            "type": "topic",
-            "durable": false,
             "auto_delete": false
           }, {
             "name": "consensus-leader",
@@ -651,14 +636,7 @@ rabbitmq:
             "durable": false,
             "auto_delete": false
           }],
-          "bindings": [{
-            "source": "gitpod.ws.local",
-            "vhost": "/",
-            "destination": "gitpod.ws",
-            "destination_type": "exchange",
-            "routing_key": "#",
-            "arguments": {}
-          }],
+          "bindings": [],
           "queues": [{
             "name": "consensus-peers",
             "vhost": "/",
@@ -694,25 +672,6 @@ rabbitmq:
     create: true
     minAvailable: 0
     maxUnavailable: 1
-  shovelsTemplate: |
-    {{ $auth := .Values.auth }}
-    {{- range $index, $shovel := .Values.shovels }}
-    - name: {{ $shovel.name | default (randAlphaNum 20) | quote }}
-      vhost: "/"
-      component: "shovel"
-      value:
-        ack-mode: "on-publish"
-        src-delete-after: "never"
-        src-exchange: {{ $shovel.srcExchange | default "gitpod.ws.local" | quote }}
-        src-exchange-key: {{ $shovel.srcExchangeKey | default "#" | quote  }}
-        src-protocol: "amqp091"
-        src-uri: {{ $shovel.srcUri | replace "$USERNAME" $auth.username | replace "$PASSWORD" $auth.password | quote }}
-        dest-add-forward-headers: {{ $shovel.destAddForwardHeaders | default true }}
-        dest-exchange: {{ $shovel.destExchange | default "gitpod.ws" | quote }}
-        dest-protocol: "amqp091"
-        dest-uri: {{ $shovel.destUri | default "amqp://" | quote }}
-        reconnect-delay: {{ $shovel.reconnectDelay | default 5 }}
-    {{- end }}
 
 cert-manager:
   enabled: false

--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -13,6 +13,7 @@ import { Transformer } from "../transformer";
 
 @Entity()
 @Index("ind_find_wsi_ws_in_period", ['workspaceId', 'startedTime', 'stoppedTime'])   // findInstancesWithWorkspaceInPeriod
+@Index("ind_phasePersisted_region", ['phasePersisted', 'region'])   // findInstancesByPhaseAndRegion
 // on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
 export class DBWorkspaceInstance implements WorkspaceInstance {
     @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)

--- a/components/gitpod-db/src/typeorm/migration/1645019483643-InstancesByPhaseAndRegion.ts
+++ b/components/gitpod-db/src/typeorm/migration/1645019483643-InstancesByPhaseAndRegion.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { indexExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_workspace_instance";
+const INDEX_NAME = "ind_phasePersisted_region";
+
+export class InstancesByPhaseAndRegion1645019483643 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if(!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE_NAME} (phasePersisted, region)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -852,6 +852,15 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         return <WorkspaceAndInstance>(res);
     }
 
+    async findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]> {
+        const repo = await this.getWorkspaceInstanceRepo();
+        // uses index: ind_phasePersisted_region
+        const qb = repo.createQueryBuilder("wsi")
+            .where("wsi.phasePersisted = :phase", { phase })
+            .andWhere("wsi.region = :region", { region });
+        return qb.getMany();
+    }
+
     async findPrebuiltWorkspacesByProject(projectId: string, branch?: string, limit?: number): Promise<PrebuiltWorkspace[]> {
         const repo = await this.getPrebuiltWorkspaceRepo();
 

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -83,6 +83,7 @@ export interface WorkspaceDB {
     findAllWorkspaces(offset: number, limit: number, orderBy: keyof Workspace, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string, minCreationTime?: Date, maxCreationDateTime?: Date, type?: WorkspaceType): Promise<{ total: number, rows: Workspace[] }>;
     findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof WorkspaceAndInstance, orderDir: "ASC" | "DESC", query?: AdminGetWorkspacesQuery, searchTerm?: string): Promise<{ total: number, rows: WorkspaceAndInstance[] }>;
     findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
+    findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
 
     findAllWorkspaceInstances(offset: number, limit: number, orderBy: keyof WorkspaceInstance, orderDir: "ASC" | "DESC", ownerId?: string, minCreationTime?: Date, maxCreationTime?: Date, onlyRunning?: boolean, type?: WorkspaceType): Promise<{ total: number, rows: WorkspaceInstance[] }>;
 

--- a/components/gitpod-messagebus/src/messagebus.ts
+++ b/components/gitpod-messagebus/src/messagebus.ts
@@ -76,7 +76,7 @@ const ASTERISK = "*";
 
 @injectable()
 export class MessageBusHelperImpl implements MessageBusHelper {
-    readonly workspaceExchange = MessageBusHelperImpl.WORKSPACE_EXCHANGE;
+    readonly workspaceExchange = MessageBusHelperImpl.WORKSPACE_EXCHANGE_LOCAL;
 
     /**
      * Ensures that the gitpod workspace exchange is present
@@ -155,7 +155,6 @@ export class MessageBusHelperImpl implements MessageBusHelper {
 }
 
 export namespace MessageBusHelperImpl {
-    export const WORKSPACE_EXCHANGE = "gitpod.ws";
     export const WORKSPACE_EXCHANGE_LOCAL = "gitpod.ws.local";
     export const PREBUILD_UPDATABLE_QUEUE = "pwsupdatable";
 }

--- a/components/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/components/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -30,7 +30,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			StoppingPhaseSeconds:             3600,
 			UnknownPhaseSeconds:              600,
 		},
-		StaticBridges: WSManagerList(),
+		EmulatePreparingIntervalSeconds: 10,
+		StaticBridges:                   WSManagerList(),
 	}
 
 	fc, err := common.ToJSONString(wsmbcfg)

--- a/components/installer/pkg/components/ws-manager-bridge/types.go
+++ b/components/installer/pkg/components/ws-manager-bridge/types.go
@@ -13,6 +13,7 @@ type Configuration struct {
 	ControllerIntervalSeconds           int32              `json:"controllerIntervalSeconds"`
 	ControllerMaxDisconnectSeconds      int32              `json:"controllerMaxDisconnectSeconds"`
 	MaxTimeToRunningPhaseSeconds        int32              `json:"maxTimeToRunningPhaseSeconds"`
+	EmulatePreparingIntervalSeconds     int32              `json:"emulatePreparingIntervalSeconds"`
 	Timeouts                            Timeouts           `json:"timeouts"`
 }
 

--- a/components/installer/third_party/charts/rabbitmq/values.yaml
+++ b/components/installer/third_party/charts/rabbitmq/values.yaml
@@ -26,7 +26,7 @@ rabbitmq:
     enabled: true
     allowExternal: true
   plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
-  extraPlugins: "rabbitmq_shovel rabbitmq_shovel_management"
+  extraPlugins: ""
   loadDefinition:
     enabled: true
     existingSecret: load-definition

--- a/components/server/src/workspace/messagebus-integration.ts
+++ b/components/server/src/workspace/messagebus-integration.ts
@@ -176,7 +176,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         await this.messageBusHelper.assertWorkspaceExchange(this.channel);
 
         // TODO(at) clarify on the exchange level
-        await super.publish(MessageBusHelperImpl.WORKSPACE_EXCHANGE, topic, Buffer.from(JSON.stringify(prebuildInfo)));
+        await super.publish(MessageBusHelperImpl.WORKSPACE_EXCHANGE_LOCAL, topic, Buffer.from(JSON.stringify(prebuildInfo)));
     }
 
     async notifyOnInstanceUpdate(userId: string, instance: WorkspaceInstance) {

--- a/components/ws-manager-bridge/src/bridge-controller.ts
+++ b/components/ws-manager-bridge/src/bridge-controller.ts
@@ -61,7 +61,7 @@ export class BridgeController {
     protected async reconcile() {
         return this.reconcileQueue.enqueue(async () => {
             const allClusters = await this.getAllWorkspaceClusters();
-            log.info("reconciling clusters...", { allClusters });
+            log.info("reconciling clusters...", { allClusters: Array.from(allClusters.values()) });
             const toDelete: string[] = [];
             try {
                 for (const [name, bridge] of this.bridges) {
@@ -81,13 +81,13 @@ export class BridgeController {
                 }
             }
 
-            this.metrics.updateClusterMetrics(Array.from(allClusters).map(c => c[1]));
+            this.metrics.updateClusterMetrics(Array.from(allClusters).map(([_, c]) => c));
             for (const [name, newCluster] of allClusters) {
                 log.debug("reconcile: create bridge for new cluster", { name });
                 const bridge = await this.createAndStartBridge(newCluster);
                 this.bridges.set(newCluster.name, bridge);
             }
-            log.info("done reconciling.", { allClusters });
+            log.info("done reconciling.", { allClusters: Array.from(allClusters.values()) });
         });
     }
 

--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -36,4 +36,7 @@ export interface Configuration {
         stoppingPhaseSeconds: number;
         unknownPhaseSeconds: number;
     }
+
+    // emulatePreparingIntervalSeconds configures how often we check for Workspaces in phase "preparing" for clusters we do not govern
+    emulatePreparingIntervalSeconds: number;
 }

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -25,6 +25,7 @@ import { newAnalyticsWriterFromEnv } from '@gitpod/gitpod-protocol/lib/util/anal
 import { MetaInstanceController } from './meta-instance-controller';
 import { IClientCallMetrics } from '@gitpod/content-service/lib/client-call-metrics';
 import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
+import { PreparingUpdateEmulator } from './preparing-update-emulator';
 
 export const containerModule = new ContainerModule(bind => {
 
@@ -68,4 +69,6 @@ export const containerModule = new ContainerModule(bind => {
     }).inSingletonScope();
 
     bind(IAnalyticsWriter).toDynamicValue(newAnalyticsWriterFromEnv).inSingletonScope();
+
+    bind(PreparingUpdateEmulator).toSelf().inSingletonScope();
 });

--- a/components/ws-manager-bridge/src/preparing-update-emulator.ts
+++ b/components/ws-manager-bridge/src/preparing-update-emulator.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+import { WorkspaceDB } from "@gitpod/gitpod-db/lib/workspace-db";
+import { Disposable, DisposableCollection, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { inject, injectable } from "inversify";
+import { Configuration } from "./config";
+import { MessageBusIntegration } from "./messagebus-integration";
+import { GarbageCollectedCache } from "@gitpod/gitpod-protocol/lib/util/garbage-collected-cache";
+import * as crypto from 'crypto';
+
+interface CacheEntry {
+    instance: WorkspaceInstance,
+    userId: string,
+    hash: string,
+}
+
+/**
+ * The purpose of this class is to emulate WorkspaceInstance updates for workspaces instances that are not governed by this bridge.
+ * It does so by polling the DB for the specific region, and if anything changed, push that update into the local messagebus.
+ * This is a work-around to enable decoupling cross-cluster messagebus instances from each other.
+ */
+@injectable()
+export class PreparingUpdateEmulator implements Disposable {
+
+    @inject(Configuration) protected readonly config: Configuration;
+    @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
+    @inject(MessageBusIntegration) protected readonly messagebus: MessageBusIntegration;
+
+
+    protected readonly cachedResponses = new GarbageCollectedCache<CacheEntry>(600, 150);
+    protected readonly disposables = new DisposableCollection();
+
+    start(region: string) {
+        this.disposables.push(
+            repeat(async () => {
+                const span = TraceContext.startSpan("preparingUpdateEmulatorRun");
+                const ctx = {span};
+                try {
+                    const instances = await this.workspaceDb.findInstancesByPhaseAndRegion("preparing", region);
+                    span.setTag("preparingUpdateEmulatorRun.nrOfInstances", instances.length);
+                    for (const instance of instances) {
+                        const hash = hasher(instance);
+                        const entry = this.cachedResponses.get(instance.id);
+                        if (entry && entry.hash === hash) {
+                            continue;
+                        }
+
+                        let userId = entry?.userId;
+                        if (!userId) {
+                            const ws = await this.workspaceDb.findById(instance.workspaceId);
+                            if (!ws) {
+                                log.debug({ instanceId: instance.id, workspaceId: instance.workspaceId }, "no workspace found for workspace instance");
+                                continue;
+                            }
+                            userId = ws.ownerId;
+                        }
+
+                        await this.messagebus.notifyOnInstanceUpdate(ctx, userId, instance);
+                        this.cachedResponses.set(instance.id, {
+                            instance,
+                            hash,
+                            userId,
+                        });
+                    }
+                } catch (err) {
+                    TraceContext.setError(ctx, err);
+                } finally {
+                    span.finish();
+                }
+            }, this.config.emulatePreparingIntervalSeconds * 1000)
+        );
+    }
+
+    dispose() {
+        this.disposables.dispose();
+    }
+}
+
+function hasher(o: {}): string {
+    return crypto.createHash('md5')
+        .update(JSON.stringify(o))
+        .digest('hex');
+}


### PR DESCRIPTION
## Description
This PR contains two complementary changes:
 1. remove the messagebus shovel config, and all non-local exchanges (`gitpod.ws`) and use local exchanges instead (`gitpod.ws.local`)
 2. change `ws-manager-bridge` so that bridges that are non-`govern`ing:
   a. still don't write updates to the DB,
   b. but do the same derivation of updates,
   c. and distributes those over their cluster's local messagebus

**Note**: This PR can be reviewed commit by commit!

## Pain points
[This polling and hashing](https://github.com/gitpod-io/gitpod/pull/7523/commits/3eacd3388e19bd3197a2291e278cd8ae4f85ed1b#diff-dda1d30e0a84afa9ad6c941cf99ebef2211138c7287c659b041cd05bbbcaebb7R41-R48) feel quite expensive, especially in scenarios where things go haywire already (a lot of workspaces hanging in preparing). But I see no way around it until we pushed image-builder into workspace clusters (https://github.com/gitpod-io/gitpod/issues/7845). :shrug:  Once that's done we should be able to just delete PreparingUpdateEmulator :wastebasket: .

## Deployment
This PR is meant to be a drop-in replacement for the current setup, which means:

    behavior before and after should be identical (order of updates, state persisted to DB before update sent, except for cross-cluster stuff, etc.)
    all currently running workspaces should behave as usual, e.g. keep running smoothly
    rolling this out will require a messagebus restart, but apart from that behave like a regular deployment

## ToDo:
 - [x] ~think about how to properly test this, ideally before~ **on** staging
 - [x] create a cleanup PR for the ops repo https://github.com/gitpod-io/ops/pull/666
 - [x] solve the "imagebuild in different cluster" case
   - [x] w.r.t. instance updates: [`PreparingUpdateEmulator`](https://github.com/gitpod-io/gitpod/pull/7523/files#diff-5c377b2cad37712ee6f512a499f1069f7641af5aab7dceaa7e8d033fc23d4780R90-R93)
   - [x] ~w.r.t. image build logs~ solved in: #7899

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7468

## How to test

### cluster-local works as before
 - start a workspace with devtools open, and watch the websocket messages that keep flowing in
 - note the onInstaceUpdate notifications
 - note how the workspace starts as expected

### cross-cluster
We'll test this on staging as the setup is already there, and an alternative setup would eat too much time at the moment.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
messagebus: remove cross-cluster dependency
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
