### PR TITLE
Fixed payment binding

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -900,7 +900,7 @@ export async function deployToDevWithHelm(deploymentConfig: DeploymentConfig, wo
             flags += ` -f ../.werft/values.payment.yaml`;
             exec(`cp /mnt/secrets/payment-provider-config/providerOptions payment-core-dev-options.json`);
             flags += ` --set payment.chargebee.providerOptionsFile=payment-core-dev-options.json`;
-            exec(`cp /mnt/secrets/payment-webhook-config/webhook payment-core-dev-webhook.json`);
+            exec(`cp /mnt/secrets/payment-webhook-config/license payment-core-dev-webhook.json`);
             flags += ` --set components.paymentEndpoint.webhookFile="payment-core-dev-webhook.json"`;
         }
         return flags;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The secret containing the payment credentials can not be copied to a preview-environment.
Symptom:
```
- [x] with-helm=true
- [x] with-payment=true
fails with:
cp: cannot stat '/mnt/secrets/payment-webhook-config/webhook': No such file or directory
[deploy|FAIL] Error: cp /mnt/secrets/payment-webhook-config/webhook payment-core-dev-webhook.json exit with non-zero status code
```
See https://werft.gitpod-dev.com/job/gitpod-build-jx-better-team-subscriptions.3/raw

This solves the problem by using the correct filename.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Either check https://werft.gitpod-dev.com/job/gitpod-build-wth-fix-payment.0/raw or push this commit to a new branch and check if the payment endpoint is working correctly.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
