### PR TITLE
werft/config: Delete core-dev namespace on branch delete

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,7 @@
 /operations/observability/mixins/workspace @gitpod-io/engineering-workspace
 /operations/observability/mixins/cross-teams @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/platform
 /.werft/observability @gitpod-io/platform
+/.werft/delete-preview-environments @gitpod-io/platform
 
 #
 # Automation

--- a/.werft/config.yaml
+++ b/.werft/config.yaml
@@ -3,3 +3,6 @@ rules:
   matchesAll:
   - or: ["repo.ref ~= refs/heads/"]
   - or: ["trigger !== deleted"]
+- path: ".werft/wipe-devstaging.yaml"
+  matchesAll:
+  - or: ["trigger == deleted"]

--- a/.werft/config.yaml
+++ b/.werft/config.yaml
@@ -3,6 +3,6 @@ rules:
   matchesAll:
   - or: ["repo.ref ~= refs/heads/"]
   - or: ["trigger !== deleted"]
-- path: ".werft/wipe-devstaging.yaml"
+- path: ".werft/delete-preview-environments/delete-preview-environment.yaml"
   matchesAll:
   - or: ["trigger == deleted"]

--- a/.werft/delete-preview-environments/delete-preview-environment.ts
+++ b/.werft/delete-preview-environments/delete-preview-environment.ts
@@ -1,0 +1,50 @@
+import { Werft } from '../util/werft';
+import * as fs from 'fs';
+import * as Tracing from '../observability/tracing';
+import { SpanStatusCode } from '@opentelemetry/api';
+import { wipePreviewEnvironmentAndNamespace, helmInstallName } from '../util/kubectl';
+
+// Will be set once tracing has been initialized
+let werft: Werft
+
+const context = JSON.parse(fs.readFileSync('context.json').toString());
+
+Tracing.initialize()
+    .then(() => {
+        werft = new Werft("delete-preview-environment")
+    })
+    .then(() => deletePreviewEnvironment())
+    .then(() => werft.endAllSpans())
+    .catch((err) => {
+        werft.rootSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err
+        })
+        werft.endAllSpans()
+    })
+
+async function deletePreviewEnvironment() {
+    werft.phase("preparing deletion")
+    const version = parseVersion();
+    const namespace = `staging-${version.split(".")[0]}`
+    werft.log("preparing deletion", `Proceeding to delete the ${namespace} namespace`)
+    werft.done("preparing deletion")
+
+    werft.phase("delete-preview")
+    try {
+        await wipePreviewEnvironmentAndNamespace(helmInstallName, namespace, { slice: 'delete-preview' })
+    } catch (err) {
+        werft.fail("delete-preview", err)
+    }
+    werft.done("delete-prewview")
+}
+
+
+export function parseVersion() {
+    let version = context.Name;
+    const PREFIX_TO_STRIP = "gitpod-delete-preview-environment-";
+    if (version.substr(0, PREFIX_TO_STRIP.length) === PREFIX_TO_STRIP) {
+        version = version.substr(PREFIX_TO_STRIP.length);
+    }
+    return version
+}

--- a/.werft/delete-preview-environments/delete-preview-environment.yaml
+++ b/.werft/delete-preview-environments/delete-preview-environment.yaml
@@ -1,0 +1,54 @@
+pod:
+  serviceAccount: werft
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: dev/workload
+            operator: In
+            values:
+            - "builds"
+  volumes:
+  - name: gcp-sa
+    secret:
+      secretName: gcp-sa-gitpod-dev-deployer
+  - name: gcp-sa-release
+    secret:
+      secretName: gcp-sa-gitpod-release-deployer
+  containers:
+  - name: build
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    workingDir: /workspace
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: gcp-sa
+      mountPath: /mnt/secrets/gcp-sa
+      readOnly: true
+    - name: gcp-sa-release
+      mountPath: /mnt/secrets/gcp-sa-release
+      readOnly: true
+    env:
+    - name: WERFT_HOST
+      value: "werft.werft.svc.cluster.local:7777"
+    - name: HONEYCOMB_DATASET
+      value: "werft"
+    - name: HONEYCOMB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: honeycomb-api-key
+          key: apikey
+    command:
+      - bash
+      - -c
+      - |
+        sleep 1
+        set -Eeuo pipefail
+
+        sudo chown -R gitpod:gitpod /workspace
+
+        (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
+        printf '{{ toJson . }}' > context.json
+
+        # We're merging with the script commented so we can safely test prior to fully commit to it
+        # npx ts-node .werft/delete-preview-environments/delete-preview-environments.ts


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
@mads-hartmann @csweichel I'm opening this one as a draft because I'm not entirely sure this is all that we need to do.

How do we tell wipe-devstaging the namespace to delete?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/981

## How to test
<!-- Provide steps to test this PR -->
Also a hard one to test, since this needs to be on main to execute

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
