### PR TITLE
Identify Call Improvements

### DIFF
--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -40,15 +40,17 @@ export async function trackSignup(user: User, request: Request, analytics: IAnal
 function fullIdentify(user: User, request: Request, analytics: IAnalyticsWriter) {
     //makes a full identify call for authenticated users
     const coords = request.get("x-glb-client-city-lat-long")?.split(", ");
+    const ip = request.get("x-forwarded-for")?.split(",")[0];
     analytics.identify({
         anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
         userId:user.id,
         context: {
-            "ip": maskIp(request.ips[0]),
+            "ip": ip ? maskIp(ip): undefined,
             "userAgent": request.get("User-Agent"),
             "location": {
                 "city": request.get("x-glb-client-city"),
                 "country": request.get("x-glb-client-region"),
+                "region": request.get("x-glb-client-region-subdivision"),
                 "latitude": coords?.length == 2 ? coords[0] : undefined,
                 "longitude": coords?.length == 2 ? coords[1] : undefined
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
PR improves data quality of identify call by making the following two changes:
- the IP is read directly from the xff header instead of the request middleware, which did not contain the client IP in the leftmost position described in the [docs](https://expressjs.com/en/api.html#req.ips). the position of IPs in the xff header was verified through server logs
- include the region as user trait. this enables to segment users on an additional granularity level between city and country
## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
The PR depends on http headers populated and modified by the load balancer, so it cannot be accurately tested in the preview environment. ensuring that none of the previous functionality breaks can be done through:
- opening preview environment and signing up
- opening the Segment's [Staging Untrusted](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) source and verifying that the identify events come through for signup and login. don't worry if the IP in the payload is nonsensical, this is to be expected in the preview environment

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->



/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe