### PR TITLE
increase gradle timeouts to stabilize builds

### DIFF
--- a/components/gitpod-protocol/java/gradle.properties
+++ b/components/gitpod-protocol/java/gradle.properties
@@ -1,4 +1,3 @@
-version=1.0-SNAPSHOT
 # See https://stackoverflow.com/a/47607857/961588
 systemProp.org.gradle.internal.http.socketTimeout=100000
 systemProp.org.gradle.internal.http.connectionTimeout=100000

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -22,3 +22,6 @@ platformPlugins=
 kotlin.stdlib.default.dependency=false
 supervisorApiProjectPath=../../../supervisor-api/java
 gitpodProtocolProjectPath=../../../gitpod-protocol/java
+# See https://stackoverflow.com/a/47607857/961588
+systemProp.org.gradle.internal.http.socketTimeout=100000
+systemProp.org.gradle.internal.http.connectionTimeout=100000

--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -21,3 +21,7 @@ platformPlugins=
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false
 gitpodProtocolProjectPath=../../../gitpod-protocol/java
+# See https://stackoverflow.com/a/47607857/961588
+systemProp.org.gradle.internal.http.socketTimeout=100000
+systemProp.org.gradle.internal.http.connectionTimeout=100000
+


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We observed that some werft jobs fail sometimes with read timeout: https://gitpod.slack.com/archives/C01KGM9AW4W/p1643642672808109

This PR tries to improve the situation by increasing network timeouts as described here: https://stackoverflow.com/a/47607857/961588

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

If build is green, merge and see whether it gets better next days.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
