### PR TITLE
Use new code server arg --server-data-dir

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -5,7 +5,7 @@ defaultArgs:
   npmPublishTrigger: "false"
   publishToNPM: true
   localAppVersion: unknown
-  codeCommit: 4591e0158896bfd22d70bbc0f37c379d5bae4265
+  codeCommit: 40c9a1fb052740734bf465b98032f1a50404c042
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.2.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.1.tar.gz"

--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -22,7 +22,6 @@
 
 export SHELL=/bin/bash
 export USER=gitpod
-export VSCODE_AGENT_FOLDER=/workspace/.vscode-remote
 
 # TODO ENVVAR CLEANUP: This stays here until we moved it to a central location, ideally workspace-full
 # (+ compatibility period)
@@ -38,7 +37,7 @@ grep -rl open-vsx.org /ide | xargs sed -i "s|https://open-vsx.org|$VSX_REGISTRY_
 
 cd /ide || exit
 if [ "$SUPERVISOR_DEBUG_ENABLE" = "true" ]; then
-    exec /ide/bin/gitpod-code --inspect --log=trace --host=0.0.0.0 --connection-token=00000 "$@"
+    exec /ide/bin/gitpod-code --inspect --log=trace "$@"
 else
-    exec /ide/bin/gitpod-code --host=0.0.0.0 --connection-token=00000 "$@"
+    exec /ide/bin/gitpod-code "$@"
 fi

--- a/components/ide/code/supervisor-ide-config.json
+++ b/components/ide/code/supervisor-ide-config.json
@@ -1,9 +1,10 @@
 {
-  "entrypoint": "/ide/startup.sh",
-  "readinessProbe": {
-    "type": "http",
-    "http": {
-      "path": "static/manifest.json"
+    "entrypoint": "/ide/startup.sh",
+    "entrypointArgs": [ "--port", "{IDEPORT}", "--host", "0.0.0.0", "--connection-token", "00000", "--server-data-dir", "/workspace/.vscode-remote" ],
+    "readinessProbe": {
+        "type": "http",
+        "http": {
+            "path": "version"
+        }
     }
-  }
 }

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -813,12 +813,10 @@ func prepareIDELaunch(cfg *Config, ideConfig *IDEConfig) *exec.Cmd {
 
 	// Add default args for IDE (not desktop IDE) to be backwards compatible
 	if ideConfig.Entrypoint == "/ide/startup.sh" && len(args) == 0 {
-		args = append(args, "{WORKSPACEROOT}")
 		args = append(args, "--port", "{IDEPORT}")
 	}
 
 	for i := range args {
-		args[i] = strings.ReplaceAll(args[i], "{WORKSPACEROOT}", cfg.WorkspaceRoot)
 		args[i] = strings.ReplaceAll(args[i], "{IDEPORT}", strconv.Itoa(cfg.IDEPort))
 		args[i] = strings.ReplaceAll(args[i], "{DESKTOPIDEPORT}", strconv.Itoa(desktopIDEPort))
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Uses new server argument `--server-data-dir` instead of `VSCODE_AGENT_FOLDER` env variable
Some cleanup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Open preview env
2. Select insiders and check server data is stored in `/workspace/.vscode-remote`
4. Select stable and check it starts correctly for folder projects and workspace (uses `.code-workspace` file e.g. gitpod repo) projetcs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

