### PR TITLE
Fix code-nightly workflow typo and upgrade leeway

### DIFF
--- a/.github/workflows/code-nightly.yaml
+++ b/.github/workflows/code-nightly.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: downlaod leeway
-        run: cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.8/leeway_0.2.8_Linux_x86_64.tar.gz | sudo tar xz
+      - name: Download leeway
+        run: cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.16/leeway_0.2.16_Linux_x86_64.tar.gz | sudo tar xz
       - name: Auth Google Cloud SDK
         uses: google-github-actions/auth@v0
         with:


### PR DESCRIPTION
## Description
Fixes a typo and upgrades leeway to its latest version: [0.2.16
](https://github.com/gitpod-io/leeway/releases/tag/v0.2.16).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NONE

## How to test
<!-- Provide steps to test this PR -->
1. Run the workflow via a `workflow_dispatch` from the Actions tab, targeting the `.ft/code-nightly-yml-typo` branch.
2. Check that all steps of the workflow are consistently named (capitalized, no typos)
3. Make sure the workflow succeeds, to make sure upgrading leeway didn't break anything.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
