### PR TITLE
Add ssh_host_key router

### DIFF
--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -112,12 +112,10 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), workspaceInfoProvider).MustServe()
-		log.Infof("started proxying on %s", cfg.Ingress.HTTPAddress)
-
+		// SSH Gateway
+		var signers []ssh.Signer
 		flist, err := os.ReadDir("/mnt/host-key")
 		if err == nil && len(flist) > 0 {
-			var signers []ssh.Signer
 			for _, f := range flist {
 				if f.IsDir() {
 					continue
@@ -142,6 +140,9 @@ var runCmd = &cobra.Command{
 				log.Info("SSHGateway is up and running")
 			}
 		}
+
+		go proxy.NewWorkspaceProxy(cfg.Ingress, cfg.Proxy, proxy.HostBasedRouter(cfg.Ingress.Header, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffix, cfg.Proxy.GitpodInstallation.WorkspaceHostSuffixRegex), workspaceInfoProvider, signers).MustServe()
+		log.Infof("started proxying on %s", cfg.Ingress.HTTPAddress)
 
 		log.Info("🚪 ws-proxy is up and running")
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR add a router for ssh_host_key, router URL is `workspaceURL/_ssh/host_keys` it will show all hostkeys

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate #8296

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace
2. Use `curl workspaceURL/_ssh/host_keys` to test, it will contain all available public hostkey and type

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
