### PR TITLE
[jb-gateway] smooth installation of the plugin

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/doc/installing.md
+++ b/components/ide/jetbrains/gateway-plugin/doc/installing.md
@@ -1,18 +1,5 @@
 ## Installing Gitpod plugin in JetBrains Gateway
 
-<!-- Uncomment when nightly channel is available
-- Start JetBrains Gateway
-- [Add a custom repository](https://www.jetbrains.com/help/idea/managing-plugins.html#add_plugin_repos)
-  for the nightly channel: https://plugins.jetbrains.com/plugins/list?channel=nightly&pluginId=18438-gitpod-gateway
-- Install `Gitpod Gateway`
-  [from the marketplace](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_repo)
-- Restart JetBrains Gateway
--->
-
-- Download the plugin archive: https://plugins.jetbrains.com/plugin/download?rel=true&updateId=154782
-    - We are in the process of establishing update channels on JetBrains marketplace to enable auto upgrade. As for now
-      if something does not work please make sure to report an issue and check here for newer version of the plugin.
-- Start JetBrains Gateway
-- [Install from the plugin archive](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk)
-  - You may see an error about a missing dependency, ignore it. We are in process of sorting it out.
-- Press `Apply` and then restart JetBrains Gateway
+- Install latest [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/)
+- Launch Gateway and open plugin settings
+- Search for "Gitpod Gateway" and click install

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
  See License-AGPL.txt in the project root for license information.
 -->
 
-<idea-plugin>
+<idea-plugin require-restart="true">
     <id>io.gitpod.jetbrains.gateway</id>
     <name>Gitpod Gateway</name>
     <vendor>Gitpod</vendor>
@@ -12,7 +12,9 @@
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
-    <depends>com.jetbrains.gateway</depends>
+    <!-- uncomment when versin mismatch in JB Marketpace for GW plugin verifier is resolved
+    see https://jetbrains.slack.com/archives/C02BRJLGPGF/p1643369943314119?thread_ts=1643358812.185799&cid=C02BRJLGPGF
+    <depends>com.jetbrains.gateway</depends> -->
 
     <extensions defaultExtensionNs="com.intellij">
         <httpRequestHandler implementation="io.gitpod.jetbrains.auth.GitpodAuthCallbackHandler"/>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR smooths installation of the plugin to JB Gateway:
- publishes it as stable to JB Marketplace, that a user can find and install it
- marks it as required restart to lead a user otherwise UI components are not enabled
- temporarily comments out some dependencies to gateway module, since there is some kind of version mismatch in JB marketplace in regards to GW plugin versions

It also fixes client side of Java client which drop a connection whenever a server sent a message which is more than 64kb.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

The plugin is already published to JB marketplace. You can use gitpod.io, select some JB product in preferences, start workspaces, and verify that you managed to install everything and connect to the workspace with JB thin client.

But use https://github.com/gitpod-io/gitpod/blob/4f6911ef32976898c41f1b3000c1af653793ab39/components/ide/jetbrains/gateway-plugin/doc/installing.md to install Gitpod plugin instead one in production.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
