### PR TITLE
Increase VM cpus to 6

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -54,7 +54,7 @@ spec:
         machine:
           type: q35
         cpu:
-          cores: 4
+          cores: 6
           sockets: 1
           threads: 1
         devices:


### PR DESCRIPTION
## Description

Currently the VMs are not able to schedule workspaces as we're using 3.3 of the 4 CPU that are allocated to the VM (and k3s node). This increases the CPUs to 6, thus unblocking the issue. We are also working on reducing the CPU request in general.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1205

## How to test
<!-- Provide steps to test this PR -->

Start a VM-based preview environment and start a workspace

```sh
werft run github -a with-vm=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A
