### PR TITLE
Use prettier for TypeScript files in .werft

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -55,3 +55,4 @@ vscode:
     - timonwong.shellcheck
     - vscjava.vscode-java-pack
     - fwcd.kotlin
+    - esbenp.prettier-vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,10 @@ repos:
     - id: shellcheck
       args: [-e, "SC1090,SC1091"]
       exclude: .*/gradlew$
+
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: "v2.5.1"
+  hooks:
+    - id: prettier
+      files: ".werft"
+      types_or: [ts]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# We dont use it for YAML yet
+*.yaml
+
+# For now we only use it for .werft
+components

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -1,60 +1,60 @@
-import * as fs from 'fs';
-import { SpanStatusCode } from '@opentelemetry/api';
-import { Werft } from './util/werft';
-import { reportBuildFailureInSlack } from './util/slack';
-import * as Tracing from './observability/tracing'
-import * as VM from './vm/vm'
-import { buildAndPublish } from './jobs/build/build-and-publish';
-import { validateChanges } from './jobs/build/validate-changes';
-import { prepare } from './jobs/build/prepare';
-import { coverage } from './jobs/build/coverage';
-import { deployToPreviewEnvironment } from './jobs/build/deploy-to-preview-environment';
-import { triggerIntegrationTests } from './jobs/build/trigger-integration-tests';
-import { jobConfig } from './jobs/build/job-config';
+import * as fs from "fs";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { Werft } from "./util/werft";
+import { reportBuildFailureInSlack } from "./util/slack";
+import * as Tracing from "./observability/tracing";
+import * as VM from "./vm/vm";
+import { buildAndPublish } from "./jobs/build/build-and-publish";
+import { validateChanges } from "./jobs/build/validate-changes";
+import { prepare } from "./jobs/build/prepare";
+import { coverage } from "./jobs/build/coverage";
+import { deployToPreviewEnvironment } from "./jobs/build/deploy-to-preview-environment";
+import { triggerIntegrationTests } from "./jobs/build/trigger-integration-tests";
+import { jobConfig } from "./jobs/build/job-config";
 
 // Will be set once tracing has been initialized
-let werft: Werft
-const context: any = JSON.parse(fs.readFileSync('context.json').toString());
+let werft: Werft;
+const context: any = JSON.parse(fs.readFileSync("context.json").toString());
 
 Tracing.initialize()
-    .then(() => {
-        werft = new Werft("build")
-    })
-    .then(() => run(context))
-    .then(() => VM.stopKubectlPortForwards())
-    .then(() => werft.endAllSpans())
-    .catch((err) => {
-        werft.rootSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err
-        })
-        werft.endAllSpans()
+  .then(() => {
+    werft = new Werft("build");
+  })
+  .then(() => run(context))
+  .then(() => VM.stopKubectlPortForwards())
+  .then(() => werft.endAllSpans())
+  .catch((err) => {
+    werft.rootSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: err,
+    });
+    werft.endAllSpans();
 
-        if (context.Repository.ref === "refs/heads/main") {
-            reportBuildFailureInSlack(context, err, () => process.exit(1));
-        } else {
-            console.log('Error', err)
-            // Explicitly not using process.exit as we need to flush tracing, see tracing.js
-            process.exitCode = 1
-        }
-
-        VM.stopKubectlPortForwards()
-    })
-
-async function run(context: any) {
-    const config = jobConfig(werft, context)
-
-    await validateChanges(werft)
-    await prepare(werft)
-    await buildAndPublish(werft, config)
-    await coverage(werft, config)
-
-    if (config.noPreview) {
-        werft.phase("deploy", "not deploying");
-        console.log("no-preview or publish-release is set");
-        return
+    if (context.Repository.ref === "refs/heads/main") {
+      reportBuildFailureInSlack(context, err, () => process.exit(1));
+    } else {
+      console.log("Error", err);
+      // Explicitly not using process.exit as we need to flush tracing, see tracing.js
+      process.exitCode = 1;
     }
 
-    await deployToPreviewEnvironment(werft, config)
-    await triggerIntegrationTests(werft, config, context.Owner)
+    VM.stopKubectlPortForwards();
+  });
+
+async function run(context: any) {
+  const config = jobConfig(werft, context);
+
+  await validateChanges(werft);
+  await prepare(werft);
+  await buildAndPublish(werft, config);
+  await coverage(werft, config);
+
+  if (config.noPreview) {
+    werft.phase("deploy", "not deploying");
+    console.log("no-preview or publish-release is set");
+    return;
+  }
+
+  await deployToPreviewEnvironment(werft, config);
+  await triggerIntegrationTests(werft, config, context.Owner);
 }

--- a/.werft/delete-preview-environments/delete-preview-environments-cron.ts
+++ b/.werft/delete-preview-environments/delete-preview-environments-cron.ts
@@ -1,72 +1,91 @@
-import { Werft } from '../util/werft';
-import * as Tracing from '../observability/tracing';
-import { SpanStatusCode } from '@opentelemetry/api';
-import { wipePreviewEnvironmentAndNamespace, helmInstallName, listAllPreviewNamespaces } from '../util/kubectl';
-import { exec } from '../util/shell';
+import { Werft } from "../util/werft";
+import * as Tracing from "../observability/tracing";
+import { SpanStatusCode } from "@opentelemetry/api";
+import {
+  wipePreviewEnvironmentAndNamespace,
+  helmInstallName,
+  listAllPreviewNamespaces,
+} from "../util/kubectl";
+import { exec } from "../util/shell";
 
 // Will be set once tracing has been initialized
-let werft: Werft
+let werft: Werft;
 
 Tracing.initialize()
-    .then(() => {
-        werft = new Werft("delete-preview-environment-cron")
-    })
-    .then(() => deletePreviewEnvironments())
-    .then(() => werft.endAllSpans())
-    .catch((err) => {
-        werft.rootSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err
-        })
-        werft.endAllSpans()
-    })
+  .then(() => {
+    werft = new Werft("delete-preview-environment-cron");
+  })
+  .then(() => deletePreviewEnvironments())
+  .then(() => werft.endAllSpans())
+  .catch((err) => {
+    werft.rootSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: err,
+    });
+    werft.endAllSpans();
+  });
 
 async function deletePreviewEnvironments() {
+  werft.phase("prep");
+  try {
+    const GCLOUD_SERVICE_ACCOUNT_PATH =
+      "/mnt/secrets/gcp-sa/service-account.json";
+    exec(
+      `gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`
+    );
+    exec(
+      "gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev"
+    );
+  } catch (err) {
+    werft.fail("prep", err);
+  }
+  werft.done("prep");
 
-    werft.phase("prep");
-    try {
-        const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.json";
-        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`);
-        exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev');
-    } catch (err) {
-        werft.fail("prep", err)
-    }
-    werft.done("prep")
+  werft.phase("Fetching branches");
+  const branches = getAllBranches();
+  const expectedPreviewEnvironmentNamespaces = new Set(
+    branches.map((branch) => parseBranch(branch))
+  );
+  werft.done("Fetching branches");
 
-    werft.phase("Fetching branches");
-    const branches = getAllBranches();
-    const expectedPreviewEnvironmentNamespaces = new Set(branches.map(branch => parseBranch(branch)));
-    werft.done("Fetching branches");
+  werft.phase("Fetching previews");
+  let previews;
+  try {
+    previews = listAllPreviewNamespaces({});
+  } catch (err) {
+    werft.fail("Fetching previews", err);
+  }
+  werft.done("Fetching previews");
 
-    werft.phase("Fetching previews");
-    let previews
-    try {
-        previews = listAllPreviewNamespaces({});
-    } catch (err) {
-        werft.fail("Fetching previews", err)
-    }
-    werft.done("Fetching previews");
+  werft.phase("Mapping previews => branches");
+  const previewsToDelete = previews.filter(
+    (ns) => !expectedPreviewEnvironmentNamespaces.has(ns)
+  );
 
-
-    werft.phase("Mapping previews => branches")
-    const previewsToDelete = previews.filter(ns => !expectedPreviewEnvironmentNamespaces.has(ns))
-
-    werft.phase("deleting previews")
-    try {
-        previewsToDelete.forEach(preview => wipePreviewEnvironmentAndNamespace(helmInstallName, preview, { slice: `Deleting preview ${preview}` }));
-    } catch (err) {
-        werft.fail("deleting previews", err)
-    }
-    werft.done("deleting previews")
+  werft.phase("deleting previews");
+  try {
+    previewsToDelete.forEach((preview) =>
+      wipePreviewEnvironmentAndNamespace(helmInstallName, preview, {
+        slice: `Deleting preview ${preview}`,
+      })
+    );
+  } catch (err) {
+    werft.fail("deleting previews", err);
+  }
+  werft.done("deleting previews");
 }
 
 function getAllBranches(): string[] {
-    return exec(`git branch -r | grep -v '\\->' | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" | while read remote; do echo "\${remote#origin/}"; done`).stdout.trim().split('\n');
+  return exec(
+    `git branch -r | grep -v '\\->' | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" | while read remote; do echo "\${remote#origin/}"; done`
+  )
+    .stdout.trim()
+    .split("\n");
 }
 
 function parseBranch(branch: string): string {
-    const prefix = 'staging-';
-    const parsedBranch = branch.normalize().split("/").join("-");
+  const prefix = "staging-";
+  const parsedBranch = branch.normalize().split("/").join("-");
 
-    return prefix + parsedBranch;
+  return prefix + parsedBranch;
 }

--- a/.werft/delete-preview-environments/delete-preview-environments.ts
+++ b/.werft/delete-preview-environments/delete-preview-environments.ts
@@ -1,50 +1,57 @@
-import { Werft } from '../util/werft';
-import * as fs from 'fs';
-import * as Tracing from '../observability/tracing';
-import { SpanStatusCode } from '@opentelemetry/api';
-import { wipePreviewEnvironmentAndNamespace, helmInstallName } from '../util/kubectl';
+import { Werft } from "../util/werft";
+import * as fs from "fs";
+import * as Tracing from "../observability/tracing";
+import { SpanStatusCode } from "@opentelemetry/api";
+import {
+  wipePreviewEnvironmentAndNamespace,
+  helmInstallName,
+} from "../util/kubectl";
 
 // Will be set once tracing has been initialized
-let werft: Werft
+let werft: Werft;
 
-const context = JSON.parse(fs.readFileSync('context.json').toString());
+const context = JSON.parse(fs.readFileSync("context.json").toString());
 
 Tracing.initialize()
-    .then(() => {
-        werft = new Werft("delete-preview-environment")
-    })
-    .then(() => deletePreviewEnvironment())
-    .then(() => werft.endAllSpans())
-    .catch((err) => {
-        werft.rootSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err
-        })
-        werft.endAllSpans()
-    })
+  .then(() => {
+    werft = new Werft("delete-preview-environment");
+  })
+  .then(() => deletePreviewEnvironment())
+  .then(() => werft.endAllSpans())
+  .catch((err) => {
+    werft.rootSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: err,
+    });
+    werft.endAllSpans();
+  });
 
 async function deletePreviewEnvironment() {
-    werft.phase("preparing deletion")
-    const version = parseVersion();
-    const namespace = `staging-${version.split(".")[0]}`
-    werft.log("preparing deletion", `Proceeding to delete the ${namespace} namespace`)
-    werft.done("preparing deletion")
+  werft.phase("preparing deletion");
+  const version = parseVersion();
+  const namespace = `staging-${version.split(".")[0]}`;
+  werft.log(
+    "preparing deletion",
+    `Proceeding to delete the ${namespace} namespace`
+  );
+  werft.done("preparing deletion");
 
-    werft.phase("delete-preview")
-    try {
-        await wipePreviewEnvironmentAndNamespace(helmInstallName, namespace, { slice: 'delete-preview' })
-    } catch (err) {
-        werft.fail("delete-preview", err)
-    }
-    werft.done("delete-prewview")
+  werft.phase("delete-preview");
+  try {
+    await wipePreviewEnvironmentAndNamespace(helmInstallName, namespace, {
+      slice: "delete-preview",
+    });
+  } catch (err) {
+    werft.fail("delete-preview", err);
+  }
+  werft.done("delete-prewview");
 }
 
-
 export function parseVersion() {
-    let version = context.Name;
-    const PREFIX_TO_STRIP = "gitpod-delete-preview-environment-";
-    if (version.substr(0, PREFIX_TO_STRIP.length) === PREFIX_TO_STRIP) {
-        version = version.substr(PREFIX_TO_STRIP.length);
-    }
-    return version
+  let version = context.Name;
+  const PREFIX_TO_STRIP = "gitpod-delete-preview-environment-";
+  if (version.substr(0, PREFIX_TO_STRIP.length) === PREFIX_TO_STRIP) {
+    version = version.substr(PREFIX_TO_STRIP.length);
+  }
+  return version;
 }

--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -1,89 +1,128 @@
-import * as semver from 'semver';
-import { exec } from '../../util/shell';
-import { Werft } from '../../util/werft';
-import { GCLOUD_SERVICE_ACCOUNT_PATH } from './const';
-import { JobConfig } from './job-config';
-
+import * as semver from "semver";
+import { exec } from "../../util/shell";
+import { Werft } from "../../util/werft";
+import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
+import { JobConfig } from "./job-config";
 
 export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
+  const {
+    publishRelease,
+    dontTest,
+    withContrib,
+    retag,
+    version,
+    localAppVersion,
+    publishToJBMarketplace,
+    publishToNpm,
+    coverageOutput,
+  } = jobConfig;
 
-    const {
-        publishRelease,
-        dontTest,
-        withContrib,
-        retag,
-        version,
-        localAppVersion,
-        publishToJBMarketplace,
-        publishToNpm,
-        coverageOutput
-    } = jobConfig
+  const releaseBranch = jobConfig.repository.ref;
 
-    const releaseBranch = jobConfig.repository.ref;
+  werft.phase("build", "build running");
+  const imageRepo = publishRelease
+    ? "gcr.io/gitpod-io/self-hosted"
+    : "eu.gcr.io/gitpod-core-dev/build";
 
-    werft.phase("build", "build running");
-    const imageRepo = publishRelease ? "gcr.io/gitpod-io/self-hosted" : "eu.gcr.io/gitpod-core-dev/build";
+  exec(
+    `LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || { echo "[build|FAIL] There are some license headers missing. Please run 'leeway run components:update-license-header'."; exit 1; }`
+  );
+  exec(`leeway vet --ignore-warnings`);
+  exec(
+    `leeway build --docker-build-options network=host --werft=true -c remote ${
+      dontTest ? "--dont-test" : ""
+    } --dont-retag --coverage-output-path=${coverageOutput} --save /tmp/dev.tar.gz -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`
+  );
 
-    exec(`LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || { echo "[build|FAIL] There are some license headers missing. Please run 'leeway run components:update-license-header'."; exit 1; }`)
-    exec(`leeway vet --ignore-warnings`);
-    exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} --dont-retag --coverage-output-path=${coverageOutput} --save /tmp/dev.tar.gz -Dversion=${version} -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev dev:all`);
+  if (publishRelease) {
+    exec(
+      `gcloud auth activate-service-account --key-file "/mnt/secrets/gcp-sa-release/service-account.json"`
+    );
+  }
+  if (withContrib || publishRelease) {
+    exec(
+      `leeway build --docker-build-options network=host --werft=true -c remote ${
+        dontTest ? "--dont-test" : ""
+      } -Dversion=${version} -DimageRepoBase=${imageRepo} contrib:all`
+    );
+  }
+  exec(
+    `leeway build --docker-build-options network=host --werft=true -c remote ${
+      dontTest ? "--dont-test" : ""
+    } ${retag} --coverage-output-path=${coverageOutput} -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo} -DlocalAppVersion=${localAppVersion} -DSEGMENT_IO_TOKEN=${
+      process.env.SEGMENT_IO_TOKEN
+    } -DnpmPublishTrigger=${
+      publishToNpm ? Date.now() : "false"
+    } -DjbMarketplacePublishTrigger=${
+      publishToJBMarketplace ? Date.now() : "false"
+    }`
+  );
+  if (publishRelease) {
+    try {
+      werft.phase("publish", "checking version semver compliance...");
+      if (!semver.valid(version)) {
+        // make this an explicit error as early as possible. Is required by helm Charts.yaml/version
+        throw new Error(
+          `'${version}' is not semver compliant and thus cannot be used for Self-Hosted releases!`
+        );
+      }
 
-    if (publishRelease) {
-        exec(`gcloud auth activate-service-account --key-file "/mnt/secrets/gcp-sa-release/service-account.json"`);
+      werft.phase("publish", "publishing Helm chart...");
+      publishHelmChart(werft, "gcr.io/gitpod-io/self-hosted", version);
+
+      werft.phase("publish", `preparing GitHub release files...`);
+      const releaseFilesTmpDir = exec("mktemp -d", {
+        silent: true,
+      }).stdout.trim();
+      const releaseTarName = "release.tar.gz";
+      exec(
+        `leeway build --docker-build-options network=host --werft=true chart:release-tars -Dversion=${version} -DimageRepoBase=${imageRepo} --save ${releaseFilesTmpDir}/${releaseTarName}`
+      );
+      exec(
+        `cd ${releaseFilesTmpDir} && tar xzf ${releaseTarName} && rm -f ${releaseTarName}`
+      );
+
+      werft.phase("publish", `publishing GitHub release ${version}...`);
+      const prereleaseFlag =
+        semver.prerelease(version) !== null ? "-prerelease" : "";
+      const tag = `v${version}`;
+      const description = `Gitpod Self-Hosted ${version}<br/><br/>Docs: https://www.gitpod.io/docs/self-hosted/latest/self-hosted/`;
+      exec(
+        `github-release ${prereleaseFlag} gitpod-io/gitpod ${tag} ${releaseBranch} '${description}' "${releaseFilesTmpDir}/*"`
+      );
+
+      werft.done("publish");
+    } catch (err) {
+      werft.fail("publish", err);
+    } finally {
+      exec(
+        `gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`
+      );
     }
-    if (withContrib || publishRelease) {
-        exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} -Dversion=${version} -DimageRepoBase=${imageRepo} contrib:all`);
-    }
-    exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} ${retag} --coverage-output-path=${coverageOutput} -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo} -DlocalAppVersion=${localAppVersion} -DSEGMENT_IO_TOKEN=${process.env.SEGMENT_IO_TOKEN} -DnpmPublishTrigger=${publishToNpm ? Date.now() : 'false'} -DjbMarketplacePublishTrigger=${publishToJBMarketplace ? Date.now() : 'false'}`);
-    if (publishRelease) {
-        try {
-            werft.phase("publish", "checking version semver compliance...");
-            if (!semver.valid(version)) {
-                // make this an explicit error as early as possible. Is required by helm Charts.yaml/version
-                throw new Error(`'${version}' is not semver compliant and thus cannot be used for Self-Hosted releases!`)
-            }
-
-            werft.phase("publish", "publishing Helm chart...");
-            publishHelmChart(werft, "gcr.io/gitpod-io/self-hosted", version);
-
-            werft.phase("publish", `preparing GitHub release files...`);
-            const releaseFilesTmpDir = exec("mktemp -d", { silent: true }).stdout.trim();
-            const releaseTarName = "release.tar.gz";
-            exec(`leeway build --docker-build-options network=host --werft=true chart:release-tars -Dversion=${version} -DimageRepoBase=${imageRepo} --save ${releaseFilesTmpDir}/${releaseTarName}`);
-            exec(`cd ${releaseFilesTmpDir} && tar xzf ${releaseTarName} && rm -f ${releaseTarName}`);
-
-            werft.phase("publish", `publishing GitHub release ${version}...`);
-            const prereleaseFlag = semver.prerelease(version) !== null ? "-prerelease" : "";
-            const tag = `v${version}`;
-            const description = `Gitpod Self-Hosted ${version}<br/><br/>Docs: https://www.gitpod.io/docs/self-hosted/latest/self-hosted/`;
-            exec(`github-release ${prereleaseFlag} gitpod-io/gitpod ${tag} ${releaseBranch} '${description}' "${releaseFilesTmpDir}/*"`);
-
-            werft.done('publish');
-        } catch (err) {
-            werft.fail('publish', err);
-        } finally {
-            exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`);
-        }
-    }
+  }
 }
 
 /**
  * Publish Charts
  */
-async function publishHelmChart(werft: Werft, imageRepoBase: string, version: string) {
-    werft.phase("publish-charts", "Publish charts");
-    [
-        "gcloud config set project gitpod-io",
-        `leeway build --docker-build-options network=host -Dversion=${version} -DimageRepoBase=${imageRepoBase} --save helm-repo.tar.gz chart:helm`,
-        "tar xzfv helm-repo.tar.gz",
-        "mkdir helm-repo",
-        "cp gitpod*tgz helm-repo/",
-        "gsutil cp gs://charts-gitpod-io-public/index.yaml old-index.yaml",
-        "cp gitpod*.tgz helm-repo/",
-        "helm3 repo index --merge old-index.yaml helm-repo",
-        "gsutil -m rsync -r helm-repo/ gs://charts-gitpod-io-public/"
-    ].forEach(cmd => {
-        exec(cmd, { slice: 'publish-charts' });
-    });
-    werft.done('publish-charts');
+async function publishHelmChart(
+  werft: Werft,
+  imageRepoBase: string,
+  version: string
+) {
+  werft.phase("publish-charts", "Publish charts");
+  [
+    "gcloud config set project gitpod-io",
+    `leeway build --docker-build-options network=host -Dversion=${version} -DimageRepoBase=${imageRepoBase} --save helm-repo.tar.gz chart:helm`,
+    "tar xzfv helm-repo.tar.gz",
+    "mkdir helm-repo",
+    "cp gitpod*tgz helm-repo/",
+    "gsutil cp gs://charts-gitpod-io-public/index.yaml old-index.yaml",
+    "cp gitpod*.tgz helm-repo/",
+    "helm3 repo index --merge old-index.yaml helm-repo",
+    "gsutil -m rsync -r helm-repo/ gs://charts-gitpod-io-public/",
+  ].forEach((cmd) => {
+    exec(cmd, { slice: "publish-charts" });
+  });
+  werft.done("publish-charts");
 }

--- a/.werft/jobs/build/const.ts
+++ b/.werft/jobs/build/const.ts
@@ -1,1 +1,2 @@
-export const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.json";
+export const GCLOUD_SERVICE_ACCOUNT_PATH =
+  "/mnt/secrets/gcp-sa/service-account.json";

--- a/.werft/jobs/build/coverage.ts
+++ b/.werft/jobs/build/coverage.ts
@@ -1,33 +1,38 @@
-import * as fs from 'fs';
-import * as util from 'util';
-import { exec } from '../../util/shell';
-import { Werft } from '../../util/werft';
-import { JobConfig } from './job-config';
+import * as fs from "fs";
+import * as util from "util";
+import { exec } from "../../util/shell";
+import { Werft } from "../../util/werft";
+import { JobConfig } from "./job-config";
 
-const readDir = util.promisify(fs.readdir)
+const readDir = util.promisify(fs.readdir);
 
 export async function coverage(werft: Werft, config: JobConfig) {
-    // Configure codecov as docker: SOURCE_BRANCH, SOURCE_COMMIT, DOCKER_REPO
-    // (there is no support for werft)
-    // --parent The commit SHA of the parent for which you are uploading coverage
-    // --dir    Directory to search for coverage reports
-    werft.phase('coverage', 'uploading code coverage to codecov');
-    const parent_commit = exec(`git rev-parse HEAD^`, { silent: true }).stdout.trim();;
-    try {
-        // if we don't remove the go directory codecov will scan it recursively
-        exec(`sudo rm -rf go`);
-        const coverageFiles = await readDir(config.coverageOutput);
-        for (let index = 0; index < coverageFiles.length; index++) {
-            const file = coverageFiles[index];
-            if (file.indexOf("-coverage.out") == -1) {
-                continue
-            }
-            let flag = file.substring(0, file.length - "-coverage.out".length);
-            exec(`codecov -N "${parent_commit}" --flags=${flag} --file "${config.coverageOutput}/${file}"`, { slice: "coverage" });
-        }
-
-        werft.done('coverage');
-    } catch (err) {
-        werft.fail('coverage', err);
+  // Configure codecov as docker: SOURCE_BRANCH, SOURCE_COMMIT, DOCKER_REPO
+  // (there is no support for werft)
+  // --parent The commit SHA of the parent for which you are uploading coverage
+  // --dir    Directory to search for coverage reports
+  werft.phase("coverage", "uploading code coverage to codecov");
+  const parent_commit = exec(`git rev-parse HEAD^`, {
+    silent: true,
+  }).stdout.trim();
+  try {
+    // if we don't remove the go directory codecov will scan it recursively
+    exec(`sudo rm -rf go`);
+    const coverageFiles = await readDir(config.coverageOutput);
+    for (let index = 0; index < coverageFiles.length; index++) {
+      const file = coverageFiles[index];
+      if (file.indexOf("-coverage.out") == -1) {
+        continue;
+      }
+      let flag = file.substring(0, file.length - "-coverage.out".length);
+      exec(
+        `codecov -N "${parent_commit}" --flags=${flag} --file "${config.coverageOutput}/${file}"`,
+        { slice: "coverage" }
+      );
     }
+
+    werft.done("coverage");
+  } catch (err) {
+    werft.fail("coverage", err);
+  }
 }

--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -1,335 +1,569 @@
 import { createHash } from "crypto";
-import * as shell from 'shelljs';
-import * as fs from 'fs';
-import { exec, ExecOptions } from '../../util/shell';
-import { InstallMonitoringSatelliteParams, installMonitoringSatellite } from '../../observability/monitoring-satellite';
-import { wipeAndRecreateNamespace, setKubectlContextNamespace, deleteNonNamespaceObjects, findFreeHostPorts, createNamespace, helmInstallName, findLastHostPort } from '../../util/kubectl';
-import { issueCertficate, installCertficate, IssueCertificateParams, InstallCertificateParams } from '../../util/certs';
-import { sleep, env } from '../../util/util';
+import * as shell from "shelljs";
+import * as fs from "fs";
+import { exec, ExecOptions } from "../../util/shell";
+import {
+  InstallMonitoringSatelliteParams,
+  installMonitoringSatellite,
+} from "../../observability/monitoring-satellite";
+import {
+  wipeAndRecreateNamespace,
+  setKubectlContextNamespace,
+  deleteNonNamespaceObjects,
+  findFreeHostPorts,
+  createNamespace,
+  helmInstallName,
+  findLastHostPort,
+} from "../../util/kubectl";
+import {
+  issueCertficate,
+  installCertficate,
+  IssueCertificateParams,
+  InstallCertificateParams,
+} from "../../util/certs";
+import { sleep, env } from "../../util/util";
 import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
 import { Werft } from "../../util/werft";
 import { JobConfig } from "./job-config";
-import * as VM from '../../vm/vm'
+import * as VM from "../../vm/vm";
 
 // used by both deploys (helm and Installer)
 const PROXY_SECRET_NAME = "proxy-config-certificates";
 const IMAGE_PULL_SECRET_NAME = "gcp-sa-registry-auth";
-const STACKDRIVER_SERVICEACCOUNT = JSON.parse(fs.readFileSync(`/mnt/secrets/monitoring-satellite-stackdriver-credentials/credentials.json`, 'utf8'));
+const STACKDRIVER_SERVICEACCOUNT = JSON.parse(
+  fs.readFileSync(
+    `/mnt/secrets/monitoring-satellite-stackdriver-credentials/credentials.json`,
+    "utf8"
+  )
+);
 
 const phases = {
-    PREDEPLOY: 'predeploy',
-    DEPLOY: 'deploy',
-    VM: 'vm'
-}
+  PREDEPLOY: "predeploy",
+  DEPLOY: "deploy",
+  VM: "vm",
+};
 
 // Werft slices for deploy phase via installer
 const installerSlices = {
-    FIND_FREE_HOST_PORTS: "find free ports",
-    IMAGE_PULL_SECRET: "image pull secret",
-    ISSUE_CERTIFICATES: "install certs",
-    CLEAN_ENV_STATE: "clean envirionment",
-    SET_CONTEXT: "set namespace",
-    INSTALLER_INIT: "installer init",
-    INSTALLER_RENDER: "installer render",
-    INSTALLER_POST_PROCESSING: "installer post processing",
-    APPLY_INSTALL_MANIFESTS: "installer apply",
-    DEPLOYMENT_WAITING: "monitor server deployment",
-    DNS_ADD_RECORD: "add dns record"
-}
+  FIND_FREE_HOST_PORTS: "find free ports",
+  IMAGE_PULL_SECRET: "image pull secret",
+  ISSUE_CERTIFICATES: "install certs",
+  CLEAN_ENV_STATE: "clean envirionment",
+  SET_CONTEXT: "set namespace",
+  INSTALLER_INIT: "installer init",
+  INSTALLER_RENDER: "installer render",
+  INSTALLER_POST_PROCESSING: "installer post processing",
+  APPLY_INSTALL_MANIFESTS: "installer apply",
+  DEPLOYMENT_WAITING: "monitor server deployment",
+  DNS_ADD_RECORD: "add dns record",
+};
 
 const vmSlices = {
-    BOOT_VM: 'Booting VM',
-    START_KUBECTL_PORT_FORWARDS: 'Start kubectl port forwards',
-    COPY_CERT_MANAGER_RESOURCES: 'Copy CertManager resources from core-dev',
-    INSTALL_LETS_ENCRYPT_ISSUER: 'Install Lets Encrypt issuer',
-    KUBECONFIG: 'Getting kubeconfig',
-    EXTERNAL_LOGGING: 'Install credentials to send logs from fluent-bit to GCP'
-}
+  BOOT_VM: "Booting VM",
+  START_KUBECTL_PORT_FORWARDS: "Start kubectl port forwards",
+  COPY_CERT_MANAGER_RESOURCES: "Copy CertManager resources from core-dev",
+  INSTALL_LETS_ENCRYPT_ISSUER: "Install Lets Encrypt issuer",
+  KUBECONFIG: "Getting kubeconfig",
+  EXTERNAL_LOGGING: "Install credentials to send logs from fluent-bit to GCP",
+};
 
-export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobConfig) {
-    const {
-        version,
-        withVM,
-        analytics,
-        cleanSlateDeployment,
-        withPayment,
-        withObservability,
-        installEELicense,
-        withHelm,
-        workspaceFeatureFlags,
-        dynamicCPULimits,
-        storage
-    } = jobConfig;
+export async function deployToPreviewEnvironment(
+  werft: Werft,
+  jobConfig: JobConfig
+) {
+  const {
+    version,
+    withVM,
+    analytics,
+    cleanSlateDeployment,
+    withPayment,
+    withObservability,
+    installEELicense,
+    withHelm,
+    workspaceFeatureFlags,
+    dynamicCPULimits,
+    storage,
+  } = jobConfig;
 
-    const {
-        destname,
-        namespace
-    } = jobConfig.previewEnvironment
+  const { destname, namespace } = jobConfig.previewEnvironment;
 
-
-
-    const domain = withVM ? `${destname}.preview.gitpod-dev.com` : `${destname}.staging.gitpod-dev.com`;
-    const monitoringDomain = `${destname}.preview.gitpod-dev.com`;
-    const url = `https://${domain}`;
-    const imagePullAuth = exec(`printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
+  const domain = withVM
+    ? `${destname}.preview.gitpod-dev.com`
+    : `${destname}.staging.gitpod-dev.com`;
+  const monitoringDomain = `${destname}.preview.gitpod-dev.com`;
+  const url = `https://${domain}`;
+  const imagePullAuth = exec(
+    `printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
         | yq r - data['.dockerconfigjson'] \
-        | base64 -d)" | base64 -w 0`, { silent: true }).stdout.trim();
+        | base64 -d)" | base64 -w 0`,
+    { silent: true }
+  ).stdout.trim();
 
-    const sweeperImage = exec(`tar xfO /tmp/dev.tar.gz ./sweeper.txt`).stdout.trim();
+  const sweeperImage = exec(
+    `tar xfO /tmp/dev.tar.gz ./sweeper.txt`
+  ).stdout.trim();
 
-    const deploymentConfig: DeploymentConfig = {
-        version,
-        destname,
-        namespace,
-        domain,
-        monitoringDomain,
-        url,
-        analytics,
-        cleanSlateDeployment,
-        sweeperImage,
-        installEELicense,
-        imagePullAuth,
-        withPayment,
-        withObservability,
-        withVM,
-    };
+  const deploymentConfig: DeploymentConfig = {
+    version,
+    destname,
+    namespace,
+    domain,
+    monitoringDomain,
+    url,
+    analytics,
+    cleanSlateDeployment,
+    sweeperImage,
+    installEELicense,
+    imagePullAuth,
+    withPayment,
+    withObservability,
+    withVM,
+  };
 
-    exec(`kubectl --namespace keys get secret host-key -o yaml > /workspace/host-key.yaml`)
+  exec(
+    `kubectl --namespace keys get secret host-key -o yaml > /workspace/host-key.yaml`
+  );
 
-    // Writing auth-provider configuration to disk prior to deploying anything.
-    // We do this because we have different auth-providers depending if we're using core-dev or Harvester VMs.
-    exec(`kubectl get secret ${withVM ? 'preview-envs-authproviders-harvester' : 'preview-envs-authproviders'} --namespace=keys -o jsonpath="{.data.authProviders}" > auth-provider-secret.yml`, { silent: true })
+  // Writing auth-provider configuration to disk prior to deploying anything.
+  // We do this because we have different auth-providers depending if we're using core-dev or Harvester VMs.
+  exec(
+    `kubectl get secret ${
+      withVM
+        ? "preview-envs-authproviders-harvester"
+        : "preview-envs-authproviders"
+    } --namespace=keys -o jsonpath="{.data.authProviders}" > auth-provider-secret.yml`,
+    { silent: true }
+  );
 
-    if (withVM) {
-        werft.phase(phases.VM, "Start VM");
+  if (withVM) {
+    werft.phase(phases.VM, "Start VM");
 
-        werft.log(vmSlices.COPY_CERT_MANAGER_RESOURCES, 'Copy over CertManager resources from core-dev')
-        exec(`kubectl get secret clouddns-dns01-solver-svc-acct -n certmanager -o yaml | sed 's/namespace: certmanager/namespace: cert-manager/g' > clouddns-dns01-solver-svc-acct.yaml`, { slice: vmSlices.COPY_CERT_MANAGER_RESOURCES })
-        exec(`kubectl get clusterissuer letsencrypt-issuer-gitpod-core-dev -o yaml | sed 's/letsencrypt-issuer-gitpod-core-dev/letsencrypt-issuer/g' > letsencrypt-issuer.yaml`, { slice: vmSlices.COPY_CERT_MANAGER_RESOURCES })
-        werft.done(vmSlices.COPY_CERT_MANAGER_RESOURCES)
+    werft.log(
+      vmSlices.COPY_CERT_MANAGER_RESOURCES,
+      "Copy over CertManager resources from core-dev"
+    );
+    exec(
+      `kubectl get secret clouddns-dns01-solver-svc-acct -n certmanager -o yaml | sed 's/namespace: certmanager/namespace: cert-manager/g' > clouddns-dns01-solver-svc-acct.yaml`,
+      { slice: vmSlices.COPY_CERT_MANAGER_RESOURCES }
+    );
+    exec(
+      `kubectl get clusterissuer letsencrypt-issuer-gitpod-core-dev -o yaml | sed 's/letsencrypt-issuer-gitpod-core-dev/letsencrypt-issuer/g' > letsencrypt-issuer.yaml`,
+      { slice: vmSlices.COPY_CERT_MANAGER_RESOURCES }
+    );
+    werft.done(vmSlices.COPY_CERT_MANAGER_RESOURCES);
 
-        const existingVM = VM.vmExists({ name: destname })
-        if (!existingVM) {
-            werft.log(vmSlices.BOOT_VM, 'Starting VM')
-            VM.startVM({ name: destname })
-            werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true)
-        } else if (cleanSlateDeployment) {
-            werft.log(vmSlices.BOOT_VM, 'Removing existing namespace')
-            VM.deleteVM({ name: destname })
-            werft.log(vmSlices.BOOT_VM, 'Starting VM')
-            VM.startVM({ name: destname })
-            werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true)
-        } else {
-            werft.log(vmSlices.BOOT_VM, 'VM already exists')
-            werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", false)
-        }
-
-        werft.log(vmSlices.BOOT_VM, 'Waiting for VM to be ready')
-        VM.waitForVM({ name: destname, timeoutSeconds: 60 * 10, slice: vmSlices.BOOT_VM })
-        werft.done(vmSlices.BOOT_VM)
-
-        werft.log(vmSlices.START_KUBECTL_PORT_FORWARDS, 'Starting SSH port forwarding')
-        VM.startSSHProxy({ name: destname, slice: vmSlices.START_KUBECTL_PORT_FORWARDS })
-        werft.done(vmSlices.START_KUBECTL_PORT_FORWARDS)
-
-        werft.log(vmSlices.KUBECONFIG, 'Copying k3s kubeconfig')
-        VM.copyk3sKubeconfig({ name: destname, path: 'k3s.yml', timeoutMS: 1000 * 60 * 3, slice: vmSlices.KUBECONFIG })
-        // NOTE: This was a quick have to override the existing kubeconfig so all future kubectl commands use the k3s cluster.
-        //       We might want to keep both kubeconfigs around and be explicit about which one we're using.s
-        exec(`mv k3s.yml /home/gitpod/.kube/config`)
-        werft.done(vmSlices.KUBECONFIG)
-
-        exec(`kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`, { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true })
-        werft.done(vmSlices.INSTALL_LETS_ENCRYPT_ISSUER)
-
-        VM.installFluentBit({ namespace: 'default', slice: vmSlices.EXTERNAL_LOGGING })
-        werft.done(vmSlices.EXTERNAL_LOGGING)
-
-
-        issueMetaCerts(werft, PROXY_SECRET_NAME, "default", domain, withVM)
-        werft.done('certificate')
-        installMonitoring(deploymentConfig.namespace, 9100, deploymentConfig.domain, STACKDRIVER_SERVICEACCOUNT, true, jobConfig.observability.branch);
-        werft.done('observability')
-    }
-
-    werft.phase(phases.PREDEPLOY, "Checking for existing installations...");
-    // the context namespace is not set at this point
-    const hasGitpodHelmInstall = exec(`helm status ${helmInstallName} -n ${deploymentConfig.namespace}`, { slice: "check for Helm install", dontCheckRc: true }).code === 0;
-    const hasGitpodInstallerInstall = exec(`kubectl get configmap gitpod-app -n ${deploymentConfig.namespace}`, { slice: "check for Installer install", dontCheckRc: true }).code === 0;
-    werft.log("result of installation checks", `has Helm install: ${hasGitpodHelmInstall}, has Installer install: ${hasGitpodInstallerInstall}`);
-
-    if (withHelm) {
-        werft.log("using Helm", "with-helm was specified.");
-        // you want helm, but left behind a Gitpod Installer installation, force a clean slate
-        if (hasGitpodInstallerInstall && !deploymentConfig.cleanSlateDeployment) {
-            werft.log("warning!", "with-helm was specified, there's an Installer install, but, `with-clean-slate-deployment=false`, forcing to true.");
-            deploymentConfig.cleanSlateDeployment = true;
-        }
-        werft.done(phases.PREDEPLOY);
-        werft.phase(phases.DEPLOY, "deploying")
-        await deployToDevWithHelm(werft, jobConfig, deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
-    } // scenario: you pushed code to an existing preview environment built with Helm, and didn't with-clean-slate-deployment=true'
-    else if (hasGitpodHelmInstall && !deploymentConfig.cleanSlateDeployment) {
-        werft.log("using Helm", "with-helm was not specified, but, a Helm installation exists, and this is not a clean slate deployment.");
-        werft.log("tip", "Set 'with-clean-slate-deployment=true' if you wish to remove the Helm install and use the Installer.");
-        werft.done(phases.PREDEPLOY);
-        werft.phase(phases.DEPLOY, "deploying to dev with Helm");
-        await deployToDevWithHelm(werft, jobConfig, deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
+    const existingVM = VM.vmExists({ name: destname });
+    if (!existingVM) {
+      werft.log(vmSlices.BOOT_VM, "Starting VM");
+      VM.startVM({ name: destname });
+      werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true);
+    } else if (cleanSlateDeployment) {
+      werft.log(vmSlices.BOOT_VM, "Removing existing namespace");
+      VM.deleteVM({ name: destname });
+      werft.log(vmSlices.BOOT_VM, "Starting VM");
+      VM.startVM({ name: destname });
+      werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true);
     } else {
-        // you get here if
-        // ...it's a new install with no flag overrides or
-        // ...it's an existing install and a Helm install doesn't exist or
-        // ...you have a prexisting Helm install, set 'with-clean-slate-deployment=true', but did not specifiy 'with-helm=true'
-        // Why? The installer is supposed to be a default so we all dog-food it.
-        // But, its new, so this may help folks transition with less issues.
-        werft.done(phases.PREDEPLOY);
-        werft.phase(phases.DEPLOY, "deploying to dev with Installer");
-        await deployToDevWithInstaller(werft, jobConfig, deploymentConfig, workspaceFeatureFlags, dynamicCPULimits, storage);
+      werft.log(vmSlices.BOOT_VM, "VM already exists");
+      werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", false);
     }
+
+    werft.log(vmSlices.BOOT_VM, "Waiting for VM to be ready");
+    VM.waitForVM({
+      name: destname,
+      timeoutSeconds: 60 * 10,
+      slice: vmSlices.BOOT_VM,
+    });
+    werft.done(vmSlices.BOOT_VM);
+
+    werft.log(
+      vmSlices.START_KUBECTL_PORT_FORWARDS,
+      "Starting SSH port forwarding"
+    );
+    VM.startSSHProxy({
+      name: destname,
+      slice: vmSlices.START_KUBECTL_PORT_FORWARDS,
+    });
+    werft.done(vmSlices.START_KUBECTL_PORT_FORWARDS);
+
+    werft.log(vmSlices.KUBECONFIG, "Copying k3s kubeconfig");
+    VM.copyk3sKubeconfig({
+      name: destname,
+      path: "k3s.yml",
+      timeoutMS: 1000 * 60 * 3,
+      slice: vmSlices.KUBECONFIG,
+    });
+    // NOTE: This was a quick have to override the existing kubeconfig so all future kubectl commands use the k3s cluster.
+    //       We might want to keep both kubeconfigs around and be explicit about which one we're using.s
+    exec(`mv k3s.yml /home/gitpod/.kube/config`);
+    werft.done(vmSlices.KUBECONFIG);
+
+    exec(
+      `kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`,
+      { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true }
+    );
+    werft.done(vmSlices.INSTALL_LETS_ENCRYPT_ISSUER);
+
+    VM.installFluentBit({
+      namespace: "default",
+      slice: vmSlices.EXTERNAL_LOGGING,
+    });
+    werft.done(vmSlices.EXTERNAL_LOGGING);
+
+    issueMetaCerts(werft, PROXY_SECRET_NAME, "default", domain, withVM);
+    werft.done("certificate");
+    installMonitoring(
+      deploymentConfig.namespace,
+      9100,
+      deploymentConfig.domain,
+      STACKDRIVER_SERVICEACCOUNT,
+      true,
+      jobConfig.observability.branch
+    );
+    werft.done("observability");
+  }
+
+  werft.phase(phases.PREDEPLOY, "Checking for existing installations...");
+  // the context namespace is not set at this point
+  const hasGitpodHelmInstall =
+    exec(`helm status ${helmInstallName} -n ${deploymentConfig.namespace}`, {
+      slice: "check for Helm install",
+      dontCheckRc: true,
+    }).code === 0;
+  const hasGitpodInstallerInstall =
+    exec(`kubectl get configmap gitpod-app -n ${deploymentConfig.namespace}`, {
+      slice: "check for Installer install",
+      dontCheckRc: true,
+    }).code === 0;
+  werft.log(
+    "result of installation checks",
+    `has Helm install: ${hasGitpodHelmInstall}, has Installer install: ${hasGitpodInstallerInstall}`
+  );
+
+  if (withHelm) {
+    werft.log("using Helm", "with-helm was specified.");
+    // you want helm, but left behind a Gitpod Installer installation, force a clean slate
+    if (hasGitpodInstallerInstall && !deploymentConfig.cleanSlateDeployment) {
+      werft.log(
+        "warning!",
+        "with-helm was specified, there's an Installer install, but, `with-clean-slate-deployment=false`, forcing to true."
+      );
+      deploymentConfig.cleanSlateDeployment = true;
+    }
+    werft.done(phases.PREDEPLOY);
+    werft.phase(phases.DEPLOY, "deploying");
+    await deployToDevWithHelm(
+      werft,
+      jobConfig,
+      deploymentConfig,
+      workspaceFeatureFlags,
+      dynamicCPULimits,
+      storage
+    );
+  } // scenario: you pushed code to an existing preview environment built with Helm, and didn't with-clean-slate-deployment=true'
+  else if (hasGitpodHelmInstall && !deploymentConfig.cleanSlateDeployment) {
+    werft.log(
+      "using Helm",
+      "with-helm was not specified, but, a Helm installation exists, and this is not a clean slate deployment."
+    );
+    werft.log(
+      "tip",
+      "Set 'with-clean-slate-deployment=true' if you wish to remove the Helm install and use the Installer."
+    );
+    werft.done(phases.PREDEPLOY);
+    werft.phase(phases.DEPLOY, "deploying to dev with Helm");
+    await deployToDevWithHelm(
+      werft,
+      jobConfig,
+      deploymentConfig,
+      workspaceFeatureFlags,
+      dynamicCPULimits,
+      storage
+    );
+  } else {
+    // you get here if
+    // ...it's a new install with no flag overrides or
+    // ...it's an existing install and a Helm install doesn't exist or
+    // ...you have a prexisting Helm install, set 'with-clean-slate-deployment=true', but did not specifiy 'with-helm=true'
+    // Why? The installer is supposed to be a default so we all dog-food it.
+    // But, its new, so this may help folks transition with less issues.
+    werft.done(phases.PREDEPLOY);
+    werft.phase(phases.DEPLOY, "deploying to dev with Installer");
+    await deployToDevWithInstaller(
+      werft,
+      jobConfig,
+      deploymentConfig,
+      workspaceFeatureFlags,
+      dynamicCPULimits,
+      storage
+    );
+  }
 }
 
 /*
-* Deploy a preview environment using the Installer
-*/
-async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, deploymentConfig: DeploymentConfig, workspaceFeatureFlags: string[], dynamicCPULimits, storage) {
-    // to test this function, change files in your workspace, sideload (-s) changed files into werft or set annotations (-a) like so:
-    // werft run github -f -j ./.werft/build.yaml -s ./.werft/build.ts -s ./.werft/post-process.sh -a with-clean-slate-deployment=true
-    const { version, destname, namespace, domain, monitoringDomain, url, withObservability, withVM } = deploymentConfig;
+ * Deploy a preview environment using the Installer
+ */
+async function deployToDevWithInstaller(
+  werft: Werft,
+  jobConfig: JobConfig,
+  deploymentConfig: DeploymentConfig,
+  workspaceFeatureFlags: string[],
+  dynamicCPULimits,
+  storage
+) {
+  // to test this function, change files in your workspace, sideload (-s) changed files into werft or set annotations (-a) like so:
+  // werft run github -f -j ./.werft/build.yaml -s ./.werft/build.ts -s ./.werft/post-process.sh -a with-clean-slate-deployment=true
+  const {
+    version,
+    destname,
+    namespace,
+    domain,
+    monitoringDomain,
+    url,
+    withObservability,
+    withVM,
+  } = deploymentConfig;
 
-    // find free ports
-    werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Find last ports");
-    let wsdaemonPortMeta = findLastHostPort(namespace, 'ws-daemon', metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }))
-    let registryNodePortMeta = findLastHostPort(namespace, 'registry-facade', metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }))
+  // find free ports
+  werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Find last ports");
+  let wsdaemonPortMeta = findLastHostPort(
+    namespace,
+    "ws-daemon",
+    metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true })
+  );
+  let registryNodePortMeta = findLastHostPort(
+    namespace,
+    "registry-facade",
+    metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true })
+  );
 
-    if (isNaN(wsdaemonPortMeta) || isNaN(wsdaemonPortMeta)) {
-        werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Can't reuse, check for some free ports.");
-        [wsdaemonPortMeta, registryNodePortMeta] = findFreeHostPorts([
-            { start: 10000, end: 11000 },
-            { start: 30000, end: 31000 },
-        ], metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }));
+  if (isNaN(wsdaemonPortMeta) || isNaN(wsdaemonPortMeta)) {
+    werft.log(
+      installerSlices.FIND_FREE_HOST_PORTS,
+      "Can't reuse, check for some free ports."
+    );
+    [wsdaemonPortMeta, registryNodePortMeta] = findFreeHostPorts(
+      [
+        { start: 10000, end: 11000 },
+        { start: 30000, end: 31000 },
+      ],
+      metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true })
+    );
+  }
+  werft.log(
+    installerSlices.FIND_FREE_HOST_PORTS,
+    `wsdaemonPortMeta: ${wsdaemonPortMeta}, registryNodePortMeta: ${registryNodePortMeta}.`
+  );
+  werft.done(installerSlices.FIND_FREE_HOST_PORTS);
+
+  // clean environment state
+  try {
+    if (deploymentConfig.cleanSlateDeployment && !withVM) {
+      werft.log(
+        installerSlices.CLEAN_ENV_STATE,
+        "Clean the preview environment slate..."
+      );
+      // re-create namespace
+      await cleanStateEnv(metaEnv());
+    } else {
+      werft.log(
+        installerSlices.CLEAN_ENV_STATE,
+        "Clean the preview environment slate..."
+      );
+      createNamespace(
+        namespace,
+        metaEnv({ slice: installerSlices.CLEAN_ENV_STATE })
+      );
     }
-    werft.log(installerSlices.FIND_FREE_HOST_PORTS,
-        `wsdaemonPortMeta: ${wsdaemonPortMeta}, registryNodePortMeta: ${registryNodePortMeta}.`);
-    werft.done(installerSlices.FIND_FREE_HOST_PORTS);
+    werft.done(installerSlices.CLEAN_ENV_STATE);
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail(installerSlices.CLEAN_ENV_STATE, err);
+    }
+    exec("exit 0");
+  }
 
-    // clean environment state
+  if (!withVM) {
+    // in a VM, the secrets have alreay been copied
+    // If using core-dev, we want to execute further kubectl operations only in the created namespace
+    setKubectlContextNamespace(
+      namespace,
+      metaEnv({ slice: installerSlices.SET_CONTEXT })
+    );
+    werft.done(installerSlices.SET_CONTEXT);
     try {
-        if (deploymentConfig.cleanSlateDeployment && !withVM) {
-            werft.log(installerSlices.CLEAN_ENV_STATE, "Clean the preview environment slate...");
-            // re-create namespace
-            await cleanStateEnv(metaEnv());
+      werft.log(
+        installerSlices.ISSUE_CERTIFICATES,
+        "organizing a certificate for the preview environment..."
+      );
 
-        } else {
-            werft.log(installerSlices.CLEAN_ENV_STATE, "Clean the preview environment slate...");
-            createNamespace(namespace, metaEnv({ slice: installerSlices.CLEAN_ENV_STATE }));
-        }
-        werft.done(installerSlices.CLEAN_ENV_STATE);
+      // trigger certificate issuing
+      await issueMetaCerts(werft, namespace, "certs", domain, withVM);
+      await installMetaCertificates(werft, namespace);
+      werft.done(installerSlices.ISSUE_CERTIFICATES);
     } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail(installerSlices.CLEAN_ENV_STATE, err);
-        }
-        exec('exit 0')
+      if (!jobConfig.mainBuild) {
+        werft.fail(installerSlices.ISSUE_CERTIFICATES, err);
+      }
+      exec("exit 0");
     }
+  }
 
-    if (!withVM) {
-        // in a VM, the secrets have alreay been copied
-        // If using core-dev, we want to execute further kubectl operations only in the created namespace
-        setKubectlContextNamespace(namespace, metaEnv({ slice: installerSlices.SET_CONTEXT }));
-        werft.done(installerSlices.SET_CONTEXT)
-        try {
-            werft.log(installerSlices.ISSUE_CERTIFICATES, "organizing a certificate for the preview environment...");
-
-            // trigger certificate issuing
-            await issueMetaCerts(werft, namespace, "certs", domain, withVM);
-            await installMetaCertificates(werft, namespace);
-            werft.done(installerSlices.ISSUE_CERTIFICATES);
-        } catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail(installerSlices.ISSUE_CERTIFICATES, err);
-            }
-            exec('exit 0')
-        }
-    }
-
-    // add the image pull secret to the namespcae if it doesn't exist
-    const hasPullSecret = (exec(`kubectl get secret ${IMAGE_PULL_SECRET_NAME} -n ${namespace}`, { slice: installerSlices.IMAGE_PULL_SECRET, dontCheckRc: true, silent: true })).code === 0;
-    if (!hasPullSecret) {
-        try {
-            werft.log(installerSlices.IMAGE_PULL_SECRET, "Adding the image pull secret to the namespace");
-            const dockerConfig = { auths: { "eu.gcr.io": { auth: deploymentConfig.imagePullAuth }, "europe-docker.pkg.dev": { auth: deploymentConfig.imagePullAuth } } };
-            fs.writeFileSync(`./${IMAGE_PULL_SECRET_NAME}`, JSON.stringify(dockerConfig));
-            exec(`kubectl create secret docker-registry ${IMAGE_PULL_SECRET_NAME} -n ${namespace} --from-file=.dockerconfigjson=./${IMAGE_PULL_SECRET_NAME}`);
-            werft.done(installerSlices.IMAGE_PULL_SECRET);
-        }
-        catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail(installerSlices.IMAGE_PULL_SECRET, err);
-            }
-            exec('exit 0')
-        }
-    }
-
-    // download and init with the installer
+  // add the image pull secret to the namespcae if it doesn't exist
+  const hasPullSecret =
+    exec(`kubectl get secret ${IMAGE_PULL_SECRET_NAME} -n ${namespace}`, {
+      slice: installerSlices.IMAGE_PULL_SECRET,
+      dontCheckRc: true,
+      silent: true,
+    }).code === 0;
+  if (!hasPullSecret) {
     try {
-        werft.log(installerSlices.INSTALLER_INIT, "Downloading installer and initializing config file");
-        exec(`docker run --entrypoint sh --rm eu.gcr.io/gitpod-core-dev/build/installer:${version} -c "cat /app/installer" > /tmp/installer`, { slice: installerSlices.INSTALLER_INIT });
-        exec(`chmod +x /tmp/installer`, { slice: installerSlices.INSTALLER_INIT });
-        exec(`/tmp/installer init > config.yaml`, { slice: installerSlices.INSTALLER_INIT });
-        werft.done(installerSlices.INSTALLER_INIT);
+      werft.log(
+        installerSlices.IMAGE_PULL_SECRET,
+        "Adding the image pull secret to the namespace"
+      );
+      const dockerConfig = {
+        auths: {
+          "eu.gcr.io": { auth: deploymentConfig.imagePullAuth },
+          "europe-docker.pkg.dev": { auth: deploymentConfig.imagePullAuth },
+        },
+      };
+      fs.writeFileSync(
+        `./${IMAGE_PULL_SECRET_NAME}`,
+        JSON.stringify(dockerConfig)
+      );
+      exec(
+        `kubectl create secret docker-registry ${IMAGE_PULL_SECRET_NAME} -n ${namespace} --from-file=.dockerconfigjson=./${IMAGE_PULL_SECRET_NAME}`
+      );
+      werft.done(installerSlices.IMAGE_PULL_SECRET);
     } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail(installerSlices.INSTALLER_INIT, err)
-        }
-        exec('exit 0')
+      if (!jobConfig.mainBuild) {
+        werft.fail(installerSlices.IMAGE_PULL_SECRET, err);
+      }
+      exec("exit 0");
+    }
+  }
+
+  // download and init with the installer
+  try {
+    werft.log(
+      installerSlices.INSTALLER_INIT,
+      "Downloading installer and initializing config file"
+    );
+    exec(
+      `docker run --entrypoint sh --rm eu.gcr.io/gitpod-core-dev/build/installer:${version} -c "cat /app/installer" > /tmp/installer`,
+      { slice: installerSlices.INSTALLER_INIT }
+    );
+    exec(`chmod +x /tmp/installer`, { slice: installerSlices.INSTALLER_INIT });
+    exec(`/tmp/installer init > config.yaml`, {
+      slice: installerSlices.INSTALLER_INIT,
+    });
+    werft.done(installerSlices.INSTALLER_INIT);
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail(installerSlices.INSTALLER_INIT, err);
+    }
+    exec("exit 0");
+  }
+
+  // prepare a proper config file
+  try {
+    werft.log(
+      installerSlices.INSTALLER_RENDER,
+      "Post process the base installer config file and render k8s manifests"
+    );
+    const PROJECT_NAME = "gitpod-core-dev";
+    const CONTAINER_REGISTRY_URL = `eu.gcr.io/${PROJECT_NAME}/build/`;
+    const CONTAINERD_RUNTIME_DIR =
+      "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io";
+
+    // get some values we need to customize the config and write them to file
+    exec(
+      `yq r ./.werft/values.dev.yaml components.server.blockNewUsers \
+        | yq prefix - 'blockNewUsers' > ./blockNewUsers`,
+      { slice: installerSlices.INSTALLER_RENDER }
+    );
+    exec(
+      `yq r ./.werft/values.variant.cpuLimits.yaml workspaceSizing | yq prefix - 'workspace' > ./workspaceSizing`,
+      { slice: installerSlices.INSTALLER_RENDER }
+    );
+
+    // merge values from files
+    exec(`yq m -i --overwrite config.yaml ./blockNewUsers`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
+    exec(`yq m -i config.yaml ./workspaceSizing`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
+
+    // write some values inline
+    exec(`yq w -i config.yaml certificate.name ${PROXY_SECRET_NAME}`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
+    exec(`yq w -i config.yaml containerRegistry.inCluster false`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
+    exec(
+      `yq w -i config.yaml containerRegistry.external.url ${CONTAINER_REGISTRY_URL}`,
+      { slice: installerSlices.INSTALLER_RENDER }
+    );
+    exec(
+      `yq w -i config.yaml containerRegistry.external.certificate.kind secret`,
+      { slice: installerSlices.INSTALLER_RENDER }
+    );
+    exec(
+      `yq w -i config.yaml containerRegistry.external.certificate.name ${IMAGE_PULL_SECRET_NAME}`,
+      { slice: installerSlices.INSTALLER_RENDER }
+    );
+    exec(`yq w -i config.yaml domain ${deploymentConfig.domain}`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
+    // TODO: Get rid of JaegerOperator as part of https://github.com/gitpod-io/ops/issues/875
+    exec(`yq w -i config.yaml jaegerOperator.inCluster false`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
+    exec(
+      `yq w -i config.yaml workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`,
+      { slice: installerSlices.INSTALLER_RENDER }
+    );
+
+    if ((deploymentConfig.analytics || "").startsWith("segment|")) {
+      exec(`yq w -i config.yaml analytics.writer segment`, {
+        slice: installerSlices.INSTALLER_RENDER,
+      });
+      exec(
+        `yq w -i config.yaml analytics.segmentKey ${deploymentConfig.analytics!.substring(
+          "segment|".length
+        )}`,
+        { slice: installerSlices.INSTALLER_RENDER }
+      );
+    } else if (!!deploymentConfig.analytics) {
+      exec(
+        `yq w -i config.yaml analytics.writer ${deploymentConfig.analytics!}`,
+        { slice: installerSlices.INSTALLER_RENDER }
+      );
     }
 
-    // prepare a proper config file
+    if (withObservability) {
+      // TODO: there's likely more to do...
+      const tracingEndpoint = exec(
+        `yq r ./.werft/values.tracing.yaml tracing.endpoint`,
+        { slice: installerSlices.INSTALLER_RENDER }
+      ).stdout.trim();
+      exec(
+        `yq w -i config.yaml observability.tracing.endpoint ${tracingEndpoint}`,
+        { slice: installerSlices.INSTALLER_RENDER }
+      );
+    }
+
+    werft.log("authProviders", "copy authProviders from secret");
     try {
-        werft.log(installerSlices.INSTALLER_RENDER, "Post process the base installer config file and render k8s manifests");
-        const PROJECT_NAME = "gitpod-core-dev";
-        const CONTAINER_REGISTRY_URL = `eu.gcr.io/${PROJECT_NAME}/build/`;
-        const CONTAINERD_RUNTIME_DIR = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io";
-
-        // get some values we need to customize the config and write them to file
-        exec(`yq r ./.werft/values.dev.yaml components.server.blockNewUsers \
-        | yq prefix - 'blockNewUsers' > ./blockNewUsers`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq r ./.werft/values.variant.cpuLimits.yaml workspaceSizing | yq prefix - 'workspace' > ./workspaceSizing`, { slice: installerSlices.INSTALLER_RENDER });
-
-        // merge values from files
-        exec(`yq m -i --overwrite config.yaml ./blockNewUsers`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq m -i config.yaml ./workspaceSizing`, { slice: installerSlices.INSTALLER_RENDER });
-
-        // write some values inline
-        exec(`yq w -i config.yaml certificate.name ${PROXY_SECRET_NAME}`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq w -i config.yaml containerRegistry.inCluster false`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq w -i config.yaml containerRegistry.external.url ${CONTAINER_REGISTRY_URL}`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq w -i config.yaml containerRegistry.external.certificate.kind secret`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq w -i config.yaml containerRegistry.external.certificate.name ${IMAGE_PULL_SECRET_NAME}`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq w -i config.yaml domain ${deploymentConfig.domain}`, { slice: installerSlices.INSTALLER_RENDER });
-        // TODO: Get rid of JaegerOperator as part of https://github.com/gitpod-io/ops/issues/875
-        exec(`yq w -i config.yaml jaegerOperator.inCluster false`, { slice: installerSlices.INSTALLER_RENDER });
-        exec(`yq w -i config.yaml workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: installerSlices.INSTALLER_RENDER });
-
-        if ((deploymentConfig.analytics || "").startsWith("segment|")) {
-            exec(`yq w -i config.yaml analytics.writer segment`, { slice: installerSlices.INSTALLER_RENDER });
-            exec(`yq w -i config.yaml analytics.segmentKey ${deploymentConfig.analytics!.substring("segment|".length)}`, { slice: installerSlices.INSTALLER_RENDER });
-        } else if (!!deploymentConfig.analytics) {
-            exec(`yq w -i config.yaml analytics.writer ${deploymentConfig.analytics!}`, { slice: installerSlices.INSTALLER_RENDER });
-        }
-
-        if (withObservability) {
-            // TODO: there's likely more to do...
-            const tracingEndpoint = exec(`yq r ./.werft/values.tracing.yaml tracing.endpoint`, { slice: installerSlices.INSTALLER_RENDER }).stdout.trim();
-            exec(`yq w -i config.yaml observability.tracing.endpoint ${tracingEndpoint}`, { slice: installerSlices.INSTALLER_RENDER });
-        }
-
-        werft.log("authProviders", "copy authProviders from secret")
-        try {
-            // auth-provider-secret.yml is a file generated by this job by reading a secret from core-dev cluster
-            // 'preview-envs-authproviders' for previews running in core-dev and
-            // 'preview-envs-authproviders-harvester' for previews running in Harvester VMs.
-            // To understand how it is generated, search for 'auth-provider-secret.yml' in the code.
-            exec(`for row in $(cat auth-provider-secret.yml \
+      // auth-provider-secret.yml is a file generated by this job by reading a secret from core-dev cluster
+      // 'preview-envs-authproviders' for previews running in core-dev and
+      // 'preview-envs-authproviders-harvester' for previews running in Harvester VMs.
+      // To understand how it is generated, search for 'auth-provider-secret.yml' in the code.
+      exec(
+        `for row in $(cat auth-provider-secret.yml \
                     | base64 -d -w 0 \
                     | yq r - authProviders -j \
                     | jq -r 'to_entries | .[] | @base64'); do
@@ -345,209 +579,308 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
                             --from-literal=provider="$data" \
                             --dry-run=client -o yaml | \
                             kubectl replace --force -f -
-                    done`, { silent: true })
+                    done`,
+        { silent: true }
+      );
 
-            werft.done('authProviders');
-        } catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail('authProviders', err);
-            }
-            exec('exit 0')
-        }
+      werft.done("authProviders");
+    } catch (err) {
+      if (!jobConfig.mainBuild) {
+        werft.fail("authProviders", err);
+      }
+      exec("exit 0");
+    }
 
-        werft.log("SSH gateway hostkey", "copy host-key from secret")
-        try {
-            exec(`cat /workspace/host-key.yaml \
+    werft.log("SSH gateway hostkey", "copy host-key from secret");
+    try {
+      exec(
+        `cat /workspace/host-key.yaml \
             | yq w - metadata.namespace ${namespace} \
             | yq d - metadata.uid \
             | yq d - metadata.resourceVersion \
             | yq d - metadata.creationTimestamp \
-            | kubectl apply -f -`, { silent: true })
-            exec(`yq w -i ./config.yaml sshGatewayHostKey.kind "secret"`)
-            exec(`yq w -i ./config.yaml sshGatewayHostKey.name "host-key"`)
-            werft.done('SSH gateway hostkey');
-        } catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail('SSH gateway hostkey', err);
-            }
-            exec('exit 0')
-        }
-
-        // validate the config
-        exec(`/tmp/installer validate config -c config.yaml`, { slice: installerSlices.INSTALLER_RENDER });
-
-        // validate the cluster
-        exec(`/tmp/installer validate cluster -c config.yaml || true`, { slice: installerSlices.INSTALLER_RENDER });
-
-        // render the k8s manifest
-        exec(`/tmp/installer render --namespace ${deploymentConfig.namespace} --config config.yaml > k8s.yaml`, { silent: true });
-        werft.done(installerSlices.INSTALLER_RENDER);
+            | kubectl apply -f -`,
+        { silent: true }
+      );
+      exec(`yq w -i ./config.yaml sshGatewayHostKey.kind "secret"`);
+      exec(`yq w -i ./config.yaml sshGatewayHostKey.name "host-key"`);
+      werft.done("SSH gateway hostkey");
     } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail(installerSlices.INSTALLER_RENDER, err)
-        }
-        exec('exit 0')
+      if (!jobConfig.mainBuild) {
+        werft.fail("SSH gateway hostkey", err);
+      }
+      exec("exit 0");
     }
 
-    try {
-        werft.log(installerSlices.INSTALLER_POST_PROCESSING, "Let's post process some k8s manifests...");
-        const nodepoolIndex = getNodePoolIndex(namespace);
+    // validate the config
+    exec(`/tmp/installer validate config -c config.yaml`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
 
-        if (deploymentConfig.installEELicense) {
-            werft.log(installerSlices.INSTALLER_POST_PROCESSING, "Adding the EE License...");
-            // Previews in core-dev and harvester use different domain, which requires different licenses.
-            exec(`cp /mnt/secrets/gpsh-${withVM ? 'harvester' : 'coredev'}/license /tmp/license`, { slice: installerSlices.INSTALLER_POST_PROCESSING });
-            // post-process.sh looks for /tmp/license, and if it exists, adds it to the configmap
-        } else {
-            exec(`touch /tmp/license`, { slice: installerSlices.INSTALLER_POST_PROCESSING });
-        }
-        exec(`touch /tmp/defaultFeatureFlags`, { slice: installerSlices.INSTALLER_POST_PROCESSING });
-        if (workspaceFeatureFlags && workspaceFeatureFlags.length > 0) {
-            werft.log(installerSlices.INSTALLER_POST_PROCESSING, "Adding feature flags...");
-            workspaceFeatureFlags.forEach(featureFlag => {
-                exec(`echo \'"${featureFlag}"\' >> /tmp/defaultFeatureFlags`, { slice: installerSlices.INSTALLER_POST_PROCESSING });
-            })
-            // post-process.sh looks for /tmp/defaultFeatureFlags
-            // each "flag" string gets added to the configmap
-        }
+    // validate the cluster
+    exec(`/tmp/installer validate cluster -c config.yaml || true`, {
+      slice: installerSlices.INSTALLER_RENDER,
+    });
 
-        const flags = withVM ? "WITH_VM=true " : ""
-        exec(`${flags}./.werft/post-process.sh ${registryNodePortMeta} ${wsdaemonPortMeta} ${nodepoolIndex} ${deploymentConfig.destname}`, { slice: installerSlices.INSTALLER_POST_PROCESSING });
-        werft.done(installerSlices.INSTALLER_POST_PROCESSING);
-    } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail(installerSlices.INSTALLER_POST_PROCESSING, err);
-        }
-        exec('exit 0')
+    // render the k8s manifest
+    exec(
+      `/tmp/installer render --namespace ${deploymentConfig.namespace} --config config.yaml > k8s.yaml`,
+      { silent: true }
+    );
+    werft.done(installerSlices.INSTALLER_RENDER);
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail(installerSlices.INSTALLER_RENDER, err);
+    }
+    exec("exit 0");
+  }
+
+  try {
+    werft.log(
+      installerSlices.INSTALLER_POST_PROCESSING,
+      "Let's post process some k8s manifests..."
+    );
+    const nodepoolIndex = getNodePoolIndex(namespace);
+
+    if (deploymentConfig.installEELicense) {
+      werft.log(
+        installerSlices.INSTALLER_POST_PROCESSING,
+        "Adding the EE License..."
+      );
+      // Previews in core-dev and harvester use different domain, which requires different licenses.
+      exec(
+        `cp /mnt/secrets/gpsh-${
+          withVM ? "harvester" : "coredev"
+        }/license /tmp/license`,
+        { slice: installerSlices.INSTALLER_POST_PROCESSING }
+      );
+      // post-process.sh looks for /tmp/license, and if it exists, adds it to the configmap
+    } else {
+      exec(`touch /tmp/license`, {
+        slice: installerSlices.INSTALLER_POST_PROCESSING,
+      });
+    }
+    exec(`touch /tmp/defaultFeatureFlags`, {
+      slice: installerSlices.INSTALLER_POST_PROCESSING,
+    });
+    if (workspaceFeatureFlags && workspaceFeatureFlags.length > 0) {
+      werft.log(
+        installerSlices.INSTALLER_POST_PROCESSING,
+        "Adding feature flags..."
+      );
+      workspaceFeatureFlags.forEach((featureFlag) => {
+        exec(`echo \'"${featureFlag}"\' >> /tmp/defaultFeatureFlags`, {
+          slice: installerSlices.INSTALLER_POST_PROCESSING,
+        });
+      });
+      // post-process.sh looks for /tmp/defaultFeatureFlags
+      // each "flag" string gets added to the configmap
     }
 
-    werft.log(installerSlices.APPLY_INSTALL_MANIFESTS, "Installing preview environment.");
-    try {
-        exec(`kubectl delete -n ${deploymentConfig.namespace} job migrations || true`, { slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
-        // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
-        exec(`kubectl apply -f k8s.yaml`, { slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true });
-        werft.done(installerSlices.APPLY_INSTALL_MANIFESTS);
-    } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail(installerSlices.APPLY_INSTALL_MANIFESTS, err);
-        }
-        exec('exit 0')
-    } finally {
-        // produce the result independently of install succeding, so that in case fails we still have the URL.
-        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces`);
+    const flags = withVM ? "WITH_VM=true " : "";
+    exec(
+      `${flags}./.werft/post-process.sh ${registryNodePortMeta} ${wsdaemonPortMeta} ${nodepoolIndex} ${deploymentConfig.destname}`,
+      { slice: installerSlices.INSTALLER_POST_PROCESSING }
+    );
+    werft.done(installerSlices.INSTALLER_POST_PROCESSING);
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail(installerSlices.INSTALLER_POST_PROCESSING, err);
     }
+    exec("exit 0");
+  }
 
-    try {
-        werft.log(installerSlices.DEPLOYMENT_WAITING, "Server not ready. Let the waiting...commence!");
-        exec(`kubectl -n ${namespace} rollout status deployment/server --timeout=5m`, { slice: installerSlices.DEPLOYMENT_WAITING });
-        werft.done(installerSlices.DEPLOYMENT_WAITING);
-    } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail(installerSlices.DEPLOYMENT_WAITING, err);
-        }
-        exec('exit 0')
+  werft.log(
+    installerSlices.APPLY_INSTALL_MANIFESTS,
+    "Installing preview environment."
+  );
+  try {
+    exec(
+      `kubectl delete -n ${deploymentConfig.namespace} job migrations || true`,
+      { slice: installerSlices.APPLY_INSTALL_MANIFESTS, silent: true }
+    );
+    // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
+    exec(`kubectl apply -f k8s.yaml`, {
+      slice: installerSlices.APPLY_INSTALL_MANIFESTS,
+      silent: true,
+    });
+    werft.done(installerSlices.APPLY_INSTALL_MANIFESTS);
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail(installerSlices.APPLY_INSTALL_MANIFESTS, err);
     }
+    exec("exit 0");
+  } finally {
+    // produce the result independently of install succeding, so that in case fails we still have the URL.
+    exec(
+      `werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces`
+    );
+  }
 
-    await addDNSRecord(werft, deploymentConfig.namespace, deploymentConfig.domain, !withVM)
+  try {
+    werft.log(
+      installerSlices.DEPLOYMENT_WAITING,
+      "Server not ready. Let the waiting...commence!"
+    );
+    exec(
+      `kubectl -n ${namespace} rollout status deployment/server --timeout=5m`,
+      { slice: installerSlices.DEPLOYMENT_WAITING }
+    );
+    werft.done(installerSlices.DEPLOYMENT_WAITING);
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail(installerSlices.DEPLOYMENT_WAITING, err);
+    }
+    exec("exit 0");
+  }
 
-    // TODO: Fix sweeper, it does not appear to be doing clean-up
-    werft.log('sweeper', 'installing Sweeper');
-    const sweeperVersion = deploymentConfig.sweeperImage.split(":")[1];
-    werft.log('sweeper', `Sweeper version: ${sweeperVersion}`);
+  await addDNSRecord(
+    werft,
+    deploymentConfig.namespace,
+    deploymentConfig.domain,
+    !withVM
+  );
 
-    // prepare args
-    const args = {
-        "period": "10m",
-        "timeout": "48h",                     // period of inactivity that triggers a removal
-        branch: jobConfig.repository.branch,  // the branch to check for deletion
-        owner: jobConfig.repository.owner,
-        repo: jobConfig.repository.repo,
-    };
-    const argsStr = Object.entries(args).map(([k, v]) => `\"--${k}\", \"${v}\"`).join(", ");
-    const allArgsStr = `--set args="{${argsStr}}" --set githubToken.secret=github-sweeper-read-branches --set githubToken.key=token`;
+  // TODO: Fix sweeper, it does not appear to be doing clean-up
+  werft.log("sweeper", "installing Sweeper");
+  const sweeperVersion = deploymentConfig.sweeperImage.split(":")[1];
+  werft.log("sweeper", `Sweeper version: ${sweeperVersion}`);
 
-    // TODO: Implement sweeper logic for VMs in Harvester
-    if (!withVM) {
-        // copy GH token into namespace
-        exec(`kubectl --namespace werft get secret github-sweeper-read-branches -o yaml \
+  // prepare args
+  const args = {
+    period: "10m",
+    timeout: "48h", // period of inactivity that triggers a removal
+    branch: jobConfig.repository.branch, // the branch to check for deletion
+    owner: jobConfig.repository.owner,
+    repo: jobConfig.repository.repo,
+  };
+  const argsStr = Object.entries(args)
+    .map(([k, v]) => `\"--${k}\", \"${v}\"`)
+    .join(", ");
+  const allArgsStr = `--set args="{${argsStr}}" --set githubToken.secret=github-sweeper-read-branches --set githubToken.key=token`;
+
+  // TODO: Implement sweeper logic for VMs in Harvester
+  if (!withVM) {
+    // copy GH token into namespace
+    exec(`kubectl --namespace werft get secret github-sweeper-read-branches -o yaml \
             | yq w - metadata.namespace ${namespace} \
             | yq d - metadata.uid \
             | yq d - metadata.resourceVersion \
             | yq d - metadata.creationTimestamp \
             | kubectl apply -f -`);
-        exec(`/usr/local/bin/helm3 upgrade --install --set image.version=${sweeperVersion} --set command="werft run github -a namespace=${namespace} --remote-job-path .werft/wipe-devstaging.yaml github.com/gitpod-io/gitpod:main" ${allArgsStr} sweeper ./dev/charts/sweeper`);
-    }
+    exec(
+      `/usr/local/bin/helm3 upgrade --install --set image.version=${sweeperVersion} --set command="werft run github -a namespace=${namespace} --remote-job-path .werft/wipe-devstaging.yaml github.com/gitpod-io/gitpod:main" ${allArgsStr} sweeper ./dev/charts/sweeper`
+    );
+  }
 
-    werft.done(phases.DEPLOY);
+  werft.done(phases.DEPLOY);
 
-    async function cleanStateEnv(shellOpts: ExecOptions) {
-        await wipeAndRecreateNamespace(helmInstallName, namespace, { ...shellOpts, slice: installerSlices.CLEAN_ENV_STATE });
-        // cleanup non-namespace objects
-        werft.log(installerSlices.CLEAN_ENV_STATE, "removing old unnamespaced objects - this might take a while");
-        try {
-            await deleteNonNamespaceObjects(namespace, destname, { ...shellOpts, slice: installerSlices.CLEAN_ENV_STATE });
-            werft.done(installerSlices.CLEAN_ENV_STATE);
-        } catch (err) {
-            werft.fail(installerSlices.CLEAN_ENV_STATE, err);
-        }
+  async function cleanStateEnv(shellOpts: ExecOptions) {
+    await wipeAndRecreateNamespace(helmInstallName, namespace, {
+      ...shellOpts,
+      slice: installerSlices.CLEAN_ENV_STATE,
+    });
+    // cleanup non-namespace objects
+    werft.log(
+      installerSlices.CLEAN_ENV_STATE,
+      "removing old unnamespaced objects - this might take a while"
+    );
+    try {
+      await deleteNonNamespaceObjects(namespace, destname, {
+        ...shellOpts,
+        slice: installerSlices.CLEAN_ENV_STATE,
+      });
+      werft.done(installerSlices.CLEAN_ENV_STATE);
+    } catch (err) {
+      werft.fail(installerSlices.CLEAN_ENV_STATE, err);
     }
+  }
 }
 
 /*
-* Deploy a preview environment using Helm
-*/
-async function deployToDevWithHelm(werft: Werft, jobConfig: JobConfig, deploymentConfig: DeploymentConfig, workspaceFeatureFlags: string[], dynamicCPULimits, storage) {
-    const { version, destname, namespace, domain, monitoringDomain, url } = deploymentConfig;
-    // find free ports
-    werft.log("find free ports", "Check for some free ports.");
-    const [wsdaemonPortMeta, registryNodePortMeta, nodeExporterPort] = findFreeHostPorts([
+ * Deploy a preview environment using Helm
+ */
+async function deployToDevWithHelm(
+  werft: Werft,
+  jobConfig: JobConfig,
+  deploymentConfig: DeploymentConfig,
+  workspaceFeatureFlags: string[],
+  dynamicCPULimits,
+  storage
+) {
+  const { version, destname, namespace, domain, monitoringDomain, url } =
+    deploymentConfig;
+  // find free ports
+  werft.log("find free ports", "Check for some free ports.");
+  const [wsdaemonPortMeta, registryNodePortMeta, nodeExporterPort] =
+    findFreeHostPorts(
+      [
         { start: 10000, end: 11000 },
         { start: 30000, end: 31000 },
         { start: 31001, end: 32000 },
-    ], metaEnv({ slice: "find free ports", silent: true }));
-    werft.log("find free ports",
-        `wsdaemonPortMeta: ${wsdaemonPortMeta}, registryNodePortMeta: ${registryNodePortMeta}, and nodeExporterPort ${nodeExporterPort}.`);
-    werft.done("find free ports");
+      ],
+      metaEnv({ slice: "find free ports", silent: true })
+    );
+  werft.log(
+    "find free ports",
+    `wsdaemonPortMeta: ${wsdaemonPortMeta}, registryNodePortMeta: ${registryNodePortMeta}, and nodeExporterPort ${nodeExporterPort}.`
+  );
+  werft.done("find free ports");
+
+  // trigger certificate issuing
+  werft.log(
+    "certificate",
+    "organizing a certificate for the preview environment..."
+  );
+  let namespaceRecreatedResolve = undefined;
+  let namespaceRecreatedPromise = new Promise((resolve) => {
+    namespaceRecreatedResolve = resolve;
+  });
+
+  try {
+    if (deploymentConfig.cleanSlateDeployment) {
+      // re-create namespace
+      await cleanStateEnv(metaEnv());
+    } else {
+      createNamespace(namespace, metaEnv({ slice: "prep" }));
+    }
+    // Now we want to execute further kubectl operations only in the created namespace
+    setKubectlContextNamespace(namespace, metaEnv({ slice: "prep" }));
 
     // trigger certificate issuing
-    werft.log('certificate', "organizing a certificate for the preview environment...");
-    let namespaceRecreatedResolve = undefined;
-    let namespaceRecreatedPromise = new Promise((resolve) => {
-        namespaceRecreatedResolve = resolve;
-    });
-
-    try {
-        if (deploymentConfig.cleanSlateDeployment) {
-            // re-create namespace
-            await cleanStateEnv(metaEnv());
-        } else {
-            createNamespace(namespace, metaEnv({ slice: 'prep' }));
-        }
-        // Now we want to execute further kubectl operations only in the created namespace
-        setKubectlContextNamespace(namespace, metaEnv({ slice: 'prep' }));
-
-        // trigger certificate issuing
-        werft.log('certificate', "organizing a certificate for the preview environment...");
-        await issueMetaCerts(werft, namespace, "certs", domain, false);
-        await installMetaCertificates(werft, namespace);
-        werft.done('certificate');
-        await addDNSRecord(werft, deploymentConfig.namespace, deploymentConfig.domain, false)
-        werft.done('prep');
-    } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail('prep', err);
-        }
-        exec('exit 0')
+    werft.log(
+      "certificate",
+      "organizing a certificate for the preview environment..."
+    );
+    await issueMetaCerts(werft, namespace, "certs", domain, false);
+    await installMetaCertificates(werft, namespace);
+    werft.done("certificate");
+    await addDNSRecord(
+      werft,
+      deploymentConfig.namespace,
+      deploymentConfig.domain,
+      false
+    );
+    werft.done("prep");
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail("prep", err);
     }
+    exec("exit 0");
+  }
 
-    // core-dev specific section start
-    werft.log("secret", "copy secret into namespace")
-    try {
-        const auth = exec(`printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
+  // core-dev specific section start
+  werft.log("secret", "copy secret into namespace");
+  try {
+    const auth = exec(
+      `printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
                         | yq r - data['.dockerconfigjson'] \
-                        | base64 -d)" | base64 -w 0`, { silent: true }).stdout.trim();
-        fs.writeFileSync("chart/gcp-sa-registry-auth",
-            `{
+                        | base64 -d)" | base64 -w 0`,
+      { silent: true }
+    ).stdout.trim();
+    fs.writeFileSync(
+      "chart/gcp-sa-registry-auth",
+      `{
     "auths": {
         "eu.gcr.io": {
             "auth": "${auth}"
@@ -556,183 +889,229 @@ async function deployToDevWithHelm(werft: Werft, jobConfig: JobConfig, deploymen
             "auth": "${auth}"
         }
     }
-}`      );
-        werft.done('secret');
-    } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail('secret', err);
-        }
-        exec('exit 0')
+}`
+    );
+    werft.done("secret");
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail("secret", err);
     }
+    exec("exit 0");
+  }
 
-    werft.log("authProviders", "copy authProviders")
-    try {
-        exec(`kubectl get secret preview-envs-authproviders --namespace=keys -o yaml \
+  werft.log("authProviders", "copy authProviders");
+  try {
+    exec(
+      `kubectl get secret preview-envs-authproviders --namespace=keys -o yaml \
                 | yq r - data.authProviders \
                 | base64 -d -w 0 \
-                > authProviders`, { slice: "authProviders" });
-        exec(`yq merge --inplace .werft/values.dev.yaml ./authProviders`, { slice: "authProviders" })
-        werft.done('authProviders');
-    } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail('authProviders', err);
-        }
-        exec('exit 0')
+                > authProviders`,
+      { slice: "authProviders" }
+    );
+    exec(`yq merge --inplace .werft/values.dev.yaml ./authProviders`, {
+      slice: "authProviders",
+    });
+    werft.done("authProviders");
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail("authProviders", err);
     }
-    // core-dev specific section end
+    exec("exit 0");
+  }
+  // core-dev specific section end
 
-
-    // If observability is enabled, we want to deploy it before installing Gitpod itself.
-    // The reason behind it is because Gitpod components will start sending traces to a non-existent
-    // OpenTelemetry-collector otherwise.
-    werft.log(`observability`, "Running observability static checks.")
-    werft.log(`observability`, "Installing monitoring-satellite...")
-    if (deploymentConfig.withObservability) {
-        try {
-            await installMonitoring(namespace, nodeExporterPort, monitoringDomain, STACKDRIVER_SERVICEACCOUNT, false, jobConfig.observability.branch);
-        } catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail('observability', err);
-            }
-            exec('exit 0')
-        }
-    } else {
-        exec(`echo '"with-observability" annotation not set, skipping...'`, { slice: `observability` })
-        exec(`echo 'To deploy monitoring-satellite, please add "/werft with-observability" to your PR description.'`, { slice: `observability` })
-    }
-    werft.done('observability');
-
-    // deployment config
+  // If observability is enabled, we want to deploy it before installing Gitpod itself.
+  // The reason behind it is because Gitpod components will start sending traces to a non-existent
+  // OpenTelemetry-collector otherwise.
+  werft.log(`observability`, "Running observability static checks.");
+  werft.log(`observability`, "Installing monitoring-satellite...");
+  if (deploymentConfig.withObservability) {
     try {
-        shell.cd("/workspace/chart");
-        werft.log('helm', 'installing Gitpod');
-
-        const commonFlags = addDeploymentFlags();
-        installGitpod(commonFlags);
-
-        werft.log('helm', 'done');
-        werft.done('helm');
+      await installMonitoring(
+        namespace,
+        nodeExporterPort,
+        monitoringDomain,
+        STACKDRIVER_SERVICEACCOUNT,
+        false,
+        jobConfig.observability.branch
+      );
     } catch (err) {
-        if (!jobConfig.mainBuild) {
-            werft.fail('deploy', err);
-        }
-        exec('exit 0')
-    } finally {
-        // produce the result independently of Helm succeding, so that in case Helm fails we still have the URL.
-        exec(`werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces`);
+      if (!jobConfig.mainBuild) {
+        werft.fail("observability", err);
+      }
+      exec("exit 0");
+    }
+  } else {
+    exec(`echo '"with-observability" annotation not set, skipping...'`, {
+      slice: `observability`,
+    });
+    exec(
+      `echo 'To deploy monitoring-satellite, please add "/werft with-observability" to your PR description.'`,
+      { slice: `observability` }
+    );
+  }
+  werft.done("observability");
+
+  // deployment config
+  try {
+    shell.cd("/workspace/chart");
+    werft.log("helm", "installing Gitpod");
+
+    const commonFlags = addDeploymentFlags();
+    installGitpod(commonFlags);
+
+    werft.log("helm", "done");
+    werft.done("helm");
+  } catch (err) {
+    if (!jobConfig.mainBuild) {
+      werft.fail("deploy", err);
+    }
+    exec("exit 0");
+  } finally {
+    // produce the result independently of Helm succeding, so that in case Helm fails we still have the URL.
+    exec(
+      `werft log result -d "dev installation" -c github-check-preview-env url ${url}/workspaces`
+    );
+  }
+
+  function installGitpod(commonFlags: string) {
+    let flags = commonFlags;
+    flags += ` --set components.wsDaemon.servicePort=${wsdaemonPortMeta}`;
+    flags += ` --set components.registryFacade.ports.registry.servicePort=${registryNodePortMeta}`;
+
+    const nodeAffinityValues = getNodeAffinities();
+
+    if (storage === "gcp") {
+      exec(
+        "kubectl get secret gcp-sa-gitpod-dev-deployer -n werft -o yaml | yq d - metadata | yq w - metadata.name remote-storage-gcloud | kubectl apply -f -"
+      );
+      flags += ` -f ../.werft/values.dev.gcp-storage.yaml`;
     }
 
-    function installGitpod(commonFlags: string) {
-        let flags = commonFlags
-        flags += ` --set components.wsDaemon.servicePort=${wsdaemonPortMeta}`;
-        flags += ` --set components.registryFacade.ports.registry.servicePort=${registryNodePortMeta}`;
-
-        const nodeAffinityValues = getNodeAffinities();
-
-        if (storage === "gcp") {
-            exec("kubectl get secret gcp-sa-gitpod-dev-deployer -n werft -o yaml | yq d - metadata | yq w - metadata.name remote-storage-gcloud | kubectl apply -f -");
-            flags += ` -f ../.werft/values.dev.gcp-storage.yaml`;
-        }
-
-        /*  A hash is caclulated from the branch name and a subset of that string is parsed to a number x,
+    /*  A hash is caclulated from the branch name and a subset of that string is parsed to a number x,
             x mod the number of different nodepool-sets defined in the files listed in nodeAffinityValues
             is used to generate a pseudo-random number that consistent as long as the branchname persists.
             We use it to reduce the number of preview-environments accumulating on a singe nodepool.
          */
-        const nodepoolIndex = getNodePoolIndex(namespace);
+    const nodepoolIndex = getNodePoolIndex(namespace);
 
-        exec(`helm dependencies up`);
-        exec(`/usr/local/bin/helm3 upgrade --install --timeout 10m -f ../.werft/${nodeAffinityValues[nodepoolIndex]} -f ../.werft/values.dev.yaml ${flags} ${helmInstallName} .`);
+    exec(`helm dependencies up`);
+    exec(
+      `/usr/local/bin/helm3 upgrade --install --timeout 10m -f ../.werft/${nodeAffinityValues[nodepoolIndex]} -f ../.werft/values.dev.yaml ${flags} ${helmInstallName} .`
+    );
 
-        werft.log('helm', 'installing Sweeper');
-        const sweeperVersion = deploymentConfig.sweeperImage.split(":")[1];
-        werft.log('helm', `Sweeper version: ${sweeperVersion}`);
+    werft.log("helm", "installing Sweeper");
+    const sweeperVersion = deploymentConfig.sweeperImage.split(":")[1];
+    werft.log("helm", `Sweeper version: ${sweeperVersion}`);
 
-        // prepare args
-        const args = {
-            "period": "10m",
-            "timeout": "48h",                    // period of inactivity that triggers a removal
-            branch: jobConfig.repository.branch, // the branch to check for deletion
-            owner: jobConfig.repository.owner,
-            repo: jobConfig.repository.repo,
-        };
-        const argsStr = Object.entries(args).map(([k, v]) => `\"--${k}\", \"${v}\"`).join(", ");
-        const allArgsStr = `--set args="{${argsStr}}" --set githubToken.secret=github-sweeper-read-branches --set githubToken.key=token`;
+    // prepare args
+    const args = {
+      period: "10m",
+      timeout: "48h", // period of inactivity that triggers a removal
+      branch: jobConfig.repository.branch, // the branch to check for deletion
+      owner: jobConfig.repository.owner,
+      repo: jobConfig.repository.repo,
+    };
+    const argsStr = Object.entries(args)
+      .map(([k, v]) => `\"--${k}\", \"${v}\"`)
+      .join(", ");
+    const allArgsStr = `--set args="{${argsStr}}" --set githubToken.secret=github-sweeper-read-branches --set githubToken.key=token`;
 
-        // copy GH token into namespace
-        exec(`kubectl --namespace werft get secret github-sweeper-read-branches -o yaml \
+    // copy GH token into namespace
+    exec(`kubectl --namespace werft get secret github-sweeper-read-branches -o yaml \
             | yq w - metadata.namespace ${namespace} \
             | yq d - metadata.uid \
             | yq d - metadata.resourceVersion \
             | yq d - metadata.creationTimestamp \
             | kubectl apply -f -`);
-        exec(`/usr/local/bin/helm3 upgrade --install --set image.version=${sweeperVersion} --set command="werft run github -a namespace=${namespace} --remote-job-path .werft/wipe-devstaging.yaml github.com/gitpod-io/gitpod:main" ${allArgsStr} sweeper ../dev/charts/sweeper`);
-    }
+    exec(
+      `/usr/local/bin/helm3 upgrade --install --set image.version=${sweeperVersion} --set command="werft run github -a namespace=${namespace} --remote-job-path .werft/wipe-devstaging.yaml github.com/gitpod-io/gitpod:main" ${allArgsStr} sweeper ../dev/charts/sweeper`
+    );
+  }
 
-    function addDeploymentFlags() {
-        let flags = ""
-        flags += ` --namespace ${namespace}`;
-        flags += ` --set components.imageBuilder.hostDindData=/mnt/disks/raid0/docker-${namespace}`;
-        flags += ` --set components.wsDaemon.hostWorkspaceArea=/mnt/disks/raid0/workspaces-${namespace}`;
-        flags += ` --set version=${version}`;
-        flags += ` --set hostname=${domain}`;
-        flags += ` --set devBranch=${destname}`;
-        workspaceFeatureFlags.forEach((f, i) => {
-            flags += ` --set components.server.defaultFeatureFlags[${i}]='${f}'`;
-        });
-        if (dynamicCPULimits) {
-            flags += ` -f ../.werft/values.variant.cpuLimits.yaml`;
-        }
-        if ((deploymentConfig.analytics || "").startsWith("segment|")) {
-            flags += ` --set analytics.writer=segment`;
-            flags += ` --set analytics.segmentKey=${deploymentConfig.analytics!.substring("segment|".length)}`;
-        } else if (!!deploymentConfig.analytics) {
-            flags += ` --set analytics.writer=${deploymentConfig.analytics!}`;
-        }
-        if (deploymentConfig.withObservability) {
-            flags += ` -f ../.werft/values.tracing.yaml`;
-        }
-        werft.log("helm", "extracting versions");
-        try {
-            exec(`docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${version} cat /versions.yaml | tee versions.yaml`);
-        } catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail('helm', err);
-            }
-            exec('exit 0')
-        }
-        const pathToVersions = `${shell.pwd().toString()}/versions.yaml`;
-        flags += ` -f ${pathToVersions}`;
-
-        if (deploymentConfig.installEELicense) {
-            // We're adding the license rather late just to prevent accidentially printing it.
-            // If anyone got ahold of the license not much would be lost, but hey, no need to plaster it on the walls.
-            flags += ` --set license=${fs.readFileSync('/mnt/secrets/gpsh-coredev/license').toString()}`
-        }
-        if (deploymentConfig.withPayment) {
-            flags += ` -f ../.werft/values.payment.yaml`;
-            exec(`cp /mnt/secrets/payment-provider-config/providerOptions payment-core-dev-options.json`);
-            flags += ` --set payment.chargebee.providerOptionsFile=payment-core-dev-options.json`;
-            exec(`cp /mnt/secrets/payment-webhook-config/license payment-core-dev-webhook.json`);
-            flags += ` --set components.paymentEndpoint.webhookFile="payment-core-dev-webhook.json"`;
-        }
-        return flags;
+  function addDeploymentFlags() {
+    let flags = "";
+    flags += ` --namespace ${namespace}`;
+    flags += ` --set components.imageBuilder.hostDindData=/mnt/disks/raid0/docker-${namespace}`;
+    flags += ` --set components.wsDaemon.hostWorkspaceArea=/mnt/disks/raid0/workspaces-${namespace}`;
+    flags += ` --set version=${version}`;
+    flags += ` --set hostname=${domain}`;
+    flags += ` --set devBranch=${destname}`;
+    workspaceFeatureFlags.forEach((f, i) => {
+      flags += ` --set components.server.defaultFeatureFlags[${i}]='${f}'`;
+    });
+    if (dynamicCPULimits) {
+      flags += ` -f ../.werft/values.variant.cpuLimits.yaml`;
     }
-
-    async function cleanStateEnv(shellOpts: ExecOptions) {
-        await wipeAndRecreateNamespace(helmInstallName, namespace, { ...shellOpts, slice: 'prep' });
-        // cleanup non-namespace objects
-        werft.log("predeploy cleanup", "removing old unnamespaced objects - this might take a while");
-        try {
-            await deleteNonNamespaceObjects(namespace, destname, { ...shellOpts, slice: 'predeploy cleanup' });
-            werft.done('predeploy cleanup');
-        } catch (err) {
-            if (!jobConfig.mainBuild) {
-                werft.fail('predeploy cleanup', err);
-            }
-            exec('exit 0')
-        }
+    if ((deploymentConfig.analytics || "").startsWith("segment|")) {
+      flags += ` --set analytics.writer=segment`;
+      flags += ` --set analytics.segmentKey=${deploymentConfig.analytics!.substring(
+        "segment|".length
+      )}`;
+    } else if (!!deploymentConfig.analytics) {
+      flags += ` --set analytics.writer=${deploymentConfig.analytics!}`;
     }
+    if (deploymentConfig.withObservability) {
+      flags += ` -f ../.werft/values.tracing.yaml`;
+    }
+    werft.log("helm", "extracting versions");
+    try {
+      exec(
+        `docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${version} cat /versions.yaml | tee versions.yaml`
+      );
+    } catch (err) {
+      if (!jobConfig.mainBuild) {
+        werft.fail("helm", err);
+      }
+      exec("exit 0");
+    }
+    const pathToVersions = `${shell.pwd().toString()}/versions.yaml`;
+    flags += ` -f ${pathToVersions}`;
+
+    if (deploymentConfig.installEELicense) {
+      // We're adding the license rather late just to prevent accidentially printing it.
+      // If anyone got ahold of the license not much would be lost, but hey, no need to plaster it on the walls.
+      flags += ` --set license=${fs
+        .readFileSync("/mnt/secrets/gpsh-coredev/license")
+        .toString()}`;
+    }
+    if (deploymentConfig.withPayment) {
+      flags += ` -f ../.werft/values.payment.yaml`;
+      exec(
+        `cp /mnt/secrets/payment-provider-config/providerOptions payment-core-dev-options.json`
+      );
+      flags += ` --set payment.chargebee.providerOptionsFile=payment-core-dev-options.json`;
+      exec(
+        `cp /mnt/secrets/payment-webhook-config/license payment-core-dev-webhook.json`
+      );
+      flags += ` --set components.paymentEndpoint.webhookFile="payment-core-dev-webhook.json"`;
+    }
+    return flags;
+  }
+
+  async function cleanStateEnv(shellOpts: ExecOptions) {
+    await wipeAndRecreateNamespace(helmInstallName, namespace, {
+      ...shellOpts,
+      slice: "prep",
+    });
+    // cleanup non-namespace objects
+    werft.log(
+      "predeploy cleanup",
+      "removing old unnamespaced objects - this might take a while"
+    );
+    try {
+      await deleteNonNamespaceObjects(namespace, destname, {
+        ...shellOpts,
+        slice: "predeploy cleanup",
+      });
+      werft.done("predeploy cleanup");
+    } catch (err) {
+      if (!jobConfig.mainBuild) {
+        werft.fail("predeploy cleanup", err);
+      }
+      exec("exit 0");
+    }
+  }
 }
 
 /*  A hash is caclulated from the branch name and a subset of that string is parsed to a number x,
@@ -741,64 +1120,86 @@ async function deployToDevWithHelm(werft: Werft, jobConfig: JobConfig, deploymen
     We use it to reduce the number of preview-environments accumulating on a singe nodepool.
 */
 function getNodePoolIndex(namespace: string): number {
-    const nodeAffinityValues = getNodeAffinities();
+  const nodeAffinityValues = getNodeAffinities();
 
-    return parseInt(createHash('sha256').update(namespace).digest('hex').substring(0, 5), 16) % nodeAffinityValues.length;
+  return (
+    parseInt(
+      createHash("sha256").update(namespace).digest("hex").substring(0, 5),
+      16
+    ) % nodeAffinityValues.length
+  );
 }
 
 function getNodeAffinities(): string[] {
-    return [
-        "values.nodeAffinities_1.yaml",
-        "values.nodeAffinities_2.yaml",
-        "values.nodeAffinities_0.yaml",
-        "values.nodeAffinities_3.yaml",
-        "values.nodeAffinities_4.yaml",
-        "values.nodeAffinities_5.yaml",
-    ]
+  return [
+    "values.nodeAffinities_1.yaml",
+    "values.nodeAffinities_2.yaml",
+    "values.nodeAffinities_0.yaml",
+    "values.nodeAffinities_3.yaml",
+    "values.nodeAffinities_4.yaml",
+    "values.nodeAffinities_5.yaml",
+  ];
 }
 
 interface DeploymentConfig {
-    version: string;
-    destname: string;
-    namespace: string;
-    domain: string;
-    monitoringDomain: string,
-    url: string;
-    analytics?: string;
-    cleanSlateDeployment: boolean;
-    sweeperImage: string;
-    installEELicense: boolean;
-    imagePullAuth: string;
-    withPayment: boolean;
-    withObservability: boolean;
-    withVM: boolean;
+  version: string;
+  destname: string;
+  namespace: string;
+  domain: string;
+  monitoringDomain: string;
+  url: string;
+  analytics?: string;
+  cleanSlateDeployment: boolean;
+  sweeperImage: string;
+  installEELicense: boolean;
+  imagePullAuth: string;
+  withPayment: boolean;
+  withObservability: boolean;
+  withVM: boolean;
 }
 
-async function addDNSRecord(werft: Werft, namespace: string, domain: string, isLoadbalancer: boolean) {
-    let wsProxyLBIP = null
-    if (isLoadbalancer === true) {
-        werft.log(installerSlices.DNS_ADD_RECORD, "Getting ws-proxy loadbalancer IP");
-        for (let i = 0; i < 60; i++) {
-            try {
-                let lb = exec(`kubectl -n ${namespace} get service ws-proxy -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'`, { silent: true })
-                if (lb.length > 4) {
-                    wsProxyLBIP = lb
-                    break
-                }
-                await sleep(1000)
-            } catch (err) {
-                await sleep(1000)
-            }
+async function addDNSRecord(
+  werft: Werft,
+  namespace: string,
+  domain: string,
+  isLoadbalancer: boolean
+) {
+  let wsProxyLBIP = null;
+  if (isLoadbalancer === true) {
+    werft.log(
+      installerSlices.DNS_ADD_RECORD,
+      "Getting ws-proxy loadbalancer IP"
+    );
+    for (let i = 0; i < 60; i++) {
+      try {
+        let lb = exec(
+          `kubectl -n ${namespace} get service ws-proxy -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'`,
+          { silent: true }
+        );
+        if (lb.length > 4) {
+          wsProxyLBIP = lb;
+          break;
         }
-        if (wsProxyLBIP == null) {
-            werft.fail(installerSlices.DNS_ADD_RECORD, new Error("Can't get ws-proxy loadbalancer IP"));
-        }
-        werft.log(installerSlices.DNS_ADD_RECORD, "Get ws-proxy loadbalancer IP: " + wsProxyLBIP);
-    } else {
-        wsProxyLBIP = getCoreDevIngressIP()
+        await sleep(1000);
+      } catch (err) {
+        await sleep(1000);
+      }
     }
+    if (wsProxyLBIP == null) {
+      werft.fail(
+        installerSlices.DNS_ADD_RECORD,
+        new Error("Can't get ws-proxy loadbalancer IP")
+      );
+    }
+    werft.log(
+      installerSlices.DNS_ADD_RECORD,
+      "Get ws-proxy loadbalancer IP: " + wsProxyLBIP
+    );
+  } else {
+    wsProxyLBIP = getCoreDevIngressIP();
+  }
 
-    var cmd = `set -x \
+  var cmd = `set -x \
     && cd /workspace/.werft/dns \
     && rm -rf .terraform* \
     && export GOOGLE_APPLICATION_CREDENTIALS="${GCLOUD_SERVICE_ACCOUNT_PATH}" \
@@ -809,54 +1210,76 @@ async function addDNSRecord(werft: Werft, namespace: string, domain: string, isL
         -var 'ingress_ip=${getCoreDevIngressIP()}' \
         -var 'ws_proxy_ip=${wsProxyLBIP}'`;
 
-    werft.log(installerSlices.DNS_ADD_RECORD, "Terraform command for create dns record: " + cmd)
-    exec(cmd, { ...metaEnv(), slice: installerSlices.DNS_ADD_RECORD });
-    werft.done(installerSlices.DNS_ADD_RECORD);
+  werft.log(
+    installerSlices.DNS_ADD_RECORD,
+    "Terraform command for create dns record: " + cmd
+  );
+  exec(cmd, { ...metaEnv(), slice: installerSlices.DNS_ADD_RECORD });
+  werft.done(installerSlices.DNS_ADD_RECORD);
 }
 
-export async function issueMetaCerts(werft: Werft, previewNamespace: string, certsNamespace: string, domain: string, withVM: boolean) {
-    let additionalSubdomains: string[] = ["", "*.", `*.ws${withVM ? '' : '-dev'}.`]
-    var metaClusterCertParams = new IssueCertificateParams();
-    metaClusterCertParams.pathToTemplate = "/workspace/.werft/util/templates";
-    metaClusterCertParams.gcpSaPath = GCLOUD_SERVICE_ACCOUNT_PATH;
-    metaClusterCertParams.namespace = previewNamespace;
-    metaClusterCertParams.certNamespace = certsNamespace;
-    metaClusterCertParams.dnsZoneDomain = "gitpod-dev.com";
-    metaClusterCertParams.domain = domain;
-    metaClusterCertParams.ip = getCoreDevIngressIP();
-    metaClusterCertParams.bucketPrefixTail = ""
-    metaClusterCertParams.additionalSubdomains = additionalSubdomains
-    await issueCertficate(werft, metaClusterCertParams, metaEnv());
+export async function issueMetaCerts(
+  werft: Werft,
+  previewNamespace: string,
+  certsNamespace: string,
+  domain: string,
+  withVM: boolean
+) {
+  let additionalSubdomains: string[] = [
+    "",
+    "*.",
+    `*.ws${withVM ? "" : "-dev"}.`,
+  ];
+  var metaClusterCertParams = new IssueCertificateParams();
+  metaClusterCertParams.pathToTemplate = "/workspace/.werft/util/templates";
+  metaClusterCertParams.gcpSaPath = GCLOUD_SERVICE_ACCOUNT_PATH;
+  metaClusterCertParams.namespace = previewNamespace;
+  metaClusterCertParams.certNamespace = certsNamespace;
+  metaClusterCertParams.dnsZoneDomain = "gitpod-dev.com";
+  metaClusterCertParams.domain = domain;
+  metaClusterCertParams.ip = getCoreDevIngressIP();
+  metaClusterCertParams.bucketPrefixTail = "";
+  metaClusterCertParams.additionalSubdomains = additionalSubdomains;
+  await issueCertficate(werft, metaClusterCertParams, metaEnv());
 }
 
 async function installMetaCertificates(werft: Werft, namespace: string) {
-    const certName = namespace;
-    const metaInstallCertParams = new InstallCertificateParams()
-    metaInstallCertParams.certName = certName
-    metaInstallCertParams.certNamespace = "certs"
-    metaInstallCertParams.certSecretName = PROXY_SECRET_NAME
-    metaInstallCertParams.destinationNamespace = namespace
-    await installCertficate(werft, metaInstallCertParams, metaEnv());
+  const certName = namespace;
+  const metaInstallCertParams = new InstallCertificateParams();
+  metaInstallCertParams.certName = certName;
+  metaInstallCertParams.certNamespace = "certs";
+  metaInstallCertParams.certSecretName = PROXY_SECRET_NAME;
+  metaInstallCertParams.destinationNamespace = namespace;
+  await installCertficate(werft, metaInstallCertParams, metaEnv());
 }
 
-async function installMonitoring(namespace: string, nodeExporterPort: number, domain: string, stackdriverServiceAccount: any, withVM: boolean, observabilityBranch: string) {
-    const installMonitoringSatelliteParams = new InstallMonitoringSatelliteParams();
-    installMonitoringSatelliteParams.branch = observabilityBranch;
-    installMonitoringSatelliteParams.pathToKubeConfig = ""
-    installMonitoringSatelliteParams.satelliteNamespace = namespace
-    installMonitoringSatelliteParams.clusterName = namespace
-    installMonitoringSatelliteParams.nodeExporterPort = nodeExporterPort
-    installMonitoringSatelliteParams.previewDomain = domain
-    installMonitoringSatelliteParams.stackdriverServiceAccount = stackdriverServiceAccount
-    installMonitoringSatelliteParams.withVM = withVM
-    installMonitoringSatellite(installMonitoringSatelliteParams);
+async function installMonitoring(
+  namespace: string,
+  nodeExporterPort: number,
+  domain: string,
+  stackdriverServiceAccount: any,
+  withVM: boolean,
+  observabilityBranch: string
+) {
+  const installMonitoringSatelliteParams =
+    new InstallMonitoringSatelliteParams();
+  installMonitoringSatelliteParams.branch = observabilityBranch;
+  installMonitoringSatelliteParams.pathToKubeConfig = "";
+  installMonitoringSatelliteParams.satelliteNamespace = namespace;
+  installMonitoringSatelliteParams.clusterName = namespace;
+  installMonitoringSatelliteParams.nodeExporterPort = nodeExporterPort;
+  installMonitoringSatelliteParams.previewDomain = domain;
+  installMonitoringSatelliteParams.stackdriverServiceAccount =
+    stackdriverServiceAccount;
+  installMonitoringSatelliteParams.withVM = withVM;
+  installMonitoringSatellite(installMonitoringSatelliteParams);
 }
 
 // returns the static IP address
 function getCoreDevIngressIP(): string {
-    return "104.199.27.246";
+  return "104.199.27.246";
 }
 
 function metaEnv(_parent?: ExecOptions): ExecOptions {
-    return env("", _parent);
+  return env("", _parent);
 }

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -3,159 +3,176 @@ import { exec } from "../../util/shell";
 import { Werft } from "../../util/werft";
 
 export interface JobConfig {
-    analytics: string
-    buildConfig: any;
-    cleanSlateDeployment: boolean
-    coverageOutput: string
-    dontTest: boolean;
-    dynamicCPULimits: boolean;
-    installEELicense: boolean
-    localAppVersion: string
-    mainBuild: boolean;
-    noPreview: boolean;
-    publishRelease: boolean;
-    publishToJBMarketplace: string
-    publishToNpm: string
-    retag: string
-    storage: string;
-    version: string;
-    withContrib: boolean
-    withHelm: boolean
-    withIntegrationTests: boolean;
-    withObservability: boolean
-    withPayment: boolean
-    withVM: boolean
-    workspaceFeatureFlags: string[];
-    previewEnvironment: PreviewEnvironmentConfig,
-    repository: Repository
-    observability: Observability
+  analytics: string;
+  buildConfig: any;
+  cleanSlateDeployment: boolean;
+  coverageOutput: string;
+  dontTest: boolean;
+  dynamicCPULimits: boolean;
+  installEELicense: boolean;
+  localAppVersion: string;
+  mainBuild: boolean;
+  noPreview: boolean;
+  publishRelease: boolean;
+  publishToJBMarketplace: string;
+  publishToNpm: string;
+  retag: string;
+  storage: string;
+  version: string;
+  withContrib: boolean;
+  withHelm: boolean;
+  withIntegrationTests: boolean;
+  withObservability: boolean;
+  withPayment: boolean;
+  withVM: boolean;
+  workspaceFeatureFlags: string[];
+  previewEnvironment: PreviewEnvironmentConfig;
+  repository: Repository;
+  observability: Observability;
 }
 
 export interface PreviewEnvironmentConfig {
-    destname: string;
-    namespace: string;
+  destname: string;
+  namespace: string;
 }
 
 export interface Repository {
-    owner: string;
-    repo: string;
-    ref: string;
-    branch: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  branch: string;
 }
 
 export interface Observability {
-    // The branch of gitpod-io/observability to use
-    branch: string
+  // The branch of gitpod-io/observability to use
+  branch: string;
 }
 
 export function jobConfig(werft: Werft, context: any): JobConfig {
-    const version = parseVersion(context)
-    const repo = `${context.Repository.host}/${context.Repository.owner}/${context.Repository.repo}`;
-    const mainBuild = repo === "github.com/gitpod-io/gitpod" && context.Repository.ref.includes("refs/heads/main");
+  const version = parseVersion(context);
+  const repo = `${context.Repository.host}/${context.Repository.owner}/${context.Repository.repo}`;
+  const mainBuild =
+    repo === "github.com/gitpod-io/gitpod" &&
+    context.Repository.ref.includes("refs/heads/main");
 
-    let buildConfig = context.Annotations || {};
-    const dontTest = "no-test" in buildConfig;
-    const publishRelease = "publish-release" in buildConfig;
-    const workspaceFeatureFlags: string[] = ((): string[] => {
-        const raw: string = buildConfig["ws-feature-flags"] || "";
-        if (!raw) {
-            return [];
-        }
-        return raw.split(",").map(e => e.trim());
-    })();
-
-    const coverageOutput = exec("mktemp -d", { silent: true }).stdout.trim();
-
-    // Main build should only contain the annotations below:
-    // ['with-contrib', 'publish-to-npm', 'publish-to-jb-marketplace', 'clean-slate-deployment']
-    const dynamicCPULimits = "dynamic-cpu-limits" in buildConfig && !mainBuild;
-    const withContrib = "with-contrib" in buildConfig || mainBuild;
-    const noPreview = ("no-preview" in buildConfig && buildConfig["no-preview"] !== "false") || publishRelease;
-    const storage = buildConfig["storage"] || "";
-    const withIntegrationTests = "with-integration-tests" in buildConfig && !mainBuild;
-    const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
-    const publishToJBMarketplace = "publish-to-jb-marketplace" in buildConfig || mainBuild;
-    const analytics = buildConfig["analytics"];
-    const localAppVersion = mainBuild || ("with-localapp-version" in buildConfig) ? version : "unknown";
-    const retag = ("with-retag" in buildConfig) ? "" : "--dont-retag";
-    const cleanSlateDeployment = mainBuild || ("with-clean-slate-deployment" in buildConfig);
-    const installEELicense = !("without-ee-license" in buildConfig) || mainBuild;
-    const withPayment = "with-payment" in buildConfig && !mainBuild;
-    const withObservability = "with-observability" in buildConfig && !mainBuild;
-    const withHelm = "with-helm" in buildConfig && !mainBuild;
-    const withVM = "with-vm" in buildConfig && !mainBuild;
-
-    const previewDestName = version.split(".")[0];
-    const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewDestName}`;
-    const previewEnvironment = {
-        destname: previewDestName,
-        namespace: previewEnvironmentNamespace
+  let buildConfig = context.Annotations || {};
+  const dontTest = "no-test" in buildConfig;
+  const publishRelease = "publish-release" in buildConfig;
+  const workspaceFeatureFlags: string[] = ((): string[] => {
+    const raw: string = buildConfig["ws-feature-flags"] || "";
+    if (!raw) {
+      return [];
     }
+    return raw.split(",").map((e) => e.trim());
+  })();
 
-    const repository: Repository = {
-        owner: context.Repository.owner,
-        repo: context.Repository.repo,
-        ref: context.Repository.ref,
-        branch: context.Repository.ref,
-    }
+  const coverageOutput = exec("mktemp -d", { silent: true }).stdout.trim();
 
-    const refsPrefix = "refs/heads/";
-    if (repository.branch.startsWith(refsPrefix)) {
-        repository.branch = repository.branch.substring(refsPrefix.length);
-    }
+  // Main build should only contain the annotations below:
+  // ['with-contrib', 'publish-to-npm', 'publish-to-jb-marketplace', 'clean-slate-deployment']
+  const dynamicCPULimits = "dynamic-cpu-limits" in buildConfig && !mainBuild;
+  const withContrib = "with-contrib" in buildConfig || mainBuild;
+  const noPreview =
+    ("no-preview" in buildConfig && buildConfig["no-preview"] !== "false") ||
+    publishRelease;
+  const storage = buildConfig["storage"] || "";
+  const withIntegrationTests =
+    "with-integration-tests" in buildConfig && !mainBuild;
+  const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
+  const publishToJBMarketplace =
+    "publish-to-jb-marketplace" in buildConfig || mainBuild;
+  const analytics = buildConfig["analytics"];
+  const localAppVersion =
+    mainBuild || "with-localapp-version" in buildConfig ? version : "unknown";
+  const retag = "with-retag" in buildConfig ? "" : "--dont-retag";
+  const cleanSlateDeployment =
+    mainBuild || "with-clean-slate-deployment" in buildConfig;
+  const installEELicense = !("without-ee-license" in buildConfig) || mainBuild;
+  const withPayment = "with-payment" in buildConfig && !mainBuild;
+  const withObservability = "with-observability" in buildConfig && !mainBuild;
+  const withHelm = "with-helm" in buildConfig && !mainBuild;
+  const withVM = "with-vm" in buildConfig && !mainBuild;
 
-    const observability: Observability = {
-        branch: context.Annotations.withObservabilityBranch || "main"
-    }
+  const previewDestName = version.split(".")[0];
+  const previewEnvironmentNamespace = withVM
+    ? `default`
+    : `staging-${previewDestName}`;
+  const previewEnvironment = {
+    destname: previewDestName,
+    namespace: previewEnvironmentNamespace,
+  };
 
-    const jobConfig = {
-        analytics,
-        buildConfig,
-        cleanSlateDeployment,
-        coverageOutput,
-        dontTest,
-        dynamicCPULimits,
-        installEELicense,
-        localAppVersion,
-        mainBuild,
-        noPreview,
-        observability,
-        previewEnvironment,
-        publishRelease,
-        publishToJBMarketplace,
-        publishToNpm,
-        repository,
-        retag,
-        storage,
-        version,
-        withContrib,
-        withHelm,
-        withIntegrationTests,
-        withObservability,
-        withPayment,
-        withVM,
-        workspaceFeatureFlags,
-    }
+  const repository: Repository = {
+    owner: context.Repository.owner,
+    repo: context.Repository.repo,
+    ref: context.Repository.ref,
+    branch: context.Repository.ref,
+  };
 
-    werft.log("job config", JSON.stringify(jobConfig));
-    werft.rootSpan.setAttributes(Object.fromEntries(Object.entries(jobConfig).map((kv) => {
-        const [key, value] = kv
-        return [`werft.job.config.${key}`, value]
-    })))
-    werft.rootSpan.setAttribute('werft.job.config.branch', context.Repository.ref)
-    return jobConfig
+  const refsPrefix = "refs/heads/";
+  if (repository.branch.startsWith(refsPrefix)) {
+    repository.branch = repository.branch.substring(refsPrefix.length);
+  }
+
+  const observability: Observability = {
+    branch: context.Annotations.withObservabilityBranch || "main",
+  };
+
+  const jobConfig = {
+    analytics,
+    buildConfig,
+    cleanSlateDeployment,
+    coverageOutput,
+    dontTest,
+    dynamicCPULimits,
+    installEELicense,
+    localAppVersion,
+    mainBuild,
+    noPreview,
+    observability,
+    previewEnvironment,
+    publishRelease,
+    publishToJBMarketplace,
+    publishToNpm,
+    repository,
+    retag,
+    storage,
+    version,
+    withContrib,
+    withHelm,
+    withIntegrationTests,
+    withObservability,
+    withPayment,
+    withVM,
+    workspaceFeatureFlags,
+  };
+
+  werft.log("job config", JSON.stringify(jobConfig));
+  werft.rootSpan.setAttributes(
+    Object.fromEntries(
+      Object.entries(jobConfig).map((kv) => {
+        const [key, value] = kv;
+        return [`werft.job.config.${key}`, value];
+      })
+    )
+  );
+  werft.rootSpan.setAttribute(
+    "werft.job.config.branch",
+    context.Repository.ref
+  );
+  return jobConfig;
 }
 
 function parseVersion(context: any) {
-    let buildConfig = context.Annotations || {};
-    const explicitVersion = buildConfig.version;
-    if (explicitVersion) {
-        return explicitVersion;
-    }
-    let version = context.Name;
-    const PREFIX_TO_STRIP = "gitpod-build-";
-    if (version.substr(0, PREFIX_TO_STRIP.length) === PREFIX_TO_STRIP) {
-        version = version.substr(PREFIX_TO_STRIP.length);
-    }
-    return version
+  let buildConfig = context.Annotations || {};
+  const explicitVersion = buildConfig.version;
+  if (explicitVersion) {
+    return explicitVersion;
+  }
+  let version = context.Name;
+  const PREFIX_TO_STRIP = "gitpod-build-";
+  if (version.substr(0, PREFIX_TO_STRIP.length) === PREFIX_TO_STRIP) {
+    version = version.substr(PREFIX_TO_STRIP.length);
+  }
+  return version;
 }

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -1,24 +1,34 @@
-import * as shell from 'shelljs';
-import { exec } from '../../util/shell';
+import * as shell from "shelljs";
+import { exec } from "../../util/shell";
 import { Werft } from "../../util/werft";
 import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
 
 export async function prepare(werft: Werft) {
-    werft.phase("prepare");
+  werft.phase("prepare");
 
-    const werftImg = shell.exec("cat .werft/build.yaml | grep dev-environment").trim().split(": ")[1];
-    const devImg = shell.exec("yq r .gitpod.yml image").trim();
-    if (werftImg !== devImg) {
-        werft.fail('prep', `Werft job image (${werftImg}) and Gitpod dev image (${devImg}) do not match`);
-    }
+  const werftImg = shell
+    .exec("cat .werft/build.yaml | grep dev-environment")
+    .trim()
+    .split(": ")[1];
+  const devImg = shell.exec("yq r .gitpod.yml image").trim();
+  if (werftImg !== devImg) {
+    werft.fail(
+      "prep",
+      `Werft job image (${werftImg}) and Gitpod dev image (${devImg}) do not match`
+    );
+  }
 
-    try {
-        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`);
-        exec("gcloud auth configure-docker --quiet");
-        exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet");
-        exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev');
-        werft.done('prep');
-    } catch (err) {
-        werft.fail('prep', err);
-    }
+  try {
+    exec(
+      `gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`
+    );
+    exec("gcloud auth configure-docker --quiet");
+    exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet");
+    exec(
+      "gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev"
+    );
+    werft.done("prep");
+  } catch (err) {
+    werft.fail("prep", err);
+  }
 }

--- a/.werft/jobs/build/trigger-integration-tests.ts
+++ b/.werft/jobs/build/trigger-integration-tests.ts
@@ -3,42 +3,53 @@ import { Werft } from "../../util/werft";
 import { JobConfig } from "./job-config";
 
 const phases = {
-    TRIGGER_INTEGRATION_TESTS: 'trigger integration tests',
-}
+  TRIGGER_INTEGRATION_TESTS: "trigger integration tests",
+};
 
 /**
  * Trigger integration tests
  */
-export async function triggerIntegrationTests(werft: Werft, config: JobConfig, username: string) {
-    werft.phase(phases.TRIGGER_INTEGRATION_TESTS, "Trigger integration tests");
+export async function triggerIntegrationTests(
+  werft: Werft,
+  config: JobConfig,
+  username: string
+) {
+  werft.phase(phases.TRIGGER_INTEGRATION_TESTS, "Trigger integration tests");
 
-    if (!config.withIntegrationTests) {
-        // If we're skipping integration tests we wont trigger the job, which in turn won't create the
-        // ci/werft/run-integration-tests Github Check. As ci/werft/run-integration-tests is a required
-        // check this means you can't merge your PR without override checks.
-        werft.log(phases.TRIGGER_INTEGRATION_TESTS, "Skipped integration tests")
-        werft.done(phases.TRIGGER_INTEGRATION_TESTS);
-        return
+  if (!config.withIntegrationTests) {
+    // If we're skipping integration tests we wont trigger the job, which in turn won't create the
+    // ci/werft/run-integration-tests Github Check. As ci/werft/run-integration-tests is a required
+    // check this means you can't merge your PR without override checks.
+    werft.log(phases.TRIGGER_INTEGRATION_TESTS, "Skipped integration tests");
+    werft.done(phases.TRIGGER_INTEGRATION_TESTS);
+    return;
+  }
+
+  try {
+    const imageVersion = exec(
+      `docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${config.version} cat /versions.yaml | yq r - 'components.integrationTest.version'`,
+      { silent: true }
+    ).stdout.trim();
+
+    exec(`git config --global user.name "${username}"`);
+    const annotations = [
+      `version=${imageVersion}`,
+      `namespace=${config.previewEnvironment.namespace}`,
+      `username=${username}`,
+      `updateGitHubStatus=gitpod-io/gitpod`,
+    ]
+      .map((annotation) => `-a ${annotation}`)
+      .join(" ");
+    exec(
+      `werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`,
+      { slice: phases.TRIGGER_INTEGRATION_TESTS }
+    ).trim();
+
+    werft.done(phases.TRIGGER_INTEGRATION_TESTS);
+  } catch (err) {
+    if (!config.mainBuild) {
+      werft.fail(phases.TRIGGER_INTEGRATION_TESTS, err);
     }
-
-    try {
-        const imageVersion = exec(`docker run --rm eu.gcr.io/gitpod-core-dev/build/versions:${config.version} cat /versions.yaml | yq r - 'components.integrationTest.version'`, { silent: true })
-            .stdout.trim();
-
-        exec(`git config --global user.name "${username}"`);
-        const annotations = [
-            `version=${imageVersion}`,
-            `namespace=${config.previewEnvironment.namespace}`,
-            `username=${username}`,
-            `updateGitHubStatus=gitpod-io/gitpod`
-        ].map(annotation => `-a ${annotation}`).join(' ')
-        exec(`werft run --remote-job-path .werft/run-integration-tests.yaml ${annotations} github`, { slice: phases.TRIGGER_INTEGRATION_TESTS }).trim();
-
-        werft.done(phases.TRIGGER_INTEGRATION_TESTS);
-    } catch (err) {
-        if (!config.mainBuild) {
-            werft.fail(phases.TRIGGER_INTEGRATION_TESTS, err);
-        }
-        exec('exit 0')
-    }
+    exec("exit 0");
+  }
 }

--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -2,11 +2,11 @@ import { exec } from "../../util/shell";
 import { Werft } from "../../util/werft";
 
 export async function validateChanges(werft: Werft) {
-    werft.phase('validate-changes', 'validating changes');
-    try {
-        exec(`pre-commit run --all-files --show-diff-on-failure`);
-        werft.done('validate-changes');
-    } catch (err) {
-        werft.fail('validate-changes', err);
-    }
+  werft.phase("validate-changes", "validating changes");
+  try {
+    exec(`pre-commit run --all-files --show-diff-on-failure`);
+    werft.done("validate-changes");
+  } catch (err) {
+    werft.fail("validate-changes", err);
+  }
 }

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -1,46 +1,64 @@
-import { exec } from '../util/shell';
-import { getGlobalWerftInstance } from '../util/werft';
-import * as shell from 'shelljs';
-import * as fs from 'fs';
+import { exec } from "../util/shell";
+import { getGlobalWerftInstance } from "../util/werft";
+import * as shell from "shelljs";
+import * as fs from "fs";
 
 /**
  * Monitoring satellite deployment bits
  */
- export class InstallMonitoringSatelliteParams {
-    pathToKubeConfig: string
-    satelliteNamespace: string
-    clusterName: string
-    nodeExporterPort: number
-    branch: string
-    previewDomain: string
-    stackdriverServiceAccount: any
-    withVM: boolean
+export class InstallMonitoringSatelliteParams {
+  pathToKubeConfig: string;
+  satelliteNamespace: string;
+  clusterName: string;
+  nodeExporterPort: number;
+  branch: string;
+  previewDomain: string;
+  stackdriverServiceAccount: any;
+  withVM: boolean;
 }
 
-const sliceName = 'observability';
+const sliceName = "observability";
 
 /**
  * installMonitoringSatellite installs monitoring-satellite, while updating its dependencies to the latest commit in the branch it is running.
  */
-export async function installMonitoringSatellite(params: InstallMonitoringSatelliteParams) {
-    const werft = getGlobalWerftInstance()
+export async function installMonitoringSatellite(
+  params: InstallMonitoringSatelliteParams
+) {
+  const werft = getGlobalWerftInstance();
 
-    werft.log(sliceName, `Cloning observability repository - Branch: ${params.branch}`)
-    exec(`git clone --branch ${params.branch} https://roboquat:$(cat /mnt/secrets/monitoring-satellite-preview-token/token)@github.com/gitpod-io/observability.git`, {silent: true})
-    let currentCommit = exec(`git rev-parse HEAD`, {silent: true}).stdout.trim()
-    let pwd = exec(`pwd`, {silent: true}).stdout.trim()
-    werft.log(sliceName, `Updating Gitpod's mixin in monitoring-satellite's jsonnetfile.json to latest commit SHA: ${currentCommit}`);
+  werft.log(
+    sliceName,
+    `Cloning observability repository - Branch: ${params.branch}`
+  );
+  exec(
+    `git clone --branch ${params.branch} https://roboquat:$(cat /mnt/secrets/monitoring-satellite-preview-token/token)@github.com/gitpod-io/observability.git`,
+    { silent: true }
+  );
+  let currentCommit = exec(`git rev-parse HEAD`, {
+    silent: true,
+  }).stdout.trim();
+  let pwd = exec(`pwd`, { silent: true }).stdout.trim();
+  werft.log(
+    sliceName,
+    `Updating Gitpod's mixin in monitoring-satellite's jsonnetfile.json to latest commit SHA: ${currentCommit}`
+  );
 
-    let jsonnetFile = JSON.parse(fs.readFileSync(`${pwd}/observability/jsonnetfile.json`, 'utf8'));
-    jsonnetFile.dependencies.forEach(dep => {
-        if(dep.name == 'gitpod') {
-            dep.version = currentCommit
-        }
-    });
-    fs.writeFileSync(`${pwd}/observability/jsonnetfile.json`, JSON.stringify(jsonnetFile));
-    exec(`cd observability && jb update`, {slice: sliceName})
+  let jsonnetFile = JSON.parse(
+    fs.readFileSync(`${pwd}/observability/jsonnetfile.json`, "utf8")
+  );
+  jsonnetFile.dependencies.forEach((dep) => {
+    if (dep.name == "gitpod") {
+      dep.version = currentCommit;
+    }
+  });
+  fs.writeFileSync(
+    `${pwd}/observability/jsonnetfile.json`,
+    JSON.stringify(jsonnetFile)
+  );
+  exec(`cd observability && jb update`, { slice: sliceName });
 
-    let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
+  let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
     --ext-code config="{
         namespace: '${params.satelliteNamespace}',
         clusterName: '${params.satelliteNamespace}',
@@ -52,7 +70,11 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
             domain: '${params.previewDomain}',
             nodeExporterPort: ${params.nodeExporterPort},
         },
-        ${params.withVM ? '' : "nodeAffinity: { nodeSelector: { 'gitpod.io/workload_services': 'true' }, },"  }
+        ${
+          params.withVM
+            ? ""
+            : "nodeAffinity: { nodeSelector: { 'gitpod.io/workload_services': 'true' }, },"
+        }
         stackdriver: {
             defaultProject: '${params.stackdriverServiceAccount.project_id}',
             clientEmail: '${params.stackdriverServiceAccount.client_email}',
@@ -60,54 +82,80 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
         },
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
-    find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
+    find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`;
 
-    werft.log(sliceName, 'rendering YAML files')
-    exec(jsonnetRenderCmd, {silent: true})
-    if(params.withVM) {
-        postProcessManifests()
-    }
+  werft.log(sliceName, "rendering YAML files");
+  exec(jsonnetRenderCmd, { silent: true });
+  if (params.withVM) {
+    postProcessManifests();
+  }
 
-    // The correct kubectl context should already be configured prior to this step
-    ensureCorrectInstallationOrder(params.satelliteNamespace)
+  // The correct kubectl context should already be configured prior to this step
+  ensureCorrectInstallationOrder(params.satelliteNamespace);
 }
 
-async function ensureCorrectInstallationOrder(namespace: string){
-    const werft = getGlobalWerftInstance()
+async function ensureCorrectInstallationOrder(namespace: string) {
+  const werft = getGlobalWerftInstance();
 
-    werft.log(sliceName, 'installing monitoring-satellite')
-    exec('cd observability && hack/deploy-satellite.sh', {slice: sliceName})
+  werft.log(sliceName, "installing monitoring-satellite");
+  exec("cd observability && hack/deploy-satellite.sh", { slice: sliceName });
 
-    deployGitpodServiceMonitors()
-    checkReadiness(namespace)
+  deployGitpodServiceMonitors();
+  checkReadiness(namespace);
 }
 
 async function checkReadiness(namespace: string) {
-    // For some reason prometheus' statefulset always take quite some time to get created
-    // Therefore we wait a couple of seconds
-    exec(`sleep 30 && kubectl rollout status -n ${namespace} statefulset prometheus-k8s`, {slice: sliceName, async: true})
-    exec(`kubectl rollout status -n ${namespace} deployment grafana`, {slice: sliceName, async: true})
-    exec(`kubectl rollout status -n ${namespace} deployment kube-state-metrics`, {slice: sliceName, async: true})
-    exec(`kubectl rollout status -n ${namespace} deployment otel-collector`, {slice: sliceName, async: true})
-    exec(`kubectl rollout status -n ${namespace} daemonset node-exporter`, {slice: sliceName, async: true})
+  // For some reason prometheus' statefulset always take quite some time to get created
+  // Therefore we wait a couple of seconds
+  exec(
+    `sleep 30 && kubectl rollout status -n ${namespace} statefulset prometheus-k8s`,
+    { slice: sliceName, async: true }
+  );
+  exec(`kubectl rollout status -n ${namespace} deployment grafana`, {
+    slice: sliceName,
+    async: true,
+  });
+  exec(`kubectl rollout status -n ${namespace} deployment kube-state-metrics`, {
+    slice: sliceName,
+    async: true,
+  });
+  exec(`kubectl rollout status -n ${namespace} deployment otel-collector`, {
+    slice: sliceName,
+    async: true,
+  });
+  exec(`kubectl rollout status -n ${namespace} daemonset node-exporter`, {
+    slice: sliceName,
+    async: true,
+  });
 }
 
 async function deployGitpodServiceMonitors() {
-    const werft = getGlobalWerftInstance()
+  const werft = getGlobalWerftInstance();
 
-    werft.log(sliceName, 'installing gitpod ServiceMonitor resources')
-    exec('kubectl apply -f observability/monitoring-satellite/manifests/gitpod/', {silent: true})
+  werft.log(sliceName, "installing gitpod ServiceMonitor resources");
+  exec(
+    "kubectl apply -f observability/monitoring-satellite/manifests/gitpod/",
+    { silent: true }
+  );
 }
 
 function postProcessManifests() {
-    const werft = getGlobalWerftInstance()
+  const werft = getGlobalWerftInstance();
 
-    // We're hardcoding nodeports, so we can use them in .werft/vm/manifests.ts
-    // We'll be able to access Prometheus and Grafana's UI by port-forwarding the harvester proxy into the nodePort
-    werft.log(sliceName, 'Post-processing manifests so it works on Harvester')
-    exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.type 'NodePort'`)
-    exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.type 'NodePort'`)
+  // We're hardcoding nodeports, so we can use them in .werft/vm/manifests.ts
+  // We'll be able to access Prometheus and Grafana's UI by port-forwarding the harvester proxy into the nodePort
+  werft.log(sliceName, "Post-processing manifests so it works on Harvester");
+  exec(
+    `yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.type 'NodePort'`
+  );
+  exec(
+    `yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.type 'NodePort'`
+  );
 
-    exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`)
-    exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.ports[0].nodePort 32000`)
+  exec(
+    `yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`
+  );
+  exec(
+    `yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.ports[0].nodePort 32000`
+  );
 }

--- a/.werft/observability/tracing.ts
+++ b/.werft/observability/tracing.ts
@@ -1,8 +1,8 @@
 import { Metadata, credentials } from "@grpc/grpc-js";
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
-import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { CollectorTraceExporter } from "@opentelemetry/exporter-collector-grpc";
 
 /**
@@ -11,36 +11,36 @@ import { CollectorTraceExporter } from "@opentelemetry/exporter-collector-grpc";
  * Registers a beforeExit event handler to gracefully flush traces upon exit.
  */
 export async function initialize() {
+  const metadata = new Metadata();
+  metadata.set("x-honeycomb-team", process.env.HONEYCOMB_API_KEY);
+  metadata.set("x-honeycomb-dataset", process.env.HONEYCOMB_DATASET);
+  const traceExporter = new CollectorTraceExporter({
+    url: "grpc://api.honeycomb.io:443/",
+    credentials: credentials.createSsl(),
+    metadata,
+  });
 
-    const metadata = new Metadata()
-    metadata.set('x-honeycomb-team', process.env.HONEYCOMB_API_KEY);
-    metadata.set('x-honeycomb-dataset', process.env.HONEYCOMB_DATASET);
-    const traceExporter = new CollectorTraceExporter({
-        url: 'grpc://api.honeycomb.io:443/',
-        credentials: credentials.createSsl(),
-        metadata
-    });
+  const sdk = new NodeSDK({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: "werft",
+    }),
+    traceExporter,
+    instrumentations: [getNodeAutoInstrumentations()],
+  });
 
-    const sdk = new NodeSDK({
-        resource: new Resource({
-            [SemanticResourceAttributes.SERVICE_NAME]: 'werft',
-        }),
-        traceExporter,
-        instrumentations: [getNodeAutoInstrumentations()]
-    });
+  console.log("Initializing tracing");
+  try {
+    await sdk.start();
+  } catch (err) {
+    console.log("Error initializing tracing", err);
+    process.exit(1);
+  }
 
-    console.log('Initializing tracing')
-    try {
-        await sdk.start()
-    } catch (err) {
-        console.log('Error initializing tracing', err)
-        process.exit(1)
-    }
-
-    process.on('beforeExit', (code) => {
-        console.log(`About to exit with code ${code}. Shutting down tracing.`)
-        sdk.shutdown()
-            .then(() => console.log('Tracing terminated'))
-            .catch((error) => console.log('Error terminating tracing', error))
-    })
+  process.on("beforeExit", (code) => {
+    console.log(`About to exit with code ${code}. Shutting down tracing.`);
+    sdk
+      .shutdown()
+      .then(() => console.log("Tracing terminated"))
+      .catch((error) => console.log("Error terminating tracing", error));
+  });
 }

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -1,94 +1,134 @@
-import { exec, ExecOptions } from './shell';
-import { sleep } from './util';
-import { readFileSync, writeFileSync } from 'fs';
-import * as path from 'path';
-
+import { exec, ExecOptions } from "./shell";
+import { sleep } from "./util";
+import { readFileSync, writeFileSync } from "fs";
+import * as path from "path";
 
 export class IssueCertificateParams {
-    pathToTemplate: string
-    gcpSaPath: string
-    namespace: string
-    dnsZoneDomain: string
-    domain: string
-    ip: string
-    additionalSubdomains: string[]
-    bucketPrefixTail: string
-    certNamespace: string
+  pathToTemplate: string;
+  gcpSaPath: string;
+  namespace: string;
+  dnsZoneDomain: string;
+  domain: string;
+  ip: string;
+  additionalSubdomains: string[];
+  bucketPrefixTail: string;
+  certNamespace: string;
 }
 
 export class InstallCertificateParams {
-    certName: string
-    certSecretName: string
-    certNamespace: string
-    destinationNamespace: string
+  certName: string;
+  certSecretName: string;
+  certNamespace: string;
+  destinationNamespace: string;
 }
 
-export async function issueCertficate(werft, params: IssueCertificateParams, shellOpts: ExecOptions) {
-    var subdomains = [];
-    werft.log("certificate", `Subdomains: ${params.additionalSubdomains}`)
-    for (const sd of params.additionalSubdomains) {
-        subdomains.push(sd);
-    }
+export async function issueCertficate(
+  werft,
+  params: IssueCertificateParams,
+  shellOpts: ExecOptions
+) {
+  var subdomains = [];
+  werft.log("certificate", `Subdomains: ${params.additionalSubdomains}`);
+  for (const sd of params.additionalSubdomains) {
+    subdomains.push(sd);
+  }
 
-    // sanity: check if there is a "SAN short enough to fit into CN (63 characters max)"
-    // source: https://community.letsencrypt.org/t/certbot-errors-with-obtaining-a-new-certificate-an-unexpected-error-occurred-the-csr-is-unacceptable-e-g-due-to-a-short-key-error-finalizing-order-issuing-precertificate-csr-doesnt-contain-a-san-short-enough-to-fit-in-cn/105513/2
-    if (!subdomains.some(sd => {
-        const san = sd + params.domain;
-        return san.length <= 63;
-    })) {
-        throw new Error(`there is no subdomain + '${params.domain}' shorter or equal to 63 characters, max. allowed length for CN. No HTTPS certs for you! Consider using a short branch name...`);
-    }
-    var cmd = `set -x \
+  // sanity: check if there is a "SAN short enough to fit into CN (63 characters max)"
+  // source: https://community.letsencrypt.org/t/certbot-errors-with-obtaining-a-new-certificate-an-unexpected-error-occurred-the-csr-is-unacceptable-e-g-due-to-a-short-key-error-finalizing-order-issuing-precertificate-csr-doesnt-contain-a-san-short-enough-to-fit-in-cn/105513/2
+  if (
+    !subdomains.some((sd) => {
+      const san = sd + params.domain;
+      return san.length <= 63;
+    })
+  ) {
+    throw new Error(
+      `there is no subdomain + '${params.domain}' shorter or equal to 63 characters, max. allowed length for CN. No HTTPS certs for you! Consider using a short branch name...`
+    );
+  }
+  var cmd = `set -x \
     && cd ${path.join(params.pathToTemplate)} \
     && cp cert-manager_certificate.tpl cert.yaml \
     && yq w -i cert.yaml metadata.name '${params.namespace}' \
     && yq w -i cert.yaml spec.secretName '${params.namespace}' \
     && yq w -i cert.yaml metadata.namespace '${params.certNamespace}' \
-    ${subdomains.map(s => `&& yq w -i cert.yaml spec.dnsNames[+] '${s+params.domain}'`).join('  ')} \
+    ${subdomains
+      .map(
+        (s) => `&& yq w -i cert.yaml spec.dnsNames[+] '${s + params.domain}'`
+      )
+      .join("  ")} \
     && kubectl apply -f cert.yaml`;
 
-    werft.log("certificate", "Kubectl command for cert creation: " + cmd)
-    exec(cmd, { ...shellOpts, slice: 'certificate' });
+  werft.log("certificate", "Kubectl command for cert creation: " + cmd);
+  exec(cmd, { ...shellOpts, slice: "certificate" });
 
-    werft.log('certificate', `waiting until certificate ${params.certNamespace}/${params.namespace} is ready...`)
-    let notReadyYet = true;
-    for (let i = 0; i < 90 && notReadyYet; i++) {
-        werft.log('certificate', `polling state of ${params.certNamespace}/${params.namespace}...`)
-        const result = exec(`kubectl -n ${params.certNamespace} get certificate ${params.namespace} -o jsonpath="{.status.conditions[?(@.type == 'Ready')].status}"`, { ...shellOpts, silent: true, dontCheckRc: true, async: false });
-        if (result != undefined && result.code === 0 && result.stdout === "True") {
-            notReadyYet = false;
-            break;
-        }
-
-        await sleep(5000);
+  werft.log(
+    "certificate",
+    `waiting until certificate ${params.certNamespace}/${params.namespace} is ready...`
+  );
+  let notReadyYet = true;
+  for (let i = 0; i < 90 && notReadyYet; i++) {
+    werft.log(
+      "certificate",
+      `polling state of ${params.certNamespace}/${params.namespace}...`
+    );
+    const result = exec(
+      `kubectl -n ${params.certNamespace} get certificate ${params.namespace} -o jsonpath="{.status.conditions[?(@.type == 'Ready')].status}"`,
+      { ...shellOpts, silent: true, dontCheckRc: true, async: false }
+    );
+    if (result != undefined && result.code === 0 && result.stdout === "True") {
+      notReadyYet = false;
+      break;
     }
+
+    await sleep(5000);
+  }
 }
 
-
-export async function installCertficate(werft, params: InstallCertificateParams, shellOpts: ExecOptions) {
-    let notReadyYet = true;
-    werft.log('certificate', `copying certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`);
-    const cmd = `kubectl get secret ${params.certName} --namespace=${params.certNamespace} -o yaml \
+export async function installCertficate(
+  werft,
+  params: InstallCertificateParams,
+  shellOpts: ExecOptions
+) {
+  let notReadyYet = true;
+  werft.log(
+    "certificate",
+    `copying certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`
+  );
+  const cmd = `kubectl get secret ${params.certName} --namespace=${params.certNamespace} -o yaml \
     | yq d - 'metadata.namespace' \
     | yq d - 'metadata.uid' \
     | yq d - 'metadata.resourceVersion' \
     | yq d - 'metadata.creationTimestamp' \
     | sed 's/${params.certName}/${params.certSecretName}/g' \
-    | kubectl apply --namespace=${params.destinationNamespace} -f -`
+    | kubectl apply --namespace=${params.destinationNamespace} -f -`;
 
-    for (let i = 0; i < 60 && notReadyYet; i++) {
-        const result = exec(cmd, { ...shellOpts, silent: true, dontCheckRc: true, async: false });
-        if (result != undefined && result.code === 0) {
-            notReadyYet = false;
-            break;
-        }
-        werft.log('certificate', `Could not copy "${params.certNamespace}/${params.certName}", will retry`);
-        await sleep(5000);
+  for (let i = 0; i < 60 && notReadyYet; i++) {
+    const result = exec(cmd, {
+      ...shellOpts,
+      silent: true,
+      dontCheckRc: true,
+      async: false,
+    });
+    if (result != undefined && result.code === 0) {
+      notReadyYet = false;
+      break;
     }
-    if (!notReadyYet) {
-        werft.log('certificate', `copied certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`);
-        werft.done('certificate')
-    } else {
-        werft.fail('certificate', `failed to copy certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`)
-    }
+    werft.log(
+      "certificate",
+      `Could not copy "${params.certNamespace}/${params.certName}", will retry`
+    );
+    await sleep(5000);
+  }
+  if (!notReadyYet) {
+    werft.log(
+      "certificate",
+      `copied certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`
+    );
+    werft.done("certificate");
+  } else {
+    werft.fail(
+      "certificate",
+      `failed to copy certificate from "${params.certNamespace}/${params.certName}" to "${params.destinationNamespace}/${params.certSecretName}"`
+    );
+  }
 }

--- a/.werft/util/gcloud.ts
+++ b/.werft/util/gcloud.ts
@@ -1,35 +1,51 @@
-import { exec } from './shell';
-import { sleep } from './util';
-import { getGlobalWerftInstance } from './werft';
+import { exec } from "./shell";
+import { sleep } from "./util";
+import { getGlobalWerftInstance } from "./werft";
 
-export async function deleteExternalIp(phase: string, name: string, region = "europe-west1") {
-    const werft = getGlobalWerftInstance()
+export async function deleteExternalIp(
+  phase: string,
+  name: string,
+  region = "europe-west1"
+) {
+  const werft = getGlobalWerftInstance();
 
-    const ip = getExternalIp(name)
-    werft.log(phase, `address describe returned: ${ip}`)
-    if (ip.indexOf("ERROR:") != -1 || ip == "") {
-        werft.log(phase, `no external static IP with matching name ${name} found`)
-        return
-    }
+  const ip = getExternalIp(name);
+  werft.log(phase, `address describe returned: ${ip}`);
+  if (ip.indexOf("ERROR:") != -1 || ip == "") {
+    werft.log(phase, `no external static IP with matching name ${name} found`);
+    return;
+  }
 
-    werft.log(phase, `found external static IP with matching name ${name}, will delete it`)
-    const cmd = `gcloud compute addresses delete ${name} --region ${region} --quiet`
-    let attempt = 0;
-    for (attempt = 0; attempt < 10; attempt++) {
-        let result = exec(cmd);
-        if (result.code === 0 && result.stdout.indexOf("Error") == -1) {
-            werft.log(phase, `external ip with name ${name} and ip ${ip} deleted`);
-            break;
-        } else {
-            werft.log(phase, `external ip with name ${name} and ip ${ip} could not be deleted, will reattempt`)
-        }
-        await sleep(5000)
+  werft.log(
+    phase,
+    `found external static IP with matching name ${name}, will delete it`
+  );
+  const cmd = `gcloud compute addresses delete ${name} --region ${region} --quiet`;
+  let attempt = 0;
+  for (attempt = 0; attempt < 10; attempt++) {
+    let result = exec(cmd);
+    if (result.code === 0 && result.stdout.indexOf("Error") == -1) {
+      werft.log(phase, `external ip with name ${name} and ip ${ip} deleted`);
+      break;
+    } else {
+      werft.log(
+        phase,
+        `external ip with name ${name} and ip ${ip} could not be deleted, will reattempt`
+      );
     }
-    if (attempt == 10) {
-        werft.log(phase, `could not delete the external ip with name ${name} and ip ${ip}`)
-    }
+    await sleep(5000);
+  }
+  if (attempt == 10) {
+    werft.log(
+      phase,
+      `could not delete the external ip with name ${name} and ip ${ip}`
+    );
+  }
 }
 
 function getExternalIp(name: string, region = "europe-west1") {
-    return exec(`gcloud compute addresses describe ${name} --region ${region}| grep 'address:' | cut -c 10-`, { silent: true }).trim();
+  return exec(
+    `gcloud compute addresses describe ${name} --region ${region}| grep 'address:' | cut -c 10-`,
+    { silent: true }
+  ).trim();
 }

--- a/.werft/util/gpctl.ts
+++ b/.werft/util/gpctl.ts
@@ -1,33 +1,51 @@
-import * as shell from 'shelljs';
-import { ExecOptions } from './shell';
+import * as shell from "shelljs";
+import { ExecOptions } from "./shell";
 
 export function buildGpctlBinary() {
-    shell.exec(`cd /workspace/dev/gpctl && go build && cd -`)
+  shell.exec(`cd /workspace/dev/gpctl && go build && cd -`);
 }
 
 export function printClustersList(shellOpts: ExecOptions): string {
-    const result = shell.exec(`/workspace/dev/gpctl/gpctl clusters list`, { ...shellOpts, async: false }).trim()
-    return result
+  const result = shell
+    .exec(`/workspace/dev/gpctl/gpctl clusters list`, {
+      ...shellOpts,
+      async: false,
+    })
+    .trim();
+  return result;
 }
 
 export function uncordonCluster(name: string, shellOpts: ExecOptions): string {
-    const result = shell.exec(`/workspace/dev/gpctl/gpctl clusters uncordon --name=${name}`, { ...shellOpts, async: false }).trim();
-    return result
+  const result = shell
+    .exec(`/workspace/dev/gpctl/gpctl clusters uncordon --name=${name}`, {
+      ...shellOpts,
+      async: false,
+    })
+    .trim();
+  return result;
 }
 
-export function registerCluster(name: string, url: string, shellOpts: ExecOptions): string {
-    const cmd = `/workspace/dev/gpctl/gpctl clusters register \
+export function registerCluster(
+  name: string,
+  url: string,
+  shellOpts: ExecOptions
+): string {
+  const cmd = `/workspace/dev/gpctl/gpctl clusters register \
 	--name ${name} \
 	--hint-cordoned \
 	--hint-govern \
 	--tls-path ./wsman-tls \
 	--url ${url}`;
-    const result = shell.exec(cmd, { ...shellOpts, async: false }).trim();
-    return result
+  const result = shell.exec(cmd, { ...shellOpts, async: false }).trim();
+  return result;
 }
 
 export function getClusterTLS(shellOpts: ExecOptions): string {
-    const result = shell.exec(`/workspace/dev/gpctl/gpctl clusters get-tls-config`, { ...shellOpts, async: false }).trim()
-    return result
+  const result = shell
+    .exec(`/workspace/dev/gpctl/gpctl clusters get-tls-config`, {
+      ...shellOpts,
+      async: false,
+    })
+    .trim();
+  return result;
 }
-

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -1,242 +1,381 @@
-import { ShellString } from 'shelljs';
-import { exec, ExecOptions } from './shell';
-import { getGlobalWerftInstance, Werft } from './werft';
-
+import { ShellString } from "shelljs";
+import { exec, ExecOptions } from "./shell";
+import { getGlobalWerftInstance, Werft } from "./werft";
 
 export const IS_PREVIEW_APP_LABEL: string = "isPreviewApp";
 
 export const helmInstallName = "gitpod";
 
-export function setKubectlContextNamespace(namespace: string, shellOpts: ExecOptions) {
-    [
-        `kubectl config current-context`,
-        `kubectl config set-context --current --namespace=${namespace}`
-    ].forEach(cmd => exec(cmd, shellOpts));
+export function setKubectlContextNamespace(
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  [
+    `kubectl config current-context`,
+    `kubectl config set-context --current --namespace=${namespace}`,
+  ].forEach((cmd) => exec(cmd, shellOpts));
 }
 
-export async function wipePreviewEnvironmentAndNamespace(helmInstallName: string, namespace: string, shellOpts: ExecOptions) {
-    const werft = getGlobalWerftInstance();
+export async function wipePreviewEnvironmentAndNamespace(
+  helmInstallName: string,
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  const werft = getGlobalWerftInstance();
 
-    // wipe preview envs built with installer
-    await wipePreviewEnvironmentInstaller(namespace, shellOpts);
+  // wipe preview envs built with installer
+  await wipePreviewEnvironmentInstaller(namespace, shellOpts);
 
-    // wipe preview envs previously built with helm
-    await wipePreviewEnvironmentHelm(helmInstallName, namespace, shellOpts)
+  // wipe preview envs previously built with helm
+  await wipePreviewEnvironmentHelm(helmInstallName, namespace, shellOpts);
 
-    deleteAllWorkspaces(namespace, shellOpts);
+  deleteAllWorkspaces(namespace, shellOpts);
 
-    await deleteAllUnnamespacedObjects(namespace, shellOpts);
+  await deleteAllUnnamespacedObjects(namespace, shellOpts);
 
-    deleteNamespace(true, namespace, shellOpts);
-    werft.done(shellOpts.slice)
+  deleteNamespace(true, namespace, shellOpts);
+  werft.done(shellOpts.slice);
 }
 
-export async function wipeAndRecreateNamespace(helmInstallName: string, namespace: string, shellOpts: ExecOptions) {
-    await wipePreviewEnvironmentAndNamespace(helmInstallName, namespace, shellOpts);
+export async function wipeAndRecreateNamespace(
+  helmInstallName: string,
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  await wipePreviewEnvironmentAndNamespace(
+    helmInstallName,
+    namespace,
+    shellOpts
+  );
 
-    createNamespace(namespace, shellOpts);
+  createNamespace(namespace, shellOpts);
 }
 
-export async function wipePreviewEnvironmentHelm(helmInstallName: string, namespace: string, shellOpts: ExecOptions) {
-    // uninstall helm first so that:
-    //  - ws-scaler can't create new ghosts in the meantime
-    //  - ws-manager can't start new probes/workspaces
-    uninstallHelm(helmInstallName, namespace, shellOpts)
+export async function wipePreviewEnvironmentHelm(
+  helmInstallName: string,
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  // uninstall helm first so that:
+  //  - ws-scaler can't create new ghosts in the meantime
+  //  - ws-manager can't start new probes/workspaces
+  uninstallHelm(helmInstallName, namespace, shellOpts);
 }
 
-async function wipePreviewEnvironmentInstaller(namespace: string, shellOpts: ExecOptions) {
-    const slice = shellOpts.slice || "installer";
-    const werft = getGlobalWerftInstance();
+async function wipePreviewEnvironmentInstaller(
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  const slice = shellOpts.slice || "installer";
+  const werft = getGlobalWerftInstance();
 
-    const hasGitpodConfigmap = (exec(`kubectl -n ${namespace} get configmap gitpod-app`, { slice, dontCheckRc: true })).code === 0;
-    if (hasGitpodConfigmap) {
-        werft.log(slice, `${namespace} has Gitpod configmap, proceeding with removal`);
-        const inWerftFolder = exec(`pwd`, { slice, dontCheckRc: true }).stdout.trim().endsWith(".werft");
-        if (inWerftFolder) {
-            // used in .werft/wipe-devstaging.yaml on preview environment clean-up
-            exec(`./util/uninstall-gitpod.sh ${namespace}`, { slice });
-        } else {
-            // used in .werft/build.yaml on 'with-clean-slate-deployment=true'
-            exec(`./.werft/util/uninstall-gitpod.sh ${namespace}`, { slice });
-        }
-
+  const hasGitpodConfigmap =
+    exec(`kubectl -n ${namespace} get configmap gitpod-app`, {
+      slice,
+      dontCheckRc: true,
+    }).code === 0;
+  if (hasGitpodConfigmap) {
+    werft.log(
+      slice,
+      `${namespace} has Gitpod configmap, proceeding with removal`
+    );
+    const inWerftFolder = exec(`pwd`, { slice, dontCheckRc: true })
+      .stdout.trim()
+      .endsWith(".werft");
+    if (inWerftFolder) {
+      // used in .werft/wipe-devstaging.yaml on preview environment clean-up
+      exec(`./util/uninstall-gitpod.sh ${namespace}`, { slice });
     } else {
-        werft.log(slice, `There is no Gitpod configmap, moving on`);
+      // used in .werft/build.yaml on 'with-clean-slate-deployment=true'
+      exec(`./.werft/util/uninstall-gitpod.sh ${namespace}`, { slice });
     }
+  } else {
+    werft.log(slice, `There is no Gitpod configmap, moving on`);
+  }
 }
 
-function uninstallHelm(installationName: string, namespace: string, shellOpts: ExecOptions) {
-    const installations = exec(`helm --namespace ${namespace} list -q`, { ...shellOpts, silent: true, dontCheckRc: true, async: false })
-        .stdout
-        .split("\n")
-        .map(o => o.trim())
-        .filter(o => o.length > 0);
-    if (!installations.some(i => i === installationName)) {
-        return;
-    }
+function uninstallHelm(
+  installationName: string,
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  const installations = exec(`helm --namespace ${namespace} list -q`, {
+    ...shellOpts,
+    silent: true,
+    dontCheckRc: true,
+    async: false,
+  })
+    .stdout.split("\n")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
+  if (!installations.some((i) => i === installationName)) {
+    return;
+  }
 
-    exec(`helm --namespace ${namespace} delete ${installationName} --wait`, shellOpts);
+  exec(
+    `helm --namespace ${namespace} delete ${installationName} --wait`,
+    shellOpts
+  );
 }
 
 // Delete pods for running workspaces, even if they are stuck in terminating because of the finalizer decorator
 function deleteAllWorkspaces(namespace: string, shellOpts: ExecOptions) {
-    const objs = exec(`kubectl get pod -l component=workspace --namespace ${namespace} --no-headers -o=custom-columns=:metadata.name`, { ...shellOpts, async: false })
-        .split("\n")
-        .map(o => o.trim())
-        .filter(o => o.length > 0);
+  const objs = exec(
+    `kubectl get pod -l component=workspace --namespace ${namespace} --no-headers -o=custom-columns=:metadata.name`,
+    { ...shellOpts, async: false }
+  )
+    .split("\n")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
 
-    objs.forEach(o => {
-        try {
-            // In most cases the calls below fails because the workspace is already gone. Ignore those cases, log others.
-            exec(`kubectl patch pod --namespace ${namespace} ${o} -p '{"metadata":{"finalizers":null}}'`, { ...shellOpts });
-            const result = exec(`kubectl delete pod --namespace ${namespace} ${o} --ignore-not-found=true --timeout=10s`, { ...shellOpts, async: false, dontCheckRc: true });
-            if (result.code !== 0) {
-                // We hit a timeout, and have no clue why. Manually re-trying has shown to consistenly being not helpful, either. Thus use THE FORCE.
-                exec(`kubectl delete pod --namespace ${namespace} ${o} --ignore-not-found=true --force`, { ...shellOpts });
-            }
-        } catch (err) {
-            const result = exec(`kubectl get pod --namespace ${namespace} ${o}`, { ...shellOpts, dontCheckRc: true, async: false });
-            if (result.code === 0) {
-                console.error(`unable to patch/delete ${o} but it's still on the dataplane`);
-            }
-        }
-    });
+  objs.forEach((o) => {
+    try {
+      // In most cases the calls below fails because the workspace is already gone. Ignore those cases, log others.
+      exec(
+        `kubectl patch pod --namespace ${namespace} ${o} -p '{"metadata":{"finalizers":null}}'`,
+        { ...shellOpts }
+      );
+      const result = exec(
+        `kubectl delete pod --namespace ${namespace} ${o} --ignore-not-found=true --timeout=10s`,
+        { ...shellOpts, async: false, dontCheckRc: true }
+      );
+      if (result.code !== 0) {
+        // We hit a timeout, and have no clue why. Manually re-trying has shown to consistenly being not helpful, either. Thus use THE FORCE.
+        exec(
+          `kubectl delete pod --namespace ${namespace} ${o} --ignore-not-found=true --force`,
+          { ...shellOpts }
+        );
+      }
+    } catch (err) {
+      const result = exec(`kubectl get pod --namespace ${namespace} ${o}`, {
+        ...shellOpts,
+        dontCheckRc: true,
+        async: false,
+      });
+      if (result.code === 0) {
+        console.error(
+          `unable to patch/delete ${o} but it's still on the dataplane`
+        );
+      }
+    }
+  });
 }
 
 // deleteAllUnnamespacedObjects deletes all unnamespaced objects for the given namespace
-async function deleteAllUnnamespacedObjects(namespace: string, shellOpts: ExecOptions): Promise<void> {
-    const werft = getGlobalWerftInstance()
-    const slice = shellOpts.slice || "deleteobjs";
+async function deleteAllUnnamespacedObjects(
+  namespace: string,
+  shellOpts: ExecOptions
+): Promise<void> {
+  const werft = getGlobalWerftInstance();
+  const slice = shellOpts.slice || "deleteobjs";
 
-    const promisedDeletes: Promise<any>[] = [];
-    for (const resType of ["clusterrole", "clusterrolebinding", "podsecuritypolicy"]) {
-        werft.log(slice, `Searching and filtering ${resType}s...`);
-        const objs = exec(`kubectl get ${resType} --no-headers -o=custom-columns=:metadata.name`, { ...shellOpts, slice, async: false })
-            .split("\n")
-            .map(o => o.trim())
-            .filter(o => o.length > 0)
-            .filter(o => o.startsWith(`${namespace}-ns-`)); // "{{ .Release.Namespace }}-ns-" is the prefix-pattern we use throughout our helm resources for un-namespaced resources
+  const promisedDeletes: Promise<any>[] = [];
+  for (const resType of [
+    "clusterrole",
+    "clusterrolebinding",
+    "podsecuritypolicy",
+  ]) {
+    werft.log(slice, `Searching and filtering ${resType}s...`);
+    const objs = exec(
+      `kubectl get ${resType} --no-headers -o=custom-columns=:metadata.name`,
+      { ...shellOpts, slice, async: false }
+    )
+      .split("\n")
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0)
+      .filter((o) => o.startsWith(`${namespace}-ns-`)); // "{{ .Release.Namespace }}-ns-" is the prefix-pattern we use throughout our helm resources for un-namespaced resources
 
-        werft.log(slice, `Deleting old ${resType}s...`);
-        for (const obj of objs) {
-            promisedDeletes.push(exec(`kubectl delete ${resType} ${obj}`, { ...shellOpts, slice, async: true }) as Promise<any>);
-        }
+    werft.log(slice, `Deleting old ${resType}s...`);
+    for (const obj of objs) {
+      promisedDeletes.push(
+        exec(`kubectl delete ${resType} ${obj}`, {
+          ...shellOpts,
+          slice,
+          async: true,
+        }) as Promise<any>
+      );
     }
-    await Promise.all(promisedDeletes);
+  }
+  await Promise.all(promisedDeletes);
 }
 
 export function createNamespace(namespace: string, shellOpts: ExecOptions) {
-    const result = (exec(`kubectl get namespace ${namespace}`, { ...shellOpts, dontCheckRc: true, async: false }));
-    const exists = result.code === 0;
-    if (exists) {
-        return;
-    }
+  const result = exec(`kubectl get namespace ${namespace}`, {
+    ...shellOpts,
+    dontCheckRc: true,
+    async: false,
+  });
+  const exists = result.code === 0;
+  if (exists) {
+    return;
+  }
 
-    // (re-)create namespace
-    [
-        `kubectl create namespace ${namespace}`,
-        `kubectl patch namespace ${namespace} --patch '{"metadata": {"labels": {"${IS_PREVIEW_APP_LABEL}": "true"}}}'`
-    ].forEach((cmd) => exec(cmd, shellOpts));
-};
+  // (re-)create namespace
+  [
+    `kubectl create namespace ${namespace}`,
+    `kubectl patch namespace ${namespace} --patch '{"metadata": {"labels": {"${IS_PREVIEW_APP_LABEL}": "true"}}}'`,
+  ].forEach((cmd) => exec(cmd, shellOpts));
+}
 
 export function listAllPreviewNamespaces(shellOpts: ExecOptions): string[] {
-    return exec(`kubectl get namespaces -l ${IS_PREVIEW_APP_LABEL}=true -o=custom-columns=:metadata.name`, { ...shellOpts, silent: true, async: false })
-        .stdout
-        .split("\n")
-        .map(o => o.trim())
-        .filter(o => o.length > 0);
+  return exec(
+    `kubectl get namespaces -l ${IS_PREVIEW_APP_LABEL}=true -o=custom-columns=:metadata.name`,
+    { ...shellOpts, silent: true, async: false }
+  )
+    .stdout.split("\n")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
 }
 
-export function deleteNamespace(wait: boolean, namespace: string, shellOpts: ExecOptions) {
-    // check if present
-    const result = (exec(`kubectl get namespace ${namespace}`, { ...shellOpts, dontCheckRc: true, async: false }));
-    if (result.code !== 0) {
-        return;
-    }
+export function deleteNamespace(
+  wait: boolean,
+  namespace: string,
+  shellOpts: ExecOptions
+) {
+  // check if present
+  const result = exec(`kubectl get namespace ${namespace}`, {
+    ...shellOpts,
+    dontCheckRc: true,
+    async: false,
+  });
+  if (result.code !== 0) {
+    return;
+  }
 
-    const cmd = `kubectl delete namespace ${namespace}`;
-    exec(cmd, shellOpts);
+  const cmd = `kubectl delete namespace ${namespace}`;
+  exec(cmd, shellOpts);
 
-    // wait until deletion was successful
-    while (wait) {
-        const result = (exec(`kubectl get namespace ${namespace}`, { ...shellOpts, dontCheckRc: true, async: false }));
-        wait = result.code === 0;
-    }
-}
-
-export async function deleteNonNamespaceObjects(namespace: string, destname: string, shellOpts: ExecOptions) {
-    exec(`/usr/local/bin/helm3 delete gitpod-${destname} || echo gitpod-${destname} was not installed yet`, { ...shellOpts });
-
-    let objs = [];
-    ["node-daemon", "cluster", "workspace", "ws-sync", "ws-manager-node", "ws-daemon", "registry-facade"].forEach(comp =>
-        ["ClusterRole", "ClusterRoleBinding", "PodSecurityPolicy"].forEach(kind =>
-            exec(`kubectl get ${kind} -l component=${comp} --no-headers -o=custom-columns=:metadata.name | grep ${namespace}-ns`, { ...shellOpts, dontCheckRc: true, async: false })
-                .split("\n")
-                .map(o => o.trim())
-                .filter(o => o.length > 0)
-                .forEach(obj => objs.push({ 'kind': kind, 'obj': obj }))
-        )
-    )
-
-    const promisedDeletes: Promise<any>[] = [];
-    objs.forEach(o => {
-        promisedDeletes.push(exec(`kubectl delete ${o.kind} ${o.obj}`, {...shellOpts, async: true}) as Promise<any>);
+  // wait until deletion was successful
+  while (wait) {
+    const result = exec(`kubectl get namespace ${namespace}`, {
+      ...shellOpts,
+      dontCheckRc: true,
+      async: false,
     });
-    await Promise.all(promisedDeletes);
+    wait = result.code === 0;
+  }
+}
+
+export async function deleteNonNamespaceObjects(
+  namespace: string,
+  destname: string,
+  shellOpts: ExecOptions
+) {
+  exec(
+    `/usr/local/bin/helm3 delete gitpod-${destname} || echo gitpod-${destname} was not installed yet`,
+    { ...shellOpts }
+  );
+
+  let objs = [];
+  [
+    "node-daemon",
+    "cluster",
+    "workspace",
+    "ws-sync",
+    "ws-manager-node",
+    "ws-daemon",
+    "registry-facade",
+  ].forEach((comp) =>
+    ["ClusterRole", "ClusterRoleBinding", "PodSecurityPolicy"].forEach((kind) =>
+      exec(
+        `kubectl get ${kind} -l component=${comp} --no-headers -o=custom-columns=:metadata.name | grep ${namespace}-ns`,
+        { ...shellOpts, dontCheckRc: true, async: false }
+      )
+        .split("\n")
+        .map((o) => o.trim())
+        .filter((o) => o.length > 0)
+        .forEach((obj) => objs.push({ kind: kind, obj: obj }))
+    )
+  );
+
+  const promisedDeletes: Promise<any>[] = [];
+  objs.forEach((o) => {
+    promisedDeletes.push(
+      exec(`kubectl delete ${o.kind} ${o.obj}`, {
+        ...shellOpts,
+        async: true,
+      }) as Promise<any>
+    );
+  });
+  await Promise.all(promisedDeletes);
 }
 
 export interface PortRange {
-    start: number;
-    end: number;
+  start: number;
+  end: number;
 }
 
-export function findLastHostPort(namespace: string, name: string, shellOpts: ExecOptions): number {
-    const portStr = exec(`kubectl get ds -n ${namespace} ${name} -o yaml | yq r - 'spec.template.spec.containers.*.ports.*.hostPort'`, { ...shellOpts, silent: true, async: false }).stdout
-    return Number.parseInt(portStr)
+export function findLastHostPort(
+  namespace: string,
+  name: string,
+  shellOpts: ExecOptions
+): number {
+  const portStr = exec(
+    `kubectl get ds -n ${namespace} ${name} -o yaml | yq r - 'spec.template.spec.containers.*.ports.*.hostPort'`,
+    { ...shellOpts, silent: true, async: false }
+  ).stdout;
+  return Number.parseInt(portStr);
 }
 
-export function findFreeHostPorts(ranges: PortRange[], shellOpts: ExecOptions): number[] {
-    const werft = getGlobalWerftInstance()
-    const hostPorts: number[] = exec(`kubectl get pods --all-namespaces -o yaml | yq r - 'items.*.spec.containers.*.ports.*.hostPort'`, { ...shellOpts, silent: true, async: false })
-        .stdout
-        .split("\n")
-        .map(l => l.trim())
-        .filter(l => l.length > 0)
-        .map(l => Number.parseInt(l));
+export function findFreeHostPorts(
+  ranges: PortRange[],
+  shellOpts: ExecOptions
+): number[] {
+  const werft = getGlobalWerftInstance();
+  const hostPorts: number[] = exec(
+    `kubectl get pods --all-namespaces -o yaml | yq r - 'items.*.spec.containers.*.ports.*.hostPort'`,
+    { ...shellOpts, silent: true, async: false }
+  )
+    .stdout.split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => Number.parseInt(l));
 
-    const nodePorts: number[] = exec(`kubectl get services --all-namespaces -o yaml | yq r - 'items.*.spec.ports.*.nodePort'`, { ...shellOpts, silent: true, async: false })
-        .stdout
-        .split("\n")
-        .map(l => l.trim())
-        .filter(l => l.length > 0)
-        .map(l => Number.parseInt(l));
-    const alreadyReservedPorts: Set<number> = new Set();
-    for (const port of hostPorts) {
-        alreadyReservedPorts.add(port);
-    }
-    for (const port of nodePorts) {
-        alreadyReservedPorts.add(port);
-    }
-    werft.log(shellOpts.slice, `already reserved ports: ${Array.from(alreadyReservedPorts.values()).map(p => ""+p).join(", ")}`);
+  const nodePorts: number[] = exec(
+    `kubectl get services --all-namespaces -o yaml | yq r - 'items.*.spec.ports.*.nodePort'`,
+    { ...shellOpts, silent: true, async: false }
+  )
+    .stdout.split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => Number.parseInt(l));
+  const alreadyReservedPorts: Set<number> = new Set();
+  for (const port of hostPorts) {
+    alreadyReservedPorts.add(port);
+  }
+  for (const port of nodePorts) {
+    alreadyReservedPorts.add(port);
+  }
+  werft.log(
+    shellOpts.slice,
+    `already reserved ports: ${Array.from(alreadyReservedPorts.values())
+      .map((p) => "" + p)
+      .join(", ")}`
+  );
 
-    const results: number[] = [];
-    for (const range of ranges) {
-        const r = range.end - range.start;
-        while (true) {
-            const hostPort = range.start + Math.floor(Math.random() * r);
-            if (alreadyReservedPorts.has(hostPort)) {
-                continue;
-            }
+  const results: number[] = [];
+  for (const range of ranges) {
+    const r = range.end - range.start;
+    while (true) {
+      const hostPort = range.start + Math.floor(Math.random() * r);
+      if (alreadyReservedPorts.has(hostPort)) {
+        continue;
+      }
 
-            // found one, now find the others
-            results.push(hostPort);
-            alreadyReservedPorts.add(hostPort);
-            break;
-        }
+      // found one, now find the others
+      results.push(hostPort);
+      alreadyReservedPorts.add(hostPort);
+      break;
     }
-    return results;
+  }
+  return results;
 }
 
-export function waitForDeploymentToSucceed(name: string, namespace: string, type: string, shellOpts: ExecOptions) {
-    exec(`kubectl rollout status ${type} ${name} -n ${namespace}`, shellOpts);
+export function waitForDeploymentToSucceed(
+  name: string,
+  namespace: string,
+  type: string,
+  shellOpts: ExecOptions
+) {
+  exec(`kubectl rollout status ${type} ${name} -n ${namespace}`, shellOpts);
 }

--- a/.werft/util/shell.ts
+++ b/.werft/util/shell.ts
@@ -1,71 +1,88 @@
-import * as shell from 'shelljs';
-import * as fs from 'fs';
-import { ChildProcess } from 'child_process';
-import { getGlobalWerftInstance } from './werft';
+import * as shell from "shelljs";
+import * as fs from "fs";
+import { ChildProcess } from "child_process";
+import { getGlobalWerftInstance } from "./werft";
 
 export type ExecOptions = shell.ExecOptions & {
-    slice?: string;
-    dontCheckRc?: boolean;
+  slice?: string;
+  dontCheckRc?: boolean;
 };
 export type ExecResult = {
-    code: number;
-    stdout: string;
-    stderr: string;
+  code: number;
+  stdout: string;
+  stderr: string;
 };
 
 // exec executes a command and throws an exception if that command exits with a non-zero exit code
 export function exec(command: string): shell.ShellString;
-export function exec(command: string, options: ExecOptions & { async?: false }): shell.ShellString;
-export function exec(command: string, options: ExecOptions & { async: true }): Promise<ExecResult>;
-export function exec(command: string, options: ExecOptions): shell.ShellString | ChildProcess;
-export function exec(cmd: string, options?: ExecOptions): ChildProcess | shell.ShellString | Promise<ExecResult> {
-    const werft = getGlobalWerftInstance()
+export function exec(
+  command: string,
+  options: ExecOptions & { async?: false }
+): shell.ShellString;
+export function exec(
+  command: string,
+  options: ExecOptions & { async: true }
+): Promise<ExecResult>;
+export function exec(
+  command: string,
+  options: ExecOptions
+): shell.ShellString | ChildProcess;
+export function exec(
+  cmd: string,
+  options?: ExecOptions
+): ChildProcess | shell.ShellString | Promise<ExecResult> {
+  const werft = getGlobalWerftInstance();
 
+  if (options && options.slice) {
+    options.silent = true;
+  }
+
+  const handleResult = (result, options) => {
     if (options && options.slice) {
-        options.silent = true;
+      werft.logOutput(options.slice, result.stderr || result.stdout);
     }
 
-    const handleResult = (result, options) => {
-        if (options && options.slice) {
-            werft.logOutput(options.slice, result.stderr || result.stdout);
-        }
-
-        if ((!options || !options.dontCheckRc) && result.code !== 0) {
-            throw new Error(`${cmd} exit with non-zero status code`);
-        }
-    };
-
-    if (options && options.async) {
-        return new Promise<ExecResult>((resolve, reject) => {
-            shell.exec(cmd, options, (code, stdout, stderr) => {
-                try {
-                    const result: ExecResult = { code, stdout, stderr };
-                    handleResult(result, options);
-                    resolve(result);
-                } catch (err) {
-                    reject(err)
-                }
-            });
-        });
-    } else {
-        const result = shell.exec(cmd, options);
-        handleResult(result, options);
-        return result;
+    if ((!options || !options.dontCheckRc) && result.code !== 0) {
+      throw new Error(`${cmd} exit with non-zero status code`);
     }
+  };
+
+  if (options && options.async) {
+    return new Promise<ExecResult>((resolve, reject) => {
+      shell.exec(cmd, options, (code, stdout, stderr) => {
+        try {
+          const result: ExecResult = { code, stdout, stderr };
+          handleResult(result, options);
+          resolve(result);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  } else {
+    const result = shell.exec(cmd, options);
+    handleResult(result, options);
+    return result;
+  }
 }
 
 // gitTag tags the current state and pushes that tag to the repo origin
 export const gitTag = (tag) => {
-    shell.mkdir("/root/.ssh")
-    fs.writeFileSync("/root/.ssh/config", `Host github.com
+  shell.mkdir("/root/.ssh");
+  fs.writeFileSync(
+    "/root/.ssh/config",
+    `Host github.com
     UserKnownHostsFile=/dev/null
     StrictHostKeyChecking no
     IdentitiesOnly yes
-    IdentityFile /mnt/secrets/github-ssh-key/github-ssh-key.pem`)
-    shell.chmod(600, '/root/.ssh/*')
-    shell.chmod(700, '/root/.ssh')
+    IdentityFile /mnt/secrets/github-ssh-key/github-ssh-key.pem`
+  );
+  shell.chmod(600, "/root/.ssh/*");
+  shell.chmod(700, "/root/.ssh");
 
-    exec("git config --global url.ssh://git@github.com/.insteadOf https://github.com/")
-    exec(`git tag -f ${tag}`)
-    exec(`git push -f origin ${tag}`)
-}
+  exec(
+    "git config --global url.ssh://git@github.com/.insteadOf https://github.com/"
+  );
+  exec(`git tag -f ${tag}`);
+  exec(`git push -f origin ${tag}`);
+};

--- a/.werft/util/slack.ts
+++ b/.werft/util/slack.ts
@@ -1,47 +1,60 @@
-import * as https from 'https';
+import * as https from "https";
 
 export function reportBuildFailureInSlack(context, err, onErr) {
-    const repo = context.Repository.host + "/" + context.Repository.owner + "/" + context.Repository.repo;
-    const data = JSON.stringify({
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": ":X: *build failure*\n_Repo:_ `" + repo + "`\n_Build:_ `" + context.Name + "`"
-                },
-                "accessory": {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Go to Werft",
-                        "emoji": true
-                    },
-                    "value": "click_me_123",
-                    "url": "https://werft.gitpod-dev.com/job/" + context.Name,
-                    "action_id": "button-action"
-                }
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "```\n" + err + "\n```"
-                }
-            }
-        ]
-    });
-    const req = https.request({
-        hostname: "hooks.slack.com",
-        port: 443,
-        path: process.env.SLACK_NOTIFICATION_PATH.trim(),
-        method: "POST",
-        headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': data.length,
-        }
-    }, onErr);
-    req.on('error', onErr);
-    req.write(data);
-    req.end();
+  const repo =
+    context.Repository.host +
+    "/" +
+    context.Repository.owner +
+    "/" +
+    context.Repository.repo;
+  const data = JSON.stringify({
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            ":X: *build failure*\n_Repo:_ `" +
+            repo +
+            "`\n_Build:_ `" +
+            context.Name +
+            "`",
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Go to Werft",
+            emoji: true,
+          },
+          value: "click_me_123",
+          url: "https://werft.gitpod-dev.com/job/" + context.Name,
+          action_id: "button-action",
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "```\n" + err + "\n```",
+        },
+      },
+    ],
+  });
+  const req = https.request(
+    {
+      hostname: "hooks.slack.com",
+      port: 443,
+      path: process.env.SLACK_NOTIFICATION_PATH.trim(),
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": data.length,
+      },
+    },
+    onErr
+  );
+  req.on("error", onErr);
+  req.write(data);
+  req.end();
 }

--- a/.werft/util/util.ts
+++ b/.werft/util/util.ts
@@ -1,30 +1,34 @@
 import { ExecOptions } from "./shell";
 
 export async function sleep(millis: number) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, millis);
-    });
+  return new Promise((resolve) => {
+    setTimeout(resolve, millis);
+  });
 }
 
 export function validateIPaddress(ipaddress) {
-  if (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress)) {
-    return true
+  if (
+    /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+      ipaddress
+    )
+  ) {
+    return true;
   }
-  return false
+  return false;
 }
 
 export function env(k8sConfigPath: string, _parent?: ExecOptions): ExecOptions {
-    const parent = _parent || {};
-    if (!parent.env) {
-        parent.env = {
-            ...process.env,
-        };
+  const parent = _parent || {};
+  if (!parent.env) {
+    parent.env = {
+      ...process.env,
     };
-    return {
-        ...parent,
-        env: {
-            ...parent.env,
-            "KUBECONFIG": k8sConfigPath,
-        },
-    }
+  }
+  return {
+    ...parent,
+    env: {
+      ...parent.env,
+      KUBECONFIG: k8sConfigPath,
+    },
+  };
 }

--- a/.werft/util/werft.ts
+++ b/.werft/util/werft.ts
@@ -1,5 +1,11 @@
-import { Span, Tracer, trace, context, SpanStatusCode } from '@opentelemetry/api';
-import { exec } from './shell';
+import {
+  Span,
+  Tracer,
+  trace,
+  context,
+  SpanStatusCode,
+} from "@opentelemetry/api";
+import { exec } from "./shell";
 
 let werft: Werft;
 
@@ -7,112 +13,137 @@ let werft: Werft;
  * For backwards compatibility with existing code we expose a global Werft instance
  */
 export function getGlobalWerftInstance() {
-    if (!werft) {
-        throw new Error("Trying to fetch global Werft instance but it hasn't been instantiated yet")
-    }
-    return werft
+  if (!werft) {
+    throw new Error(
+      "Trying to fetch global Werft instance but it hasn't been instantiated yet"
+    );
+  }
+  return werft;
 }
 
 /**
  * Class for producing Werft compatible log output and generating traces
  */
 export class Werft {
-    private tracer: Tracer;
-    public rootSpan: Span;
-    private sliceSpans: { [slice: string]: Span } = {}
-    public currentPhaseSpan: Span;
+  private tracer: Tracer;
+  public rootSpan: Span;
+  private sliceSpans: { [slice: string]: Span } = {};
+  public currentPhaseSpan: Span;
 
-    constructor(job: string) {
-        if (werft) {
-            throw new Error("Only one Werft instance should be instantiated per job")
+  constructor(job: string) {
+    if (werft) {
+      throw new Error("Only one Werft instance should be instantiated per job");
+    }
+    this.tracer = trace.getTracer("default");
+    this.rootSpan = this.tracer.startSpan(`job: ${job}`, {
+      root: true,
+      attributes: { "werft.job.name": job },
+    });
+
+    // Expose this instance as part of getGlobalWerftInstance
+    werft = this;
+  }
+
+  public phase(name, desc?: string) {
+    // When you start a new phase the previous phase is implicitly closed.
+    if (this.currentPhaseSpan) {
+      this.endPhase();
+    }
+
+    const rootSpanCtx = trace.setSpan(context.active(), this.rootSpan);
+    this.currentPhaseSpan = this.tracer.startSpan(
+      `phase: ${name}`,
+      {
+        attributes: {
+          "werft.phase.name": name,
+          "werft.phase.description": desc,
+        },
+      },
+      rootSpanCtx
+    );
+
+    console.log(`[${name}|PHASE] ${desc || name}`);
+  }
+
+  public log(slice, msg) {
+    if (!this.sliceSpans[slice]) {
+      const parentSpanCtx = trace.setSpan(
+        context.active(),
+        this.currentPhaseSpan
+      );
+      const sliceSpan = this.tracer.startSpan(
+        `slice: ${slice}`,
+        undefined,
+        parentSpanCtx
+      );
+      this.sliceSpans[slice] = sliceSpan;
+    }
+    console.log(`[${slice}] ${msg}`);
+  }
+
+  public logOutput(slice, cmd) {
+    cmd
+      .toString()
+      .split("\n")
+      .forEach((line: string) => this.log(slice, line));
+  }
+
+  public fail(slice, err) {
+    // Set the status on the span for the slice and also propagate the status to the phase and root span
+    // as well so we can query on all phases that had an error regardless of which slice produced the error.
+    [this.sliceSpans[slice], this.rootSpan, this.currentPhaseSpan].forEach(
+      (span: Span) => {
+        if (!span) {
+          return;
         }
-        this.tracer = trace.getTracer("default");
-        this.rootSpan = this.tracer.startSpan(`job: ${job}`, { root: true, attributes: { 'werft.job.name': job } });
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err,
+        });
+      }
+    );
 
-        // Expose this instance as part of getGlobalWerftInstance
-        werft = this;
+    this.endAllSpans();
+
+    console.log(`[${slice}|FAIL] ${err}`);
+    throw err;
+  }
+
+  public done(slice: string) {
+    const span = this.sliceSpans[slice];
+    if (span) {
+      span.end();
+      delete this.sliceSpans[slice];
     }
+    console.log(`[${slice}|DONE]`);
+  }
 
-    public phase(name, desc?: string) {
-        // When you start a new phase the previous phase is implicitly closed.
-        if (this.currentPhaseSpan) {
-            this.endPhase()
-        }
+  public result(description: string, channel: string, value: string) {
+    exec(`werft log result -d "${description}" -c "${channel}" ${value}`);
+  }
 
-        const rootSpanCtx = trace.setSpan(context.active(), this.rootSpan);
-        this.currentPhaseSpan = this.tracer.startSpan(`phase: ${name}`, {
-            attributes: {
-                'werft.phase.name': name,
-                'werft.phase.description': desc
-            }
-        }, rootSpanCtx)
+  private endPhase() {
+    // End all open slices
+    Object.entries(this.sliceSpans).forEach((kv) => {
+      const [id, span] = kv;
+      span.end();
+      delete this.sliceSpans[id];
+    });
+    // End the phase
+    this.currentPhaseSpan.end();
+  }
 
-        console.log(`[${name}|PHASE] ${desc || name}`)
-    }
-
-    public log(slice, msg) {
-        if (!this.sliceSpans[slice]) {
-            const parentSpanCtx = trace.setSpan(context.active(), this.currentPhaseSpan);
-            const sliceSpan = this.tracer.startSpan(`slice: ${slice}`, undefined, parentSpanCtx)
-            this.sliceSpans[slice] = sliceSpan
-        }
-        console.log(`[${slice}] ${msg}`)
-    }
-
-    public logOutput(slice, cmd) {
-        cmd.toString().split("\n").forEach((line: string) => this.log(slice, line))
-    }
-
-    public fail(slice, err) {
-        // Set the status on the span for the slice and also propagate the status to the phase and root span
-        // as well so we can query on all phases that had an error regardless of which slice produced the error.
-        [this.sliceSpans[slice], this.rootSpan, this.currentPhaseSpan].forEach((span: Span) => {
-            if (!span) {
-                return
-            }
-            span.setStatus({
-                code: SpanStatusCode.ERROR,
-                message: err
-            })
-        })
-
-        this.endAllSpans()
-
-        console.log(`[${slice}|FAIL] ${err}`);
-        throw err;
-    }
-
-    public done(slice: string) {
-        const span = this.sliceSpans[slice]
-        if (span) {
-            span.end()
-            delete this.sliceSpans[slice]
-        }
-        console.log(`[${slice}|DONE]`)
-    }
-
-    public result(description: string, channel: string, value: string) {
-        exec(`werft log result -d "${description}" -c "${channel}" ${value}`);
-    }
-
-    private endPhase() {
-        // End all open slices
-        Object.entries(this.sliceSpans).forEach((kv) => {
-            const [id, span] = kv
-            span.end()
-            delete this.sliceSpans[id]
-        })
-        // End the phase
-        this.currentPhaseSpan.end()
-    }
-
-    public endAllSpans() {
-        const traceID = this.rootSpan.spanContext().traceId
-        const nowUnix =  Math.round(new Date().getTime() / 1000);
-        // At the moment we're just looking for traces in a 30 minutes timerange with the specific traceID
-        // A smarter approach would be to get a start timestamp from tracing.Initialize()
-        exec(`werft log result -d "Honeycomb trace" -c github-check-honeycomb-trace url "https://ui.honeycomb.io/gitpod/datasets/werft/trace?trace_id=${traceID}&trace_start_ts=${nowUnix - 1800}&trace_end_ts=${nowUnix + 5}"`);
-        this.endPhase()
-        this.rootSpan.end()
-    }
+  public endAllSpans() {
+    const traceID = this.rootSpan.spanContext().traceId;
+    const nowUnix = Math.round(new Date().getTime() / 1000);
+    // At the moment we're just looking for traces in a 30 minutes timerange with the specific traceID
+    // A smarter approach would be to get a start timestamp from tracing.Initialize()
+    exec(
+      `werft log result -d "Honeycomb trace" -c github-check-honeycomb-trace url "https://ui.honeycomb.io/gitpod/datasets/werft/trace?trace_id=${traceID}&trace_start_ts=${
+        nowUnix - 1800
+      }&trace_end_ts=${nowUnix + 5}"`
+    );
+    this.endPhase();
+    this.rootSpan.end();
+  }
 }

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -1,6 +1,6 @@
 type NamespaceManifestOptions = {
-  namespace: string
-}
+  namespace: string;
+};
 
 export function NamespaceManifest({ namespace }: NamespaceManifestOptions) {
   return `
@@ -8,17 +8,22 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ${namespace}
-`
+`;
 }
 
 type VirtualMachineManifestArguments = {
-  vmName: string
-  namespace: string
-  claimName: string
-  userDataSecretName: string
-}
+  vmName: string;
+  namespace: string;
+  claimName: string;
+  userDataSecretName: string;
+};
 
-export function VirtualMachineManifest({ vmName, namespace, claimName, userDataSecretName }: VirtualMachineManifestArguments) {
+export function VirtualMachineManifest({
+  vmName,
+  namespace,
+  claimName,
+  userDataSecretName,
+}: VirtualMachineManifestArguments) {
   return `
 apiVersion: kubevirt.io/v1
 type: kubevirt.io.virtualmachine
@@ -89,13 +94,13 @@ spec:
             secretRef:
               name: ${userDataSecretName}
 
-`
+`;
 }
 
 type ServiceManifestOptions = {
-  vmName: string
-  namespace: string
-}
+  vmName: string;
+  namespace: string;
+};
 
 export function ServiceManifest({ vmName, namespace }: ServiceManifestOptions) {
   return `
@@ -137,17 +142,22 @@ spec:
   selector:
     harvesterhci.io/vmName: ${vmName}
   type: ClusterIP
-`
+`;
 }
 
 type UserDataSecretManifestOptions = {
-  vmName: string
-  namespace: string,
-  secretName: string
-}
+  vmName: string;
+  namespace: string;
+  secretName: string;
+};
 
-export function UserDataSecretManifest({vmName, namespace, secretName }: UserDataSecretManifestOptions) {
-  const userdata = Buffer.from(`#cloud-config
+export function UserDataSecretManifest({
+  vmName,
+  namespace,
+  secretName,
+}: UserDataSecretManifestOptions) {
+  const userdata = Buffer.from(
+    `#cloud-config
 users:
 - name: ubuntu
   sudo: "ALL=(ALL) NOPASSWD: ALL"
@@ -213,7 +223,8 @@ write_files:
       export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
       EOF
 runcmd:
- - bash /usr/local/bin/bootstrap-k3s.sh`).toString("base64")
+ - bash /usr/local/bin/bootstrap-k3s.sh`
+  ).toString("base64");
   return `
 apiVersion: v1
 type: secret
@@ -224,5 +235,5 @@ data:
 metadata:
   name: ${secretName}
   namespace: ${namespace}
-`
+`;
 }

--- a/.werft/wipe-devstaging.ts
+++ b/.werft/wipe-devstaging.ts
@@ -1,54 +1,60 @@
-import { Werft } from './util/werft'
-import { wipePreviewEnvironmentAndNamespace, listAllPreviewNamespaces, helmInstallName } from './util/kubectl';
-import * as fs from 'fs';
-import { deleteExternalIp } from './util/gcloud';
-import * as Tracing from './observability/tracing'
-import { SpanStatusCode } from '@opentelemetry/api';
-import { ExecOptions } from './util/shell';
-import { env } from './util/util';
+import { Werft } from "./util/werft";
+import {
+  wipePreviewEnvironmentAndNamespace,
+  listAllPreviewNamespaces,
+  helmInstallName,
+} from "./util/kubectl";
+import * as fs from "fs";
+import { deleteExternalIp } from "./util/gcloud";
+import * as Tracing from "./observability/tracing";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { ExecOptions } from "./util/shell";
+import { env } from "./util/util";
 
 // Will be set once tracing has been initialized
-let werft: Werft
+let werft: Werft;
 
 async function wipePreviewCluster(shellOpts: ExecOptions) {
-    const namespace_raw = process.env.NAMESPACE;
-    const namespaces: string[] = [];
-    if (namespace_raw === "<no value>" || !namespace_raw) {
-        werft.log('wipe', "Going to wipe all namespaces");
-        listAllPreviewNamespaces(shellOpts)
-            .map(ns => namespaces.push(ns));
-    } else {
-        werft.log('wipe', `Going to wipe namespace ${namespace_raw}`);
-        namespaces.push(namespace_raw);
-    }
+  const namespace_raw = process.env.NAMESPACE;
+  const namespaces: string[] = [];
+  if (namespace_raw === "<no value>" || !namespace_raw) {
+    werft.log("wipe", "Going to wipe all namespaces");
+    listAllPreviewNamespaces(shellOpts).map((ns) => namespaces.push(ns));
+  } else {
+    werft.log("wipe", `Going to wipe namespace ${namespace_raw}`);
+    namespaces.push(namespace_raw);
+  }
 
-    for (const namespace of namespaces) {
-        await wipePreviewEnvironmentAndNamespace(helmInstallName, namespace, { ...shellOpts, slice: 'wipe' });
-    }
+  for (const namespace of namespaces) {
+    await wipePreviewEnvironmentAndNamespace(helmInstallName, namespace, {
+      ...shellOpts,
+      slice: "wipe",
+    });
+  }
 }
 
 // clean up the dev cluster in gitpod-core-dev
 async function devCleanup() {
-    await wipePreviewCluster(env(""))
+  await wipePreviewCluster(env(""));
 }
 
 // sweeper runs in the dev cluster so we need to delete the k3s cluster first and then delete self contained namespace
 
 Tracing.initialize()
-    .then(() => {
-        werft = new Werft("wipe-devstaging")
-        werft.phase('wipe')
-    })
-    .then(() => devCleanup())
-    .then(() => werft.done('wipe'))
-    .then(() => werft.endAllSpans())
-    .catch((err) => {
-        werft.rootSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err
-        })
-        werft.endAllSpans()
-        console.log('Error', err)
-        // Explicitly not using process.exit as we need to flush tracing, see tracing.js
-        process.exitCode = 1
+  .then(() => {
+    werft = new Werft("wipe-devstaging");
+    werft.phase("wipe");
+  })
+  .then(() => devCleanup())
+  .then(() => werft.done("wipe"))
+  .then(() => werft.endAllSpans())
+  .catch((err) => {
+    werft.rootSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: err,
     });
+    werft.endAllSpans();
+    console.log("Error", err);
+    // Explicitly not using process.exit as we need to flush tracing, see tracing.js
+    process.exitCode = 1;
+  });

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -30,6 +30,10 @@
    ],
    "settings": {
       "typescript.tsdk": "gitpod/node_modules/typescript/lib",
+      "[typescript]": {
+         "editor.formatOnSave": true,
+         "editor.defaultFormatter": "esbenp.prettier-vscode"
+      },
       "[json]": {
          "editor.insertSpaces": true,
          "editor.tabSize": 2


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces automatic formatting of all TypeScript files in the `.werft` folder. 

1. It configures [prettier](https://prettier.io/) to perform automatic formatting on all TypeScript files in the `.werft` folder as part of our pre-commit hooks.
2. It adds `esbenp.prettier-vscode` to the list of extensions
3. It configures VSCode to fun "format on save" on TypeScript files and sets prettier as the formatter

This PR also includes performing the automatic formatting, hence the rather large diff. For the actual code review I suggest you focus on [43ca5ee](https://github.com/gitpod-io/gitpod/pull/8245/commits/43ca5ee418fbdf15433134dce9fbbc579d7d1bcb).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8066

## How to test
<!-- Provide steps to test this PR -->

Verify that it performs formatting when you run

```
pre-commit run --all-files --show-diff-on-failure
```

Edit a `ts` file in `server` and verify it doesn't use prettier to format the file when saving (that is, the prettier extension that is now installed as part of the workspace correctly ignores the entire components folder)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A