### PR TITLE
[installer] Telemetry should not run in workspace clusters

### DIFF
--- a/installer/pkg/components/gitpod/cronjob.go
+++ b/installer/pkg/components/gitpod/cronjob.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,10 @@ import (
 )
 
 func cronjob(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if ctx.Config.Kind == config.InstallationWorkspace {
+		return []runtime.Object{}, nil
+	}
+
 	installationTelemetryComponent := fmt.Sprintf("%s-telemetry", Component)
 
 	objectMeta := metav1.ObjectMeta{


### PR DESCRIPTION
## Description

There is no database in workspace clusters

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7686

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Telemetry should not run in workspace clusters
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
