### PR TITLE
[observability] add cross-teams codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,6 +71,7 @@
 /operations/observability/mixins/IDE @gitpod-io/engineering-ide
 /operations/observability/mixins/meta @gitpod-io/engineering-webapp
 /operations/observability/mixins/workspace @gitpod-io/engineering-workspace
+/operations/observability/mixins/cross-teams @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/platform
 /.werft/observability @gitpod-io/platform
 
 #


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We are [unable to merge a PR](https://github.com/gitpod-io/gitpod/pull/7931/files), I think, because the cross-teams sub-folder lacks owners.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
n/a

## How to test
<!-- Provide steps to test this PR -->
See how [this PR has not merged](https://github.com/gitpod-io/gitpod/pull/7931/files), Tide says `Not mergeable.` in the check.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
