### PR TITLE
Added support to send logs from preview-environment to GCP

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -86,7 +86,8 @@ const vmSlices = {
     START_KUBECTL_PORT_FORWARDS: 'Start kubectl port forwards',
     COPY_CERT_MANAGER_RESOURCES: 'Copy CertManager resources from core-dev',
     INSTALL_LETS_ENCRYPT_ISSUER: 'Install Lets Encrypt issuer',
-    KUBECONFIG: 'Getting kubeconfig'
+    KUBECONFIG: 'Getting kubeconfig',
+    EXTERNAL_LOGGING: 'Install credentials to send logs from fluent-bit to GCP'
 }
 
 export function parseVersion(context) {
@@ -352,6 +353,10 @@ export async function build(context, version) {
 
         exec(`kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`, { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true })
         werft.done(vmSlices.INSTALL_LETS_ENCRYPT_ISSUER)
+
+        VM.installFluentBit({namespace: 'default', slice: vmSlices.EXTERNAL_LOGGING})
+        werft.done(vmSlices.EXTERNAL_LOGGING)
+
 
         issueMetaCerts(PROXY_SECRET_NAME, "default", domain, withVM)
         werft.done('certificate')

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -45,6 +45,9 @@ pod:
   - name: harvester-vm-ssh-keys
     secret:
       secretName: harvester-vm-ssh-keys
+  - name: fluent-bit-external
+    secret:
+      secretName: fluent-bit-external
   # - name: deploy-key
   #   secret:
   #     secretName: deploy-key
@@ -98,6 +101,8 @@ pod:
       mountPath: /mnt/secrets/harvester-kubeconfig
     - name: harvester-vm-ssh-keys
       mountPath: /mnt/secrets/harvester-vm-ssh-keys
+    - name: fluent-bit-external
+      mountPath: /mnt/fluent-bit-external
     # - name: deploy-key
     #   mountPath: /mnt/secrets/deploy-key
     #   readOnly: true

--- a/.werft/vm/charts/fluentbit/values.yaml
+++ b/.werft/vm/charts/fluentbit/values.yaml
@@ -1,0 +1,20 @@
+config:
+  outputs: |
+    [OUTPUT]
+        Name stackdriver
+        Match *
+
+env:
+  - name: GOOGLE_SERVICE_CREDENTIALS
+    value: /gcp/credentials.json
+
+
+extraVolumes:
+  - name: fluent-bit-external
+    secret:
+      secretName: fluent-bit-external
+      defaultMode: 420
+
+extraVolumeMounts:
+  - name: fluent-bit-external
+    mountPath: /gcp

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -179,3 +179,13 @@ export function startSSHProxy(options: { name: string, slice: string }) {
 export function stopKubectlPortForwards() {
     exec(`sudo killall kubectl || true`)
 }
+
+/**
+ * Install Fluent-Bit sending logs to GCP
+ */
+export function installFluentBit(options: {namespace: string, slice: string}) {
+    exec(`kubectl create secret generic fluent-bit-external --save-config --dry-run=client --from-file=credentials.json=/mnt/fluent-bit-external/credentials.json -o yaml | kubectl apply -n ${options.namespace} -f -`, { slice: options.slice, dontCheckRc: true})
+    exec(`helm3 repo add fluent https://fluent.github.io/helm-charts`, { slice: options.slice, dontCheckRc: true})
+    exec(`helm3 repo update`, { slice: options.slice, dontCheckRc: true})
+    exec(`helm3 upgrade --install fluent-bit fluent/fluent-bit -n ${options.namespace} -f .werft/vm/charts/fluentbit/values.yaml`, { slice: options.slice, dontCheckRc: true})
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds `fluent-bit` to preview-environment VMs sending logs to GCP.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/640

## How to test
<!-- Provide steps to test this PR -->
- checkout a new branch
- push a commit creating a new VM
- check GCP logging by searching for `jsonPayload.kubernetes.host="<NAMESPACE>"`

The NAMESPACE is the normalized branch name like we already do it for domains. In this case it is "wth-prev-log".

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
