### PR TITLE
jb: auto preconfigure module SDK as well

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
@@ -4,35 +4,72 @@
 
 package io.gitpod.jetbrains.remote
 
+import com.intellij.ProjectTopics
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.ModuleListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.util.application
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
+import java.util.concurrent.CompletableFuture
+
 
 class GitpodProjectManager(
         private val project: Project
 ) {
 
-    init {
-        application.invokeLaterOnWriteThread {
-            application.runWriteAction {
-                configureSdk()
-            }
-        }
-    }
-
     /**
      * It is a workaround for https://youtrack.jetbrains.com/issue/GTW-88
      */
-    private fun configureSdk() {
-        ProjectJdkTable.getInstance().preconfigure()
-        val sdk = ProjectJdkTable.getInstance().allJdks.firstOrNull() ?: return
-        val projectRootManager = ProjectRootManager.getInstance(project)
-        if (projectRootManager.projectSdk != null) {
-            return
+    init {
+        val pendingSdk = CompletableFuture<Sdk>()
+        application.invokeLaterOnWriteThread {
+            application.runWriteAction {
+                try {
+                    ProjectJdkTable.getInstance().preconfigure()
+                    pendingSdk.complete(ProjectJdkTable.getInstance().allJdks.firstOrNull())
+                } catch (t: Throwable) {
+                    pendingSdk.completeExceptionally(t)
+                }
+            }
         }
-        projectRootManager.projectSdk = sdk
-        thisLogger().warn("gitpod: SDK was auto preconfigured: $sdk")
+        GlobalScope.launch {
+            val sdk = pendingSdk.await() ?: return@launch
+            thisLogger().warn("gitpod: '${project.name}' project: SDK detected: $sdk")
+            project.messageBus.connect().subscribe(ProjectTopics.MODULES, object : ModuleListener {
+                override fun moduleAdded(project: Project, module: Module) {
+                    configureSdk(sdk)
+                }
+            })
+            configureSdk(sdk)
+        }
+    }
+
+    private fun configureSdk(sdk: Sdk) {
+        application.invokeLaterOnWriteThread {
+            application.runWriteAction {
+                val projectRootManager = ProjectRootManager.getInstance(project)
+                if (projectRootManager.projectSdk == null) {
+                    projectRootManager.projectSdk = sdk
+                    thisLogger().warn("gitpod: '${project.name}' project: SDK was auto preconfigured: $sdk")
+                }
+            }
+        }
+        for (module in ModuleManager.getInstance(project).modules) {
+            ModuleRootModificationUtil.updateModel(module) { m ->
+                if (m.sdk == null) {
+                    m.sdk = sdk
+                    thisLogger().warn("gitpod: '${module.name}' module: SDK was auto preconfigured: $sdk")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It is a follow-up of https://github.com/gitpod-io/gitpod/pull/8406. It turned out that configuring SDK on project level is not enough, depending on timing module SDK will inherit it or not. This PR listeners to new modules and configures them as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace **without** .idea folder https://ak-jb-module-sdk.staging.gitpod-dev.com/#referrer:jetbrains-gateway/https://github.com/ErnstHaagsman/spring-petclinic
- Open PetClinicApplication and check that smartness is available, and you don't see a pop up about configuring SDK
- Start a workspace **with** .idea folder https://ak-jb-module-sdk.staging.gitpod-dev.com/#referrer:jetbrains-gateway/https://github.com/gitpod-io/spring-petclinic
- Open PetClinicApplication and check that smartness is available, and you don't see a pop up about configuring SDK

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
