### PR TITLE
.werft/observability: Add stackdriver support

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -14,6 +14,9 @@ pod:
   - name: monitoring-satellite-preview-token
     secret:
       secretName: monitoring-satellite-preview-token
+  - name: monitoring-satellite-stackdriver-credentials
+    secret:
+      secretName: monitoring-satellite-stackdriver-credentials
   - name: gcp-sa
     secret:
       secretName: gcp-sa-gitpod-dev-deployer
@@ -66,6 +69,8 @@ pod:
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:
+    - name: monitoring-satellite-stackdriver-credentials
+      mountPath: /mnt/secrets/monitoring-satellite-stackdriver-credentials
     - name: monitoring-satellite-preview-token
       mountPath: /mnt/secrets/monitoring-satellite-preview-token
     - name: gcp-sa


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Adds support for Grafana's stackdriver datasource 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/7859

## How to test
<!-- Provide steps to test this PR -->
Deploy and access grafana following the [How-to](https://www.notion.so/gitpod/Getting-access-to-Grafana-and-Prometheus-in-preview-environments-f2938b2bcb0c4c8c99afe1d2b872380e), try to create a new dashboard using the stackdrive datasource. It should work :) 

![image](https://user-images.githubusercontent.com/24193764/152014316-55dbfb98-2d81-4d2f-bd56-b84310facd9b.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
