### PR TITLE
Fix overflow on port not found page

### DIFF
--- a/components/ws-proxy/public/port-not-found.html
+++ b/components/ws-proxy/public/port-not-found.html
@@ -36,6 +36,7 @@
     }
 
     body {
+      margin: 0;
       font-family:
         system-ui,
         -apple-system,


### PR DESCRIPTION
## Description
Fixed Y overflow on port not found page

 

## How to test
Open a port on which nothing is running.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
