### PR TITLE
[installer] Add missing kube-rbac-proxy container in ws-manager deployment

### DIFF
--- a/installer/pkg/components/ws-manager/deployment.go
+++ b/installer/pkg/components/ws-manager/deployment.go
@@ -72,7 +72,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				MountPath: "/certs",
 				ReadOnly:  true,
 			}},
-		}},
+		},
+			*common.KubeRBACProxyContainer(ctx),
+		},
 		Volumes: []corev1.Volume{
 			{
 				Name: VolumeConfig,


### PR DESCRIPTION
Fixes  https://github.com/gitpod-io/gitpod/issues/7766
## How to test

Initialize and render the manifests created by the installer CLI and verify the `kube-rbac-proxy` container is present in `ws-manager` deployment

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Add missing kube-rbac-proxy container in ws-manager deployment
```
