### PR TITLE
[protocol] Make ContextURL.parseToURL support the newly-accepted 'git@{host}:{user}/{repo}.git' format

### DIFF
--- a/components/gitpod-protocol/src/context-url.spec.ts
+++ b/components/gitpod-protocol/src/context-url.spec.ts
@@ -24,6 +24,12 @@ export class ContextUrlTest {
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
     }
 
+    @test public parseContextUrl_withEnvVar_sshUrl() {
+        const actual = ContextURL.parseToURL("passedin=test%20value/git@github.com:gitpod-io/gitpod-test-repo.git");
+        expect(actual?.host).to.equal("github.com");
+        expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo.git");
+    }
+
     @test public parseContextUrl_withPrebuild() {
         const actual = ContextURL.parseToURL("prebuild/https://github.com/gitpod-io/gitpod-test-repo");
         expect(actual?.host).to.equal("github.com");
@@ -34,6 +40,11 @@ export class ContextUrlTest {
         const actual = ContextURL.parseToURL("prebuild/github.com/gitpod-io/gitpod-test-repo");
         expect(actual?.host).to.equal("github.com");
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
+    }
+
+    @test public parseContextUrl_badUrl() {
+        const actual = ContextURL.parseToURL("[Object object]");
+        expect(actual).to.be.undefined;
     }
 }
 module.exports = new ContextUrlTest()


### PR DESCRIPTION
Companion to https://github.com/gitpod-io/gitpod/pull/7951 and https://github.com/gitpod-io/gitpod/pull/8099

## Description
<!-- Describe your changes in detail -->
Makes `ContextURL.parseToURL` support the newly-accepted `git@{host}:{user}/{repo}.git` format

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8097

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make `ContextURL.parseToURL` support the newly-accepted `git@{host}:{user}/{repo}.git` format
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
