### PR TITLE
[server] fix for wrong token selected if multiple

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -291,7 +291,7 @@ export class TypeORMUserDBImpl implements UserDB {
         if (tokenEntries.length === 0) {
             return undefined;
         }
-        return tokenEntries.sort((a, b) => `${a.token.updateDate}`.localeCompare(`${b.token.updateDate}`))[0]?.token;
+        return tokenEntries.sort((a, b) => `${a.token.updateDate}`.localeCompare(`${b.token.updateDate}`)).reverse()[0]?.token;
     }
 
     public async findTokensForIdentity(identity: Identity, includeDeleted?: boolean): Promise<TokenEntry[]> {


### PR DESCRIPTION
This is a followup to #7837 and fixes incorrect order of tokens. The intention was to select the latest token. 

```release-note
Fix wrong token selection if multiple found for a profile.
```