### PR TITLE
[dashboard] Don't offer to add common email domains as a verified student domains in Admin

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -54,9 +54,6 @@ export default function UserDetail(p: { user: User }) {
     };
 
     const addStudentDomain = async () => {
-        if (emailDomain === 'gmail.com') {
-            throw new Error(`Sanity check: Not adding '${emailDomain}' as a verified student email domain`);
-        }
         await updateUser(async u => {
             await getGitpodService().server.adminAddStudentEmailDomain(u.id, emailDomain);
             await getGitpodService().server.adminIsStudent(u.id).then(
@@ -165,7 +162,7 @@ export default function UserDetail(p: { user: User }) {
                             }]}
                         >{user.rolesOrPermissions?.join(', ') || '---'}</Property>
                         <Property name="Student"
-                            actions={ !isStudent ? [{
+                            actions={ (!isStudent && !['gmail.com', 'yahoo.com', 'hotmail.com'].includes(emailDomain)) ? [{
                                 label: `Make '${emailDomain}' a student domain`,
                                 onClick: addStudentDomain
                             }] :  undefined}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow-up to https://github.com/gitpod-io/gitpod/pull/7637 -- don't show a link (that silently fails) when the email domain is `gmail.com`, `yahoo.com` or `hotmail.com` (the 3 most common email domains).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Don't offer to add common email domains as a verified student domains in Admin
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc