### PR TITLE
[installer] Remove default workspace template

### DIFF
--- a/components/installer/pkg/components/ws-manager/configmap.go
+++ b/components/installer/pkg/components/ws-manager/configmap.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	"github.com/gitpod-io/gitpod/common-go/grpc"
@@ -157,19 +156,6 @@ func buildWorkspaceTemplates(ctx *common.RenderContext) (config.WorkspacePodTemp
 	cfgTpls := ctx.Config.Workspace.Templates
 	if cfgTpls == nil {
 		cfgTpls = &configv1.WorkspaceTemplates{}
-	}
-
-	cfgTpls.Default = &corev1.Pod{
-		Spec: corev1.PodSpec{
-			EnableServiceLinks: pointer.Bool(false),
-			DNSConfig: &corev1.PodDNSConfig{
-				Nameservers: []string{
-					"1.1.1.1",
-					"8.8.8.8",
-				},
-			},
-			DNSPolicy: corev1.DNSNone,
-		},
 	}
 
 	ops := []struct {

--- a/components/installer/pkg/components/ws-manager/configmap_test.go
+++ b/components/installer/pkg/components/ws-manager/configmap_test.go
@@ -29,19 +29,13 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 		Expectation       Expectation
 	}{
 		{
-			Name: "no templates",
-			Expectation: Expectation{
-				TplConfig: wsmancfg.WorkspacePodTemplateConfiguration{DefaultPath: "/workspace-templates/default.yaml"},
-				Data:      map[string]bool{"default.yaml": true},
-			},
+			Name:        "no templates",
+			Expectation: Expectation{},
 		},
 		{
-			Name:   "empty templates",
-			Config: &configv1.WorkspaceTemplates{},
-			Expectation: Expectation{
-				TplConfig: wsmancfg.WorkspacePodTemplateConfiguration{DefaultPath: "/workspace-templates/default.yaml"},
-				Data:      map[string]bool{"default.yaml": true},
-			},
+			Name:        "empty templates",
+			Config:      &configv1.WorkspaceTemplates{},
+			Expectation: Expectation{},
 		},
 		{
 			Name: "default tpl",
@@ -60,11 +54,9 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 			},
 			Expectation: Expectation{
 				TplConfig: wsmancfg.WorkspacePodTemplateConfiguration{
-					DefaultPath: "/workspace-templates/default.yaml",
 					RegularPath: "/workspace-templates/regular.yaml",
 				},
 				Data: map[string]bool{
-					"default.yaml": true,
 					"regular.yaml": true,
 				},
 			},
@@ -76,11 +68,9 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 			},
 			Expectation: Expectation{
 				TplConfig: wsmancfg.WorkspacePodTemplateConfiguration{
-					DefaultPath:  "/workspace-templates/default.yaml",
 					PrebuildPath: "/workspace-templates/prebuild.yaml",
 				},
 				Data: map[string]bool{
-					"default.yaml":  true,
 					"prebuild.yaml": true,
 				},
 			},
@@ -92,12 +82,10 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 			},
 			Expectation: Expectation{
 				TplConfig: wsmancfg.WorkspacePodTemplateConfiguration{
-					DefaultPath: "/workspace-templates/default.yaml",
-					GhostPath:   "/workspace-templates/ghost.yaml",
+					GhostPath: "/workspace-templates/ghost.yaml",
 				},
 				Data: map[string]bool{
-					"default.yaml": true,
-					"ghost.yaml":   true,
+					"ghost.yaml": true,
 				},
 			},
 		},
@@ -108,11 +96,9 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 			},
 			Expectation: Expectation{
 				TplConfig: wsmancfg.WorkspacePodTemplateConfiguration{
-					DefaultPath:    "/workspace-templates/default.yaml",
 					ImagebuildPath: "/workspace-templates/imagebuild.yaml",
 				},
 				Data: map[string]bool{
-					"default.yaml":    true,
 					"imagebuild.yaml": true,
 				},
 			},


### PR DESCRIPTION
## Description
With this change, the installer does not add the default workspace template (e.g. default DNS settings) when no workspace template is given. The old implementation even overwrote the self-configured settings.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8221

## How to test
```
docker create -ti --name installer eu.gcr.io/gitpod-core-dev/build/installer:clu-installer-don-8221.0
docker cp installer:/app/installer ./installer
docker rm -f installer
./installer init > gitpod.config.yaml
./installer render --config gitpod.config.yaml > gitpod.yaml
```

Verify that workspace-templates configmap has no templates like this:
```
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    app: gitpod
    component: ws-manager
    gitpod.io/nodeService: ws-manager
  name: workspace-templates
  namespace: default
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Installer does not set default nameserver settings for workspaces anymore
```
