### PR TITLE
Mads/clean up werft build nodes

### DIFF
--- a/.werft/clean-up-werft-build-nodes.yaml
+++ b/.werft/clean-up-werft-build-nodes.yaml
@@ -39,7 +39,7 @@ pod:
           export DOCKER_HOST=tcp://$NODENAME:2475
 
           werft log phase docker-engine-prune "Cleaning up Docker Engine used by Werft builds"
-          docker system prune --force --all 2>&1 | werft log slice docker-engine-prune
+          docker system prune --force --all --filter 'until=72h' 2>&1 | werft log slice docker-engine-prune
 
           werft log phase werft-build-cache-prune "Cleaning up Werft build caches older than 12 hours"
           find /werft-build-caches/* -maxdepth 0 -mmin +720 -print -exec sudo rm -rf "{}" \; | werft log slice werft-build-cache-prune

--- a/.werft/clean-up-werft-build-nodes.yaml
+++ b/.werft/clean-up-werft-build-nodes.yaml
@@ -1,0 +1,45 @@
+pod:
+  serviceAccount: werft
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: dev/workload
+                operator: In
+                values:
+                  - "builds"
+  volumes:
+    - name: werft-build-caches
+      hostPath:
+        path: /mnt/disks/ssd0/builds
+        type: Directory
+  containers:
+    - name: build
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+      workingDir: /workspace
+      imagePullPolicy: Always
+      env:
+        - name: WERFT_HOST
+          value: "werft.werft.svc.cluster.local:7777"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      volumeMounts:
+        - mountPath: /werft-build-caches
+          name: werft-build-caches
+      command:
+        - bash
+        - -c
+        - |
+          sleep 1
+          set -Eeuo pipefail
+
+          export DOCKER_HOST=tcp://$NODENAME:2475
+
+          werft log phase docker-engine-prune "Cleaning up Docker Engine used by Werft builds"
+          docker system prune --force --all 2>&1 | werft log slice docker-engine-prune
+
+          werft log phase werft-build-cache-prune "Cleaning up Werft build caches older than 12 hours"
+          find /werft-build-caches/* -maxdepth 0 -mmin +720 -print -exec sudo rm -rf "{}" \; | werft log slice werft-build-cache-prune


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Our Werft build nodes have been filling up their disks which has caused jobs to fail. This PR introduces a Werft job for cleaning up Werft build nodes by pruning the Docker Engine and deleting old Werft build caches.

The intention is to configure Werft to run this as a cron job. That will happen in a follow up PR in the ops repository. I decided to use a Werft job over a standard Kubernetes job as this will provide us easy access to historic jobs and allows us to run the jobs easily ad-hoc using the `werft cli`

```sh
werft run github -j .werft/clean-up-werft-build-nodes.yaml -f
```

You can see an example of a successful job [here](https://werft.gitpod-dev.com/job/gitpod-clean-up-werft-build-nodes-mads-clean-up-werft-buil.7).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/857

## How to test
<!-- Provide steps to test this PR -->

Open a workspace and trigger the job

```sh
werft run github -j .werft/clean-up-werft-build-nodes.yaml -f
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A