### PR TITLE
Update GitpodWorkspaceTooManyRegularNotActive severity level

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -61,16 +61,16 @@
           {
             alert: 'GitpodWorkspaceTooManyRegularNotActive',
             labels: {
-              severity: 'warning',
+              severity: 'critical',
             },
-            'for': '10m',
+            'for': '15m',
             annotations: {
               runbook_url: 'none',
               summary: 'too many running but inactive workspaces',
               description: 'too many running but inactive workspaces',
             },
             expr: |||
-              gitpod_workspace_regular_not_active_percentage > 0.10 AND sum(gitpod_ws_manager_workspace_activity_total) > 100
+              gitpod_workspace_regular_not_active_percentage > 0.15 AND sum(gitpod_ws_manager_workspace_activity_total) > 100
             |||,
           },
         ],

--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -65,7 +65,7 @@
             },
             'for': '15m',
             annotations: {
-              runbook_url: 'none',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md',
               summary: 'too many running but inactive workspaces',
               description: 'too many running but inactive workspaces',
             },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update the severity of the alert to critical and change the threshold based on previous alerts generated by `GitpodWorkspaceStuckOnStopping` which is usually alerted right after the `GitpodWorkspaceTooManyRegularNotActive` threshold breach.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8051

## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
