### PR TITLE
Chaged docker port from 2475 to back to 2375

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -183,7 +183,7 @@ pod:
         sudo chown gitpod:gitpod $GOCACHE
         export GITHUB_TOKEN=$(echo $GITHUB_TOKEN | xargs)
 
-        export DOCKER_HOST=tcp://$NODENAME:2475
+        export DOCKER_HOST=tcp://$NODENAME:2375
         sudo chown -R gitpod:gitpod /workspace
 
         mkdir /workspace/.ssh

--- a/.werft/clean-up-werft-build-nodes.yaml
+++ b/.werft/clean-up-werft-build-nodes.yaml
@@ -36,7 +36,7 @@ pod:
           sleep 1
           set -Eeuo pipefail
 
-          export DOCKER_HOST=tcp://$NODENAME:2475
+          export DOCKER_HOST=tcp://$NODENAME:2375
 
           werft log phase docker-engine-prune "Cleaning up Docker Engine used by Werft builds"
           docker system prune --force --all --filter 'until=72h' 2>&1 | werft log slice docker-engine-prune

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -153,7 +153,7 @@ pod:
         sudo chown gitpod:gitpod $GOCACHE
         export GITHUB_TOKEN=$(echo $GITHUB_TOKEN | xargs)
 
-        export DOCKER_HOST=tcp://$NODENAME:2475
+        export DOCKER_HOST=tcp://$NODENAME:2375
         sudo chown -R gitpod:gitpod /workspace
 
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We are currently running two docker installtions in `core-dev`, `docker-engine` and `docker-engine-update`. The latter one has been added to unblock Gitpod deployments as should have been a temporary solution. But after upgrading the first one we forgot to do so. This changes the port to use the `docker-engine` again. After merging we could remove the other one after all branches are using docker on port 2375.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
`werft` builds should work as before like [this job](https://werft.gitpod-dev.com/job/gitpod-build-wth-change-docker-port.0).
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
