### PR TITLE
Ship env vars as one-time secret

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -603,12 +603,22 @@ export class WorkspaceStarter {
         if (WithEnvvarsContext.is(context)) {
             allEnvVars = allEnvVars.concat(context.envvars);
         }
-        const envvars = allEnvVars.map(uv => {
-            const ev = new EnvironmentVariable();
-            ev.setName(uv.name);
-            ev.setValue(uv.value);
-            return ev;
-        });
+
+        // we copy the envvars to a stable format so that things don't break when someone changes the
+        // EnvVarWithValue shape. The JSON.stringify(envvars) will be consumed by supervisor and we
+        // need to make sure we're speaking the same language.
+        const stableEnvvars = allEnvVars.map(e => { return { name: e.name, value: e.value }});
+
+        // we ship the user-specific env vars as OTS because they might contain secrets
+        const envvarOTSExpirationTime = new Date();
+        envvarOTSExpirationTime.setMinutes(envvarOTSExpirationTime.getMinutes() + 30);
+        const envvarOTS = await this.otsServer.serve(traceCtx, JSON.stringify(stableEnvvars), envvarOTSExpirationTime);
+
+        const envvars: EnvironmentVariable[] = [];
+        const ev = new EnvironmentVariable();
+        ev.setName("SUPERVISOR_ENVVAR_OTS");
+        ev.setValue(envvarOTS.token);
+        envvars.push(ev);
 
         const ideAlias = user.additionalData?.ideSettings?.defaultIde;
         if (ideAlias && ideConfig.ideOptions.options[ideAlias]) {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -620,6 +620,15 @@ export class WorkspaceStarter {
         ev.setValue(envvarOTS.token);
         envvars.push(ev);
 
+        // TODO(cw): for the time being we're still pushing the env vars as we did before.
+        //           Once everything is running with the latest supervisor, we can stop doing that.
+        allEnvVars.forEach(e => {
+            const ev = new EnvironmentVariable();
+            ev.setName(e.name);
+            ev.setValue(e.name);
+            envvars.push(ev);
+        })
+
         const ideAlias = user.additionalData?.ideSettings?.defaultIde;
         if (ideAlias && ideConfig.ideOptions.options[ideAlias]) {
             const ideAliasEnv = new EnvironmentVariable();

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -240,6 +240,12 @@ type WorkspaceConfig struct {
 	// DotfileRepo is a user-configurable repository which contains their dotfiles to customise
 	// the in-workspace epxerience.
 	DotfileRepo string `env:"SUPERVISOR_DOTFILE_REPO"`
+
+	// EnvvarOTS points to a URL from which environment variables for child processes can be downloaded from.
+	// This provides a safer means to transport environment variables compared to shipping them on the Kubernetes pod.
+	//
+	// The format of the content downloaded from this URL is expected to be JSON in the form of [{"name":"name", "value":"value"}]
+	EnvvarOTS string `env:"SUPERVISOR_ENVVAR_OTS"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service.

--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/process"
 )
 
-func newSSHServer(ctx context.Context, cfg *Config) (*sshServer, error) {
+func newSSHServer(ctx context.Context, cfg *Config, envvars []string) (*sshServer, error) {
 	bin, err := os.Executable()
 	if err != nil {
 		return nil, xerrors.Errorf("cannot find executable path: %w", err)
@@ -33,21 +33,23 @@ func newSSHServer(ctx context.Context, cfg *Config) (*sshServer, error) {
 			return nil, xerrors.Errorf("unexpected error creating SSH key: %w", err)
 		}
 	}
-	err = writeSSHEnv(cfg)
+	err = writeSSHEnv(cfg, envvars)
 	if err != nil {
 		return nil, xerrors.Errorf("unexpected error creating SSH env: %w", err)
 	}
 
 	return &sshServer{
-		ctx:    ctx,
-		cfg:    cfg,
-		sshkey: sshkey,
+		ctx:     ctx,
+		cfg:     cfg,
+		sshkey:  sshkey,
+		envvars: envvars,
 	}, nil
 }
 
 type sshServer struct {
-	ctx context.Context
-	cfg *Config
+	ctx     context.Context
+	cfg     *Config
+	envvars []string
 
 	sshkey string
 }
@@ -114,7 +116,7 @@ func (s *sshServer) handleConn(ctx context.Context, conn net.Conn) {
 	log.WithField("args", args).Debug("sshd flags")
 	cmd := exec.CommandContext(ctx, openssh, args...)
 	cmd = runAsGitpodUser(cmd)
-	cmd.Env = buildChildProcEnv(s.cfg, nil)
+	cmd.Env = s.envvars
 	cmd.ExtraFiles = []*os.File{socketFD}
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = bufio.NewReader(socketFD)
@@ -190,7 +192,7 @@ func prepareSSHKey(ctx context.Context, sshkey string) error {
 	return nil
 }
 
-func writeSSHEnv(cfg *Config) error {
+func writeSSHEnv(cfg *Config, envvars []string) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -203,8 +205,7 @@ func writeSSHEnv(cfg *Config) error {
 	}
 
 	fn := filepath.Join(d, "supervisor_env")
-	env := strings.Join(buildChildProcEnv(cfg, nil), "\n")
-	err = os.WriteFile(fn, []byte(env), 0o644)
+	err = os.WriteFile(fn, []byte(strings.Join(envvars, "\n")), 0o644)
 	if err != nil {
 		return xerrors.Errorf("cannot write %s: %w", fn, err)
 	}


### PR DESCRIPTION
## Description
Today user environment variables become environment variables on the workspace pod. This is a clean and straight forward way to implement env vars, but it suffers from a drawback: values are stored in clear-text on the pod. If one isn't careful about logging, those values could be spread into the logs, and are visible to everyone with access to the cluster.

This PR starts shipping env vars as one-time secret, much like we ship the Git hoster token. This way, environment variable values are not visible to anyone, except within the workspace.

## How to test
1. Set up user and project level environment variables.
2. Start a workspace and ensure those env vars are present
3. Run `kubectl get pod -o yaml ws-...` and ensure the user env vars are not present.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improved in-transit security of user environment variables
```
