### PR TITLE
Revert dev image Dockerfile to use internal workspace full base image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:dashboard-e2e-fork.1
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-dogfood.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -62,7 +62,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:dashboard-e2e-fork.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-dogfood.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:dashboard-e2e-fork.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-dogfood.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:dashboard-e2e-fork.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-dogfood.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:dashboard-e2e-fork.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-dogfood.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -2,7 +2,10 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM gitpod/workspace-full-vnc:latest
+# if you want to run this image in a workspace, follow these steps:
+# gcloud auth configure-docker europe-docker.pkg.dev
+# gcloud auth login --no-launch-browser
+FROM europe-docker.pkg.dev/gitpod-artifacts/docker-dev/workspace-base-images:full
 
 ENV TRIGGER_REBUILD 16
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Revert the base image change for dev image so that it refers to the internal image generated from dazzlev2 images.
The `workspace-base-images:full` image already has tool-vnc as one of the chunks. This was changed with an assumption that we require the vnc image in order to run cypress tests.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
Following tests were performed. You can test the same cases. Create a new branch from this branch and then try to create a workspace in the corresponding preview env.

### Tests continue to work

![image](https://user-images.githubusercontent.com/32481722/150494811-e47fb3e9-f4ab-4cc8-a633-d7daac100159.png)

### Commands run in preview env terminal

![image](https://user-images.githubusercontent.com/32481722/150494950-fa480f90-3765-4b7f-8d65-ef0928fc9fe3.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

- [x] /werft with-clean-slate-deployment=