### PR TITLE
ws-daemon: Name the magic exit code to make it common

### DIFF
--- a/components/ws-daemon/cmd/content-initializer/main.go
+++ b/components/ws-daemon/cmd/content-initializer/main.go
@@ -22,6 +22,6 @@ func main() {
 		errfd := os.NewFile(uintptr(3), "errout")
 		_, _ = fmt.Fprintf(errfd, err.Error())
 
-		os.Exit(42)
+		os.Exit(content.FAIL_CONTENT_INITIALIZER_EXIT_CODE)
 	}
 }

--- a/components/ws-daemon/pkg/content/exit-code.go
+++ b/components/ws-daemon/pkg/content/exit-code.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package content
+
+const (
+	FAIL_CONTENT_INITIALIZER_EXIT_CODE = 42
+)

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -272,8 +272,8 @@ func RunInitializer(ctx context.Context, destination string, initializer *csapi.
 	}
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			// The program has exited with an exit code != 0. If it's 42, it was deliberate.
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == 42 {
+			// The program has exited with an exit code != 0. If it's FAIL_CONTENT_INITIALIZER_EXIT_CODE, it was deliberate.
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == FAIL_CONTENT_INITIALIZER_EXIT_CODE {
 				log.WithError(err).WithField("exitCode", status.ExitStatus()).WithField("args", args).Error("content init failed")
 				return xerrors.Errorf(string(errmsg))
 			}


### PR DESCRIPTION
## Description
Naming the hard coding of exit codes to make them more understandable.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
Pass the tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No