### PR TITLE
werft/VM: Fix certificates and lack of resources

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -342,7 +342,7 @@ export async function build(context, version) {
 
         exec(`kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`, { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true })
 
-        issueMetaCerts(PROXY_SECRET_NAME, "default", domain)
+        issueMetaCerts(PROXY_SECRET_NAME, "default", domain, withVM)
     }
 
     werft.phase(phases.PREDEPLOY, "Checking for existing installations...");
@@ -443,7 +443,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
             werft.log(installerSlices.ISSUE_CERTIFICATES, "organizing a certificate for the preview environment...");
 
             // trigger certificate issuing
-            await issueMetaCerts(namespace, "certs", domain);
+            await issueMetaCerts(namespace, "certs", domain, withVM);
             await installMetaCertificates(namespace);
             werft.done(installerSlices.ISSUE_CERTIFICATES);
         } catch (err) {
@@ -711,7 +711,7 @@ export async function deployToDevWithHelm(deploymentConfig: DeploymentConfig, wo
 
         // trigger certificate issuing
         werft.log('certificate', "organizing a certificate for the preview environment...");
-        await issueMetaCerts(namespace, "certs", domain);
+        await issueMetaCerts(namespace, "certs", domain, false);
         await installMetaCertificates(namespace);
         werft.done('certificate');
         await addDNSRecord(deploymentConfig.namespace, deploymentConfig.domain, false)
@@ -952,8 +952,8 @@ async function addDNSRecord(namespace: string, domain: string, isLoadbalancer: b
     werft.done(installerSlices.DNS_ADD_RECORD);
 }
 
-export async function issueMetaCerts(previewNamespace: string, certsNamespace:string, domain: string) {
-    let additionalSubdomains: string[] = ["", "*.", "*.ws-dev."]
+export async function issueMetaCerts(previewNamespace: string, certsNamespace: string, domain: string, withVM: boolean) {
+    let additionalSubdomains: string[] = ["", "*.", `*.ws${ withVM ? '' : '-dev' }.`]
     var metaClusterCertParams = new IssueCertificateParams();
     metaClusterCertParams.pathToTemplate = "/workspace/.werft/util/templates";
     metaClusterCertParams.gcpSaPath = GCLOUD_SERVICE_ACCOUNT_PATH;

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -72,8 +72,8 @@ spec:
                 bus: virtio
         resources:
           limits:
-            memory: 8Gi
-            cpu: 4
+            memory: 12Gi
+            cpu: 6
       evictionStrategy: LiveMigrate
       networks:
         - pod: {}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Problems with certificates was that we were issuing certificates for `*.ws-dev.<branch>.preview.gitpod-dev.com`, while starting workspace under the domain `*.ws.<branch>.preview.gitpod-dev.com`.

![image](https://user-images.githubusercontent.com/24193764/149209095-5afafef1-28af-4998-94e0-fef6c70b56a2.png)
![image](https://user-images.githubusercontent.com/24193764/149209133-987f5f11-0332-41b1-b78e-43a8b36076c5.png)


I've spent a lot more time than I feel comfortable to admit trying to understand how to configure Gitpod to start workspaces on a different domain. I couldn't find out and in the end, I just changed our certificate to the domain that gitpod uses by default.

After fixing the certificate issues, I've also noticed that imagebuild pods were not starting due to lack of resources, so I'm also increasing it in this same PR(different commits).

![image](https://user-images.githubusercontent.com/24193764/149209439-897493c1-8582-4f63-b82a-a265b3098eb7.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/675

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft with-vm=true