### PR TITLE
Load test proc mount in a workspace

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -61,7 +61,7 @@ There are 4 different types of tests:
 To run the tests:
 1. Clone this repo (`git clone git@github.com:gitpod-io/gitpod.git`), and `cd` to `./gitpod/test`
 2. Run the tests like so
-  ```bash
+  ```console
   go test -v ./... \
   -kubeconfig=<path_to_kube_config_file> \
   -namespace=<namespace_where_gitpod_is_installed> \

--- a/test/leeway-build.sh
+++ b/test/leeway-build.sh
@@ -19,4 +19,5 @@ for COMPONENT in tests/components/*; do
     go test -trimpath -ldflags="-buildid= -w -s" -c -o bin/"$OUTPUT".test ./"$COMPONENT"
 done
 
-go test -trimpath -ldflags="-buildid= -w -s" -o bin/workspace -c ./tests/workspace
+echo building test tests/workspace
+go test -trimpath -ldflags="-buildid= -w -s" -o bin/workspace.test -c ./tests/workspace

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+)
+
+const (
+	numberOfMount = 500
+)
+
+func TestMountProc(t *testing.T) {
+	f := features.New("proc mount").
+		WithLabel("component", "workspace").
+		Assess("load test proc mount", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			ws, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(ws.Req.Id), integration.WithWorkspacekitLift(true))
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting workspace: %v", err)
+			}
+			defer rsa.Close()
+			integration.DeferCloser(t, closer)
+
+			var resp agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/",
+				Command: "bash",
+				Args: []string{
+					"-c",
+					fmt.Sprintf("for i in $(seq 1 %d); do sudo unshare -m --propagation unchanged mount -t proc proc $(mktemp -d) || exit 1 done", numberOfMount),
+				},
+			}, &resp)
+			if err != nil {
+				t.Fatalf("proc mount run failed: %v\n%s\n%s", err, resp.Stdout, resp.Stderr)
+			}
+
+			if resp.ExitCode != 0 {
+				t.Fatalf("proc mount run failed: %s\n%s", resp.Stdout, resp.Stderr)
+			}
+
+			err = integration.DeleteWorkspace(ctx, api, ws.Req.Id)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description

* Add stress test for mount proc
* Fix workspace tests not running

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8098 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add stress test for mount proc
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
