### PR TITLE
[ws-manager] Refactor connectToWorkspaceDaemon helper

### DIFF
--- a/components/ws-manager/pkg/manager/manager_test.go
+++ b/components/ws-manager/pkg/manager/manager_test.go
@@ -302,7 +302,7 @@ func TestConnectToWorkspaceDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedErr: "no matching endpoint",
+			ExpectedErr: "no running ws-daemon pod found",
 		},
 		{
 			Name: "handles no endpoint on current node",
@@ -316,40 +316,32 @@ func TestConnectToWorkspaceDaemon(t *testing.T) {
 					},
 				},
 				Objs: []client.Object{
-					&corev1.Endpoints{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Endpoints",
-							APIVersion: "v1",
-						},
+					&corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "ws-daemon-endpoints",
+							Name:      "ws-daemon",
 							Namespace: "default",
 							Labels: labels.Set{
 								"component": "ws-daemon",
-								"kind":      "service",
+								"app":       "gitpod",
 							},
 						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.1.2.3",
-										NodeName: &badNodeName,
-									},
-								},
-								Ports: []corev1.EndpointPort{
-									{
-										Name:     "port1",
-										Port:     7766,
-										Protocol: "TCP",
-									},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "workspace",
+									Image: "dummy",
 								},
 							},
+							NodeName: badNodeName,
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							PodIP: "10.1.2.3",
 						},
 					},
 				},
 			},
-			ExpectedErr: "no matching endpoint",
+			ExpectedErr: "no running ws-daemon pod found",
 		},
 		{
 			Name: "finds endpoint on current node",
@@ -363,35 +355,27 @@ func TestConnectToWorkspaceDaemon(t *testing.T) {
 					},
 				},
 				Objs: []client.Object{
-					&corev1.Endpoints{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Endpoints",
-							APIVersion: "v1",
-						},
+					&corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "ws-daemon-endpoints",
 							Namespace: "default",
 							Labels: labels.Set{
 								"component": "ws-daemon",
-								"kind":      "service",
+								"app":       "gitpod",
 							},
 						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.1.2.3",
-										NodeName: &goodNodeName,
-									},
-								},
-								Ports: []corev1.EndpointPort{
-									{
-										Name:     "port1",
-										Port:     7766,
-										Protocol: "TCP",
-									},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "workspace",
+									Image: "dummy",
 								},
 							},
+							NodeName: goodNodeName,
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							PodIP: "10.1.2.3",
 						},
 					},
 				},
@@ -438,34 +422,27 @@ func TestCheckWSDaemonEntpoint(t *testing.T) {
 			Name: "handles no endpoint on current node",
 			Args: Args{
 				Objs: []client.Object{
-					&corev1.Endpoints{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Endpoints",
-							APIVersion: "v1",
-						},
+					&corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "ws-daemon-endpoints",
 							Namespace: "default",
 							Labels: labels.Set{
 								"component": "ws-daemon",
-								"kind":      "service",
+								"app":       "gitpod",
 							},
 						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP: "10.1.2.2",
-									},
-								},
-								Ports: []corev1.EndpointPort{
-									{
-										Name:     "port1",
-										Port:     7766,
-										Protocol: "TCP",
-									},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "workspace",
+									Image: "dummy",
 								},
 							},
+							NodeName: "nodeName",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							PodIP: "10.1.2.2",
 						},
 					},
 				},
@@ -477,34 +454,27 @@ func TestCheckWSDaemonEntpoint(t *testing.T) {
 			Input: "10.1.2.3",
 			Args: Args{
 				Objs: []client.Object{
-					&corev1.Endpoints{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Endpoints",
-							APIVersion: "v1",
-						},
+					&corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "ws-daemon-endpoints",
 							Namespace: "default",
 							Labels: labels.Set{
 								"component": "ws-daemon",
-								"kind":      "service",
+								"app":       "gitpod",
 							},
 						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP: "10.1.2.3",
-									},
-								},
-								Ports: []corev1.EndpointPort{
-									{
-										Name:     "port1",
-										Port:     7766,
-										Protocol: "TCP",
-									},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "workspace",
+									Image: "dummy",
 								},
 							},
+							NodeName: "nodeName",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+							PodIP: "10.1.2.3",
 						},
 					},
 				},


### PR DESCRIPTION
## Description

Do not rely on endpoints but instead, search ws-daemon pods.

xref: https://github.com/gitpod-io/gitpod/issues/7688

## How to test
- Workspaces should open without errors
- ws-manager los should not contain `cannot connect to ws-daemon`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[wa-manager] Refactor connectToWorkspaceDaemon helper
```
