### PR TITLE
Add environment variable name/value length validation in UI

### DIFF
--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -155,11 +155,17 @@ export default function EnvVars() {
         if (name.trim() === '') {
             return 'Name must not be empty.';
         }
+        if (name.length > 255) {
+            return 'Name too long. Maximum name length is 255 characters.';
+        }
         if (!/^[a-zA-Z0-9_]*$/.test(name)) {
             return 'Name must match /[a-zA-Z_]+[a-zA-Z0-9_]*/.';
         }
         if (variable.value.trim() === '') {
             return 'Value must not be empty.';
+        }
+        if (variable.value.length > 32768) {
+            return 'Value too long. Maximum value length is 32768 characters.';
         }
         if (pattern.trim() === '') {
             return 'Scope must not be empty.';


### PR DESCRIPTION
Also, decrease maxlen for value from ~64k*3/4 to a nice round 32k.

## Description
On variable save, we now validate:
- name len is shorter than 256
- value len is shorter than 32k+1

and inform the user of the error, instead of silently failing.

The 32k limit might be worth some discussion. The db limit is mysql's `TEXT` max of 64k, but that's after encryption and base64 encoding, resulting with a real current limit of about ~48k. I chose 32k because it looks nicer :laughing:.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8045

## How to test
1. Try to create a variable with either name longer than 255 chars or value longer than 32768 chars.
2. Create a new variable, then try updating the name and value with strings longer than the limits above.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add user environment variable name length and value length validation in settings UI modal.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No update.
