### PR TITLE
[ReadMe] - update Integrated Code reviews link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and 
 
 👐 [GitLab, GitHub, and Bitbucket integration](https://www.gitpod.io/docs/integrations/) - Gitpod seamlessly integrates in your workflow and works with all major git hosting platforms including GitHub, GitLab and Bitbucket.
 
-👀 [Integrated code reviews](https://www.gitpod.io/docs/code-reviews/#code-reviews) - with Gitpod you can do native code reviews on any PR/MR. No need to switch context anymore and clutter your local machine with your colleagues PR/MR.
+👀 [Integrated code reviews](https://www.gitpod.io/docs/context-urls#pullmerge-request-context) - with Gitpod you can do native code reviews on any PR/MR. No need to switch context anymore and clutter your local machine with your colleagues PR/MR.
 
 👯‍♀️ [Collaboration](https://www.gitpod.io/docs/sharing-and-collaboration/) - invite team members to your dev environment or snapshot any state of your dev environment to share it with your team asynchronously.
 


### PR DESCRIPTION
## Description

The code reviews link in the ReadMe points to a non-existent page. As suggested by @axonasif , updated the link to the right resource.

## Related Issue(s)

[7911](https://github.com/gitpod-io/gitpod/issues/7911)

Fixes #

## How to test
1. Go to: https://github.com/gitpod-io/gitpod - ReadMe.md 
2. Go to Features: https://github.com/gitpod-io/gitpod#features
3. Click "Integrated code reviews" - the URL will go to the existing page of Contexts on Docs 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```