### PR TITLE
[workspacekit] make /etc/hosts modifiable

### DIFF
--- a/components/workspacekit/cmd/rings_test.go
+++ b/components/workspacekit/cmd/rings_test.go
@@ -28,7 +28,6 @@ func TestFindBindMountCandidates(t *testing.T) {
 				"/dev",
 				"/sys",
 				"/workspace",
-				"/etc/hosts",
 				"/etc/hostname",
 			},
 		},
@@ -39,7 +38,6 @@ func TestFindBindMountCandidates(t *testing.T) {
 			Expectation: []string{
 				"/dev",
 				"/sys",
-				"/etc/hosts",
 				"/etc/hostname",
 			},
 		},
@@ -56,7 +54,6 @@ func TestFindBindMountCandidates(t *testing.T) {
 				"/dev",
 				"/sys",
 				"/workspace",
-				"/etc/hosts",
 				"/etc/hostname",
 				"/custom-certs",
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Recently we introduced workspace-wide network namespace #6409  for all workspace
This causes the network devices seen in the workspace to be independent of the workspace pod, and the hostname is expected to resolve to an accessible IP address, so it makes sense to point to 127.0.0.1

This does not cause other problems, instead the original value (workspace pod ip) causes some programs to not work properly because it not accessible

And make /ect/hosts editable make sense for users they can customize hosts in .gitpod.yaml or dotfiles

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7981

## How to test
<!-- Provide steps to test this PR -->
this contain 2 test case
1. ensure /etc/hosts modifiable and check the hostname record is point to 127.0.0.1
    1.1 Open a workspace and edit /etc/hosts

2. ensure resolve #7981
    2.1 start [petclinic](https://github.com/gitpod-io/spring-petclinic) with IntelliJ
    2.2 change config flag to "-Dcom.sun.management.jmxremote.local.only=true"
    2.3 launch run configuration
    2.4 it should work without any jmx security errors

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
