### PR TITLE
[installer] Add missing nil check for experimental ws-daemon config

### DIFF
--- a/components/installer/pkg/components/ws-daemon/configmap.go
+++ b/components/installer/pkg/components/ws-daemon/configmap.go
@@ -44,10 +44,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ControlPeriod:  util.Duration(15 * time.Second),
 	}
 	ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		cpuLimitConfig.Enabled = ucfg.Workspace.CPULimits.Enabled
-		cpuLimitConfig.BurstLimit = ucfg.Workspace.CPULimits.BurstLimit
-		cpuLimitConfig.Limit = ucfg.Workspace.CPULimits.Limit
-		cpuLimitConfig.TotalBandwidth = ucfg.Workspace.CPULimits.NodeCPUBandwidth
+		if ucfg.Workspace != nil {
+			cpuLimitConfig.Enabled = ucfg.Workspace.CPULimits.Enabled
+			cpuLimitConfig.BurstLimit = ucfg.Workspace.CPULimits.BurstLimit
+			cpuLimitConfig.Limit = ucfg.Workspace.CPULimits.Limit
+			cpuLimitConfig.TotalBandwidth = ucfg.Workspace.CPULimits.NodeCPUBandwidth
+		}
 		return nil
 	})
 


### PR DESCRIPTION
## Description
Add missing nil check for experimental ws-daemon config

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8223

## How to test
<!-- Provide steps to test this PR -->

**Step 1:** Get the current installer:
```
docker create -ti --name installer eu.gcr.io/gitpod-core-dev/build/installer:main.2486
docker cp installer:/app/installer ./installer
docker rm -f installer
./installer init > gitpod.config.yaml
```

**Step 2:** Add
```yaml
experimental:
  IDEConfig:
```
to the Gitpod config and run
```
$ ./installer render --danger-use-unsupported-config --config gitpod.config.yaml > gitpod.yaml
```
You get:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1a3d056]
```

**Step 3:** Get the installer of this PR:
```
docker create -ti --name installer eu.gcr.io/gitpod-core-dev/build/installer:corneliusludmann-installer-fix-8223.0
docker cp installer:/app/installer ./installer
docker rm -f installer
```
run
```
$ ./installer render --danger-use-unsupported-config --config gitpod.config.yaml > gitpod.yaml
```
Should work without errors.

Bonus points for setting proper workspace CPULimits and testing if it still renders as it should.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
