### PR TITLE
[installer]: put component ownership under webapp/workspace teams

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -105,8 +105,8 @@ func renderKubernetesObjects(cfgVersion string, cfg *configv1.Config) ([]string,
 		renderable = components.FullObjects
 		helmCharts = components.FullHelmDependencies
 	case configv1.InstallationMeta:
-		renderable = components.MetaObjects
-		helmCharts = components.MetaHelmDependencies
+		renderable = components.WebAppObjects
+		helmCharts = components.WebAppHelmDependencies
 	case configv1.InstallationWorkspace:
 		renderable = components.WorkspaceObjects
 		helmCharts = components.WorkspaceHelmDependencies

--- a/installer/pkg/components/components-webapp/OWNERS
+++ b/installer/pkg/components/components-webapp/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-webapp
+
+labels:
+  - "team: webapp"

--- a/installer/pkg/components/components-webapp/components.go
+++ b/installer/pkg/components/components-webapp/components.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package componentswebapp
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	contentservice "github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/dashboard"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/database"
+	ide_proxy "github.com/gitpod-io/gitpod/installer/pkg/components/ide-proxy"
+	imagebuildermk3 "github.com/gitpod-io/gitpod/installer/pkg/components/image-builder-mk3"
+	jaegeroperator "github.com/gitpod-io/gitpod/installer/pkg/components/jaeger-operator"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/migrations"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/minio"
+	openvsxproxy "github.com/gitpod-io/gitpod/installer/pkg/components/openvsx-proxy"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/rabbitmq"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
+	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
+)
+
+var Objects = common.CompositeRenderFunc(
+	contentservice.Objects,
+	dashboard.Objects,
+	database.Objects,
+	ide_proxy.Objects,
+	imagebuildermk3.Objects,
+	migrations.Objects,
+	minio.Objects,
+	openvsxproxy.Objects,
+	proxy.Objects,
+	rabbitmq.Objects,
+	server.Objects,
+	wsmanagerbridge.Objects,
+)
+
+var Helm = common.CompositeHelmFunc(
+	database.Helm,
+	jaegeroperator.Helm,
+	minio.Helm,
+	rabbitmq.Helm,
+)

--- a/installer/pkg/components/components-workspace/OWNERS
+++ b/installer/pkg/components/components-workspace/OWNERS
@@ -1,0 +1,9 @@
+
+options:
+  no_parent_owners: true
+
+approvers:
+  - engineering-workspace
+
+labels:
+  - "team: workspace"

--- a/installer/pkg/components/components-workspace/components.go
+++ b/installer/pkg/components/components-workspace/components.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package componentsworkspace
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	agentsmith "github.com/gitpod-io/gitpod/installer/pkg/components/agent-smith"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/blobserve"
+	registryfacade "github.com/gitpod-io/gitpod/installer/pkg/components/registry-facade"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
+	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
+	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
+	wsproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ws-proxy"
+)
+
+var Objects = common.CompositeRenderFunc(
+	agentsmith.Objects,
+	blobserve.Objects,
+	registryfacade.Objects,
+	workspace.Objects,
+	wsdaemon.Objects,
+	wsmanager.Objects,
+	wsproxy.Objects,
+)
+
+var Helm = common.CompositeHelmFunc()

--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -6,72 +6,36 @@ package components
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	agentsmith "github.com/gitpod-io/gitpod/installer/pkg/components/agent-smith"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/blobserve"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/cluster"
-	contentservice "github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/dashboard"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/database"
+	componentswebapp "github.com/gitpod-io/gitpod/installer/pkg/components/components-webapp"
+	componentsworkspace "github.com/gitpod-io/gitpod/installer/pkg/components/components-workspace"
 	dockerregistry "github.com/gitpod-io/gitpod/installer/pkg/components/docker-registry"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/gitpod"
-	ide_proxy "github.com/gitpod-io/gitpod/installer/pkg/components/ide-proxy"
-	imagebuildermk3 "github.com/gitpod-io/gitpod/installer/pkg/components/image-builder-mk3"
-	jaegeroperator "github.com/gitpod-io/gitpod/installer/pkg/components/jaeger-operator"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/migrations"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/minio"
-	openvsxproxy "github.com/gitpod-io/gitpod/installer/pkg/components/openvsx-proxy"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/rabbitmq"
-	registryfacade "github.com/gitpod-io/gitpod/installer/pkg/components/registry-facade"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
-	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
-	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
-	wsproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ws-proxy"
 )
 
-var MetaObjects = common.CompositeRenderFunc(
-	contentservice.Objects,
-	proxy.Objects,
-	dashboard.Objects,
-	database.Objects,
-	ide_proxy.Objects,
-	imagebuildermk3.Objects,
-	migrations.Objects,
-	minio.Objects,
-	openvsxproxy.Objects,
-	rabbitmq.Objects,
-	server.Objects,
-	wsmanagerbridge.Objects,
+var WebAppObjects = common.CompositeRenderFunc(
+	componentswebapp.Objects,
 )
 
 var WorkspaceObjects = common.CompositeRenderFunc(
-	agentsmith.Objects,
-	blobserve.Objects,
-	registryfacade.Objects,
-	workspace.Objects,
-	wsdaemon.Objects,
-	wsmanager.Objects,
-	wsproxy.Objects,
+	componentsworkspace.Objects,
 )
 
 var FullObjects = common.CompositeRenderFunc(
-	MetaObjects,
+	WebAppObjects,
 	WorkspaceObjects,
 )
 
-var MetaHelmDependencies = common.CompositeHelmFunc(
-	database.Helm,
-	jaegeroperator.Helm,
-	minio.Helm,
-	rabbitmq.Helm,
+var WebAppHelmDependencies = common.CompositeHelmFunc(
+	componentswebapp.Helm,
 )
 
-var WorkspaceHelmDependencies = common.CompositeHelmFunc()
+var WorkspaceHelmDependencies = common.CompositeHelmFunc(
+	componentsworkspace.Helm,
+)
 
 var FullHelmDependencies = common.CompositeHelmFunc(
-	MetaHelmDependencies,
+	WebAppHelmDependencies,
 	WorkspaceHelmDependencies,
 )
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Create a `components-webapp` and `components-workspace` package to make the Kubernetes objects subject to per-team approval.

A couple of observations as to why I did it the way I did:
 - I originally wanted to put it in format `/pkg/components/workspace/<packages>`, but this caused cyclic dependency issues. The use of a `components-<package>` is a way of avoiding this, even though it's arguably a less elegant solution. I'm open to ideas on alternative ways of achieving this
 - All the `components-workspace` packages are owned by @gitpod-io/engineering-workspace. The `components-webapp` packages are owned by different teams, but I have elected to make the folder owned solely by @gitpod-io/engineering-webapp
 - The common components remain owned by @gitpod-io/engineering-self-hosted, so no changes are made here

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7690

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: put component ownership under webapp/workspace teams
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
