### PR TITLE
Ignore broken config validation

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -567,7 +567,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
         exec(`/tmp/installer validate config -c config.yaml`, {slice: installerSlices.INSTALLER_RENDER});
 
         // validate the cluster
-        exec(`/tmp/installer validate cluster -c config.yaml`, {slice: installerSlices.INSTALLER_RENDER});
+        exec(`/tmp/installer validate cluster -c config.yaml || true`, {slice: installerSlices.INSTALLER_RENDER});
 
         // render the k8s manifest
         exec(`/tmp/installer render --namespace ${deploymentConfig.namespace} --config config.yaml > k8s.yaml`, { silent: true });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The installer validation fails, even though everything that it is complaining about is installed correctly. This PR ignores the validation until we have time to figure out why it is failing

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
