### PR TITLE
Fixing a broken link / typo in installer's readme

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -20,7 +20,7 @@ The best way to get started with Gitpod
 - A [Kubernetes cluster configured](https://www.gitpod.io/docs/self-hosted/latest/installation)
 - A [TLS certificate](#tls-certificates)
 
-Or, [open a Gitpod workspace](https://gitpod.io/from-referer/)
+Or, [open a Gitpod workspace](https://gitpod.io/from-referrer/)
 
 The process to install Gitpod is:
 1. generate a base config


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The installer README includes a broken link
cc: @gtsiolis 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
View the README in `installer/` directory.

Follow the link in `Or, open a Gitpod workspace`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
