### PR TITLE
Improve tracing for websocket notifications

### DIFF
--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -40,6 +40,24 @@ export namespace TraceContext {
         return { span };
     }
 
+    export function withSpan(operation: string, callback: () => void, ctx?: TraceContext, ...referencedSpans: (opentracing.Span | undefined)[]): void {
+        // if we don't have a parent span, don't create a trace here as those <trace-without-root-spans> are not useful.
+        if (!ctx || !ctx.span || !ctx.span.context()) {
+            callback();
+            return;
+        }
+
+        const span = TraceContext.startSpan(operation, ctx, ...referencedSpans);
+        try {
+            callback();
+        } catch (e) {
+            TraceContext.setError({span}, e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
     export function setError(ctx: TraceContext, err: Error) {
         if (!ctx.span) {
             return;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -76,8 +76,8 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
     @inject(SnapshotService) protected readonly snapshotService: SnapshotService;
 
-    initialize(client: GitpodClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientMetadata: ClientMetadata, clientHeaderFields: ClientHeaderFields): void {
-        super.initialize(client, user, accessGuard, clientMetadata, clientHeaderFields);
+    initialize(client: GitpodClient | undefined, user: User | undefined, accessGuard: ResourceAccessGuard, clientMetadata: ClientMetadata, connectionCtx: TraceContext | undefined, clientHeaderFields: ClientHeaderFields): void {
+        super.initialize(client, user, accessGuard, clientMetadata, connectionCtx, clientHeaderFields);
 
         this.listenToCreditAlerts();
         this.listenForPrebuildUpdates();

--- a/components/server/src/user/enforcement-endpoint.ts
+++ b/components/server/src/user/enforcement-endpoint.ts
@@ -48,7 +48,7 @@ export class EnforcementController {
             another architecture is not necessary.
         */
         const server = this.serverFactory()
-        server.initialize(undefined, user, resourceAccessGuard, ClientMetadata.from(user.id), {});
+        server.initialize(undefined, user, resourceAccessGuard, ClientMetadata.from(user.id), undefined, {});
         return server;
     }
 


### PR DESCRIPTION
## Description
With this PR we can see from our traces:
 - who is connecting to our (websocket) API (`version`, `origin`)
 - which clients we send websocket notifications to

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7550

Context: #7054 

## How to test
### Test that websocket connections are established as usual
### Check server logs to contain no websocket connection related errors
### Honeycomb
 - see results in honeycomb: https://ui.honeycomb.io/gitpod/datasets/preview-environments/result/EQusUJ2qDj3/trace/qbZxxdD9MuN?span=13f75d05855cc22c
   - it contains the new fields `client.origin.instanceId`, `client.origin.workspaceId` and `client.version`
![image](https://user-images.githubusercontent.com/32448529/149127821-6ba9baa9-c898-405a-ac36-c63ef80b012d.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


- [x] /werft with-observability
- [x] /werft with-helm