### PR TITLE
Update VS Code References (settings sync schema, leeway)

### DIFF
--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
@@ -85,7 +85,7 @@ export class CodeSyncResourceDBSpec {
         let manifest = await this.db.getManifest(this.userId);
         expect(manifest).to.deep.eq(<IUserDataManifest>{
             session: this.userId,
-            latest: {}
+            latest: {},
         });
 
         let machinesRev = await this.db.insert(this.userId, 'machines', async () => { });
@@ -94,7 +94,7 @@ export class CodeSyncResourceDBSpec {
             session: this.userId,
             latest: {
                 machines: machinesRev
-            }
+            },
         });
 
         let extensionsRev = await this.db.insert(this.userId, SyncResource.Extensions, async () => { });
@@ -104,7 +104,7 @@ export class CodeSyncResourceDBSpec {
             latest: {
                 machines: machinesRev,
                 extensions: extensionsRev
-            }
+            },
         });
 
         machinesRev = await this.db.insert(this.userId, 'machines', async () => { });
@@ -114,7 +114,7 @@ export class CodeSyncResourceDBSpec {
             latest: {
                 machines: machinesRev,
                 extensions: extensionsRev
-            }
+            },
         });
     }
 

--- a/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
@@ -7,7 +7,7 @@
 import { Entity, Column, PrimaryColumn, Index } from "typeorm";
 import { TypeORM } from "../typeorm";
 
-// should be aligned with https://github.com/gitpod-io/vscode/blob/75c71b49cc25554adc408e63b876b76dcc984bc1/src/vs/platform/userDataSync/common/userDataSync.ts#L113-L156
+// should be aligned with https://github.com/gitpod-io/openvscode-server/blob/a9286bef87ed21bbf108371aa1f62d9a5bc48fc4/src/vs/platform/userDataSync/common/userDataSync.ts#L110-L160
 export interface IUserData {
     ref: string;
     content: string | null;
@@ -17,14 +17,20 @@ export const enum SyncResource {
     Settings = 'settings',
     Keybindings = 'keybindings',
     Snippets = 'snippets',
+    Tasks = 'tasks',
     Extensions = 'extensions',
-    GlobalState = 'globalState'
+    GlobalState = 'globalState',
 }
-export const ALL_SYNC_RESOURCES: SyncResource[] = [SyncResource.Settings, SyncResource.Keybindings, SyncResource.Snippets, SyncResource.Extensions, SyncResource.GlobalState];
+export const ALL_SYNC_RESOURCES: SyncResource[] = [SyncResource.Settings, SyncResource.Keybindings, SyncResource.Snippets, SyncResource.Tasks, SyncResource.Extensions, SyncResource.GlobalState];
 
 export interface IUserDataManifest {
-    latest: Record<ServerResource, string>
-    session: string;
+	readonly latest?: Record<ServerResource, string>;
+	readonly session: string;
+    /**
+     * This property reflects a weak ETag for caching code sync responses,
+     * in the server, this is send in the Etag header and it's calculated by Express.js or we can override it manually.
+     */
+	//readonly ref: string;
 }
 
 export type ServerResource = SyncResource | 'machines';

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -9,7 +9,7 @@ ARG CODE_COMMIT
 RUN mkdir /gp-code \
     && cd /gp-code \
     && git init \
-    && git remote add origin https://github.com/gitpod-io/vscode \
+    && git remote add origin https://github.com/gitpod-io/openvscode-server \
     && git fetch origin $CODE_COMMIT --depth=1 \
     && git reset --hard FETCH_HEAD
 WORKDIR /gp-code
@@ -34,7 +34,7 @@ ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
 RUN mkdir /gp-code \
     && cd /gp-code \
     && git init \
-    && git remote add origin https://github.com/gitpod-io/vscode \
+    && git remote add origin https://github.com/gitpod-io/openvscode-server \
     && git fetch origin $CODE_COMMIT --depth=1 \
     && git reset --hard FETCH_HEAD
 WORKDIR /gp-code

--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -114,10 +114,10 @@ export class CodeSyncService {
                 return;
             }
             const manifest = await this.db.getManifest(req.user.id);
-            if (!manifest.latest.extensions) {
+            if (manifest.latest && !manifest.latest.extensions) {
                 manifest.latest.extensions = fromTheiaRev;
             }
-            if (!manifest.latest.settings) {
+            if (manifest.latest && !manifest.latest.settings) {
                 manifest.latest.settings = fromTheiaRev;
             }
             res.json(manifest);


### PR DESCRIPTION
## Description
This PR does two things:
1. It updates the Settings Sync types and schema, including the pointer to VS Code's code base
	a. Specifically, user tasks can be synced with this PR 
2. It migrates the old name of our VS Code repo -> `vscode` to the new one -> `openvscode-server`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up to #8048 

## How to test
Make sure user tasks are synced correctly. In order to do that, do the following:
1. Open a workspace in the preview environment, for instance [the Node.js example](https://ft-update-vscode-refs.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-typescript-node).
2. Open the command pallete (<kbd>F1</kbd>) and execute <kbd>Tasks: Open User Tasks</kbd>
3. A JSON file will open in your editor with a default config, we need to alter this config, here is an example one:
	  ```json
	  {
	      "version": "2.0.0",
	      "tasks": [
	          {
	              "label": "Test sync",
	              "type": "shell",
	              "command": "echo 'Hewo Gitpod (ᵘʷᵘ)'",
	          }
	      ]
	  }
	  ```
4. Open another workspace and repeat step two; the task should be synced in your new workspace and executable via <kbd>Tasks: Run Task</kbd> (your task will be listed first). Then confirm by selecting <kbd>Continue without scanning the task output</kbd>.

## Release Notes
```release-note
NONE
```
