### PR TITLE
Include in the README where to access the development environment when developing dashboards using gitpod

### DIFF
--- a/components/dashboard/README.md
+++ b/components/dashboard/README.md
@@ -59,5 +59,6 @@ After creating a new component, run the following to update the license header:
 - Replace `GITPOD_HOST` with _SaaS Gitpod host_ (e.g. `gitpod.io`) or _self-hosted Gitpod host_ (e.g. the base URL of your target self-hosted Gitpod)
 - Replace `__REPLACE_YOUR_COOKIE__` with the stringified value of your auth cookie taken from your browser's dev tools while visiting your target Gitpod host (e.g. `_gitpod_io_=s%3Axxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.XXXXXXXXXXXXXXX` for `gitpod.io`).
   ![Where to get the auth cookie name and value from](how-to-get-cookie.png)
+- You can view the dashboard at https://`PORT_NUMBER`-`GITPOD_WORKSPACE_URL`.
 
 🚀 After following the above steps, run `yarn run start` to start developing.


### PR DESCRIPTION
Signed-off-by: utam0k <k0ma@utam0k.jp>

## Description

I was a bit confused when I tried to start developing the dashboard, so I added a README to solve that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
None

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-notes
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
