### PR TITLE
Explicitly launch code server on 0.0.0.0

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -5,7 +5,7 @@ defaultArgs:
   npmPublishTrigger: "false"
   publishToNPM: true
   localAppVersion: unknown
-  codeCommit: 2467ffbd5d32c464d85debaf7e9e354b3df7c2e5
+  codeCommit: 4591e0158896bfd22d70bbc0f37c379d5bae4265
 
 provenance:
   enabled: true

--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -38,7 +38,7 @@ grep -rl open-vsx.org /ide | xargs sed -i "s|https://open-vsx.org|$VSX_REGISTRY_
 
 cd /ide || exit
 if [ "$SUPERVISOR_DEBUG_ENABLE" = "true" ]; then
-    exec /ide/bin/gitpod-code --inspect --verbose --log trace --connection-token 00000 "$@"
+    exec /ide/bin/gitpod-code --inspect --log=trace --host=0.0.0.0 --connection-token=00000 "$@"
 else
-    exec /ide/bin/gitpod-code --connection-token 00000 "$@"
+    exec /ide/bin/gitpod-code --host=0.0.0.0 --connection-token=00000 "$@"
 fi

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -813,13 +813,11 @@ func prepareIDELaunch(cfg *Config, ideConfig *IDEConfig) *exec.Cmd {
 	if ideConfig.Entrypoint == "/ide/startup.sh" && len(args) == 0 {
 		args = append(args, "{WORKSPACEROOT}")
 		args = append(args, "--port", "{IDEPORT}")
-		args = append(args, "--hostname", "{IDEHOSTNAME}")
 	}
 
 	for i := range args {
 		args[i] = strings.ReplaceAll(args[i], "{WORKSPACEROOT}", cfg.WorkspaceRoot)
 		args[i] = strings.ReplaceAll(args[i], "{IDEPORT}", strconv.Itoa(cfg.IDEPort))
-		args[i] = strings.ReplaceAll(args[i], "{IDEHOSTNAME}", "0.0.0.0")
 		args[i] = strings.ReplaceAll(args[i], "{DESKTOPIDEPORT}", strconv.Itoa(desktopIDEPort))
 	}
 	log.WithField("args", args).WithField("entrypoint", ideConfig.Entrypoint).Info("preparing IDE launch")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
After vscode server upstream changes, the server now launches on `127.0.0.1` by default, so I updated the startup script to launch explicitly on `0.0.0.0`

## How to test
<!-- Provide steps to test this PR -->
1. Select insiders 
2. Launch a workspace
3. Run on terminal `sudo lsof -i -P -n | grep 23000 | grep LISTEN` or `netstat -anlp | grep 23000 | grep LISTEN` and check bound address is `0.0.0.0`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
