### PR TITLE
[installer] Add disableDefinitelyGp config option

### DIFF
--- a/components/installer/pkg/components/server/configmap.go
+++ b/components/installer/pkg/components/server/configmap.go
@@ -45,7 +45,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MaxAgeMs: 259200000,
 			Secret:   "Important!Really-Change-This-Key!", // todo(sje): how best to do this?
 		},
-		DefinitelyGpDisabled: false,
+		DefinitelyGpDisabled: ctx.Config.DisableDefinitelyGP,
 		WorkspaceGarbageCollection: WorkspaceGarbageCollection{
 			ChunkLimit:                 1000,
 			ContentChunkLimit:          1000,

--- a/components/installer/pkg/config/v1/config.go
+++ b/components/installer/pkg/config/v1/config.go
@@ -88,6 +88,8 @@ type Config struct {
 
 	SSHGatewayHostKey *ObjectRef `json:"sshGatewayHostKey,omitempty"`
 
+	DisableDefinitelyGP bool `json:"disableDefinitelyGp,omitempty"`
+
 	Experimental *experimental.Config `json:"experimental,omitempty"`
 }
 


### PR DESCRIPTION
## Description
This change allows disabling definitelyGP with the installer. Useful for air-gap installations.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8222

## How to test
```
docker create -ti --name installer eu.gcr.io/gitpod-core-dev/build/installer:corneliusludmann-installer-add-8222.0
docker cp installer:/app/installer ./installer
docker rm -f installer
./installer init > gitpod.config.yaml
```
Add `disableDefinitelyGp: true` to `gitpod.config.yaml`
```
./installer render --config gitpod.config.yaml > gitpod.yaml
```
Search for `definitelyGpDisabled` in `gitpod.yaml` and make sure it is set to `true`.

Bonus points for checking that `definitelyGpDisabled` in `gitpod.yaml` is set to `false` when `disableDefinitelyGp` is not set in `gitpod.config.yaml` file.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Add `disableDefinitelyGp` config option
```

## Meta
/werft no-preview
