### PR TITLE
[supervisor] Improve observability/error handling around openPort

### DIFF
--- a/components/gitpod-protocol/go/reconnecting-ws.go
+++ b/components/gitpod-protocol/go/reconnecting-ws.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -170,9 +171,11 @@ func (rc *ReconnectingWebsocket) Dial(ctx context.Context) error {
 			connCh <- conn
 		case <-rc.errCh:
 			conn.Close()
+			log.Warnf("reconnecting-ws: connection was temporarily closed")
 
 			time.Sleep(1 * time.Second)
 			conn = rc.connect(ctx)
+			log.Warnf("reconnecting-ws: connection was re-established")
 			if conn != nil && rc.ReconnectionHandler != nil {
 				go rc.ReconnectionHandler()
 			}


### PR DESCRIPTION
## Description
To move on with issue #7054 ("port stuck in observing bc of lost workspace updates") and identifying it's root cause, here are some constructive suggestions how to a) extend the logging increase observability of this issue and b) improve the stability around the `openPort` call:
 - when # of API call attempts are exceeded: print a warning and forward error to client (happen regularly, e.g. due to rate limiter)
 - log `.Warn`ings whenever there is a temporary disconnect. The code waits for 1 second before reconnect; could very well explain a leak - especially if we do not re-fetch afterwards
 - Fetch WorkspaceInstance after reconnection happened

@jeanp413 @iQQBot I hope that one of you can pick this up and complete it.

/cc @akosyakov 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #7054 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
