### PR TITLE
Limit desktop editor options width on large viewports

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -126,7 +126,7 @@ export default function Preferences() {
                 {desktopIdeOptions && <>
                     <h3 className="mt-12">Desktop Editor <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel></h3>
                     <p className="text-base text-gray-500 dark:text-gray-400">Optionally, choose the default desktop editor for opening workspaces.</p>
-                    <div className="my-4 gap-4 flex flex-wrap">
+                    <div className="my-4 gap-4 flex flex-wrap max-w-2xl">
                         {
                             desktopIdeOptions.map(([id, option]) => {
                                 const selected = defaultDesktopIde === id;


### PR DESCRIPTION
## Description

This will limit the desktop editor options width, following the practice we've used in acount settings[[1](https://github.com/gitpod-io/gitpod/blob/f9ec0f8cc6a137aaa05b746ca63724c12e040198/components/dashboard/src/settings/Account.tsx#L50)].

See [relevant discussion](https://gitpod.slack.com/archives/C02CBKZEVS8/p1638795733242600?thread_ts=1638366112.229500&cid=C02CBKZEVS8) (internal) and https://github.com/gitpod-io/gitpod/pull/7031#discussion_r766124754. Cc @gitpod-io/engineering-ide 

## Screenshots

Some preferences options have been removed to demonstrate this better.

| BEFORE | AFTER |
|-|-|
| <img width="2560" alt="Screenshot 2022-01-26 at 5 08 59 PM" src="https://user-images.githubusercontent.com/120486/151189998-5f2b791a-a0d5-45bf-9d76-8dc301462be0.png"> | <img width="2560" alt="Screenshot 2022-01-26 at 5 09 36 PM" src="https://user-images.githubusercontent.com/120486/151190010-314793f9-a38f-43bb-bbe9-cdafd7af484d.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```