### PR TITLE
[installer] Add MINIO_SKIP_CLIENT=yes to minio

### DIFF
--- a/components/installer/third_party/charts/minio/values.yaml
+++ b/components/installer/third_party/charts/minio/values.yaml
@@ -11,3 +11,6 @@ minio:
     requests:
       # defaults to 4GB, set to 2GB to be able to start on smaller instances
       memory: 2G
+  extraEnvVars:
+    - name: MINIO_SKIP_CLIENT
+      value: "yes"


### PR DESCRIPTION
## Description
This skips MinIO client configuration in the minio container. The client configuration leads to a crash loop on air-gap installations and since we don't use the minio client in Gitpod we simply skip the client configuration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8269

## How to test
<!-- Provide steps to test this PR -->
The only way to test this is to install a Gitpod installation with built-in MinIO and verify that everything still works. I did this and everything works.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[self-hosted] Skip MinIO client configuration in the MinIO container because it breaks air-gap installations.
```

## Meta
/werft no-preview