### PR TITLE
[installer] Add missing object for meta installations

### DIFF
--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -43,6 +43,7 @@ var MetaObjects = common.CompositeRenderFunc(
 	openvsxproxy.Objects,
 	rabbitmq.Objects,
 	server.Objects,
+	wsdaemon.Objects,
 	wsmanager.Objects,
 	wsmanagerbridge.Objects,
 )

--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -43,6 +43,7 @@ var MetaObjects = common.CompositeRenderFunc(
 	openvsxproxy.Objects,
 	rabbitmq.Objects,
 	server.Objects,
+	wsmanager.Objects,
 	wsmanagerbridge.Objects,
 )
 


### PR DESCRIPTION
## Description

> MountVolume.SetUp failed for volume "wsman-tls-certs" : secret "ws-manager-client-tls" not found

image builder mk3 requires ws-manager secret

## How to test

Use the installer with the option `kind: Meta`. After the installation, all the pods should be Running.


## Release Notes
```release-note
[installer] Add missing object for meta installations
```
