### PR TITLE
build: add Prettier support and configurations

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -43,7 +43,8 @@ tasks:
 vscode:
   extensions:
     - bradlc.vscode-tailwindcss
-    - EditorConfig.EditorConfig
+    - editorconfig.editorconfig
+    - esbenp.prettier-vscode
     - golang.go
     - hashicorp.terraform
     - ms-azuretools.vscode-docker

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Add files here to ignore them from prettier formatting
+
+build/
+dist/
+templates/
+
+# YAML is supported, but let's play it safe for now
+*.yaml
+*.yml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2
+}

--- a/components/dashboard/.eslintrc.js
+++ b/components/dashboard/.eslintrc.js
@@ -5,9 +5,9 @@
  */
 
 module.exports = {
-    root: true,
-    extends: ['react-app'],
-    rules: {
-        "import/no-anonymous-default-export": "off",
-    }
-}
+  root: true,
+  extends: ['react-app', 'prettier'],
+  rules: {
+    'import/no-anonymous-default-export': 'off',
+  },
+};

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -38,6 +38,7 @@
     "classnames": "^2.3.1",
     "cypress": "^9.2.1",
     "eslint": "^7.24.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
     "postcss": "^7.0.36",
     "react-scripts": "^4.0.3",

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -30,13 +30,22 @@
    ],
    "settings": {
       "typescript.tsdk": "gitpod/node_modules/typescript/lib",
+      "[javascript]": {
+         "editor.defaultFormatter": "esbenp.prettier-vscode",
+         "editor.formatOnSave": true
+      },
+      "[typescript]": {
+         "editor.defaultFormatter": "esbenp.prettier-vscode",
+         "editor.formatOnSave": true
+      },
       "[json]": {
          "editor.insertSpaces": true,
          "editor.tabSize": 2
       },
       "[yaml]": {
          "editor.insertSpaces": true,
-         "editor.tabSize": 2
+         "editor.tabSize": 2,
+         "editor.defaultFormatter": "esbenp.prettier-vscode"
       },
       "[go]": {
          "editor.formatOnSave": true

--- a/package.json
+++ b/package.json
@@ -1,29 +1,30 @@
 {
-    "private": true,
-    "name": "parent",
-    "version": "0.0.0",
-    "license": "UNLICENSED",
-    "devDependencies": {
-        "@types/node": "^16.11.0",
-        "@types/shelljs": "^0.8.9",
-        "json": "^11.0.0",
-        "rimraf": "^3.0.2",
-        "ts-node": "10.4.0",
-        "typescript": "~4.4.4"
-    },
-    "scripts": {
-        "build": "leeway exec --filter-type yarn --components -- yarn build",
-        "watch": "leeway exec --package components:all --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
-        "clean": "leeway exec --filter-type yarn --components -- yarn clean && rm -rf node_modules"
-    },
-    "workspaces": {
-        "packages": [
-            "components/*",
-            "components/ee/*",
-            "components/*/typescript",
-            "components/*/typescript-*",
-            "components/supervisor/frontend",
-            "charts/"
-        ]
-    }
+  "private": true,
+  "name": "parent",
+  "version": "0.0.0",
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "@types/node": "^16.11.0",
+    "@types/shelljs": "^0.8.9",
+    "json": "^11.0.0",
+    "prettier": "2.5.1",
+    "rimraf": "^3.0.2",
+    "ts-node": "10.4.0",
+    "typescript": "~4.4.4"
+  },
+  "scripts": {
+    "build": "leeway exec --filter-type yarn --components -- yarn build",
+    "watch": "leeway exec --package components:all --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
+    "clean": "leeway exec --filter-type yarn --components -- yarn clean && rm -rf node_modules"
+  },
+  "workspaces": {
+    "packages": [
+      "components/*",
+      "components/ee/*",
+      "components/*/typescript",
+      "components/*/typescript-*",
+      "components/supervisor/frontend",
+      "charts/"
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7321,6 +7321,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
 eslint-config-react-app@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"
@@ -14071,6 +14076,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## Description

Opening this new one since https://github.com/gitpod-io/gitpod/pull/7757 was too much.

## Why

- I'm about to start working on fixing the linting problems the dashboard app logs #3841, but ESLint and Prettier have some common gray area and it's better to start with consistently formatted code to have an easier time in handling this common area
- Basically why Prettier exists: having an automated coding style which is readable, consistent, and not particularly prone to be argued upon: again, @loujaybee this improves DevX
- I just took a look at the codebase (not just at the dashboard) and I found inconsistent formatting (file A with double quotes, file B with single quotes, file C with **both**, same for indentation etc).

**This makes contributing harder than it should be. It's either contributors having to format their code without automated formatters, or having PRs full of irrelevant style changes with the actual feature or fix hidden somewhere.**

But don't take my word for it: https://prettier.io/docs/en/why-prettier.html

## What

- Adds Prettier support and configurations
- Activates format on save for the VSCode workspace
- Prettier is not invasive, it doesn't change how code works (that's ESLint), just how it looks, it doesn't break anything (that's potentially again ESLint)

## Disclaimer

This is the minimum viable contribution to get things going in the right direction and over time get to a point where all the code is formatted the same way and code formatting is automated.

Its biggest con is that after you merge this, for months, every single PR of code written with VSCode or another IDE with active Prettier support will be full of irrelevant - **but much needed for the reasons stated above** - code formatting changes.

Formatting all at once (again, this is not linting, it doesn't change how the code works and it's supposed to be safe), instead, gives you a solid starting point and doesn't impact future PRs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Edit a TS (for example) file in VSCode and save it. You should see the formatting change, unless your own user settings specifically turn off format on save and Prettier support.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make it easier to contribute to Gitpod by automating code formatting via Prettier
```
