### PR TITLE
[workspacekit] modify supervisor entry to init

### DIFF
--- a/components/ee/agent-smith/pkg/detector/proc.go
+++ b/components/ee/agent-smith/pkg/detector/proc.go
@@ -425,7 +425,7 @@ func findWorkspaces(proc discoverableProcFS, p *process, d int, ws *common.Works
 }
 
 func isSupervisor(cmdline []string) bool {
-	return len(cmdline) == 2 && cmdline[0] == "supervisor" && cmdline[1] == "run"
+	return len(cmdline) == 2 && cmdline[0] == "supervisor" && cmdline[1] == "init"
 }
 
 func extractWorkspaceFromWorkspacekit(proc discoverableProcFS, pid int) *common.Workspace {

--- a/components/ee/agent-smith/pkg/detector/proc_test.go
+++ b/components/ee/agent-smith/pkg/detector/proc_test.go
@@ -68,7 +68,7 @@ func TestFindWorkspaces(t *testing.T) {
 					P:   &process{PID: 2, Parent: res[1].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 					Env: []string{"GITPOD_WORKSPACE_ID=foobar", "GITPOD_INSTANCE_ID=baz"},
 				}
-				res[3] = memoryProcEntry{P: &process{PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "run"}}}
+				res[3] = memoryProcEntry{P: &process{PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "init"}}}
 				res[1].P.Children = []*process{res[2].P}
 				res[2].P.Children = []*process{res[3].P}
 				return res
@@ -87,7 +87,7 @@ func TestFindWorkspaces(t *testing.T) {
 					P:   &process{PID: 2, Parent: res[1].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 					Env: []string{"GITPOD_WORKSPACE_ID=foobar", "GITPOD_INSTANCE_ID=baz"},
 				}
-				res[3] = memoryProcEntry{P: &process{PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "run"}}}
+				res[3] = memoryProcEntry{P: &process{PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "init"}}}
 				res[4] = memoryProcEntry{P: &process{PID: 4, Parent: res[2].P, Cmdline: []string{"slirp4netns"}}}
 				res[1].P.Children = []*process{res[2].P}
 				res[2].P.Children = []*process{res[3].P, res[4].P}
@@ -108,7 +108,7 @@ func TestFindWorkspaces(t *testing.T) {
 					P:   &process{PID: 2, Parent: res[1].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 					Env: []string{"GITPOD_WORKSPACE_ID=foobar", "GITPOD_INSTANCE_ID=baz"},
 				}
-				res[3] = memoryProcEntry{P: &process{PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "run"}}}
+				res[3] = memoryProcEntry{P: &process{PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "init"}}}
 				res[1].P.Children = []*process{res[2].P}
 				res[2].P.Children = []*process{res[3].P}
 
@@ -116,7 +116,7 @@ func TestFindWorkspaces(t *testing.T) {
 					P:   &process{PID: 4, Parent: res[3].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 					Env: []string{"GITPOD_WORKSPACE_ID=bla", "GITPOD_INSTANCE_ID=blabla"},
 				}
-				res[5] = memoryProcEntry{P: &process{PID: 5, Parent: res[4].P, Cmdline: []string{"supervisor", "run"}}}
+				res[5] = memoryProcEntry{P: &process{PID: 5, Parent: res[4].P, Cmdline: []string{"supervisor", "init"}}}
 				res[3].P.Children = []*process{res[4].P}
 				res[4].P.Children = []*process{res[5].P}
 
@@ -145,7 +145,7 @@ func TestFindWorkspaces(t *testing.T) {
 					P:   &process{PID: 4, Parent: res[3].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 					Env: []string{"GITPOD_WORKSPACE_ID=bla", "GITPOD_INSTANCE_ID=blabla"},
 				}
-				res[5] = memoryProcEntry{P: &process{PID: 5, Parent: res[4].P, Cmdline: []string{"supervisor", "run"}}}
+				res[5] = memoryProcEntry{P: &process{PID: 5, Parent: res[4].P, Cmdline: []string{"supervisor", "init"}}}
 				res[3].P.Children = []*process{res[4].P}
 				res[4].P.Children = []*process{res[5].P}
 
@@ -153,7 +153,7 @@ func TestFindWorkspaces(t *testing.T) {
 					P:   &process{PID: 6, Parent: res[3].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 					Env: []string{"GITPOD_WORKSPACE_ID=second-ws", "GITPOD_INSTANCE_ID=second-ws"},
 				}
-				res[7] = memoryProcEntry{P: &process{PID: 7, Parent: res[4].P, Cmdline: []string{"supervisor", "run"}}}
+				res[7] = memoryProcEntry{P: &process{PID: 7, Parent: res[4].P, Cmdline: []string{"supervisor", "init"}}}
 				res[3].P.Children = []*process{res[4].P, res[6].P}
 				res[6].P.Children = []*process{res[7].P}
 
@@ -217,7 +217,7 @@ func TestRunDetector(t *testing.T) {
 						P:   &process{Hash: 2, PID: 2, Parent: res[1].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 						Env: []string{"GITPOD_WORKSPACE_ID=foobar", "GITPOD_INSTANCE_ID=baz"},
 					}
-					res[3] = memoryProcEntry{P: &process{Hash: 3, PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "run"}}}
+					res[3] = memoryProcEntry{P: &process{Hash: 3, PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "init"}}}
 					res[4] = memoryProcEntry{P: &process{Hash: 4, PID: 4, Parent: res[3].P, Cmdline: []string{"bad-actor", "has", "args"}}}
 					res[1].P.Children = []*process{res[2].P}
 					res[2].P.Children = []*process{res[3].P}
@@ -231,7 +231,7 @@ func TestRunDetector(t *testing.T) {
 						P:   &process{Hash: 2, PID: 2, Parent: res[1].P, Cmdline: []string{"/proc/self/exe", "ring1"}},
 						Env: []string{"GITPOD_WORKSPACE_ID=foobar", "GITPOD_INSTANCE_ID=baz"},
 					}
-					res[3] = memoryProcEntry{P: &process{Hash: 3, PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "run"}}}
+					res[3] = memoryProcEntry{P: &process{Hash: 3, PID: 3, Parent: res[2].P, Cmdline: []string{"supervisor", "init"}}}
 					res[4] = memoryProcEntry{P: &process{Hash: 4, PID: 4, Parent: res[3].P, Cmdline: []string{"bad-actor", "has", "args"}}}
 					res[5] = memoryProcEntry{P: &process{Hash: 5, PID: 5, Parent: res[3].P, Cmdline: []string{"another-bad-actor", "has", "args"}}}
 					res[1].P.Children = []*process{res[2].P}

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -806,7 +806,7 @@ var ring2Cmd = &cobra.Command{
 			return
 		}
 
-		err = unix.Exec(ring2Opts.SupervisorPath, []string{"supervisor", "run"}, os.Environ())
+		err = unix.Exec(ring2Opts.SupervisorPath, []string{"supervisor", "init"}, os.Environ())
 		if err != nil {
 			if eerr, ok := err.(*exec.ExitError); ok {
 				exitCode = eerr.ExitCode()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
this is part 2 of #8075

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate #8056 

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace
2. watch the log
3. stop a workspace
4. see there are no `no child process` any more
5. check the stop log, the behavior should be same with before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
