### PR TITLE
Switch to our own libseccomp bindings

### DIFF
--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/workspacekit
 
 go 1.17
 
-replace github.com/seccomp/libseccomp-golang => github.com/kinvolk/libseccomp-golang v0.9.2-0.20201113182948-883917843313
+replace github.com/seccomp/libseccomp-golang => github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000

--- a/components/workspacekit/go.sum
+++ b/components/workspacekit/go.sum
@@ -64,6 +64,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1 h1:Z97P8/nLkIJf7uKQ1hjz3MdIfZyX3t8zWspNFj3Ox5M=
+github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/components/ws-daemon/nsinsider/go.mod
+++ b/components/ws-daemon/nsinsider/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/nsinsider
 
 go 1.17
 
-replace github.com/seccomp/libseccomp-golang => github.com/kinvolk/libseccomp-golang v0.9.2-0.20201113182948-883917843313 // leeway indirect from components/workspacekit:lib
+replace github.com/seccomp/libseccomp-golang => github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1 // leeway indirect from components/workspacekit:lib
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Description
This replaces the libseccomp bindings from kinvolk with our own fork. For rationale see https://github.com/gitpod-io/gitpod/issues/7793#issuecomment-1028298627 and https://github.com/gitpod-io/libseccomp-golang/pull/1

## Related Issue(s)
Fixes #7793

## How to test
Open workspace and execute docker run

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```