### PR TITLE
[supervisor] nicely handle OOM killed IDE processes

### DIFF
--- a/components/ide/jetbrains/image/startup.sh
+++ b/components/ide/jetbrains/image/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -li
+#!/bin/bash
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -732,6 +732,8 @@ supervisorLoop:
 
 		select {
 		case <-ideStopped:
+			// kill all processes in same pgid
+			_ = syscall.Kill(-1*cmd.Process.Pid, syscall.SIGKILL)
 			// IDE was stopped - let's just restart it after a small delay (in case the IDE doesn't start at all) in the next round
 			if ideStatus == statusShouldShutdown {
 				break supervisorLoop


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
nicely handle OOM killed IDE processes by kill all sub processes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6545

## How to test
<!-- Provide steps to test this PR -->
1. [optional] configure your preference to *Open in Desktop IDE*
2. start a workspace
3. `kill -9 <ide_desktop_startup_sh_pid>`
4. check process restart and workspace status
5. [optional] `kill -9 <ide_server_sh_pid>`
6. [optional] repeat step 4

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
