### PR TITLE
Don't try to connect to opened ports

### DIFF
--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -26,6 +26,12 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/api"
 )
 
+var workspaceIPAdress string
+
+func init() {
+	workspaceIPAdress = defaultRoutableIP()
+}
+
 // NewManager creates a new port manager
 func NewManager(exposed ExposedPortsInterface, served ServedPortsObserver, config ConfigInterace, tunneled TunneledPortsInterface, slirp SlirpClient, internalPorts ...uint32) *Manager {
 	state := make(map[uint32]*managedPort)
@@ -159,42 +165,6 @@ func (pm *Manager) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}()
 	defer cancel()
 
-	// set a health check for exposed port trough the proxies
-	go func() {
-		tick := time.NewTicker(2 * time.Second)
-		defer tick.Stop()
-
-		for {
-			<-tick.C
-
-			pm.mu.RLock()
-			servedGlobal := make(map[uint32]struct{})
-			for _, p := range pm.served {
-				if !p.BoundToLocalhost {
-					servedGlobal[p.Port] = struct{}{}
-				}
-			}
-			pm.mu.RUnlock()
-
-			for localPort, proxy := range pm.proxies {
-				_, openedGlobal := servedGlobal[localPort]
-				openedLocal := isLocalPortOpen(int(localPort))
-				if !openedLocal && openedGlobal {
-					pm.mu.Lock()
-					delete(pm.proxies, localPort)
-					pm.mu.Unlock()
-
-					err := proxy.Close()
-					if err != nil {
-						log.WithError(err).WithField("localPort", localPort).Warn("cannot stop localhost proxy")
-					} else {
-						log.WithField("localPort", localPort).Info("localhost proxy has been stopped")
-					}
-				}
-			}
-		}
-	}()
-
 	go pm.E.Run(ctx)
 	exposedUpdates, exposedErrors := pm.E.Observe(ctx)
 	servedUpdates, servedErrors := pm.S.Observe(ctx)
@@ -289,6 +259,12 @@ func (pm *Manager) updateState(ctx context.Context, exposed []ExposedPort, serve
 	if served != nil {
 		servedMap := make(map[uint32]ServedPort)
 		for _, port := range served {
+			if port.Address.String() == workspaceIPAdress {
+				// Ignore entries that are bound to the workspace ip address
+				// as they are created by the reverse proxy
+				continue
+			}
+
 			current, exists := servedMap[port.Port]
 			if !exists || (!port.BoundToLocalhost && current.BoundToLocalhost) {
 				servedMap[port.Port] = port
@@ -575,13 +551,20 @@ func (pm *Manager) updateSlirp() {
 }
 
 func (pm *Manager) updateProxies() {
-	servedLocal := make(map[uint32]struct{})
-	servedGlobal := make(map[uint32]struct{})
-	for _, p := range pm.served {
-		if p.BoundToLocalhost {
-			servedLocal[p.Port] = struct{}{}
-		} else {
-			servedGlobal[p.Port] = struct{}{}
+	servedPortMap := map[uint32]bool{}
+	for _, s := range pm.served {
+		servedPortMap[s.Port] = s.BoundToLocalhost
+	}
+
+	for port, proxy := range pm.proxies {
+		if boundToLocalhost, exists := servedPortMap[port]; !exists || !boundToLocalhost {
+			delete(pm.proxies, port)
+			err := proxy.Close()
+			if err != nil {
+				log.WithError(err).WithField("localPort", port).Warn("cannot stop localhost proxy")
+			} else {
+				log.WithField("localPort", port).Info("localhost proxy has been stopped")
+			}
 		}
 	}
 
@@ -801,11 +784,6 @@ func (pm *Manager) getPortStatus(port uint32) *api.PortsStatus {
 	return ps
 }
 
-var workspaceIPAdress string
-
-func init() {
-	workspaceIPAdress = defaultRoutableIP()
-}
 func startLocalhostProxy(port uint32) (io.Closer, error) {
 	host := fmt.Sprintf("localhost:%d", port)
 
@@ -863,20 +841,4 @@ func defaultRoutableIP() string {
 	}
 
 	return addresses[0].(*net.IPNet).IP.String()
-}
-
-func isLocalPortOpen(port int) bool {
-	timeout := 1 * time.Second
-	target := fmt.Sprintf("127.0.0.1:%d", port)
-	conn, err := net.DialTimeout("tcp", target, timeout)
-	if err != nil {
-		return false
-	}
-
-	if conn != nil {
-		conn.Close()
-		return true
-	}
-
-	return false
 }

--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -49,10 +49,10 @@ func TestPortsUpdateState(t *testing.T) {
 		{
 			Desc: "basic locally served",
 			Changes: []Change{
-				{Served: []ServedPort{{"0100007F", 8080, true}}},
+				{Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 8080, true}}},
 				{Exposed: []ExposedPort{{LocalPort: 8080, URL: "foobar"}}},
-				{Served: []ServedPort{{"0100007F", 8080, true}, {"00000000", 60000, false}}},
-				{Served: []ServedPort{{"00000000", 60000, false}}},
+				{Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 8080, true}, {net.IPv4zero, 60000, false}}},
+				{Served: []ServedPort{{net.IPv4zero, 60000, false}}},
 				{Served: []ServedPort{}},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -71,7 +71,7 @@ func TestPortsUpdateState(t *testing.T) {
 		{
 			Desc: "basic globally served",
 			Changes: []Change{
-				{Served: []ServedPort{{"00000000", 8080, false}}},
+				{Served: []ServedPort{{net.IPv4zero, 8080, false}}},
 				{Served: []ServedPort{}},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -102,7 +102,7 @@ func TestPortsUpdateState(t *testing.T) {
 			InternalPorts: []uint32{8080},
 			Changes: []Change{
 				{Served: []ServedPort{}},
-				{Served: []ServedPort{{"00000000", 8080, false}}},
+				{Served: []ServedPort{{net.IPv4zero, 8080, false}}},
 			},
 
 			ExpectedExposure: ExposureExpectation(nil),
@@ -125,8 +125,8 @@ func TestPortsUpdateState(t *testing.T) {
 				},
 				{
 					Served: []ServedPort{
-						{"00000000", 8080, false},
-						{"0100007F", 9229, true},
+						{net.IPv4zero, 8080, false},
+						{net.IPv4(127, 0, 0, 1), 9229, true},
 					},
 				},
 			},
@@ -156,9 +156,9 @@ func TestPortsUpdateState(t *testing.T) {
 						Port:   "4000-5000",
 					}},
 				}},
-				{Served: []ServedPort{{"0100007F", 4040, true}}},
+				{Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 4040, true}}},
 				{Exposed: []ExposedPort{{LocalPort: 4040, Public: true, URL: "4040-foobar"}}},
-				{Served: []ServedPort{{"0100007F", 4040, true}, {"00000000", 60000, false}}},
+				{Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 4040, true}, {net.IPv4zero, 60000, false}}},
 			},
 			ExpectedExposure: []ExposedPort{
 				{LocalPort: 4040},
@@ -189,19 +189,19 @@ func TestPortsUpdateState(t *testing.T) {
 					Exposed: []ExposedPort{{LocalPort: 8080, Public: true, URL: "foobar"}},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 8080, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 8080, true}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 8080, Public: true, URL: "foobar"}},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 8080, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 8080, true}},
 				},
 				{
 					Served: []ServedPort{},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 8080, false}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 8080, false}},
 				},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -221,7 +221,7 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "starting multiple proxies for the same served event",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"0100007F", 8080, true}, {"00000000", 3000, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 8080, true}, {net.IPv4zero, 3000, true}},
 				},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -245,7 +245,7 @@ func TestPortsUpdateState(t *testing.T) {
 					}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 8080, false}},
+					Served: []ServedPort{{net.IPv4zero, 8080, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 8080, Public: false, URL: "foobar"}},
@@ -265,13 +265,13 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served locally and then globally too, prefer globally (exposed in between)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}, {"00000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}, {net.IPv4zero, 5900, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
@@ -290,10 +290,10 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served locally and then globally too, prefer globally (exposed after)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}, {"00000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}, {net.IPv4zero, 5900, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
@@ -315,13 +315,13 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served globally and then locally too, prefer globally (exposed in between)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"00000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 5900, false}, {"0100007F", 5900, true}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}, {net.IPv4(127, 0, 0, 1), 5900, true}},
 				},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -337,10 +337,10 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served globally and then locally too, prefer globally (exposed after)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"00000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 5900, false}, {"0100007F", 5900, true}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}, {net.IPv4(127, 0, 0, 1), 5900, true}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
@@ -359,13 +359,13 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served locally on ip4 and then locally on ip6 too, prefer first (exposed in between)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}, {"00000000000000000000010000000000", 5900, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}, {net.IPv6zero, 5900, true}},
 				},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -381,10 +381,10 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served locally on ip4 and then locally on ip6 too, prefer first (exposed after)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}},
 				},
 				{
-					Served: []ServedPort{{"0100007F", 5900, true}, {"00000000000000000000010000000000", 5900, true}},
+					Served: []ServedPort{{net.IPv4(127, 0, 0, 1), 5900, true}, {net.IPv6zero, 5900, true}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
@@ -403,13 +403,13 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served locally on ip4 and then globally on ip6 too, prefer first (exposed in between)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"00000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 5900, false}, {"00000000000000000000000000000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}, {net.IPv6zero, 5900, false}},
 				},
 			},
 			ExpectedExposure: []ExposedPort{
@@ -425,10 +425,10 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "the same port served locally on ip4 and then globally on ip6 too, prefer first (exposed after)",
 			Changes: []Change{
 				{
-					Served: []ServedPort{{"00000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 5900, false}, {"00000000000000000000000000000000", 5900, false}},
+					Served: []ServedPort{{net.IPv4zero, 5900, false}, {net.IPv6zero, 5900, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 5900, URL: "foobar"}},
@@ -452,7 +452,7 @@ func TestPortsUpdateState(t *testing.T) {
 					}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 8080, false}},
+					Served: []ServedPort{{net.IPv4zero, 8080, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 8080, Public: false, URL: "foobar"}},
@@ -477,7 +477,7 @@ func TestPortsUpdateState(t *testing.T) {
 					}},
 				},
 				{
-					Served: []ServedPort{{"00000000", 3000, false}},
+					Served: []ServedPort{{net.IPv4zero, 3000, false}},
 				},
 				{
 					Exposed: []ExposedPort{{LocalPort: 3000, Public: false, URL: "foobar"}},

--- a/components/supervisor/pkg/ports/served-ports_test.go
+++ b/components/supervisor/pkg/ports/served-ports_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -50,13 +51,13 @@ func TestObserve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				{
-					{Address: "0100007F", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000", Port: 6080},
-					{Address: "00000000", Port: 23000},
-					{Address: "00000000000000000000000001000000", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000000000000000000000000000", Port: 22999},
-					{Address: "00000000000000000000000000000000", Port: 35900},
-					{Address: "00000000000000000000000000000000", Port: 36080},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv4zero, Port: 6080},
+					{Address: net.IPv4zero, Port: 23000},
+					{Address: net.IPv6loopback, Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv6zero, Port: 22999},
+					{Address: net.IPv6zero, Port: 35900},
+					{Address: net.IPv6zero, Port: 36080},
 				},
 			},
 		},
@@ -75,12 +76,12 @@ func TestObserve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				{
-					{Address: "0100007F", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000", Port: 6080},
-					{Address: "00000000", Port: 23000},
-					{Address: "00000000000000000000000001000000", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000000000000000000000000000", Port: 22999},
-					{Address: "00000000000000000000000000000000", Port: 60000},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv4zero, Port: 6080},
+					{Address: net.IPv4zero, Port: 23000},
+					{Address: net.IPv6loopback, Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv6zero, Port: 22999},
+					{Address: net.IPv6zero, Port: 60000},
 				},
 			},
 		},
@@ -99,12 +100,12 @@ func TestObserve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				{
-					{Address: "0100007F", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000", Port: 6080},
-					{Address: "00000000", Port: 23000},
-					{Address: "00000000000000000000000000000000", Port: 5900, BoundToLocalhost: false},
-					{Address: "00000000000000000000000000000000", Port: 22999},
-					{Address: "00000000000000000000000000000000", Port: 60000},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv4zero, Port: 6080},
+					{Address: net.IPv4zero, Port: 23000},
+					{Address: net.IPv6zero, Port: 5900, BoundToLocalhost: false},
+					{Address: net.IPv6zero, Port: 22999},
+					{Address: net.IPv6zero, Port: 60000},
 				},
 			},
 		},
@@ -123,12 +124,12 @@ func TestObserve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				{
-					{Address: "00000000", Port: 5900},
-					{Address: "00000000", Port: 6080},
-					{Address: "00000000", Port: 23000},
-					{Address: "00000000000000000000000001000000", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000000000000000000000000000", Port: 22999},
-					{Address: "00000000000000000000000000000000", Port: 60000},
+					{Address: net.IPv4zero, Port: 5900},
+					{Address: net.IPv4zero, Port: 6080},
+					{Address: net.IPv4zero, Port: 23000},
+					{Address: net.IPv6loopback, Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv6zero, Port: 22999},
+					{Address: net.IPv6zero, Port: 60000},
 				},
 			},
 		},
@@ -162,11 +163,11 @@ func TestObserve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				{
-					{Address: "AD0E600A", Port: 9229},
-					{Address: "0100007F", Port: 9229, BoundToLocalhost: true},
-					{Address: "00000000", Port: 23000},
-					{Address: "AD0E600A", Port: 27017, BoundToLocalhost: false},
-					{Address: "0100007F", Port: 27017, BoundToLocalhost: true},
+					{Address: net.IPv4(10, 96, 14, 173), Port: 9229},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 9229, BoundToLocalhost: true},
+					{Address: net.IPv4zero, Port: 23000},
+					{Address: net.IPv4(10, 96, 14, 173), Port: 27017, BoundToLocalhost: false},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 27017, BoundToLocalhost: true},
 				},
 			},
 		},
@@ -196,10 +197,10 @@ func TestObserve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				{
-					{Address: "220E600A", Port: 9229},
-					{Address: "0100007F", Port: 9229, BoundToLocalhost: true},
-					{Address: "00000000", Port: 23000},
-					{Address: "220E600A", Port: 27017},
+					{Address: net.IPv4(10, 96, 14, 34), Port: 9229},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 9229, BoundToLocalhost: true},
+					{Address: net.IPv4zero, Port: 23000},
+					{Address: net.IPv4(10, 96, 14, 34), Port: 27017},
 				},
 			},
 		},
@@ -261,9 +262,9 @@ func TestReadNetTCPFile(t *testing.T) {
 			ListeningOnly: true,
 			Expectation: Expectation{
 				Ports: []ServedPort{
-					{Address: "0100007F", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000", Port: 6080},
-					{Address: "00000000", Port: 23000},
+					{Address: net.IPv4(127, 0, 0, 1), Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv4zero, Port: 6080},
+					{Address: net.IPv4zero, Port: 23000},
 				},
 			},
 		},
@@ -273,10 +274,10 @@ func TestReadNetTCPFile(t *testing.T) {
 			ListeningOnly: true,
 			Expectation: Expectation{
 				Ports: []ServedPort{
-					{Address: "00000000000000000000000001000000", Port: 5900, BoundToLocalhost: true},
-					{Address: "00000000000000000000000000000000", Port: 22999},
-					{Address: "00000000000000000000000000000000", Port: 35900},
-					{Address: "00000000000000000000000000000000", Port: 36080},
+					{Address: net.IPv6loopback, Port: 5900, BoundToLocalhost: true},
+					{Address: net.IPv6zero, Port: 22999},
+					{Address: net.IPv6zero, Port: 35900},
+					{Address: net.IPv6zero, Port: 36080},
 				},
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
With the current approach (calling `net.DialTimeout`) it causes exceptions to be thrown continuously in the vscode-js-debug extension when debugging, internally it creates a tcp server and then extension host connects to it, this connection should only happen once as it's tracked internally, after some time this exceptions make the the extension host crash.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7313
Fixes #7628

## How to test
<!-- Provide steps to test this PR -->
1. Open https://github.com/Foxhoundn/synthax-code-theme in a prev env
2. Press f5 to start debugging
3. Open dev tools on main window and observe in console there are no errors of this type
```
workbench.web.api.js:1923 Error: Cannot find target c0f0b7985e02a5dd08c2a37e
	at t.SessionManager.createNewChildSession (/ide/extensions/ms-vscode.js-debug/src/extension.js:2:1344943)
	at /ide/extensions/ms-vscode.js-debug/src/extension.js:2:1342437
	at Server.<anonymous> (/ide/extensions/ms-vscode.js-debug/src/extension.js:2:1342653)
	at Server.emit (/events.js:315:20)
	at TCP.onconnection (/net.js:1560:8)
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
