### PR TITLE
remove vscode-database plugin in .gitpod.yaml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,7 +42,6 @@ tasks:
     openMode: split-right
 vscode:
   extensions:
-    - bajdzis.vscode-database
     - bradlc.vscode-tailwindcss
     - EditorConfig.EditorConfig
     - golang.go

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -48,16 +48,6 @@
       "go.formatTool": "goimports",
       "go.useLanguageServer": true,
       "workspace.supportMultiRootWorkspace": true,
-      "database.connections": [
-         {
-            "type": "mysql",
-            "name": "devstaging DB",
-            "host": "127.0.0.1:23306",
-            "username": "gitpod",
-            "database": "gitpod",
-            "password": "test"
-         }
-      ],
       "launch": {},
       "files.exclude": {
          "**/.git": true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The vscode-database plugin last update time is 2 years ago, and it seem not compatible with our vscode version now
![image](https://user-images.githubusercontent.com/8299500/151660986-2c01dd35-9135-4dba-881b-354f2cfcfe05.png)

![image](https://user-images.githubusercontent.com/8299500/151660977-5cc99e79-b719-4576-9d6d-5f4b632d895d.png)

And when you open new gitpod workspace, you always get an error popup:
connect ECONNREFUSED 127.0.0.1:23306
![image](https://user-images.githubusercontent.com/8299500/151661004-f6ea6357-06d2-4ef2-b730-38956cd985ed.png)
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7903

## How to test
<!-- Provide steps to test this PR -->
open a new workspace, you will no to see `connect ECONNREFUSED 127.0.0.1:23306` error popup

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
