### PR TITLE
Truncate workspace name on workspace start page

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -391,7 +391,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
           <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 bg-gray-100 dark:bg-gray-800">
             <div className="rounded-full w-3 h-3 text-sm bg-gitpod-kumquat">&nbsp;</div>
             <div>
-              <p className="text-gray-700 dark:text-gray-200 font-semibold">{this.state.workspaceInstance.workspaceId}</p>
+              <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
               <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
             </div>
           </div>
@@ -418,7 +418,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
           <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
             <div className="rounded-full w-3 h-3 text-sm bg-gray-300">&nbsp;</div>
             <div>
-              <p className="text-gray-700 dark:text-gray-200 font-semibold">{this.state.workspaceInstance.workspaceId}</p>
+              <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
               <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
             </div>
           </div>


### PR DESCRIPTION
## Description

Following the fix in https://github.com/gitpod-io/gitpod/pull/7711#discussion_r789668683 that wil truncate the new workspace name in the workspace start page, this will duplicate this approach to truncate the workspace name on all workspace start pages.

## How to test
1. Start a new workspace
2. Stop the workspace or let the workspace time out
3. Notice the workspace name no longer wraps but is truncated

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-02-09 at 8 24 17 PM (2)" src="https://user-images.githubusercontent.com/120486/153265968-f858936d-cd8f-454e-a13b-239cafa10b52.png"> | <img width="1440" alt="Screenshot 2022-02-09 at 8 24 25 PM (2)" src="https://user-images.githubusercontent.com/120486/153265974-949de262-be9c-4c04-aa2b-a2066f9ebdd9.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
