### PR TITLE
[jb] clarify to install release not EAP gateway

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/doc/installing.md
+++ b/components/ide/jetbrains/gateway-plugin/doc/installing.md
@@ -1,5 +1,6 @@
 ## Installing Gitpod plugin in JetBrains Gateway
 
-- Install latest [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/)
+- Install latest [JetBrains Gateway](https://www.jetbrains.com/help/idea/remote-development-a.html#gateway)
+  - Please make sure to install Release, not EAP version.
 - Launch Gateway and open plugin settings
 - Search for "Gitpod Gateway" and click install


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Clarify to install release not EAP of JB Gateway, since Gitpod plugin does not work with EAP yet.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Work around for https://github.com/gitpod-io/gitpod/issues/8247

## How to test
<!-- Provide steps to test this PR -->

See changes.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
