### PR TITLE
Log cfs quota and period

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -52,7 +52,7 @@ func (basePath CgroupCFSController) SetLimit(limit Bandwidth) (changed bool, err
 
 	err = os.WriteFile(filepath.Join(string(basePath), "cpu.cfs_quota_us"), []byte(strconv.FormatInt(target.Microseconds(), 10)), 0644)
 	if err != nil {
-		return false, xerrors.Errorf("cannot set CFS quota: %w", err)
+		return false, xerrors.Errorf("cannot set CFS quota of %d (period is %d): %w", target.Microseconds(), period.Microseconds(), err)
 	}
 	return true, nil
 }


### PR DESCRIPTION
## Description
Log cfs quota and period. We sometimes get invalid argument when writing to the cgroup interface files. This should help us find out which values are rejected

## Related Issue(s)
n.a.

## How to test
n.a.

## Release Notes
```release-note
NONE
```