### PR TITLE
[ws-manager] Wait for workspace pod to be ready

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -263,7 +263,7 @@ func podRunning(clientset client.Client, podName, namespace string) wait.Conditi
 		case corev1.PodFailed, corev1.PodSucceeded:
 			return false, fmt.Errorf("pod ran to completion")
 		case corev1.PodPending:
-			if pod.Status.Reason == "OutOfmemory" || pod.Status.Reason == "OutOfcpu" {
+			if pod.Status.Reason == "OutOfMemory" || pod.Status.Reason == "OutOfCpu" {
 				return false, xerrors.Errorf("cannot schedule pod, reason: %s", pod.Status.Reason)
 			}
 

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -199,7 +199,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	backoff := wait.Backoff{
 		Steps:    10,
 		Duration: 100 * time.Millisecond,
-		Factor:   5.0,
+		Factor:   2.5,
 		Jitter:   0.1,
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Make sure to wait for container to start up, in case of out of memory or other errors.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8253

## How to test
<!-- Provide steps to test this PR -->
Spin up new cluster in workspace preview env:
`./new-vm.sh -v aledbf-wait.10 -z us-west1-c`
then try to start up workspaces in it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve handling of "Out of Memory" error when starting up workspaces
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
