### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,82 @@
+#
+# The CODEOWNERS files is owned by all teams.
+# To change ownerhip all teams need to approve.
+#
+/.github/CODEOWNERS @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/engineering-self-hosted  @gitpod-io/platform
+
+/components/blobserve @gitpod-io/engineering-workspace
+/components/common-go @gitpod-io/engineering-workspace
+/components/content-service-api @csweichel @geropl
+/components/content-service @gitpod-io/engineering-workspace
+/components/dashboard @gitpod-io/engineering-webapp
+/components/docker-up @gitpod-io/engineering-workspace
+/components/ee/agent-smith @gitpod-io/engineering-workspace
+/components/ee/db-sync @gitpod-io/engineering-webapp
+/components/ee/kedge @gitpod-io/engineering-webapp
+/components/ee/payment-endpoint @gitpod-io/engineering-webapp
+/components/gitpod-cli @gitpod-io/engineering-ide
+/components/gitpod-db @gitpod-io/engineering-webapp
+/components/gitpod-messagebus @gitpod-io/engineering-webapp
+/components/gitpod-protocol @gitpod-io/engineering-webapp
+/components/gitpod-protocol/java @gitpod-io/engineering-ide
+/components/ide @gitpod-io/engineering-ide
+/components/ide-proxy @gitpod-io/engineering-ide
+/components/image-builder-api @csweichel @geropl
+/components/image-builder-bob @gitpod-io/engineering-workspace
+/components/image-builder-mk3 @gitpod-io/engineering-workspace
+/components/installation-telemetry @gitpod-io/engineering-self-hosted
+/components/licensor @gitpod-io/engineering-webapp
+/components/local-app-api @csweichel @akosyakov
+/components/local-app @gitpod-io/engineering-ide
+/components/openvsx-proxy @gitpod-io/engineering-ide
+/components/proxy @gitpod-io/engineering-webapp
+/components/registry-facade-api @csweichel @aledbf
+/components/registry-facade @gitpod-io/engineering-workspace
+/components/server @gitpod-io/engineering-webapp
+/components/service-waiter @gitpod-io/engineering-webapp
+/components/supervisor-api @csweichel @akosyakov
+/components/supervisor @gitpod-io/engineering-ide
+/components/workspacekit @gitpod-io/engineering-workspace
+/components/ws-daemon-api @csweichel @aledbf
+/components/ws-daemon @gitpod-io/engineering-workspace
+/components/ws-manager-api @csweichel @aledbf
+/components/ws-manager-bridge-api @csweichel @geropl
+/components/ws-manager-bridge @gitpod-io/engineering-webapp
+/components/ws-manager @gitpod-io/engineering-workspace
+/components/ws-proxy @gitpod-io/engineering-workspace
+/dev/gpctl @gitpod-io/engineering-workspace
+/dev/loadgen @gitpod-io/engineering-workspace
+/installer @gitpod-io/engineering-self-hosted
+/installer/pkg/components/agent-smith @gitpod-io/engineering-workspace
+/installer/pkg/components/blobserve @gitpod-io/engineering-workspace
+/installer/pkg/components/components-webapp @gitpod-io/engineering-webapp
+/installer/pkg/components/components-workspace @gitpod-io/engineering-workspace
+/installer/pkg/components/content-service @gitpod-io/engineering-workspace
+/installer/pkg/components/dashboard @gitpod-io/engineering-webapp
+/installer/pkg/components/ide-proxy @gitpod-io/engineering-ide
+/installer/pkg/components/image-builder-mk3 @gitpod-io/engineering-workspace
+/installer/pkg/components/openvsx-proxy @gitpod-io/engineering-ide
+/installer/pkg/components/proxy @gitpod-io/engineering-webapp
+/installer/pkg/components/registry-facade @gitpod-io/engineering-workspace
+/installer/pkg/components/server @gitpod-io/engineering-webapp
+/installer/pkg/components/server/ide @gitpod-io/engineering-ide
+/installer/pkg/components/workspace @gitpod-io/engineering-workspace
+/installer/pkg/components/workspace/ide @gitpod-io/engineering-ide
+/installer/pkg/components/ws-daemon @gitpod-io/engineering-workspace
+/installer/pkg/components/ws-manager-bridge @gitpod-io/engineering-webapp
+/installer/pkg/components/ws-manager @gitpod-io/engineering-workspace
+/installer/pkg/components/ws-proxy @gitpod-io/engineering-workspace
+/installer/pkg/config/versions @gitpod-io/engineering-ide @gitpod-io/engineering-ide @gitpod-io/engineering-ide @gitpod-io/engineering-ide
+/operations/observability/mixins @gitpod-io/platform
+/operations/observability/mixins/IDE @gitpod-io/engineering-ide
+/operations/observability/mixins/meta @gitpod-io/engineering-webapp
+/operations/observability/mixins/workspace @gitpod-io/engineering-workspace
+/.werft/observability @gitpod-io/platform
+
+#
+# Automation
+# The following files are updated automatically so we don't want to have a specific code-owner
+# A single review is enough. Usually the review will be done by RoboQuat but we don't want to add
+# that user as an owner in case we need to manually approve changes
+#
+/CHANGELOG.md


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

As part of moving to using Github for PR review automation we are going to remove OWNERS in favour of CODEOWNERS (see [RFC](https://www.notion.so/gitpod/Using-GitHub-for-PR-review-automation-35d5e77a7e4b4999a72b5eef2458f636) for details).

This PR adds the CODEOWNERS file. We will remove the OWNERS files once we have switched Tide to use Github Reviews (instead of the approved label, see https://github.com/gitpod-io/gitbot/pull/65).

This can be merged now. The CODEOWNERS will then show up as "suggested" reviewers when you open a PR but reviews from CODEOWNERS are not required (we'll enable that later).

The CODEOWNERS file was generated using the following script and then modified slightly 

```sh
#!/usr/bin/env bash

set -euo pipefail

function format-owner {
    for owner in $*
    do
        case $owner in
            engineering-platform)
                echo -n "@gitpod-io/platform "
                ;;
            engineering-*)
                echo -n "@gitpod-io/$1 "
                ;;
            *)
                echo -n "@$owner "
                ;;
        esac
    done
}

CODEOWNERS_FILE=/workspace/gitpod/.github/CODEOWNERS

rm -f "${CODEOWNERS_FILE}"
touch "${CODEOWNERS_FILE}"

shopt -s globstar nullglob
for OWNERS in **/OWNERS .werft/**/OWNERS; do
    owners="$(yq read --tojson "${OWNERS}" 'approvers' | jq -r 'join(" ")')"
    github_owners="$(format-owner $owners)"
    path="${OWNERS/\/OWNERS/}"
    echo "/$path $github_owners" >> "${CODEOWNERS_FILE}"
done

# Sort file based on path
sort -o "${CODEOWNERS_FILE}" "${CODEOWNERS_FILE}"

# Remoe trailing newlines (introduce by format-owner)
sed -i 's/\s+$//g' "${CODEOWNERS_FILE}"
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/839

## How to test
<!-- Provide steps to test this PR -->

CODEOWNERS is hard to test. Once merged we should see the CODEOWNERS show up as suggested Reviewers when opening PRs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A