### PR TITLE
werft/build: Add SIGTERM handling

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -21,6 +21,12 @@ Tracing.initialize()
         werft = new Werft("build")
     })
     .then(() => run(context))
+    .then(() => {
+        process.on('SIGTERM', () => {
+            console.log('SIGTERM signal received.');
+            werft.endAllSpans()
+        });
+    })
     .then(() => VM.stopKubectlPortForwards())
     .then(() => werft.endAllSpans())
     .catch((err) => {

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -205,6 +205,9 @@ pod:
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
         printf '{{ toJson . }}' > context.json
 
-        npx ts-node .werft/build.ts
+        trap 'kill $(jobs -p)' SIGINT SIGTERM
+
+        npx ts-node .werft/build.ts &
+        wait $!
 sidecars:
 - testdb


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Just adds SIGTERM handling so we can close spans before killing a pod.

The problem is that this isn't working as expected and I believe that the reason is the way we call `build.ts`

Exec-ing into the build container, I can see that the process PID 1 executes a `sh` process, which then calls the `node` that runs our script:
![image](https://user-images.githubusercontent.com/24193764/153569864-41daaac8-388e-47e5-9882-1997f55a6e19.png)

By killing a POD, the container runtime sends a SIGTERM to the PID 1 process of all containers of the pod. If PID 1 process has child processes, the responsibility of propagation of the SIGTERM to the child processes lies in the hands of said process.

The command `sh`, however, doesn't propagate SIGTERM, so our `node` process will never receive a SIGTERM


[Source](https://pracucci.com/graceful-shutdown-of-kubernetes-pods.html#:~:text=When%20a%20pod%20should%20be,see%20below%20to%20change%20it).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Should've fixed https://github.com/gitpod-io/ops/issues/865

## How to test
<!-- Provide steps to test this PR -->
Run a job and kill it mid execution with 
```
kubectl delete pod -n werft gitpod-build-<sanitized-namespace>
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A