### PR TITLE
workspacekit: Enable scmpid check.

### DIFF
--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -208,12 +208,11 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 	}
 	defer memFile.Close()
 
-	// TODO(cw): find why this breaks
-	// err = libseccomp.NotifIDValid(fd, req.ID)
-	// if err != nil {
-	// 	log.WithError(err).Error("invalid notif ID")
-	// 	return Errno(unix.EPERM)
-	// }
+	err = libseccomp.NotifIDValid(h.FD, req.ID)
+	if err != nil {
+		log.WithError(err).Error("invalid notify ID", req.ID)
+		return Errno(unix.EPERM)
+	}
 
 	source, err := readarg.ReadString(memFile, int64(req.Data.Args[0]))
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It seems to have failed to check the id of seccomp notify before, but now that I have upgraded the version of libseccomp-golang, I tried again and succeeded.
https://github.com/gitpod-io/gitpod/pull/8004

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
1. Go to https://to-enable-checking-scmpid.staging.gitpod-dev.com/workspaces
2. Create a workspace
3. Run `docker run hello-world` in a workspace you created and succeeded

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Enable id check for seccomp notify
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No