### PR TITLE
Basic Bitbucket Server support (login and workspace start)

### DIFF
--- a/components/server/ee/src/auth/host-container-mapping.ts
+++ b/components/server/ee/src/auth/host-container-mapping.ts
@@ -21,6 +21,9 @@ export class HostContainerMappingEE extends HostContainerMapping {
             return (modules || []).concat([gitlabContainerModuleEE]);
         case "Bitbucket":
             return (modules || []).concat([bitbucketContainerModuleEE]);
+        // case "BitbucketServer":
+            // FIXME
+            // return (modules || []).concat([bitbucketContainerModuleEE]);
         case "GitHub":
             return (modules || []).concat([gitHubContainerModuleEE]);
         default:

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -27,6 +27,7 @@
     "/dist"
   ],
   "dependencies": {
+    "@atlassian/bitbucket-server": "^0.0.6",
     "@gitbeaker/node": "^25.6.0",
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-db": "0.1.5",

--- a/components/server/src/auth/host-container-mapping.ts
+++ b/components/server/src/auth/host-container-mapping.ts
@@ -9,6 +9,7 @@ import { githubContainerModule } from "../github/github-container-module";
 import { gitlabContainerModule } from "../gitlab/gitlab-container-module";
 import { genericAuthContainerModule } from "./oauth-container-module";
 import { bitbucketContainerModule } from "../bitbucket/bitbucket-container-module";
+import { bitbucketServerContainerModule } from "../bitbucket-server/bitbucket-server-container-module";
 
 @injectable()
 export class HostContainerMapping {
@@ -23,6 +24,8 @@ export class HostContainerMapping {
             return [genericAuthContainerModule];
         case "Bitbucket":
             return [bitbucketContainerModule];
+        case "BitbucketServer":
+            return [bitbucketServerContainerModule];
         default:
             return undefined;
         }

--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import fetch from 'node-fetch';
+import { User } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { BitbucketServerTokenHelper } from './bitbucket-server-token-handler';
+
+@injectable()
+export class BitbucketServerApi {
+
+    @inject(AuthProviderParams) protected readonly config: AuthProviderParams;
+    @inject(BitbucketServerTokenHelper) protected readonly tokenHelper: BitbucketServerTokenHelper;
+
+    public async runQuery<T>(user: User, urlPath: string): Promise<T> {
+        const token = (await this.tokenHelper.getTokenWithScopes(user, [])).value;
+        const fullUrl = `${this.baseUrl}${urlPath}`;
+        const response = await fetch(fullUrl, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            }
+        });
+        if (!response.ok) {
+            throw Error(response.statusText);
+        }
+        const result = await response.json();
+        return result as T;
+    }
+
+    protected get baseUrl(): string {
+        return `https://${this.config.host}/rest/api/1.0`;
+    }
+
+    getRepository(user: User, params: { kind: "projects" | "users", userOrProject: string; repositorySlug: string; }): Promise<BitbucketServer.Repository> {
+        return this.runQuery<BitbucketServer.Repository>(user, `/${params.kind}/${params.userOrProject}/repos/${params.repositorySlug}`);
+    }
+
+    getCommits(user: User, params: { kind: "projects" | "users", userOrProject: string, repositorySlug: string, q?: { limit: number } }): Promise<BitbucketServer.Paginated<BitbucketServer.Commit>> {
+        return this.runQuery<BitbucketServer.Paginated<BitbucketServer.Commit>>(user, `/${params.kind}/${params.userOrProject}/repos/${params.repositorySlug}/commits`);
+    }
+
+    getDefaultBranch(user: User, params: { kind: "projects" | "users", userOrProject: string, repositorySlug: string }): Promise<BitbucketServer.Branch> {
+        //https://bitbucket.gitpod-self-hosted.com/rest/api/1.0/users/jldec/repos/test-repo/default-branch
+        return this.runQuery<BitbucketServer.Branch>(user, `/${params.kind}/${params.userOrProject}/repos/${params.repositorySlug}/default-branch`);
+    }
+}
+
+
+export namespace BitbucketServer {
+    export interface Repository {
+        id: number;
+        slug: string;
+        name: string;
+        public: boolean;
+        links: {
+            clone: {
+                href: string;
+                name: string;
+            }[]
+        }
+        project: Project;
+    }
+
+    export interface Project {
+        key: string;
+        owner?: User;
+        id: number;
+        name: string;
+        public: boolean;
+    }
+
+    export interface Branch {
+        "id": string,
+        "displayId": string,
+        "type": "BRANCH" | string,
+        "latestCommit": string,
+        "isDefault": boolean
+    }
+
+    export interface User {
+        "name": string,
+        "emailAddress": string,
+        "id": number,
+        "displayName": string,
+        "active": boolean,
+        "slug": string,
+        "type": string,
+        "links": {
+            "self": [
+                {
+                    "href": string
+                }
+            ]
+        }
+    }
+
+    export interface Commit {
+        "id": string,
+        "displayId": string,
+        "author": BitbucketServer.User
+    }
+
+    export interface Paginated<T> {
+        isLastPage?: boolean;
+        limit?: number;
+        size?: number;
+        start?: number;
+        values?: T[];
+        [k: string]: any;
+    }
+
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import * as express from "express";
+import { injectable } from "inversify";
+import fetch from "node-fetch";
+import { AuthUserSetup } from "../auth/auth-provider";
+import { GenericAuthProvider } from "../auth/generic-auth-provider";
+import { BitbucketServerOAuthScopes } from "./bitbucket-server-oauth-scopes";
+import * as BitbucketServer from "@atlassian/bitbucket-server";
+
+@injectable()
+export class BitbucketServerAuthProvider extends GenericAuthProvider {
+
+    get info(): AuthProviderInfo {
+        return {
+            ...this.defaultInfo(),
+            scopes: BitbucketServerOAuthScopes.ALL,
+            requirements: {
+                default: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                publicRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+                privateRepo: BitbucketServerOAuthScopes.Requirements.DEFAULT,
+            },
+        }
+    }
+
+    /**
+     * Augmented OAuthConfig for Bitbucket
+     */
+    protected get oauthConfig() {
+        const oauth = this.params.oauth!;
+        const scopeSeparator = " ";
+        return <typeof oauth>{
+            ...oauth,
+            authorizationUrl: oauth.authorizationUrl || `https://${this.params.host}/rest/oauth2/latest/authorize`,
+            tokenUrl: oauth.tokenUrl || `https://${this.params.host}/rest/oauth2/latest/token`,
+            settingsUrl: oauth.settingsUrl || `https://${this.params.host}/plugins/servlet/oauth/users/access-tokens/`,
+            scope: BitbucketServerOAuthScopes.ALL.join(scopeSeparator),
+            scopeSeparator
+        };
+    }
+
+    protected get tokenUsername(): string {
+        return "x-token-auth";
+    }
+
+    authorize(req: express.Request, res: express.Response, next: express.NextFunction, scope?: string[]): void {
+        super.authorize(req, res, next, scope ? scope : BitbucketServerOAuthScopes.Requirements.DEFAULT);
+    }
+
+    protected readAuthUserSetup = async (accessToken: string, _tokenResponse: object) => {
+        try {
+            const fetchResult = await fetch(`https://${this.params.host}/plugins/servlet/applinks/whoami`, {
+                headers: {
+                    "Authorization": `Bearer ${accessToken}`,
+                }
+            });
+            if (!fetchResult.ok) {
+                throw new Error(fetchResult.statusText);
+            }
+            const username = await fetchResult.text();
+            if (!username) {
+                throw new Error("username missing");
+            }
+
+            log.warn(`(${this.strategyName}) username ${username}`);
+
+            const options = {
+                baseUrl: `https://${this.params.host}`,
+            };
+            const client = new BitbucketServer(options);
+
+            client.authenticate({ type: "token", token: accessToken });
+            const result = await client.api.getUser({ userSlug: username });
+
+            const user = result.data;
+
+            // TODO: check if user.active === true?
+
+            return <AuthUserSetup>{
+                authUser: {
+                    authId: `${user.id!}`,
+                    authName: user.slug!,
+                    primaryEmail: user.emailAddress!,
+                    name: user.displayName!,
+                    // avatarUrl: user.links!.avatar!.href // TODO
+                },
+                currentScopes: BitbucketServerOAuthScopes.ALL,
+            }
+
+        } catch (error) {
+            log.error(`(${this.strategyName}) Reading current user info failed`, error, { accessToken, error });
+            throw error;
+        }
+    }
+
+    protected normalizeScopes(scopes: string[]) {
+        const set = new Set(scopes);
+        for (const item of set.values()) {
+            if (!(BitbucketServerOAuthScopes.Requirements.DEFAULT.includes(item))) {
+                set.delete(item);
+            }
+        }
+        return Array.from(set).sort();
+    }
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-container-module.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-container-module.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { ContainerModule } from "inversify";
+import { AuthProvider } from "../auth/auth-provider";
+import { FileProvider, LanguagesProvider, RepositoryHost, RepositoryProvider } from "../repohost";
+import { IContextParser } from "../workspace/context-parser";
+import { BitbucketServerApi } from "./bitbucket-server-api";
+import { BitbucketServerAuthProvider } from "./bitbucket-server-auth-provider";
+import { BitbucketServerContextParser } from "./bitbucket-server-context-parser";
+import { BitbucketServerFileProvider } from "./bitbucket-server-file-provider";
+import { BitbucketServerLanguagesProvider } from "./bitbucket-server-language-provider";
+import { BitbucketServerRepositoryProvider } from "./bitbucket-server-repository-provider";
+import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
+
+export const bitbucketServerContainerModule = new ContainerModule((bind, _unbind, _isBound, _rebind) => {
+    bind(RepositoryHost).toSelf().inSingletonScope();
+    bind(BitbucketServerApi).toSelf().inSingletonScope();
+    bind(BitbucketServerFileProvider).toSelf().inSingletonScope();
+    bind(FileProvider).toService(BitbucketServerFileProvider);
+    bind(BitbucketServerContextParser).toSelf().inSingletonScope();
+    bind(BitbucketServerLanguagesProvider).toSelf().inSingletonScope();
+    bind(LanguagesProvider).toService(BitbucketServerLanguagesProvider);
+    bind(IContextParser).toService(BitbucketServerContextParser);
+    bind(BitbucketServerRepositoryProvider).toSelf().inSingletonScope();
+    bind(RepositoryProvider).toService(BitbucketServerRepositoryProvider);
+    bind(BitbucketServerAuthProvider).toSelf().inSingletonScope();
+    bind(AuthProvider).to(BitbucketServerAuthProvider).inSingletonScope();
+    bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+});

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { NavigatorContext, Repository, User, WorkspaceContext } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { inject, injectable } from "inversify";
+import { NotFoundError } from "../errors";
+import { AbstractContextParser, IContextParser, URLParts } from "../workspace/context-parser";
+import { URL } from "url";
+import { BitbucketServer, BitbucketServerApi } from "./bitbucket-server-api";
+import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
+
+const DEFAULT_BRANCH = "master";
+
+@injectable()
+export class BitbucketServerContextParser extends AbstractContextParser implements IContextParser {
+
+    @inject(BitbucketServerTokenHelper) protected readonly tokenHelper: BitbucketServerTokenHelper;
+    @inject(BitbucketServerApi) protected readonly api: BitbucketServerApi;
+
+    public async handle(ctx: TraceContext, user: User, contextUrl: string): Promise<WorkspaceContext> {
+        const span = TraceContext.startSpan("BitbucketServerContextParser.handle", ctx);
+
+        try {
+            const { resourceKind, host, owner, repoName, /*moreSegments, searchParams*/ } = await this.parseURL(user, contextUrl);
+
+            return await this.handleNavigatorContext(ctx, user, resourceKind, host, owner, repoName);
+        } catch (e) {
+            span.addTags({ contextUrl }).log({ error: e });
+            log.error({ userId: user.id }, "Error parsing Bitbucket context", e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
+    public async parseURL(user: User, contextUrl: string): Promise<{ resourceKind: string } & URLParts> {
+        const url = new URL(contextUrl);
+        const pathname = url.pathname.replace(/^\//, "").replace(/\/$/, ""); // pathname without leading and trailing slash
+        const segments = pathname.split('/');
+
+        const host = this.host; // as per contract, cf. `canHandle(user, contextURL)`
+
+        const lenghtOfRelativePath = host.split("/").length - 1; // e.g. "123.123.123.123/gitlab" => length of 1
+        if (lenghtOfRelativePath > 0) {
+            // remove segments from the path to be consider further, which belong to the relative location of the host
+            // cf. https://github.com/gitpod-io/gitpod/issues/2637
+            segments.splice(0, lenghtOfRelativePath);
+        }
+
+        const resourceKind = segments[0];
+        const owner: string = segments[1];
+        const repoName: string = segments[3];
+        const moreSegmentsStart: number = 4;
+        const endsWithRepoName = segments.length === moreSegmentsStart;
+        const searchParams = url.searchParams;
+        return {
+            resourceKind,
+            host,
+            owner,
+            repoName: this.parseRepoName(repoName, endsWithRepoName),
+            moreSegments: endsWithRepoName ? [] : segments.slice(moreSegmentsStart),
+            searchParams
+        }
+    }
+
+    public async fetchCommitHistory(ctx: TraceContext, user: User, contextUrl: string, commit: string, maxDepth: number): Promise<string[] | undefined> {
+        return undefined;
+    }
+
+    protected async handleNavigatorContext(ctx: TraceContext, user: User, resourceKind: string, host: string, owner: string, repoName: string, more: Partial<NavigatorContext> = {}): Promise<NavigatorContext> {
+        const span = TraceContext.startSpan("BitbucketServerContextParser.handleNavigatorContext", ctx);
+        try {
+            if (resourceKind !== "users" && resourceKind !== "projects") {
+                throw new Error("Only /users/ and /projects/ resources are supported.");
+            }
+            const repo = (await this.api.getRepository(user, { kind: resourceKind, userOrProject: owner, repositorySlug: repoName }));
+            const defaultBranch = (await this.api.getDefaultBranch(user, { kind: resourceKind, userOrProject: owner, repositorySlug: repoName }));
+            const repository = await this.toRepository(user, host, repo, defaultBranch);
+            span.log({ "request.finished": "" });
+
+            if (!repo) {
+                throw await NotFoundError.create(await this.tokenHelper.getCurrentToken(user), user, this.config.host, owner, repoName);
+            }
+
+            if (!more.revision) {
+                more.ref = more.ref || repository.defaultBranch;
+            }
+            more.refType = more.refType || "branch";
+
+            if (!more.revision) {
+                const tipCommitOnDefaultBranch = await this.api.getCommits(user, { kind: resourceKind, userOrProject: owner, repositorySlug: repoName, q: { limit: 1 } });
+                const commits = tipCommitOnDefaultBranch?.values || [];
+                if (commits.length === 0) {
+                    // empty repo
+                    more.ref = undefined;
+                    more.revision = "";
+                    more.refType = undefined;
+                } else {
+                    more.revision = commits[0].id;
+                    more.refType = "revision";
+                }
+            }
+
+            return {
+                ...more,
+                title: `${owner}/${repoName} - ${more.ref || more.revision}${more.path ? ':' + more.path : ''}`,
+                repository,
+            } as NavigatorContext;
+        } catch (e) {
+            span.log({ error: e });
+            log.error({ userId: user.id }, "Error parsing Bitbucket navigator request context", e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
+
+    protected async toRepository(user: User, host: string, repo: BitbucketServer.Repository, defaultBranch: BitbucketServer.Branch): Promise<Repository> {
+        if (!repo) {
+            throw new Error('Unknown repository.');
+        }
+
+        const owner = repo.project.owner ? repo.project.owner.slug : repo.project.key;
+        const name = repo.name;
+        const cloneUrl = repo.links.clone.find(u => u.name === "http")?.href!;
+
+        const result: Repository = {
+            cloneUrl,
+            host,
+            name,
+            owner,
+            private: !repo.public,
+            defaultBranch: defaultBranch.displayId || DEFAULT_BRANCH,
+        }
+
+        return result;
+    }
+
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-file-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-file-provider.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Commit, Repository, User } from "@gitpod/gitpod-protocol";
+import { injectable } from 'inversify';
+import { FileProvider, MaybeContent } from "../repohost/file-provider";
+
+@injectable()
+export class BitbucketServerFileProvider implements FileProvider {
+
+    public async getGitpodFileContent(commit: Commit, user: User): Promise<MaybeContent> {
+        return undefined;
+        // const yamlVersion1 = await Promise.all([
+        //     this.getFileContent(commit, user, '.gitpod.yml'),
+        //     this.getFileContent(commit, user, '.gitpod')
+        // ]);
+        // return yamlVersion1.filter(f => !!f)[0];
+    }
+
+    public async getLastChangeRevision(repository: Repository, revisionOrBranch: string, user: User, path: string): Promise<string> {
+        // try {
+        //     const api = await this.apiFactory.create(user);
+        //     const fileMetaData = (await api.repositories.readSrc({ workspace: repository.owner, repo_slug: repository.name, commit: revisionOrBranch, path, format: "meta" })).data;
+        //     return (fileMetaData as any).commit.hash;
+        // } catch (err) {
+        //     log.error({ userId: user.id }, err);
+        //     throw new Error(`Could not fetch ${path} of repository ${repository.owner}/${repository.name}: ${err}`);
+        // }
+        return "f00";
+    }
+
+    public async getFileContent(commit: Commit, user: User, path: string) {
+        return undefined;
+        // if (!commit.revision) {
+        //     return undefined;
+        // }
+
+        // try {
+        //     const api = await this.apiFactory.create(user);
+        //     const contents = (await api.repositories.readSrc({ workspace: commit.repository.owner, repo_slug: commit.repository.name, commit: commit.revision, path })).data;
+        //     return contents as string;
+        // } catch (err) {
+        //     log.error({ userId: user.id }, err);
+        // }
+    }
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-language-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-language-provider.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Repository, User } from "@gitpod/gitpod-protocol";
+import { injectable } from 'inversify';
+import { LanguagesProvider } from '../repohost/languages-provider';
+
+@injectable()
+export class BitbucketServerLanguagesProvider implements LanguagesProvider {
+
+    async getLanguages(repository: Repository, user: User): Promise<object> {
+        // try {
+        //     const api = await this.apiFactory.create(user);
+        //     const repo = await api.repositories.get({ workspace: repository.owner, repo_slug: repository.name });
+        //     const language = repo.data.language;
+        //     if (language) {
+        //         return { [language]: 100.0 };
+        //     }
+        // } catch (e) {
+        //     log.warn({ userId: user.id }, "Could not get languages of Bitbucket repo.");
+        // }
+        return {};
+    }
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+// https://confluence.atlassian.com/bitbucketserver/bitbucket-oauth-2-0-provider-api-1108483661.html#BitbucketOAuth2.0providerAPI-scopesScopes
+
+export namespace BitbucketServerOAuthScopes {
+    /** View projects and repositories that are publicly accessible, including pulling code and cloning repositories. */
+    export const PUBLIC_REPOS = "PUBLIC_REPOS";
+    /** View projects and repositories the user account can view, including pulling code, cloning, and forking repositories. Create and comment on pull requests. */
+    export const REPOSITORY_READ = "REPO_READ";
+    /** Push over https, fork repo */
+    export const REPOSITORY_WRITE = "REPO_WRITE";
+
+    export const ALL = [PUBLIC_REPOS, REPOSITORY_READ, REPOSITORY_WRITE];
+
+    export const Requirements = {
+        /**
+         * Minimal required permission.
+         */
+        DEFAULT: ALL
+    }
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Branch, CommitInfo, Repository, User } from "@gitpod/gitpod-protocol";
+import { injectable } from 'inversify';
+import { RepositoryProvider } from '../repohost/repository-provider';
+
+@injectable()
+export class BitbucketServerRepositoryProvider implements RepositoryProvider {
+
+    getUserRepos(user: User): Promise<string[]> {
+        throw new Error("getUserRepos not implemented.");
+    }
+
+    async getRepo(user: User, owner: string, name: string): Promise<Repository> {
+        // const api = await this.apiFactory.create(user);
+        // const repo = (await api.repositories.get({ workspace: owner, repo_slug: name })).data;
+        // let cloneUrl = repo.links!.clone!.find((x: any) => x.name === "https")!.href!;
+        // if (cloneUrl) {
+        //     const url = new URL(cloneUrl);
+        //     url.username = '';
+        //     cloneUrl = url.toString();
+        // }
+        // const host = RepoURL.parseRepoUrl(cloneUrl)!.host;
+        // const description = repo.description;
+        // const avatarUrl = repo.owner!.links!.avatar!.href;
+        // const webUrl = repo.links!.html!.href;
+        // const defaultBranch = repo.mainbranch?.name;
+        // return { host, owner, name, cloneUrl, description, avatarUrl, webUrl, defaultBranch };
+        throw new Error("getRepo unimplemented");
+    }
+
+    async getBranch(user: User, owner: string, repo: string, branchName: string): Promise<Branch> {
+        // const api = await this.apiFactory.create(user);
+        // const response = await api.repositories.getBranch({
+        //     workspace: owner,
+        //     repo_slug: repo,
+        //     name: branchName
+        // })
+
+        // const branch = response.data;
+
+        // return {
+        //     htmlUrl: branch.links?.html?.href!,
+        //     name: branch.name!,
+        //     commit: {
+        //         sha: branch.target?.hash!,
+        //         author: branch.target?.author?.user?.display_name!,
+        //         authorAvatarUrl: branch.target?.author?.user?.links?.avatar?.href,
+        //         authorDate: branch.target?.date!,
+        //         commitMessage: branch.target?.message || "missing commit message",
+        //     }
+        // };
+        throw new Error("getBranch unimplemented");
+    }
+
+    async getBranches(user: User, owner: string, repo: string): Promise<Branch[]> {
+        const branches: Branch[] = [];
+        // const api = await this.apiFactory.create(user);
+        // const response = await api.repositories.listBranches({
+        //     workspace: owner,
+        //     repo_slug: repo,
+        //     sort: "target.date"
+        // })
+
+        // for (const branch of response.data.values!) {
+        //     branches.push({
+        //         htmlUrl: branch.links?.html?.href!,
+        //         name: branch.name!,
+        //         commit: {
+        //             sha: branch.target?.hash!,
+        //             author: branch.target?.author?.user?.display_name!,
+        //             authorAvatarUrl: branch.target?.author?.user?.links?.avatar?.href,
+        //             authorDate: branch.target?.date!,
+        //             commitMessage: branch.target?.message || "missing commit message",
+        //         }
+        //     });
+        // }
+
+        return branches;
+    }
+
+    async getCommitInfo(user: User, owner: string, repo: string, ref: string): Promise<CommitInfo | undefined> {
+        return undefined;
+        // const api = await this.apiFactory.create(user);
+        // const response = await api.commits.get({
+        //     workspace: owner,
+        //     repo_slug: repo,
+        //     commit: ref
+        // })
+        // const commit = response.data;
+        // return {
+        //     sha: commit.hash!,
+        //     author: commit.author?.user?.display_name!,
+        //     authorDate: commit.date!,
+        //     commitMessage: commit.message || "missing commit message",
+        //     authorAvatarUrl: commit.author?.user?.links?.avatar?.href,
+        // };
+    }
+}

--- a/components/server/src/bitbucket-server/bitbucket-server-token-handler.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-token-handler.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Token, User } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { UnauthorizedError } from "../errors";
+import { TokenProvider } from "../user/token-provider";
+import { BitbucketServerOAuthScopes } from "./bitbucket-server-oauth-scopes";
+
+@injectable()
+export class BitbucketServerTokenHelper {
+
+    @inject(AuthProviderParams) readonly config: AuthProviderParams;
+    @inject(TokenProvider) protected readonly tokenProvider: TokenProvider;
+
+    async getCurrentToken(user: User) {
+        try {
+            return await this.getTokenWithScopes(user, [/* any scopes */]);
+        } catch {
+            // no token
+        }
+    }
+
+    async getTokenWithScopes(user: User, requiredScopes: string[]) {
+        const { host } = this.config;
+        try {
+            const token = await this.tokenProvider.getTokenForHost(user, host);
+            if (this.containsScopes(token, requiredScopes)) {
+                return token;
+            }
+        } catch {
+            // no token
+        }
+        if (requiredScopes.length === 0) {
+            requiredScopes = BitbucketServerOAuthScopes.Requirements.DEFAULT
+        }
+        throw UnauthorizedError.create(host, requiredScopes, "missing-identity");
+    }
+    protected containsScopes(token: Token, wantedScopes: string[] | undefined): boolean {
+        const set = new Set(wantedScopes);
+        token.scopes.forEach(s => set.delete(s));
+        return set.size === 0;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@atlassian/bitbucket-server@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@atlassian/bitbucket-server/-/bitbucket-server-0.0.6.tgz#7a0678264083c851e50a66216e66021efe1638cf"
+  integrity sha512-92EpKlSPw0ZZXiS4Qt+1DKuDxSIntL2j8Q0CWc8o/nUNOJAW/D9szIgcef5VPTbVslHeb2C3gBSMNnETdykdmQ==
+  dependencies:
+    before-after-hook "^1.1.0"
+    btoa-lite "^1.0.0"
+    debug "^3.1.0"
+    is-plain-object "^2.0.4"
+    node-fetch "^2.1.2"
+    url-template "^2.0.8"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -4579,6 +4591,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+before-after-hook@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
+  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
 before-after-hook@^2.1.0, before-after-hook@^2.2.0:
   version "2.2.2"
@@ -12028,6 +12045,13 @@ node-emoji@^1.11.0:
   integrity sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==
   dependencies:
     lodash "^4.17.21"
+
+node-fetch@^2.1.2:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.5:
   version "2.6.6"


### PR DESCRIPTION
## Description
The most recent version of Bitbucket Server (7.20) supports OAuth2 for authentication, we're now able to connect Gitpod with. 

This PR enables login and start of plain workspaces for a repository hosted on a Bitbucket Server (version 7.20).

Known limitations and things out of scope here:
 * support for `/` context of the default branch by default, i.e. no issue/pr context supported
 * broken token validation in the IDE, i.e. it reports missing permissions, though the commits might get pushed
 * no support for projects/webhooks/prebuilds so far
 * no support UI to configure the integration with, i.e. server's config is to be manually adjusted to add an entry for `authProviderConfigs`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7957

## How to test

Unfortunately, there is no way to set up the auth provider in the frontend. One needs to patch the `server-config` configmap in order to get this running in a Gitpod installation. To do so you need to edit the config map:

```
EDITOR="code --wait" kubectl edit configmap server-config
```

and add such a configuration:

```
"authProviderConfigs": [{
    "id": "bitbucketserver",
    "type": "BitbucketServer",
    "host": "bitbucket.gitpod-self-hosted.com",
    "hiddenOnDashboard": false,
    "disallowLogin": false,
    "oauth": {
        "clientId": "<REDACTED>",
        "clientSecret": "<REDACTED>",
        "callBackUrl": "https://clu-bitbucket-server.staging.gitpod-dev.com/auth/bitbucket.gitpod-self-hosted.com/callback",
        "authorizationUrl": "https://bitbucket.gitpod-self-hosted.com/rest/oauth2/latest/authorize",
        "tokenUrl": "https://bitbucket.gitpod-self-hosted.com/rest/oauth2/latest/token",
        "scope": "PUBLIC_REPOS REPO_READ REPO_WRITE",
        "scopeSeparator": " "
    }
}]
```

after that, you'd need to restart the server pods by running:

```
kubeclt delete pod server-[TAB]
```


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Bitbucket Server: Authorize with Bitbucket Server 7.20 and start workspaces.
```



