### PR TITLE
[sshproxy] Add heartbeating

### DIFF
--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -55,6 +55,14 @@ data:
         },
         "pprofAddr": ":6060",
         "readinessProbeAddr": ":60088",
-        "prometheusAddr": "localhost:9500"
+        "prometheusAddr": "localhost:9500",
+        "wsManager": {
+            "addr": "ws-manager:8080",
+            "tls": {
+                "ca": "/ws-manager-client-tls-certs/ca.crt",
+                "crt": "/ws-manager-client-tls-certs/tls.crt",
+                "key": "/ws-manager-client-tls-certs/tls.key"
+            }
+        }
     }
 {{- end -}}

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -86,6 +86,9 @@ spec:
         - name: config
           mountPath: "/config"
           readOnly: true
+        - name: ws-manager-client-tls-certs
+          mountPath: "/ws-manager-client-tls-certs"
+          readOnly: true
 {{- if $.Values.certificatesSecret.secretName }}
         - name: config-certificates
           mountPath: "/mnt/certificates"

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -5,18 +5,24 @@
 package cmd
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/bombsimon/logrusr"
+	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
+	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/config"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/proxy"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/sshproxy"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -77,6 +83,35 @@ var runCmd = &cobra.Command{
 
 		log.Infof("workspace info provider started")
 
+		var heartbeat sshproxy.Heartbeat
+		if wsm := cfg.WorkspaceManager; wsm != nil {
+			var dialOption grpc.DialOption = grpc.WithInsecure()
+			if wsm.TLS.CA != "" && wsm.TLS.Cert != "" && wsm.TLS.Key != "" {
+				tlsConfig, err := common_grpc.ClientAuthTLSConfig(
+					wsm.TLS.CA, wsm.TLS.Cert, wsm.TLS.Key,
+					common_grpc.WithSetRootCAs(true),
+					common_grpc.WithServerName("ws-manager"),
+				)
+				if err != nil {
+					log.WithField("config", wsm.TLS).Error("Cannot load ws-manager certs - this is a configuration issue.")
+					log.WithError(err).Fatal("cannot load ws-manager certs")
+				}
+
+				dialOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
+			}
+
+			dialctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			conn, err := grpc.DialContext(dialctx, wsm.Addr, dialOption, grpc.WithBlock())
+			cancel()
+			if err != nil {
+				log.WithError(err).Fatal("cannot connect to ws-manager")
+			}
+
+			heartbeat = &sshproxy.WorkspaceManagerHeartbeat{
+				Client: wsmanapi.NewWorkspaceManagerClient(conn),
+			}
+		}
+
 		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), workspaceInfoProvider).MustServe()
 		log.Infof("started proxying on %s", cfg.Ingress.HTTPAddress)
 
@@ -98,7 +133,7 @@ var runCmd = &cobra.Command{
 				signers = append(signers, hostSigner)
 			}
 			if len(signers) > 0 {
-				server := sshproxy.New(signers, workspaceInfoProvider)
+				server := sshproxy.New(signers, workspaceInfoProvider, heartbeat)
 				l, err := net.Listen("tcp", ":2200")
 				if err != nil {
 					panic(err)

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.39.1
 	k8s.io/api v0.22.2
@@ -39,6 +40,8 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -58,7 +61,6 @@ require (
 	github.com/uber/jaeger-client-go v2.29.1+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.8.0 // indirect
-	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
 	golang.org/x/oauth2 v0.0.0-20210615190721-d04028783cf1 // indirect
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -243,7 +243,9 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=

--- a/components/ws-proxy/pkg/config/config.go
+++ b/components/ws-proxy/pkg/config/config.go
@@ -21,6 +21,16 @@ type Config struct {
 	PrometheusAddr     string                       `json:"prometheusAddr"`
 	ReadinessProbeAddr string                       `json:"readinessProbeAddr"`
 	Namespace          string                       `json:"namespace"`
+	WorkspaceManager   *WorkspaceManagerConn        `json:"wsManager"`
+}
+
+type WorkspaceManagerConn struct {
+	Addr string `json:"addr"`
+	TLS  struct {
+		CA   string `json:"ca"`
+		Cert string `json:"crt"`
+		Key  string `json:"key"`
+	} `json:"tls"`
 }
 
 // Validate validates the configuration to catch issues during startup and not at runtime.

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package sshproxy
+
+import (
+	"context"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
+)
+
+type Heartbeat interface {
+	// SendHeartbeat sends a heartbeat for a workspace
+	SendHeartbeat(instanceID string)
+}
+
+type noHeartbeat struct{}
+
+func (noHeartbeat) SendHeartbeat(instanceID string) {}
+
+type WorkspaceManagerHeartbeat struct {
+	Client wsmanapi.WorkspaceManagerClient
+}
+
+func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := m.Client.MarkActive(ctx, &wsmanapi.MarkActiveRequest{
+		Id: instanceID,
+	})
+	if err != nil {
+		log.WithError(err).Warn("cannot send heartbeat for workspace instance")
+	} else {
+		log.WithField("instanceId", instanceID).Debug("sent heartbeat to ws-manager")
+	}
+}

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -14,22 +14,23 @@ import (
 
 type Heartbeat interface {
 	// SendHeartbeat sends a heartbeat for a workspace
-	SendHeartbeat(instanceID string)
+	SendHeartbeat(instanceID string, isClosed bool)
 }
 
 type noHeartbeat struct{}
 
-func (noHeartbeat) SendHeartbeat(instanceID string) {}
+func (noHeartbeat) SendHeartbeat(instanceID string, isClosed bool) {}
 
 type WorkspaceManagerHeartbeat struct {
 	Client wsmanapi.WorkspaceManagerClient
 }
 
-func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string) {
+func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string, isClosed bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, err := m.Client.MarkActive(ctx, &wsmanapi.MarkActiveRequest{
-		Id: instanceID,
+		Id:     instanceID,
+		Closed: isClosed,
 	})
 	if err != nil {
 		log.WithError(err).Warn("cannot send heartbeat for workspace instance")

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -64,8 +64,8 @@ func New(signers []ssh.Signer, workspaceInfoProvider p.WorkspaceInfoProvider, he
 			}, nil
 		},
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-			args := strings.Split(conn.User(), ":")
-			// workspaceId:ownerToken
+			args := strings.Split(conn.User(), "#")
+			// workspaceId#ownerToken
 			if len(args) != 2 {
 				return nil, fmt.Errorf("username error")
 			}

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -45,6 +45,9 @@ func New(signers []ssh.Signer, workspaceInfoProvider p.WorkspaceInfoProvider, he
 		workspaceInfoProvider: workspaceInfoProvider,
 		Heartbeater:           &noHeartbeat{},
 	}
+	if heartbeat != nil {
+		server.Heartbeater = heartbeat
+	}
 
 	server.sshConfig = &ssh.ServerConfig{
 		ServerVersion: "SSH-2.0-GITPOD-GATEWAY",

--- a/installer/pkg/components/ws-proxy/configmap.go
+++ b/installer/pkg/components/ws-proxy/configmap.go
@@ -65,6 +65,18 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		PProfAddr:          ":60060",
 		PrometheusAddr:     ":60095",
 		ReadinessProbeAddr: ":60088",
+		WorkspaceManager: &config.WorkspaceManagerConn{
+			Addr: "ws-manager:8080",
+			TLS: struct {
+				CA   string "json:\"ca\""
+				Cert string "json:\"crt\""
+				Key  string "json:\"key\""
+			}{
+				CA:   "/ws-manager-client-tls-certs/ca.crt",
+				Cert: "/ws-manager-client-tls-certs/tls.crt",
+				Key:  "/ws-manager-client-tls-certs/tls.key",
+			},
+		},
 	}
 
 	fc, err := common.ToJSONString(wspcfg)


### PR DESCRIPTION
## Description
Adds heartbeating to SSH PTY channels. This way, input from an SSH session counts towards a workspace's activity and prevents its timeout.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #4779

## How to test
- start a workspace
- SSH into that workspace using the owner token
- produce input on the SSH session
- observe that the workspace does not time out

ways to speed this up:
- use a custom timeout annotation
- check the debug logs of ws-proxy which will show when heartbeats are being sent

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support heartbeats from SSH sessions
```
