### PR TITLE
Not exposing port 22 if not configured ssh gateway hostkey

### DIFF
--- a/installer/pkg/components/proxy/deployment.go
+++ b/installer/pkg/components/proxy/deployment.go
@@ -161,10 +161,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							}},
 							Ports: []corev1.ContainerPort{{
-								ContainerPort: ContainerSSHPort,
-								Name:          ContainerSSHName,
-								Protocol:      *common.TCPProtocol,
-							}, {
 								ContainerPort: PrometheusPort,
 								Name:          MetricsContainerName,
 								Protocol:      *common.TCPProtocol,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Not exposing port 22 if not configured ssh gateway hostkey

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7729

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
