### PR TITLE
Reduce CPU requests from 1 core to 100m

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -310,6 +310,9 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
         exec(`yq w -i config.yaml jaegerOperator.inCluster false`, { slice: installerSlices.INSTALLER_RENDER });
         exec(`yq w -i config.yaml workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: installerSlices.INSTALLER_RENDER });
 
+        // Relax CPU contraints
+        exec(`yq w -i config.yaml workspace.resources.requests.cpu "100m"`, { slice: installerSlices.INSTALLER_RENDER });
+
         if ((deploymentConfig.analytics || "").startsWith("segment|")) {
             exec(`yq w -i config.yaml analytics.writer segment`, { slice: installerSlices.INSTALLER_RENDER });
             exec(`yq w -i config.yaml analytics.segmentKey ${deploymentConfig.analytics!.substring("segment|".length)}`, { slice: installerSlices.INSTALLER_RENDER });


### PR DESCRIPTION
/werft with-vm=true

## Description
<!-- Describe your changes in detail -->

To avoid having workspaces be unschedulable when running in a dedicated k3s cluster in a VM this PR is reducing the CPU requests from 1 full CPU to 100m. As this is just the request (and not the limit) this shouldn't have any performance impact during development. In https://github.com/gitpod-io/gitpod/pull/8276 we increased the CPUs of the VMs to 6 (instead of 4) but even so, requesting a full CPU means you won't be able to have very many workspaces running during development so I still believe we should reduce the CPU requests for workspaces during development.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1205

## How to test
<!-- Provide steps to test this PR -->

Start a VM-based preview environment and start a workspace

```sh
werft run github -a with-vm=true
```

I was able to get a workspace scheduled and verified it was using the updated CPU requests

```
gitpod /workspace/gitpod (mads/reduce-cpu-requests) $ kubectl get pod ws-e9b0fe35-77e9-4bea-a992-412ec8358679 -o yaml | grep cpu: 
        cpu: 100m
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A