### PR TITLE
Add bottom padding for projects, branches, and prebuilds

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -185,7 +185,7 @@ export default function () {
                         <span>Branch</span>
                     </ItemField>
                 </Item>
-                {isLoadingPrebuilds && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16">
+                {isLoadingPrebuilds && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
                     <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
                     <span>Fetching prebuilds...</span>
                 </div>}

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -215,7 +215,7 @@ export default function () {
                             <span>Prebuild</span>
                         </ItemField>
                     </Item>
-                    {isLoadingBranches && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16">
+                    {isLoadingBranches && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
                         <img className="h-4 w-4 animate-spin" src={Spinner} />
                         <span>Fetching repository branches...</span>
                     </div>}

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -150,7 +150,7 @@ export default function () {
                     {team && <Link to="./members" className="flex"><button className="ml-2 secondary">Invite Members</button></Link>}
                     <button className="ml-2" onClick={() => onNewProject()}>New Project</button>
                 </div>
-                <div className="mt-4 grid grid-cols-3 gap-4">
+                <div className="mt-4 grid grid-cols-3 gap-4 pb-40">
                     {projects.filter(filter).sort(hasNewerPrebuild).map(p => (<div key={`project-${p.id}`} className="h-52">
                         <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
                             <div className="h-32 p-6">


### PR DESCRIPTION
## Description

This will add some bottom padding for the Projects, Branches, and Prebuilds pages, following the changes in https://github.com/gitpod-io/gitpod/pull/7388.

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-01-12 at 11 15 58 PM (2)" src="https://user-images.githubusercontent.com/120486/149222778-329c3244-c342-41b5-996b-32c9930d198b.png"> | <img width="1440" alt="Screenshot 2022-01-12 at 11 16 12 PM (2)" src="https://user-images.githubusercontent.com/120486/149222783-495c47cc-ebcc-4361-a14c-247dca1fa5b0.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add bottom padding for Projects, Branches, and Prebuilds pages
```