### PR TITLE
Add workspace count metric

### DIFF
--- a/components/ee/agent-smith/pkg/detector/proc_test.go
+++ b/components/ee/agent-smith/pkg/detector/proc_test.go
@@ -254,6 +254,7 @@ func TestRunDetector(t *testing.T) {
 			det := ProcfsDetector{
 				indexSizeGuage:     prometheus.NewGauge(prometheus.GaugeOpts{Name: "dont"}),
 				cacheUseCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"use"}),
+				workspaceGauge:     prometheus.NewGauge(prometheus.GaugeOpts{Name: "dont"}),
 				cache:              cache,
 			}
 

--- a/operations/observability/mixins/workspace/dashboards/components/agent-smith.json
+++ b/operations/observability/mixins/workspace/dashboards/components/agent-smith.json
@@ -615,7 +615,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The number of workspaces detected by agent-smith",
+      "description": "Difference between workspaces found by agent-smith and workspaces ws-manager knows about",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -690,13 +690,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum(gitpod_agent_smith_procfs_detector_workspace_count{cluster=~\"$cluster\"}) by (cluster)",
+          "expr": "sum(gitpod_ws_manager_workspace_phase_total{cluster=~\"()\", phase=\"RUNNING\", type=\"REGULAR\"})  by (cluster) - on (cluster) sum(gitpod_agent_smith_procfs_detector_workspace_count{cluster=~\"()\"}) by (cluster)",
           "interval": "",
-          "legendFormat": "{{cluster}}",
+          "legendFormat": "Difference",
           "refId": "A"
         }
       ],
-      "title": "Detected Workspaces",
+      "title": "Workspace Difference",
       "type": "timeseries"
     },
     {

--- a/operations/observability/mixins/workspace/dashboards/components/agent-smith.json
+++ b/operations/observability/mixins/workspace/dashboards/components/agent-smith.json
@@ -22,7 +22,8 @@
   "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1634665862423,
+  "id": 52,
+  "iteration": 1643114727790,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -607,6 +608,95 @@
         }
       ],
       "title": "Signature Cache Miss",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The number of workspaces detected by agent-smith",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "exemplar": true,
+          "expr": "sum(gitpod_agent_smith_procfs_detector_workspace_count{cluster=~\"$cluster\"}) by (cluster)",
+          "interval": "",
+          "legendFormat": "{{cluster}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Detected Workspaces",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Description
Add a metric that shows the difference between what agent-smith is seeing and the workspaces ws-manager knows about. If there is a considerable difference we probably have broken the workspace detection in agent-smith.

![agent-smith-detected-workspaces](https://user-images.githubusercontent.com/24721048/151370389-2a020717-cd05-4d53-a717-ac7f7f198598.png)

## Related Issue(s)
Fixes #7202

## How to test
Open Grafana in preview environment, select agent-smith dashboard and look at "Detected workspaces" metric.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```