### PR TITLE
[server] Disable inference of extensions

### DIFF
--- a/components/server/src/config/config-inferrer.spec.ts
+++ b/components/server/src/config/config-inferrer.spec.ts
@@ -11,6 +11,7 @@ import { WorkspaceConfig } from "@gitpod/gitpod-protocol";
 
 function context(files: {[path:string]:string}): Context {
     return {
+        excludeVsCodeConfig: false,
         config: {},
         exists: async (path: string) => path.toString() in files,
         read: async (path: string) => files[path.toString()],

--- a/components/server/src/config/config-inferrer.ts
+++ b/components/server/src/config/config-inferrer.ts
@@ -8,6 +8,7 @@ import { WorkspaceConfig } from "@gitpod/gitpod-protocol";
 
 export interface Context {
     config: WorkspaceConfig;
+    excludeVsCodeConfig: boolean;
     exists(path: string): Promise<boolean>;
     read(path: string): Promise<string | undefined>;
 }
@@ -93,6 +94,9 @@ export class ConfigInferrer {
     }
 
     protected addExtension(ctx: Context, extensionName: string) {
+        if (ctx.excludeVsCodeConfig) {
+            return;
+        }
         if (!ctx.config.vscode || !ctx.config.vscode.extensions) {
             ctx.config.vscode = {
                 extensions: []

--- a/components/server/src/config/configuration-service.ts
+++ b/components/server/src/config/configuration-service.ts
@@ -38,6 +38,8 @@ export class ConfigurationService {
         this.requestedPaths.forEach(path => !(path in cache) && readFile(path));
         const configInferrer = new ConfigInferrer();
         const config: WorkspaceConfig = await configInferrer.getConfig({
+            // TODO(se) pass down information about currently used IDE. Defaulting to disabling vscode extensions for now, to not bother non VS Code users.
+            excludeVsCodeConfig: true,
             config: {},
             read: readFile,
             exists: async (path: string) => !!(await readFile(path)),


### PR DESCRIPTION
This disables the automatic inference of VS Code extensions. Ideally, this could happy when people start from a VS Code IDE. In light of priorities, I opted for disabling it all together for now.

fixes #8050

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
