### PR TITLE
Fix incorrect type in GithubAppPrebuildConfig

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1805,7 +1805,7 @@ type GithubAppConfig struct {
 // GithubAppPrebuildConfig is the GithubAppPrebuildConfig message type
 type GithubAppPrebuildConfig struct {
 	AddBadge              bool        `json:"addBadge,omitempty"`
-	AddCheck              bool        `json:"addCheck,omitempty"`
+	AddCheck              interface{} `json:"addCheck,omitempty"`
 	AddComment            bool        `json:"addComment,omitempty"`
 	AddLabel              interface{} `json:"addLabel,omitempty"`
 	Branches              bool        `json:"branches,omitempty"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix incorrect type in GithubAppPrebuildConfig, this broke opening workspaces in vscode desktop

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7718 
This broke in https://github.com/gitpod-io/gitpod/pull/7535
cc @svenefftinge 

## How to test
<!-- Provide steps to test this PR -->
1. Open a preview env
2. Open a repo with  `addCheck: prevent-merge-on-error` in .gitpod.yml e.g. https://github.com/jeanp413/test-gp
3. Connect to workspace with local vscode desktop stable/insiders should work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
