### PR TITLE
Running ssh-vm.sh gives instant access to the Harvester VM running for that workspace

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -43,7 +43,7 @@ spec:
     spec:
       readinessProbe:
         tcpSocket:
-          port: 22
+          port: 2200
         initialDelaySeconds: 120
         periodSeconds: 20
         timeoutSeconds: 10
@@ -106,10 +106,14 @@ metadata:
   namespace: ${namespace}
 spec:
   ports:
-    - name: ssh
+    - name: ssh-gateway
       protocol: TCP
       port: 22
       targetPort: 22
+    - name: vm-ssh
+      protocol: TCP
+      port: 2200
+      targetPort: 2200
     - name: http
       protocol: TCP
       port: 80
@@ -146,6 +150,10 @@ chpasswd:
     ubuntu:ubuntu
   expire: False
 write_files:
+  - path: /etc/ssh/sshd_config.d/101-change-ssh-port.conf
+    permission: 0644
+    owner: root
+    content: 'Port 2200'
   - path: /usr/local/bin/bootstrap-k3s.sh
     permissions: 0744
     owner: root

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -170,7 +170,7 @@ export function copyk3sKubeconfig(options: { name: string, path: string, timeout
  */
 export function startSSHProxy(options: { name: string, slice: string }) {
     const namespace = `preview-${options.name}`
-    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 22:22`, { async: true, silent: true, slice: options.slice, dontCheckRc: true })
+    exec(`sudo kubectl --kubeconfig=${KUBECONFIG_PATH} -n ${namespace} port-forward service/proxy 22:2200`, { async: true, silent: true, slice: options.slice, dontCheckRc: true })
 }
 
 /**

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -120,6 +120,8 @@ RUN install-packages \
     libasound2 \
     libxtst6 \
     xauth
+# Install netcat to use it as proxy for SSH access to Harvester VMs
+RUN install-packages netcat
 
 USER gitpod
 

--- a/dev/preview/install-vm-ssh-keys.sh
+++ b/dev/preview/install-vm-ssh-keys.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+THIS_DIR="$(dirname "$0")"
+PRIVATE_KEY_PATH="$HOME/.ssh/vm_id_rsa"
+PUBLIC_KEY_PATH="$HOME/.ssh/vm_id_rsa.pub"
+
+function log {
+    echo "[$(date)] $*"
+}
+
+function has-dev-access {
+    kubectl --context=dev auth can-i get secrets > /dev/null 2>&1 || false
+}
+
+if ! has-dev-access; then
+    log "Setting up kubeconfig"
+    "$THIS_DIR"/download-and-merge-harvester-kubeconfig.sh
+fi
+
+log "Downloading private key to ${PRIVATE_KEY_PATH}"
+kubectl --context dev -n werft get secret harvester-vm-ssh-keys -o jsonpath='{.data}' \
+| jq -r '.["id_rsa"]' \
+| base64 -d > "${PRIVATE_KEY_PATH}"
+
+log "Downloading public key to ${PUBLIC_KEY_PATH}"
+kubectl --context dev -n werft get secret harvester-vm-ssh-keys -o jsonpath='{.data}' \
+| jq -r '.["id_rsa.pub"]' \
+| base64 -d > "${PUBLIC_KEY_PATH}"
+
+log "Setting permission"
+chmod 600 "${PRIVATE_KEY_PATH}"
+chmod 644 "${PUBLIC_KEY_PATH}"

--- a/dev/preview/ssh-proxy-command.sh
+++ b/dev/preview/ssh-proxy-command.sh
@@ -12,11 +12,11 @@ do
     esac
 done
 
-pkill -f "kubectl --context=harvester (.*)${PORT}:22"
+pkill -f "kubectl --context=harvester (.*)${PORT}:2200"
 kubectl \
     --context=harvester \
     --kubeconfig=/home/gitpod/.kube/config \
-    -n "${NAMESPACE}" port-forward service/proxy "${PORT}:22" > /dev/null 2>&1 &
+    -n "${NAMESPACE}" port-forward service/proxy "${PORT}:2200" > /dev/null 2>&1 &
 
 # Wait for the port to be read
 while true; do

--- a/dev/preview/ssh-proxy-command.sh
+++ b/dev/preview/ssh-proxy-command.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+NAMESPACE="preview-${VM_NAME}"
+
+while getopts n:p: flag
+do
+    case "${flag}" in
+        n) NAMESPACE="${OPTARG}";;
+        p) PORT="${OPTARG}";;
+        *) ;;
+    esac
+done
+
+pkill -f "kubectl --context=harvester (.*)${PORT}:22"
+kubectl \
+    --context=harvester \
+    --kubeconfig=/home/gitpod/.kube/config \
+    -n "${NAMESPACE}" port-forward service/proxy "${PORT}:22" > /dev/null 2>&1 &
+
+# Wait for the port to be read
+while true; do
+    sleep 1
+    if [[ "$(netcat -z localhost 8022)" -eq 0 ]]; then
+        break
+    fi
+done
+
+# Use netcat as SSH expects ProxyCommand to read and write using stdin/stdout
+netcat -X connect localhost "${PORT}"

--- a/dev/preview/ssh-vm.sh
+++ b/dev/preview/ssh-vm.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Provides SSH access to the the VM where your preview environment is installed.
+#
+
+set -euo pipefail
+
+VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+NAMESPACE="preview-${VM_NAME}"
+
+PRIVATE_KEY=$HOME/.ssh/vm_id_rsa
+PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub
+PORT=8022
+THIS_DIR="$(dirname "$0")"
+USER="ubuntu"
+
+while getopts n:p:u: flag
+do
+    case "${flag}" in
+        n) NAMESPACE="${OPTARG}";;
+        p) PORT="${OPTARG}";;
+        u) USER="${OPTARG}";;
+        *) ;;
+    esac
+done
+
+
+function log {
+    echo "[$(date)] $*"
+}
+
+function has-harvester-access {
+    kubectl --context=harvester auth can-i get secrets > /dev/null 2>&1 || false
+}
+
+function set-up-ssh {
+    if [[ (! -f $PRIVATE_KEY) || (! -f $PUBLIC_KEY) ]]; then
+        echo Setting up ssh-keys
+        "$THIS_DIR"/install-vm-ssh-keys.sh
+    fi
+}
+
+if ! has-harvester-access; then
+    echo Setting up kubeconfig
+    "$THIS_DIR"/download-and-merge-harvester-kubeconfig.sh
+fi
+
+set-up-ssh
+
+ssh "$USER"@127.0.0.1 \
+    -o UserKnownHostsFile=/dev/null \
+    -o StrictHostKeyChecking=no \
+    -o "ProxyCommand=$THIS_DIR/ssh-proxy-command.sh -p $PORT -n $NAMESPACE" \
+    -i "$HOME/.ssh/vm_id_rsa" \
+    -p "$PORT"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This gives instant access to a running VM on harvester using the command `./dev/preview/ssh-vm.sh`. If the namespace is changed the new SSH connection closes the old forwarding and creates a new connection. This can also be avoided by adding the options "-p PORT -n NAMESPACE". This way a new connection is created using another port keeping the old one.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #643

## How to test
<!-- Provide steps to test this PR -->
Create a new branch and a commit with `/werft with-vm=true` and login to the machine using `./dev/preview/ssh-vm.sh`. Create another branch and a commit like before. After the VM has started you can login with `./dev/preview/ssh-vm.sh -p 8023`. This keeps the connection 8022 and opens a new connection on port 8023 to the new VM.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
