### PR TITLE
Fix the `gitpod.yml` checker Action

### DIFF
--- a/.github/workflows/check-gitpodyaml.yml
+++ b/.github/workflows/check-gitpodyaml.yml
@@ -1,9 +1,5 @@
 name: Check gitpod.yaml changes
 on:
-  push:
-    paths:
-      - ".gitpod.yml"
-      - ".github/workflows/check-gitpodyaml.yml"
   pull_request:
     paths:
       - ".gitpod.yml"
@@ -15,10 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-          -X POST -d '{"body": ":warning: Hey reviewer! BE CAREFUL :warning: \n Review the code before opening in your Gitpod. .gitpod.yaml was changed and it might be harmful."}' \
-          "https://api.github.com/repos/gitpod-io/gitpod/issues/${pull_number}/comments"
+        uses: KeisukeYamashita/create-comment@v1
+        with:
+          number: ${{ github.event.pull_request.number }}
+          comment: |
+            :warning: Hey reviewer! BE CAREFUL :warning:
+            Review the code before opening in your Gitpod. `.gitpod.yml` was changed and it might be harmful.


### PR DESCRIPTION
## Description
Fixes the current behavior of the `gitpod.yml` file checker for PRs in this repo. More details are available in the linked issue.

## Related Issue(s)
Fixes #7481 

## How to test
~~I am not sure how; I don't think it's possible to easily test it. I am open to ideas, though!~~

Edit: looks like it triggered automatically if you scroll down on this PR, so you can check the output! 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
