### PR TITLE
[installer] Ensure ws-proxy is scheduled in different nodes

### DIFF
--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -83,8 +83,16 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						PriorityClassName:  common.SystemNodeCritical,
-						Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
+						PriorityClassName: common.SystemNodeCritical,
+						Affinity:          common.Affinity(cluster.AffinityLabelWorkspaceServices),
+						TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+							corev1.TopologySpreadConstraint{
+								LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+								MaxSkew:           1,
+								TopologyKey:       "kubernetes.io/hostname",
+								WhenUnsatisfiable: corev1.DoNotSchedule,
+							},
+						},
 						EnableServiceLinks: pointer.Bool(false),
 						ServiceAccountName: Component,
 						SecurityContext: &corev1.PodSecurityContext{


### PR DESCRIPTION
## Description

By default, the installer deploys one ws-proxy replica. If we need to scale up, ensure we schedule the pod in a different host.

## How to test

- Install a cluster and scale ws-proxy to more than one replica

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Ensure multiple ws-proxy replicas are scheduled in different nodes
```
