### PR TITLE
[installer] Set the mandatory KUBE_STAGE env value

### DIFF
--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -49,6 +49,7 @@ func DefaultEnv(cfg *config.Config) []corev1.EnvVar {
 	}
 
 	return []corev1.EnvVar{
+		{Name: "KUBE_STAGE", Value: "production"}, // TODO: from the code, this can be production -> prod, staging -> prodcopy and "" -> dev
 		{Name: "GITPOD_DOMAIN", Value: cfg.Domain},
 		{Name: "GITPOD_INSTALLATION_LONGNAME", Value: cfg.Domain},  // todo(sje): figure out these values
 		{Name: "GITPOD_INSTALLATION_SHORTNAME", Value: cfg.Domain}, // todo(sje): figure out these values


### PR DESCRIPTION

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7776


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Set the mandatory KUBE_STAGE env value
```