### PR TITLE
Support custom docker daemon args 

### DIFF
--- a/components/docker-up/.gitignore
+++ b/components/docker-up/.gitignore
@@ -2,3 +2,4 @@ bin
 docker-compose
 docker.tgz
 slirp4netns
+runc

--- a/components/docker-up/dependencies.sh
+++ b/components/docker-up/dependencies.sh
@@ -10,3 +10,4 @@ DOCKER_COMPOSE_VERSION=1.29.2
 
 curl -o docker.tgz      -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz
 curl -o docker-compose  -fsSL https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
+curl -o runc            -fsSL https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64

--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -75,6 +75,12 @@ func main() {
 		logger.Fatalf("Docker socket already exists at %s.\nIn a Gitpod workspace Docker will start automatically when used.\nIf all else fails, please remove %s and try again.", dockerSocketFN, dockerSocketFN)
 	}
 
+	if _, exists := os.LookupEnv("DOCKER_DAEMON_ARGS"); exists {
+		log.Debug("DOCKER_DAEMON_ARGS exists")
+	} else {
+		log.Debug("DOCKER_DAEMON_ARGS does not exist")
+	}
+
 	err = ensurePrerequisites()
 	if err != nil {
 		log.WithError(err).Fatal("failed")

--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -233,7 +233,10 @@ func adaptSubid(oldfile string, id int) error {
 		return err
 	}
 
-	newfile.WriteString(fmt.Sprintf("gitpod:%d:%d\n", 1, id))
+	if id != 0 {
+		newfile.WriteString(fmt.Sprintf("gitpod:%d:%d\n", 1, id))
+	}
+
 	newfile.WriteString("gitpod:33333:1\n")
 
 	uidScanner := bufio.NewScanner(uid)

--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -85,7 +85,7 @@ func main() {
 	if _, exists := os.LookupEnv("DOCKER_DAEMON_ARGS"); exists {
 		log.Debug("DOCKER_DAEMON_ARGS exists")
 	} else {
-		log.Debug("DOCKER_DAEMON_ARGS does not exist")
+		log.Debug("DOCKER_DAEMON_ARGS does not exist ___")
 	}
 
 	err = ensurePrerequisites()

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1388,12 +1388,6 @@ func socketActivationForDocker(ctx context.Context, wg *sync.WaitGroup, term *te
 		l.Close()
 	}()
 
-	if _, exists := os.LookupEnv("DOCKER_DAEMON_ARGS"); exists {
-		log.Debug("DOCKER_DAEMON_ARGS exists")
-	} else {
-		log.Debug("DOCKER_DAEMON_ARGS does not exist")
-	}
-
 	_ = os.Chown(fn, gitpodUID, gitpodGID)
 	for ctx.Err() == nil {
 		err = activation.Listen(ctx, l, func(socketFD *os.File) error {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1388,6 +1388,12 @@ func socketActivationForDocker(ctx context.Context, wg *sync.WaitGroup, term *te
 		l.Close()
 	}()
 
+	if _, exists := os.LookupEnv("DOCKER_DAEMON_ARGS"); exists {
+		log.Debug("DOCKER_DAEMON_ARGS exists")
+	} else {
+		log.Debug("DOCKER_DAEMON_ARGS does not exist")
+	}
+
 	_ = os.Chown(fn, gitpodUID, gitpodGID)
 	for ctx.Err() == nil {
 		err = activation.Listen(ctx, l, func(socketFD *os.File) error {


### PR DESCRIPTION
## Description
This allows users to add arguments to the docker daemon running in the workspace. As a first step mapping the container user to the gitpod user is supported. 

## Related Issue(s)
Fixes #8103

## How to test
- Add environment variable DOCKER_DAEMON_ARGS to your user settings. The content should look like this:
`{ "remap-user": "1000" }` (Means container id 1000 will be mapped to gitpod user)
- Start workspace
- Run docker image which supports running as unprivileged user e.g. `sudo docker run -it -u node -v /tmp/me:/tmp node sh`
- Create file within container e.g. touch /tmp/foo
- Verify that the created file has gitpod:gitpod permissions in the workspace

## Release Notes

```release-note
Docker in workspaces now allows mapping the user id of a container user to the gitpod user
```

## Documentation

