### PR TITLE
[jb] track client project sessions

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,15 +2,6 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
-      <module name="jetbrains-backend-plugin" target="11" />
-      <module name="jetbrains-backend-plugin.gitpod-protocol" target="11" />
-      <module name="jetbrains-backend-plugin.gitpod-protocol.main" target="11" />
-      <module name="jetbrains-backend-plugin.gitpod-protocol.test" target="11" />
-      <module name="jetbrains-backend-plugin.main" target="11" />
-      <module name="jetbrains-backend-plugin.supervisor-api" target="11" />
-      <module name="jetbrains-backend-plugin.supervisor-api.main" target="11" />
-      <module name="jetbrains-backend-plugin.supervisor-api.test" target="11" />
-      <module name="jetbrains-backend-plugin.test" target="11" />
       <module name="jetbrains-gateway-gitpod-plugin" target="11" />
       <module name="jetbrains-gateway-gitpod-plugin.gitpod-protocol" target="11" />
       <module name="jetbrains-gateway-gitpod-plugin.gitpod-protocol.main" target="11" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,17 +15,6 @@
           </set>
         </option>
       </GradleProjectSettings>
-      <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
-        <option name="gradleJvm" value="11" />
-        <option name="modules">
-          <set>
-            <option value="$PROJECT_DIR$/components/gitpod-protocol/java" />
-            <option value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
-          </set>
-        </option>
-      </GradleProjectSettings>
     </option>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/GitpodServer.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/GitpodServer.java
@@ -18,6 +18,9 @@ public interface GitpodServer {
     CompletableFuture<Void> sendHeartBeat(SendHeartBeatOptions options);
 
     @JsonRequest
+    CompletableFuture<Void> trackEvent(RemoteTrackMessage event);
+
+    @JsonRequest
     CompletableFuture<List<String>> getGitpodTokenScopes(String tokenHash);
 
     @JsonRequest

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/RemoteTrackMessage.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/RemoteTrackMessage.java
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.gitpodprotocol.api.entities;
+
+public class RemoteTrackMessage {
+    private String event;
+    private Object properties;
+
+    public String getEvent() {
+        return event;
+    }
+
+    public void setEvent(String event) {
+        this.event = event;
+    }
+
+    public Object getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Object properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteTrackMessage{" +
+                "event='" + event + '\'' +
+                ", properties=" + properties +
+                '}';
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -26,6 +26,7 @@ if [ ! -d "$TEST_DIR" ]; then
   git clone $TEST_REPO $TEST_DIR
 fi
 
+export JB_DEV=true
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0"
 
 $TEST_BACKEND_DIR/bin/remote-dev-server.sh run $TEST_DIR

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.client.ClientProjectSession
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.thisLogger
+import io.gitpod.gitpodprotocol.api.entities.RemoteTrackMessage
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
+
+class GitpodClientProjectSessionTracker(
+        private val session: ClientProjectSession
+) {
+
+    private val manager = service<GitpodManager>()
+    init {
+        GlobalScope.launch {
+            val info = manager.pendingInfo.await()
+            val event = RemoteTrackMessage().apply {
+                event = "jb_session"
+                properties = mapOf(
+                        "sessionId" to session.clientId.value,
+                        "instanceId" to info.infoResponse.instanceId,
+                        "workspaceId" to info.infoResponse.workspaceId,
+                        "appName" to ApplicationInfo.getInstance().versionName,
+                        "appVersion" to ApplicationInfo.getInstance().fullVersion,
+                        "timestamp" to System.currentTimeMillis()
+                )
+            }
+            if (manager.devMode) {
+                thisLogger().warn("gitpod: $event")
+            } else {
+                manager.client.server.trackEvent(event)
+            }
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
@@ -4,31 +4,24 @@
 
 package io.gitpod.jetbrains.remote.services
 
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
-import com.intellij.openapi.extensions.PluginId
-import io.gitpod.gitpodprotocol.api.GitpodClient
-import io.gitpod.gitpodprotocol.api.GitpodServerLauncher
 import io.gitpod.gitpodprotocol.api.entities.SendHeartBeatOptions
+import io.gitpod.jetbrains.remote.GitpodManager
 import io.gitpod.jetbrains.remote.services.ControllerStatusService.ControllerStatus
 import kotlinx.coroutines.*
 import kotlinx.coroutines.future.await
-import javax.websocket.DeploymentException
-import kotlin.coroutines.coroutineContext
 import kotlin.random.Random.Default.nextInt
 
 @Service
 class HeartbeatService : Disposable {
 
+    private val manager = service<GitpodManager>()
+
     private val job = GlobalScope.launch {
-        val info = SupervisorInfoService.fetch()
-        val client = GitpodClient()
-        val launcher = GitpodServerLauncher.create(client)
-        launch {
-            connectToServer(info, launcher)
-        }
+        val info = manager.pendingInfo.await()
         val intervalInSeconds = 30
         var current = ControllerStatus(
             connected = false,
@@ -47,72 +40,13 @@ class HeartbeatService : Disposable {
                 }
 
                 if (wasClosed != null) {
-                    client.server.sendHeartBeat(SendHeartBeatOptions(info.infoResponse.instanceId, wasClosed)).await()
+                    manager.client.server.sendHeartBeat(SendHeartBeatOptions(info.infoResponse.instanceId, wasClosed)).await()
                 }
             } catch (t: Throwable) {
                 thisLogger().error("gitpod: failed to check activity:", t)
             }
             delay(intervalInSeconds * 1000L)
         }
-    }
-
-    private suspend fun connectToServer(info: SupervisorInfoService.Result, launcher: GitpodServerLauncher) {
-        val plugin = PluginManagerCore.getPlugin(PluginId.getId("io.gitpod.jetbrains.remote"))!!
-        val connect = {
-            val originalClassLoader = Thread.currentThread().contextClassLoader
-            try {
-                // see https://intellij-support.jetbrains.com/hc/en-us/community/posts/360003146180/comments/360000376240
-                Thread.currentThread().contextClassLoader = HeartbeatService::class.java.classLoader
-                launcher.listen(
-                    info.infoResponse.gitpodApi.endpoint,
-                    info.infoResponse.gitpodHost,
-                    plugin.pluginId.idString,
-                    plugin.version,
-                    info.tokenResponse.token
-                )
-            } finally {
-                Thread.currentThread().contextClassLoader = originalClassLoader;
-            }
-        }
-
-        val minReconnectionDelay = 2 * 1000L
-        val maxReconnectionDelay = 30 * 1000L
-        val reconnectionDelayGrowFactor = 1.5;
-        var reconnectionDelay = minReconnectionDelay;
-        val gitpodHost = info.infoResponse.gitpodApi.host
-        var closeReason: Any = "cancelled"
-        try {
-            while (coroutineContext.isActive) {
-                try {
-                    val connection = connect()
-                    thisLogger().info("$gitpodHost: connected")
-                    reconnectionDelay = minReconnectionDelay
-                    closeReason = connection.await()
-                    thisLogger().warn("$gitpodHost: connection closed, reconnecting after $reconnectionDelay milliseconds: $closeReason")
-                } catch (t: Throwable) {
-                    if (t is DeploymentException) {
-                        // connection is alright, but server does not want to handshake, there is no point to try with the same token again
-                        throw t
-                    }
-                    closeReason = t
-                    thisLogger().warn(
-                        "$gitpodHost: failed to connect, trying again after $reconnectionDelay milliseconds:",
-                        closeReason
-                    )
-                }
-                delay(reconnectionDelay)
-                closeReason = "cancelled"
-                reconnectionDelay = (reconnectionDelay * reconnectionDelayGrowFactor).toLong()
-                if (reconnectionDelay > maxReconnectionDelay) {
-                    reconnectionDelay = maxReconnectionDelay
-                }
-            }
-        } catch (t: Throwable) {
-            if (t !is CancellationException) {
-                closeReason = t
-            }
-        }
-        thisLogger().warn("$gitpodHost: connection permanently closed: $closeReason")
     }
 
     override fun dispose() = job.cancel()

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/SupervisorInfoService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/SupervisorInfoService.kt
@@ -37,6 +37,7 @@ object SupervisorInfoService {
             val request = GetTokenRequest.newBuilder()
                 .setHost(infoResponse.gitpodApi.host)
                 .addScope("function:sendHeartBeat")
+                    .addScope("function:trackEvent")
                 .setKind("gitpod")
                 .build()
 

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,7 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker" client="guest" preload="true"/>
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds `jb_session` event to track how many sessions (thin clients) were opened for a given workspace instance.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7916

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace: 
- Try to close and open thin clients.
- For each thin client you should see `jb_session` in [staging untrusted source](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe