### PR TITLE
ws-manager: Add a error handling when the ws-daemon service is not found

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -946,6 +946,10 @@ func (m *Manager) connectToWorkspaceDaemon(ctx context.Context, wso workspaceObj
 		return nil, err
 	}
 
+	if len(endpointsList.Items) == 0 {
+		return nil, xerrors.Errorf("ws-daemon service does not exist")
+	}
+
 	// Find the ws-daemon endpoint on this node
 	var hostIP string
 	for _, pod := range endpointsList.Items {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
By adding this error handling, when an error around the connection `ws-daemon` from` ws-manager`, we can judge if there are no Pod or Service.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/7688

## How to test
<!-- Provide steps to test this PR -->
None

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
no
