### PR TITLE
[code] update stable to 1.64

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -356,7 +356,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-dc3be5ab7e8dd88d7b3d9c40fa8a2b2130106c2d"
+      stableVersion: "commit-adaa5e19c625d55704417e59083d0b38a5c0f0f4"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/installer/pkg/components/workspace/ide/constants.go
+++ b/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-dc3be5ab7e8dd88d7b3d9c40fa8a2b2130106c2d" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-adaa5e19c625d55704417e59083d0b38a5c0f0f4" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates stable VS Code Web to 1.64
VSCode Endgame: https://github.com/microsoft/vscode/issues/141298

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Select vscode stable in dashboard settings
- Start a workspace.
- Use about dialog to check that version is 1.64.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```