### PR TITLE
[supervisor] move reaper to another process

### DIFF
--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "init the supervisor",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Init(ServiceName, Version, true, false)
+		// Because we're reaping with PID -1, we'll catch the child process for
+		// which we've missed the notification anyways.
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGCHLD)
+
+		// The reaper can be turned into a terminating reaper by writing true to this channel.
+		// When in terminating mode, the reaper will send SIGTERM to each child that gets reparented
+		// to us and is still running. We use this mechanism to send SIGTERM to a shell child processes
+		// that get reparented once their parent shell terminates during shutdown.
+		var terminating bool
+
+		reaper := func() {
+			for range sigs {
+				for {
+					// wait on the process, hence remove it from the process table
+					pid, err := unix.Wait4(-1, nil, 0, nil)
+					// if we've been interrupted, try again until we're done
+					for err == syscall.EINTR {
+						pid, err = unix.Wait4(-1, nil, 0, nil)
+					}
+					// The calling process does not have any unwaited-for children. Let's wait for a SIGCHLD notification.
+					if err == unix.ECHILD {
+						break
+					}
+					if err != nil {
+						log.WithField("pid", pid).WithError(err).Debug("cannot call waitpid() for re-parented child")
+					}
+					if !terminating {
+						continue
+					}
+					proc, err := os.FindProcess(pid)
+					if err != nil {
+						log.WithField("pid", pid).WithError(err).Debug("cannot find re-parented process")
+						continue
+					}
+					err = proc.Signal(syscall.SIGTERM)
+					if err != nil {
+						if !strings.Contains(err.Error(), "os: process already finished") {
+							log.WithField("pid", pid).WithError(err).Debug("cannot send SIGTERM to re-parented process")
+						}
+						continue
+					}
+					log.WithField("pid", pid).Debug("SIGTERM'ed reparented child process")
+				}
+			}
+		}
+		go reaper()
+
+		supervisorPath, err := os.Executable()
+		if err != nil {
+			supervisorPath = "/.supervisor/supervisor"
+		}
+		runCommand := exec.Command(supervisorPath, "run")
+		runCommand.Args[0] = "supervisor"
+		runCommand.Stdin = os.Stdin
+		runCommand.Stdout = os.Stdout
+		runCommand.Stderr = os.Stderr
+		runCommand.Env = os.Environ()
+		err = runCommand.Start()
+		if err != nil {
+			log.WithError(err).Error("supervisor run start error")
+			return
+		}
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			err := runCommand.Wait()
+			if err != nil && !(strings.Contains(err.Error(), "signal: interrupt") || strings.Contains(err.Error(), "no child processes")) {
+				log.WithError(err).Error("supervisor run error")
+				return
+			}
+			wg.Done()
+		}()
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		s := <-sigChan
+		terminating = true
+		_ = runCommand.Process.Signal(s)
+		wg.Wait()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Note: this is part 1, This PR only contain `supervisor init` command

This PR move reaper to `supervisor init` in order to avoid `no child process` error

This reaper not only reap zombie processes (where the parent process is not pid 1 and the parent process is dead), but also reap processes (this part will result in `no child process`)
the root cause is reaper is running in a goroutine, it will cause resource competition with `execCommand.Wait()` or other wait function

There are many places in our code where the error is ignored by determining whether the error is `no child process`, but this can mislead our judgment, and we have no way of knowing whether the process exited unexpectedly or normally

There are other alternative solutions
1. start an additional small init process (like tini) when the supervisor starts a new process and set PR_GET_CHILD_SUBREAPER so that this init process is responsible for reap its child processes
👍 No changes to the supervisor structure
👎 The number of processes will become larger and the process tree will be ugly

2. give a random delay when the supervisor receives a SIGCHLD, hoping to avoid resource competition
👍  minimal changes
👎  this is not a cure, but just a reduction of probability

3. scan all /proc/[pid]/stat when a SIGCHLD is received, and recycle only when a zombie process is identified
👍 No change to the supervisor structure
👎 slower recovery efficiency


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate #8056 

## How to test
<!-- Provide steps to test this PR -->
This part don't need test, please use this PR for test #8114 and #8115
~~1. start a workspace~~
~~2. watch the log~~
~~3. stop a workspace~~
~~4. see there are no `no child process` any more~~
~~5. check the stop log, the behavior should be same with before~~

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
