### PR TITLE
add metrics to track success or failure of downloadOTS requests

### DIFF
--- a/components/content-service/cmd/run.go
+++ b/components/content-service/cmd/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
 	"github.com/gitpod-io/gitpod/content-service/pkg/service"
 )
 
@@ -33,6 +34,11 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := getConfig()
 		reg := prometheus.NewRegistry()
+
+		err := initializer.NewMetrics(prometheus.WrapRegistererWithPrefix("content_service_", reg))
+		if err != nil {
+			log.WithError(err).Error("failed to register initializer metrics")
+		}
 
 		common_grpc.SetupLogging()
 

--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -314,11 +314,17 @@ func downloadOTS(ctx context.Context, url string) (user, pwd string, err error) 
 			break
 		}
 		log.WithError(err).WithField("attempt", i).Warn("cannot download OTS")
+		if metrics != nil {
+			metrics.DownloadOTSCounter.WithLabelValues("failure").Inc()
+		}
 	}
 	if err != nil {
 		return "", "", err
 	}
 
+	if metrics != nil {
+		metrics.DownloadOTSCounter.WithLabelValues("success").Inc()
+	}
 	return user, pwd, nil
 }
 

--- a/components/content-service/pkg/initializer/metrics.go
+++ b/components/content-service/pkg/initializer/metrics.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package initializer
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type initializer_metrics struct {
+	DownloadOTSCounter *prometheus.CounterVec
+}
+
+var metrics *initializer_metrics
+
+func NewMetrics(reg prometheus.Registerer) error {
+	downloadOTSCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "req_download_ots_total",
+			Help: "number of download ots requests",
+		}, []string{"type"},
+	)
+	err := reg.Register(downloadOTSCounter)
+	if err != nil {
+		return err
+	}
+
+	metrics = &initializer_metrics{
+		DownloadOTSCounter: downloadOTSCounter,
+	}
+	return nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add metrics for content service to track download OTS requests, and to track how many have failed or succeeded. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related issue: #8096 

## How to test
<!-- Provide steps to test this PR -->
I tried to spin up several workspaces from private repo in staging env, but did not see anything in content-service pod that would indicate it was doing anything. I might be missing something here. Need a second pair of :eyes: to confirm if local content-service pod is  supposed to call downloadOTS when opening a private repo from staging env.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add metrics to content-service to track download OTS requests
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
