### PR TITLE
werft/job-config: Make previews from 20+ character branches possible

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -85,7 +85,16 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const withHelm = "with-helm" in buildConfig && !mainBuild;
     const withVM = "with-vm" in buildConfig && !mainBuild;
 
-    const previewDestName = version.split(".")[0];
+    let previewDestName = version.split(".")[0];
+    // For various reasons, we can't have preview names bigger than 20 characters
+    // For more info, see: https://github.com/gitpod-io/ops/issues/1252
+    if (previewDestName.length >= 20) {
+        // Werft job names can end with the '-' character when getting hard cut on 20 characters.
+        // We make sure to remove the ending '-' character because it is not a valid namespace name.
+        var trimmingRegex = /-$/gi;
+        previewDestName = previewDestName.substring(0, 19).replace(trimmingRegex, "").split("/").join("-")
+    }
+
     const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewDestName}`;
     const previewEnvironment = {
         destname: previewDestName,

--- a/scripts/branch-namespace.sh
+++ b/scripts/branch-namespace.sh
@@ -2,7 +2,7 @@
 
 branch=$(git symbolic-ref HEAD 2>&1) || error "cannot set kubectl namespace: no branch"
 currentContext=$(kubectl config current-context 2>&1) || error "cannot set kubectl namespace: no current context"
-namespace=staging-$(echo "$branch" | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')
+namespace=staging-$(echo "${branch:0:19}" | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')
 
 echo "Setting kubectl namespace: $namespace"
 kubectl config set-context "$currentContext" --namespace "$namespace"


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
This PR effectively makes it possible to create preview environments from super long branch names by cutting it into 20 characters max. The reasons why we can't use more than 20 characters are listed [here](https://github.com/gitpod-io/ops/issues/1252).


**_I'm opening this as a draft because_**:
The initial idea of adding a label does not work out-of-the-box as we expected.

* Label values can't have special characters like `/`, which are commonly used by our branch names
* Label values still have a 63 characters limit

Creating this PR to start the discussion, should we give up on verifying a possible conflicting namespace? Should we go with a mixture of branch name + hash?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1252

## How to test
<!-- Provide steps to test this PR -->
Create a super long branch(from this PR) and create a new preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```