### PR TITLE
[content-init] Propagate sensible error messages

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -142,7 +142,7 @@ func NewFromRequest(ctx context.Context, loc string, rs storage.DirectDownloader
 		initializer = &EmptyInitializer{}
 	}
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("cannot initialize workspace: %v", err))
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	return initializer, nil
 }

--- a/components/ws-daemon/cmd/content-initializer/main.go
+++ b/components/ws-daemon/cmd/content-initializer/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -18,6 +19,9 @@ func main() {
 
 	err := content.RunInitializerChild()
 	if err != nil {
+		errfd := os.NewFile(uintptr(3), "errout")
+		_, _ = fmt.Fprintf(errfd, err.Error())
+
 		os.Exit(42)
 	}
 }

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -235,7 +235,7 @@ func (s *WorkspaceService) InitWorkspace(ctx context.Context, req *api.InitWorks
 		err = RunInitializer(ctx, workspace.Location, req.Initializer, remoteContent, opts)
 		if err != nil {
 			log.WithError(err).WithField("workspaceId", req.Id).Error("cannot initialize workspace")
-			return nil, status.Error(codes.Internal, fmt.Sprintf("cannot initialize workspace: %s", err.Error()))
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
 		}
 	}
 
@@ -243,7 +243,7 @@ func (s *WorkspaceService) InitWorkspace(ctx context.Context, req *api.InitWorks
 	err = workspace.MarkInitDone(ctx)
 	if err != nil {
 		log.WithError(err).WithField("workspaceId", req.Id).Error("cannot initialize workspace")
-		return nil, status.Error(codes.Internal, fmt.Sprintf("cannot finish workspace init: %v", err))
+		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("cannot finish workspace init: %v", err))
 	}
 
 	return &api.InitWorkspaceResponse{}, nil


### PR DESCRIPTION
## Description
This PR provides more detailed error messages when the content initializer fails. It does that by passing a unix pipe to the content initializer process started by ws-daemon, to which that process can write error messages. We can't just use the stderr/stdout of the content initializer process because that's too verbose and JSON formatted. With this design we have more control over the final error message.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7605

## How to test
- Open repo which is known to fail, e.g. https://github.com/csweichel/gitpod-hello-ui-demo (until #7749 is merged)
- Start a workspace, stop it, delete its backup and try to start it again. You should see something like

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improved feedback when content initialisation fails
```
