### PR TITLE
Use internal workspace-images to create and dog food dev environment images

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-test-dazzle-rewrite.79
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -126,6 +126,7 @@ export async function build(context, version) {
     try {
         exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`);
         exec("gcloud auth configure-docker --quiet");
+        exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet");
         exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev');
         werft.done('prep');
     } catch (err) {
@@ -284,7 +285,7 @@ export async function build(context, version) {
     const domain = withVM ? `${destname}.preview.gitpod-dev.com` : `${destname}.staging.gitpod-dev.com`;
     const monitoringDomain = `${destname}.preview.gitpod-dev.com`;
     const url = `https://${domain}`;
-    const imagePullAuth = exec(`echo -n "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
+    const imagePullAuth = exec(`printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
         | yq r - data['.dockerconfigjson'] \
         | base64 -d)" | base64 -w 0`, { silent: true }).stdout.trim();
     const deploymentConfig: DeploymentConfig = {
@@ -453,7 +454,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
     if (!hasPullSecret) {
         try {
             werft.log(installerSlices.IMAGE_PULL_SECRET, "Adding the image pull secret to the namespace");
-            const dockerConfig = { auths: { "eu.gcr.io": { auth: deploymentConfig.imagePullAuth } } };
+            const dockerConfig = { auths: { "eu.gcr.io": { auth: deploymentConfig.imagePullAuth }, "europe-docker.pkg.dev": { auth: deploymentConfig.imagePullAuth } } };
             fs.writeFileSync(`./${IMAGE_PULL_SECRET_NAME}`, JSON.stringify(dockerConfig));
             exec(`kubectl create secret docker-registry ${IMAGE_PULL_SECRET_NAME} -n ${namespace} --from-file=.dockerconfigjson=./${IMAGE_PULL_SECRET_NAME}`);
             werft.done(installerSlices.IMAGE_PULL_SECRET);
@@ -720,13 +721,16 @@ export async function deployToDevWithHelm(deploymentConfig: DeploymentConfig, wo
     // core-dev specific section start
     werft.log("secret", "copy secret into namespace")
     try {
-        const auth = exec(`echo -n "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
+        const auth = exec(`printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
                         | yq r - data['.dockerconfigjson'] \
                         | base64 -d)" | base64 -w 0`, { silent: true }).stdout.trim();
         fs.writeFileSync("chart/gcp-sa-registry-auth",
             `{
     "auths": {
         "eu.gcr.io": {
+            "auth": "${auth}"
+        },
+        "europe-docker.pkg.dev": {
             "auth": "${auth}"
         }
     }

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -62,7 +62,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-test-dazzle-rewrite.79
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-test-dazzle-rewrite.79
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-test-dazzle-rewrite.79
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.29
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-test-dazzle-rewrite.79
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -2,7 +2,10 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM gitpod/workspace-full:latest
+# if you want to run this image in a workspace, follow these steps:
+# gcloud auth configure-docker europe-docker.pkg.dev
+# gcloud auth login --no-launch-browser
+FROM europe-docker.pkg.dev/gitpod-artifacts/docker-dev/workspace-base-images:full
 
 ENV TRIGGER_REBUILD 16
 
@@ -139,7 +142,7 @@ RUN sudo install-packages \
     python-dev \
     python-setuptools
 
-RUN bash -c "pip uninstall crcmod; pip install --no-cache-dir -U crcmod"
+RUN sudo python3 -m pip uninstall crcmod; sudo python3 -m pip install --no-cache-dir -U crcmod
 
 ### gitpod-core specific gcloud/kubectl config
 # Copy GCloud default config that points to gitpod-dev
@@ -159,7 +162,7 @@ ENV LEEWAY_WORKSPACE_ROOT=/workspace/gitpod
 ENV LEEWAY_REMOTE_CACHE_BUCKET=gitpod-core-leeway-cache-branch
 
 ### AWS Cli ###
-RUN pip install --no-cache-dir awscli
+RUN sudo python3 -m pip install --no-cache-dir awscli
 
 # Install aws-iam-authenticator
 RUN sudo curl -fsSL -o aws-iam-authenticator "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" \
@@ -189,7 +192,7 @@ RUN sudo curl -fsSL https://uploader.codecov.io/latest/codecov-linux -o /usr/loc
 
 # Install pre-commit https://pre-commit.com/#install
 RUN sudo install-packages shellcheck \
-    && sudo pip3 install pre-commit
+    && sudo python3 -m pip install pre-commit
 
 # Install observability-related binaries
 ARG PROM_VERSION="2.30.0"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use internal workspace full image `europe-docker.pkg.dev/gitpod-artifacts/docker-dev/workspace-base-images:full` for the creation of dev-environment image `eu.gcr.io/gitpod-core-dev/dev/dev-environment`.
This dev-environment image is produced by werft job. We want to consume this image in order to dog food our workspace images which are being generated by [dazzle-rewrite](https://github.com/gitpod-io/workspace-images/pull/593).
This will help us discover any issue with the base image quicker as gitpod developers would be actively using the dev env based on this image.


Update the werft build script to configure docker to use gcloud as credential helper in order to pull image from internal repo.

Fix werft secret creation of `gcp-registry-auth`. Using `echo` within the `exec` function of typescript resulted in conversion of all newline characters `\n` with actual newlines. i.e. something like below
```
echo -n "this\nis\ngitpod"
```
resulted in an output
```
this
is
gitpod
```
whereas we expected
```
this\nis\ngitpod
```
This broke the image pull secret.

This was not discovered until now as the image repo being used in the preview environment had public access. Introducing a private repo uncovered this issue.

## Current status
There's an issue with GPG keys for `llvm` and `docker` resulting in NO_PUBKEY errors, which was preventing install of `kubectl`. We've put a temporary hack in the dev image's Dockerfile to add the missing keys, and are working on solution for `workspace-images`. This way, users won't have a bad experience when using `add-apt-repository`.

Also, we're looking into an issue with the dev image's Dockerfile, it had some path trouble with Python utils (it didn't previously). This is an indicator that there are some path changes which are breaking.

These will not prevent us from dog fooding, but there is some more testing we have to do before sharing with Gitpodders.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7042

## How to test
<!-- Provide steps to test this PR -->
0. Test with the [Gitpod repo](https://prs-test-dazzle-rewrite.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod)
1. Checkout a new branch from HEAD of this branch and push it to repo.
2. This will run a werft build
2.1.  The build will use the internal workspace image -> Passing build means success
2.2. The build will create a dev-environment image which can be seen in the output tab of werft build -> This image is already updated in the .gitpod.yml of this PR (with a different tag). Opening this branch in gitpod -> Successful test
2.3. The build will deploy a preview env. -> Able to access gitpod dashboard -> Successful test
2.4. Use the gitpod installation in preview env to open a repo branch (eg. [this](https://github.com/princerachit/atheoscommune.github.io/blob/dev-env-test/.gitpod.yml)) which uses the internal workspace image. -> Workspace opens means successful test


[Open a workspace for the Gitpod repo using the dev image](https://prs-test-dazzle-rewrite.staging.gitpod-dev.com/#https://github.com/gitpod-io/gitpod) Succeded ✅ 
[Helm installation](https://werft.gitpod-dev.com/job/gitpod-build-prs-test-dazzle-rewrite.76/results) Succeded ✅ 
[Installer installation](https://werft.gitpod-dev.com/job/gitpod-build-prs-test-dazzle-rewrite.77) Succeeded ✅ 
[Leeway No cache Build](https://werft.gitpod-dev.com/job/gitpod-build-prs-test-dazzle-rewrite.91/results) Succeeded ✅ 
<!-- Add the findings with the secret decoding and why the issue was not found -->



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

### PR Build Controls
- [ ] /werft with-helm=true 
- [x] /werft with-clean-slate-deployment=
- [ ] /werft with-vm=