### PR TITLE
[content-service] Don't let composite initializer swallow errors

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -57,15 +57,16 @@ func (e *EmptyInitializer) Run(ctx context.Context, mappings []archive.IDMapping
 }
 
 // CompositeInitializer does nothing
-type CompositeInitializer struct {
-	Initializer []Initializer
-}
+type CompositeInitializer []Initializer
 
 // Run calls run on all child initializers
-func (e *CompositeInitializer) Run(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error) {
+func (e CompositeInitializer) Run(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error) {
 	_, ctx = opentracing.StartSpanFromContext(ctx, "CompositeInitializer.Run")
-	for _, init := range e.Initializer {
-		init.Run(ctx, mappings)
+	for _, init := range e {
+		_, err := init.Run(ctx, mappings)
+		if err != nil {
+			return csapi.WorkspaceInitFromOther, err
+		}
 	}
 	return csapi.WorkspaceInitFromOther, nil
 }
@@ -99,9 +100,7 @@ func NewFromRequest(ctx context.Context, loc string, rs storage.DirectDownloader
 				return nil, err
 			}
 		}
-		initializer = &CompositeInitializer{
-			Initializer: initializers,
-		}
+		initializer = CompositeInitializer(initializers)
 	} else if ir, ok := spec.(*csapi.WorkspaceInitializer_Git); ok {
 		if ir.Git == nil {
 			return nil, status.Error(codes.InvalidArgument, "missing Git initializer spec")

--- a/components/content-service/pkg/initializer/initializer_test.go
+++ b/components/content-service/pkg/initializer/initializer_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package initializer_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
+	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
+)
+
+type InitializerFunc func(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error)
+
+func (f InitializerFunc) Run(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error) {
+	return f(ctx, mappings)
+}
+
+type RecordingInitializer struct {
+	CallCount int
+}
+
+func (f *RecordingInitializer) Run(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error) {
+	f.CallCount++
+	return csapi.WorkspaceInitFromOther, nil
+}
+
+func TestCompositeInitializer(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Children []initializer.Initializer
+		Eval     func(t *testing.T, src csapi.WorkspaceInitSource, err error, children []initializer.Initializer)
+	}{
+		{
+			Name: "empty",
+			Eval: func(t *testing.T, src csapi.WorkspaceInitSource, err error, children []initializer.Initializer) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			Name: "single",
+			Children: []initializer.Initializer{
+				&RecordingInitializer{},
+			},
+			Eval: func(t *testing.T, src csapi.WorkspaceInitSource, err error, children []initializer.Initializer) {
+				if cc := children[0].(*RecordingInitializer).CallCount; cc != 1 {
+					t.Errorf("unexpected call count: expected 1, got %d", cc)
+				}
+			},
+		},
+		{
+			Name: "multiple",
+			Children: []initializer.Initializer{
+				&RecordingInitializer{},
+				&RecordingInitializer{},
+				&RecordingInitializer{},
+			},
+			Eval: func(t *testing.T, src csapi.WorkspaceInitSource, err error, children []initializer.Initializer) {
+				for i := range children {
+					if cc := children[i].(*RecordingInitializer).CallCount; cc != 1 {
+						t.Errorf("unexpected call count on initializer %d: expected 1, got %d", i, cc)
+					}
+				}
+			},
+		},
+		{
+			Name: "error propagation",
+			Children: []initializer.Initializer{
+				&RecordingInitializer{},
+				InitializerFunc(func(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error) {
+					return csapi.WorkspaceInitFromOther, fmt.Errorf("error happened here")
+				}),
+				&RecordingInitializer{},
+			},
+			Eval: func(t *testing.T, src csapi.WorkspaceInitSource, err error, children []initializer.Initializer) {
+				if err == nil {
+					t.Errorf("expected error, got nothing")
+				}
+				if cc := children[0].(*RecordingInitializer).CallCount; cc != 1 {
+					t.Errorf("unexpected call count on first initializer: expected 1, got %d", cc)
+				}
+				if cc := children[2].(*RecordingInitializer).CallCount; cc != 0 {
+					t.Errorf("unexpected call count on last initializer: expected 0, got %d", cc)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			comp := initializer.CompositeInitializer(test.Children)
+			src, err := comp.Run(context.Background(), nil)
+			test.Eval(t, src, err, test.Children)
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR makes a composite content initializer fail if any of its initializers fail. This way we don't swallow errors when a repo doesn't have a `.gitpod.yml`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8156

## How to test
This one is tough to test, because you need to make a Git content initializer fail - something we work hard to avoid :) 
One way would be to have a broken GitLab installation which reports an invalid clone URL.
Otherwise, we'll have to rely on the unit test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Composite content initializer now correctly report errors.
```
