### PR TITLE
[installation-telemetry]: log data sent to Segment

### DIFF
--- a/components/installation-telemetry/cmd/send.go
+++ b/components/installation-telemetry/cmd/send.go
@@ -45,14 +45,16 @@ var sendCmd = &cobra.Command{
 			err = client.Close()
 		}()
 
-		client.Enqueue(analytics.Track{
+		telemetry := analytics.Track{
 			UserId: domainHash,
 			Event:  "Installation telemetry",
 			Properties: analytics.NewProperties().
 				Set("version", versionId),
-		})
+		}
 
-		log.Info("installation-telemetry has successfully sent data - exiting")
+		client.Enqueue(telemetry)
+
+		log.WithField("telemetry", telemetry).Info("installation-telemetry has successfully sent data - exiting")
 
 		return err
 	},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Log data sent to Segment to the console. This is to provide transparency in the data we send and to prove that we're not providing anything that could be used to identify an installation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7540

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installation-telemetry]: log data sent to Segment
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
