### PR TITLE
fix nil pointer deref when trying to log an error in docker-up

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -68,6 +68,8 @@ func main() {
 		logger.SetLevel(logrus.DebugLevel)
 	}
 
+	log := logrus.NewEntry(logger)
+
 	listenFD := os.Getenv("LISTEN_FDS") != ""
 	if _, err := os.Stat(dockerSocketFN); !listenFD && (err == nil || !os.IsNotExist(err)) {
 		logger.Fatalf("Docker socket already exists at %s.\nIn a Gitpod workspace Docker will start automatically when used.\nIf all else fails, please remove %s and try again.", dockerSocketFN, dockerSocketFN)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I think there is a nil pointer deref in here since `log` is not initialized. 
https://github.com/gitpod-io/gitpod/blob/5b74af751837f95839e0a645b42bbdd10748fc40/components/docker-up/docker-up/main.go#L172

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7983

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
