### PR TITLE
Download instead of view account statement

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -21,7 +21,6 @@ export default function UserDetail(p: { user: User }) {
     const [activity, setActivity] = useState(false);
     const [user, setUser] = useState(p.user);
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
-    const [viewAccountStatement, setViewAccountStatement] = useState(false);
     const [isStudent, setIsStudent] = useState<boolean>();
     const [editFeatureFlags, setEditFeatureFlags] = useState(false);
     const [editRoles, setEditRoles] = useState(false);
@@ -86,6 +85,23 @@ export default function UserDetail(p: { user: User }) {
     const flags = getFlags(user, updateUser);
     const rop = getRopEntries(user, updateUser);
 
+    const downloadAccountStatement = async () => {
+        if (!accountStatement) {
+            return;
+        }
+        try {
+            const blob = new Blob([JSON.stringify(accountStatement)], { type: 'application/json' });
+            const fileDownloadUrl = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = fileDownloadUrl;
+            link.setAttribute('download', 'AccountStatement.json');
+            document.body.appendChild(link);
+            link.click();
+        } catch (error) {
+            console.error(`Error downloading account statement `, error);
+        }
+    }
+
     return <>
         <PageWithSubMenu subMenu={adminMenu} title="Users" subtitle="Search and manage all users.">
             <div className="flex">
@@ -106,8 +122,8 @@ export default function UserDetail(p: { user: User }) {
                         <Property name="Remaining Hours"
                             actions={
                                 accountStatement && [{
-                                    label: 'View Account Statement',
-                                    onClick: () => setViewAccountStatement(true)
+                                    label: 'Download Account Statement',
+                                    onClick: () => downloadAccountStatement()
                                 }, {
                                     label: 'Grant 20 Extra Hours',
                                     onClick: async () => {
@@ -173,15 +189,6 @@ export default function UserDetail(p: { user: User }) {
             <div className="flex flex-col">
                 {
                     rop.map(e => <CheckBox key={e.title} title={e.title} desc="" checked={!!e.checked} onChange={e.onClick} />)
-                }
-            </div>
-        </Modal>
-        <Modal visible={viewAccountStatement} onClose={() => setViewAccountStatement(false)} title="Edit Roles" buttons={[
-            <button className="secondary" onClick={() => setViewAccountStatement(false)}>Done</button>
-        ]}>
-            <div className="flex flex-col">
-                {
-                    JSON.stringify(accountStatement, null, '  ')
                 }
             </div>
         </Modal>


### PR DESCRIPTION
## Description
Account statement is downloadable instead of viewed in the browser.

| BEFORE | NOW |
| - | - |
| <img width="236" alt="Screenshot 2022-01-17 at 10 26 20" src="https://user-images.githubusercontent.com/8015191/149743153-20ea69e7-c3bd-4570-86d6-b3ed9cda2117.png"> |
<img width="236" alt="Screenshot 2022-01-17 at 10 25 30" src="https://user-images.githubusercontent.com/8015191/149742967-6ddb76a0-064a-414e-93bc-340668a21e98.png"> |

## Related Issue(s)
Fixes #7583

## How to test
1. Go to [the Admin page](https://laushinka-account-statement-7583.staging.gitpod-dev.com/admin)
2. Search for a user
3. Click on `Download Account Statement` 
4. See the account statement downloaded locally

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Admin users can download the account statement.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
