### PR TITLE
[installer] Fix mysql image pull policy

### DIFF
--- a/installer/pkg/components/database/incluster/helm.go
+++ b/installer/pkg/components/database/incluster/helm.go
@@ -38,6 +38,7 @@ var Helm = common.CompositeHelmFunc(
 					helm.ImagePullSecrets("mysql.metrics.image.pullSecrets", cfg),
 					helm.KeyValue("mysql.metrics.image.registry", common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)),
 					helm.ImagePullSecrets("mysql.volumePermissions.image.pullSecrets", cfg),
+					helm.KeyValue("mysql.volumePermissions.image.pullPolicy", "IfNotPresent"),
 					helm.KeyValue("mysql.volumePermissions.image.registry", common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)),
 
 					// improve start time


### PR DESCRIPTION
## Description

In case of network issue, using `Always` can avoid a pod restart, even if the image is present in the node.

## Release Notes

```release-note
[installer] Fix mysql image pull policy
```
