### PR TITLE
Update helm installer with config for new cpu limiter

### DIFF
--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -44,16 +44,12 @@ daemon:
       - start: 100000
         size: 70000
   resources:
-    cgroupBasePath: "/mnt/node-cgroups"
-    cpuBuckets:
-{{ .Values.workspaceSizing.dynamic.cpu.buckets | toYaml | indent 6 }}
-    processPriorities:
-      supervisor: 0
-      theia: 5
-      shell: 6
-      default: 10
-    controlPeriod: {{ .Values.workspaceSizing.dynamic.cpu.controlPeriod | quote }}
-    samplingPeriod: {{ .Values.workspaceSizing.dynamic.cpu.samplingPeriod | quote }}
+    enabled: {{ $comp.cpuLimit.enabled }}
+    totalBandwidth: {{ $comp.cpuLimit.totalBandwidth }}
+    limit: {{ $comp.cpuLimit.limit }}
+    burstLimit: {{ $comp.cpuLimit.limit}}
+    controlPeriod: {{ $comp.cpuLimit.controlPeriod }}
+    cgroupBasePath: {{ $comp.cpuLimit.cgroupBasePath }}
   hosts:
     enabled: true
     nodeHostsFile: "/mnt/hosts"

--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -43,7 +43,7 @@ daemon:
     userUIDRange:
       - start: 100000
         size: 70000
-  resources:
+  cpuLimit:
     enabled: {{ $comp.cpuLimit.enabled }}
     totalBandwidth: {{ $comp.cpuLimit.totalBandwidth }}
     limit: {{ $comp.cpuLimit.limit }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -476,6 +476,13 @@ components:
     clusterIP: "None"
     selectorKind: daemonset
     workspaceSizeLimit: "50g"
+    cpuLimit:
+      enabled: true
+      totalBandwidth: 12
+      limit: 2
+      burstLimit: 6
+      controlPeriod: "15s"
+      cgroupBasePath: "/mnt/node-cgroups"
     containerRuntime:
       enabled: true
       runtime: containerd

--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -26,7 +26,7 @@ type Config struct {
 	Enabled        bool              `json:"enabled"`
 	TotalBandwidth resource.Quantity `json:"totalBandwidth"`
 	Limit          resource.Quantity `json:"limit"`
-	BurstLimit     resource.Quantity `json:"bustLimit"`
+	BurstLimit     resource.Quantity `json:"burstLimit"`
 
 	ControlPeriod  util.Duration `json:"controlPeriod"`
 	CGroupBasePath string        `json:"cgroupBasePath"`


### PR DESCRIPTION
## Description
#8036 reworked the cpu limiting that ws-daemon is doing. We also need to update the helm installer with the new configuration for ws-daemon. This broke staging as ws-daemon expected the new configuration but the configmap still had the old configuration.

## Related Issue(s)
n.a.

## How to test
Open [preview environment](https://furisto-cpu-config.staging.gitpod-dev.com/workspaces) which has been installed with helm and check that ws-daemon is running and workspaces can be opened

## Release Notes

```release-note
NONE
```
