### PR TITLE
[installer]: add yq and kubectl to docker image

### DIFF
--- a/installer/leeway.Dockerfile
+++ b/installer/leeway.Dockerfile
@@ -4,5 +4,8 @@
 
 FROM alpine:3.15
 COPY installer--app/installer installer--app/provenance-bundle.jsonl /app/
+RUN apk add --no-cache curl yq  \
+    && curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
 ENTRYPOINT [ "/app/installer" ]
 CMD [ "help" ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds the latest versions of `yq` and `kubectl` to the Docker image. This is to help with automated installations such as Replicated

## How to test
<!-- Provide steps to test this PR -->
Run container with `--entrypoint=yq` or `--entrypoint=kubectl`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
