### PR TITLE
Fix exposed ports edge case

### DIFF
--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -259,9 +259,9 @@ func (pm *Manager) updateState(ctx context.Context, exposed []ExposedPort, serve
 	if served != nil {
 		servedMap := make(map[uint32]ServedPort)
 		for _, port := range served {
-			if port.Address.String() == workspaceIPAdress {
+			if _, existProxy := pm.proxies[port.Port]; existProxy && port.Address.String() == workspaceIPAdress {
 				// Ignore entries that are bound to the workspace ip address
-				// as they are created by the reverse proxy
+				// as they are created by the internal reverse proxy
 				continue
 			}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
From https://github.com/gitpod-io/gitpod/pull/7534#discussion_r785480728
Only ignore served ports bound to the workspace IP address if we have a corresponding reverse proxy

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace
2. Run in terminal `python -m http.server 8989 --bind 10.0.2.100`
3. Verify `8989` port appears in remote explorer view

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

