### PR TITLE
Refactor and improve SSH gateway compatibility with some automatic client

### DIFF
--- a/chart/templates/ws-proxy-configmap.yaml
+++ b/chart/templates/ws-proxy-configmap.yaml
@@ -55,6 +55,14 @@ data:
         },
         "pprofAddr": ":6060",
         "readinessProbeAddr": ":60088",
-        "prometheusAddr": "localhost:9500"
+        "prometheusAddr": "localhost:9500",
+        "wsManager": {
+            "addr": "ws-manager:8080",
+            "tls": {
+                "ca": "/ws-manager-client-tls-certs/ca.crt",
+                "crt": "/ws-manager-client-tls-certs/tls.crt",
+                "key": "/ws-manager-client-tls-certs/tls.key"
+            }
+        }
     }
 {{- end -}}

--- a/chart/templates/ws-proxy-deployment.yaml
+++ b/chart/templates/ws-proxy-deployment.yaml
@@ -86,6 +86,9 @@ spec:
         - name: config
           mountPath: "/config"
           readOnly: true
+        - name: ws-manager-client-tls-certs
+          mountPath: "/ws-manager-client-tls-certs"
+          readOnly: true
 {{- if $.Values.certificatesSecret.secretName }}
         - name: config-certificates
           mountPath: "/mnt/certificates"

--- a/components/ws-proxy/pkg/sshproxy/heartbeat.go
+++ b/components/ws-proxy/pkg/sshproxy/heartbeat.go
@@ -14,22 +14,23 @@ import (
 
 type Heartbeat interface {
 	// SendHeartbeat sends a heartbeat for a workspace
-	SendHeartbeat(instanceID string)
+	SendHeartbeat(instanceID string, isClosed bool)
 }
 
 type noHeartbeat struct{}
 
-func (noHeartbeat) SendHeartbeat(instanceID string) {}
+func (noHeartbeat) SendHeartbeat(instanceID string, isClosed bool) {}
 
 type WorkspaceManagerHeartbeat struct {
 	Client wsmanapi.WorkspaceManagerClient
 }
 
-func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string) {
+func (m *WorkspaceManagerHeartbeat) SendHeartbeat(instanceID string, isClosed bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, err := m.Client.MarkActive(ctx, &wsmanapi.MarkActiveRequest{
-		Id: instanceID,
+		Id:     instanceID,
+		Closed: isClosed,
 	})
 	if err != nil {
 		log.WithError(err).Warn("cannot send heartbeat for workspace instance")

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -64,8 +64,8 @@ func New(signers []ssh.Signer, workspaceInfoProvider p.WorkspaceInfoProvider, he
 			}, nil
 		},
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-			args := strings.Split(conn.User(), ":")
-			// workspaceId:ownerToken
+			args := strings.Split(conn.User(), "#")
+			// workspaceId#ownerToken
 			if len(args) != 2 {
 				return nil, fmt.Errorf("username error")
 			}

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -45,6 +45,9 @@ func New(signers []ssh.Signer, workspaceInfoProvider p.WorkspaceInfoProvider, he
 		workspaceInfoProvider: workspaceInfoProvider,
 		Heartbeater:           &noHeartbeat{},
 	}
+	if heartbeat != nil {
+		server.Heartbeater = heartbeat
+	}
 
 	server.sshConfig = &ssh.ServerConfig{
 		ServerVersion: "SSH-2.0-GITPOD-GATEWAY",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When use golang ssh client connect to workspace and execute some command, it return a error Err:wait: remote command exited without exit status or exit signal

This is because golang client send EOF flag too early

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7771

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
