### PR TITLE
increase downloadOTS attempts to 20

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -40,7 +40,7 @@ const (
 	GitpodGID = 33333
 
 	// otsDownloadAttempts is the number of times we'll attempt to download the one-time secret
-	otsDownloadAttempts = 10
+	otsDownloadAttempts = 20
 )
 
 // Initializer can initialize a workspace with content


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As described in #8096 we sometimes fail to download OTS due to db not being in sync.
As suggested by @geropl a bandaid solution for now is to increase timeout to 20 sec from 10sec that should cover 99% of cases. Each attempt is done every second. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8096

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
