### PR TITLE
werft/post-process: Configure different registry facade DNS for Harvester previews

### DIFF
--- a/.werft/post-process.sh
+++ b/.werft/post-process.sh
@@ -179,6 +179,9 @@ while [ "$i" -le "$DOCS" ]; do
       # is expected to be reg.<branch-name-with-dashes>.staging.gitpod-dev.com:$REG_DAEMON_PORT
       # Change the port we use to connect to ws-daemon
       REGISTRY_FACADE_HOST="reg.$DEV_BRANCH.staging.gitpod-dev.com:$REG_DAEMON_PORT"
+      if [[ -v WITH_VM ]]; then
+         REGISTRY_FACADE_HOST="reg.$DEV_BRANCH.preview.gitpod-dev.com:$REG_DAEMON_PORT"
+      fi
       yq r /tmp/"$NAME"overrides.yaml 'data.[config.json]' \
       | jq --arg REGISTRY_FACADE_HOST "$REGISTRY_FACADE_HOST" '.manager.registryFacadeHost = $REGISTRY_FACADE_HOST' \
       | jq ".manager.wsdaemon.port = $WS_DAEMON_PORT" > /tmp/"$NAME"-cm-overrides.json


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR updates the ws-manager post-processing configuration, updating the Registry-facade DNS used to pull workspace images.

Workspaces are finally starting in harvester previews 🎉, although we're having some network issues and pulling images is taking super long.

_PS: Looking forward to refactoring our main CI pipeline and getting rid of post-processing 😅_ 

## How to test
<!-- Provide steps to test this PR -->
Open the preview environment of this PR and start a workspace. After some time(~30m) it should start

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```