### PR TITLE
[server] Order suggested repository URLs case-insensitively

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1062,7 +1062,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const uniqueURLs = new Set();
         return suggestions
-            .sort((a, b) => a > b ? 1 : -1)
+            .sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1)
             .filter(r => {
                 if (uniqueURLs.has(r)) {
                     return false;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Quick hotfix to the alphabetical sorting order of suggested repository URLs in the new `Open in Gitpod` modal.

Note: Better improvements to the sorting order will come soon. This is just a quick logical hotfix.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Authorize the GitHub App for all repositories under https://github.com/gitpod-io/
2. Hit `Cmd+O` and type `gitpod-io/gitpod`
3. Alphabetically, `https://github.com/gitpod-io/gitpod` should come first (before any longer repository URLs like `https://github.com/gitpod-io/Gitpod-Ruby-On-Rails`)

To illustrate the problem, here is the result order when you type `gitpod-io/gitpod`:

| Expected: Case-insensitive (shorter first 🎯) | Actual: Case-sensitive (uppercase first 😖) |
| --- | --- |
| <img width="398" alt="Screenshot 2022-02-15 at 11 00 00" src="https://user-images.githubusercontent.com/599268/154038855-a93fec84-25a2-440f-ac8c-4524fbb172d5.png"> | <img width="402" alt="Screenshot 2022-02-15 at 10 59 01" src="https://user-images.githubusercontent.com/599268/154038844-66e6b2ac-56cb-4dad-b2d6-7db1de26b9d0.png"> |


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
