### PR TITLE
Update leeway user commands to get DB credentials

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -179,8 +179,8 @@ scripts:
     deps:
       - components/service-waiter:app
     script: |
-      export DB_USERNAME=root
-      export DB_PASSWORD=test
+      export DB_USERNAME=$(kubectl get secrets mysql -o jsonpath="{.data.username}" | base64 -d)
+      export DB_PASSWORD=$(kubectl get secrets mysql -o jsonpath="{.data.password}" | base64 -d)
       kubectl port-forward statefulset/mysql 3306 &
       PID=$!
       service-waiter database -t 10s
@@ -211,8 +211,8 @@ scripts:
     deps:
       - components/service-waiter:app
     script: |
-      export DB_USERNAME=root
-      export DB_PASSWORD=test
+      export DB_USERNAME=$(kubectl get secrets mysql -o jsonpath="{.data.username}" | base64 -d)
+      export DB_PASSWORD=$(kubectl get secrets mysql -o jsonpath="{.data.password}" | base64 -d)
       kubectl port-forward statefulset/mysql 3306 &
       PID=$!
       service-waiter database -t 10s
@@ -228,7 +228,7 @@ scripts:
       printf "\nCurrent namespace:         $(kubens -c)\n"
 
       printf "\nAvailable users (max 10):\n$result\n\n"
-      printf "Enter user to unblock (empty to abort): "
+      printf "Enter user to make admin (empty to abort): "
       read user
       if [[ -z "$user" ]]; then
         echo "No input."


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update the leeway `make-user-admin` and `unblock-user` commands to get the MySQL database from the `mysql` secret.

Also, updates the message on the admin command

## How to test
<!-- Provide steps to test this PR -->
Run `leeway run components:unblock-user` and `leeway run components:make-user-admin`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
