### PR TITLE
Added KUBCONFIG to /etc/bash.bashrc

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -209,7 +209,7 @@ write_files:
       kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
       kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml
 
-      cat <<EOF >> /root/.bashrc
+      cat <<EOF >> /etc/bash.bashrc
       export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
       EOF
 runcmd:

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -22,7 +22,7 @@ EOF
  */
  function kubectlDeleteManifest(manifest: string, options?: { validate?: boolean }) {
     exec(`
-        cat <<EOF | kubectl --kubeconfig ${KUBECONFIG_PATH} delete
+        cat <<EOF | kubectl --kubeconfig ${KUBECONFIG_PATH} delete -f -
 ${manifest}
 EOF
     `)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This sets the KUBECONFIG environment variable globally so it is automatically set after a SSH login.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/638

## How to test
<!-- Provide steps to test this PR -->
Start a new VM and run `./dev/preview/ssh-vm.sh` to access the VM. `helm list` will show an empty list. Youi can also add a new repo and install any helm chart.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
