### PR TITLE
[installer] add an experimental config section

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -22,6 +22,7 @@ var renderOpts struct {
 	ConfigFN               string
 	Namespace              string
 	ValidateConfigDisabled bool
+	UseExperimentalConfig  bool
 }
 
 // renderCmd represents the render command
@@ -40,6 +41,15 @@ A config file is required which can be generated with the init command.`,
 		_, cfgVersion, cfg, err := loadConfig(renderOpts.ConfigFN)
 		if err != nil {
 			return err
+		}
+
+		if cfg.Experimental != nil {
+			if renderOpts.UseExperimentalConfig {
+				fmt.Fprintf(os.Stderr, "rendering using experimental config - here be dragons\n")
+			} else {
+				fmt.Fprintf(os.Stderr, "config contains experimental options - ignoring them\n")
+				cfg.Experimental = nil
+			}
 		}
 
 		yaml, err := renderKubernetesObjects(cfgVersion, cfg)
@@ -168,4 +178,5 @@ func init() {
 	renderCmd.PersistentFlags().StringVarP(&renderOpts.ConfigFN, "config", "c", os.Getenv("GITPOD_INSTALLER_CONFIG"), "path to the config file")
 	renderCmd.PersistentFlags().StringVarP(&renderOpts.Namespace, "namespace", "n", "default", "namespace to deploy to")
 	renderCmd.Flags().BoolVar(&renderOpts.ValidateConfigDisabled, "no-validation", false, "if set, the config will not be validated before running")
+	renderCmd.Flags().BoolVar(&renderOpts.UseExperimentalConfig, "danger-use-unsupported-config", false, "enable use of unsupported config")
 }

--- a/installer/pkg/common/storage.go
+++ b/installer/pkg/common/storage.go
@@ -7,9 +7,11 @@ package common
 import (
 	"fmt"
 
-	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
-	"k8s.io/utils/pointer"
 	"path/filepath"
+
+	storageconfig "github.com/gitpod-io/gitpod/content-service/api/config"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"k8s.io/utils/pointer"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -86,6 +88,13 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 	}
 	// 5 GiB
 	res.BlobQuota = 5 * 1024 * 1024 * 1024
+
+	_ = context.WithExperimental(func(ucfg *experimental.Config) error {
+		if ucfg.Workspace != nil {
+			res.Stage = storageconfig.Stage(ucfg.Workspace.Stage)
+		}
+		return nil
+	})
 
 	return *res
 }

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/config"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -86,6 +87,8 @@ type Config struct {
 	License       *ObjectRef    `json:"license,omitempty"`
 
 	SSHGatewayHostKey *ObjectRef `json:"sshGatewayHostKey,omitempty"`
+
+	Experimental *experimental.Config `json:"experimental,omitempty"`
 }
 
 type Metadata struct {

--- a/installer/pkg/config/v1/experimental/experimental.go
+++ b/installer/pkg/config/v1/experimental/experimental.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+// experimental bundles all internal bits of configuration for which we do not offer
+// support. We use those flags internally to operate SaaS, but do not expect anyone
+// outside of Gitpod to use.
+//
+// Changes in this section will NOT be backwards compatible change at will without prior notice.
+// If you use any setting herein, you forfeit support from Gitpod.
+package experimental
+
+// Config contains all experimental configuration.
+type Config struct {
+	Workspace *WorkspaceConfig `json:"workspace"`
+	WebApp    *WebAppConfig    `json:"webapp"`
+	IDE       *IDEConfig       `json:"ide"`
+}
+
+type WorkspaceConfig struct {
+	Stage string `json:"stage"`
+}
+
+type WebAppConfig struct {
+}
+
+type IDEConfig struct{}


### PR DESCRIPTION
## Description
This PR adds an `experimental` section to the config surface. The intent is to give the product engineering teams a home for their configuration specifically for operating Gitpod SaaS. 

As a first use-case we introduce the "kubeStage" used for the content-service to compute bucket names.

**Note:** we want to keep a close eye on the use of experimental config, so as to not introduce too much variance. That's why ordinarily the experimental config is nil always, and one has to access it using `RenderContext`'s new `WithExperimental` function. This way, we can group and keep tabs on code which relies on this kind of configuration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7776

Note: this issue blocks/hinders the workspace team's adoption of the installer.

## How to test
1. `installer init > config.yaml`
2. edit `config.yaml` and add:
    ```YAML
    experimental:
      workspace:
        stage: prod
    ```
3. render the config and observe the warning re experimental config: `installer render --config config.yaml`
4. render the config with experimental config enabled: `installer render --config config.yaml --danger-use-experimental-config`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
