### PR TITLE
ws-manager-bridge: Print audit logs when client header is set

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -65,6 +65,7 @@ export class ClusterService implements IClusterServiceServer {
     protected readonly queue: Queue = new Queue();
 
     public register(call: grpc.ServerUnaryCall<RegisterRequest, RegisterResponse>, callback: grpc.sendUnaryData<RegisterResponse>) {
+        log.info("requested clusters.register", getClientInfo(call))
         this.queue.enqueue(async () => {
             try {
                 // check if the name or URL are already registered/in use
@@ -147,6 +148,7 @@ export class ClusterService implements IClusterServiceServer {
     }
 
     public update(call: grpc.ServerUnaryCall<UpdateRequest, UpdateResponse>, callback: grpc.sendUnaryData<UpdateResponse>) {
+        log.info("requested clusters.update", getClientInfo(call))
         this.queue.enqueue(async () => {
             try {
                 const req = call.request.toObject();
@@ -208,6 +210,7 @@ export class ClusterService implements IClusterServiceServer {
     }
 
     public deregister(call: grpc.ServerUnaryCall<DeregisterRequest, DeregisterResponse>, callback: grpc.sendUnaryData<DeregisterResponse>) {
+        log.info("requested clusters.deregister", getClientInfo(call))
         this.queue.enqueue(async () => {
             try {
                 const req = call.request.toObject();
@@ -231,6 +234,7 @@ export class ClusterService implements IClusterServiceServer {
     }
 
     public list(call: grpc.ServerUnaryCall<ListRequest, ListResponse>, callback: grpc.sendUnaryData<ListResponse>) {
+        log.info("requested clusters.list", getClientInfo(call))
         this.queue.enqueue(async () => {
             try {
                 const response = new ListResponse();
@@ -355,6 +359,21 @@ function mapToGRPCError(err: any): any {
         return new GRPCError(grpc.status.INTERNAL, err);
     }
     return err;
+}
+
+function getClientInfo(call: grpc.ServerUnaryCall<any,any>) {
+    const clientNameHeader = call.metadata.get("client-name")
+    const userAgentHeader = call.metadata.get("user-agent")
+
+    let [clientName, userAgent] = ["", ""]
+    if (clientNameHeader.length != 0) {
+        clientName = clientNameHeader[0].toString()
+    }
+    if (userAgentHeader.length != 0) {
+        userAgent = userAgentHeader[0].toString()
+    }
+    const clientIP = call.getPeer();
+    return {clientIP, clientName, userAgent}
 }
 
 // "grpc" does not allow additional methods on it's "ServiceServer"s so we have an additional wrapper here


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Print the operation and the client info.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7858

## How to test
<!-- Provide steps to test this PR -->
This PR can be tested via the changes of https://github.com/gitpod-io/gitpod/pull/7976.

The logs were visible in the `ws-manager-bridge` when `gpctl clusters list` was run using binary generated from above PR.

```json
{"component":"ws-manager-bridge","severity":"INFO","time":"2022-02-04T05:50:13.917Z","message":"requested clusters.list","payload":{"clientIP":"127.0.0.1:57924","clientName":"gpctl:gitpod@gitpodio-gitpod-36z8o2s861y","userAgent":"grpc-go/1.39.1"}}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
