### PR TITLE
Switch to prometheus collectors package

### DIFF
--- a/components/blobserve/cmd/run.go
+++ b/components/blobserve/cmd/run.go
@@ -5,17 +5,19 @@
 package cmd
 
 import (
-	"github.com/gitpod-io/gitpod/blobserve/pkg/config"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
 
+	"github.com/gitpod-io/gitpod/blobserve/pkg/config"
+
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
@@ -82,8 +84,8 @@ var runCmd = &cobra.Command{
 		}
 		if cfg.PrometheusAddr != "" {
 			reg.MustRegister(
-				prometheus.NewGoCollector(),
-				prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+				collectors.NewGoCollector(),
+				collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 			)
 
 			handler := http.NewServeMux()

--- a/components/content-service/cmd/run.go
+++ b/components/content-service/cmd/run.go
@@ -13,6 +13,7 @@ import (
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -100,8 +101,8 @@ var runCmd = &cobra.Command{
 
 		if cfg.Prometheus.Addr != "" {
 			reg.MustRegister(
-				prometheus.NewGoCollector(),
-				prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+				collectors.NewGoCollector(),
+				collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 			)
 
 			handler := http.NewServeMux()

--- a/components/openvsx-proxy/pkg/prometheus.go
+++ b/components/openvsx-proxy/pkg/prometheus.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -33,8 +34,8 @@ func (p *Prometheus) Start(cfg *Config) {
 
 	if cfg.PrometheusAddr != "" {
 		p.reg.MustRegister(
-			prometheus.NewGoCollector(),
-			prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+			collectors.NewGoCollector(),
+			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		)
 
 		handler := http.NewServeMux()

--- a/components/ws-daemon/cmd/run.go
+++ b/components/ws-daemon/cmd/run.go
@@ -13,6 +13,7 @@ import (
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -73,8 +74,8 @@ var runCmd = &cobra.Command{
 
 		if cfg.Prometheus.Addr != "" {
 			reg.MustRegister(
-				prometheus.NewGoCollector(),
-				prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+				collectors.NewGoCollector(),
+				collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 			)
 
 			handler := http.NewServeMux()


### PR DESCRIPTION
## Description
Since prometheus client 1.11.0 registering the go and process collectors should be done through the collectors package. The current way has been deprecated.

## Related Issue(s)
None

## How to test
Check if go and process metrics are available as before. The new methods are wrappers around the old ones, so everything should be the same. Also already used in imagebuilder.

## Release Notes
```release-note
None
```