### PR TITLE
Werft: Add attribute that identifies runs with VMs pre-made

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -332,13 +332,16 @@ export async function build(context, version) {
         if (!existingVM) {
             werft.log(vmSlices.BOOT_VM, 'Starting VM')
             VM.startVM({ name: destname })
+            werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true)
         } else if (cleanSlateDeployment) {
             werft.log(vmSlices.BOOT_VM, 'Removing existing namespace')
             VM.deleteVM({ name: destname })
             werft.log(vmSlices.BOOT_VM, 'Starting VM')
             VM.startVM({ name: destname })
+            werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true)
         } else {
             werft.log(vmSlices.BOOT_VM, 'VM already exists')
+            werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", false)
         }
 
         werft.log(vmSlices.BOOT_VM, 'Waiting for VM to be ready')

--- a/.werft/util/werft.ts
+++ b/.werft/util/werft.ts
@@ -20,7 +20,7 @@ export class Werft {
     private tracer: Tracer;
     public rootSpan: Span;
     private sliceSpans: { [slice: string]: Span } = {}
-    private currentPhaseSpan: Span;
+    public currentPhaseSpan: Span;
 
     constructor(job: string) {
         if (werft) {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Adds a new attribute to our traces that explains if the CI run with a pre-existing VM or if it creates a new one.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1044

## How to test
<!-- Provide steps to test this PR -->
* Create a new branch from this PR and run the werft job twice with the following annotation: `with-vm=true`
* Look at the trace shown in the results and notice that new attribute `werft.harvester.created_vm` present in the VM phase.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
