### PR TITLE
[jb] Integrate .gitpod.yml tasks into JetBrains IDEs

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -16,7 +16,7 @@ platformVersion=213-EAP-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=Git4Idea
+platformPlugins=Git4Idea, org.jetbrains.plugins.terminal
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/TerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/TerminalService.kt
@@ -1,0 +1,114 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.services
+
+import com.intellij.codeWithMe.ClientId
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.client.ClientSessionsManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ProjectManagerListener
+import io.gitpod.supervisor.api.TerminalOuterClass.*
+import io.gitpod.supervisor.api.TerminalServiceGrpc
+import kotlinx.coroutines.*
+import kotlinx.coroutines.guava.asDeferred
+import org.jetbrains.plugins.terminal.TerminalView
+
+@OptIn(DelicateCoroutinesApi::class)
+@Service
+class TerminalService {
+    init {
+        val connection = ApplicationManager.getApplication().messageBus.connect()
+        connection.subscribe(ProjectManager.TOPIC, object : ProjectManagerListener {
+            override fun projectOpened(project: Project) {
+                thisLogger().warn("[Gitpod] TerminalService detected a new project: ${project.name}.")
+                GlobalScope.launch {
+                    waitUntilGuestConnectsAsync(project, this).await()
+                    runInEdt {
+                        withClient(project) { p -> p?.let { openTerminalView(it) } }
+                    }
+                }
+            }
+        })
+    }
+
+    private suspend fun waitUntilGuestConnectsAsync(project: Project, parentScope: CoroutineScope) =
+        parentScope.async {
+            if (!isActive) {
+                return@async false
+            }
+
+            thisLogger().warn("[Gitpod] TerminalService is waiting for the guest client to connect.")
+
+            waitForClientSession(project, 1000L)
+
+            true
+        }
+
+    @Suppress("UnstableApiUsage")
+    tailrec suspend fun waitForClientSession(project: Project, checkPeriod: Long): Boolean {
+        val session = ClientSessionsManager.getInstance(project).getSessions(false).firstOrNull()
+        if (session != null) return true
+        delay(checkPeriod)
+        return waitForClientSession(project, checkPeriod)
+    }
+
+    private fun openTerminalView(project: Project) {
+        try {
+            val terminalView = TerminalView.getInstance(project)
+            terminalView.createLocalShellWidget(project.basePath, "GP Terminal", true)
+                .executeCommand("gp --help")
+            thisLogger().warn("[Gitpod] TerminalService opened a terminal.")
+        } catch (e: Exception) {
+            thisLogger().error("[Gitpod] TerminalService failed to open terminal:", e)
+        }
+
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun withClient(project: Project, action: (project: Project?) -> Unit) {
+        val session = ClientSessionsManager.getInstance(project).getSessions(false).firstOrNull()
+        if (session != null) {
+            ClientId.withClientId(session.clientId) {
+                action(project)
+            }
+        } else {
+            thisLogger().warn("[Gitpod] TerminalService failed to find the client session.")
+        }
+    }
+
+    suspend fun registerTasks() {
+        val terminalSize = TerminalSize.newBuilder().setCols(1).setRows(1).build()
+
+        val listenTerminalRequest = ListenTerminalRequest.newBuilder()/*.setAlias("aliasFromSupervisor")*/.build()
+
+        val writeTerminalResponse =
+            TerminalServiceGrpc.newFutureStub(SupervisorInfoService.channel)
+                .write(WriteTerminalRequest.newBuilder().build())
+                .asDeferred()
+                .await()
+
+        val setTerminalSizeResponse =
+            TerminalServiceGrpc.newFutureStub(SupervisorInfoService.channel)
+                .setSize(SetTerminalSizeRequest.newBuilder().build())
+                .asDeferred()
+                .await()
+
+        val shutdownTerminalResponse =
+            TerminalServiceGrpc.newFutureStub(SupervisorInfoService.channel)
+                .shutdown(ShutdownTerminalRequest.newBuilder().build())
+                .asDeferred()
+                .await()
+
+        val listTerminalsResponse =
+            TerminalServiceGrpc.newFutureStub(SupervisorInfoService.channel)
+                .list(ListTerminalsRequest.newBuilder().build())
+                .asDeferred()
+                .await()
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -14,9 +14,11 @@
     <dependencies>
         <plugin id="com.intellij.modules.platform"/>
         <plugin id="Git4Idea"/>
+        <plugin id="org.jetbrains.plugins.terminal"/>
     </dependencies>
 
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.TerminalService" preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService" preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />


### PR DESCRIPTION
## Description

Integrate .gitpod.yml tasks into JetBrains IDEs

Note: due to the branch name length, we need to run werft with the following parameters:  
/werft run version=gp-tasks-in-jb-terminals namespace=gp-tasks-in-jb-terminals

## Related Issue(s)

Fixes #6525

## How to test

_To be defined._

Test URL: https://gp-tasks-in-jb-terminals.staging.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/spring-petclinic

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
_To be defined._