### PR TITLE
Add Replicated as a Gitpod license evaluator

### DIFF
--- a/components/licensor/ee/pkg/licensor/gitpod.go
+++ b/components/licensor/ee/pkg/licensor/gitpod.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package licensor
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// GitpodEvaluator determines what a license allows for
+type GitpodEvaluator struct {
+	invalid string
+	lic     LicensePayload
+}
+
+// Validate returns false if the license isn't valid and a message explaining why that is.
+func (e *GitpodEvaluator) Validate() (msg string, valid bool) {
+	if e.invalid == "" {
+		return "", true
+	}
+
+	return e.invalid, false
+}
+
+// Enabled determines if a feature is enabled by the license
+func (e *GitpodEvaluator) Enabled(feature Feature) bool {
+	if e.invalid != "" {
+		return false
+	}
+
+	_, ok := e.lic.Level.allowance().Features[feature]
+	return ok
+}
+
+// HasEnoughSeats returns true if the license supports at least the give amount of seats
+func (e *GitpodEvaluator) HasEnoughSeats(seats int) bool {
+	if e.invalid != "" {
+		return false
+	}
+
+	return e.lic.Seats == 0 || seats <= e.lic.Seats
+}
+
+// Inspect returns the license information this evaluator holds.
+// This function is intended for transparency/debugging purposes only and must
+// never be used to determine feature eligibility under a license. All code making
+// those kinds of decisions must be part of the Evaluator.
+func (e *GitpodEvaluator) Inspect() LicensePayload {
+	return e.lic
+}
+
+// NewGitpodEvaluator produces a new license evaluator from a license key
+func NewGitpodEvaluator(key []byte, domain string) (res *GitpodEvaluator) {
+	if len(key) == 0 {
+		// fallback to the default license
+		return &GitpodEvaluator{
+			lic: defaultLicense,
+		}
+	}
+
+	deckey := make([]byte, base64.StdEncoding.DecodedLen(len(key)))
+	n, err := base64.StdEncoding.Decode(deckey, key)
+	if err != nil {
+		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot decode key: %q", err)}
+	}
+	deckey = deckey[:n]
+
+	var lic licensePayload
+	err = json.Unmarshal(deckey, &lic)
+	if err != nil {
+		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot unmarshal key: %q", err)}
+	}
+
+	keyWoSig, err := json.Marshal(lic.LicensePayload)
+	if err != nil {
+		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot remarshal key: %q", err)}
+	}
+	hashed := sha256.Sum256(keyWoSig)
+
+	for _, k := range publicKeys {
+		err = rsa.VerifyPKCS1v15(k, crypto.SHA256, hashed[:], lic.Signature)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot verify key: %q", err)}
+	}
+
+	if !matchesDomain(lic.Domain, domain) {
+		return &GitpodEvaluator{invalid: "wrong domain"}
+	}
+
+	if lic.ValidUntil.Before(time.Now()) {
+		return &GitpodEvaluator{invalid: "not valid anymore"}
+	}
+
+	return &GitpodEvaluator{
+		lic: lic.LicensePayload,
+	}
+}

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the Gitpod Enterprise Source Code License,
+// See License.enterprise.txt in the project root folder.
+
+package licensor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	replicatedLicenseApiEndpoint = "http://kotsadm:3000/license/v1/license"
+	replicatedLicenseApiTimeout  = 5 * time.Second
+)
+
+type replicatedFields struct {
+	Field string      `json:"field"`
+	Title string      `json:"title"`
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"` // This is of type "fieldType"
+}
+
+// replicatedLicensePayload exists to convert the JSON structure to a LicensePayload
+type replicatedLicensePayload struct {
+	LicenseID      string             `json:"license_id"`
+	InstallationID string             `json:"installation_id"`
+	Assignee       string             `json:"assignee"`
+	ReleaseChannel string             `json:"release_channel"`
+	LicenseType    string             `json:"license_type"`
+	ExpirationTime *time.Time         `json:"expiration_time,omitempty"` // Not set if license never expires
+	Fields         []replicatedFields `json:"fields"`
+}
+
+type ReplicatedEvaluator struct {
+	invalid string
+	lic     LicensePayload
+}
+
+func (e *ReplicatedEvaluator) Enabled(feature Feature) bool {
+	if e.invalid != "" {
+		return false
+	}
+
+	_, ok := e.lic.Level.allowance().Features[feature]
+	return ok
+}
+
+func (e *ReplicatedEvaluator) HasEnoughSeats(seats int) bool {
+	if e.invalid != "" {
+		return false
+	}
+
+	return e.lic.Seats == 0 || seats <= e.lic.Seats
+}
+
+func (e *ReplicatedEvaluator) Inspect() LicensePayload {
+	return e.lic
+}
+
+func (e *ReplicatedEvaluator) Validate() (msg string, valid bool) {
+	if e.invalid == "" {
+		return "", true
+	}
+
+	return e.invalid, false
+}
+
+// defaultReplicatedLicense this is the default license if call fails
+func defaultReplicatedLicense() *ReplicatedEvaluator {
+	return &ReplicatedEvaluator{
+		lic: defaultLicense,
+	}
+}
+
+// newReplicatedEvaluator exists to allow mocking of client
+func newReplicatedEvaluator(client *http.Client, domain string) (res *ReplicatedEvaluator) {
+	resp, err := client.Get(replicatedLicenseApiEndpoint)
+	if err != nil {
+		return &ReplicatedEvaluator{invalid: fmt.Sprintf("cannot query kots admin, %q", err)}
+	}
+	defer resp.Body.Close()
+
+	var replicatedPayload replicatedLicensePayload
+	err = json.NewDecoder(resp.Body).Decode(&replicatedPayload)
+	if err != nil {
+		return &ReplicatedEvaluator{invalid: fmt.Sprintf("cannot decode json data, %q", err)}
+	}
+
+	lic := LicensePayload{
+		ID: replicatedPayload.LicenseID,
+	}
+
+	// Search for the fields
+	for _, i := range replicatedPayload.Fields {
+		switch i.Field {
+		case "domain":
+			lic.Domain = i.Value.(string)
+
+		case "levelId":
+			lic.Level = LicenseLevel(i.Value.(float64))
+
+		case "seats":
+			lic.Seats = int(i.Value.(float64))
+		}
+	}
+
+	if !matchesDomain(lic.Domain, domain) {
+		return defaultReplicatedLicense()
+	}
+
+	if replicatedPayload.ExpirationTime != nil {
+		lic.ValidUntil = *replicatedPayload.ExpirationTime
+
+		if lic.ValidUntil.Before(time.Now()) {
+			return defaultReplicatedLicense()
+		}
+	}
+
+	return &ReplicatedEvaluator{
+		lic: lic,
+	}
+}
+
+// NewReplicatedEvaluator gets the license data from the kots admin panel
+func NewReplicatedEvaluator(domain string) (res *ReplicatedEvaluator) {
+	return newReplicatedEvaluator(&http.Client{Timeout: replicatedLicenseApiTimeout}, domain)
+}

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -236,6 +236,13 @@ type OpenVSX struct {
 	URL string `json:"url" validate:"url"`
 }
 
+type LicensorType string
+
+const (
+	LicensorTypeGitpod     LicensorType = "gitpod"
+	LicensorTypeReplicated LicensorType = "replicated"
+)
+
 type FSShiftMethod string
 
 const (

--- a/install/installer/pkg/config/v1/validation.go
+++ b/install/installer/pkg/config/v1/validation.go
@@ -41,6 +41,11 @@ var FSShiftMethodList = map[FSShiftMethod]struct{}{
 	FSShiftShiftFS: {},
 }
 
+var LicensorTypeList = map[LicensorType]struct{}{
+	LicensorTypeGitpod:     {},
+	LicensorTypeReplicated: {},
+}
+
 // LoadValidationFuncs load custom validation functions for this version of the config API
 func (v version) LoadValidationFuncs(validate *validator.Validate) error {
 	funcs := map[string]validator.Func{
@@ -120,7 +125,25 @@ func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
 
 	if cfg.License != nil {
 		secretName := cfg.License.Name
-		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("license")))
+		licensorKey := "type"
+		res = append(res, cluster.CheckSecret(secretName, cluster.CheckSecretRequiredData("license"), cluster.CheckSecretRecommendedData(licensorKey), cluster.CheckSecretRule(func(s *corev1.Secret) ([]cluster.ValidationError, error) {
+			errors := make([]cluster.ValidationError, 0)
+
+			licensor := LicensorType(s.Data[licensorKey])
+			if licensor != "" {
+				// This field is optional, so blank is valid
+				_, ok := LicensorTypeList[licensor]
+
+				if !ok {
+					errors = append(errors, cluster.ValidationError{
+						Message: fmt.Sprintf("Secret '%s' has invalid license type '%s'", secretName, licensor),
+						Type:    cluster.ValidationStatusError,
+					})
+				}
+			}
+
+			return errors, nil
+		})))
 	}
 
 	if len(cfg.AuthProviders) > 0 {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
> For the purpose of this, "enterprise" means any user that has a paid-for license

[Replicated](https://www.replicated.com/) is how we will now distribute Gitpod to enterprise teams. This adds Replicated as a licensor and is used if the secret has `type = replicated` (which sets the envvar `GITPOD_LICENSE_TYPE=replicated` in the `server`).

This PR also renames the `Evaluator` as `GitpodEvaluator` and introduces an `Evaluator` interface, which the `GitpodEvaluator` and `ReplicatedEvaluator` implements. The GitpodEvaluator will remain in-place for existing customers (eventually, will migrate to Replicated) and also for SaaS.

Like the Gitpod license, the Replicated license is only validated at runtime. If the user wishes to update their license, they would have to click "sync license" in their Kots portal which would tell them to redeploy the application - this would create a new `server` pod which would verify the new license at runtime.

Unlike the Gitpod license, the Replicated license is retrieved from a local service and has no (obvious) way of verifying the data is from a legitimate source, rather than a mocked service. For that reason, the [URL is hardcoded as per the docs](https://kots.io/vendor/entitlements/creating-entitlements/#querying-entitlements-at-runtime) and offers no way of configuring this.

The license has three custom entitlements - `domain`, `levelId` and `seats`. An entitlement is custom data that's attached to the license. These are used to provide the data that we use for validation.

### Future improvements

Talk with Replicated and establish a way of verifying that the data is valid and from an approved source. Replicated provides a signature which has an `innerSignature` which has a public key and signature but this verification is entirely undocumented.

We may also want to verify community licenses slightly differently, eg without the domain so we can just have a single community license. **NB** it may be tricky for a user to go from community to paid if we have a single license - this will need raising with Replicated

### Resources
 - [License API docs](https://help.replicated.com/api/integration-api/license-api/)
 - [License entitlements](https://kots.io/vendor/entitlements/creating-entitlements/)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/replicated/issues/1

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add Replicated as a Gitpod license evaluator
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
