### PR TITLE
jb-gw: wrap start hint comment if it does not fit

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.CompositeDisposable
 import com.intellij.openapi.components.service
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.remoteDev.util.onTerminationOrNow
-import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_NO_WRAP
+import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_WORD_WRAP
 import com.intellij.ui.dsl.builder.RightGap
 import com.intellij.ui.dsl.builder.TopGap
 import com.intellij.ui.dsl.builder.panel
@@ -90,7 +90,7 @@ class GitpodStartWorkspaceView(
         }.topGap(TopGap.NONE)
             .rowComment(
                 "Create and start a new workspace via browser. If an IDE does not open automatically, check progress in your browser.",
-                MAX_LINE_LENGTH_NO_WRAP
+                MAX_LINE_LENGTH_WORD_WRAP
             )
     }.apply {
         this.background = WelcomeScreenUIManager.getMainAssociatedComponentBackground()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Before:
<img width="827" alt="Screenshot 2022-02-15 at 13 29 14" src="https://user-images.githubusercontent.com/3082655/154062553-4e10eca6-b67e-49d4-96bf-e7f13bcc9263.png">

After:
<img width="826" alt="Screenshot 2022-02-15 at 13 28 55" src="https://user-images.githubusercontent.com/3082655/154062565-56a75871-eb12-42dd-977e-79b297f47b7b.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Download a plugin: https://plugins.jetbrains.com/plugin/download?rel=true&updateId=158229
- Install in your gateway and restart.
- Check in recent view that start hing comment now fits.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
