### PR TITLE
Use full-vnc as base for dev image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dazzlev2-test.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -62,7 +62,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dazzlev2-test.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dazzlev2-test.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dazzlev2-test.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dazzlev2-test.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -5,7 +5,7 @@
 # if you want to run this image in a workspace, follow these steps:
 # gcloud auth configure-docker europe-docker.pkg.dev
 # gcloud auth login --no-launch-browser
-FROM europe-docker.pkg.dev/gitpod-artifacts/docker-dev/workspace-full:2022-01-27-08-27-20
+FROM europe-docker.pkg.dev/gitpod-artifacts/docker-dev/workspace-full-vnc:2022-01-28-04-35-05
 
 ENV TRIGGER_REBUILD 16
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use full-vnc as base for dev image. We have modified the full image to remove the vnc chunk, therefore, we need the change in base image for the tests in gitpod to work.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
