### PR TITLE
Revert "[supervisor] Add log for exposed port instance update"

### DIFF
--- a/components/supervisor/pkg/ports/exposed-ports.go
+++ b/components/supervisor/pkg/ports/exposed-ports.go
@@ -109,11 +109,8 @@ func (g *GitpodExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
 			select {
 			case u := <-updates:
 				if u == nil {
-					log.WithFields(log.OWI("", g.WorkspaceID, g.InstanceID)).Info("GitpodExposedPorts: instance update is nil")
 					return
 				}
-
-				log.WithFields(log.OWI("", g.WorkspaceID, g.InstanceID)).WithField("instance", u).Info("GitpodExposedPorts: new instance update")
 
 				res := make([]ExposedPort, len(u.Status.ExposedPorts))
 				for i, p := range u.Status.ExposedPorts {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This reverts commit 73e93f3f5497978f98d2628e7651b70e9915992a.

Undetected ports turned out to be a server issue: https://github.com/gitpod-io/gitpod/pull/7621
We don't need logging anymore to prove it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/6778

## How to test
<!-- Provide steps to test this PR -->

Do a smoke test of workspace and check that ports are exposed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
