### PR TITLE
[server] Ensure ws connection gets closed

### DIFF
--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -4,23 +4,11 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { WsRequestHandler } from './express/ws-handler';
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { URL } from 'url';
 import * as express from 'express';
 import * as crypto from 'crypto';
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 import * as session from 'express-session';
-
-export const handleError: WsRequestHandler = (ws, req, next) => {
-    ws.on('error', (err: any) => {
-        if (err.code !== 'ECONNRESET') {
-            log.error('Websocket error', err, { ws, req });
-        }
-        ws.terminate();
-    });
-    next();
-}
 
 export const query = (...tuples: [string, string][]) => {
     if (tuples.length === 0) {

--- a/components/server/src/express/ws-connection-handler.ts
+++ b/components/server/src/express/ws-connection-handler.ts
@@ -26,6 +26,7 @@ export class WsConnectionHandler implements Disposable {
         const TIMEOUT = INTERVAL;
         const CLOSING_TIMEOUT = INTERVAL;
         const timer = repeat(async () => {
+            log.debug("ws connection handler", { clients: this.clients.size });
             this.clients.forEach((ws) => {
                 try {
                     switch (ws.readyState) {

--- a/components/server/src/express/ws-connection-handler.ts
+++ b/components/server/src/express/ws-connection-handler.ts
@@ -15,7 +15,7 @@ import { WsNextFunction, WsRequestHandler } from './ws-handler';
  * This class provides a websocket handler that manages ping-pong behavior for all incoming websocket requests.
  * Clients that to not respond in time are terminated.
  */
-export class WsPingPongHandler implements Disposable {
+export class WsConnectionHandler implements Disposable {
 
     protected readonly disposables: DisposableCollection = new DisposableCollection();
     protected readonly clients: Set<websocket> = new Set();

--- a/components/server/src/express/ws-ping-pong-handler.ts
+++ b/components/server/src/express/ws-ping-pong-handler.ts
@@ -95,6 +95,14 @@ export class WsPingPongHandler implements Disposable {
                 ws.pong(data);
             });
 
+            // error handling
+            ws.on('error', (err: any) => {
+                if (err.code !== 'ECONNRESET' && err.code !== 'EPIPE') {    // exclude very common errors
+                    log.warn('websocket error, closing.', err, { ws, req });
+                }
+                ws.close(); // ws should trigger close() itself on any socket error. We do this just to be sure.
+            });
+
             next();
         };
     }


### PR DESCRIPTION
## Description
Ensures that we actually close websocket connections correctly upon error

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #7082

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
