### PR TITLE
[server] only resolve image by content changed or interval

### DIFF
--- a/components/server/src/ide-config.ts
+++ b/components/server/src/ide-config.ts
@@ -103,7 +103,11 @@ export class IDEConfigService {
         this.configPath = filePathTelepresenceAware(configPath);
         this.validate = this.ajv.compile(scheme);
         this.reconcile("initial");
-        fs.watchFile(this.configPath, () => this.reconcile("file changed"));
+        fs.watchFile(this.configPath, (curr, prev) => {
+            if (curr.mtimeMs != prev.mtimeMs) {
+                this.reconcile("file changed");
+            }
+        });
         repeat(() => this.reconcile("interval"), 60 * 60 * 1000 /* 1 hour */);
     }
 

--- a/components/server/src/ide-config.ts
+++ b/components/server/src/ide-config.ts
@@ -134,7 +134,8 @@ export class IDEConfigService {
 
             const newValue: IDEConfig = JSON.parse(fileContent);
             const contentHash = crypto.createHash('sha256').update(fileContent, 'utf8').digest('hex');
-            if (this.contentHash !== contentHash) {
+            const contentChanged = this.contentHash !== contentHash
+            if (contentChanged) {
                 this.contentHash = contentHash;
 
                 this.validate(newValue);
@@ -175,6 +176,11 @@ export class IDEConfigService {
 
             if (!value) {
                 return;
+            }
+
+            // we only want to resolve image by interval or content changed
+            if (!(contentChanged || trigger === 'interval')) {
+                return
             }
 
             for (const [id, option] of Object.entries(newValue.ideOptions.options).filter(([_, x]) => !!x.resolveImageDigest)) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[server] only resolve image by content changed or interval

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
start a preview environment, see server log, there should be not too many resolve image log every 1~2 min
change `ide-config` configmap, and see server log, should be update and resolve image

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
