### PR TITLE
Release 2022.01

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,1 +1,3 @@
 installer
+dist
+versions.yaml

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,0 +1,36 @@
+OUTPUT ?= dist
+VERSION_MANIFEST = ./pkg/config/versions/versions.yaml
+
+all: clean deps versionManifest compile
+
+build:
+	@echo "Building for ${GOOS}-${GOARCH}"
+	CGO_ENABLED=0 go build -tags embedVersion -o ${OUTPUT}/gitpod-installer-${GOOS}-${GOARCH}${EXT}
+	(cd ${OUTPUT} && sha256sum gitpod-installer-${GOOS}-${GOARCH} > gitpod-installer-${GOOS}-${GOARCH}.sha256)
+.PHONY: build
+
+clean:
+	@echo "Cleaning ${OUTPUT}"
+	rm -Rf ${OUTPUT}
+	mkdir -p ${OUTPUT}
+	rm -f ${VERSION_MANIFEST}
+.PHONY: clean
+
+compile:
+	@echo "Compiling for every supported OS and platform"
+
+	GOOS=linux GOARCH=amd64 $(MAKE) build
+	GOOS=linux GOARCH=386 $(MAKE) build
+	GOOS=linux GOARCH=arm $(MAKE) build
+	GOOS=linux GOARCH=arm64 $(MAKE) build
+.PHONY: compile
+
+deps:
+	@echo "Installing Helm dependencies"
+	@for f in $(shell ls -d third_party/charts/*/); do cd $${f} && helm dep up && cd -; done
+.PHONY: deps
+
+versionManifest:
+	@echo "Downloading version manifest for ${VERSION}"
+	docker run -it --rm eu.gcr.io/gitpod-core-dev/build/versions:${VERSION} cat versions.yaml > ${VERSION_MANIFEST}
+.PHONY: versionManifest

--- a/installer/README.md
+++ b/installer/README.md
@@ -14,8 +14,8 @@ The best way to get started with Gitpod
 
 # Requirements
 
-- A machine running Linux/MacOS and Docker
-    - Windows is not currently supported, but will be in future
+- A machine running Linux
+    - MacOS and Windows are not currently supported, but may be in future
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
 - A [Kubernetes cluster configured](https://www.gitpod.io/docs/self-hosted/latest/installation)
 - A [TLS certificate](#tls-certificates)
@@ -31,35 +31,53 @@ The process to install Gitpod is:
 
 # Quickstart
 
-## Get your binary
+## Download the Installer on Linux
 
-> There is work to be done on improving the distribution of the binary
-> [#6766](https://github.com/gitpod-io/gitpod/issues/6766).
+Releases can be downloaded from [GitHub Releases](https://github.com/gitpod-io/gitpod/releases/)
+Select your desired binary, download and install
 
-From [werft](https://werft.gitpod-dev.com), search for the tag you want, such as
-`main.1919` - set this value to `$TAG`
-
-### Option 1 - download the pre-build Installer
+1. Download the latest release with the command:
 
 ```shell
-docker create -ti --name installer eu.gcr.io/gitpod-core-dev/build/installer:$TAG
-docker cp installer:/app/installer ./installer
-docker rm -f installer
+curl -fsSLO https://github.com/gitpod-io/gitpod/releases/download/2022.01/gitpod-installer-linux-amd64
 ```
 
-### Option 2 - use `go run`
+2. Validate the binary (optional)
+
+Download the checksum file:
 
 ```shell
-# Get the versions
-docker run -it --rm eu.gcr.io/gitpod-core-dev/build/versions:$TAG cat /versions.yaml > versions.yaml
+curl -fsSLO https://github.com/gitpod-io/gitpod/releases/download/2022.01/gitpod-installer-linux-amd64.sha256
 ```
 
-For every command below, replace `installer` with `go run . --debug-version-file ./versions.yaml`.
+Validate the binary against the checksum file:
+
+```shell
+echo "$(<gitpod-installer-linux-amd64.sha256)" | sha256sum --check
+```
+
+If valid, the output is:
+
+```shell:
+gitpod-installer-linux-amd64: OK
+```
+
+3. Install the binary
+
+```shell
+sudo install -o root -g root gitpod-installer-linux-amd64 /usr/local/bin/gitpod-installer
+```
+
+4. Test to ensure the version you installed it up-to-date:
+
+```shell
+gitpod-installer version
+```
 
 ## Generate the base config
 
 ```shell
-./installer init > gitpod.config.yaml
+gitpod-installer init > gitpod.config.yaml
 ```
 
 ## Customise your config
@@ -74,7 +92,7 @@ own.
 
 ```shell
 # Checks the validity of the configuration YAML
-./installer validate config --config gitpod.config.yaml
+gitpod-installer validate config --config gitpod.config.yaml
 ```
 
 Any errors here must be fixed before deploying. See [Config](#config) for
@@ -82,7 +100,7 @@ more details.
 
 ```shell
 # Checks that your cluster is ready to install Gitpod
-./installer validate cluster --kubeconfig ~/.kube/config --config gitpod.config.yaml
+gitpod-installer validate cluster --kubeconfig ~/.kube/config --config gitpod.config.yaml
 ```
 
 Any errors here must be fixed before deploying. See [Cluster Dependencies](#cluster-dependencies)
@@ -91,7 +109,7 @@ for more details.
 ## Render the YAML
 
 ```shell
-./installer render --config gitpod.config.yaml > gitpod.yaml
+gitpod-installer render --config gitpod.config.yaml > gitpod.yaml
 ```
 
 ## Deploy
@@ -492,14 +510,14 @@ To install to a different namespace, pass a `namespace` flag to the `render`
 command.
 
 ```shell
-./installer render --config gitpod.config.yaml --namespace gitpod > gitpod.yaml
+gitpod-installer render --config gitpod.config.yaml --namespace gitpod > gitpod.yaml
 ```
 
 The `validate cluster` command also accepts a namespace, allowing you to run
 the checks on that namespace.
 
 ```shell
-./installer validate cluster --kubeconfig ~/.kube/config --config gitpod.config.yaml --namespace gitpod
+gitpod-installer validate cluster --kubeconfig ~/.kube/config --config gitpod.config.yaml --namespace gitpod
 ```
 
 **IMPORTANT**: this does not create the namespace, so you will need to create

--- a/installer/cmd/version.go
+++ b/installer/cmd/version.go
@@ -39,6 +39,14 @@ var versionCmd = &cobra.Command{
 }
 
 func getVersionManifest() (*versions.Manifest, error) {
+	embeddedManifest, err := versions.Embedded()
+	if err != nil {
+		return nil, err
+	}
+	if embeddedManifest != nil {
+		return embeddedManifest, nil
+	}
+
 	var data []byte
 	if rootOpts.VersionMF != "" {
 		var err error
@@ -68,7 +76,7 @@ func getVersionManifest() (*versions.Manifest, error) {
 	}
 
 	var res versions.Manifest
-	err := yaml.Unmarshal(data, &res)
+	err = yaml.Unmarshal(data, &res)
 	if err != nil {
 		return nil, err
 	}

--- a/installer/pkg/config/v1/config.go
+++ b/installer/pkg/config/v1/config.go
@@ -52,7 +52,7 @@ func (v version) Defaults(in interface{}) error {
 		corev1.ResourceCPU:    resource.MustParse("1000m"),
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
 	}
-	cfg.Workspace.Runtime.FSShiftMethod = FSShiftFuseFS
+	cfg.Workspace.Runtime.FSShiftMethod = FSShiftShiftFS
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
 

--- a/installer/pkg/config/versions/embed.go
+++ b/installer/pkg/config/versions/embed.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+//go:build embedVersion
+
+package versions
+
+import (
+	_ "embed"
+
+	"sigs.k8s.io/yaml"
+)
+
+//go:embed versions.yaml
+var embeddedVersion []byte
+
+func loadEmbedded() (*Manifest, error) {
+	var res Manifest
+	err := yaml.Unmarshal(embeddedVersion, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/installer/pkg/config/versions/noembed.go
+++ b/installer/pkg/config/versions/noembed.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+//go:build !embedVersion
+
+package versions
+
+func loadEmbedded() (*Manifest, error) {
+	return nil, nil
+}

--- a/installer/pkg/config/versions/versions.go
+++ b/installer/pkg/config/versions/versions.go
@@ -62,3 +62,9 @@ type Components struct {
 	WSManagerBridge Versioned `json:"wsManagerBridge"`
 	WSProxy         Versioned `json:"wsProxy"`
 }
+
+// var embedded embed.FS
+
+func Embedded() (*Manifest, error) {
+	return loadEmbedded()
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The first proper release of the Installer 🎉 🎉 🥳 

This is mostly documentation and stuff to help the build. The only code change is to add in a build tag for `embedVersion`, to allow for the build step to incorporate the versions at build time. This is in addition to the previous two methods of bringing the versions (use of `--debug-version-file` flag and amending binary with `objcopy`) This was added because cannot run the `objcopy` when doing cross-platform builds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7658 

## How to test
<!-- Provide steps to test this PR -->
All testing within AWS/Azure/GCP has been done as part of this PR, conforming to the tests defined in #7789 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Installer]: release 2022.01
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
