### PR TITLE
[dashboard] Fix broken client.dispose()

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -383,10 +383,12 @@ export class GitpodCompositeClient<Client extends GitpodClient> implements Gitpo
 
     public registerClient(client: Partial<Client>): Disposable {
         this.clients.push(client);
-        const index = this.clients.length;
         return {
             dispose: () => {
-                this.clients.slice(index, 1);
+                const index = this.clients.indexOf(client);
+                if (index > -1) {
+                    this.clients.splice(index, 1);
+                }
             }
         }
     }
@@ -576,7 +578,7 @@ export class WorkspaceInstanceUpdateListener {
 }
 
 export interface GitpodServiceOptions {
-    onReconnect?: () => (void | Promise<void>)
+    onReconnect?: () => (void | Promise<void>)
 }
 
 export class GitpodServiceImpl<Client extends GitpodClient, Server extends GitpodServer> {


### PR DESCRIPTION
## Description
This leads to wrong API clients being removed on `dispose`, leading to missed connect/disconnect events and lost notifications.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #7054 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
