### PR TITLE
[helm] registry-facade, ws-daemon: Add postStart and preStop lifecycl…

### DIFF
--- a/chart/templates/registry-facade-clusterrole.yaml
+++ b/chart/templates/registry-facade-clusterrole.yaml
@@ -17,4 +17,11 @@ rules:
     verbs: ["use"]
     resourceNames:
     - {{ .Release.Namespace }}-ns-registry-facade
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs:
+    - get
+    - list
+    - update
+    - patch
 {{- end -}}

--- a/chart/templates/registry-facade-daemonset.yaml
+++ b/chart/templates/registry-facade-daemonset.yaml
@@ -53,6 +53,10 @@ spec:
 {{ include "gitpod.container.tracingEnv" $this | indent 8 }}
         - name: GRPC_GO_RETRY
           value: "on"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: cache
           mountPath: "/mnt/cache"
@@ -71,6 +75,19 @@ spec:
         - name: https-certificates
           mountPath: "/mnt/certificates"
         {{- end }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - kubectl label --overwrite nodes ${NODENAME} gitpod.io/registry-facade_ready_ns_${KUBE_NAMESPACE}=true
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - kubectl label nodes ${NODENAME} gitpod.io/registry-facade_ready_ns_${KUBE_NAMESPACE}-
 {{ include "gitpod.kube-rbac-proxy" $this | indent 6 }}
       volumes:
       - name: cache

--- a/chart/templates/registry-facade-rolebinding.yaml
+++ b/chart/templates/registry-facade-rolebinding.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: registry-facade
+  name: {{ .Release.Namespace }}-ns-registry-facade
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: registry-facade
@@ -13,6 +13,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: registry-facade
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Release.Namespace }}-ns-registry-facade

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -288,6 +288,19 @@ spec:
             path: "/"
           initialDelaySeconds: 5
           periodSeconds: 10
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - kubectl label --overwrite nodes ${NODENAME} gitpod.io/ws-daemon_ready_ns_${KUBE_NAMESPACE}=true
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - kubectl label nodes ${NODENAME} gitpod.io/ws-daemon_ready_ns_${KUBE_NAMESPACE}-
         livenessProbe:
           httpGet:
             port: 9999

--- a/chart/templates/ws-daemon-rolebinding.yaml
+++ b/chart/templates/ws-daemon-rolebinding.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: ws-daemon-rb
+  name: {{ .Release.Namespace }}-ns-ws-daemon-rb
   labels:
     app: {{ template "gitpod.fullname" . }}
     component: ws-daemon
@@ -13,6 +13,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: ws-daemon
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Release.Namespace }}-ns-ws-daemon


### PR DESCRIPTION
…e hooks akin to installer

## Description
Adjusts helm chart to match installer again.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes: #7809

Context: #7472

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-helm