### PR TITLE
[ci] Fix JB Nightly GitHub Action

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -20,8 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: downlaod leeway
-        run: cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.16/leeway_0.2.16_Linux_x86_64.tar.gz | sudo tar xz
+      - name: Download leeway
+        run: cd /usr/local/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.16/leeway_0.2.16_Linux_x86_64.tar.gz | tar xz
+      - name: Download golangci-lint
+        run: cd /usr/local && curl -fsSL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.42.0
+      - name: Download GoKart
+        run: cd /usr/local/bin && curl -L https://github.com/praetorian-inc/gokart/releases/download/v0.3.0/gokart_0.3.0_linux_x86_64.tar.gz | tar xzv gokart
       - name: Auth Google Cloud SDK
         uses: google-github-actions/auth@v0
         with:
@@ -29,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: '11'
+          java-version: "11"
       - name: Leeway build
         uses: google-github-actions/setup-gcloud@v0
         with:


### PR DESCRIPTION
## Description

This PR fixes the [JB Nightly GitHub Action](https://github.com/gitpod-io/gitpod/actions/runs/1802105838).

"GoKart" and "golangci-lint" were required to run the CI, as now [we have this Go lib listed as a dependency](https://github.com/gitpod-io/gitpod/commit/13862fed89fc784734afa7a9cd15c9346f5c5277#diff-4defccbad55f23ea3f1d8a743f62a8d6fe01adaf9daf183b82190b8f2ddcb034R12), which causes [leeway to execute Go lintCommand](https://github.com/gitpod-io/gitpod/blob/f87ae97b9a8e17259b16772ebe3c3339f9b4c6a9/WORKSPACE.yaml#L25).

## Related Issue(s)

NONE

## How to test

I think the only way to test it is by adding the following in [jetbrains-auto-update.yml](https://github.com/gitpod-io/gitpod/blob/fc2d38ac48d767e71d996c518bfe74534ce5c6c1/.github/workflows/jetbrains-auto-update.yml#L2):

```yml
  push:
    branches: [vn/gh-action-fix-jetbrains-auto-update]
```

I did it, and you can see that the action successfully ran with these changes here: https://github.com/gitpod-io/gitpod/runs/5090958393 - after that, I removed the code and force pushed this branch.

## Release Notes
```release-note
NONE
```
## Documentation

NONE
