### PR TITLE
telemetry: show collected data under the toggle

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -30,7 +30,7 @@ import { GithubUpgradeURL, PlanCoupon } from './payment-protocol';
 import { TeamSubscription, TeamSubscriptionSlot, TeamSubscriptionSlotResolved } from './team-subscription-protocol';
 import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from './analytics';
 import { IDEServer } from './ide-protocol';
-import { InstallationAdminSettings } from './installation-admin-protocol';
+import { InstallationAdminSettings, TelemetryData } from './installation-admin-protocol';
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -136,6 +136,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     // Admin Settings
     adminGetSettings(): Promise<InstallationAdminSettings>;
     adminUpdateSettings(settings: InstallationAdminSettings): Promise<void>;
+    adminGetTelemetryData(): Promise<TelemetryData>;
 
     // Projects
     getProviderRepositoriesForUser(params: GetProviderRepositoriesParams): Promise<ProviderRepository[]>;

--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -23,7 +23,7 @@ export interface InstallationAdmin {
     settings: InstallationAdminSettings;
 }
 
-export interface Data {
+export interface TelemetryData {
     installationAdmin: InstallationAdmin
     totalUsers: number
     totalWorkspaces: number

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -148,6 +148,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "adminSetLicense": { group: "default", points: 1 },
         "adminGetSettings": { group: "default", points: 1 },
         "adminUpdateSettings": { group: "default", points: 1 },
+        "adminGetTelemetryData": {group: "default", points: 1},
 
         "validateLicense": { group: "default", points: 1 },
         "getLicenseInfo": { group: "default", points: 1 },

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -81,6 +81,7 @@ import { DebugApp } from './debug-app';
 import { LocalMessageBroker, LocalRabbitMQBackedMessageBroker } from './messaging/local-message-broker';
 import { contentServiceBinder } from '@gitpod/content-service/lib/sugar';
 import { ReferrerPrefixParser } from './workspace/referrer-prefix-context-parser';
+import { InstallationAdminTelemetryDataProvider } from './installation-admin/telemetry-data-provider';
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -192,6 +193,8 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(BearerAuth).toSelf().inSingletonScope();
 
     bind(TermsProvider).toSelf().inSingletonScope();
+
+    bind(InstallationAdminTelemetryDataProvider).toSelf().inSingletonScope();
 
     // binds all content services
     (contentServiceBinder((ctx) => {

--- a/components/server/src/installation-admin/installation-admin-controller.ts
+++ b/components/server/src/installation-admin/installation-admin-controller.ts
@@ -6,27 +6,17 @@
 
 import { injectable, inject } from 'inversify';
 import * as express from 'express';
-import { InstallationAdminDB, UserDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
-import { Data } from '@gitpod/gitpod-protocol'
+import { InstallationAdminTelemetryDataProvider } from './telemetry-data-provider';
 
 @injectable()
 export class InstallationAdminController {
-    @inject(InstallationAdminDB) protected readonly installationAdminDb: InstallationAdminDB;
-    @inject(UserDB) protected readonly userDb: UserDB
-    @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB
+    @inject(InstallationAdminTelemetryDataProvider) protected readonly telemetryDataProvider: InstallationAdminTelemetryDataProvider;
 
     public create(): express.Application {
         const app = express();
 
         app.get('/data', async (req: express.Request, res: express.Response) => {
-            const data: Data = {
-                installationAdmin: await this.installationAdminDb.getData(),
-                totalUsers: await this.userDb.getUserCount(true),
-                totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
-                totalInstances: await this.workspaceDb.getInstanceCount(),
-            } as Data;
-
-            res.status(200).json(data);
+            res.status(200).json(await this.telemetryDataProvider.getTelemetryData());
         });
 
         return app;

--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+ import { injectable, inject } from 'inversify';
+
+ import { TelemetryData } from "@gitpod/gitpod-protocol"
+ import { InstallationAdminDB, UserDB, WorkspaceDB } from '@gitpod/gitpod-db/lib';
+
+ @injectable()
+ export class InstallationAdminTelemetryDataProvider {
+    @inject(InstallationAdminDB) protected readonly installationAdminDb: InstallationAdminDB;
+    @inject(UserDB) protected readonly userDb: UserDB
+    @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB
+
+     async getTelemetryData(): Promise<TelemetryData> {
+            const data: TelemetryData = {
+                installationAdmin: await this.installationAdminDb.getData(),
+                totalUsers: await this.userDb.getUserCount(true),
+                totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
+                totalInstances: await this.workspaceDb.getInstanceCount(),
+            } as TelemetryData;
+
+            return data;
+        }
+ }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -57,8 +57,9 @@ import { PartialProject } from '@gitpod/gitpod-protocol/src/teams-projects-proto
 import { ClientMetadata, traceClientMetadata } from '../websocket/websocket-connection-manager';
 import { ConfigurationService } from '../config/configuration-service';
 import { ProjectEnvVar } from '@gitpod/gitpod-protocol/src/protocol';
-import { InstallationAdminSettings } from '@gitpod/gitpod-protocol';
+import { InstallationAdminSettings, TelemetryData } from '@gitpod/gitpod-protocol';
 import { Deferred } from '@gitpod/gitpod-protocol/lib/util/deferred';
+import { InstallationAdminTelemetryDataProvider } from '../installation-admin/telemetry-data-provider';
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi);    // userId is already taken care of in WebsocketConnectionManager
@@ -80,6 +81,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
     @inject(GitpodFileParser) protected readonly gitpodParser: GitpodFileParser;
     @inject(InstallationAdminDB) protected readonly installationAdminDb: InstallationAdminDB;
+    @inject(InstallationAdminTelemetryDataProvider) protected readonly telemetryDataProvider: InstallationAdminTelemetryDataProvider;
+
 
     @inject(WorkspaceStarter) protected readonly workspaceStarter: WorkspaceStarter;
     @inject(WorkspaceManagerClientProvider) protected readonly workspaceManagerClientProvider: WorkspaceManagerClientProvider;
@@ -2202,6 +2205,16 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         await this.installationAdminDb.setSettings(newSettings);
     }
+
+    async adminGetTelemetryData(ctx: TraceContext): Promise<TelemetryData> {
+        traceAPIParams(ctx, {});
+
+        await this.guardAdminAccess("adminGetTelemetryData", {}, Permission.ADMIN_API);
+
+       return await this.telemetryDataProvider.getTelemetryData();
+    }
+
+
 
     async getLicenseInfo(): Promise<GetLicenseInfoResult> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Licensing is implemented in Gitpod's Enterprise Edition`);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, The service ping can be disabled by going into the
admin settings. Users are more likely to do that if they have
no clue what is being sent.

This PR tries to improve this experience, by showcasing the
exact data that is being sent below the option. This is possible
by creating a new TelemetryDataProvider and injecting that
both in the `installation-admin-collector` controller
and the `gitpod-service` (`getTelemetryData` func is added here
that can be used).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7891

## How to test
<!-- Provide steps to test this PR -->

1. Run `yarn telepresence` in `/server`
2. Head-over to the `admin` settings page, and view the new information below the service ping option

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show collected telemetry data below the telemetry toggle
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
