### PR TITLE
use fragment instead of query in jetbrains gateway links

### DIFF
--- a/components/ide/jetbrains/image/status/main.go
+++ b/components/ide/jetbrains/image/status/main.go
@@ -58,7 +58,7 @@ func main() {
 		link := url.URL{
 			Scheme:   "jetbrains-gateway",
 			Host:     "connect",
-			RawQuery: fmt.Sprintf("gitpodHost=%s&workspaceId=%s", url.QueryEscape(gitpodUrl.Hostname()), url.QueryEscape(wsInfo.WorkspaceId)),
+			Fragment: fmt.Sprintf("gitpodHost=%s&workspaceId=%s", gitpodUrl.Hostname(), wsInfo.WorkspaceId),
 		}
 		response := make(map[string]string)
 		response["link"] = link.String()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It turned out that gateway links expect parameters to be encoded in fragment not query. It worked somehow, but was not correct and broke for some clients.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7965

## How to test
<!-- Provide steps to test this PR -->

- Start a new workspace: https://ak-fix-jb-gw-links.staging.gitpod-dev.com/#referrer:jetbrains-gateway/https://github.com/open-vsx/publish-extensions
- Make sure that Gateway can connect to it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
