### PR TITLE
[ws-manager-bridge] fix error handling for register & update, show all admission-constraints for list

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -258,6 +258,8 @@ export class ClusterService implements IClusterServiceServer {
                     response.addStatus(clusterStatus);
                 }
 
+                log.info("response status for clusters.list", response.getStatusList())
+
                 callback(null, response);
             } catch (err) {
                 callback(mapToGRPCError(err), null);
@@ -294,8 +296,10 @@ function convertToGRPC(ws: WorkspaceClusterWoTLS): ClusterStatus {
                 break;
             case "has-user-level":
                 constraint.setHasUserLevel(c.level);
+                break;
             case "has-more-resources":
                 constraint.setHasMoreResources(true);
+                break;
             default:
                 return;
         }

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -70,20 +70,23 @@ export class ClusterService implements IClusterServiceServer {
             try {
                 // check if the name or URL are already registered/in use
                 const req = call.request.toObject();
-                await Promise.all([
-                    async () => {
-                        const oldCluster = await this.clusterDB.findByName(req.name);
-                        if (!oldCluster) {
-                            throw new GRPCError(grpc.status.ALREADY_EXISTS, `a WorkspaceCluster with name ${req.name} already exists in the DB`);
-                        }
-                    },
-                    async () => {
-                        const oldCluster = await this.clusterDB.findFiltered({ url: req.url });
-                        if (!oldCluster) {
-                            throw new GRPCError(grpc.status.ALREADY_EXISTS, `a WorkspaceCluster with url ${req.url} already exists in the DB`);
-                        }
-                    }
+
+                const clusterByNamePromise = this.clusterDB.findByName(req.name);
+                const clusterByUrlPromise = this.clusterDB.findFiltered({ url: req.url })
+
+                const [clusterByName, clusterByUrl] = await Promise.all([
+                    clusterByNamePromise,
+                    clusterByUrlPromise
                 ]);
+
+                if (!!clusterByName) {
+                    throw new GRPCError(grpc.status.ALREADY_EXISTS, `a WorkspaceCluster with name ${req.name} already exists in the DB`);
+                }
+                if (!!clusterByUrl) {
+                    if (clusterByUrl.length > 0) {
+                        throw new GRPCError(grpc.status.ALREADY_EXISTS, `a WorkspaceCluster with url ${req.url} already exists in the DB`);
+                    }
+                }
 
                 // store the ws-manager into the database
                 let perfereability = Preferability.NONE;
@@ -154,7 +157,7 @@ export class ClusterService implements IClusterServiceServer {
                 const req = call.request.toObject();
                 const cluster = await this.clusterDB.findByName(req.name);
                 if (!cluster) {
-                    throw new GRPCError(grpc.status.ALREADY_EXISTS, `a WorkspaceCluster with name ${req.name} already exists in the DB!`);
+                    throw new GRPCError(grpc.status.NOT_FOUND, `a WorkspaceCluster with name ${req.name} does not exist in the DB!`);
                 }
 
                 if (call.request.hasMaxScore()) {
@@ -257,8 +260,6 @@ export class ClusterService implements IClusterServiceServer {
                     clusterStatus.setStatic(true);
                     response.addStatus(clusterStatus);
                 }
-
-                log.info("response status for clusters.list", response.getStatusList())
 
                 callback(null, response);
             } catch (err) {

--- a/dev/gpctl/.vscode/launch.json
+++ b/dev/gpctl/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "gpctl",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileWorkspaceFolder}",
+            "args": [
+                "clusters",
+                "list",
+            ]
+        },
+    ]
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The following changes are necessary to improve the experience for managing workspace clusters when using `gpctl`.

1. Cluster `list` was not showing certain admission constraints, like `has-more-resources`. As an administrator, we want to see all admission constraints, so we can understand how access is controlled to workspace clusters.
2. It was possible to `register` duplicate workspace cluster names. As an administrator, we want to prevent overwriting existing configured clusters and prevent unwanted behavior, so we can maximize system up-time and have predictability. 
3. The error message for `update` when a workspace cluster name does not exist was incorrect. As an administrator, we want to clearly see what is wrong when updating, so we can effectively manage configuration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
These issues were found while building and and testing faster clusters for #8054.

## How to test
<!-- Provide steps to test this PR -->

The error message when a name does not exist on `update`:
```shell
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters update score 0 --name defaul2
FATA[0001] rpc error: code = Unknown desc = a WorkspaceCluster with name defaul2 does not exist in the DB! 
```

`update` still works:
```shell
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters update admission-constraint add has-more-resources --name workworkwork
cluster 'workworkwork' updated with admission constraint add:true  constraint:{has_more_resources:true}
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters list
NAME                URL                           STATIC        STATE            SCORE        GOVERNED        ADMISSION CONSTRAINTS
workworkwork        5.6.7.8:9090           false         AVAILABLE        50           true            [has_more_resources:true]
default             dns:///ws-manager:8080        true          AVAILABLE        50           true            []
```

The output for `list` when a workspace cluster includes `has-more-resources` admission constraint:
```shell
#
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters list
NAME                URL                           STATIC        STATE            SCORE        GOVERNED        ADMISSION CONSTRAINTS
workworkwork        5.6.7.8:9090           false         AVAILABLE        10000        true            [has_more_resources:true]
default             dns:///ws-manager:8080        true          AVAILABLE        50           true            []
```

The error when you try to `register` a workspace cluster with a name that already exists:
```
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters list
NAME                URL                           STATIC        STATE            SCORE        GOVERNED        ADMISSION CONSTRAINTS
workworkwork        5.6.7.8:9090           false         CORDONED         50           true            []
default             dns:///ws-manager:8080        true          AVAILABLE        50           true            []
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters register --name workworkwork --hint-cordoned --hint-govern --url 5.6.7.8:9090 --tls-path ./wsman-tls/
FATA[0001] rpc error: code = Unknown desc = a WorkspaceCluster with name workworkwork already exists in the DB 
```

Register still works:
```
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters list
NAME           URL                           STATIC        STATE            SCORE        GOVERNED        ADMISSION CONSTRAINTS
default        dns:///ws-manager:8080        true          AVAILABLE        50           true            []
gitpod /workspace/gitpod (kyleb/faster-clusters) $ gpctl clusters register --name workworkwork --hint-cordoned --hint-govern --url 5.6.7.8:9090 --tls-path ./wsman-tls/
cluster registered: name:"workworkwork"  url:"5.6.7.8:9090"  tls:{redacted}  hints:{cordoned:true  govern:true}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve error handling for workspace cluster register & update
Show all admission constraints for workspace cluster list
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
