### PR TITLE
Ensure docker in workspace works with fuse

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -398,7 +398,7 @@ var ring1Cmd = &cobra.Command{
 		procLoc := filepath.Join(ring2Root, "proc")
 		err = os.MkdirAll(procLoc, 0755)
 		if err != nil {
-			log.WithError(err).Error("cannot mount proc")
+			log.WithError(err).Error("cannot create directory for mounting proc")
 			return
 		}
 
@@ -828,20 +828,6 @@ func pivotRoot(rootfs string, fsshift api.FSShiftMethod) error {
 	// /proc/self/cwd being the old root. Since we can play around with the cwd
 	// with pivot_root this allows us to pivot without creating directories in
 	// the rootfs. Shout-outs to the LXC developers for giving us this idea.
-
-	if fsshift == api.FSShiftMethod_FUSE {
-		err := unix.Chroot(rootfs)
-		if err != nil {
-			return xerrors.Errorf("cannot chroot: %v", err)
-		}
-
-		err = unix.Chdir("/")
-		if err != nil {
-			return xerrors.Errorf("cannot chdir to new root :%v", err)
-		}
-
-		return nil
-	}
 
 	oldroot, err := unix.Open("/", unix.O_DIRECTORY|unix.O_RDONLY, 0)
 	if err != nil {


### PR DESCRIPTION
## Description
This fixes an issue where trying to run a docker container within a workspace would fail when fuse-overlayfs was used as shift method for the rootfs. Chroot only affects the calling process while pivot_root affects the whole mount namespace. @csweichel Do you know why chroot was used for fuse and pivot_root for shiftfs? Trying to understand if this would have other side effects.

## Related Issue(s)
#8020

## How to test
- Ensure that fuse is selected as shift method (already done for the preview environment)
- Open workspace
- Try to run docker container in workspace 

Side note: I am currently not able to get logs from ws-daemon or exec into it in my preview environment. I do not believe this has anything to do with my changes and should not affect anything but a second set of eyes on this would be good.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed a bug where docker in workspaces could not be used when overlay-fusefs was used as shift method
```
cc: @utam0k 