### PR TITLE
[code] Port telemetry to stable

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -357,7 +357,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-2533c9bc91273bb35f7bb067b7127e2cc925a387"
+      stableVersion: "commit-dc3be5ab7e8dd88d7b3d9c40fa8a2b2130106c2d"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/installer/pkg/components/workspace/ide/constants.go
+++ b/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-2533c9bc91273bb35f7bb067b7127e2cc925a387" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-dc3be5ab7e8dd88d7b3d9c40fa8a2b2130106c2d" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
- [x] /werft with-clean-slate-deployment

## Description
<!-- Describe your changes in detail -->
Port telemetry events to code web stable

## How to test
<!-- Provide steps to test this PR -->
1. Select stable
2. Open a workspace
3. Check telemetry events (starting with vscode_) are generated in https://app.segment.com/gitpod/sources/staging_untrusted/debugger

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe