### PR TITLE
[installer]: add namespace to validate cluster command

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -495,6 +495,13 @@ command.
 ./installer render --config gitpod.config.yaml --namespace gitpod > gitpod.yaml
 ```
 
+The `validate cluster` command also accepts a namespace, allowing you to run
+the checks on that namespace.
+
+```shell
+./installer validate cluster --kubeconfig ~/.kube/config --config gitpod.config.yaml --namespace gitpod
+```
+
 **IMPORTANT**: this does not create the namespace, so you will need to create
 that separately. This is so that uninstallation of Gitpod does not remove any
 Kubernetes objects, such as your TLS certificate or connection secrets.

--- a/installer/cmd/validate_cluster.go
+++ b/installer/cmd/validate_cluster.go
@@ -18,8 +18,9 @@ import (
 )
 
 var validateClusterOpts struct {
-	Kube   kubeConfig
-	Config string
+	Kube      kubeConfig
+	Namespace string
+	Config    string
 }
 
 // validateClusterCmd represents the cluster command
@@ -39,18 +40,14 @@ var validateClusterCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		namespace, _, err := clientcfg.Namespace()
-		if err != nil {
-			return err
-		}
 
-		result, err := cluster.ClusterChecks.Validate(context.Background(), res, namespace)
+		result, err := cluster.ClusterChecks.Validate(context.Background(), res, validateClusterOpts.Namespace)
 		if err != nil {
 			return err
 		}
 
 		if validateClusterOpts.Config != "" {
-			res, err := runClusterConfigValidation(context.Background(), res, namespace)
+			res, err := runClusterConfigValidation(context.Background(), res, validateClusterOpts.Namespace)
 			if err != nil {
 				return err
 			}
@@ -107,4 +104,5 @@ func init() {
 
 	validateClusterCmd.PersistentFlags().StringVar(&validateClusterOpts.Kube.Config, "kubeconfig", "", "path to the kubeconfig file")
 	validateClusterCmd.PersistentFlags().StringVarP(&validateClusterOpts.Config, "config", "c", os.Getenv("GITPOD_INSTALLER_CONFIG"), "path to the config file")
+	validateClusterCmd.PersistentFlags().StringVarP(&validateClusterOpts.Namespace, "namespace", "n", "default", "namespace to deploy to")
 }

--- a/installer/go.mod
+++ b/installer/go.mod
@@ -174,6 +174,7 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/seccomp/libseccomp-golang v0.9.1 // indirect
 	github.com/shirou/gopsutil v2.20.9+incompatible // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/installer/go.sum
+++ b/installer/go.sum
@@ -1076,6 +1076,7 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/installer/pkg/cluster/validation.go
+++ b/installer/pkg/cluster/validation.go
@@ -75,6 +75,11 @@ var ClusterChecks = ValidationChecks{
 		Check:       checkCertManagerInstalled,
 		Description: "cert-manager is installed and has available issuer",
 	},
+	{
+		Name:        "Namespace exists",
+		Description: "ensure that the target namespace exists",
+		Check:       checkNamespaceExists,
+	},
 }
 
 // ValidationChecks are a group of validations


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a namespace flag to the validate cluster command. This updates the validation checks to receive the namespace from the flag.

A new check to ensure the existence of the namespace is added. The Installer does not create the namespace for reasons discussed [here](https://github.com/gitpod-io/gitpod/tree/main/installer#how-can-i-install-to-a-kubernetes-namespace)

Finally, have renamed the command file `validate-cluster.go` to `validate_cluster.go` to maintain consistency in naming convention and fixed a couple of nits in `checks.go`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7497

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: add namespace to validate cluster command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
