### PR TITLE
Fix PREVENT_METADATA_ACCESS is not effact

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -184,6 +184,9 @@ while [ "$i" -le "$DOCS" ]; do
       yq r /tmp/"$NAME"overrides.yaml 'data.[config.json]' \
       | jq --arg REGISTRY_FACADE_HOST "$REGISTRY_FACADE_HOST" '.manager.registryFacadeHost = $REGISTRY_FACADE_HOST' \
       | jq ".manager.wsdaemon.port = $WS_DAEMON_PORT" > /tmp/"$NAME"-cm-overrides.json
+
+      yq w -i -j /tmp/"$NAME"-cm-overrides.json manager.podTemplate.defaultPath /workspace-templates/default.yaml
+
       touch /tmp/"$NAME"-cm-overrides.yaml
       # write a yaml file with the json as a multiline string
       yq w -i /tmp/"$NAME"-cm-overrides.yaml "data.[config.json]" -- "$(< /tmp/"$NAME"-cm-overrides.json)"
@@ -245,6 +248,9 @@ while [ "$i" -le "$DOCS" ]; do
       LABEL="gitpod.io/workspace_$NODE_POOL_INDEX"
       yq w -i /tmp/"$NAME"overrides.yaml spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key "$LABEL"
       yq w -i /tmp/"$NAME"overrides.yaml spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator Exists
+      yq w -i /tmp/"$NAME"overrides.yaml spec.containers[+].name workspace
+      yq w -i /tmp/"$NAME"overrides.yaml "spec.containers.(name==workspace).env[+].name" GITPOD_PREVENT_METADATA_ACCESS
+      yq w -i /tmp/"$NAME"overrides.yaml "spec.containers.(name==workspace).env.(name==GITPOD_PREVENT_METADATA_ACCESS).value" "true"
 
       yq w -i k8s.yaml -d "$i" "data.[default.yaml]" -- "$(< /tmp/"$NAME"overrides.yaml)"
    fi

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -198,7 +198,7 @@ type WorkspaceConfig struct {
 
 	// PreventMetadataAccess exits supervisor/stops the workspace if we can access Google Cloud
 	// compute metadata from within the container.
-	PreventMetadataAccess bool `env:"THEIA_PREVENT_METADATA_ACCESS"`
+	PreventMetadataAccess bool `env:"GITPOD_PREVENT_METADATA_ACCESS"`
 
 	// LogRateLimit limits the log output of the IDE process.
 	// Any output that exceeds this limit is silently dropped.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
rename THEIA_PREVENT_METADATA_ACCESS to GITPOD_PREVENT_METADATA_ACCESS
and fix is not effect in coredev
also fix workspace `nodeAffinity` in core-dev maybe it can improve stable for core-dev

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate https://github.com/gitpod-io/ops/pull/1246/files

## How to test
<!-- Provide steps to test this PR -->
1. start workspace
2. you will get shutdown immediately
3. and you can find `metadata access is possible` log in GCP

![image](https://user-images.githubusercontent.com/8299500/155574141-e030837e-7d7f-40f2-8c7b-3f4c5a9c9074.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
