### PR TITLE
[ci] notify ide-jobs slack channel

### DIFF
--- a/.github/workflows/code-nightly.yaml
+++ b/.github/workflows/code-nightly.yaml
@@ -1,4 +1,4 @@
-name: Code-Nightly
+name: Code Nightly
 
 on:
   workflow_dispatch:
@@ -27,3 +27,9 @@ jobs:
           headCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main)
           cd components/ide/code
           leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit .:docker
+      - name: Slack Notification
+        if: always()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -12,6 +12,8 @@ on:
         required: true
       serviceAccountKey:
         required: true
+      slackWebhook:
+        required: true
 
 jobs:
   update-jetbrains:
@@ -41,3 +43,10 @@ jobs:
           link=$(echo "$data" | jq -r '.[0].releases[0].downloads.linux.link')
           cd components/ide/jetbrains/image
           leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -D${{ inputs.productId }}DownloadUrl=$link .:${{ inputs.productId }}
+      - name: Slack Notification
+        if: always()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ${{ inputs.productId }}

--- a/.github/workflows/jetbrains-auto-update.yml
+++ b/.github/workflows/jetbrains-auto-update.yml
@@ -1,4 +1,4 @@
-name: rollout for new JetBrains IDE releases
+name: JB Nightly
 on:
   workflow_dispatch:
   schedule:
@@ -7,34 +7,38 @@ on:
 
 jobs:
   intellij:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-auto-update-template.yml@main
+    uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: intellij
       productCode: IIU
     secrets:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
   goland:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-auto-update-template.yml@main
+    uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: goland
       productCode: GO
     secrets:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
   pycharm:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-auto-update-template.yml@main
+    uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: pycharm
       productCode: PCP
     secrets:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
   phpstorm:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-auto-update-template.yml@main
+    uses: ./.github/workflows/jetbrains-auto-update-template.yml
     with:
       productId: phpstorm
       productCode: PS
     secrets:
       projectId: ${{ secrets.GCP_PROJECT_ID }}
       serviceAccountKey: ${{ secrets.GCP_SA_KEY }}
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}

--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -13,6 +13,9 @@ on:
       productType:
         type: string
         required: true
+    secrets:
+      slackWebhook:
+        required: true
 
 jobs:
   update-jetbrains:
@@ -64,3 +67,10 @@ jobs:
             ```
           commit-message: "[${{ inputs.productId }}] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
           branch: "jetbrains/${{ inputs.productId }}-${{ steps.latest-release.outputs.version2 }}"
+      - name: Slack Notification
+        if: always()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ${{ inputs.productName }}

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -1,4 +1,4 @@
-name: Check for new JetBrains IDE releases
+name: JB Releases
 on:
   workflow_dispatch:
   schedule:
@@ -7,30 +7,38 @@ on:
 
 jobs:
   intellij:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-updates-template.yml@main
+    uses: ./.github/workflows/jetbrains-updates-template.yml
     with:
       productName: IntelliJ IDEA
       productId: intellij
       productCode: IIU
       productType: release
+    secrets:
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
   goland:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-updates-template.yml@main
+    uses: ./.github/workflows/jetbrains-updates-template.yml
     with:
       productName: GoLand
       productId: goland
       productCode: GO
       productType: release
+    secrets:
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
   pycharm:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-updates-template.yml@main
+    uses: ./.github/workflows/jetbrains-updates-template.yml
     with:
       productName: PyCharm
       productId: pycharm
       productCode: PCP
       productType: release
+    secrets:
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
   phpstorm:
-    uses: gitpod-io/gitpod/.github/workflows/jetbrains-updates-template.yml@main
+    uses: ./.github/workflows/jetbrains-updates-template.yml
     with:
       productName: PhpStorm
       productId: phpstorm
       productCode: PS
       productType: release
+    secrets:
+      slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR makes sure that IDE team aware of the state of nightly upgrade jobs.

It also renames jobs to make them concise and aligned, i.e. `Code Nightly`, `JB Nightly` and `JB Releases`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Check that GH actions executed for this branch are reports to [ide-jobs](https://gitpod.slack.com/archives/C02F9LQU4DR) slack channel.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
