### PR TITLE
[Analytics] Prepare for Mixpanel Migration of website Insights

### DIFF
--- a/components/gitpod-protocol/src/util/analytics.ts
+++ b/components/gitpod-protocol/src/util/analytics.ts
@@ -30,7 +30,13 @@ class SegmentAnalyticsWriter implements IAnalyticsWriter {
 
         identify(msg: IdentifyMessage) {
         try {
-            this.analytics.identify(msg, (err: Error) => {
+            this.analytics.identify({
+                ...msg,
+                integrations: {
+                    "All": true,
+                    "Mixpanel": !!msg.userId
+                }
+            }, (err: Error) => {
                 if (err) {
                     log.warn("analytics.identify failed", err);
                 }
@@ -42,7 +48,13 @@ class SegmentAnalyticsWriter implements IAnalyticsWriter {
 
     track(msg: TrackMessage) {
         try {
-            this.analytics.track(msg, (err: Error) => {
+            this.analytics.track({
+                ...msg,
+                integrations: {
+                    "All": true,
+                    "Mixpanel": !!msg.userId
+                }
+            }, (err: Error) => {
                 if (err) {
                     log.warn("analytics.track failed", err);
                 }
@@ -54,7 +66,13 @@ class SegmentAnalyticsWriter implements IAnalyticsWriter {
 
     page(msg: PageMessage) {
         try{
-            this.analytics.page(msg, (err: Error) => {
+            this.analytics.page({
+                ...msg,
+                integrations: {
+                    "All": true,
+                    "Mixpanel": !!msg.userId
+                }
+            }, (err: Error) => {
                 if (err) {
                     log.warn("analytics.page failed", err);
                 }

--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -33,6 +33,7 @@ export async function trackSignup(user: User, request: Request, analytics: IAnal
             event: "signup",
             properties: {
                 "auth_provider": user.identities[0].authProviderId,
+                "qualified": !!request.cookies["gitpod-marketing-website-visited"]
             }
         });
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
PR prepares to move visitor (i.e. everyone but authenticated user) data out of mixpanel through the following two steps:
- track the qualification (whether user has previously visited the website) at signup. as it will not be possible to compute this in mixpanel anymore by checking if a website visit was tracked from the user's profile previously, this is now passed to the app through a cookie and inside the payload of the signup event
- extend the implementation of the `SegmentAnalyticsWriter` to feature the integrations object in the payload, which ensures that an event is not forwarded to Mixpanel if the user is not authenticated. This has to be specified in the app as the event filtering in Segment unfortunately does not allow to check for the existence of `userId`

These two changes are prerequisites to converting to a paying subscription with Mixpanel as we would else either risk data loss or a spike in the cost of ownership.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
- open preview environment and [Segment's Staging Untrusted](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)
- Check in the raw tab of the first `page()` call whether `integrations` exists with `"Mixpanel": false` (the initial page call should occur before authenticating and thus not be forwarded to Mixpanel as the `userId` is not passed along)
- sign up
- Check in the raw tab of the `signup` track event sent to Segment that `integrations` exists with `"Mixpanel": true` (signups always contain the `userId`, so Segment should forward this to Mixpanel). Then, check that the signup event contains a `qualified` property with the value `false` (as the cookie `gitpod-marketing-website-visited` should not yet exist for this domain)
- Next, open a different browser or incognito window, and open the preview environment once again. Then, set the cookie `gitpod-marketing-website-visited=true` (current domain, expiry at least session; one way to do this is to go to the console of the developer tool and enter `document.cookie="gitpod-marketing-website-visited=true"`)
- Now, sign up with a different account to trigger another `signup` event call and make sure that the `qualified` property in the Segment Debugger is `true` this time

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->



/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe