### PR TITLE
[protocol] use owner and repo in lower case in ws IDs

### DIFF
--- a/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
@@ -34,6 +34,7 @@ const expect = chai.expect
             ['gitpod-io','gitpod','gitpodio-gitpod-'],
             ['this is rather long and has some "§$"% special chars','also here pretty long and needs abbreviation','thisisratherlon-alsohere-'],
             ['breatheco-de', 'python-flask-api-tutorial', 'breathecode-pythonflaska-'],
+            ['UPPER', "CaSe", "upper-case-"]
         ]
         for (const d of data) {
             const id = await generateWorkspaceID(d[0], d[1]);

--- a/components/gitpod-protocol/src/util/generate-workspace-id.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.ts
@@ -15,6 +15,7 @@ function clean(segment: string | undefined, maxChars: number = 15) {
   if (!segment) {
     return undefined;
   }
+  segment = segment.toLowerCase();
   let result = '';
   for (let i =0; i < segment.length; i++) {
     if (characters.indexOf(segment[i]) !== -1) {


### PR DESCRIPTION
Follow up to #7391

I don't want to be "anoehnlein"

```release-notes
NONE
```