### PR TITLE
[server] allow prevent merge on failed prebuilds

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -184,6 +184,18 @@
                             "type": "boolean",
                             "description": "Add a Review in Gitpod badge to pull requests. Defaults to true."
                         },
+                        "addCheck": {
+                            "type": [
+                                "boolean",
+                                "string"
+                            ],
+                            "enum": [
+                                true,
+                                false,
+                                "prevent-merge-on-error"
+                            ],
+                            "description": "Add a commit check to pull requests. Set to 'fail-on-error' if you want broken prebuilds to block merging. Defaults to true."
+                        },
                         "addLabel": {
                             "type": [
                                 "boolean",

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -591,7 +591,7 @@ export interface GithubAppPrebuildConfig {
     branches?: boolean
     pullRequests?: boolean
     pullRequestsFromForks?: boolean
-    addCheck?: boolean
+    addCheck?: boolean | 'prevent-merge-on-error'
     addBadge?: boolean
     addLabel?: boolean | string
     addComment?: boolean

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -271,8 +271,8 @@ export class GithubApp {
             await this.statusMaintainer.registerCheckRun({ span }, installationId, pws, {
                 ...ctx.repo(),
                 head_sha: ctx.payload.pull_request.head.sha,
-                details_url: this.config.hostUrl.withContext(ctx.payload.pull_request.html_url).toString()
-            });
+                details_url: this.config.hostUrl.withContext(ctx.payload.pull_request.html_url).toString(),
+            }, config);
         } catch (err) {
             TraceContext.setError({ span }, err);
             throw err;


### PR DESCRIPTION
Introduces an option to make the commit checks pass on the status of the prebuild, i.e. allows to prevent merging a PR when a prebuild failed.

fixes #7518

## Release Notes
```release-note
[GitHub] Optionally prevent merging pull requests when prebuilds fail.
```

## Documentation

https://github.com/gitpod-io/website/pull/1446