### PR TITLE
[server, dashboard] Fix usage and parsing of ws.ontextURL

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -63,7 +63,7 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                 <div className="flex w-full mt-6">
                     <Property name="Created">{moment(workspace.workspaceCreationTime).format('MMM D, YYYY')}</Property>
                     <Property name="Last Start">{moment(workspace.instanceCreationTime).fromNow()}</Property>
-                    <Property name="Context"><a className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400" href={ContextURL.parseToURL(workspace.contextURL)?.toString()}>{workspace.context.title}</a></Property>
+                    <Property name="Context"><a className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400" href={ContextURL.getNormalizedURL(workspace)?.toString()}>{workspace.context.title}</a></Property>
                 </div>
                 <div className="flex w-full mt-6">
                     <Property name="User"><Link className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400" to={"/admin/users/" + props.workspace.ownerId}>{user?.name || props.workspace.ownerId}</Link></Property>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { AdminGetListResult, AdminGetWorkspacesQuery, User, WorkspaceAndInstance } from "@gitpod/gitpod-protocol";
+import { AdminGetListResult, AdminGetWorkspacesQuery, ContextURL, User, WorkspaceAndInstance } from "@gitpod/gitpod-protocol";
 import { matchesInstanceIdOrLegacyWorkspaceIdExactly, matchesNewWorkspaceIdExactly } from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
 import moment from "moment";
 import { useContext, useEffect, useState } from "react";
@@ -133,7 +133,7 @@ function WorkspaceEntry(p: { ws: WorkspaceAndInstance }) {
             </div>
             <div className="flex flex-col w-5/12 self-center truncate">
                 <div className="text-gray-500 overflow-ellipsis truncate">{p.ws.description}</div>
-                <div className="text-sm text-gray-400 overflow-ellipsis truncate">{p.ws.contextURL}</div>
+                <div className="text-sm text-gray-400 overflow-ellipsis truncate">{ContextURL.getNormalizedURL(p.ws)?.toString()}</div>
             </div>
             <div className="flex w-2/12 self-center">
                 <div className="text-sm w-full text-gray-400 truncate">{moment(p.ws.instanceCreationTime || p.ws.workspaceCreationTime).fromNow()}</div>

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -6,7 +6,7 @@
 
 import EventEmitter from "events";
 import React, { useEffect, Suspense, useContext, useState } from "react";
-import { CreateWorkspaceMode, WorkspaceCreationResult, RunningWorkspacePrebuildStarting } from "@gitpod/gitpod-protocol";
+import { CreateWorkspaceMode, WorkspaceCreationResult, RunningWorkspacePrebuildStarting, ContextURL } from "@gitpod/gitpod-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import Modal from "../components/Modal";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
@@ -163,14 +163,17 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
           <p className="mt-1 mb-2 text-base">You already have running workspaces with the same context. You can open an existing one or open a new workspace.</p>
           <>
-            {result?.existingWorkspaces?.map(w =>
-              <a href={w.latestInstance?.ideUrl || gitpodHostUrl.with({ pathname: '/start/', hash: '#' + w.latestInstance?.workspaceId }).toString()} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-3 my-1">
-                <div className="w-full">
-                  <p className="text-base text-black dark:text-gray-100 font-bold">{w.workspace.id}</p>
-                  <p className="truncate" title={w.workspace.contextURL}>{w.workspace.contextURL}</p>
-                </div>
-              </a>
-            )}
+            {result?.existingWorkspaces?.map(w => {
+              const normalizedContextUrl = ContextURL.getNormalizedURL(w.workspace)?.toString() || "undefined";
+              return (
+                <a href={w.latestInstance?.ideUrl || gitpodHostUrl.with({ pathname: '/start/', hash: '#' + w.latestInstance?.workspaceId }).toString()} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-3 my-1">
+                  <div className="w-full">
+                    <p className="text-base text-black dark:text-gray-100 font-bold">{w.workspace.id}</p>
+                    <p className="truncate" title={normalizedContextUrl}>{normalizedContextUrl}</p>
+                  </div>
+                </a>
+              );
+            })}
           </>
         </div>
         <div className="flex justify-end mt-6">

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -226,7 +226,8 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
     // Successfully stopped and headless: the prebuild is done, let's try to use it!
     if (!error && workspaceInstance.status.phase === 'stopped' && this.state.workspace?.type !== 'regular') {
-      const contextURL = ContextURL.parseToURL(this.state.workspace?.contextURL);
+      // here we want to point to the original context, w/o any modifiers "workspace" was started with (as this might have been a manually triggered prebuild!)
+      const contextURL = ContextURL.getNormalizedURL(this.state.workspace);
       if (contextURL) {
         this.redirectTo(gitpodHostUrl.withContext(contextURL.toString()).toString());
       } else {
@@ -272,7 +273,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     let phase = StartPhase.Preparing;
     let title = undefined;
     let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
-    const contextURL = this.state.workspace?.context.normalizedContextURL || ContextURL.parseToURL(this.state.workspace?.contextURL)?.toString();
+    const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
 
     switch (this.state?.workspaceInstance?.status.phase) {
       // unknown indicates an issue within the system in that it cannot determine the actual phase of

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -129,6 +129,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         }
     }
 
+    const normalizedContextUrl = ContextURL.getNormalizedURL(ws)?.toString() || "undefined";
     return <Item className="whitespace-nowrap py-6 px-6">
         <ItemFieldIcon>
             <WorkspaceStatusIndicator instance={desc?.latestInstance} />
@@ -141,8 +142,8 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         </ItemField>
         <ItemField className="w-4/12 flex flex-col my-auto">
             <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">{workspaceDescription}</div>
-            <a href={ContextURL.parseToURL(ws.contextURL)?.toString()}>
-                <div className="text-sm text-gray-400 dark:text-gray-500 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">{ws.contextURL}</div>
+            <a href={normalizedContextUrl}>
+                <div className="text-sm text-gray-400 dark:text-gray-500 overflow-ellipsis truncate hover:text-blue-600 dark:hover:text-blue-400">{normalizedContextUrl}</div>
             </a>
         </ItemField>
         <ItemField className="w-2/12 flex flex-col my-auto">

--- a/components/gitpod-protocol/src/context-url.spec.ts
+++ b/components/gitpod-protocol/src/context-url.spec.ts
@@ -6,44 +6,47 @@
 
 import * as chai from 'chai';
 import { suite, test } from 'mocha-typescript';
+import { Workspace } from '.';
 import { ContextURL } from './context-url';
 const expect = chai.expect;
+
+type WsContextUrl = Pick<Workspace, "context" | "contextURL">;
 
 @suite
 export class ContextUrlTest {
 
     @test public parseContextUrl_withEnvVar() {
-        const actual = ContextURL.parseToURL("passedin=test%20value/https://github.com/gitpod-io/gitpod-test-repo");
+        const actual = ContextURL.getNormalizedURL({ contextURL: "passedin=test%20value/https://github.com/gitpod-io/gitpod-test-repo", context: {} } as WsContextUrl);
         expect(actual?.host).to.equal("github.com");
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
     }
 
     @test public parseContextUrl_withEnvVar_withoutSchema() {
-        const actual = ContextURL.parseToURL("passedin=test%20value/github.com/gitpod-io/gitpod-test-repo");
+        const actual = ContextURL.getNormalizedURL({ contextURL: "passedin=test%20value/github.com/gitpod-io/gitpod-test-repo", context: {} } as WsContextUrl);
         expect(actual?.host).to.equal("github.com");
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
     }
 
     @test public parseContextUrl_withEnvVar_sshUrl() {
-        const actual = ContextURL.parseToURL("passedin=test%20value/git@github.com:gitpod-io/gitpod-test-repo.git");
+        const actual = ContextURL.getNormalizedURL({ contextURL: "passedin=test%20value/git@github.com:gitpod-io/gitpod-test-repo.git", context: {} } as WsContextUrl);
         expect(actual?.host).to.equal("github.com");
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo.git");
     }
 
     @test public parseContextUrl_withPrebuild() {
-        const actual = ContextURL.parseToURL("prebuild/https://github.com/gitpod-io/gitpod-test-repo");
+        const actual = ContextURL.getNormalizedURL({ contextURL: "prebuild/https://github.com/gitpod-io/gitpod-test-repo", context: {} } as WsContextUrl);
         expect(actual?.host).to.equal("github.com");
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
     }
 
     @test public parseContextUrl_withPrebuild_withoutSchema() {
-        const actual = ContextURL.parseToURL("prebuild/github.com/gitpod-io/gitpod-test-repo");
+        const actual = ContextURL.getNormalizedURL({ contextURL: "prebuild/github.com/gitpod-io/gitpod-test-repo", context: {} } as WsContextUrl);
         expect(actual?.host).to.equal("github.com");
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
     }
 
     @test public parseContextUrl_badUrl() {
-        const actual = ContextURL.parseToURL("[Object object]");
+        const actual = ContextURL.getNormalizedURL({ contextURL: "[Object object]", context: {} } as WsContextUrl);
         expect(actual).to.be.undefined;
     }
 }

--- a/components/gitpod-protocol/src/context-url.ts
+++ b/components/gitpod-protocol/src/context-url.ts
@@ -4,11 +4,62 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { Workspace } from ".";
+
+/**
+ * The whole point of these methods is to overcome inconsistencies in our data model.
+ * Ideally we remove it at some point once we fixed our model, as it:
+ *  - duplicates logic
+ *  - but additional burden on clients (using this, copying this to other languages!)
+ *
+ * TODO(gpl) See if we can get this into `server` code to remove the burden from clients
+ */
 export namespace ContextURL {
   export const INCREMENTAL_PREBUILD_PREFIX = "incremental-prebuild";
   export const PREBUILD_PREFIX = "prebuild";
   export const IMAGEBUILD_PREFIX = "imagebuild";
+  export const SNAPSHOT_PREFIX = "snapshot";
   export const REFERRER_PREFIX = 'referrer:';
+
+  /**
+   * This function will (try to) return the HTTP(S) URL of the context the user originally created this workspace on.
+   * Especially it will not contain any modifiers or be of different scheme than HTTP(S).
+   *
+   * Use this function if you need to provided a _working_ URL to the original context.
+   * @param ws
+   * @returns
+   */
+  export function getNormalizedURL(ws: Pick<Workspace, "context" | "contextURL"> | undefined): URL | undefined {
+    const normalized = normalize(ws);
+    if (!normalized) {
+      return undefined;
+    }
+
+    try {
+      return new URL(normalized);
+    } catch (err) {
+      console.error(`unable to parse URL from normalized contextURL: '${normalized}'`, err);
+    }
+    return undefined;
+  }
+
+  function normalize(ws: Pick<Workspace, "context" | "contextURL"> | undefined): string | undefined {
+    if (!ws) {
+      return undefined;
+    }
+    if (ws.context.normalizedContextURL) {
+      return ws.context.normalizedContextURL;
+    }
+
+    // fallback: we do not yet set normalizedContextURL on all workspaces, yet, let alone older existing workspaces
+    let fallback: string | undefined = undefined;
+    try {
+      fallback = removePrefixes(ws.contextURL);
+    } catch (err) {
+      console.error(`unable to remove prefixes from contextURL: '${ws.contextURL}'`, err);
+    }
+    return fallback;
+  }
 
   /**
    * The field "contextUrl" might contain prefixes like:
@@ -16,45 +67,41 @@ export namespace ContextURL {
    *  - prebuild/...
    * This is the analogon to the (Prefix)ContextParser structure in "server".
    */
-  export function parseToURL(contextUrl: string | undefined): URL | undefined {
+  function removePrefixes(contextUrl: string | undefined): string | undefined {
     if (contextUrl === undefined) {
       return undefined;
     }
 
-    try {
-      const segments = contextUrl.split("/");
-      if (segments.length === 1) {
-        return new URL(segments[0]);  // this might be something, we just try
-      }
-
-      const segmentsToURL = (offset: number): URL | undefined => {
-        let rest = segments.slice(offset).join("/");
-        if (/^git@[^:\/]+:/.test(rest)) {
-          rest = rest.replace(/^git@([^:\/]+):/, 'https://$1/');
-        }
-        if (!rest.startsWith("http")) {
-          rest = 'https://' + rest;
-        }
-        return new URL(rest);
-      };
-
-      const firstSegment = segments[0];
-      if (firstSegment === PREBUILD_PREFIX ||
-          firstSegment === INCREMENTAL_PREBUILD_PREFIX ||
-          firstSegment === IMAGEBUILD_PREFIX ||
-          firstSegment.startsWith(REFERRER_PREFIX)) {
-        return segmentsToURL(1);
-      }
-
-      // check for env vars
-      if (firstSegment.indexOf("=") !== -1) {
-        return segmentsToURL(1);
-      }
-
-      return segmentsToURL(0);
-    } catch (error) {
-      console.error(error);
+    const segments = contextUrl.split("/");
+    if (segments.length === 1) {
+      return segments[0];  // this might be something, we just try
     }
 
+    const segmentsToURL = (offset: number): string => {
+      let rest = segments.slice(offset).join("/");
+      if (/^git@[^:\/]+:/.test(rest)) {
+        rest = rest.replace(/^git@([^:\/]+):/, 'https://$1/');
+      }
+      if (!rest.startsWith("http")) {
+        rest = 'https://' + rest;
+      }
+      return rest;
+    };
+
+    const firstSegment = segments[0];
+    if (firstSegment === PREBUILD_PREFIX ||
+        firstSegment === INCREMENTAL_PREBUILD_PREFIX ||
+        firstSegment === IMAGEBUILD_PREFIX ||
+        firstSegment === SNAPSHOT_PREFIX ||
+        firstSegment.startsWith(REFERRER_PREFIX)) {
+      return segmentsToURL(1);
+    }
+
+    // check for env vars
+    if (firstSegment.indexOf("=") !== -1) {
+      return segmentsToURL(1);
+    }
+
+    return segmentsToURL(0);
   }
 }

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -480,7 +480,7 @@ export class WorkspaceLogAccessGuard implements ResourceAccessGuard {
 
         // Check if user can access repositories headless logs
         const ws = resource.subject;
-        const contextURL = ContextURL.parseToURL(ws.contextURL);
+        const contextURL = ContextURL.getNormalizedURL(ws);
         if (!contextURL) {
             throw new Error(`unable to parse ContextURL: ${contextURL}`);
         }

--- a/components/server/src/workspace/snapshot-context-parser.ts
+++ b/components/server/src/workspace/snapshot-context-parser.ts
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { User, SnapshotContext } from "@gitpod/gitpod-protocol";
+import { User, SnapshotContext, ContextURL } from "@gitpod/gitpod-protocol";
 import { injectable, inject } from "inversify";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { IContextParser } from "../workspace/context-parser";
@@ -15,7 +15,7 @@ export class SnapshotContextParser implements IContextParser {
 
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
 
-    static PREFIX = 'snapshot/';
+    static PREFIX = ContextURL.SNAPSHOT_PREFIX + '/';
 
     public canHandle(user: User, context: string): boolean {
         return context.startsWith(SnapshotContextParser.PREFIX);


### PR DESCRIPTION
## Description
 1. Never fail when trying to parse `contextURL`
 2. prefer `normalizedContextURL` if present
 3. if `normalizedContextURL` is not present, try to parse it from `contextURL`
 3. ~handle broken "git@github:" contextURLs in the DB (@jankeromnes )~ Done with #8100


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8097

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix dashboard contextURL handling
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
