### PR TITLE
Add blobserve rules for new vscode insiders

### DIFF
--- a/chart/templates/blobserve-configmap.yaml
+++ b/chart/templates/blobserve-configmap.yaml
@@ -27,11 +27,14 @@ data:
                     "workdir": "/ide",
                     "replacements": [
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" },
+                        { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.main.js" },
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js" }
                         {{- if not .Values.components.openVsxProxy.disabled }}
                         , { "search": "https://open-vsx.org", "replacement": "https://open-vsx.{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" }
+                        , { "search": "https://open-vsx.org", "replacement": "https://open-vsx.{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.main.js" }
                         {{- else if (and .Values.components.openVsxProxy.vsxRegistryUrl (ne .Values.components.openVsxProxy.vsxRegistryUrl "https://open-vsx.org")) }}
                         , { "search": "https://open-vsx.org", "replacement": "{{ .Values.components.openVsxProxy.vsxRegistryUrl }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" }
+                        , { "search": "https://open-vsx.org", "replacement": "{{ .Values.components.openVsxProxy.vsxRegistryUrl }}", "path": "/ide/out/vs/workbench/workbench.web.main.js" }
                         {{- end }}
                     ],
                     "inlineStatic": [

--- a/components/blobserve/pkg/blobserve/blobspace.go
+++ b/components/blobserve/pkg/blobserve/blobspace.go
@@ -216,7 +216,7 @@ func (b *diskBlobspace) AddFromTar(ctx context.Context, name string, in io.Reade
 	for _, mod := range modifications {
 		err := b.modifyFile(name, mod.Path, mod.Modifier)
 		if err != nil {
-			return xerrors.Errorf("cannot modify blob %s: %w", mod.Path, err)
+			log.WithField("path", mod.Path).WithError(err).Error("Blobspace::AddFromTar error while trying to modify file")
 		}
 	}
 

--- a/installer/pkg/components/blobserve/configmap.go
+++ b/installer/pkg/components/blobserve/configmap.go
@@ -45,11 +45,19 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					}, {
 						Search:      "vscode-webview.net",
 						Replacement: ctx.Config.Domain,
+						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
+					}, {
+						Search:      "vscode-webview.net",
+						Replacement: ctx.Config.Domain,
 						Path:        "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
 					}, {
 						Search:      "open-vsx.org",
 						Replacement: openVSXProxyUrl,
 						Path:        "/ide/out/vs/workbench/workbench.web.api.js",
+					}, {
+						Search:      "open-vsx.org",
+						Replacement: openVSXProxyUrl,
+						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
 					}},
 					InlineStatic: []blobserve.InlineReplacement{{
 						Search:      "${window.location.origin}",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds new blobserve rules required by new version of vscode insiders and next stable version to be released this week hopefully. 
Related https://github.com/gitpod-io/gitpod/pull/7930


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Test already done in https://github.com/gitpod-io/gitpod/pull/7930 but just in case
- Open a workspace using vscode stable, then open simple browser extension webview should load successfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

