### PR TITLE
WIP testing: remove track event vscode_session phase running and end

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 8428da4b36e80a122af3c3e2b58b1fcffb5d5f8e
+  codeCommit: a8cf2c01c89debd3fc8767176ad7ff2589ee12d4
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 0175d2fd7b619fb1c34dcf2a0e17a909acd1be3e
+  codeCommit: 8428da4b36e80a122af3c3e2b58b1fcffb5d5f8e
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove track event `vscode_session` phase `running` and `end`, see changes here https://github.com/gitpod-io/openvscode-server/commit/a8cf2c01c89debd3fc8767176ad7ff2589ee12d4

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related #8375

## How to test
<!-- Provide steps to test this PR -->
1. Use vscode insiders
2. Open a workspace
3. Go to segment `staging_untrusted` filter with `vscode_session`, you should see a track without `phase` and `focused` props

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe