### PR TITLE
[server] Support 'git@{host}:{user}/{repo}.git' format in context URLs

### DIFF
--- a/components/server/src/workspace/context-parser.ts
+++ b/components/server/src/workspace/context-parser.ts
@@ -32,6 +32,9 @@ export abstract class AbstractContextParser implements IContextParser {
         if (url.startsWith(`${this.host}/`)) {
             url = `https://${url}`;
         }
+        if (url.startsWith(`git@${this.host}:`)) {
+            return `https://${this.host}/` + url.slice(`git@${this.host}:`.length);
+        }
         if (url.startsWith(`https://${this.host}/`)) {
             return url;
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Supports context URLs like `git@github.com:gitpod-io/gitpod.git` (but without actual SSH authentication)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7950

## How to test
<!-- Provide steps to test this PR -->

1. https://jx-ssh-context.staging.gitpod-dev.com/#git@github.com:gitpod-io/gitpod.git

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Support 'git@{host}:{user}/{repo}.git' format in context URLs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
