### PR TITLE
[server] asyncForEach: avoid long sync loops by using setImmediate

### DIFF
--- a/components/gitpod-protocol/src/util/foreach.ts
+++ b/components/gitpod-protocol/src/util/foreach.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export async function asyncForEach<T>(it: IterableIterator<T>, callback: (t: T) => void, maxPerTick: number = 100): Promise<void> {
+    return new Promise(resolve => {
+        const iterate = () => {
+            let i = 0;
+            while (i < maxPerTick) {
+                const v = it.next();
+                if (v.done) {
+                    resolve();
+                    return;
+                }
+                callback(v.value);
+                i++;
+            }
+            setImmediate(iterate);
+        };
+        iterate();
+    });
+}

--- a/components/server/src/express/ws-connection-handler.ts
+++ b/components/server/src/express/ws-connection-handler.ts
@@ -8,6 +8,7 @@
  import * as websocket from 'ws';
 import { Disposable, DisposableCollection } from "@gitpod/gitpod-protocol";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { asyncForEach } from "@gitpod/gitpod-protocol/lib/util/foreach";
 import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
 import { WsNextFunction, WsRequestHandler } from './ws-handler';
 
@@ -27,7 +28,7 @@ export class WsConnectionHandler implements Disposable {
         const CLOSING_TIMEOUT = INTERVAL;
         const timer = repeat(async () => {
             log.debug("ws connection handler", { clients: this.clients.size });
-            this.clients.forEach((ws) => {
+            await asyncForEach(this.clients.values(), (ws) => {
                 try {
                     switch (ws.readyState) {
                         case websocket.CLOSED:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
