### PR TITLE
[installer] Use fuse as default ShiftFS method

### DIFF
--- a/components/installer/pkg/config/v1/config.go
+++ b/components/installer/pkg/config/v1/config.go
@@ -52,7 +52,7 @@ func (v version) Defaults(in interface{}) error {
 		corev1.ResourceCPU:    resource.MustParse("1000m"),
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
 	}
-	cfg.Workspace.Runtime.FSShiftMethod = FSShiftShiftFS
+	cfg.Workspace.Runtime.FSShiftMethod = FSShiftFuseFS
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
 


### PR DESCRIPTION
## Description
Set `fuse` as the default ShiftFS method again since it has been fixed in https://github.com/gitpod-io/gitpod/pull/8181 and is more robust than `shiftfs`.

This reverts https://github.com/gitpod-io/gitpod/commit/5f9f701835292bbe28e71c8eb70f8a09965cb5ab.

Internal discussion:
- https://gitpod.slack.com/archives/C01KLC56NP7/p1645447044221539
- https://gitpod.slack.com/archives/C02F19UUW6S/p1645447088498019

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Use fuse as default ShiftFS method.
```

## Meta

/werft no-preview
