### PR TITLE
[content-initializer] Force local tags when fetching

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -281,7 +281,7 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 func (c *Client) Fetch(ctx context.Context) (err error) {
 	// we need to fetch with pruning to avoid issues like github.com/gitpod-io/gitpod/issues/7561.
 	// See https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---prune for more details.
-	return c.Git(ctx, "fetch", "-p", "-P")
+	return c.Git(ctx, "fetch", "-p", "-P", "--tags", "-f")
 }
 
 // UpdateRemote performs a git fetch on the upstream remote URI


### PR DESCRIPTION
## Description
This PR improves the `git fetch` operation when using a prebuild. We've seen reports where that fetch operation failed if local and remote tags were at odds.

## How to test
Open a prebuild on https://github.com/gitpod-io/openvscode-server/tree/main

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
