### PR TITLE
[dashboard, supervisor, ws-proxy] Break redirect loop on failing workspaces starts

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -9,6 +9,7 @@
     "js-cookie": "^3.0.1",
     "moment": "^2.29.1",
     "monaco-editor": "^0.25.2",
+    "query-string": "^7.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -27,6 +27,7 @@ import { settingsPathAccount, settingsPathIntegrations, settingsPathMain, settin
 import { projectsPathInstallGitHubApp, projectsPathMain, projectsPathMainWithParams, projectsPathNew } from './projects/projects.routes';
 import { refreshSearchData } from './components/RepositoryFinder';
 import { StartWorkspaceModal } from './workspaces/StartWorkspaceModal';
+import { parseProps } from './start/StartWorkspace';
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ './Setup'));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ './workspaces/Workspaces'));
@@ -412,7 +413,7 @@ function App() {
     } else if (isCreation) {
         toRender = <CreateWorkspace contextUrl={hash} />;
     } else if (isWsStart) {
-        toRender = <StartWorkspace workspaceId={hash} />;
+        toRender = <StartWorkspace {...parseProps(hash, window.location.search)} />;
     } else if (/^(github|gitlab)\.com\/.+?/i.test(window.location.pathname)) {
         let url = new URL(window.location.href)
         url.hash = url.pathname

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -12,7 +12,7 @@ import Modal from "../components/Modal";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
-import StartWorkspace from "./StartWorkspace";
+import StartWorkspace, { parseProps } from "./StartWorkspace";
 import { openAuthorizeWindow } from "../provider-utils";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { SelectAccountModal } from "../settings/SelectAccountModal";
@@ -154,7 +154,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
 
     const result = this.state?.result;
     if (result?.createdWorkspaceId) {
-      return <StartWorkspace workspaceId={result.createdWorkspaceId} />;
+      return <StartWorkspace {...parseProps(result?.createdWorkspaceId, window.location.search)} />;
     }
 
     else if (result?.existingWorkspaces) {

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -8,6 +8,7 @@ import { ContextURL, DisposableCollection, GitpodServer, RateLimiterError, Start
 import { IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import EventEmitter from "events";
+import * as queryString from "query-string";
 import React, { Suspense, useEffect } from "react";
 import { v4 } from 'uuid';
 import Arrow from "../components/Arrow";
@@ -21,10 +22,54 @@ const sessionId = v4();
 const WorkspaceLogs = React.lazy(() => import('../components/WorkspaceLogs'));
 
 export interface StartWorkspaceProps {
-  workspaceId: string;
+  workspaceId: string,
+  runsInIFrame: boolean,
+  /**
+   * This flag is used to break the autostart-cycle explained in https://github.com/gitpod-io/gitpod/issues/8043
+   */
+  dontAutostart: boolean,
+}
+
+export function parseProps(workspaceId: string, search?: string): StartWorkspaceProps {
+  const params = parseParameters(search);
+  const runsInIFrame = window.top !== window.self;
+  return {
+    workspaceId,
+    runsInIFrame: window.top !== window.self,
+    // Either:
+    //  - not_found: we were sent back from a workspace cluster/IDE URL where we expected a workspace to be running but it wasn't because either:
+    //    - this is a (very) old tab and the workspace already timed out
+    //    - due to a start error our workspace terminated very quickly between:
+    //      a) us being redirected to that IDEUrl (based on the first ws-manager update) and
+    //      b) our requests being validated by ws-proxy
+    //  - runsInIFrame (IDE case):
+    //    - we assume the workspace has already been started for us
+    //    - we don't know it's instanceId
+    dontAutostart: params.notFound || runsInIFrame,
+  }
+}
+
+function parseParameters(search?: string): { notFound?: boolean } {
+  try {
+    if (search === undefined) {
+      return {};
+    }
+    const params = queryString.parse(search, {parseBooleans: true});
+    const notFound = !!(params && params["not_found"]);
+    return {
+      notFound,
+    };
+  } catch (err) {
+    console.error("/start: error parsing search params", err);
+    return {};
+  }
 }
 
 export interface StartWorkspaceState {
+  /**
+   * This is set to the istanceId we started (think we started on).
+   * We only receive updates for this particular instance, or none if not set.
+  */
   startedInstanceId?: string;
   workspaceInstance?: WorkspaceInstance;
   workspace?: Workspace;
@@ -34,8 +79,8 @@ export interface StartWorkspaceState {
     link: string
     label: string
     clientID?: string
-  }
-  ideOptions?: IDEOptions
+  };
+  ideOptions?: IDEOptions;
 }
 
 export default class StartWorkspace extends React.Component<StartWorkspaceProps, StartWorkspaceState> {
@@ -47,7 +92,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
   private readonly toDispose = new DisposableCollection();
   componentWillMount() {
-    if (this.runsInIFrame()) {
+    if (this.props.runsInIFrame) {
       window.parent.postMessage({ type: '$setSessionId', sessionId }, '*');
       const setStateEventListener = (event: MessageEvent) => {
         if (event.data.type === 'setState' && 'state' in event.data && typeof event.data['state'] === 'object') {
@@ -75,8 +120,15 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       this.setState({ error });
     }
 
+    if (this.props.dontAutostart) {
+      this.fetchWorkspaceInfo(undefined);
+      return;
+    }
+
+    // dashboard case (no previous errors): start workspace as quickly as possible
     this.startWorkspace();
-    getGitpodService().server.getIDEOptions().then(ideOptions => this.setState({ ideOptions }))
+    // query IDE options so we can show them if necessary once the workspace is running
+    getGitpodService().server.getIDEOptions().then(ideOptions => this.setState({ ideOptions }));
   }
 
   componentWillUnmount() {
@@ -130,14 +182,13 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
       }
       console.log("/start: started workspace instance: " + result.instanceID);
       // redirect to workspaceURL if we are not yet running in an iframe
-      if (!this.runsInIFrame() && result.workspaceURL) {
+      if (!this.props.runsInIFrame && result.workspaceURL) {
         this.redirectTo(result.workspaceURL);
         return;
       }
-      this.setState({ startedInstanceId: result.instanceID });
-      // Explicitly query state to guarantee we get at least one update
+      // Start listening too instance updates - and explicitly query state once to guarantee we get at least one update
       // (needed for already started workspaces, and not hanging in 'Starting ...' for too long)
-      this.fetchWorkspaceInfo();
+      this.fetchWorkspaceInfo(result.instanceID);
     } catch (error) {
       console.error(error);
       if (typeof error === 'string') {
@@ -180,15 +231,28 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     }
   }
 
-  async fetchWorkspaceInfo() {
+  /**
+   * Fetches initial WorkspaceInfo from the server. If there is a WorkspaceInstance for workspaceId, we feed it
+   * into "onInstanceUpdate" and start accepting further updates.
+   *
+   * @param startedInstanceId The instanceId we want to listen on
+   */
+  async fetchWorkspaceInfo(startedInstanceId: string | undefined) {
+    // this ensures we're receiving updates for this instance
+    if (startedInstanceId) {
+      this.setState({ startedInstanceId });
+    }
+
     const { workspaceId } = this.props;
     try {
       const info = await getGitpodService().server.getWorkspace(workspaceId);
       if (info.latestInstance) {
-        this.setState({
-          workspace: info.workspace
-        });
-        this.onInstanceUpdate(info.latestInstance);
+        const instance = info.latestInstance;
+        this.setState((s) => ({
+          workspace: info.workspace,
+          startedInstanceId: s.startedInstanceId || instance.id,  // note: here's a potential mismatch between startedInstanceId and instance.id. TODO(gpl) How to handle this?
+        }));
+        this.onInstanceUpdate(instance);
       }
     } catch (error) {
       console.error(error);
@@ -197,20 +261,35 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
   }
 
   notifyDidOpenConnection() {
-    this.fetchWorkspaceInfo();
+    this.fetchWorkspaceInfo(undefined);
   }
 
   async onInstanceUpdate(workspaceInstance: WorkspaceInstance) {
-    const startedInstanceId = this.state?.startedInstanceId;
-    if (workspaceInstance.workspaceId !== this.props.workspaceId || startedInstanceId !== workspaceInstance.id) {
+    if (workspaceInstance.workspaceId !== this.props.workspaceId) {
       return;
+    }
+
+    // Here we filter out updates to instances we haven't started to avoid issues with updates coming in out-of-order
+    // (e.g., multiple "stopped" events from the older instance, where we already started a fresh one after the first)
+    // Only exception is when we do the switch from the "old" to the "new" one.
+    const startedInstanceId = this.state?.startedInstanceId;
+    if (startedInstanceId !== workspaceInstance.id) {
+      // do we want to switch to "new" instance we just received an update for?
+      const switchToNewInstance = this.state.workspaceInstance?.status.phase === "stopped" && workspaceInstance.status.phase !== "stopped";
+      if (!switchToNewInstance) {
+        return;
+      }
+      this.setState({
+        startedInstanceId: workspaceInstance.id,
+        workspaceInstance,
+      });
     }
 
     await this.ensureWorkspaceAuth(workspaceInstance.id);
 
     // Redirect to workspaceURL if we are not yet running in an iframe.
     // It happens this late if we were waiting for a docker build.
-    if (!this.runsInIFrame() && workspaceInstance.ideUrl) {
+    if (!this.props.runsInIFrame && workspaceInstance.ideUrl && !this.props.dontAutostart) {
       this.redirectTo(workspaceInstance.ideUrl);
       return;
     }
@@ -255,22 +334,18 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
   }
 
   redirectTo(url: string) {
-    if (this.runsInIFrame()) {
+    if (this.props.runsInIFrame) {
       window.parent.postMessage({ type: 'relocate', url }, '*');
     } else {
       window.location.href = url;
     }
   }
 
-  runsInIFrame() {
-    return window.top !== window.self;
-  }
-
   render() {
     const { error } = this.state;
     const isHeadless = this.state.workspace?.type !== 'regular';
     const isPrebuilt = WithPrebuild.is(this.state.workspace?.context);
-    let phase = StartPhase.Preparing;
+    let phase: StartPhase | undefined = StartPhase.Preparing;
     let title = undefined;
     let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
     const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
@@ -317,7 +392,29 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
         if (!this.state.desktopIde) {
           phase = StartPhase.Running;
-          statusMessage = <p className="text-base text-gray-400">Opening Workspace …</p>;
+
+          if (this.props.dontAutostart) {
+            // hide the progress bar, as we're already running
+            phase = undefined;
+            title = 'Running';
+
+            // in case we dontAutostart the IDE we have to provide controls to do so
+            statusMessage = <div>
+                <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
+                  <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
+                  <div>
+                    <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
+                    <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
+                  </div>
+                </div>
+                <div className="mt-10 justify-center flex space-x-2">
+                  <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}><button className="secondary">Go to Dashboard</button></a>
+                  <a target="_parent" href={gitpodHostUrl.asStart(this.props.workspaceId).toString() /** move over 'start' here to fetch fresh credentials in case this is an older tab */}><button>Open Workspace</button></a>
+                </div>
+            </div>;
+          } else {
+            statusMessage = <p className="text-base text-gray-400">Opening Workspace …</p>;
+          }
         } else {
           phase = StartPhase.IdeReady;
           const openLink = this.state.desktopIde.link;

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -106,7 +106,6 @@ const toStop = new DisposableCollection();
 
     //#region current-frame
     let current: HTMLElement = loading.frame;
-    let stopped = false;
     let desktopRedirected = false;
     const nextFrame = () => {
         const instance = gitpodServiceClient.info.latestInstance;
@@ -141,19 +140,6 @@ const toStop = new DisposableCollection();
                 if (ideService.state === 'ready') {
                     return document.body;
                 }
-            }
-            if (instance.status.phase === 'stopped') {
-                stopped = true;
-            }
-            if (stopped && (
-                instance.status.phase === 'preparing' ||
-                instance.status.phase === 'pending' ||
-                instance.status.phase === 'creating' ||
-                instance.status.phase === 'initializing')) {
-                // reload the page if the workspace was restarted to ensure:
-                // - graceful reconnection of IDEs
-                // - new owner token is set
-                window.location.href = startUrl.toString();
             }
         }
         return loading.frame;

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -550,7 +550,7 @@ func workspaceMustExistHandler(config *Config, infoProvider WorkspaceInfoProvide
 			info := infoProvider.WorkspaceInfo(coords.ID)
 			if info == nil {
 				log.WithFields(log.OWI("", coords.ID, "")).Info("no workspace info found - redirecting to start")
-				redirectURL := fmt.Sprintf("%s://%s/start/#%s", config.GitpodInstallation.Scheme, config.GitpodInstallation.HostName, coords.ID)
+				redirectURL := fmt.Sprintf("%s://%s/start/?not_found=true#%s", config.GitpodInstallation.Scheme, config.GitpodInstallation.HostName, coords.ID)
 				http.Redirect(resp, req, redirectURL, http.StatusFound)
 				return
 			}

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -414,10 +414,10 @@ func TestRoutes(t *testing.T) {
 				Status: http.StatusFound,
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
-					"Location":     {"https://test-domain.com/start/#blabla-smelt-9ba20cc1"},
+					"Location":     {"https://test-domain.com/start/?not_found=true#blabla-smelt-9ba20cc1"},
 					"Vary":         {"Accept-Encoding"},
 				},
-				Body: ("<a href=\"https://test-domain.com/start/#blabla-smelt-9ba20cc1\">Found</a>.\n\n"),
+				Body: ("<a href=\"https://test-domain.com/start/?not_found=true#blabla-smelt-9ba20cc1\">Found</a>.\n\n"),
 			},
 		},
 		{
@@ -429,10 +429,10 @@ func TestRoutes(t *testing.T) {
 				Status: http.StatusFound,
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
-					"Location":     {"https://test-domain.com/start/#blabla-smelt-9ba20cc1"},
+					"Location":     {"https://test-domain.com/start/?not_found=true#blabla-smelt-9ba20cc1"},
 					"Vary":         {"Accept-Encoding"},
 				},
-				Body: ("<a href=\"https://test-domain.com/start/#blabla-smelt-9ba20cc1\">Found</a>.\n\n"),
+				Body: ("<a href=\"https://test-domain.com/start/?not_found=true#blabla-smelt-9ba20cc1\">Found</a>.\n\n"),
 			},
 		},
 		{

--- a/yarn.lock
+++ b/yarn.lock
@@ -14397,6 +14397,16 @@ query-string@^6.13.3:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
+query-string@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"


### PR DESCRIPTION
## Description
This PR breaks the restart cycles we recently oberserve for workspaces that fail quickly enough.

The basic cycle was:
 1. `StartWorkspace` (dashboard, /start) -> onload: `server.startWorkspace`
 2. `server.startWorkspace` returns :+1: inkl. `ideUrl` (1. instance)
 2. `StartWorkspace` redirects to `ideUrl`
 3. `StartWorkspace` (inframe, IDE url) -> onload: `server.startWorkspace`:
    a. expecting `server` to return the already running instance from step 1)
    b. but that was already stopped with an error, so started a fresh one (2. instance)
    c. `supervisor` frontend suspected a re-start (because it sees `stopped` updates from 1. instance, followed by `pending`/`creating` from 2.), and to properly re-connect the frontend, re-directs to `StartWorkspace` :repeat: 

This PR changes three things:
 - if workspace is not found, [`ws-proxy`](https://github.com/gitpod-io/gitpod/blob/2c302638122f9471cac25371d0b765a14aeaf22f/components/ws-proxy/pkg/proxy/routes.go#L553) now re-direct to `/start/?not_found=true`. `StartWorkspace` reads that parameter and [sets `dontAutostart`](https://github.com/gitpod-io/gitpod/blob/1b0bd82d7f43a1f244d9596f5370139649ee3aca/components/dashboard/src/start/StartWorkspace.tsx#L128-L140), which in turn ensures `startWorkspace(id)` is not called on load
 - when `StartWorkspace` is loaded inside an iframe (when already on the ideUrl) [`dontAutostart: true` is set as well](https://github.com/gitpod-io/gitpod/blob/1b0bd82d7f43a1f244d9596f5370139649ee3aca/components/dashboard/src/start/StartWorkspace.tsx#L142-L152).
 - the [reload behavior in `supervisor` frontend](https://github.com/gitpod-io/gitpod/pull/8125/files#diff-3cab7118ea66c275e7be9d00fb70116dae530eeb132a44a1fd643639748c1a11L145-L157) got removed, and replaced with a [similar](https://github.com/gitpod-io/gitpod/pull/8125/files#diff-d897e36a784992a6a4d3b76c09147a96375add6c80bd14dca49657dcff06b3a7R275-R291) mechanism in `StartWorkspace`.

### Effects on the "start workspace" flow
 - :+1:  if you come back to a (very) old workspace tabs that were unloaded, a mere "tab activation" will no longer re-start the workspace. Instead, you have to actively hit "Open Workspace".
 - :+1: we do not call `startWorkspace` that often, which should help with not confusing the rate-limiter (and potentially fasten the startup process :crossed_fingers: )
 - :-1: maybe: If there have been other errors in the startup-chain, they have so-long been covered by the "auto-restart" behavior. Now users have to actively click "Open workspace" again in such cases. Not sure how relevant this is, and IMO we have to find out
 - :-1: ... ?


## UI
Currently the cycle breaks with this screen:
![image](https://user-images.githubusercontent.com/32448529/153249902-093bc042-4956-49b7-afd8-607ff6d0a703.png)
 

Alternatively we could use a modal but I found it to be bad because:
 - it hides the error message
 - if we added the error message to the screen we'd just duplicate the original screen
**Update**: removed that code

## Alternatives

~Alternatively, and to further strengthen the process, we could try to find a way to pass the `instanceId` from `dashboard` to `supervisor` frontend. This would avoid the whole issue altogether (and make code in supervisor frontend easier), because we know upfront which instance we expect to see here.
The only way I can think of is to make it part of the url; `<workspaceId>.ws-<cluster>.gitpod.io/#<instanceId>`, for example. But I'm unsure if and how this affects IDE, and if yes, how to avoid that (/cc @akosyakov )~

Dismissed [here](https://github.com/gitpod-io/gitpod/pull/8125#issuecomment-1034694867).

**Note**: There sometimes seems to be CORS issues with redirects from `ws-proxy`, but sometimes they work. I assumed them to be out-of-scope here, because this PR does not touch CORS or any domains used.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8043

## How to test

### Negative
 - in this preview env all workspaces will fail: https://gpl-8043-break-redirect-loop.staging.gitpod-dev.com/workspaces
 - tab 1: start [any workspace](https://gpl-8043-break-redirect-loop.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-typescript-node)
 - tab 2: open the same workspace
 - note how both end up in the error state
 - hit "open workspace" again on one tab
 - note how a) both update, and show up-to-date state, and b) both end up in the error state again

### Positive
 - in this preview env all workspaces should succeed: https://gpl-8043-break-redirect-loop-w.staging.gitpod-dev.com/workspaces
 - tab 1: start [any workspace](https://gpl-8043-break-redirect-loop-w.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-typescript-node)
 - tab 2: open the same workspace
 - note how both end up in the IDE
 - stop the workspace
 - note how both end up in "Stopped"
 - open the workspace again from tab 2
 - Note how:
   - a) both workspaces show up-to-date state
   - b) only tab 2 reveals the IDE
   - c) tab 1 still shows the up-to-date state (RUNNING), incl. controls to open/reveal the IDE (with fresh credentials)
![image](https://user-images.githubusercontent.com/32448529/153583763-61b48779-a4cb-4aa6-bf48-5a9cfbaefd9e.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
make workspace startup more robust
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
