### PR TITLE
Retrieve telemetry send status from server component

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -57,6 +57,8 @@ import { ProjectDBImpl } from './typeorm/project-db-impl';
 import { EntityManager } from 'typeorm';
 import { OssAllowListDB } from './oss-allowlist-db';
 import { OssAllowListDBImpl } from './typeorm/oss-allowlist-db-impl';
+import { TypeORMInstallationAdminImpl } from './typeorm/installation-admin-db-impl';
+import { InstallationAdminDB } from './installation-admin-db';
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -71,6 +73,9 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
     bind(TermsAcceptanceDBImpl).toSelf().inSingletonScope();
     bind(TermsAcceptanceDB).toService(TermsAcceptanceDBImpl);
     bindDbWithTracing(TracedUserDB, bind, UserDB).inSingletonScope();
+
+    bind(TypeORMInstallationAdminImpl).toSelf().inSingletonScope();
+    bind(InstallationAdminDB).toService(TypeORMInstallationAdminImpl);
 
     bind(AuthProviderEntryDB).to(AuthProviderEntryDBImpl).inSingletonScope();
 

--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -37,3 +37,4 @@ export * from "./email-domain-filter-db";
 export * from "./typeorm/entity/db-account-entry";
 export * from "./project-db";
 export * from "./team-db";
+export * from "./installation-admin-db";

--- a/components/gitpod-db/src/installation-admin-db.ts
+++ b/components/gitpod-db/src/installation-admin-db.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { InstallationAdmin } from "@gitpod/gitpod-protocol";
+
+export const InstallationAdminDB = Symbol('InstallationAdminDB');
+export interface InstallationAdminDB {
+    getTelemetryData(): Promise<InstallationAdmin>;
+}

--- a/components/gitpod-db/src/typeorm/entity/db-installation-admin.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-installation-admin.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { InstallationAdmin, InstallationAdminSettings } from "@gitpod/gitpod-protocol";
+import { Entity, Column, PrimaryColumn } from "typeorm";
+import { TypeORM } from "../typeorm";
+
+@Entity()
+export class DBInstallationAdmin implements InstallationAdmin {
+  @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+  id: string;
+
+  @Column('simple-json')
+  settings: InstallationAdminSettings;
+}

--- a/components/gitpod-db/src/typeorm/installation-admin-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/installation-admin-db-impl.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable, } from 'inversify';
+import { InstallationAdmin } from '@gitpod/gitpod-protocol';
+import { v4 as uuidv4 } from 'uuid';
+import { Repository } from 'typeorm';
+import { TypeORM } from './typeorm';
+import { InstallationAdminDB } from '../installation-admin-db';
+import { DBInstallationAdmin } from './entity/db-installation-admin';
+
+@injectable()
+export class TypeORMInstallationAdminImpl implements InstallationAdminDB {
+    @inject(TypeORM) typeORM: TypeORM;
+
+    protected async getEntityManager() {
+        return (await this.typeORM.getConnection()).manager;
+    }
+
+    protected async createDefaultRecord(): Promise<InstallationAdmin> {
+        const record: InstallationAdmin = {
+            id: uuidv4(),
+            settings: {
+                sendTelemetry: false,
+            },
+        };
+
+        const repo = await this.getInstallationAdminRepo();
+        return repo.save(record);
+    }
+
+    async getInstallationAdminRepo(): Promise<Repository<DBInstallationAdmin>> {
+        return (await this.getEntityManager()).getRepository<DBInstallationAdmin>(DBInstallationAdmin);
+    }
+
+    /**
+     * Get Telemetry Data
+     *
+     * Returns the first record found or creates a
+     * new record.
+     *
+     * @returns Promise<InstallationAdmin>
+     */
+    async getTelemetryData(): Promise<InstallationAdmin> {
+        const repo = await this.getInstallationAdminRepo();
+        const [record] = await repo.find();
+
+        if (record) {
+            return record;
+        }
+
+        /* Record not found - create one */
+        return this.createDefaultRecord();
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1642422506330-InstallationAdminTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1642422506330-InstallationAdminTable.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { tableExists } from "./helper/helper";
+
+export class InstallationAdminTable1642422506330 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await tableExists(queryRunner, "d_b_installation_admin"))) {
+            await queryRunner.query("CREATE TABLE IF NOT EXISTS `d_b_installation_admin` (`id` char(128) NOT NULL, `settings` text NULL, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY(`id`)) ENGINE=InnoDB");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await tableExists(queryRunner, "d_b_installation_admin")) {
+            await queryRunner.query("DROP TABLE `d_b_installation_admin`");
+        }
+    }
+
+}

--- a/components/gitpod-protocol/src/index.ts
+++ b/components/gitpod-protocol/src/index.ts
@@ -19,3 +19,4 @@ export * from './context-url';
 export * from './teams-projects-protocol';
 export * from './snapshot-url';
 export * from './oss-allowlist';
+export * from './installation-admin-protocol';

--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export interface InstallationAdminSettings {
+    sendTelemetry: boolean;
+}
+
+export interface InstallationAdmin {
+    id: string;
+    settings: InstallationAdminSettings;
+}

--- a/components/installation-telemetry/go.mod
+++ b/components/installation-telemetry/go.mod
@@ -19,3 +19,53 @@ require (
 )
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace k8s.io/api => k8s.io/api v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiserver => k8s.io/apiserver v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/client-go => k8s.io/client-go v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/code-generator => k8s.io/code-generator v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-base => k8s.io/component-base v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cri-api => k8s.io/cri-api v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubelet => k8s.io/kubelet v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/metrics => k8s.io/metrics v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-helpers => k8s.io/component-helpers v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/controller-manager => k8s.io/controller-manager v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubectl => k8s.io/kubectl v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/mount-utils => k8s.io/mount-utils v0.22.2 // leeway indirect from components/common-go:lib
+
+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.22.2 // leeway indirect from components/common-go:lib

--- a/components/installation-telemetry/pkg/common/config.go
+++ b/components/installation-telemetry/pkg/common/config.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package common
+
+import (
+	"fmt"
+	"os"
+)
+
+type Config struct {
+	Server string
+}
+
+func NewConfig() (*Config, error) {
+	config := Config{
+		Server: os.Getenv("SERVER_URL"),
+	}
+
+	if config.Server == "" {
+		return nil, fmt.Errorf("SERVER_URL required")
+	}
+
+	return &config, nil
+}

--- a/components/installation-telemetry/pkg/server/installationAdmin.go
+++ b/components/installation-telemetry/pkg/server/installationAdmin.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/gitpod-io/gitpod/installation-telemetry/pkg/common"
+)
+
+type InstallationAdminSettings struct {
+	SendTelemetry bool `json:"sendTelemetry"`
+}
+
+type InstallationAdminData struct {
+	ID       string                    `json:"id"`
+	Settings InstallationAdminSettings `json:"settings"`
+}
+
+func GetInstallationAdminData(config common.Config) (*InstallationAdminData, error) {
+	resp, err := http.Get(fmt.Sprintf("%s/data", config.Server))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var data InstallationAdminData
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -12,6 +12,7 @@ import { SessionHandlerProvider } from './session-handler';
 import { GitpodFileParser } from '@gitpod/gitpod-protocol/lib/gitpod-file-parser';
 import { WorkspaceFactory } from './workspace/workspace-factory';
 import { UserController } from './user/user-controller';
+import { InstallationAdminController } from './installation-admin/installation-admin-controller';
 import { GitpodServerImpl } from './workspace/gitpod-server-impl';
 import { ConfigProvider } from './workspace/config-provider';
 import { MessageBusIntegration } from './workspace/messagebus-integration';
@@ -115,6 +116,8 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(EnforcementControllerServerFactory).toAutoFactory(GitpodServerImpl);
     bind(EnforcementController).toSelf().inSingletonScope();
 
+    bind(InstallationAdminController).toSelf().inSingletonScope();
+
     bind(MessagebusConfiguration).toSelf().inSingletonScope();
     bind(MessageBusHelper).to(MessageBusHelperImpl).inSingletonScope();
     bind(MessageBusIntegration).toSelf().inSingletonScope();
@@ -124,11 +127,11 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(GitpodServerImpl).toSelf();
     bind(WebsocketConnectionManager).toDynamicValue(ctx => {
-            const serverFactory = () => ctx.container.get<GitpodServerImpl>(GitpodServerImpl);
-            const hostContextProvider = ctx.container.get<HostContextProvider>(HostContextProvider);
-            const config = ctx.container.get<Config>(Config);
-            return new WebsocketConnectionManager(serverFactory, hostContextProvider, config.rateLimiter);
-        }
+        const serverFactory = () => ctx.container.get<GitpodServerImpl>(GitpodServerImpl);
+        const hostContextProvider = ctx.container.get<HostContextProvider>(HostContextProvider);
+        const config = ctx.container.get<Config>(Config);
+        return new WebsocketConnectionManager(serverFactory, hostContextProvider, config.rateLimiter);
+    }
     ).inSingletonScope();
 
     bind(PrometheusClientCallMetrics).toSelf().inSingletonScope();

--- a/components/server/src/installation-admin/installation-admin-controller.ts
+++ b/components/server/src/installation-admin/installation-admin-controller.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { injectable, inject } from 'inversify';
+import * as express from 'express';
+import { InstallationAdminDB } from '@gitpod/gitpod-db/lib';
+
+@injectable()
+export class InstallationAdminController {
+    @inject(InstallationAdminDB) protected readonly installationAdminDb: InstallationAdminDB;
+
+    public create(): express.Application {
+        const app = express();
+
+        app.get('/data', async (req: express.Request, res: express.Response) => {
+            const data = await this.installationAdminDb.getTelemetryData();
+
+            res.send(data);
+        });
+
+        return app;
+    }
+}

--- a/installer/go.mod
+++ b/installer/go.mod
@@ -242,9 +242,15 @@ replace github.com/gitpod-io/gitpod/content-service/api => ../components/content
 
 replace github.com/gitpod-io/gitpod/gitpod-protocol => ../components/gitpod-protocol/go // leeway
 
+replace github.com/gitpod-io/gitpod/image-builder/api => ../components/image-builder-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/openvsx-proxy => ../components/openvsx-proxy // leeway
+
 replace github.com/gitpod-io/gitpod/registry-facade => ../components/registry-facade // leeway
 
 replace github.com/gitpod-io/gitpod/registry-facade/api => ../components/registry-facade-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/supervisor/api => ../components/supervisor-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-daemon => ../components/ws-daemon // leeway
 
@@ -252,7 +258,9 @@ replace github.com/gitpod-io/gitpod/ws-daemon/api => ../components/ws-daemon-api
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../components/ws-manager-api/go // leeway
 
-replace github.com/gitpod-io/gitpod/supervisor/api => ../components/supervisor-api/go // leeway
+replace github.com/gitpod-io/gitpod/ws-proxy => ../components/ws-proxy // leeway
+
+replace github.com/gitpod-io/gitpod/ws-scheduler => ../components/ee/ws-scheduler // leeway
 
 replace k8s.io/api => k8s.io/api v0.22.2 // leeway indirect from components/common-go:lib
 

--- a/installer/pkg/common/constants.go
+++ b/installer/pkg/common/constants.go
@@ -38,6 +38,7 @@ const (
 	RegistryFacadeServicePort   = 30000
 	RegistryFacadeTLSCertSecret = "builtin-registry-facade-cert"
 	ServerComponent             = "server"
+	ServerInstallationAdminPort = 9000
 	SystemNodeCritical          = "system-node-critical"
 	WSManagerComponent          = "ws-manager"
 	WSManagerBridgeComponent    = "ws-manager-bridge"

--- a/installer/pkg/components/gitpod/cronjob.go
+++ b/installer/pkg/components/gitpod/cronjob.go
@@ -5,7 +5,6 @@
 package gitpod
 
 import (
-	"crypto/sha512"
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -61,12 +60,12 @@ func cronjob(ctx *common.RenderContext) ([]runtime.Object, error) {
 										},
 										Env: []v1.EnvVar{
 											{
-												Name:  "GITPOD_DOMAIN_HASH",
-												Value: fmt.Sprintf("%x", sha512.Sum512([]byte(ctx.Config.Domain))),
-											},
-											{
 												Name:  "GITPOD_INSTALLATION_VERSION",
 												Value: ctx.VersionManifest.Version,
+											},
+											{
+												Name:  "SERVER_URL",
+												Value: fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", common.ServerComponent, ctx.Namespace, common.ServerInstallationAdminPort),
 											},
 										},
 									},

--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -10,4 +10,5 @@ var Objects = common.CompositeRenderFunc(
 	configmap,
 	cronjob,
 	common.DefaultServiceAccount(Component),
+	rolebinding,
 )

--- a/installer/pkg/components/gitpod/rolebinding.go
+++ b/installer/pkg/components/gitpod/rolebinding.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package gitpod
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.DefaultLabels(Component)
+
+	return []runtime.Object{
+		&rbacv1.RoleBinding{
+			TypeMeta: common.TypeMetaRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind: "ServiceAccount",
+				Name: Component,
+			}},
+		},
+	}, nil
+}

--- a/installer/pkg/components/server/constants.go
+++ b/installer/pkg/components/server/constants.go
@@ -9,12 +9,14 @@ import (
 )
 
 const (
-	Component            = common.ServerComponent
-	ContainerPort        = 3000
-	ContainerPortName    = "http"
-	authProviderFilePath = "/gitpod/auth-providers"
-	licenseFilePath      = "/gitpod/license"
-	PrometheusPort       = 9500
-	PrometheusPortName   = "metrics"
-	ServicePort          = 3000
+	Component             = common.ServerComponent
+	ContainerPort         = 3000
+	ContainerPortName     = "http"
+	authProviderFilePath  = "/gitpod/auth-providers"
+	licenseFilePath       = "/gitpod/license"
+	PrometheusPort        = 9500
+	PrometheusPortName    = "metrics"
+	InstallationAdminPort = common.ServerInstallationAdminPort
+	InstallationAdminName = "installation-admin"
+	ServicePort           = 3000
 )

--- a/installer/pkg/components/server/networkpolicy.go
+++ b/installer/pkg/components/server/networkpolicy.go
@@ -6,6 +6,7 @@ package server
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/gitpod"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,40 +17,76 @@ import (
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
-	return []runtime.Object{&networkingv1.NetworkPolicy{
-		TypeMeta: common.TypeMetaNetworkPolicy,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    labels,
+	return []runtime.Object{
+		&networkingv1.NetworkPolicy{
+			TypeMeta: common.TypeMetaNetworkPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: labels},
+				PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: ContainerPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.ProxyComponent,
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: PrometheusPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"chart": common.MonitoringChart,
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.ProxyComponent,
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: InstallationAdminPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": gitpod.Component,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: labels},
-			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: ContainerPort},
-				}},
-				From: []networkingv1.NetworkPolicyPeer{{
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": common.ProxyComponent,
-					}},
-				}},
-			}, {
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: PrometheusPort},
-				}},
-				From: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"chart": common.MonitoringChart,
-					}},
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": common.ProxyComponent,
-					}},
-				}},
-			}},
-		},
-	}}, nil
+	}, nil
 }

--- a/installer/pkg/components/server/objects.go
+++ b/installer/pkg/components/server/objects.go
@@ -25,6 +25,10 @@ var Objects = common.CompositeRenderFunc(
 			ContainerPort: PrometheusPort,
 			ServicePort:   PrometheusPort,
 		},
+		InstallationAdminName: {
+			ContainerPort: InstallationAdminPort,
+			ServicePort:   InstallationAdminPort,
+		},
 	}),
 	common.DefaultServiceAccount(Component),
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Creates the installation admin controller in the `server` component and associated database. This database works on the basis that there is only one record created per installation - in future, this will be the backing for the installation's admin panel. At the moment, this only has one record (`sendTelemetry`), but will have more records in future.

The `sendTelemetry` boolean currently defaults to `false` and will do until the admin panel exists then it will change to default `true`.

It amends the Installer to cater for these changes. It allows the `gitpod-telemetry` job to access the `server` component. It also removed the `GITPOD_DOMAIN_HASH` and uses the randomly generated ID for installation identification.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7571
Fixes #7585 

## How to test
<!-- Provide steps to test this PR -->
Deploy via werft and check that you can access `GET:/installation-admin/data` when port forwarding to the server component.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server]: Create installation admin controller
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
