### PR TITLE
[Dashboard]: add send telemetry to admin settings

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { Login } from './Login';
 import { UserContext } from './user-context';
 import { TeamsContext } from './teams/teams-context';
 import { ThemeContext } from './theme-context';
+import { AdminContext } from './admin-context';
 import { getGitpodService } from './service/service';
 import { shouldSeeWhatsNew, WhatsNew } from './whatsnew/WhatsNew';
 import gitpodIcon from './icons/gitpod.svg';
@@ -52,6 +53,7 @@ const InstallGitHubApp = React.lazy(() => import(/* webpackPrefetch: true */ './
 const FromReferrer = React.lazy(() => import(/* webpackPrefetch: true */ './FromReferrer'));
 const UserSearch = React.lazy(() => import(/* webpackPrefetch: true */ './admin/UserSearch'));
 const WorkspacesSearch = React.lazy(() => import(/* webpackPrefetch: true */ './admin/WorkspacesSearch'));
+const AdminSettings = React.lazy(() => import(/* webpackPrefetch: true */ './admin/Settings'));
 const OAuthClientApproval = React.lazy(() => import(/* webpackPrefetch: true */ './OauthClientApproval'));
 
 function Loading() {
@@ -98,11 +100,12 @@ export function getURLHash() {
 function App() {
     const { user, setUser } = useContext(UserContext);
     const { teams, setTeams } = useContext(TeamsContext);
+    const { setAdminSettings } = useContext(AdminContext);
     const { setIsDark } = useContext(ThemeContext);
 
-    const [ loading, setLoading ] = useState<boolean>(true);
-    const [ isWhatsNewShown, setWhatsNewShown ] = useState(false);
-    const [ isSetupRequired, setSetupRequired ] = useState(false);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [isWhatsNewShown, setWhatsNewShown] = useState(false);
+    const [isSetupRequired, setSetupRequired] = useState(false);
     const history = useHistory();
 
     useEffect(() => {
@@ -132,6 +135,11 @@ function App() {
                     }
                 }
                 setTeams(teams);
+
+                if (user?.rolesOrPermissions?.includes('admin')) {
+                    const adminSettings = await getGitpodService().server.adminGetSettings();
+                    setAdminSettings(adminSettings);
+                }
             } catch (error) {
                 console.error(error);
                 if (error && "code" in error) {
@@ -279,6 +287,7 @@ function App() {
 
                 <Route path="/admin/users" component={UserSearch} />
                 <Route path="/admin/workspaces" component={WorkspacesSearch} />
+                <Route path="/admin/settings" component={AdminSettings} />
 
                 <Route path={["/", "/login"]} exact>
                     <Redirect to={workspacesPathMain} />

--- a/components/dashboard/src/admin-context.tsx
+++ b/components/dashboard/src/admin-context.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import React, { createContext, useState } from 'react';
+import {  InstallationAdminSettings } from "@gitpod/gitpod-protocol";
+
+const AdminContext = createContext<{
+    adminSettings?: InstallationAdminSettings,
+    setAdminSettings: React.Dispatch<InstallationAdminSettings>,
+}>({
+    setAdminSettings: () => null,
+});
+
+const AdminContextProvider: React.FC = ({ children }) => {
+    const [adminSettings, setAdminSettings] = useState<InstallationAdminSettings>();
+    return (
+        <AdminContext.Provider value={{ adminSettings, setAdminSettings }}>
+            {children}
+        </AdminContext.Provider>
+    );
+};
+
+export { AdminContext, AdminContextProvider };

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext } from "react";
+import { InstallationAdminSettings } from "@gitpod/gitpod-protocol";
+import { AdminContext } from "../admin-context";
+import CheckBox from "../components/CheckBox";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { getGitpodService } from "../service/service";
+import { adminMenu } from "./admin-menu";
+
+export default function Settings() {
+    const { adminSettings, setAdminSettings } = useContext(AdminContext);
+
+    const actuallySetTelemetryPrefs = async (value: InstallationAdminSettings) => {
+        await getGitpodService().server.adminUpdateSettings(value);
+        setAdminSettings(value);
+    }
+
+    return (
+        <div>
+            <PageWithSubMenu subMenu={adminMenu} title="Settings" subtitle="Configure settings for your Gitpod cluster.">
+                <h3>Usage Statistics</h3>
+                <CheckBox
+                    title="Enable Service Ping"
+                    desc={<span>This is used to provide insights on how you use your cluster so we can provide a better overall experience. <a className="gp-link" href="https://www.gitpod.io/privacy">Read our Privacy Policy</a></span>}
+                    checked={adminSettings?.sendTelemetry ?? false}
+                    onChange={(evt) => actuallySetTelemetryPrefs({
+                        sendTelemetry: evt.target.checked,
+                    })} />
+            </PageWithSubMenu>
+        </div >
+    )
+}

--- a/components/dashboard/src/admin/admin-menu.ts
+++ b/components/dashboard/src/admin/admin-menu.ts
@@ -10,4 +10,7 @@ export const adminMenu = [{
 }, {
     title: 'Workspaces',
     link: ['/admin/workspaces']
+}, {
+    title: 'Settings',
+    link: ['/admin/settings']
 },];

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import { UserContextProvider } from './user-context';
+import { AdminContextProvider } from './admin-context';
 import { TeamsContextProvider } from './teams/teams-context';
 import { ProjectContextProvider } from './projects/project-context';
 import { ThemeContextProvider } from './theme-context';
@@ -18,15 +19,17 @@ import "./index.css"
 ReactDOM.render(
     <React.StrictMode>
         <UserContextProvider>
-            <TeamsContextProvider>
-                <ProjectContextProvider>
-                    <ThemeContextProvider>
-                        <BrowserRouter>
-                            <App />
-                        </BrowserRouter>
-                    </ThemeContextProvider>
-                </ProjectContextProvider>
-            </TeamsContextProvider>
+            <AdminContextProvider>
+                <TeamsContextProvider>
+                    <ProjectContextProvider>
+                        <ThemeContextProvider>
+                            <BrowserRouter>
+                                <App />
+                            </BrowserRouter>
+                        </ThemeContextProvider>
+                    </ProjectContextProvider>
+                </TeamsContextProvider>
+            </AdminContextProvider>
         </UserContextProvider>
     </React.StrictMode>,
     document.getElementById('root')

--- a/components/gitpod-db/src/installation-admin-db.ts
+++ b/components/gitpod-db/src/installation-admin-db.ts
@@ -4,9 +4,10 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { InstallationAdmin } from "@gitpod/gitpod-protocol";
+import { InstallationAdmin, InstallationAdminSettings } from "@gitpod/gitpod-protocol";
 
 export const InstallationAdminDB = Symbol('InstallationAdminDB');
 export interface InstallationAdminDB {
-    getTelemetryData(): Promise<InstallationAdmin>;
+    getData(): Promise<InstallationAdmin>;
+    setSettings(settings: Partial<InstallationAdminSettings>): Promise<void>;
 }

--- a/components/gitpod-db/src/typeorm/installation-admin-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/installation-admin-db-impl.ts
@@ -5,8 +5,7 @@
  */
 
 import { inject, injectable, } from 'inversify';
-import { InstallationAdmin } from '@gitpod/gitpod-protocol';
-import { v4 as uuidv4 } from 'uuid';
+import { InstallationAdmin, InstallationAdminSettings } from '@gitpod/gitpod-protocol';
 import { Repository } from 'typeorm';
 import { TypeORM } from './typeorm';
 import { InstallationAdminDB } from '../installation-admin-db';
@@ -21,12 +20,7 @@ export class TypeORMInstallationAdminImpl implements InstallationAdminDB {
     }
 
     protected async createDefaultRecord(): Promise<InstallationAdmin> {
-        const record: InstallationAdmin = {
-            id: uuidv4(),
-            settings: {
-                sendTelemetry: false,
-            },
-        };
+        const record = InstallationAdmin.createDefault();
 
         const repo = await this.getInstallationAdminRepo();
         return repo.save(record);
@@ -37,14 +31,14 @@ export class TypeORMInstallationAdminImpl implements InstallationAdminDB {
     }
 
     /**
-     * Get Telemetry Data
+     * Get Data
      *
      * Returns the first record found or creates a
      * new record.
      *
      * @returns Promise<InstallationAdmin>
      */
-    async getTelemetryData(): Promise<InstallationAdmin> {
+    async getData(): Promise<InstallationAdmin> {
         const repo = await this.getInstallationAdminRepo();
         const [record] = await repo.find();
 
@@ -54,5 +48,15 @@ export class TypeORMInstallationAdminImpl implements InstallationAdminDB {
 
         /* Record not found - create one */
         return this.createDefaultRecord();
+    }
+
+    async setSettings(settings: InstallationAdminSettings): Promise<void> {
+        const record = await this.getData();
+        record.settings = {
+            ...settings,
+        }
+
+        const repo = await this.getInstallationAdminRepo();
+        await repo.save(record);
     }
 }

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -8,6 +8,7 @@ import { User, Workspace, NamedWorkspaceFeatureFlag } from "./protocol";
 import { WorkspaceInstance, WorkspaceInstancePhase } from "./workspace-instance";
 import { RoleOrPermission } from "./permission";
 import { AccountStatement } from "./accounting-protocol";
+import { InstallationAdminSettings } from "./installation-admin-protocol";
 
 export interface AdminServer {
     adminGetUsers(req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>>;
@@ -29,6 +30,9 @@ export interface AdminServer {
     adminIsStudent(userId: string): Promise<boolean>;
     adminAddStudentEmailDomain(userId: string, domain: string): Promise<void>;
     adminGrantExtraHours(userId: string, extraHours: number): Promise<void>;
+
+    adminGetSettings(): Promise<InstallationAdminSettings>
+    adminUpdateSettings(settings: InstallationAdminSettings): Promise<void>
 }
 
 export interface AdminGetListRequest<T> {
@@ -65,7 +69,7 @@ export interface AdminModifyPermanentWorkspaceFeatureFlagRequest {
     }[]
 }
 
-export interface WorkspaceAndInstance extends Omit<Workspace, "id"|"creationTime">, Omit<WorkspaceInstance, "id"|"creationTime"> {
+export interface WorkspaceAndInstance extends Omit<Workspace, "id" | "creationTime">, Omit<WorkspaceInstance, "id" | "creationTime"> {
     workspaceId: string;
     workspaceCreationTime: string;
     instanceId: string;
@@ -78,7 +82,7 @@ export namespace WorkspaceAndInstance {
         return {
             id: wai.workspaceId,
             creationTime: wai.workspaceCreationTime,
-            ... wai
+            ...wai
         };
     }
 
@@ -89,7 +93,7 @@ export namespace WorkspaceAndInstance {
         return {
             id: wai.instanceId,
             creationTime: wai.instanceCreationTime,
-            ... wai
+            ...wai
         };
     }
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -30,6 +30,7 @@ import { GithubUpgradeURL, PlanCoupon } from './payment-protocol';
 import { TeamSubscription, TeamSubscriptionSlot, TeamSubscriptionSlotResolved } from './team-subscription-protocol';
 import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from './analytics';
 import { IDEServer } from './ide-protocol';
+import { InstallationAdminSettings } from './installation-admin-protocol';
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -130,6 +131,10 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getGenericInvite(teamId: string): Promise<TeamMembershipInvite>;
     resetGenericInvite(inviteId: string): Promise<TeamMembershipInvite>;
     deleteTeam(teamId: string, userId: string): Promise<void>;
+
+    // Admin Settings
+    adminGetSettings(): Promise<InstallationAdminSettings>;
+    adminUpdateSettings(settings: InstallationAdminSettings): Promise<void>;
 
     // Projects
     getProviderRepositoriesForUser(params: GetProviderRepositoriesParams): Promise<ProviderRepository[]>;

--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -4,11 +4,32 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-export interface InstallationAdminSettings {
-    sendTelemetry: boolean;
+import { v4 as uuidv4 } from 'uuid';
+
+const InstallationAdminSettingsPrototype = {
+    sendTelemetry: true
+}
+
+export type InstallationAdminSettings = typeof InstallationAdminSettingsPrototype;
+
+export namespace InstallationAdminSettings {
+    export function fields(): (keyof InstallationAdminSettings)[] {
+        return Object.keys(InstallationAdminSettingsPrototype) as (keyof InstallationAdminSettings)[];
+    }
 }
 
 export interface InstallationAdmin {
     id: string;
     settings: InstallationAdminSettings;
+}
+
+export namespace InstallationAdmin {
+    export function createDefault(): InstallationAdmin {
+        return {
+            id: uuidv4(),
+            settings: {
+                ...InstallationAdminSettingsPrototype,
+            }
+        };
+    }
 }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -7,7 +7,7 @@
 import { injectable, inject } from "inversify";
 import { GitpodServerImpl, traceAPIParams, traceWI, censor } from "../../../src/workspace/gitpod-server-impl";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { GitpodServer, GitpodClient, AdminGetListRequest, User, AdminGetListResult, Permission, AdminBlockUserRequest, AdminModifyRoleOrPermissionRequest, RoleOrPermission, AdminModifyPermanentWorkspaceFeatureFlagRequest, UserFeatureSettings, AdminGetWorkspacesRequest, WorkspaceAndInstance, GetWorkspaceTimeoutResult, WorkspaceTimeoutDuration, WorkspaceTimeoutValues, SetWorkspaceTimeoutResult, WorkspaceContext, CreateWorkspaceMode, WorkspaceCreationResult, PrebuiltWorkspaceContext, CommitContext, PrebuiltWorkspace, PermissionName, WorkspaceInstance, EduEmailDomain, ProviderRepository, Queue, PrebuildWithStatus, CreateProjectParams, Project, StartPrebuildResult, ClientHeaderFields, Workspace } from "@gitpod/gitpod-protocol";
+import { GitpodServer, GitpodClient, AdminGetListRequest, User, AdminGetListResult, Permission, AdminBlockUserRequest, AdminModifyRoleOrPermissionRequest, RoleOrPermission, AdminModifyPermanentWorkspaceFeatureFlagRequest, UserFeatureSettings, AdminGetWorkspacesRequest, WorkspaceAndInstance, GetWorkspaceTimeoutResult, WorkspaceTimeoutDuration, WorkspaceTimeoutValues, SetWorkspaceTimeoutResult, WorkspaceContext, CreateWorkspaceMode, WorkspaceCreationResult, PrebuiltWorkspaceContext, CommitContext, PrebuiltWorkspace, WorkspaceInstance, EduEmailDomain, ProviderRepository, Queue, PrebuildWithStatus, CreateProjectParams, Project, StartPrebuildResult, ClientHeaderFields, Workspace } from "@gitpod/gitpod-protocol";
 import { ResponseError } from "vscode-jsonrpc";
 import { TakeSnapshotRequest, AdmissionLevel, ControlAdmissionRequest, StopWorkspacePolicy, DescribeWorkspaceRequest, SetTimeoutRequest } from "@gitpod/ws-manager/lib";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -600,15 +600,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             ws.pinned = true;
             await db.store(ws);
         });
-    }
-
-    protected async guardAdminAccess(method: string, params: any, requiredPermission: PermissionName) {
-        const user = this.checkAndBlockUser(method);
-        if (!this.authorizationService.hasPermission(user, requiredPermission)) {
-            log.warn({ userId: this.user?.id }, "unauthorised admin access", { authorised: false, method, params });
-            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, "not allowed");
-        }
-        log.info({ userId: this.user?.id }, "admin access", { authorised: true, method, params });
     }
 
     protected async findPrebuiltWorkspace(parentCtx: TraceContext, user: User, context: WorkspaceContext, mode: CreateWorkspaceMode): Promise<WorkspaceCreationResult | PrebuiltWorkspaceContext | undefined> {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -136,6 +136,8 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "adminForceStopWorkspace": { group: "default", points: 1 },
         "adminRestoreSoftDeletedWorkspace": { group: "default", points: 1 },
         "adminSetLicense": { group: "default", points: 1 },
+        "adminGetSettings": { group: "default", points: 1 },
+        "adminUpdateSettings": { group: "default", points: 1 },
 
         "validateLicense": { group: "default", points: 1 },
         "getLicenseInfo": { group: "default", points: 1 },

--- a/components/server/src/installation-admin/installation-admin-controller.ts
+++ b/components/server/src/installation-admin/installation-admin-controller.ts
@@ -16,9 +16,9 @@ export class InstallationAdminController {
         const app = express();
 
         app.get('/data', async (req: express.Request, res: express.Response) => {
-            const data = await this.installationAdminDb.getTelemetryData();
+            const data = await this.installationAdminDb.getData();
 
-            res.send(data);
+            res.status(200).json(data);
         });
 
         return app;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds the "send telemetry" checkbox to the Admin dashboard and sets the default option to `true` - the front-end for #7591

It also moves the `guardAdminAccess` method from the EE `gitpod-server-impl.ts` to the one in `src`. This is because we're going to open up more dashboard administrative options to users regardless of whether they have an enterprise license or not - clearly, the option to disable telemetry should be available to all users.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7573

## How to test
<!-- Provide steps to test this PR -->
Go to the [Dashboard](https://sje-installation-admin-dashboard.staging.gitpod-dev.com/workspaces) -> Settings and click the "send telemetry" checkbox

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Dashboard]: add send telemetry to admin settings
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
