### PR TITLE
Properly handle provider host name when using http(s) prefix when adding a new integration

### DIFF
--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -548,16 +548,14 @@ export function GitIntegrationModal(props: ({
     const updateHostValue = (host: string) => {
         if (mode === "new") {
 
-            let verifiedHost = host;
+            let newHostValue = host;
 
             if (host.startsWith("https://")) {
-                verifiedHost = host.replace("https://","");
-            } else if (host.startsWith("http://")) {
-                verifiedHost = host.replace("http://","");
+                newHostValue = host.replace("https://","");
             }
 
-            setHost(verifiedHost);
-            setRedirectURL(callbackUrl(verifiedHost));
+            setHost(newHostValue);
+            setRedirectURL(callbackUrl(newHostValue));
             setErrorMessage(undefined);
         }
     }

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -550,9 +550,9 @@ export function GitIntegrationModal(props: ({
 
             let verifiedHost = host;
 
-            if (host.includes("https://")) {
+            if (host.startsWith("https://")) {
                 verifiedHost = host.replace("https://","");
-            } else if (host.includes("http://")) {
+            } else if (host.startsWith("http://")) {
                 verifiedHost = host.replace("http://","");
             }
 

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -547,8 +547,17 @@ export function GitIntegrationModal(props: ({
 
     const updateHostValue = (host: string) => {
         if (mode === "new") {
-            setHost(host);
-            setRedirectURL(callbackUrl(host));
+
+            let verifiedHost = host;
+
+            if (host.includes("https://")) {
+                verifiedHost = host.replace("https://","");
+            } else if (host.includes("http://")) {
+                verifiedHost = host.replace("http://","");
+            }
+
+            setHost(verifiedHost);
+            setRedirectURL(callbackUrl(verifiedHost));
             setErrorMessage(undefined);
         }
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When a user has manually included http(s) prefixes in their provider hostname, strip it off so that it uses only the gitpod provided prefix in the configured URL and Redirect URL.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7492 

## How to test
<!-- Provide steps to test this PR -->
Go to dashboard and under integrations try to add new integration with a self-hosted instance of a provider, then notice that any HTTP(s) prefix is removed from the configured URL

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Git Integrations UI – improve handling of host name.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
