### PR TITLE
[dashboard][server] Make Project overview page load faster by pre-fetching and caching Git provider data (branch details)

### DIFF
--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -21,4 +21,6 @@ export interface ProjectDB {
     getProjectEnvironmentVariableById(variableId: string): Promise<ProjectEnvVar | undefined>;
     deleteProjectEnvironmentVariable(variableId: string): Promise<void>;
     getProjectEnvironmentVariableValues(envVars: ProjectEnvVar[]): Promise<ProjectEnvVarWithValue[]>;
+    findCachedProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
+    storeCachedProjectOverview(projectId: string, overview: Project.Overview): Promise<void>;
 }

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -251,6 +251,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             deletionColumn: 'deleted',
             timeColumn: '_lastModified',
         },
+        {
+            name: 'd_b_project_info',
+            primaryKeys: ['projectId'],
+            deletionColumn: 'deleted',
+            timeColumn: '_lastModified',
+        },
         /**
          * BEWARE
          *

--- a/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
+++ b/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
@@ -59,6 +59,7 @@ const tables: TableWithDeletion[] = [
     { deletionColumn: "deleted", name: "d_b_prebuild_info" },
     { deletionColumn: "deleted", name: "d_b_oss_allow_list" },
     { deletionColumn: "deleted", name: "d_b_project_env_var" },
+    { deletionColumn: "deleted", name: "d_b_project_info" },
 ];
 
 interface TableWithDeletion {

--- a/components/gitpod-db/src/typeorm/entity/db-project-info.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project-info.ts
@@ -5,15 +5,16 @@
  */
 
 import { Entity, Column, PrimaryColumn } from "typeorm";
-import { PrebuildInfo } from "@gitpod/gitpod-protocol";
+import { Project } from "@gitpod/gitpod-protocol";
 
 import { TypeORM } from "../../typeorm/typeorm";
 
 @Entity()
-export class DBPrebuildInfo {
+// on DB but not Typeorm: @Index("ind_dbsync", ["_lastModified"])   // DBSync
+export class DBProjectInfo {
 
     @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
-    prebuildId: string;
+    projectId: string;
 
     @Column({
         type: 'simple-json',
@@ -25,13 +26,18 @@ export class DBPrebuildInfo {
                 from(value: any): any {
                     try {
                         const obj = JSON.parse(value);
-                        return PrebuildInfo.is(obj) ? obj : undefined;
+                        if (Project.Overview.is(obj)) {
+                            return obj;
+                        }
                     } catch (error) {
                     }
                 }
             };
         })()
     })
-    info: PrebuildInfo;
+    overview: Project.Overview;
 
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/migration/1642497869312-ProjectInfo.ts
+++ b/components/gitpod-db/src/typeorm/migration/1642497869312-ProjectInfo.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ProjectInfo1642497869312 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("CREATE TABLE IF NOT EXISTS `d_b_project_info` ( `projectId` char(36) NOT NULL, `overview` longtext NOT NULL, `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`projectId`), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -42,7 +42,13 @@ export namespace Project {
     }
 
     export interface Overview {
-        branches: BranchDetails[]
+        branches: BranchDetails[];
+    }
+
+    export namespace Overview {
+        export function is(data?: any): data is Project.Overview {
+            return Array.isArray(data?.branches);
+        }
     }
 
     export interface BranchDetails {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1644,7 +1644,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
         await this.guardProjectOperation(user, projectId, "get");
         try {
-            return await this.projectsService.getProjectOverview(user, project);
+            return await this.projectsService.getProjectOverviewCached(user, project);
         } catch (error) {
             if (UnauthorizedError.is(error)) {
                 throw new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "Unauthorized", error.data);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Make Project Branches page load faster by pre-fetching and caching GitHub/GitLab/Bitbucket data (branch details).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7536

## How to test
<!-- Provide steps to test this PR -->

1. Open any Branches page on https://gitpod.io -- notice it sometimes takes 30-40s to load 🙄
2. Add Projects in the preview environment and open its Branches page -- should be fast ⚡

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard][server] Make Project overview page load faster by pre-fetching and caching Git provider data (branch details)
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-clean-slate-deployment

/uncc