### PR TITLE
Write unique error message if ready file create fails

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -490,29 +490,29 @@ func PlaceWorkspaceReadyFile(ctx context.Context, wspath string, initsrc csapi.W
 	gitpodDir := filepath.Join(wspath, filepath.Dir(WorkspaceReadyFile))
 	err = os.MkdirAll(gitpodDir, 0777)
 	if err != nil {
-		return xerrors.Errorf("cannot write workspace ready file: %w", err)
+		return xerrors.Errorf("cannot create directory for workspace ready file: %w", err)
 	}
 	err = os.Chown(gitpodDir, uid, gid)
 	if err != nil {
-		return xerrors.Errorf("cannot write workspace-ready file: %w", err)
+		return xerrors.Errorf("cannot chown directory for workspace ready file: %w", err)
 	}
 
 	tempWorkspaceReadyFile := WorkspaceReadyFile + ".tmp"
 	fn := filepath.Join(wspath, tempWorkspaceReadyFile)
 	err = os.WriteFile(fn, []byte(fc), 0644)
 	if err != nil {
-		return xerrors.Errorf("cannot write workspace ready file: %w", err)
+		return xerrors.Errorf("cannot write workspace ready file content: %w", err)
 	}
 	err = os.Chown(fn, uid, gid)
 	if err != nil {
-		return xerrors.Errorf("cannot write workspace ready file: %w", err)
+		return xerrors.Errorf("cannot chown workspace ready file: %w", err)
 	}
 
 	// Theia will listen for a rename event as trigger to start the tasks. This is a rename event
 	// because we're writing to the file and this is the most convenient way we can tell Theia that we're done writing.
 	err = os.Rename(fn, filepath.Join(wspath, WorkspaceReadyFile))
 	if err != nil {
-		return xerrors.Errorf("cannot write workspace ready file: %w", err)
+		return xerrors.Errorf("cannot rename workspace ready file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
When the creation of the ready file fails, it is hard to distinguish on which operation it actually failed.

## Related Issue(s)
n.a.

## How to test
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


