### PR TITLE
Move local companions behind ide proxy

### DIFF
--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -36,7 +36,6 @@ packages:
     deps:
       - :app
       - :static
-      - components/local-app:app
       - components/gitpod-protocol:gitpod-schema
     argdeps:
       - imageRepoBase

--- a/components/dashboard/conf/Caddyfile
+++ b/components/dashboard/conf/Caddyfile
@@ -12,28 +12,11 @@
 		path /static/* /favicon* /manifest.json
 	}
 
-    rewrite /static/bin/gitpod-local-companion-linux /static/bin/gitpod-local-companion-linux-amd64
-    rewrite /static/bin/gitpod-local-companion-darwin /static/bin/gitpod-local-companion-darwin-amd64
-    rewrite /static/bin/gitpod-local-companion-windows.exe /static/bin/gitpod-local-companion-windows-amd64.exe
-    rewrite /static/bin/gitpod-local-companion-linux.gz /static/bin/gitpod-local-companion-linux-amd64.gz
-    rewrite /static/bin/gitpod-local-companion-darwin.gz /static/bin/gitpod-local-companion-darwin-amd64.gz
-    rewrite /static/bin/gitpod-local-companion-windows.exe.gz /static/bin/gitpod-local-companion-windows-amd64.exe.gz
-
-	@bin_asset {
-		file
-		path /static/bin/*
-	}
-
 	# static assets configure cache headers and do not check for changes
 	header @static_asset {
 		Cache-Control "public, max-age=31536000"
 		# remove Last-Modified header
 		-Last-Modified
-	}
-
-	header @bin_asset {
-		Content-Type application/octet-stream
-		Content-Disposition attachment
 	}
 }
 
@@ -76,8 +59,8 @@
 	}
 
 	handle {
-        respond "404 - Not Found" 404
-    }
+		respond "404 - Not Found" 404
+	}
 }
 
 # health-check

--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -16,19 +16,7 @@ RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '
 RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.png' -o -name '*.svg' -o -name '*.map' -o -name '*.json' \) \
   -exec /bin/sh -c 'brotli -v -q 11 -o "$1.br" "$1"' /bin/sh {} \;
 
-COPY components-local-app--app/components-local-app--app-linux-amd64/local-app /www/static/bin/gitpod-local-companion-linux-amd64
-COPY components-local-app--app/components-local-app--app-darwin-amd64/local-app /www/static/bin/gitpod-local-companion-darwin-amd64
-COPY components-local-app--app/components-local-app--app-windows-amd64/local-app.exe /www/static/bin/gitpod-local-companion-windows-amd64.exe
-COPY components-local-app--app/components-local-app--app-linux-arm64/local-app /www/static/bin/gitpod-local-companion-linux-arm64
-COPY components-local-app--app/components-local-app--app-darwin-arm64/local-app /www/static/bin/gitpod-local-companion-darwin-arm64
-COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe /www/static/bin/gitpod-local-companion-windows-arm64.exe
-COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe /www/static/bin/gitpod-local-companion-windows-386.exe
-
 COPY components-gitpod-protocol--gitpod-schema/gitpod-schema.json /www/static/schemas/gitpod-schema.json
-
-RUN for FILE in `ls /www/static/bin/gitpod-local-companion*`;do \
-  gzip -v -f -9 -k "$FILE"; \
-done
 
 FROM caddy/caddy:2.4.0-alpine
 

--- a/components/ide-proxy/BUILD.yaml
+++ b/components/ide-proxy/BUILD.yaml
@@ -4,6 +4,8 @@ packages:
     srcs:
       - "conf/**"
       - "static/**"
+    deps:
+      - components/local-app:app
     argdeps:
       - imageRepoBase
     config:

--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -1,8 +1,26 @@
-# Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
+
+FROM alpine:3.15 as compress
+
+RUN apk add brotli gzip
+
+COPY components-local-app--app/components-local-app--app-linux-amd64/local-app /bin/gitpod-local-companion-linux-amd64
+COPY components-local-app--app/components-local-app--app-darwin-amd64/local-app /bin/gitpod-local-companion-darwin-amd64
+COPY components-local-app--app/components-local-app--app-windows-amd64/local-app.exe /bin/gitpod-local-companion-windows-amd64.exe
+COPY components-local-app--app/components-local-app--app-linux-arm64/local-app /bin/gitpod-local-companion-linux-arm64
+COPY components-local-app--app/components-local-app--app-darwin-arm64/local-app /bin/gitpod-local-companion-darwin-arm64
+COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe /bin/gitpod-local-companion-windows-arm64.exe
+COPY components-local-app--app/components-local-app--app-windows-386/local-app.exe /bin/gitpod-local-companion-windows-386.exe
+
+RUN for FILE in `ls /bin/gitpod-local-companion*`;do \
+  gzip -v -f -9 -k "$FILE"; \
+done
+
 
 FROM caddy/caddy:2.4.6-alpine
 
 COPY conf/Caddyfile /etc/caddy/Caddyfile
 COPY static /www/
+COPY --from=compress /bin /www/static/bin

--- a/components/ide-proxy/conf/Caddyfile
+++ b/components/ide-proxy/conf/Caddyfile
@@ -11,6 +11,23 @@
 		precompressed gzip br
 	}
 
+	rewrite /static/bin/gitpod-local-companion-linux /static/bin/gitpod-local-companion-linux-amd64
+	rewrite /static/bin/gitpod-local-companion-darwin /static/bin/gitpod-local-companion-darwin-amd64
+	rewrite /static/bin/gitpod-local-companion-windows.exe /static/bin/gitpod-local-companion-windows-amd64.exe
+	rewrite /static/bin/gitpod-local-companion-linux.gz /static/bin/gitpod-local-companion-linux-amd64.gz
+	rewrite /static/bin/gitpod-local-companion-darwin.gz /static/bin/gitpod-local-companion-darwin-amd64.gz
+	rewrite /static/bin/gitpod-local-companion-windows.exe.gz /static/bin/gitpod-local-companion-windows-amd64.exe.gz
+
+	@bin_asset {
+		file
+		path /static/bin/*
+	}
+
+	header @bin_asset {
+		Content-Type application/octet-stream
+		Content-Disposition attachment
+	}
+
 	@static_path {
 		path /*
 	}

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -223,6 +223,18 @@ https://{$GITPOD_DOMAIN} {
 		}
 	}
 
+	@local_app {
+		path /static/bin/gitpod-local-companion-*
+	}
+	handle @local_app {
+		import compression
+
+		reverse_proxy ide-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:80 {
+			import upstream_headers
+			import upstream_connection
+		}
+	}
+
 	@to_server path /auth/github/callback /auth /auth/* /apps /apps/*
 	handle @to_server {
 		import compression


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Move local companions behind ide proxy

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7744

## How to test
<!-- Provide steps to test this PR -->
https://mustard-mh-move-local-companions-7744.staging.gitpod-dev.com/static/bin/gitpod-local-companion-darwin-arm64

https://ide.mustard-mh-move-local-companions-7744.staging.gitpod-dev.com/static/bin/gitpod-local-companion-darwin-arm64

Both links above can download local-companion

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
