### PR TITLE
[ws-manager] fix incorrect status when image pull is done

### DIFF
--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -453,15 +453,6 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 				result.Message = fmt.Sprintf("container %s was terminated unexpectedly - workspace is recovering", cs.Name)
 				return nil
 			}
-
-			_, neverWereReady := pod.Annotations[workspaceNeverReadyAnnotation]
-			if neverWereReady && !cs.Ready {
-				// container isn't ready yet (never has been), thus we're still in the creating phase.
-				result.Phase = api.WorkspacePhase_CREATING
-				result.Message = "containers are starting"
-				result.Conditions.PullingImages = api.WorkspaceConditionBool_FALSE
-				return nil
-			}
 		}
 
 		tpe, err := wso.WorkspaceType()

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
@@ -14,11 +14,11 @@
             "url": "http://10.0.0.114:8082",
             "ide_image": {}
         },
-        "phase": 2,
+        "phase": 3,
         "conditions": {
             "failed": "container sync completed; containers of a workspace pod are not supposed to do that"
         },
-        "message": "containers are starting",
+        "message": "workspace initializer is running",
         "runtime": {
             "node_name": "gke-gitpod-dev-worker-pool-2-184c607e-g6l3",
             "pod_name": "ws-foobar",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ws-manager] fix incorrect status when image pull is done
If `pod` is running, the workspace status should be change to `initializing`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8323

## How to test
<!-- Provide steps to test this PR -->
1. create a workspace
2. write a big file using `dd`
3. stop workspace
4. restart this workspace
5. you will see the most time cost is `initializing` instead of `pulling image`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
