### PR TITLE
[server] Ensure incremental prebuilds always use the latest config

### DIFF
--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -108,6 +108,13 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                     prebuiltWorkspace: parentPrebuild,
                 }
                 ws = await this.createForPrebuiltWorkspace({span}, user, incrementalPrebuildContext, normalizedContextURL);
+                // Overwrite the config from the parent prebuild:
+                //   `createForPrebuiltWorkspace` 1:1 copies the config from the parent prebuild.
+                //   Above, we've made sure that the parent's prebuild tasks (before/init/prebuild) are still the same as now.
+                //   However, other non-prebuild config items might be outdated (e.g. any command task, VS Code extension, ...)
+                //   To fix this, we overwrite the new prebuild's config with the most-recently fetched config.
+                // See also: https://github.com/gitpod-io/gitpod/issues/7475
+                ws.config = config;
                 break;
             }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Ensure Incremental Prebuilds always use the latest config (by always overwriting the parent prebuild's config with the most-recently fetched config).

From the in-line comment:

> `createForPrebuiltWorkspace` 1:1 copies the config from the parent prebuild.
> Above, we've made sure that the parent's prebuild tasks (before/init/prebuild) are still the same as now.
> However, other non-prebuild config items might be outdated (e.g. any command task, VS Code extension, ...)
> To fix this, we overwrite the new prebuild's config with the most-recently fetched config.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7475

## How to test
<!-- Provide steps to test this PR -->

See "Steps to reproduce" in https://github.com/gitpod-io/gitpod/issues/7475

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Ensure incremental prebuilds always use the latest config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
