### PR TITLE
[server] Remove tracing errors

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -780,7 +780,7 @@ export async function deployToDevWithHelm(deploymentConfig: DeploymentConfig, wo
         werft.fail('deploy', err);
     } finally {
         // produce the result independently of Helm succeding, so that in case Helm fails we still have the URL.
-        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/projects`);
+        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces`);
     }
 
     function installGitpod(commonFlags: string) {


### PR DESCRIPTION
## Description
We're logging [quite](https://console.cloud.google.com/errors/CNHMjt3r6YOJXA?service=server&time=P7D&project=gitpod-191109) a [bunch](https://console.cloud.google.com/errors/CPfVveC20-b9wAE?service=server&time=P7D&project=gitpod-191109) of errors because of missing `spanId`s. This adds a simple filter to prevent it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
