### PR TITLE
Update to vscode 1.64

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 40c9a1fb052740734bf465b98032f1a50404c042
+  codeCommit: 4035f15a03e6d92cb9815e366b856e43f1caabe7
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.2.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"

--- a/components/ide/code/supervisor-ide-config.json
+++ b/components/ide/code/supervisor-ide-config.json
@@ -1,6 +1,6 @@
 {
     "entrypoint": "/ide/startup.sh",
-    "entrypointArgs": [ "--port", "{IDEPORT}", "--host", "0.0.0.0", "--connection-token", "00000", "--server-data-dir", "/workspace/.vscode-remote" ],
+    "entrypointArgs": [ "--port", "{IDEPORT}", "--host", "0.0.0.0", "--without-connection-token", "--server-data-dir", "/workspace/.vscode-remote" ],
     "readinessProbe": {
         "type": "http",
         "http": {


### PR DESCRIPTION
# IMPORTANT
Wait for https://github.com/gitpod-io/gitpod/pull/7990 to be merged and deployed before merging this

## Description
<!-- Describe your changes in detail -->
- Update vscode to version 1.64
- Use `--without-connection-token` when launching vscode

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- Switch to stable VS Code in settings and test you can start a workspace properly.
---------

- Switch to latest VS Code in settings.
- Start a workspace.
- Test following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data are sync across workspaces as well as on workspace restart, especially for extensions
   - [x] extensions from .gitpod.yml are not installed as sync
   - [x] extensions installed as sync are actually sync in new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - websockets and workers are properly proxied
    - [x] diff editor should be operatable
    - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old websockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. F1 → type Gitpod prefix
  - [x] that a PR view is preloaded on the PR url
  - [x] test gp open and preview
  - [x] test open in VS Code Desktop, check gp open and preview in task/user terminals
  - [x] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe

