### PR TITLE
Create an index for contextURL column

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace.ts
@@ -27,6 +27,7 @@ export class DBWorkspace implements Workspace {
     ownerId: string;
 
     @Column("text")
+    @Index('ind_contextURL')
     contextURL: string;
 
     @Column({

--- a/components/gitpod-db/src/typeorm/migration/1644327547997-IndexWorkspaceContextUrl.ts
+++ b/components/gitpod-db/src/typeorm/migration/1644327547997-IndexWorkspaceContextUrl.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { indexExists } from "./helper/helper";
+
+export class IndexWorkspaceContextUrl1644327547997 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const TABLE_NAME = "d_b_workspace";
+        const INDEX_NAME = "ind_contextURL";
+
+        if(!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query("ALTER TABLE d_b_workspace MODIFY COLUMN `contextURL` varchar(255) NOT NULL");
+            await queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE_NAME} (contextURL)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
## Description
The workspace search queries the contextURL column of the db_workspace table and that was not indexed.
The hypothesis is that indexing this column will improve the search, which can currently be seen in this Honeycomb query[[1](https://ui.honeycomb.io/gitpod/datasets/gitpod-production/result/nZ7mf4rWHDW)].

## Related Issue(s)
Fixes #8005 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
