### PR TITLE
Update dev installation root URL

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -615,7 +615,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
         werft.fail(installerSlices.APPLY_INSTALL_MANIFESTS, err);
     } finally {
         // produce the result independently of install succeding, so that in case fails we still have the URL.
-        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/projects`);
+        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces`);
     }
 
     try {


### PR DESCRIPTION
## Description

This will update the dev installation URL linked in GitHub PRs when contributing to Gitpod.

## How to test

Check the dev installation URL below in this GitHub PR. It should link to :a: [this](https://gt-update-dev-installation-dev-url.staging.gitpod-dev.com/workspaces/), not :b: [this](https://gt-update-dev-installation-dev-url.staging.gitpod-dev.com/projects/).

Note: Refrained from using `/` which redirects back to `www.gitpod.io`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```