### PR TITLE
[Installer]: remove the deprecated TypeORM migration command

### DIFF
--- a/installer/pkg/components/migrations/job.go
+++ b/installer/pkg/components/migrations/job.go
@@ -45,7 +45,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Command: []string{
 							"sh",
 							"-c",
-							"cd /app/node_modules/@gitpod/gitpod-db && yarn run wait-for-db && yarn run typeorm migrations:run",
+							"cd /app/node_modules/@gitpod/gitpod-db && yarn run wait-for-db && yarn run typeorm migration:show || true && yarn run typeorm migration:run",
 						},
 					}},
 				},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The `migrations:run` command is now deprecated, replaced in favour of `migration:run` (singular, not plural).

For additional debugging, have also added in the "show" command to display the migration files that will show the migrations that will be applied.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7641

## How to test
<!-- Provide steps to test this PR -->
Deploy to werft and check migration job, within 60 seconds.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Installer]: remove the deprecated TypeORM migration command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
