### PR TITLE
Pre-populate Cmd+O modal and sort suggested context URLs by most-recently-used first

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -6,7 +6,6 @@
 
 import { User } from "@gitpod/gitpod-protocol";
 import React, { useContext, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 
@@ -14,7 +13,7 @@ type SearchResult = string;
 type SearchData = SearchResult[];
 
 const LOCAL_STORAGE_KEY = 'open-in-gitpod-search-data';
-const MAX_DISPLAYED_ITEMS = 15;
+const MAX_DISPLAYED_ITEMS = 20;
 
 export default function RepositoryFinder(props: { initialQuery?: string }) {
     const { user } = useContext(UserContext);
@@ -37,6 +36,10 @@ export default function RepositoryFinder(props: { initialQuery?: string }) {
             await findResults(query, onResults);
         }
     }
+
+    useEffect(() => {
+        search('');
+    }, []);
 
     // Up/Down keyboard navigation between results
     const onKeyDown = (event: React.KeyboardEvent) => {
@@ -81,18 +84,9 @@ export default function RepositoryFinder(props: { initialQuery?: string }) {
             <div className="py-4">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" /></svg>
             </div>
-            <input type="search" className="flex-grow" placeholder="Search repositories and examples" autoFocus value={searchQuery} onChange={e => search(e.target.value)} onKeyDown={onKeyDown} />
+            <input type="search" className="flex-grow" placeholder="Paste repository URL or type to find suggestions" autoFocus value={searchQuery} onChange={e => search(e.target.value)} onKeyDown={onKeyDown} />
         </div>
         <div className="mt-3 -mx-5 px-5 flex flex-col space-y-2 h-64 overflow-y-auto">
-            {searchQuery === '' && searchResults.length === 0 &&
-                <div className="mt-12 mx-auto w-96 text-gray-500">
-                    Paste a <a className="gp-link" href="https://www.gitpod.io/docs/context-urls">repository context URL</a>, or start typing to see suggestions from:
-                    <ul className="list-disc mt-4 pl-7 flex flex-col space-y-1">
-                        <li>Your recent repositories</li>
-                        <li>Your repositories from <Link className="gp-link" to="/integrations">connected integrations</Link></li>
-                        <li>Example repositories</li>
-                    </ul>
-                </div>}
             {searchResults.slice(0, MAX_DISPLAYED_ITEMS).map((result, index) =>
                 <a className={`px-4 py-3 rounded-xl` + (result === selectedSearchResult ? ' bg-gray-600 text-gray-50 dark:bg-gray-700' : '')} href={`/#${result}`} key={`search-result-${index}`} onMouseEnter={() => setSelectedSearchResult(result)}>
                     {searchQuery.length < 2
@@ -157,10 +151,6 @@ async function actuallyRefreshSearchData(query: string, user: User | undefined):
 }
 
 async function findResults(query: string, onResults: (results: string[]) => void) {
-    if (!query) {
-        onResults([]);
-        return;
-    }
     const searchData = loadSearchData();
     try {
         // If the query is a URL, and it's not present in the proposed results, "artificially" add it here.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change "brings back" recent repositories:
- [x] Pre-populate Cmd+O modal with unfiltered suggestions
- [x] Sort suggestions by most-recently-used first

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Addresses the first part of https://github.com/gitpod-io/gitpod/issues/8088:

> 1. **Recover behavior to show recents by default** 
>     - Autopopulate results even when input is empty
>     - Tweak result ranking to show recents first
>     - Remove current help text
>     - Set placeholder = “Paste repository URL or type for suggestions”

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Pre-populate Cmd+O modal and sort suggested context URLs by most-recently-used first
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
