### PR TITLE
Added a script to download k3s kubeconfig for preview-environments

### DIFF
--- a/dev/preview/install-k3s-kubeconfig.sh
+++ b/dev/preview/install-k3s-kubeconfig.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+
+PRIVATE_KEY=$HOME/.ssh/vm_id_rsa
+PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub
+THIS_DIR="$(dirname "$0")"
+USER="ubuntu"
+
+KUBECONFIG_PATH="/home/gitpod/.kube/config"
+K3S_KUBECONFIG_PATH="$(mktemp)"
+MERGED_KUBECONFIG_PATH="$(mktemp)"
+
+K3S_CONTEXT="k3s-preview-environment"
+K3S_ENDPOINT="${VM_NAME}.kube.gitpod-dev.com"
+
+while getopts n:p:u: flag
+do
+    case "${flag}" in
+        u) USER="${OPTARG}";;
+        *) ;;
+    esac
+done
+
+
+function log {
+    echo "[$(date)] $*"
+}
+
+function set-up-ssh {
+    if [[ (! -f $PRIVATE_KEY) || (! -f $PUBLIC_KEY) ]]; then
+        log Setting up ssh-keys
+        "$THIS_DIR"/install-vm-ssh-keys.sh
+    fi
+}
+
+set-up-ssh
+
+"$THIS_DIR"/ssh-vm.sh \
+    -c "sudo cat /etc/rancher/k3s/k3s.yaml" \
+    | sed 's/default/'${K3S_CONTEXT}'/g' \
+    | sed -e 's/127.0.0.1/'"${K3S_ENDPOINT}"'/g' \
+    > "${K3S_KUBECONFIG_PATH}"
+
+log "Merging kubeconfig files ${KUBECONFIG_PATH} ${K3S_KUBECONFIG_PATH} into ${MERGED_KUBECONFIG_PATH}"
+KUBECONFIG="${KUBECONFIG_PATH}:${K3S_KUBECONFIG_PATH}" \
+    kubectl config view --flatten --merge > "${MERGED_KUBECONFIG_PATH}"
+
+log "Overwriting ${KUBECONFIG_PATH}"
+mv "${MERGED_KUBECONFIG_PATH}" "${KUBECONFIG_PATH}"
+
+log "Cleaning up temporay K3S kubeconfig"
+rm "${K3S_KUBECONFIG_PATH}"
+
+log "Done"

--- a/dev/preview/ssh-vm.sh
+++ b/dev/preview/ssh-vm.sh
@@ -13,10 +13,12 @@ PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub
 PORT=8022
 THIS_DIR="$(dirname "$0")"
 USER="ubuntu"
+COMMAND=""
 
-while getopts n:p:u: flag
+while getopts c:n:p:u: flag
 do
     case "${flag}" in
+        c) COMMAND="${OPTARG}";;
         n) NAMESPACE="${OPTARG}";;
         p) PORT="${OPTARG}";;
         u) USER="${OPTARG}";;
@@ -52,4 +54,5 @@ ssh "$USER"@127.0.0.1 \
     -o StrictHostKeyChecking=no \
     -o "ProxyCommand=$THIS_DIR/ssh-proxy-command.sh -p $PORT -n $NAMESPACE" \
     -i "$HOME/.ssh/vm_id_rsa" \
-    -p "$PORT"
+    -p "$PORT" \
+    "$COMMAND"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds the script `install-k3s-kubeconfig.sh`. It connects to the k3s cluster inside the preview VM and downloads the kubeconfig `k3s.yaml` replacing the context name and endpoint. The script reuses a lot of parts from other scripts and we might refactor it to reduce code.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/644

## How to test
<!-- Provide steps to test this PR -->
Start a new workspace and push a new commit that creates a VM.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
