### PR TITLE
Add tiny load testing script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,7 @@
 /components/ws-proxy @gitpod-io/engineering-workspace
 /dev/gpctl @gitpod-io/engineering-workspace
 /dev/loadgen @gitpod-io/engineering-workspace
+/dev/preview @gitpod-io/platform
 /operations/observability/mixins @gitpod-io/platform
 /operations/observability/mixins/IDE @gitpod-io/engineering-ide
 /operations/observability/mixins/meta @gitpod-io/engineering-webapp

--- a/dev/preview/test/load-test.sh
+++ b/dev/preview/test/load-test.sh
@@ -25,7 +25,7 @@ opts=$(getopt \
   -- "$@"
 )
 
-eval set --$opts
+eval set -- "$opts"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/dev/preview/test/load-test.sh
+++ b/dev/preview/test/load-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# This script makes it possible to run load tests against VM-based preview
+# environments.
+#
+# Usage:
+#   ./dev/preview/test/load-test.sh
+#   ./dev/preview/test/load-test.sh --base-branch-name my-load-test-base-branch-name --start 1 --end 5
+#
+
+set -euo pipefail
+
+function log {
+    echo "[$(date)] $*"
+}
+
+START=1
+END=15
+BASE_BRANCH_NAME="vm-load-test"
+
+opts=$(getopt \
+  --longoptions "start:,end:,base-branch-name:" \
+  --name "$(basename "$0")" \
+  --options "" \
+  -- "$@"
+)
+
+eval set --$opts
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --start) START=$2 ; shift 2 ;;
+    --end) END=$2 ; shift 2 ;;
+    --base-branch-name) BASE_BRANCH_NAME=$2 ;  shift 2 ;;
+    *) break ;;
+  esac
+done
+
+while true; do
+    read -rp "
+Are you sure you want to run the load test with the following configuration?
+
+START=${START}
+END=${END}
+BASE_BRANCH_NAME=${BASE_BRANCH_NAME}
+
+y/n: " yn
+    case "$yn" in
+        [Yy]* ) break;;
+        [Nn]* ) echo "Aborting load test" ; exit 0;;
+        * ) echo "Please answer y/n";;
+    esac
+done
+
+log "Creating base branch ${BASE_BRANCH_NAME}"
+git checkout -b "${BASE_BRANCH_NAME}"
+git commit --allow-empty -m "Prepare load test" -m "/werft with-vm=true"
+
+for number in $(seq "${START}" "${END}"); do
+    branch="${BASE_BRANCH_NAME}-${number}"
+
+    log "Creating and pushing branch ${branch}"
+    git checkout -b "${branch}"
+    git push -u origin "${branch}"
+
+    log "Back to base branch ${BASE_BRANCH_NAME}"
+    git checkout "${BASE_BRANCH_NAME}"
+
+    log "Sleeping 30 seconds"
+    sleep 30
+done


### PR DESCRIPTION
## Description

This introduces a tiny script for running load tests against our VM-based preview environments. It prepares a base branch with an empty commit that contains `/werft with-vm` and then pushes as many branches as you have requested so that Werft will run the build job and thus create a VM and deploy Gitpod to it.

The base branch is based off the current branch, that means you can use this to create load tests based on whatever is configured on your branch. E.g. if we wanted to run the load test using a separate VM image than what we have on main then we'd just create a branch where we switch the VM image and then run the load script from that branch.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1215

## How to test
<!-- Provide steps to test this PR -->

If you just want to try it out you can use it to trigger a single VM with the following.

```
./dev/preview/test/load-test.sh --base-branch-name your-name-vm-load-test --start 1 --end 1
```

I have used this script quite a few times to run small loads tests against Harvester. You can see one analysis of running the script here ([internal link](https://www.notion.so/gitpod/Harvester-tiny-load-test-1b449ab34d1a4d5b9b99a4743b740194)). 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A