### PR TITLE
Bump Node version for building the VS Code image

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 8ddd713183a0913e86d27d3945eeac94fb429e78
+  codeCommit: 0175d2fd7b619fb1c34dcf2a0e17a909acd1be3e
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -4,7 +4,6 @@ packages:
     srcs:
       - "startup.sh"
       - "supervisor-ide-config.json"
-      - "bin/*"
     argdeps:
       - imageRepoBase
       - codeCommit

--- a/components/ide/code/bin/code
+++ b/components/ide/code/bin/code
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-exec /ide/bin/remote-cli/gitpod-code "$@"

--- a/components/ide/code/bin/gp-code
+++ b/components/ide/code/bin/gp-code
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-exec /ide/bin/remote-cli/gitpod-code "$@"

--- a/components/ide/code/bin/open
+++ b/components/ide/code/bin/open
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-exec /ide/bin/remote-cli/gitpod-code "$@"

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -20,16 +20,16 @@ FROM gitpod/openvscode-server-linux-build-agent:bionic-x64 as code_builder
 
 ARG CODE_COMMIT
 
-ARG NODE_VERSION=14.19.0
+ARG NODE_VERSION=16.14.0
 ARG NVM_DIR="/root/.nvm"
 RUN mkdir -p $NVM_DIR \
     && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | sh \
     && . $NVM_DIR/nvm.sh \
     && nvm alias default $NODE_VERSION
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD 1
-ENV ELECTRON_SKIP_BINARY_DOWNLOAD 1
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
 
 RUN mkdir /gp-code \
     && cd /gp-code \
@@ -38,6 +38,7 @@ RUN mkdir /gp-code \
     && git fetch origin $CODE_COMMIT --depth=1 \
     && git reset --hard FETCH_HEAD
 WORKDIR /gp-code
+ENV npm_config_arch=x64
 RUN yarn --frozen-lockfile --network-timeout 180000
 
 # copy remote dependencies build in dependencies_builder image
@@ -56,9 +57,9 @@ RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/in
     && sed -i -e 's#static/##g' /vscode-web/index.html
 
 # cli config: alises to gitpod-code
-# can't use relative symlink as they break when copied to the image below
-COPY bin /ide/bin
-RUN chmod -R ugo+x /ide/bin
+RUN cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/code \
+    && cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/gp-code \
+    && cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/open
 
 # grant write permissions for built-in extensions
 RUN chmod -R ugo+w /vscode-reh-linux-x64/extensions
@@ -70,14 +71,12 @@ COPY --from=code_builder --chown=33333:33333 /vscode-web/ /ide/
 COPY --from=code_builder --chown=33333:33333 /vscode-reh-linux-x64/ /ide/
 COPY --chown=33333:33333 startup.sh supervisor-ide-config.json /ide/
 
-COPY --from=code_builder --chown=33333:33333 /ide/bin /ide/bin/remote-cli
-
-ENV GITPOD_ENV_APPEND_PATH /ide/bin/remote-cli:
+ENV GITPOD_ENV_APPEND_PATH=/ide/bin/remote-cli:
 
 # editor config
-ENV GITPOD_ENV_SET_EDITOR /ide/bin/remote-cli/gitpod-code
-ENV GITPOD_ENV_SET_VISUAL "$GITPOD_ENV_SET_EDITOR"
-ENV GITPOD_ENV_SET_GP_OPEN_EDITOR "$GITPOD_ENV_SET_EDITOR"
-ENV GITPOD_ENV_SET_GIT_EDITOR "$GITPOD_ENV_SET_EDITOR --wait"
-ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER "/ide/bin/remote-cli/gitpod-code --preview"
-ENV GITPOD_ENV_SET_GP_EXTERNAL_BROWSER "/ide/bin/remote-cli/gitpod-code --openExternal"
+ENV GITPOD_ENV_SET_EDITOR=/ide/bin/remote-cli/gitpod-code
+ENV GITPOD_ENV_SET_VISUAL="$GITPOD_ENV_SET_EDITOR"
+ENV GITPOD_ENV_SET_GP_OPEN_EDITOR="$GITPOD_ENV_SET_EDITOR"
+ENV GITPOD_ENV_SET_GIT_EDITOR="$GITPOD_ENV_SET_EDITOR --wait"
+ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER="/ide/bin/remote-cli/gitpod-code --preview"
+ENV GITPOD_ENV_SET_GP_EXTERNAL_BROWSER="/ide/bin/remote-cli/gitpod-code --openExternal"


### PR DESCRIPTION
## Description
We are upgrading to Node.js 16 for VS Code everywhere.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Complimentary PRs and commits: https://github.com/gitpod-io/openvscode-server/pull/308 & https://github.com/gitpod-io/openvscode-releases/commit/fa53924077d4f2c4e615a7817b71783aae1f2d99.

## How to test
Make sure the build passes, try to open a workspace with VS Code. 

@jeanp413 maybe this is not enough and we need to trigger a rebuild of the IDE?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
