### PR TITLE
ws-daemon: A bit of improvements to cache_reclaim

### DIFF
--- a/components/ws-daemon/pkg/daemon/cache_reclaim.go
+++ b/components/ws-daemon/pkg/daemon/cache_reclaim.go
@@ -124,11 +124,11 @@ func readLimit(memCgroupPath string) (uint64, error) {
 		return math.MaxUint64, nil
 	}
 
-	p, err := strconv.ParseInt(s, 10, 64)
+	p, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return 0, xerrors.Errorf("cannot parse memory.limit_in_bytes (%s): %v", s, err)
 	}
-	return uint64(p), nil
+	return p, nil
 }
 
 func readCache(memCgroupPath string) (uint64, error) {
@@ -147,11 +147,11 @@ func readCache(memCgroupPath string) (uint64, error) {
 			continue
 		}
 
-		r, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(l, prefixCache)), 10, 64)
+		r, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(l, prefixCache)), 10, 64)
 		if err != nil {
 			return 0, xerrors.Errorf("cannot parse memory.stat: %s: %w", l, err)
 		}
-		return uint64(r), nil
+		return r, nil
 	}
 	return 0, xerrors.Errorf("memory.stat did not contain cache")
 }

--- a/components/ws-daemon/pkg/daemon/cache_reclaim_test.go
+++ b/components/ws-daemon/pkg/daemon/cache_reclaim_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+func init() {
+	cgroups.TestMode = true
+}
+
+func createTempDir(t *testing.T, subsystem string) string {
+	path := filepath.Join(t.TempDir(), subsystem)
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadCache(t *testing.T) {
+	const cache = 512
+	tempdir := createTempDir(t, "memory")
+	err := cgroups.WriteFile(tempdir, "memory.stat", fmt.Sprintf("cache %d\nrss 1024", cache))
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := readCache(tempdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != cache {
+		t.Fatalf("unexpected error: is '%v' but expected '%v'", value, cache)
+	}
+}
+
+func TestReadCacheBadValue(t *testing.T) {
+	tempdir := createTempDir(t, "memory")
+	invalidValues := []string{
+		"invalid",
+		"cache -1",
+	}
+	for _, v := range invalidValues {
+		err := cgroups.WriteFile(tempdir, "memory.stat", v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = readCache(tempdir)
+		if err == nil {
+			t.Fatal("expected failure")
+		}
+	}
+}


### PR DESCRIPTION
## Description
- add some unit tests.
- use `ParseUint` instead of `ParseInt`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
in gipod
```console
$ cd /workspace/gitpod/components/ws-daemon/pkg/daemon
$ go test -v
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
A bit of improvements to cache_reclaim
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
