### PR TITLE
[server] Disable tracing errors

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -272,6 +272,9 @@ env:
   value: {{ $tracing.samplerType }}
 - name: JAEGER_SAMPLER_PARAM
   value: "{{ $tracing.samplerParam }}"
+{{- else }}
+- name: JAEGER_DISABLED
+  value: "true"
 {{- end }}
 {{- end -}}
 

--- a/components/gitpod-protocol/src/util/tracing.ts
+++ b/components/gitpod-protocol/src/util/tracing.ts
@@ -44,16 +44,16 @@ export namespace TraceContext {
         return { span };
     }
 
-    export function withSpan(operation: string, callback: () => void, ctx?: TraceContext): void {
+    export function withSpan(operation: string, callback: (ctx: TraceContext) => void, ctx?: TraceContext): void {
         // if we don't have a parent span, don't create a trace here as those <trace-without-root-spans> are not useful.
         if (!ctx || !ctx.span || !ctx.span.context()) {
-            callback();
+            callback({});
             return;
         }
 
         const span = TraceContext.startSpan(operation, ctx);
         try {
-            callback();
+            callback({span});
         } catch (e) {
             TraceContext.setError({span}, e);
             throw e;

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -337,7 +337,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
             increaseApiCallUserCounter(method, "anonymous");
         }
 
-        const span = TraceContext.startSpan(method, undefined, this.connectionCtx.span);
+        const span = TraceContext.startSpan(method, undefined);
         const ctx = { span };
         const userId = this.clientMetadata.userId;
         try {
@@ -400,7 +400,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
 
 }
 
-function traceClientMetadata(ctx: TraceContext, clientMetadata: ClientMetadata) {
+export function traceClientMetadata(ctx: TraceContext, clientMetadata: ClientMetadata) {
     TraceContext.addNestedTags(ctx, {
         client: {
             id: clientMetadata.id,

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -160,7 +160,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         //           to clients who might not otherwise have access to that information.
         this.disposables.push(this.localMessageBroker.listenForWorkspaceInstanceUpdates(
             this.user.id,
-            (ctx, instance) => TraceContext.withSpan("forwardInstanceUpdateToClient", () => this.client?.onInstanceUpdate(this.censorInstance(instance)), ctx, this.connectionCtx?.span)
+            (ctx, instance) => TraceContext.withSpan("forwardInstanceUpdateToClient", () => this.client?.onInstanceUpdate(this.censorInstance(instance)), ctx)
         ));
 
     }

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -68,6 +68,7 @@ func DefaultEnv(cfg *config.Config) []corev1.EnvVar {
 
 func TracingEnv(context *RenderContext) (res []corev1.EnvVar) {
 	if context.Config.Observability.Tracing == nil {
+		res = append(res, corev1.EnvVar{Name: "JAEGER_DISABLED", Value: "true"})
 		return
 	}
 


### PR DESCRIPTION
## Description
 - server: don't use FOLLOWS_FROM references
 - replace references by manually enriching spans for websocket notifications
 - set `JAEGER_DISABLED` when tracing is not configured explicitly to avoid noisy error messages (for SH case, for example)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - as `with-observability` is [not working atm](https://github.com/gitpod-io/gitpod/issues/8194):
   - `kubectl logs server-79dfdf9bbd-f6fmn server -f`
   - start a workspace
   - note that the `server` logs do not contain any tracing-related errors/warnings

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[tracing] avoid noisy error messages
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [ ] /werft with-observability=true
- [ ] /werft with-helm=true
- [x] /werft with-clean-slate-deployment