### PR TITLE
Update dev-environment image for gpctl changes

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -68,7 +68,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/clean-up-werft-build-nodes.yaml
+++ b/.werft/clean-up-werft-build-nodes.yaml
@@ -16,7 +16,7 @@ pod:
         type: Directory
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-dev-image-update.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update dev-environment image to include latest gpctl created with PR https://github.com/gitpod-io/gitpod/pull/7976

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # NA

## How to test
<!-- Provide steps to test this PR -->
I tested this by running `gpctl` from the image against `staging-main` namespace in `core-dev` cluster. The output of ws-manager bridge:
```json
{"component":"ws-manager-bridge","severity":"INFO","time":"2022-02-04T11:27:35.568Z","message":"requested clusters.list","payload":{"clientIP":"127.0.0.1:41442","clientName":"gpctl:gitpod@1abdd41bb0a1","userAgent":"grpc-go/1.39.1"}}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
