### PR TITLE
Fix server dashboard default time range

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/server.json
+++ b/operations/observability/mixins/meta/dashboards/components/server.json
@@ -21,7 +21,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1642071215299,
+  "iteration": 1643631956016,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -76,7 +76,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -164,7 +164,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -699,7 +699,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1611,7 +1611,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1733,7 +1733,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2832,13 +2832,13 @@
     ]
   },
   "time": {
-    "from": "2022-01-12T14:58:54.017Z",
-    "to": "2022-01-12T15:17:24.390Z"
+    "from": "now-1h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "utc",
   "title": "Gitpod / Component / server",
   "uid": "server",
-  "version": 6,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
When visiting the server dashboard, it had a specific time range that was confusing. 
Now it's set to the last one hour.

| BEFORE | AFTER |
| - | - |
| <img width="522" alt="Screenshot 2022-01-31 at 13 30 59" src="https://user-images.githubusercontent.com/8015191/151794298-ce5145c1-7a45-4f12-90ee-5ee6793050c2.png"> | <img width="598" alt="Screenshot 2022-01-31 at 13 31 07" src="https://user-images.githubusercontent.com/8015191/151794327-48f19ebf-a356-45a3-b249-d0583cdf8859.png"> |



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
no-issue

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
