### PR TITLE
dashboard: set correct default setting for telemetry

### DIFF
--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -28,6 +28,9 @@ export default function Settings() {
         (async () => {
             const data = await getGitpodService().server.adminGetTelemetryData();
             setTelemetryData(data)
+
+            const setting = await getGitpodService().server.adminGetSettings();
+            setAdminSettings(setting)
         })();
     }, []);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`Enable Service Ping` seems to be set to `false` by defaut until
the UI is re-loaded. This fixes it by also adding the retrieval
logic into `useEffect` thereby calling it everytime, even during
initial render.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8344


## How to test
<!-- Provide steps to test this PR -->

Open the `admin/settings` dashboard, and check if its set to `true` by default without a refresh.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show correct admin telemetry settings during first visit
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
