### PR TITLE
added support for cleanSlateDeployment

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -321,6 +321,11 @@ export async function build(context, version) {
         if (!existingVM) {
             werft.log(vmSlices.BOOT_VM, 'Starting VM')
             VM.startVM({ name: destname })
+        } else if (cleanSlateDeployment) {
+            werft.log(vmSlices.BOOT_VM, 'Removing existing namespace')
+            VM.deleteVM({ name: destname })
+            werft.log(vmSlices.BOOT_VM, 'Starting VM')
+            VM.startVM({ name: destname })
         } else {
             werft.log(vmSlices.BOOT_VM, 'VM already exists')
         }
@@ -417,7 +422,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
 
     // clean environment state
     try {
-        if (deploymentConfig.cleanSlateDeployment) {
+        if (deploymentConfig.cleanSlateDeployment && !withVM) {
             werft.log(installerSlices.CLEAN_ENV_STATE, "Clean the preview environment slate...");
             // re-create namespace
             await cleanStateEnv(metaEnv());


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds clean-slate-deployment for preview-environments on Harvester.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7542

## How to test
<!-- Provide steps to test this PR -->
Make two commits on a new branch with the comment `/werft with-vm=true`. The first one will create a new prev-environment, the second one will do remove the previous installation when the comment `/werft with-clean-slate-deployment=true` is added.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
