### PR TITLE
Ignore missing data-mysql-0 pvc during uninstall

### DIFF
--- a/.werft/util/uninstall-gitpod.sh
+++ b/.werft/util/uninstall-gitpod.sh
@@ -13,7 +13,7 @@ echo "Removing Gitpod in namespace ${NAMESPACE}"
 kubectl get configmap gitpod-app -n "${NAMESPACE}" -o jsonpath='{.data.app\.yaml}' | kubectl delete --ignore-not-found=true -f -
 
 echo "Removing Gitpod storage from ${NAMESPACE}"
-kubectl -n "${NAMESPACE}" delete pvc data-mysql-0
+kubectl -n "${NAMESPACE}" --ignore-not-found=true delete pvc data-mysql-0
 # the installer includes the minio PVC in it's config mpap, this is a "just in case"
 kubectl -n "${NAMESPACE}" delete pvc minio || true
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

A werft job was failing due to `[prep] Error from server (NotFound): persistentvolumeclaims "data-mysql-0" not found` (see [job](https://werft.gitpod-dev.com/job/gitpod-build-ak-jb-gateway-plugin.144)).

It looks like the uninstaller is not handling the case where the `data-mysql-0` pvc is not present during uninstall.

This PR adds `--ignore-not-found=true` so that uninstall won't fail if the resource is missing - this was suggested by @iQQBot and is in line with other `kubectl delete` invocations in the script.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

This can be tested by deploying using the installer, deleting the `data-mysql-0` PVC manually, and then deploying again using `with-clean-slate-deployment`:

1. First [job](https://werft.gitpod-dev.com/job/gitpod-build-mads-ignore-missing-pvc.1) resulting in a working preview environments
2. I manually deleted the pvc
3. Ran with `werft run github -a with-clean-slate-deployment=true` ([job](https://werft.gitpod-dev.com/job/gitpod-build-mads-ignore-missing-pvc.1))

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A