### PR TITLE
Misc bug fixes for Bitbucket

### DIFF
--- a/components/server/ee/src/bitbucket/bitbucket-app-support.ts
+++ b/components/server/ee/src/bitbucket/bitbucket-app-support.ts
@@ -20,6 +20,7 @@ export class BitbucketAppSupport {
         const oauthToken = token.value;
 
         const api = new Bitbucket({
+            notice: false,
             baseUrl: `https://api.${params.provider.host}/2.0`,
             auth: {
                 token: oauthToken

--- a/components/server/ee/src/prebuilds/bitbucket-service.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-service.ts
@@ -73,7 +73,7 @@ export class BitbucketService extends RepositoryService {
             }
             console.log('Installed Bitbucket Webhook for ' + cloneUrl);
         } catch (error) {
-            console.error(error);
+            console.error('Failed to install Bitbucket webhook for ' + cloneUrl, error);
         }
     }
 

--- a/components/server/src/bitbucket/bitbucket-api-factory.ts
+++ b/components/server/src/bitbucket/bitbucket-api-factory.ts
@@ -27,6 +27,7 @@ export class BitbucketApiFactory {
 
     protected createBitbucket(baseUrl: string, token: Token): APIClient {
         return new Bitbucket({
+            notice: false,
             baseUrl,
             auth: {
                 token: token.value
@@ -44,6 +45,7 @@ export class BasicAuthBitbucketApiFactory extends BitbucketApiFactory {
     protected createBitbucket(baseUrl: string, token: Token): APIClient {
 
         return new Bitbucket({
+            notice: false,
             baseUrl,
             auth: {
                 username: token.username!,

--- a/components/server/src/bitbucket/bitbucket-auth-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-auth-provider.ts
@@ -60,6 +60,7 @@ export class BitbucketAuthProvider extends GenericAuthProvider {
         try {
 
             const options = {
+                notice: false,
                 auth: { token: accessToken },
                 baseUrl: `https://api.${this.params.host}/2.0`,
             };

--- a/components/server/src/bitbucket/bitbucket-token-validator.ts
+++ b/components/server/src/bitbucket/bitbucket-token-validator.ts
@@ -23,6 +23,7 @@ export class BitbucketTokenValidator implements IGitTokenValidator {
         };
 
         const options = {
+            notice: false,
             auth: { token: token },
             baseUrl: `https://api.${host}/2.0`,
         };


### PR DESCRIPTION
* fix response codes for webhook events, so that they are not resent whenever we answer with code 5xx. cf. https://support.atlassian.com/bitbucket-cloud/docs/troubleshoot-webhooks/
* don't log notice message


This PR doesn't add new features.
```release-note
NONE
```