### PR TITLE
fix #7054: fix disposing of listeners

### DIFF
--- a/components/server/src/messaging/local-message-broker.ts
+++ b/components/server/src/messaging/local-message-broker.ts
@@ -170,7 +170,7 @@ export class LocalRabbitMQBackedMessageBroker implements LocalMessageBroker {
             const ls = listeners!;
             let idx = ls.findIndex((l) => l === listener);
             if (idx !== -1) {
-                ls.splice(idx);
+                ls.splice(idx, 1);
             }
             if (ls.length === 0) {
                 listenersStore.delete(key);

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -135,7 +135,7 @@ export class WebsocketClientContext {
     removeEndpoint(server: GitpodServerImpl) {
         const index = this.servers.findIndex(s => s.uuid === server.uuid);
         if (index !== -1) {
-            this.servers.splice(index);
+            this.servers.splice(index, 1);
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Server was removing all listeners after removed listener. This PR fixes that it removes only one listener.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7054

## How to test
<!-- Provide steps to test this PR -->

Actually it should be quite easy to reproduce anyway:
- have 2 clients for the same workspace and user
- close first one
- second will stop receiving ws events

With this PR you should not be able to reproduce it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
