### PR TITLE
.werft: Add honeycomb trace as job result

### DIFF
--- a/.werft/util/werft.ts
+++ b/.werft/util/werft.ts
@@ -107,6 +107,11 @@ export class Werft {
     }
 
     public endAllSpans() {
+        const traceID = this.rootSpan.spanContext().traceId
+        const nowUnix =  Math.round(new Date().getTime() / 1000);
+        // At the moment we're just looking for traces in a 30 minutes timerange with the specific traceID
+        // A smarter approach would be to get a start timestamp from tracing.Initialize()
+        exec(`werft log result -d "Honeycomb trace" -c github-check-honeycomb-trace url "https://ui.honeycomb.io/gitpod/datasets/werft/trace?trace_id=${traceID}&trace_start_ts=${nowUnix - 1800}&trace_end_ts=${nowUnix + 5}"`);
         this.endPhase()
         this.rootSpan.end()
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Hmmm, unfortunately, this one doesn't seem to be possible at the moment.

After starting a [job that adds the result](https://werft.gitpod-dev.com/job/gitpod-build-arthursens-werft-add-honeycomb-7996.4/results), the result URL redirects us to [a non-existing trace](https://ui.honeycomb.io/gitpod/datasets/werft/trace/1afedf4da7b133862fde27257bbfa9e7?span=c24c3da57e6f51b6). Since [the trace is queriable using the UI](https://ui.honeycomb.io/gitpod/datasets/werft/result/xQiEs99h58j) we know it was ingested without problems, however, after[ looking into the trace](https://ui.honeycomb.io/gitpod/datasets/werft/result/wdPLAyCjbNC/trace/iuw1mpetckW?span=c24c3da57e6f51b6) we notice that Honeycomb generates a random identifier for each trace, making it impossible to build a stable URL for our jobs :(


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Should have fixed #7996 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
