### PR TITLE
.werft/config: Fix typo on job trigger

### DIFF
--- a/.werft/config.yaml
+++ b/.werft/config.yaml
@@ -5,4 +5,4 @@ rules:
   - or: ["trigger !== deleted"]
 - path: ".werft/delete-preview-environments/delete-preview-environment.yaml"
   matchesAll:
-  - or: ["trigger == deleted"]
+  - or: ["trigger === deleted"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
After merging https://github.com/gitpod-io/gitpod/pull/8087, we've noticed that the configured job isn't running after branches are deleted.

I tried looking for docs under https://github.com/csweichel/werft but got no luck. I'm now wondering if we have a `=` missing. @csweichel, could you confirm that this change is what we need to make the jobs run on branch deletion?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
