### PR TITLE
Fix integration tests

### DIFF
--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -61,9 +61,7 @@ pod:
       set -Eeuo pipefail
 
       echo "[prep] receiving config..."
-      mkdir /root/.config
-      cp -R /config/gcloud /root/.config/gcloud
-      export GOOGLE_APPLICATION_CREDENTIALS=/config/gcloud/legacy_credentials/gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json
+      export GOOGLE_APPLICATION_CREDENTIALS="/config/gcloud/legacy_credentials/cd-gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json"
       echo "[prep] received config."
 
       USERNAME="{{ .Annotations.username }}"
@@ -71,9 +69,15 @@ pod:
         USERNAME=""
       fi
       echo "[prep] using username: $USERNAME"
+
+      args=()
+      args+=( '-kubeconfig=/config/kubeconfig' )
+      args+=( "-namespace={{ .Annotations.namespace }}" )
+      [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
+      echo "[prep] args: ${args[@]}"
       echo "[prep|DONE]"
 
-      /entrypoint.sh -kubeconfig=/config/kubeconfig -namespace={{ .Annotations.namespace }} -username=$USERNAME 2>&1 | ts "[int-tests] "
+      /entrypoint.sh "${args[@]}" 2>&1 | ts "[int-tests] "
 
       RC=${PIPESTATUS[0]}
       if [ $RC -eq 1 ]; then

--- a/test/README.md
+++ b/test/README.md
@@ -32,11 +32,33 @@ Example command:
 werft job run github -j .werft/run-integration-tests.yaml -a namespace=staging-gpl-2658-int-tests -a version=gpl-2658-int-tests.57 -f
 ```
 
-### Manually against a Kubernetes cluster
+### Manually
 
-You may want to run tests to assert whether your Gitpod installation is successfully integrated.
+You may want to run tests to assert whether a Gitpod installation is successfully integrated.
 
-To test your Gitpod installation:
+#### Using a pod
+
+Best for when you want to validate an environment.
+
+1. Create a service account, role, and role-binding for integration testing.
+   * [`kubectl apply -f ./integration.yaml`](./integration.yaml)
+2. Run a pod to execute the tests like so:
+    ```bash
+    # Replace <number>, <namespace>, and <gitpod_username> with meaningful values
+    kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.<number> \
+    integ-tests --serviceaccount=integration-svc \
+    --restart=Never \
+    --requests='cpu=2,memory=4Gi' \
+    -- /bin/sh -namespace=<namespace> -username=<gitpod_username>
+    ```
+3. Check logs to inspect test results like so `kubectl logs -f integ-tests`.
+4. Tear down the integration user and pod when testing is done.
+   * [`kubectl delete -f ./integration.yaml`](./integration.yaml)
+   * `kubectl delete pod integ-user`
+
+#### Go test
+
+Best for when you're actively developing Gitpod.
 
 1. Set your kubectl context to the cluster you want to test
 2. Integrate the Gitpod installation with OAuth for Github and/or Gitlab, otherwise related tests may fail

--- a/test/README.md
+++ b/test/README.md
@@ -29,7 +29,7 @@ There is a [werft job](../.werft/run-integration-tests.yaml) that runs the integ
 
 Example command:
 ```
-werft job run github -j .werft/run-integration-tests.yaml -a namespace=staging-gpl-2658-int-tests -a version=gpl-2658-int-tests.57 -f
+werft run github -j .werft/run-integration-tests.yaml -a namespace=staging-gpl-2658-int-tests -a version=gpl-2658-int-tests.57 -f
 ```
 
 ### Manually
@@ -51,7 +51,7 @@ Best for when you want to validate an environment.
 #### Go test
 
 Best for when you're actively developing Gitpod.
-Test will work if images that they use are already cached by gitpod instnance. If not, they might fail if it takes too long to pull an image.
+Test will work if images that they use are already cached by Gitpod instance. If not, they might fail if it takes too long to pull an image.
 There are 4 different types of tests:
 1. Enterprise specific, that require valid license to be installed. Run those with `-enterprise=true`
 2. Tests that require correct user (user should have github OAuth integration setup with gitpod). Run those with `-username=<gitpod_username>`. Make sure to load https://github.com/gitpod-io/gitpod-test-repo and https://github.com/gitpod-io/gitpod workspaces inside your gitpod that you are testing to preload those images onto your node. Wait for it to finish pulling those image, this will ensure that test will not fail due to timeout while waiting to pull an image for the first time.

--- a/test/README.md
+++ b/test/README.md
@@ -40,33 +40,34 @@ You may want to run tests to assert whether a Gitpod installation is successfull
 
 Best for when you want to validate an environment.
 
-1. Create a service account, role, and role-binding for integration testing.
+1. Update image name in `integration.yaml` for job `integration-job` to latest built by werft.
+2. Optionally add your username in that job argument or any other additional params.
+2. Apply yaml file that will add all necessary permissions and create a job that will run tests.
    * [`kubectl apply -f ./integration.yaml`](./integration.yaml)
-2. Run a pod to execute the tests like so:
-    ```bash
-    # Replace <number>, <namespace>, and <gitpod_username> with meaningful values
-    kubectl run --image=eu.gcr.io/gitpod-core-dev/build/integration-tests:main.<number> \
-    integ-tests --serviceaccount=integration-svc \
-    --restart=Never \
-    --requests='cpu=2,memory=4Gi' \
-    -- /bin/sh -namespace=<namespace> -username=<gitpod_username>
-    ```
-3. Check logs to inspect test results like so `kubectl logs -f integ-tests`.
-4. Tear down the integration user and pod when testing is done.
+3. Check logs to inspect test results like so `kubectl logs -f jobs/integration-job`.
+4. Tear down the integration user and job when testing is done.
    * [`kubectl delete -f ./integration.yaml`](./integration.yaml)
-   * `kubectl delete pod integ-user`
 
 #### Go test
 
 Best for when you're actively developing Gitpod.
+Test will work if images that they use are already cached by gitpod instnance. If not, they might fail if it takes too long to pull an image.
+There are 4 different types of tests:
+1. Enterprise specific, that require valid license to be installed. Run those with `-enterprise=true`
+2. Tests that require correct user (user should have github OAuth integration setup with gitpod). Run those with `-username=<gitpod_username>`. Make sure to load https://github.com/gitpod-io/gitpod-test-repo and https://github.com/gitpod-io/gitpod workspaces inside your gitpod that you are testing to preload those images onto your node. Wait for it to finish pulling those image, this will ensure that test will not fail due to timeout while waiting to pull an image for the first time.
+3. To test gitlab integration, add `-gitlab=true`
+4. All other tests.
 
-1. Set your kubectl context to the cluster you want to test
-2. Integrate the Gitpod installation with OAuth for Github and/or Gitlab, otherwise related tests may fail
-3. Clone this repo, and `cd` to `./gitpod/test`
-4. Run the tests like so
+To run the tests:
+1. Clone this repo (`git clone git@github.com:gitpod-io/gitpod.git`), and `cd` to `./gitpod/test`
+2. Run the tests like so
   ```bash
   go test -v ./... \
   -kubeconfig=<path_to_kube_config_file> \
   -namespace=<namespace_where_gitpod_is_installed> \
-  -username=<a_user_in_the_gitpod_database>
+  -username=<gitpod_user_with_oauth_setup> \
+  -enterprise=<true|false> \
+  -gitlab=<true|false>
   ```
+3. Tests `TestUploadDownloadBlob` and `TestUploadDownloadBlobViaServer` will fail when testing locally, as they are trying to connect to cluster local resources directly. To test them use docker image instead that runs within the cluster.
+4. If you want to run specific test, add `-run <test>` before `-kubeconfig` parameter.

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -11,7 +11,7 @@ export PATH=$PATH:/tests
 
 FAILURE_COUNT=0
 # shellcheck disable=SC2045
-for i in $(find /tests/ -name "*.test" | sort -R); do
+for i in $(find /tests/ -name "*.test" | sort); do
     "$i" "$@";
     TEST_STATUS=$?
     if [ "$TEST_STATUS" -ne "0" ]; then

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -3,11 +3,29 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-set -ex
+# exclude 'e' (exit on any error)
+# there are many test binaries, each can have failures
+set -x
 
 export PATH=$PATH:/tests
 
+FAILURE_COUNT=0
 # shellcheck disable=SC2045
 for i in $(find /tests/ -name "*.test" | sort -R); do
     "$i" "$@";
+    TEST_STATUS=$?
+    if [ "$TEST_STATUS" -ne "0" ]; then
+        FAILURE_COUNT=$((FAILURE_COUNT+1))
+        echo "Test failed at $(date)"
+    else
+        echo "Test succeeded at $(date)"
+    fi;
 done
+
+if [ "$FAILURE_COUNT" -ne "0" ]; then
+    # exit with the number of test binaries that failed
+    echo "Test suite ended with failure at $(date)"
+    exit $FAILURE_COUNT
+fi;
+
+echo "Test suite ended with success at $(date)"

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -12,6 +12,7 @@ export PATH=$PATH:/tests
 FAILURE_COUNT=0
 # shellcheck disable=SC2045
 for i in $(find /tests/ -name "*.test" | sort); do
+    echo "running test: $i"
     "$i" "$@";
     TEST_STATUS=$?
     if [ "$TEST_STATUS" -ne "0" ]; then

--- a/test/integration.yaml
+++ b/test/integration.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: integration-svc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: integration-role
+rules:
+    - apiGroups:
+        - ''
+      resources:
+        - 'pods'
+        - 'secrets'
+        - 'services'
+        - 'configmaps'
+      verbs:
+        - 'list'
+        - 'get'
+    - apiGroups:
+        - ''
+      resources:
+        - 'pods/portforward'
+      verbs:
+        - 'create'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: integration-rolebind
+subjects:
+    - kind: ServiceAccount
+      name: integration-svc
+roleRef:
+    kind: Role
+    name: integration-role
+    apiGroup: rbac.authorization.k8s.io

--- a/test/integration.yaml
+++ b/test/integration.yaml
@@ -15,6 +15,7 @@ rules:
         - 'secrets'
         - 'services'
         - 'configmaps'
+        - 'endpoints'
       verbs:
         - 'list'
         - 'get'
@@ -22,9 +23,9 @@ rules:
         - ''
       resources:
         - 'pods/portforward'
+        - 'pods/exec'
       verbs:
         - 'create'
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -37,3 +38,25 @@ roleRef:
     kind: Role
     name: integration-role
     apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: integration-job
+spec:
+  template:
+    spec:
+      serviceAccountName: integration-svc
+      containers:
+      - name: tests
+        image: eu.gcr.io/gitpod-core-dev/build/integration-tests:kyleb-installer-integration.24
+        imagePullPolicy: Always
+        #args: ["-username=sagor999"]
+        #args: ["-enterprise=true"]
+        #args: ["-gitlab=true"]
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+      restartPolicy: Never
+  backoffLimit: 0

--- a/test/leeway.Dockerfile
+++ b/test/leeway.Dockerfile
@@ -8,10 +8,15 @@ FROM alpine:3.15
 RUN  apk upgrade --no-cache \
   && apk add --no-cache \
     ca-certificates \
-    coreutils
+    coreutils \
+    curl
 
 # convenience scripting tools
 RUN apk add --no-cache bash moreutils
+
+# deps for tests to run
+RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
+  && chmod +x /usr/local/bin/kubectl
 
 COPY test--app/bin /tests
 ENV PATH=$PATH:/tests

--- a/test/pkg/integration/setup.go
+++ b/test/pkg/integration/setup.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -29,9 +30,40 @@ func SkipWithoutUsername(t *testing.T, username string) {
 		t.Skip("Skipping because requires a username")
 	}
 }
-func Setup(ctx context.Context) (string, string, env.Environment) {
+
+func SkipWithoutEnterpriseLicense(t *testing.T, enterpise bool) {
+	if !enterpise {
+		t.Skip("Skipping because requires enterprise license")
+	}
+}
+
+func EnsureUserExists(t *testing.T, username string, api *ComponentAPI) string {
+	if username == "" {
+		t.Logf("no username provided, creating temporary one")
+		rand.Seed(time.Now().UnixNano())
+		randN := rand.Intn(1000)
+		newUser := fmt.Sprintf("johndoe%d", randN)
+		userId, err := CreateUser(newUser, false, api)
+		if err != nil {
+			t.Fatalf("cannot create user: %q", err)
+		}
+		t.Cleanup(func() {
+			err := DeleteUser(userId, api)
+			if err != nil {
+				t.Fatalf("error deleting user %q", err)
+			}
+		})
+		t.Logf("user '%s' with ID %s created", newUser, userId)
+		return newUser
+	}
+	return username
+}
+
+func Setup(ctx context.Context) (string, string, env.Environment, bool, string, bool) {
 	var (
 		username        string
+		enterprise      bool
+		gitlab          bool
 		waitGitpodReady time.Duration
 
 		namespace  string
@@ -46,6 +78,8 @@ func Setup(ctx context.Context) (string, string, env.Environment) {
 	klog.InitFlags(flagset)
 
 	flagset.StringVar(&username, "username", "", "username to execute the tests with. Chooses one automatically if left blank.")
+	flagset.BoolVar(&enterprise, "enterprise", false, "whether to test enterprise features. requires enterprise lisence installed.")
+	flagset.BoolVar(&gitlab, "gitlab", false, "whether to test gitlab integration.")
 	flagset.DurationVar(&waitGitpodReady, "wait-gitpod-timeout", 5*time.Minute, `wait time for Gitpod components before starting integration test`)
 	flagset.StringVar(&namespace, "namespace", "", "Kubernetes cluster namespaces to use")
 	flagset.StringVar(&kubeconfig, "kubeconfig", "", "The path to the kubeconfig file")
@@ -90,7 +124,7 @@ func Setup(ctx context.Context) (string, string, env.Environment) {
 		waitOnGitpodRunning(e.Namespace(), waitGitpodReady),
 	)
 
-	return username, e.Namespace(), testenv
+	return username, e.Namespace(), testenv, enterprise, kubeconfig, gitlab
 }
 
 func waitOnGitpodRunning(namespace string, waitTimeout time.Duration) env.Func {

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -136,7 +136,7 @@ func LaunchWorkspaceDirectly(ctx context.Context, api *ComponentAPI, opts ...Lau
 		if err != nil {
 			return nil, xerrors.Errorf("cannot find server IDE config: %q", err)
 		}
-		ideImage = cfg.IDEImageAliases.Code
+		ideImage = cfg.IDEOptions.Options.Code.Image
 		if ideImage == "" {
 			return nil, xerrors.Errorf("cannot start workspaces without an IDE image (required by registry-facade resolver)")
 		}

--- a/test/tests/components/content-service/content-service_test.go
+++ b/test/tests/components/content-service/content-service_test.go
@@ -68,7 +68,7 @@ func TestUploadUrl(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -128,7 +128,7 @@ func TestDownloadUrl(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -174,7 +174,7 @@ func TestUploadDownloadBlob(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -217,14 +217,13 @@ func TestUploadDownloadBlob(t *testing.T) {
 // TestUploadDownloadBlobViaServer uploads a blob via server → content-server and downloads it afterwards
 func TestUploadDownloadBlobViaServer(t *testing.T) {
 	integration.SkipWithoutUsername(t, username)
-
 	f := features.New("UploadDownloadBlobViaServer").
 		WithLabel("component", "content-server").
 		Assess("it should uploads a blob via server → content-server and downloads it afterwards", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/components/content-service/main_test.go
+++ b/test/tests/components/content-service/main_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/components/database/db_test.go
+++ b/test/tests/components/database/db_test.go
@@ -22,7 +22,7 @@ func TestBuiltinUserExists(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/components/database/main_test.go
+++ b/test/tests/components/database/main_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/components/image-builder/builder_test.go
+++ b/test/tests/components/image-builder/builder_test.go
@@ -28,7 +28,7 @@ func TestBaseImageBuild(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -44,12 +44,12 @@ func TestBaseImageBuild(t *testing.T) {
 					From: &imgapi.BuildSource_File{
 						File: &imgapi.BuildSourceDockerfile{
 							DockerfileVersion: "some-version",
-							DockerfilePath:    ".gitpod.Dockerfile",
+							DockerfilePath:    "test/tests/components/image-builder/test.Dockerfile",
 							ContextPath:       ".",
 							Source: &csapi.WorkspaceInitializer{
 								Spec: &csapi.WorkspaceInitializer_Git{
 									Git: &csapi.GitInitializer{
-										RemoteUri:  "https://github.com/gitpod-io/dazzle.git",
+										RemoteUri:  "https://github.com/gitpod-io/gitpod.git",
 										TargetMode: csapi.CloneTargetMode_REMOTE_BRANCH,
 										CloneTaget: "main",
 										Config: &csapi.GitConfig{
@@ -104,7 +104,7 @@ func TestParallelBaseImageBuild(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -120,12 +120,12 @@ func TestParallelBaseImageBuild(t *testing.T) {
 					From: &imgapi.BuildSource_File{
 						File: &imgapi.BuildSourceDockerfile{
 							DockerfileVersion: "some-version",
-							DockerfilePath:    ".gitpod.Dockerfile",
+							DockerfilePath:    "test/tests/components/image-builder/test.Dockerfile",
 							ContextPath:       ".",
 							Source: &csapi.WorkspaceInitializer{
 								Spec: &csapi.WorkspaceInitializer_Git{
 									Git: &csapi.GitInitializer{
-										RemoteUri:  "https://github.com/gitpod-io/dazzle.git",
+										RemoteUri:  "https://github.com/gitpod-io/gitpod.git",
 										TargetMode: csapi.CloneTargetMode_REMOTE_BRANCH,
 										CloneTaget: "main",
 										Config: &csapi.GitConfig{

--- a/test/tests/components/image-builder/main_test.go
+++ b/test/tests/components/image-builder/main_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/components/server/blockuser_test.go
+++ b/test/tests/components/server/blockuser_test.go
@@ -19,13 +19,14 @@ import (
 )
 
 func TestAdminBlockUser(t *testing.T) {
+	integration.SkipWithoutEnterpriseLicense(t, enterprise)
 	f := features.New("block user").
 		WithLabel("component", "server").
 		Assess("it should block new created user", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/components/server/main_test.go
+++ b/test/tests/components/server/main_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	enterprise bool
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, enterprise, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/components/server/server_test.go
+++ b/test/tests/components/server/server_test.go
@@ -23,10 +23,12 @@ func TestServerAccess(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
+
+			username := integration.EnsureUserExists(t, username, api)
 
 			server, err := api.GitpodServer(integration.WithGitpodUser(username))
 			if err != nil {
@@ -54,7 +56,7 @@ func TestStartWorkspace(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/components/ws-daemon/main_test.go
+++ b/test/tests/components/ws-daemon/main_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/components/ws-daemon/storage_test.go
+++ b/test/tests/components/ws-daemon/storage_test.go
@@ -24,7 +24,7 @@ func TestCreateBucket(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			rsa, closer, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), cfg.Client(),
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspaceDaemon, "daemon", cfg.Namespace(), kubeconfig, cfg.Client(),
 				integration.WithWorkspacekitLift(false),
 				integration.WithContainer("ws-daemon"),
 			)

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -26,7 +26,7 @@ func TestBackup(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -41,7 +41,7 @@ func TestBackup(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(),
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 				integration.WithInstanceID(ws.Req.Id),
 				integration.WithContainer("workspace"),
 				integration.WithWorkspacekitLift(true),
@@ -87,7 +87,7 @@ func TestBackup(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rsa, closer, err = integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(),
+			rsa, closer, err = integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 				integration.WithInstanceID(ws.Req.Id),
 			)
 			if err != nil {
@@ -141,7 +141,7 @@ func TestMissingBackup(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/components/ws-manager/main_test.go
+++ b/test/tests/components/ws-manager/main_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -23,7 +23,7 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -60,7 +60,7 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -52,7 +52,7 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -113,7 +113,7 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 						}
 					}
 
-					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(), integration.WithInstanceID(nfo.Req.Id))
+					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.Req.Id))
 					if err != nil {
 						t.Fatalf("unexpected error instrumenting workspace: %v", err)
 					}

--- a/test/tests/components/ws-manager/wsmanager_test.go
+++ b/test/tests/components/ws-manager/wsmanager_test.go
@@ -23,7 +23,7 @@ func TestGetWorkspaces(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/ide/main_test.go
+++ b/test/tests/ide/main_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }

--- a/test/tests/ide/python_ws_test.go
+++ b/test/tests/ide/python_ws_test.go
@@ -39,13 +39,14 @@ func poolTask(task func() (bool, error)) (bool, error) {
 }
 
 func TestPythonExtWorkspace(t *testing.T) {
+	integration.SkipWithoutUsername(t, username)
 	f := features.New("PythonExtensionWorkspace").
 		WithLabel("component", "server").
 		Assess("it can run python extension in a workspace", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -80,7 +81,7 @@ func TestPythonExtWorkspace(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID), integration.WithWorkspacekitLift(true))
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID), integration.WithWorkspacekitLift(true))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -59,8 +59,9 @@ func TestGitHubContexts(t *testing.T) {
 }
 
 func TestGitLabContexts(t *testing.T) {
-	integration.SkipWithoutUsername(t, username)
-
+	if !gitlab {
+		t.Skip("Skipping gitlab integration tests")
+	}
 	tests := []ContextTest{
 		{
 			Name:           "open repository",
@@ -93,6 +94,7 @@ func TestGitLabContexts(t *testing.T) {
 }
 
 func runContextTests(t *testing.T, tests []ContextTest) {
+	integration.SkipWithoutUsername(t, username)
 	f := features.New("context").
 		WithLabel("component", "server").
 		Assess("should run context tests", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -107,14 +109,10 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 					defer cancel()
 
-					api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					t.Cleanup(func() {
 						api.Done(t)
 					})
-
-					if username == "" && test.ExpectedBranchFunc != nil {
-						t.Skipf("skipping '%s' because there is not username configured", test.Name)
-					}
 
 					nfo, stopWS, err := integration.LaunchWorkspaceFromContextURL(ctx, test.ContextURL, username, api)
 					if err != nil {
@@ -127,7 +125,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 						t.Fatal(err)
 					}
 
-					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
+					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -23,7 +23,7 @@ func TestRunDocker(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -33,7 +33,7 @@ func TestRunDocker(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(), integration.WithInstanceID(ws.Req.Id), integration.WithWorkspacekitLift(true))
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(ws.Req.Id), integration.WithWorkspacekitLift(true))
 			if err != nil {
 				t.Fatalf("unexpected error instrumenting workspace: %v", err)
 			}

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -17,13 +17,14 @@ import (
 )
 
 func TestWorkspaceInstrumentation(t *testing.T) {
+	integration.SkipWithoutUsername(t, username)
 	f := features.New("instrumentation").
 		WithLabel("component", "server").
 		Assess("it can instrument a workspace", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -34,7 +35,7 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 			}
 			defer stopWs(true)
 
-			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -66,7 +67,7 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/workspace/ghost_test.go
+++ b/test/tests/workspace/ghost_test.go
@@ -23,7 +23,7 @@ func TestGhostWorkspace(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -30,6 +30,7 @@ type GitTest struct {
 type GitFunc func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) error
 
 func TestGitActions(t *testing.T) {
+	integration.SkipWithoutUsername(t, username)
 	tests := []GitTest{
 		{
 			Name:          "create, add and commit",
@@ -102,7 +103,7 @@ func TestGitActions(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
-			api := integration.NewComponentAPI(ctx, cfg.Namespace(), cfg.Client())
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {
 				api.Done(t)
 			})
@@ -125,7 +126,7 @@ func TestGitActions(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
+					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/test/tests/workspace/main_test.go
+++ b/test/tests/workspace/main_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 var (
-	testEnv   env.Environment
-	username  string
-	namespace string
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
+	gitlab     bool
 )
 
 func TestMain(m *testing.M) {
-	username, namespace, testEnv = integration.Setup(context.Background())
+	username, namespace, testEnv, _, kubeconfig, gitlab = integration.Setup(context.Background())
 	os.Exit(testEnv.Run(m))
 }


### PR DESCRIPTION
## Description
Fixes integrations tests. Made sure it runs manually via `go` or `docker`.
Added optional parameters to test additional tests (for example one that requires enterprise license or gitlab integration).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7675 

## How to test
Spin up new cluster via [`workspace-preview`](https://github.com/gitpod-io/workspace-preview) and follow steps in README.md file for manual testing via running `go test` directly or via docker container that werft builds.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix integration tests
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
