### PR TITLE
[installer] Fix lifecycle PostStart label update

### DIFF
--- a/installer/pkg/components/registry-facade/daemonset.go
+++ b/installer/pkg/components/registry-facade/daemonset.go
@@ -185,7 +185,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							PostStart: &corev1.Handler{
 								Exec: &corev1.ExecAction{
 									Command: []string{
-										"/bin/bash", "-c", `kubectl label nodes ${NODENAME} gitpod.io/registry-facade_ready_ns_${KUBE_NAMESPACE}=true`,
+										"/bin/bash", "-c", `kubectl label --overwrite nodes ${NODENAME} gitpod.io/registry-facade_ready_ns_${KUBE_NAMESPACE}=true`,
 									},
 								},
 							},

--- a/installer/pkg/components/ws-daemon/daemonset.go
+++ b/installer/pkg/components/ws-daemon/daemonset.go
@@ -285,7 +285,7 @@ fi
 					PostStart: &corev1.Handler{
 						Exec: &corev1.ExecAction{
 							Command: []string{
-								"/bin/bash", "-c", `kubectl label nodes ${NODENAME} gitpod.io/ws-daemon_ready_ns_${KUBE_NAMESPACE}=true`,
+								"/bin/bash", "-c", `kubectl label --overwrite nodes ${NODENAME} gitpod.io/ws-daemon_ready_ns_${KUBE_NAMESPACE}=true`,
 							},
 						},
 					},


### PR DESCRIPTION
## Description

Avoid issues with the `postStart` hook when the node already contains the label.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
[installer] Fix lifecycle PostStart label update
```
