### PR TITLE
observability/mixins: Add Makefile step that generates dashboards

### DIFF
--- a/operations/observability/mixins/.gitignore
+++ b/operations/observability/mixins/.gitignore
@@ -1,3 +1,4 @@
 tmp/
 prometheus_alerts.yaml
 vendor/
+dashboards_out/

--- a/operations/observability/mixins/Makefile
+++ b/operations/observability/mixins/Makefile
@@ -39,3 +39,8 @@ unit-tests: vendor
 	jsonnet tests/alertsSeverityLabel.jsonnet -J vendor/
 	@echo 'Testing alert descripion annotation'
 	jsonnet tests/alertsDescriptionAnnotation.jsonnet -J vendor/
+
+.PHONY: dashboards_out
+dashboards_out:
+	@mkdir -p dashboards_out
+	jsonnet -J vendor -m dashboards_out dashboards.jsonnet

--- a/operations/observability/mixins/dashboards.jsonnet
+++ b/operations/observability/mixins/dashboards.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+local dashboards =
+  (import 'cross-teams/mixin.libsonnet').grafanaDashboards +
+  (import 'IDE/mixin.libsonnet').grafanaDashboards +
+  (import 'meta/mixin.libsonnet').grafanaDashboards +
+  (import 'workspace/mixin.libsonnet').grafanaDashboards
+;
+
+{
+  [name]: dashboards[name]
+  for name in std.objectFields(dashboards)
+}


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Just a small improvement to the DevX when developing mixins with Jsonnet. 

When getting started it's hard to understand how all the imports and dependencies work, so I'm just adding a Makefile step that is able to generate the JSON file for all dashboards included in our mixins. Useful to make sure we've imported dashboards objects to the right place

cc @sagor999 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/pull/7966#issuecomment-1027778859

## How to test
<!-- Provide steps to test this PR -->
```shell
cd operations/observability/mixins
make dashboards_out
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```