### PR TITLE
Deal with when `cpu.cfs_quota_us` is negative

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -86,7 +86,7 @@ func (basePath CgroupCFSController) readCfsPeriod() (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	return time.Duration(uint(p)) * time.Microsecond, nil
+	return time.Duration(uint64(p)) * time.Microsecond, nil
 }
 
 func (basePath CgroupCFSController) readCfsQuota() (time.Duration, error) {

--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -6,7 +6,6 @@ package cpulimit
 
 import (
 	"bufio"
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -82,9 +81,6 @@ func (basePath CgroupCFSController) readCfsPeriod() (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	if s == "max" {
-		return time.Duration(math.MaxInt64), nil
-	}
 
 	p, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
@@ -99,10 +95,6 @@ func (basePath CgroupCFSController) readCfsQuota() (time.Duration, error) {
 		return 0, err
 	}
 
-	if s == "max" {
-		return math.MaxInt64, nil
-	}
-
 	p, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return 0, err
@@ -114,9 +106,6 @@ func (basePath CgroupCFSController) readCpuUsage() (time.Duration, error) {
 	s, err := basePath.readString("cpuacct.usage")
 	if err != nil {
 		return 0, err
-	}
-	if s == "max" {
-		return time.Duration(math.MaxInt64), nil
 	}
 
 	p, err := strconv.ParseInt(s, 10, 64)

--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -6,6 +6,7 @@ package cpulimit
 
 import (
 	"bufio"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,7 +21,6 @@ type CgroupCFSController string
 
 // Usage returns the cpuacct.usage value of the cgroup
 func (basePath CgroupCFSController) Usage() (usage CPUTime, err error) {
-
 	cputime, err := basePath.readCpuUsage()
 	if err != nil {
 		return 0, xerrors.Errorf("cannot read cpuacct.usage: %w", err)
@@ -98,6 +98,10 @@ func (basePath CgroupCFSController) readCfsQuota() (time.Duration, error) {
 	p, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return 0, err
+	}
+
+	if p < 0 {
+		return time.Duration(math.MaxInt64), nil
 	}
 	return time.Duration(p) * time.Microsecond, nil
 }

--- a/components/ws-daemon/pkg/cpulimit/cfs_test.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs_test.go
@@ -57,7 +57,6 @@ func TestCfsSetLimit(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-
 		tempdir := createTempDir(t, "cpu")
 		err := cgroups.WriteFile(tempdir, "cpu.cfs_period_us", strconv.Itoa(tc.beforeCfsPeriodUs))
 		if err != nil {

--- a/components/ws-daemon/pkg/cpulimit/cfs_test.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cpulimit
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+func init() {
+	cgroups.TestMode = true
+}
+
+func createTempDir(t *testing.T, subsystem string) string {
+	path := filepath.Join(t.TempDir(), subsystem)
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCfsSetLimit(t *testing.T) {
+	type test struct {
+		beforeCfsPeriodUs int
+		beforeCfsQuotaUs  int
+		bandWidth         Bandwidth
+		cfsQuotaUs        int
+		changed           bool
+	}
+	tests := []test{
+		{
+			beforeCfsPeriodUs: 10000,
+			beforeCfsQuotaUs:  -1,
+			bandWidth:         Bandwidth(6000),
+			cfsQuotaUs:        60000,
+			changed:           true,
+		},
+		{
+			beforeCfsPeriodUs: 5000,
+			beforeCfsQuotaUs:  -1,
+			bandWidth:         Bandwidth(6000),
+			cfsQuotaUs:        30000,
+			changed:           true,
+		},
+		{
+			beforeCfsPeriodUs: 10000,
+			beforeCfsQuotaUs:  60000,
+			bandWidth:         Bandwidth(6000),
+			cfsQuotaUs:        60000,
+			changed:           false,
+		},
+	}
+	for _, tc := range tests {
+
+		tempdir := createTempDir(t, "cpu")
+		err := cgroups.WriteFile(tempdir, "cpu.cfs_period_us", strconv.Itoa(tc.beforeCfsPeriodUs))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cgroups.WriteFile(tempdir, "cpu.cfs_quota_us", strconv.Itoa(tc.beforeCfsQuotaUs))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfs := CgroupCFSController(tempdir)
+		changed, err := cfs.SetLimit(tc.bandWidth)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed != tc.changed {
+			t.Fatalf("unexpected error: changed is '%v' but expected '%v'", changed, tc.changed)
+		}
+		cfsQuotaUs, err := cgroups.ReadFile(tempdir, "cpu.cfs_quota_us")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfsQuotaUs != strconv.Itoa(tc.cfsQuotaUs) {
+			t.Fatalf("unexpected error: cfsQuotaUs is '%v' but expected '%v'", cfsQuotaUs, tc.cfsQuotaUs)
+		}
+	}
+
+}

--- a/components/ws-daemon/pkg/cpulimit/cfs_test.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs_test.go
@@ -83,5 +83,72 @@ func TestCfsSetLimit(t *testing.T) {
 			t.Fatalf("unexpected error: cfsQuotaUs is '%v' but expected '%v'", cfsQuotaUs, tc.cfsQuotaUs)
 		}
 	}
+}
 
+func TestReadCfsQuota(t *testing.T) {
+	tests := []int{
+		100000,
+		-1,
+	}
+	for _, tc := range tests {
+		tempdir := createTempDir(t, "cpu")
+		err := cgroups.WriteFile(tempdir, "cpu.cfs_quota_us", strconv.Itoa(tc))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfs := CgroupCFSController(tempdir)
+		v, err := cfs.readCfsQuota()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.Microseconds() != int64(tc) {
+			t.Fatalf("unexpected error: cfs quota is '%v' but expected '%v'", v, tc)
+		}
+	}
+}
+
+func TestReadCfsPeriod(t *testing.T) {
+	tests := []int{
+		10000,
+	}
+	for _, tc := range tests {
+		tempdir := createTempDir(t, "cpu")
+		err := cgroups.WriteFile(tempdir, "cpu.cfs_period_us", strconv.Itoa(tc))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfs := CgroupCFSController(tempdir)
+		v, err := cfs.readCfsPeriod()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.Microseconds() != int64(tc) {
+			t.Fatalf("unexpected error: cfs period is '%v' but expected '%v'", v, tc)
+		}
+	}
+}
+
+func TestReadCpuUsage(t *testing.T) {
+	tests := []int{
+		0,
+		100000,
+	}
+	for _, tc := range tests {
+		tempdir := createTempDir(t, "cpu")
+		err := cgroups.WriteFile(tempdir, "cpuacct.usage", strconv.Itoa(tc))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfs := CgroupCFSController(tempdir)
+		v, err := cfs.readCpuUsage()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.Nanoseconds() != int64(tc) {
+			t.Fatalf("unexpected error: cpu usage is '%v' but expected '%v'", v, tc)
+		}
+	}
 }


### PR DESCRIPTION
## Description
Deal with when cpu.cfs_quota_us is negative

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

```console
$ cd /workspace/gitpod/components/ws-daemon
$ go test -v ./...
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Deal with when cpu.cfs_quota_us is negative
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No