### PR TITLE
fix team owner style

### DIFF
--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -30,7 +30,12 @@ export default function ProjectDetail(props: { project: Project, owner: string |
                         </>
                     </Property>
                     :
-                    <Property name="Owner">{`${props.owner} (Team)`}</Property>}
+                    <Property name="Owner">
+                        <>
+                            {props.owner}
+                            <span className="text-gray-400 dark:text-gray-500"> (Team)</span>
+                        </>
+                    </Property>}
             </div>
             <div className="flex w-full mt-6">
                 <Property name="Incremental Prebuilds">{props.project.settings?.useIncrementalPrebuilds ? "Yes" : "No"}</Property>


### PR DESCRIPTION
## Description
Quick style fix for Project Search team owner property.

|BEFORE|AFTER|
| - | - |
| <img width="601" alt="Screenshot 2022-02-03 at 10 34 52" src="https://user-images.githubusercontent.com/8015191/152316986-e353796a-e870-473b-bf21-ab6c2a424976.png"> | <img width="821" alt="Screenshot 2022-02-03 at 10 34 21" src="https://user-images.githubusercontent.com/8015191/152317019-357553f2-673d-4ae7-be14-9c87f3c0975c.png"> |


## Related Issue(s)
no-issue

## How to test
1. Add a project to a team.
2. Go to https://gitpod-staging.com/admin/projects and search for the project. The detail should show the team owner style as in the description.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
