### PR TITLE
[gitlab] support nested repos in envvar patterns

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -258,8 +258,8 @@ export namespace UserEnvVar {
     // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
     export function splitRepositoryPattern(repositoryPattern: string): string[] {
         const patterns = repositoryPattern.split('/');
-        const repoPattern = patterns.pop() || "";
-        const ownerPattern = patterns.join('/');
+        const repoPattern = patterns.slice(1).join('/')
+        const ownerPattern = patterns[0];
         return [ownerPattern, repoPattern];
     }
 }


### PR DESCRIPTION
## Description
Support nested repos in user-scoped env var patterns.

## Related Issue(s)
Fixes #2702

## How to test
See #2702

## Release Notes
```release-note
[gitlab] user-scoped env vars can now be filtered for nested repos on Gitlab
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
