### PR TITLE
[gitlab] support nested repos in envvar patterns

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -258,8 +258,8 @@ export namespace UserEnvVar {
     // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
     export function splitRepositoryPattern(repositoryPattern: string): string[] {
         const patterns = repositoryPattern.split('/');
-        const repoPattern = patterns.pop() || "";
-        const ownerPattern = patterns.join('/');
+        const repoPattern = patterns.slice(1).join('/')
+        const ownerPattern = patterns[0];
         return [ownerPattern, repoPattern];
     }
 }


### PR DESCRIPTION
## Description
Support nested repos in user-scoped env var patterns.
Now with a s[hort enough branch name](https://github.com/gitpod-io/gitpod/pull/7975)...


## Related Issue(s)
Fixes #2702

## How to test
- You can try with https://gitlab.com/g2506/group1/foo
- Add a user-scoped var with pattern `g2506/*`
- Open https://jk-env-vars-nested-gl.staging.gitpod-dev.com/#https://gitlab.com/g2506/group1/foo
- Open a terminal, enter `gp env` and make sure the variable shows up

## Release Notes
```release-note
[gitlab] user-scoped env vars can now be filtered for nested repos on Gitlab
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
