### PR TITLE
jb: configure SDK workaround

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.util.application
+
+class GitpodProjectManager(
+        private val project: Project
+) {
+
+    init {
+        application.invokeLaterOnWriteThread {
+            application.runWriteAction {
+                configureSdk()
+            }
+        }
+    }
+
+    /**
+     * It is a workaround for https://youtrack.jetbrains.com/issue/GTW-88
+     */
+    private fun configureSdk() {
+        ProjectJdkTable.getInstance().preconfigure()
+        val sdk = ProjectJdkTable.getInstance().allJdks.firstOrNull() ?: return
+        val projectRootManager = ProjectRootManager.getInstance(project)
+        if (projectRootManager.projectSdk != null) {
+            return
+        }
+        projectRootManager.projectSdk = sdk
+        thisLogger().warn("gitpod: SDK was auto preconfigured: $sdk")
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,7 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodBranding"
                             serviceInterface="com.intellij.remoteDev.customization.GatewayBranding"
                             overrides="true" />
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodProjectManager" preload="true"/>
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

As for now IntelliJ cannot apply JDK automatically to detected projects. This PR adds a workaround which will configure a project sdk on startup if it is not configured.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace **without** .idea folder https://ak-jb-preconfigure-jdk.staging.gitpod-dev.com/#referrer:jetbrains-gateway/https://github.com/ErnstHaagsman/spring-petclinic
- Open PetClinicApplication and check that smartness is available, and you don't see a pop up about configuring SDK
- Start a workspace **with** .idea folder https://ak-jb-preconfigure-jdk.staging.gitpod-dev.com/#referrer:jetbrains-gateway/https://github.com/gitpod-io/spring-petclinic
- Open PetClinicApplication and check that smartness is available, and you don't see a pop up about configuring SDK

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
