### PR TITLE
[installer] Fix ws-daemon image pull policy

### DIFF
--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -6,6 +6,7 @@ package wsdaemon
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
@@ -275,7 +276,7 @@ fi
 					InitialDelaySeconds: 5,
 					PeriodSeconds:       10,
 				},
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				SecurityContext: &corev1.SecurityContext{
 					Privileged: pointer.Bool(true),
 				},


### PR DESCRIPTION
## Description

In case of network issue, using `Always` can avoid a pod restart, even if the image is present in the node.

## Release Notes

```release-note
[installer] Fix ws-daemon image pull policy
```
