### PR TITLE
Update WebApp team label in component owners

### DIFF
--- a/components/dashboard/OWNERS
+++ b/components/dashboard/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/ee/db-sync/OWNERS
+++ b/components/ee/db-sync/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/ee/kedge/OWNERS
+++ b/components/ee/kedge/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/ee/payment-endpoint/OWNERS
+++ b/components/ee/payment-endpoint/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/gitpod-db/OWNERS
+++ b/components/gitpod-db/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/gitpod-protocol/OWNERS
+++ b/components/gitpod-protocol/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/licensor/OWNERS
+++ b/components/licensor/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/proxy/OWNERS
+++ b/components/proxy/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/server/OWNERS
+++ b/components/server/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/service-waiter/OWNERS
+++ b/components/service-waiter/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/components/ws-manager-bridge/OWNERS
+++ b/components/ws-manager-bridge/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/installer/pkg/components/dashboard/OWNERS
+++ b/installer/pkg/components/dashboard/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/installer/pkg/components/proxy/OWNERS
+++ b/installer/pkg/components/proxy/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/installer/pkg/components/server/OWNERS
+++ b/installer/pkg/components/server/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/installer/pkg/components/ws-manager-bridge/OWNERS
+++ b/installer/pkg/components/ws-manager-bridge/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"

--- a/installer/pkg/config/versions/OWNERS
+++ b/installer/pkg/config/versions/OWNERS
@@ -10,6 +10,6 @@ approvers:
 
 labels:
   - "team: IDE"
-  - "team: meta"
+  - "team: webapp"
   - "team: self-hosted"
   - "team: workspace"

--- a/operations/observability/mixins/meta/OWNERS
+++ b/operations/observability/mixins/meta/OWNERS
@@ -6,4 +6,4 @@ approvers:
   - engineering-webapp
 
 labels:
-  - "team: meta"
+  - "team: webapp"


### PR DESCRIPTION
## Description

Following up on the changes in https://github.com/gitpod-io/gitbot/pull/64 and https://github.com/gitpod-io/gitpod/pull/7817, this will also update the WebApp team label in component owners.

Cc @gitpod-io/engineering-webapp 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```