### PR TITLE
Add env var name/value length validation

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -242,11 +242,17 @@ export namespace UserEnvVar {
         if (name.trim() === "") {
             return "Name must not be empty.";
         }
+        if (name.length > 255) {
+            return 'Name too long. Maximum name length is 255 characters.';
+        }
         if (!/^[a-zA-Z_]+[a-zA-Z0-9_]*$/.test(name)) {
             return "Name must match /^[a-zA-Z_]+[a-zA-Z0-9_]*$/.";
         }
         if (variable.value.trim() === "") {
             return "Value must not be empty.";
+        }
+        if (variable.value.length > 32768) {
+            return 'Value too long. Maximum value length is 32768 characters.';
         }
         if (pattern.trim() === "") {
             return "Scope must not be empty.";

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -251,8 +251,8 @@ export namespace UserEnvVar {
         if (variable.value.trim() === "") {
             return "Value must not be empty.";
         }
-        if (variable.value.length > 32768) {
-            return 'Value too long. Maximum value length is 32768 characters.';
+        if (variable.value.length > 32767) {
+            return 'Value too long. Maximum value length is 32767 characters.';
         }
         if (pattern.trim() === "") {
             return "Scope must not be empty.";


### PR DESCRIPTION
Redo #8046, this time with shorter branch name that werft [can digest](https://github.com/gitpod-io/gitpod/pull/8046#issuecomment-1041383189).

Fixes #8045.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add user environment variable name length and value length validation in settings UI modal.
```