### PR TITLE
Update helm cpu limit

### DIFF
--- a/chart/templates/ws-manager-configmap.yaml
+++ b/chart/templates/ws-manager-configmap.yaml
@@ -44,7 +44,7 @@ data:
                         "memory": "{{ .Values.workspaceSizing.memoryRequest }}Mi"
                     },
                     "limits": {
-                        "cpu": "5",
+                        "cpu": "6",
                         "memory": "{{ .Values.workspaceSizing.memoryLimit }}Mi"
                     },
                     {{ else -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,7 +36,7 @@ workspaceSizing:
     memory: "2.25Gi"
     ephemeral-storage: "5Gi"
   limits:
-    cpu: "5"
+    cpu: "6"
     memory: "12Gi"
   dynamic:
     # Gitpod supports dynamic CPU limiting. We express those limits in "buckets of CPU time" (jiffies where 1 jiffie is 1% of a vCPU).


### PR DESCRIPTION
## Description
Updates the helm cpu limit, similar to https://github.com/gitpod-io/ops/pull/1280. Still required as some teams still use the helm installer.

## Related Issue(s)
n.a.

## How to test
- Open workspace
- Check resource limits of workspace pod

## Release Notes
```release-note
NONE
```