### PR TITLE
Fix project details layout

### DIFF
--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -18,7 +18,7 @@ export default function ProjectDetail(props: { project: Project, owner: string |
                 <p>{props.project.cloneUrl}</p>
             </div>
         </div>
-        <div className="flex flex-col w-full -ml-3">
+        <div className="flex flex-col w-full">
             <div className="flex w-full mt-6">
                 <Property name="Created">{moment(props.project.creationTime).format('MMM D, YYYY')}</Property>
                 <Property name="Repository"><a className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate" href={props.project.cloneUrl}>{props.project.name}</a></Property>

--- a/components/dashboard/src/admin/Property.tsx
+++ b/components/dashboard/src/admin/Property.tsx
@@ -7,11 +7,11 @@
 import { ReactChild } from 'react';
 
 function Property(p: { name: string, children: string | ReactChild, actions?: { label: string, onClick: () => void }[] }) {
-    return <div className="ml-3 flex flex-col w-4/12 truncate">
+    return <div className="flex flex-col w-4/12 truncate">
         <div className="text-base text-gray-500 truncate">
             {p.name}
         </div>
-        <div className="text-lg text-gray-600 font-semibold truncate">
+        <div className="mr-3 text-lg text-gray-600 font-semibold truncate">
             {p.children}
         </div>
         {(p.actions || []).map(a =>


### PR DESCRIPTION
## Description

Follow up from https://github.com/gitpod-io/gitpod/pull/7882#discussion_r796626073.

## How to test
1. Add a project
2. Go to admin
3. Search for projects
4. Open project details
5. Notice the minor layout shift

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-02-01 at 11 07 19 PM (2)" src="https://user-images.githubusercontent.com/120486/152059287-bf4d041d-9513-41fa-b5f8-fb9b850d5582.png"> | <img width="1440" alt="Screenshot 2022-02-01 at 11 09 05 PM (2)" src="https://user-images.githubusercontent.com/120486/152059309-fb15e6bb-6f67-43e7-89ab-10a4fe56affb.png"> | 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```