### PR TITLE
[Installer]: allow for the telemetry hash to be further hashed

### DIFF
--- a/components/installation-telemetry/cmd/send.go
+++ b/components/installation-telemetry/cmd/send.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"crypto/sha512"
 	"fmt"
 	"os"
 
@@ -38,6 +39,12 @@ var sendCmd = &cobra.Command{
 		versionId := os.Getenv("GITPOD_INSTALLATION_VERSION")
 		if versionId == "" {
 			return fmt.Errorf("GITPOD_INSTALLATION_VERSION envvar not set")
+		}
+
+		customHash := os.Getenv("GITPOD_CUSTOM_HASH")
+		if customHash != "" {
+			log.Info("Applying additional hash to the domain hash")
+			domainHash = fmt.Sprintf("%x", sha512.Sum512([]byte(domainHash+customHash)))
 		}
 
 		client, err := analytics.NewWithConfig(segmentIOToken, analytics.Config{})

--- a/installer/example-config.yaml
+++ b/installer/example-config.yaml
@@ -8,6 +8,7 @@ certificate:
   name: https-certificates
 containerRegistry:
   inCluster: true
+  s3storage: null
 database:
   inCluster: true
 domain: gitpod.example.com
@@ -28,6 +29,6 @@ workspace:
       cpu: "1"
       memory: 2Gi
   runtime:
-    containerdRuntimeDir: /run/containerd/io.containerd.runtime.v2.task/k8s.io
+    containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
     containerdSocket: /run/containerd/containerd.sock
     fsShiftMethod: fuse

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -86,6 +86,8 @@ type Config struct {
 	License       *ObjectRef    `json:"license,omitempty"`
 
 	SSHGatewayHostKey *ObjectRef `json:"sshGatewayHostKey,omitempty"`
+
+	Telemetry *ObjectRef `json:"telemetry,omitempty"`
 }
 
 type Metadata struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The `GITPOD_DOMAIN_HASH` envvar receives a hash of the Gitpod domain. Whilst cryptographically secure, it's not too difficult to guess domains where Gitpod might be running and see if a hash is in the database.

This allows for an additional and optional secret to be provided to further hash the unique token. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7538

## How to test
<!-- Provide steps to test this PR -->
 - Create a secret `kubectl create secret generic telemetry --from-literal=hash=<your-custom-hash>`
 - Add to config:
```yaml
telemetry:
  kind: secret
  name: telemetry
```
 - Validate the config/cluster
 - Deploy and check that `GITPOD_CUSTOM_HASH` set to the `installation-telemetry` cronjob
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Installer]: allow for the telemetry hash to be further hashed
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
