### PR TITLE
Increase timeout of failing testIssue4045Minimal test

### DIFF
--- a/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
+++ b/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
@@ -92,6 +92,7 @@ const end = new Date(Date.UTC(2000, 2, 1)).toISOString();
         });
     }
 
+    @timeout(4000)
     @test async testIssue4045Minimal() {
         // We want a clean state
         await this.setupPurgeDB();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
One of the [tests `testIssue4045Minimal` failed](https://werft.gitpod-dev.com/job/gitpod-build-prs-test-dazzle-rewrite.86/logs#build:components/ee/payment-endpoint:dbtest) during werft build due to timeout. Based on an[ internal discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1642490476252300) I have increased the test's timeout to 4000ms

## How to test
<!-- Provide steps to test this PR -->
Werft build success. No additional testing required.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
