### PR TITLE
Fix credential helper regression

### DIFF
--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -46,11 +46,16 @@ var credentialHelper = &cobra.Command{
 		defer func() {
 			// Credentials not found, return `quit=true` so no further helpers will be consulted, nor will the user be prompted.
 			// From https://git-scm.com/docs/gitcredentials#_custom_helpers
-			if user == "" || token == "" {
+			if token == "" {
 				fmt.Print("quit=true\n")
-			} else {
-				fmt.Printf("username=%s\npassword=%s\n", user, token)
+				return
 			}
+			// Server could return only the token and not the username, so we fallback to hardcoded `oauth2` username.
+			// See https://github.com/gitpod-io/gitpod/pull/7889#discussion_r801670957
+			if user == "" {
+				user = "oauth2"
+			}
+			fmt.Printf("username=%s\npassword=%s\n", user, token)
 		}()
 
 		host, err := parseHostFromStdin()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Server could return only the token and not the username, so we fallback to hardcoded `oauth2` username.
See https://github.com/gitpod-io/gitpod/pull/7889#discussion_r801670957

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

