### PR TITLE
[server] allow having +1 active tokens

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -19,6 +19,7 @@ import { DBUser } from './entity/db-user';
 import { DBUserEnvVar } from "./entity/db-user-env-vars";
 import { DBWorkspace } from "./entity/db-workspace";
 import { TypeORM } from './typeorm';
+import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 
 // OAuth token expiry
 const tokenExpiryInFuture = new DateInterval("7d");
@@ -285,12 +286,12 @@ export class TypeORMUserDBImpl implements UserDB {
     public async findTokenForIdentity(identity: Identity): Promise<Token | undefined> {
         const tokenEntries = await this.findTokensForIdentity(identity);
         if (tokenEntries.length > 1) {
-            throw new Error(`Found more than one active token for ${identity.authProviderId} and user ${identity.authName}`);
+            log.warn(`Found more than one active token for ${identity.authProviderId}.`, { identity });
         }
         if (tokenEntries.length === 0) {
             return undefined;
         }
-        return tokenEntries[0].token;
+        return tokenEntries.sort((a, b) => `${a.token.updateDate}`.localeCompare(`${b.token.updateDate}`))[0]?.token;
     }
 
     public async findTokensForIdentity(identity: Identity, includeDeleted?: boolean): Promise<TokenEntry[]> {


### PR DESCRIPTION
We've seen cases where more than one active token is persisted in the DB, which might be cased by db-sync issues. Given that this case is quite rare, this PR drops the hard assertion and replaces it by logging a warning. This is a mitigation for #7196.

Fixes #7196

```release-note
Fix "token not found" issues.
```