### PR TITLE
[werft] add reuse last port and include nodePort for find free port

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { exec, ExecOptions } from './util/shell';
 import { Werft } from './util/werft';
-import { waitForDeploymentToSucceed, wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespaceObjects, findFreeHostPorts, createNamespace, helmInstallName } from './util/kubectl';
+import { waitForDeploymentToSucceed, wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespaceObjects, findFreeHostPorts, createNamespace, helmInstallName, findLastHostPort } from './util/kubectl';
 import { issueCertficate, installCertficate, IssueCertificateParams, InstallCertificateParams } from './util/certs';
 import { reportBuildFailureInSlack } from './util/slack';
 import * as semver from 'semver';
@@ -427,14 +427,19 @@ export async function deployToDevWithInstaller(deploymentConfig: DeploymentConfi
     const { version, destname, namespace, domain, monitoringDomain, url, withObservability, withVM } = deploymentConfig;
 
     // find free ports
-    werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Check for some free ports.");
-    const [wsdaemonPortMeta, registryNodePortMeta, nodeExporterPort] = findFreeHostPorts([
-        { start: 10000, end: 11000 },
-        { start: 30000, end: 31000 },
-        { start: 31001, end: 32000 },
-    ], metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }));
+    werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Find last ports");
+    let wsdaemonPortMeta = findLastHostPort(namespace, 'ws-daemon', metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }))
+    let registryNodePortMeta = findLastHostPort(namespace, 'registry-facade', metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }))
+
+    if (isNaN(wsdaemonPortMeta) || isNaN(wsdaemonPortMeta)) {
+        werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Can't reuse, check for some free ports.");
+        [wsdaemonPortMeta, registryNodePortMeta] = findFreeHostPorts([
+            { start: 10000, end: 11000 },
+            { start: 30000, end: 31000 },
+        ], metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }));
+    }
     werft.log(installerSlices.FIND_FREE_HOST_PORTS,
-        `wsdaemonPortMeta: ${wsdaemonPortMeta}, registryNodePortMeta: ${registryNodePortMeta}, and nodeExporterPort ${nodeExporterPort}.`);
+        `wsdaemonPortMeta: ${wsdaemonPortMeta}, registryNodePortMeta: ${registryNodePortMeta}.`);
     werft.done(installerSlices.FIND_FREE_HOST_PORTS);
 
     // clean environment state


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[werft] add reuse last port and include nodePort for find free port
I think this is root cause core-dev start workspace loop forever, and stuck in Allocating Resources
I notice some services nodePort and registry-facad's hostPost are same
start workspace, then pull image failed ....

this PR also add a function to reuse the last port, in order to save time from build and avoid find free port every time

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
