### PR TITLE
[dashboard] Setup (component) integration tests

### DIFF
--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -14,11 +14,13 @@ packages:
       - craco.config.js
       - postcss.config.js
       - .eslintrc.js
+      - scripts/run-integration-tests.sh
     deps:
       - components/gitpod-protocol:lib
     config:
       commands:
         build: ["yarn", "build"]
+        test: ["yarn", "test"]
       yarnLock: ${coreYarnLockBase}/yarn.lock
       dontTest: true
       packaging: archive

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -49,9 +49,11 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build --verbose",
-    "test": "craco test",
+    "test": "yarn test:unit && ./scripts/run-integration-tests.sh",
+    "test:unit": "craco test --all --watchAll=false",
+    "test:unit:watch": "craco test --all",
     "test:integration:watch": "cypress open",
-    "test:integration:run": "cypress run",
+    "test:integration:run": "cypress install && cypress run",
     "eject": "react-scripts eject",
     "telepresence": "TELEPRESENCE_USE_DEPLOYMENT=1 leeway run .:telepresence"
   },

--- a/components/dashboard/scripts/run-integration-tests.sh
+++ b/components/dashboard/scripts/run-integration-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+
+wait_port() {
+    local RC=1;
+    while [ $RC -ne 0 ]; do
+        curl -s --max-time "$1" "$2" > /dev/null;
+        RC=$?;
+    done
+}
+
+trap "exit" INT TERM SIGINT SIGTERM
+trap "kill 0" EXIT
+
+# start dashboard in background
+yarn start &
+
+# wait for the dashboard to become available
+echo "waiting 60s for localhost:3000 to open..."
+wait_port 60 localhost:3000
+echo "localhost:3000 responded, running tests."
+
+# run actual tests
+yarn test:integration:run


### PR DESCRIPTION
## Description
Makes `yarn test` executed unit (craco test) and (dashboard) integration tests (cypress) in non-interactive mode.
Also, `yarn test` now runs during builds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
