### PR TITLE
installer: make OpenVSX URL configurable in the openvsx proxy

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/configmap.go
+++ b/install/installer/pkg/components/openvsx-proxy/configmap.go
@@ -22,7 +22,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		LogDebug:             false,
 		CacheDurationRegular: util.Duration(time.Minute),
 		CacheDurationBackup:  util.Duration(time.Hour * 72),
-		URLUpstream:          "https://open-vsx.org", // todo(sje): make configurable
+		URLUpstream:          ctx.Config.OpenVSX.URL,
 		URLLocal:             fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain),
 		MaxIdleConns:         1000,
 		MaxIdleConnsPerHost:  1000,

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -55,6 +55,7 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Workspace.Runtime.FSShiftMethod = FSShiftFuseFS
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
+	cfg.OpenVSX.URL = "https://open-vsx.org"
 
 	return nil
 }
@@ -81,6 +82,8 @@ type Config struct {
 	ImagePullSecrets []ObjectRef `json:"imagePullSecrets"`
 
 	Workspace Workspace `json:"workspace" validate:"required"`
+
+	OpenVSX OpenVSX `json:"openVSX"`
 
 	AuthProviders []ObjectRef   `json:"authProviders" validate:"dive"`
 	BlockNewUsers BlockNewUsers `json:"blockNewUsers"`
@@ -227,6 +230,10 @@ type Workspace struct {
 	Runtime   WorkspaceRuntime    `json:"runtime" validate:"required"`
 	Resources Resources           `json:"resources" validate:"required"`
 	Templates *WorkspaceTemplates `json:"templates,omitempty"`
+}
+
+type OpenVSX struct {
+	URL string `json:"url" validate:"url"`
 }
 
 type FSShiftMethod string

--- a/install/installer/pkg/config/v1/load.go
+++ b/install/installer/pkg/config/v1/load.go
@@ -50,6 +50,9 @@ func LoadMock() *Config {
 			Kind: ObjectRefSecret,
 			Name: "https-certs",
 		},
+		OpenVSX: OpenVSX{
+			URL: "https://open-vsx.org",
+		},
 		Workspace: Workspace{
 			Runtime: WorkspaceRuntime{
 				FSShiftMethod:        FSShiftFuseFS,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds a new `OpenVSX` object into the top-level `Config` field
to support configurations of the `openvsx-proxy` component. Currently,
Only `URL` field is present. This is needed to support air-gap
instlalations where people are expected to host their own open-vsx.

This config is top-level and not under the workspace or IDE as this
configures the proxy, but not the IDE.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8224

## How to test
<!-- Provide steps to test this PR -->

Set `openVSX.url` to something else and do a `./installer render -c ./config.yaml | grep <something>`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make Open VSX upstream URL configurable in the installer for air-gap installations
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
