### PR TITLE
Trigger node high load warnings sooner

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -14,13 +14,13 @@
             labels: {
               severity: 'warning',
             },
-            'for': '5m',
+            'for': '2m',
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md',
-              summary: "Workspace node's normalized load average is higher than 5 for more than 5 minutes.",
+              summary: "Workspace node's normalized load average is higher than 3 for more than 2 minutes. Check for abuse.",
               description: 'Node {{ $labels.node }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.',
             },
-            expr: 'nodepool:node_load1:normalized{nodepool=~".*workspace.*"} > 5',
+            expr: 'nodepool:node_load1:normalized{nodepool=~".*workspace.*"} > 3',
           },
         ],
       },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Send warnings sooner when load is high.
We just noticed a spike that would not have triggered this warning in its current form.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
See https://github.com/gitpod-io/gitpod/pull/7710

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
