### PR TITLE
[ws-daemon] Improve cache error handling

### DIFF
--- a/components/ws-daemon/pkg/daemon/cache_reclaim.go
+++ b/components/ws-daemon/pkg/daemon/cache_reclaim.go
@@ -7,6 +7,8 @@ package daemon
 import (
 	"bufio"
 	"context"
+	"errors"
+	"io/fs"
 	"io/ioutil"
 	"math"
 	"os"
@@ -116,6 +118,11 @@ func readLimit(memCgroupPath string) (uint64, error) {
 	fn := filepath.Join(string(memCgroupPath), "memory.limit_in_bytes")
 	fc, err := os.ReadFile(fn)
 	if err != nil {
+		// TODO(toru): find out why the file does not exists
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+
 		return 0, xerrors.Errorf("cannot read memory.limit_in_bytes: %v", err)
 	}
 
@@ -134,6 +141,11 @@ func readLimit(memCgroupPath string) (uint64, error) {
 func readCache(memCgroupPath string) (uint64, error) {
 	f, err := os.Open(filepath.Join(string(memCgroupPath), "memory.stat"))
 	if err != nil {
+		// TODO(toru): find out why the file does not exists
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+
 		return 0, xerrors.Errorf("cannot read memory.stat: %w", err)
 	}
 	defer f.Close()

--- a/components/ws-daemon/pkg/daemon/cache_reclaim_test.go
+++ b/components/ws-daemon/pkg/daemon/cache_reclaim_test.go
@@ -54,8 +54,8 @@ func TestReadLimitBadValue(t *testing.T) {
 			t.Fatal(err)
 		}
 		_, err = readCache(tempdir)
-		if err == nil {
-			t.Fatal("expected failure")
+		if err != nil {
+			t.Fatalf("unexpected error: is '%v' but expected no error", err)
 		}
 	}
 }


### PR DESCRIPTION
## Description

A non-existing file is not an error (in these cases)

Check logging events https://cloudlogging.app.goo.gl/FPPVKf8QeobE9PYq6

## Release Notes
```release-note
NONE
```
