### PR TITLE
[prebuild-init] Prune while fetching

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -276,9 +276,11 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 	return c.Git(ctx, "clone", args...)
 }
 
-// Fetch runs git fetch
+// Fetch runs git fetch and prunes remote-tracking references as well as ALL LOCAL TAGS.
 func (c *Client) Fetch(ctx context.Context) (err error) {
-	return c.Git(ctx, "fetch")
+	// we need to fetch with pruning to avoid issues like github.com/gitpod-io/gitpod/issues/7561.
+	// See https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---prune for more details.
+	return c.Git(ctx, "fetch", "-p", "-P")
 }
 
 // UpdateRemote performs a git fetch on the upstream remote URI


### PR DESCRIPTION
## Description
When branches are deleted in a repo's remote origin, we might fail when initialising workspace content from a prebuild during the `git fetch` operation. Git would try and fetch the remote tracking reference, but fail because it no longer exists. This PR makes the `git fetch` operation pruning to avoid this issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7561

## How to test
Try and clone a repo that has overlapping branch names, e.g. created by:
```

```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/hold