### PR TITLE
werft/observability: Reduce Prometheus resource requests

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -58,6 +58,11 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
             clientEmail: '${params.stackdriverServiceAccount.client_email}',
             privateKey: '${params.stackdriverServiceAccount.private_key}',
         },
+        prometheus: {
+            resources: {
+                requests: { memory: '200Mi', cpu: '50m' },
+            },
+        },
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Our Prometheus instances being deployed to both core-dev and harvester previews were requesting way more resources than necessary since the load for previews is much lower than production.

This PR significantly reduces Prometheus' resource requests for all preview environments.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1208

## How to test
<!-- Provide steps to test this PR -->
* Run `werft run github -a with-vm=true`
* SSH into VM 
* Describe Prometheus' pod and look for resource requests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
