### PR TITLE
[Analytics] Include anonymous ID in login and signup track calls

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -210,7 +210,7 @@ function App() {
             //check if current target or any ancestor up to document is button or anchor
             while (!(curr instanceof Document)) {
                 if (curr instanceof HTMLButtonElement || curr instanceof HTMLAnchorElement || (curr instanceof HTMLDivElement && curr.onclick)) {
-                    trackButtonOrAnchor(curr, !!user);
+                    trackButtonOrAnchor(curr);
                     break; //finding first ancestor is sufficient
                 }
                 curr = curr.parentNode as HTMLElement;

--- a/components/dashboard/src/settings/Notifications.tsx
+++ b/components/dashboard/src/settings/Notifications.tsx
@@ -10,6 +10,7 @@ import { UserContext } from "../user-context";
 import CheckBox from "../components/CheckBox";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import settingsMenu from "./settings-menu";
+import { identifyUser } from "../Analytics";
 
 export default function Notifications() {
     const { user, setUser } = useContext(UserContext);
@@ -30,9 +31,7 @@ export default function Notifications() {
                     }
                 }
             });
-            await getGitpodService().server.identifyUser({
-                traits: { "unsubscribed_onboarding": !newIsOnboardingMail }
-            })
+            identifyUser({"unsubscribed_onboarding": !newIsOnboardingMail});
             setUser(user);
             setOnboardingMail(newIsOnboardingMail);
         }
@@ -51,9 +50,7 @@ export default function Notifications() {
                     }
                 }
             });
-            await getGitpodService().server.identifyUser({
-                traits: { "unsubscribed_changelog": !newIsChangelogMail }
-            })
+            identifyUser({ "unsubscribed_changelog": !newIsChangelogMail });
             setUser(user);
             setChangelogMail(newIsChangelogMail);
         }
@@ -72,9 +69,7 @@ export default function Notifications() {
                     }
                 }
             });
-            await getGitpodService().server.identifyUser({
-                traits: { "unsubscribed_devx": !newIsDevXMail }
-            })
+            identifyUser({ "unsubscribed_devx": !newIsDevXMail });
             setUser(user);
             setDevXMail(newIsDevXMail);
         }

--- a/components/gitpod-protocol/src/analytics.ts
+++ b/components/gitpod-protocol/src/analytics.ts
@@ -8,7 +8,7 @@
 export const IAnalyticsWriter = Symbol("IAnalyticsWriter");
 
 type Identity =
-    | { userId: string | number }
+    | { userId: string | number; anonymousId?: string | number }
     | { userId?: string | number; anonymousId: string | number };
 
 interface Message {
@@ -34,14 +34,12 @@ export type PageMessage = Message & Identity & {
     context?: any;
 };
 
-export type RemoteTrackMessage = Omit<TrackMessage, "timestamp" | "userId" | "anonymousId"> & {
-    anonymousId?: string | number;
-};
+export type RemoteTrackMessage = Omit<TrackMessage, "timestamp" | "userId">;
 export type RemotePageMessage = Omit<PageMessage, "timestamp" | "userId"> & {
-    anonymousId?: string | number;
+    includePII?: boolean;
 };
 
-export type RemoteIdentifyMessage = Omit<IdentifyMessage, "timestamp" | "userId" | "anonymousId">;
+export type RemoteIdentifyMessage = Omit<IdentifyMessage, "timestamp" | "userId">;
 
 export interface IAnalyticsWriter {
 

--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -14,6 +14,7 @@ export async function trackLogin(user: User, request: Request, authHost: string,
     //track the login
     analytics.track({
         userId: user.id,
+        anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
         event: "login",
         properties: {
             "loginContext": authHost
@@ -28,6 +29,7 @@ export async function trackSignup(user: User, request: Request, analytics: IAnal
         //track the signup
         analytics.track({
             userId: user.id,
+            anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
             event: "signup",
             properties: {
                 "auth_provider": user.identities[0].authProviderId,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR includes the `anonymousId` used for tracking unauthenticated website and product engagement in server track calls where possible, therefore simplifying the mapping of website to product activities.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
- sign up in preview environment
- ensure that the `anonymousId` is included in the payload for the `signup` and `login` track call sent to the [staging untrusted source](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe