### PR TITLE
[ws-daemon] Support git lfs

### DIFF
--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -14,7 +14,7 @@ RUN apk upgrade \
   && rm -rf /var/cache/apk/*
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
-RUN apk add --no-cache git bash openssh-client lz4 e2fsprogs coreutils tar strace xfsprogs-extra
+RUN apk add --no-cache git git-lfs bash openssh-client lz4 e2fsprogs coreutils tar strace xfsprogs-extra
 
 RUN apk add --no-cache kubectl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 


### PR DESCRIPTION
## Description
This PR adds support for Git LFS during content init. Content init runs in the context of ws-dameon, hence git-lfs needs to be installed there.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8105

## How to test
1. Open a repo with Git LFS enabled

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added support for Git LFS during content init
```
