### PR TITLE
nsinsider: Match the usage of nsinsider to the current codebase.

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -25,7 +25,7 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name:  "move-mount",
-				Usage: "calls move_mount with fd 3 to target",
+				Usage: "calls move_mount with the pipe-fd to target",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "target",
@@ -42,7 +42,7 @@ func main() {
 			},
 			{
 				Name:  "open-tree",
-				Usage: "opens a and writes the resulting mountfd to the Unix pipe on fd 3",
+				Usage: "opens a and writes the resulting mountfd to the Unix pipe on the pipe-fd",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "target",


### PR DESCRIPTION
## Description
Update the usage. Previously, 3 was used for hard coding.
https://github.com/gitpod-io/gitpod/blob/2b4ae94df1677936c1f36344e3767779635d0f58/components/ws-daemon/nsinsider/main.go#L31

## Related Issue(s)
None

## How to test
<!-- Provide steps to test this PR -->
None

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update the usage of nsinsider.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
