### PR TITLE
Add epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,104 @@
+name: Epic
+description: Create an epic
+title: "Epic: "
+labels: ["type: epic"]
+body:
+- type: markdown
+  attributes:
+    value: Before raising an epic, please search for existing epics[[1](https://github.com/gitpod-io/gitpod/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+epic%22)][[2](https://github.com/gitpod-io/gitpod/issues?q=is%3Aopen+is%3Aissue+%22Epic%3A+%22)] to avoid creating duplicates. Read more about [Epics](https://www.notion.so/gitpod/Development-Process-2-0-6681854173ab4d2f92880f9f3d85cab5#321619f5a4bd4391be83c66feb2cdb49) (internal) in **Development Process**.
+- type: textarea
+  id: summary
+  attributes:
+    label: Summary
+    description: TLDR description of the epic. Give a succinct and plain overview of what the epic is about.
+    placeholder: Give a succinct and plain overview of what the epic is about.
+  validations:
+    required: true
+- type: textarea
+  id: context
+  attributes:
+    label: Context
+    description: What thinking led to this? Provide any necessary historical context required to understand this epic.
+    placeholder: Provide any necessary historical context required to understand this epic.
+  validations:
+    required: true
+- type: textarea
+  id: value
+  attributes:
+    label: Value
+    description: Why should we do it? How do we know this is a real problem and worth solving?
+    placeholder: Explicitly describe the value to Gitpod and/or our users. I.e. why answer should we undertake this epic?
+  validations:
+    required: true
+- type: textarea
+  id: acceptance-criteria
+  attributes:
+    label: Acceptance Criteria
+    description: What needs to be done before the work is considered complete? The checks which must be complete for this epic to be considered done.
+    placeholder: Defines clearly when the work is complete. Acts as a litmus test for "done" and avoids "done" being ambiguous. Useful for implicit assumptions, e.g. ensuring docs updates are not forgotten.
+  validations:
+    required: true
+- type: textarea
+  id: measurement
+  attributes:
+    label: Measurement
+    description: How will we know whether we've been successful / solved the problem? How will you measure the success of the epic? Ideally this metric is one of our key product metrics.
+    placeholder: Important as it's how we track the outcomes (not just output) of the work and prove a change was worth it. Or it should be removed or iterated.
+  validations:
+    required: true
+- type: textarea
+  id: growth-area
+  attributes:
+    label: Growth Area
+    description: Which aspect of Gitpod do we expect improvements in? Acquisition/Onboarding/Exploration/Expansion as defined in [Funnel Proposal](https://www.notion.so/gitpod/Funnel-Proposal-d7d0dba8aced4184b660092a74f8dd3a) (internal)
+    placeholder: Growth is key. This allows us to frame epics from a growth context. Which areas are we expecting this epic to help us with our growth initiatives?
+  validations:
+    required: false
+- type: textarea
+  id: personas
+  attributes:
+    label: Persona(s)
+    description: Who will be impacted by this change? Which of our personas will be impacted by this change?
+    placeholder: Why? To bring persona's into our work. Persona's can help us prioritise our markets. Currently, we are not focusing on the education/training persona currently. We should avoid epics which target this persona.
+  validations:
+    required: false
+- type: textarea
+  id: hypothesis
+  attributes:
+    label: Hypothesis
+    description: If we do X, we expect Y
+    placeholder: Can be useful if the work is explicitly experimental.
+  validations:
+    required: false
+- type: textarea
+  id: in-scope
+  attributes:
+    label: In scope
+    description: Explicitly define the items in scope.
+    placeholder: Optional, sometimes is useful for explicitness.
+  validations:
+    required: false
+- type: textarea
+  id: out-of-scope
+  attributes:
+    label: Out of scope
+    description: Explicitly define the items out of scope.
+    placeholder: Optional, sometimes is useful for explicitness.
+  validations:
+    required: false
+- type: textarea
+  id: complexities
+  attributes:
+    label: Complexities
+    description: Discuss any known complexities
+    placeholder: Optional, sometimes is useful for explicitness.
+  validations:
+    required: false
+- type: textarea
+  id: press-release
+  attributes:
+    label: Press release
+    description: Create excitement about the idea
+    placeholder: Useful if you want to spend the extra time to get stakeholders, the team, or customers excited.
+  validations:
+    required: false


### PR DESCRIPTION
## Description

This will add an Epic template according to the [Epics](https://www.notion.so/gitpod/Development-Process-2-0-6681854173ab4d2f92880f9f3d85cab5#321619f5a4bd4391be83c66feb2cdb49) (internal) the new [Development Process](https://www.notion.so/gitpod/Development-Process-2-0-6681854173ab4d2f92880f9f3d85cab5) (internal) using Issue Forms[[1](https://gh-community.github.io/issue-template-feedback/structured/)]. Alternatively, instead of the issue form this could use plain markdown and inline all comments to  make the template more compact.

See how the [bug report](https://github.com/gitpod-io/gitpod/issues/new?assignees=&labels=bug&template=bug_report.yml) renders. See also [`bug_report.yml`](https://github.com/gitpod-io/gitpod/blob/gt/add-epic-issue-template/.github/ISSUE_TEMPLATE/bug_report.yml) and [`epic.yml`](https://github.com/gitpod-io/gitpod/blob/gt/add-epic-issue-template/.github/ISSUE_TEMPLATE/epic.yml).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```