### PR TITLE
Prune everything (remove filter)

### DIFF
--- a/.werft/clean-up-werft-build-nodes.yaml
+++ b/.werft/clean-up-werft-build-nodes.yaml
@@ -39,7 +39,7 @@ pod:
           export DOCKER_HOST=tcp://$NODENAME:2375
 
           werft log phase docker-engine-prune "Cleaning up Docker Engine used by Werft builds"
-          docker system prune --force --all --filter 'until=72h' 2>&1 | werft log slice docker-engine-prune
+          docker system prune --force --all 2>&1 | werft log slice docker-engine-prune
 
           werft log phase werft-build-cache-prune "Cleaning up Werft build caches older than 12 hours"
           find /werft-build-caches/* -maxdepth 0 -mmin +720 -print -exec sudo rm -rf "{}" \; | werft log slice werft-build-cache-prune


### PR DESCRIPTION
## Description

When we're pruning the docker system used by the Werft builds we're currently filtering to only include images older than 72h. This was put into place to reduce the risk of breaking builds ([see comment](https://github.com/gitpod-io/ops/issues/857#issuecomment-1024168675)). Unfortunately this does clean up enough and the disks are still filling up ([see Slack thread](https://gitpod.slack.com/archives/C032A46PWR0/p1645111317850339)) causing all builds to break.

Because of this we are removing the filter so that it prunes the entire docker system. As the job runs at midnight where there currently low build traffic this seems like the better option for now - when the disks fill up then *all* builds fail, so even if we break a single build every once in a while that is preferable.

In the long term we should find a proper solution to this.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

There is nothing to test, but we will have to monitor the builds for:

1. Whether or not the build nodes are still filling up over the next couple of days/weeks
2. If builds are breaking due to this

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A