### PR TITLE
Fix DB migration order

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1642493449937-ProjectEnvVars.ts
+++ b/components/gitpod-db/src/typeorm/migration/1642493449937-ProjectEnvVars.ts
@@ -6,7 +6,7 @@
 
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class ProjectEnvVars1639735838107 implements MigrationInterface {
+export class ProjectEnvVars1642493449937 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query("CREATE TABLE IF NOT EXISTS `d_b_project_env_var` (`id` char(36) NOT NULL, `projectId` char(36) NOT NULL, `name` varchar(255) NOT NULL, `value` text NOT NULL, `censored` tinyint(4) NOT NULL, `creationTime` varchar(255) NOT NULL, `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`, `projectId`), KEY `ind_projectid` (projectId), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We expect new DB migrations to be added at the bottom of [components/gitpod-db/src/typeorm/migration](https://github.com/gitpod-io/gitpod/tree/main/components/gitpod-db/src/typeorm/migration).

Project-specific env vars added a migration with a timestamp that's older than the latest migration (DropDBPaymentSourceInfo) which could break DB migrations.

Renaming the new migration with today's timestamp should solve this.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
