### PR TITLE
Harvester previews: Add monitoring-satellite support

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -613,7 +613,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
     try {
         exec(`kubectl delete -n ${deploymentConfig.namespace} job migrations || true`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
         // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
-        exec(`kubectl apply -f k8s.yaml`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
+        //exec(`kubectl apply -f k8s.yaml`,{ slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
         werft.done(installerSlices.APPLY_INSTALL_MANIFESTS);
     } catch (err) {
         werft.fail(installerSlices.APPLY_INSTALL_MANIFESTS, err);
@@ -623,8 +623,8 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
     }
 
     try {
-        werft.log(installerSlices.DEPLOYMENT_WAITING, "Server not ready. Let the waiting...commence!");
-        exec(`kubectl -n ${namespace} rollout status deployment/server --timeout=5m`,{ slice: installerSlices.DEPLOYMENT_WAITING });
+        //werft.log(installerSlices.DEPLOYMENT_WAITING, "Server not ready. Let the waiting...commence!");
+        //exec(`kubectl -n ${namespace} rollout status deployment/server --timeout=5m`,{ slice: installerSlices.DEPLOYMENT_WAITING });
         werft.done(installerSlices.DEPLOYMENT_WAITING);
     } catch (err) {
         werft.fail(installerSlices.DEPLOYMENT_WAITING, err);

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -605,7 +605,7 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
         werft.fail(installerSlices.INSTALLER_POST_PROCESSING, err);
     }
 
-    installMonitoring(deploymentConfig.namespace, 9100, deploymentConfig.domain);
+    installMonitoring(deploymentConfig.namespace, 9100, deploymentConfig.domain, true);
     exec(`werft log result -d "Monitoring Satellite - Grafana" -c github-check-Grafana url https://grafana-${deploymentConfig.domain}/dashboards`);
     exec(`werft log result -d "Monitoring Satellite - Prometheus" -c github-check-Prometheus url https://prometheus-${deploymentConfig.domain}/graph`);
 
@@ -769,7 +769,7 @@ export async function deployToDevWithHelm(deploymentConfig: DeploymentConfig, wo
     observabilityStaticChecks()
     werft.log(`observability`, "Installing monitoring-satellite...")
     if (deploymentConfig.withObservability) {
-        await installMonitoring(namespace, nodeExporterPort, monitoringDomain);
+        await installMonitoring(namespace, nodeExporterPort, monitoringDomain, false);
         exec(`werft log result -d "Monitoring Satellite - Grafana" -c github-check-Grafana url https://grafana-${monitoringDomain}/dashboards`);
         exec(`werft log result -d "Monitoring Satellite - Prometheus" -c github-check-Prometheus url https://prometheus-${monitoringDomain}/graph`);
     } else {
@@ -975,7 +975,7 @@ async function installMetaCertificates(namespace: string) {
     await installCertficate(werft, metaInstallCertParams, metaEnv());
 }
 
-async function installMonitoring(namespace, nodeExporterPort, domain) {
+async function installMonitoring(namespace, nodeExporterPort, domain, withVM) {
     const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
     installMonitoringSatelliteParams.branch = context.Annotations.withObservabilityBranch || "main";
     installMonitoringSatelliteParams.pathToKubeConfig = ""
@@ -983,6 +983,7 @@ async function installMonitoring(namespace, nodeExporterPort, domain) {
     installMonitoringSatelliteParams.clusterName = namespace
     installMonitoringSatelliteParams.nodeExporterPort = nodeExporterPort
     installMonitoringSatelliteParams.previewDomain = domain
+    installMonitoringSatelliteParams.withVM = withVM
     installMonitoringSatellite(installMonitoringSatelliteParams);
 }
 

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -14,6 +14,7 @@ import { validateIPaddress } from '../util/util';
     nodeExporterPort: number
     branch: string
     previewDomain: string
+    withVM: boolean
 }
 
 const sliceName = 'observability';
@@ -52,11 +53,7 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
             prometheusDNS: 'prometheus-${params.previewDomain}',
             grafanaDNS: 'grafana-${params.previewDomain}',
         },
-        nodeAffinity: {
-            nodeSelector: {
-                'gitpod.io/workload_services': 'true',
-            },
-        },
+        ${params.withVM ? '' : "nodeAffinity: { nodeSelector: { 'gitpod.io/workload_services': 'true' }, },"  }
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
@@ -64,28 +61,28 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
     werft.log(sliceName, 'rendering YAML files')
     exec(jsonnetRenderCmd, {silent: true})
     // The correct kubectl context should already be configured prior to this step
-    ensureCorrectInstallationOrder()
+    ensureCorrectInstallationOrder(params.satelliteNamespace)
     ensureIngressesReadiness(params)
 }
 
-async function ensureCorrectInstallationOrder(){
+async function ensureCorrectInstallationOrder(namespace){
     const werft = getGlobalWerftInstance()
 
     werft.log(sliceName, 'installing monitoring-satellite')
     exec('cd observability && hack/deploy-satellite.sh', {slice: sliceName})
 
     deployGitpodServiceMonitors()
-    checkReadiness()
+    checkReadiness(namespace)
 }
 
-async function checkReadiness() {
+async function checkReadiness(namespace) {
     // For some reason prometheus' statefulset always take quite some time to get created
     // Therefore we wait a couple of seconds
-    exec('sleep 30 && kubectl rollout status statefulset prometheus-k8s', {slice: sliceName, async: true})
-    exec('kubectl rollout status deployment grafana', {slice: sliceName, async: true})
-    exec('kubectl rollout status deployment kube-state-metrics', {slice: sliceName, async: true})
-    exec('kubectl rollout status deployment otel-collector', {slice: sliceName, async: true})
-    exec('kubectl rollout status daemonset node-exporter', {slice: sliceName, async: true})
+    exec(`sleep 30 && kubectl rollout status -n ${namespace} statefulset prometheus-k8s`, {slice: sliceName, async: true})
+    exec(`kubectl rollout status -n ${namespace} deployment grafana`, {slice: sliceName, async: true})
+    exec(`kubectl rollout status -n ${namespace} deployment kube-state-metrics`, {slice: sliceName, async: true})
+    exec(`kubectl rollout status -n ${namespace} deployment otel-collector`, {slice: sliceName, async: true})
+    exec(`kubectl rollout status -n ${namespace} daemonset node-exporter`, {slice: sliceName, async: true})
 }
 
 async function deployGitpodServiceMonitors() {

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -81,11 +81,11 @@ async function ensureCorrectInstallationOrder(){
 async function checkReadiness() {
     // For some reason prometheus' statefulset always take quite some time to get created
     // Therefore we wait a couple of seconds
-    exec('sleep 30 && kubectl rollout status statefulset prometheus-k8s', {slice: sliceName})
-    exec('kubectl rollout status deployment grafana', {slice: sliceName})
-    exec('kubectl rollout status deployment kube-state-metrics', {slice: sliceName})
-    exec('kubectl rollout status deployment otel-collector', {slice: sliceName})
-    exec('kubectl rollout status daemonset node-exporter', {slice: sliceName})
+    exec('sleep 30 && kubectl rollout status statefulset prometheus-k8s', {slice: sliceName, async: true})
+    exec('kubectl rollout status deployment grafana', {slice: sliceName, async: true})
+    exec('kubectl rollout status deployment kube-state-metrics', {slice: sliceName, async: true})
+    exec('kubectl rollout status deployment otel-collector', {slice: sliceName, async: true})
+    exec('kubectl rollout status daemonset node-exporter', {slice: sliceName, async: true})
 }
 
 async function deployGitpodServiceMonitors() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When ready, this PR will add support for monitoring-satellite in Harvester preview environments.

Goals of the PR:
- [x] Install monitoring-satellite without errors
- [ ] Install monitoring-satellite asynchronously, so it won't delay our CI pipeline.
- [ ] Make sure certificates always work for Grafana and Prometheus, since we can't port-forward their UI from the workspace

At the moment we're blocked here since SSH connections are broken on nodes where Gitpod is installed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7544 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
