### PR TITLE
[installer] Fix registry-facade ClusterRoleBinding name

### DIFF
--- a/installer/pkg/components/registry-facade/rolebinding.go
+++ b/installer/pkg/components/registry-facade/rolebinding.go
@@ -21,7 +21,7 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&rbacv1.ClusterRoleBinding{
 			TypeMeta: common.TypeMetaClusterRoleBinding,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   Component,
+				Name:   fmt.Sprintf("%s-%s-rb", ctx.Namespace, Component),
 				Labels: labels,
 			},
 			RoleRef: rbacv1.RoleRef{


### PR DESCRIPTION
## Description

The ClusterRoleBinding must include the namespace to allow multiple installations

## Release Notes
```release-note
[installer] Fix registry-facade ClusterRoleBinding name
```
