### PR TITLE
[jb-gateway] fix awt deadlocks

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -11,6 +11,7 @@ import com.intellij.remote.RemoteCredentialsHolder
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
+import com.intellij.util.application
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import com.jetbrains.gateway.api.ConnectionRequestor
@@ -230,11 +231,15 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                 )
                                 val client = connector.connect()
                                 client.clientClosed.advise(connectionLifetime) {
-                                    connectionLifetime.terminate()
+                                    application.invokeLater {
+                                        connectionLifetime.terminate()
+                                    }
                                 }
                                 client.onClientPresenceChanged.advise(connectionLifetime) {
-                                    if (client.clientPresent) {
-                                        statusMessage.text = ""
+                                    application.invokeLater {
+                                        if (client.clientPresent) {
+                                            statusMessage.text = ""
+                                        }
                                     }
                                 }
                                 thinClient = client


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It should be possible to start several clients on Ubuntu while another is stopping.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

@MrSimonEmms Could you download https://plugins.jetbrains.com/plugin/download?rel=true&updateId=156149 and install manually in your Gateway and check whether you can open multiple clients now? 🙏 

If you test please make sure that you uninstall plugin first from Gateway and then install from zip to avoid auto upgrade.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
