### PR TITLE
Restore beta label for the desktop editor settings

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -124,7 +124,7 @@ export default function Preferences() {
                     }
                 </>}
                 {desktopIdeOptions && <>
-                    <h3 className="mt-12">Desktop Editor</h3>
+                    <h3 className="mt-12">Desktop Editor <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel></h3>
                     <p className="text-base text-gray-500 dark:text-gray-400">Optionally, choose the default desktop editor for opening workspaces.</p>
                     <div className="my-4 gap-4 flex flex-wrap">
                         {


### PR DESCRIPTION
## Description

Following the changes in https://github.com/gitpod-io/gitpod/pull/7653, this will restore beta label for the desktop editor settings. Cc @mustard-mh 

See also [relevant discussion](https://gitpod.slack.com/archives/C02V17DGFNE/p1642799546007600) (internal).

## How to test
1. Go to [`/preferences`](https://gt-restore-beta-label.staging.gitpod-dev.com/preferences)
2. Notice there's a beta label next to _Desktop Editor_ settings.

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="660" alt="settings-before" src="https://user-images.githubusercontent.com/120486/150648867-22bd9e5c-eb2e-4a9c-b9e3-be8fde7986dd.png"> | <img width="660" alt="settings-after" src="https://user-images.githubusercontent.com/120486/150648870-a080c72b-ec49-40d7-89f9-7c250a124116.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```