### PR TITLE
[ws-manager-api] Minor cluster selection refactoring

### DIFF
--- a/components/gitpod-protocol/src/permission.ts
+++ b/components/gitpod-protocol/src/permission.ts
@@ -35,6 +35,20 @@ export interface Role {
     permissions: PermissionName[],
 }
 
+export namespace RolesOrPermissions {
+    export function toPermissionSet(rolesOrPermissions: RoleOrPermission[] = []): Set<PermissionName> {
+        const permissions = new Set<PermissionName>();
+        for (const rop of rolesOrPermissions) {
+            if (Permission.is(rop)) {
+                permissions.add(rop);
+            } else if (RoleName.is(rop)) {
+                Role.getByName(rop).permissions.forEach(p => permissions.add(p));
+            }
+        }
+        return permissions;
+    };
+}
+
 export namespace Permission {
     /** The permission to monitor the (live) state of a Gitpod installation */
     export const MONITOR: PermissionName = "monitor";
@@ -66,9 +80,7 @@ export namespace Permission {
     }
 
     export const all = (): PermissionName[] => {
-        return Object.keys(Permission)
-            .map(k => (Permission as any)[k])
-            .filter(k => typeof(k) === 'string');
+        return Object.keys(Permissions) as PermissionName[];
     };
 }
 

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -52,12 +52,25 @@ export namespace TLSConfig {
 export type WorkspaceClusterWoTLS = Omit<WorkspaceCluster, "tls">;
 export type WorkspaceManagerConnectionInfo = Pick<WorkspaceCluster, "name" | "url" | "tls">;
 
-export type AdmissionConstraint = AdmissionConstraintFeaturePreview | AdmissionConstraintHasRole | AdmissionConstraintHasUserLevel | AdmissionConstraintHasMoreResources;
+export type AdmissionConstraint = AdmissionConstraintFeaturePreview | AdmissionConstraintHasPermission | AdmissionConstraintHasUserLevel | AdmissionConstraintHasMoreResources;
 export type AdmissionConstraintFeaturePreview = { type: "has-feature-preview" };
-export type AdmissionConstraintHasRole = { type: "has-permission", permission: PermissionName };
+export type AdmissionConstraintHasPermission = { type: "has-permission", permission: PermissionName };
 export type AdmissionConstraintHasUserLevel = { type: "has-user-level", level: string };
 export type AdmissionConstraintHasMoreResources = { type: "has-more-resources" };
 
+export namespace AdmissionConstraint {
+    export function is(o: any): o is AdmissionConstraint {
+        return !!o
+            && 'type' in o;
+    }
+    export function isHasPermissionConstraint(o: any): o is AdmissionConstraintHasPermission {
+        return is(o)
+            && o.type === "has-permission";
+    }
+    export function hasPermission(ac: AdmissionConstraint, permission: PermissionName): boolean {
+        return isHasPermissionConstraint(ac) && ac.permission === permission;
+    }
+}
 
 export const WorkspaceClusterDB = Symbol("WorkspaceClusterDB");
 export interface WorkspaceClusterDB {

--- a/components/server/src/user/authorization-service.ts
+++ b/components/server/src/user/authorization-service.ts
@@ -6,7 +6,7 @@
 
 import { injectable } from "inversify";
 
-import { Permission, RoleOrPermission, RoleName, PermissionName, Role } from "@gitpod/gitpod-protocol/lib/permission";
+import { RoleOrPermission, PermissionName, RolesOrPermissions } from "@gitpod/gitpod-protocol/lib/permission";
 import { User } from "@gitpod/gitpod-protocol";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 
@@ -20,26 +20,11 @@ export class AuthorizationServiceImpl implements AuthorizationService {
     public hasPermission(user: User, permission: PermissionName): boolean {
         const rop: RoleOrPermission[] = user.rolesOrPermissions || [];
         try {
-            const permissions = this.calculatePermissions(rop);
-            return permissions.includes(permission);
+            const permissions = RolesOrPermissions.toPermissionSet(rop);
+            return permissions.has(permission);
         } catch (err) {
             log.error({ userId: user.id }, 'Invalid role or permission', { rolesOrPermissions: rop });
             return false;
         }
     }
-
-    protected calculatePermissions = (rolesOrPermissions: RoleOrPermission[]): PermissionName[] => {
-        const permissions: PermissionName[] = [];
-        for (const rop of rolesOrPermissions) {
-            if (Permission.is(rop)) {
-                permissions.push(rop as PermissionName);
-            } else if (RoleName.is(rop)) {
-                Role.getByName(rop).permissions.forEach(p => permissions.push(p));
-            }
-        }
-
-        const result: PermissionName[] = [];
-        new Set(permissions).forEach(e => result.push(e));
-        return result;
-    };
 }

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc && cp -f src/*.js src/*d.ts lib",
     "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
-    "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'"
+    "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
+    "test:brk": "yarn test --inspect-brk"
   },
   "dependencies": {
     "@gitpod/content-service": "0.1.5",

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -12,7 +12,7 @@ import { WorkspaceClusterWoTLS, WorkspaceManagerConnectionInfo } from '@gitpod/g
 import * as grpc from "@grpc/grpc-js";
 import { inject, injectable, optional } from 'inversify';
 import { WorkspaceManagerClientProviderCompositeSource, WorkspaceManagerClientProviderSource } from "./client-provider-source";
-import { ExtendedUser, workspaceClusterSets } from "./constraints";
+import { ExtendedUser, workspaceClusterSetsAuthorized } from "./constraints";
 import { WorkspaceManagerClient } from './core_grpc_pb';
 import { linearBackoffStrategy, PromisifiedWorkspaceManagerClient } from "./promisified-client";
 
@@ -45,7 +45,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
         const allClusters = await this.source.getAllWorkspaceClusters();
         const availableClusters = allClusters.filter(c => c.score > 0 && c.state === "available");
 
-        const sets = workspaceClusterSets.map(constraints => {
+        const sets = workspaceClusterSetsAuthorized.map(constraints => {
             const r = constraints.constraint(availableClusters, user, workspace, instance);
             if (!r) {
                 return;

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -7,7 +7,7 @@
 import { WorkspaceDB } from '@gitpod/gitpod-db/lib/workspace-db';
 import { Queue } from '@gitpod/gitpod-protocol';
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
-import { WorkspaceCluster, WorkspaceClusterDB, WorkspaceClusterState, TLSConfig, AdmissionConstraint, AdmissionConstraintHasRole, WorkspaceClusterWoTLS, AdmissionConstraintHasUserLevel, AdmissionConstraintHasMoreResources } from '@gitpod/gitpod-protocol/lib/workspace-cluster';
+import { WorkspaceCluster, WorkspaceClusterDB, WorkspaceClusterState, TLSConfig, AdmissionConstraint, AdmissionConstraintHasPermission, WorkspaceClusterWoTLS, AdmissionConstraintHasUserLevel, AdmissionConstraintHasMoreResources } from '@gitpod/gitpod-protocol/lib/workspace-cluster';
 import {
     ClusterServiceService,
     ClusterState,
@@ -182,7 +182,7 @@ export class ClusterService implements IClusterServiceServer {
                                     case "has-feature-preview":
                                         return false;
                                     case "has-permission":
-                                        if (v.permission === (c as AdmissionConstraintHasRole).permission) {
+                                        if (v.permission === (c as AdmissionConstraintHasPermission).permission) {
                                             return false;
                                         }
                                         break;
@@ -318,7 +318,7 @@ function mapAdmissionConstraint(c: GRPCAdmissionConstraint | undefined): Admissi
             return;
         }
 
-        return <AdmissionConstraintHasRole>{type: "has-permission", permission};
+        return <AdmissionConstraintHasPermission>{type: "has-permission", permission};
     }
     if (c.hasHasUserLevel()) {
         const level = c.getHasUserLevel();


### PR DESCRIPTION
## Description
After sleeping another night over the cluster selection implementation I had two gripes with it:
 1. cluster authorization is a [more](https://github.com/gitpod-io/gitpod/compare/gpl/cluster-selection-permissions?expand=1#diff-a6b16d5a1259e7e5284f0194a3e49ab4481fe395723eacc8d4570e7a6bfb9b59L98-L101) or [less](https://github.com/gitpod-io/gitpod/compare/gpl/cluster-selection-permissions?expand=1#diff-a6b16d5a1259e7e5284f0194a3e49ab4481fe395723eacc8d4570e7a6bfb9b59L117-L121) an "optimization" of the precedence implementation.
 This is now [implemented in a central constraint](https://github.com/gitpod-io/gitpod/pull/8034/files#diff-a6b16d5a1259e7e5284f0194a3e49ab4481fe395723eacc8d4570e7a6bfb9b59R140-R160), and [applied to every ClusterSet][(https://github.com/gitpod-io/gitpod/compare/gpl/cluster-selection-permissions?expand=1#diff-69bcfb2991d810011d47c337182d6096cde4f6646da291505e7ba082b80fc0e0R49-R54](https://github.com/gitpod-io/gitpod/pull/8034/files#diff-a6b16d5a1259e7e5284f0194a3e49ab4481fe395723eacc8d4570e7a6bfb9b59R67-R76)).
 This has the additional benefit that precedence and authorization are nicely decoupled and can be tested more easily.
 
 2. `constraintNewWorkspaceCluster` was somewhat of a special case because it was the only permission relevant for precedence so far ([while filtering _all_ permissions](https://github.com/gitpod-io/gitpod/compare/gpl/cluster-selection-permissions?expand=1#diff-a6b16d5a1259e7e5284f0194a3e49ab4481fe395723eacc8d4570e7a6bfb9b59L104)). This is now generalized into [`constraintHasPermissions`](https://github.com/gitpod-io/gitpod/compare/gpl/cluster-selection-permissions?expand=1#diff-a6b16d5a1259e7e5284f0194a3e49ab4481fe395723eacc8d4570e7a6bfb9b59R113-R117). With the change above this means all permissions may serve as qualifier for authorization (match cluster & user), while also, independently can serve as marker for precedence.

I wrote this PR to express my thoughts, so happy to discuss if others have other views on how this should evolve! :upside_down_face: :basketball: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - `yarn test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
