### PR TITLE
[content-init] Ensure .gitpod path is available

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -260,8 +260,9 @@ func (c *Client) Status(ctx context.Context) (res *Status, err error) {
 
 // Clone runs git clone
 func (c *Client) Clone(ctx context.Context) (err error) {
-	if err := os.MkdirAll(c.Location, 0755); err != nil {
-		log.WithError(err).Error()
+	err = os.MkdirAll(c.Location, 0755)
+	if err != nil {
+		log.WithError(err).Error("cannot create clone location")
 	}
 
 	args := []string{"--depth=1", "--no-single-branch", c.RemoteURI}

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -309,6 +309,13 @@ func RunInitializerChild() (err error) {
 		return err
 	}
 
+	// some workspace content may have a `/dst/.gitpod` file or directory. That would break
+	// the workspace ready file placement (see https://github.com/gitpod-io/gitpod/issues/7694).
+	err = wsinit.EnsureCleanDotGitpodDirectory(ctx, "/dst")
+	if err != nil {
+		return err
+	}
+
 	// Place the ready file to make Theia "open its gates"
 	err = wsinit.PlaceWorkspaceReadyFile(ctx, "/dst", initSource, initmsg.UID, initmsg.GID)
 	if err != nil {


### PR DESCRIPTION
## Description
When repositories contain a `.gitpod` file this can cause the content initializer to fail because we use `/workspace/.gitpod` internally. This change introduces special handling such cases where we try to `git mv` or `mv` the `.gitpod` file to `.gitpod.yaml`. If `.gitpod.yaml` already exists, we delete `.gitpod`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7694

## How to test
Open https://cw-fix-7694.staging.gitpod-dev.com/#https://github.com/csweichel/gitpod-hello-ui-demo
If the build starts (might not complete due to other issues), we're good. Compare with prod where the build fails to start due to a content init error.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```