### PR TITLE
[jb][gw] allow to install without restart

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
  See License-AGPL.txt in the project root for license information.
 -->
 
-<idea-plugin require-restart="true">
+<idea-plugin require-restart="false">
     <id>io.gitpod.jetbrains.gateway</id>
     <name>Gitpod Gateway</name>
     <vendor>Gitpod</vendor>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

JB folks worked on dynamic installation of GW plugin, they would like to test it with the marketplace.

This PR disables restarts, as soon as the PR gets merged, a new version will be published to nightly channel on the marketplace for testing with JB.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NONE

## How to test
<!-- Provide steps to test this PR -->
NONE

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
