### PR TITLE
[dashboard] Prevent adding 'gmail.com' as a verified student email domain

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -54,6 +54,9 @@ export default function UserDetail(p: { user: User }) {
     };
 
     const addStudentDomain = async () => {
+        if (emailDomain === 'gmail.com') {
+            throw new Error(`Sanity check: Not adding '${emailDomain}' as a verified student email domain`);
+        }
         await updateUser(async u => {
             await getGitpodService().server.adminAddStudentEmailDomain(u.id, emailDomain);
             await getGitpodService().server.adminIsStudent(u.id).then(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When a site admin tries to add `gmail.com` as a recognized student email domain -- throw an error instead of adding it (99.99% chance that it's a mistake).

But, only validate on client-side (so that, if for some reason you do absolutely need to recognize everyone `@gmail.com` as a student, you can still do it manually via the API or in the DB directly).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

1. Log in with an account tied to a `@gitpod.io` address (unblocks you & gives you Admin access)
2. Log in as a different user that has a `@gmail.com` email address as primary email (or ask someone who has that to log in)
3. Find the user from 2. in the Admin dashboard, and try to click on "Make 'gmail.com' a student domain"

Expected: Doesn't actually do it, logs an error instead

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc