### PR TITLE
Introduce GitHub Action to apply team labels based on reviewers

### DIFF
--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -1,0 +1,19 @@
+name: Team Labeler
+on:
+  pull_request:
+    types: [review_requested]
+jobs:
+  label:
+    name: Apply team labels
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set team labels as output
+        id: team_labels
+        run: |
+          LABELS="team: ${{ join(github.event.pull_request.requested_teams.*.slug, ', team: ') }}"
+          echo ::set-output name=label::${LABELS//engineering-/}
+      - name: Add team labels
+        if: join(github.event.pull_request.requested_teams.*.slug, '') != ''
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "${{ steps.team_labels.outputs.label }}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

As part of moving to CODEOWNERS we will be removing the OWNERS files and thus break the existing method of applying team labels (see [RFC](https://www.notion.so/gitpod/Using-GitHub-for-PR-review-automation-35d5e77a7e4b4999a72b5eef2458f636) for details on current and the upcoming process and their implementation).

This PR introduces a GitHub Action which will apply team labels based on who is tagged as reviewers. As CODEOWNERS will be mapping paths to reviewers, this means that we effectively have a way to apply team labels based on who owns the files that were modified.

This has been used in the ops repository for a while now.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/840

## How to test
<!-- Provide steps to test this PR -->

Testing changes to GitHub Actions can be a bit tedious so I have been using a test repository to experiment with this. See this [PR](https://github.com/gitpod-io/codeowners-test/pull/11) that shows the appropriate labels are applied. 

Once merged I will keep an eye on PRs in this repo to make sure the right labels are indeed applied.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A