### PR TITLE
[ws-manager-api] Fix cluster selection

### DIFF
--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -43,7 +43,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
      */
     public async getStartClusterSets(user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): Promise<IWorkspaceClusterStartSet> {
         const allClusters = await this.source.getAllWorkspaceClusters();
-        const availableClusters = allClusters.filter(c => c.score >= 0 && c.state === "available");
+        const availableClusters = allClusters.filter(c => c.score > 0 && c.state === "available");
 
         const sets = workspaceClusterSets.map(constraints => {
             const r = constraints.constraint(availableClusters, user, workspace, instance);
@@ -62,9 +62,9 @@ export class WorkspaceManagerClientProvider implements Disposable {
                                 return {done: true, value: undefined};
                             }
 
-                            let res = await sets[sets.length - 1].next();
+                            let res = await sets[0].next();
                             if (!!res.done) {
-                                sets.pop();
+                                sets.splice(0, 1);
                                 continue;
                             }
 


### PR DESCRIPTION
## Description
Fixes two issues with the recently introduce cluster selection mechanism that were discovered during testing (thx @laushinka ):
 - ordering of ClusterSets was reversed compared to what is [the comments](https://github.com/gitpod-io/gitpod/blob/b67e3ecdb7e7cc3c1be3f943858a449d74cb6ea2/components/ws-manager-api/typescript/src/constraints.ts#L24-L28) and [in the RFC](https://www.notion.so/gitpod/Workspace-start-cluster-selection-9dceafb290214af891cb31521ca8678d#f433e5eeb88349ffa767b33320c100ae)
 - we would not filter out clusters with `score === 0` ([link](https://github.com/gitpod-io/gitpod/compare/gpl/fix-cluster-precedence?expand=1#diff-69bcfb2991d810011d47c337182d6096cde4f6646da291505e7ba082b80fc0e0L46))
 - (the test logic was flawed)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #7949

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
