### PR TITLE
jb: fix update gateway instructions

### DIFF
--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -110,19 +110,19 @@ clients:
     defaultDesktopIDE: "code-desktop"
     desktopIDEs: ["code-desktop"]
     installationSteps: [
-      "If you don't see an open dialog by the browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/download'>VS Code</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+      "If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/download'>VS Code</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
     ]
   vscode-insiders:
     defaultDesktopIDE: "code-desktop-insiders"
     desktopIDEs: ["code-desktop-insiders"]
     installationSteps: [
-      "If you don't see an open dialog by the browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'>VS Code Insiders</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+      "If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'>VS Code Insiders</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
     ]
   jetbrains-gateway:
     defaultDesktopIDE: "intellij"
     desktopIDEs: ["intellij", "goland", "pycharm", "phpstorm"]
     installationSteps: [
-      "If you don't see an open dialog by the browser, make sure you have <a target='_blank' class='gp-link' href='https://www.jetbrains.com/remote-development/gateway'>JetBrains Gateway</a> with <a target='_blank' class='gp-link' href='https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/doc/installing.md'>Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+      "If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
     ]
 {{ end }}
 

--- a/components/ide/jetbrains/gateway-plugin/doc/installing.md
+++ b/components/ide/jetbrains/gateway-plugin/doc/installing.md
@@ -1,6 +1,0 @@
-## Installing Gitpod plugin in JetBrains Gateway
-
-- Install latest [JetBrains Gateway](https://www.jetbrains.com/help/idea/remote-development-a.html#gateway)
-  - Please make sure to install Release, not EAP version.
-- Launch Gateway and open plugin settings
-- Search for "Gitpod Gateway" and click install

--- a/install/installer/pkg/components/server/ide/configmap.go
+++ b/install/installer/pkg/components/server/ide/configmap.go
@@ -39,21 +39,21 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					DefaultDesktopIDE: codeDesktop,
 					DesktopIDEs:       []string{codeDesktop},
 					InstallationSteps: []string{
-						"If you don't see an open dialog by the browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/download'>VS Code</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+						"If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/download'>VS Code</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
 					},
 				},
 				"vscode-insiders": {
 					DefaultDesktopIDE: codeDesktopInsiders,
 					DesktopIDEs:       []string{codeDesktopInsiders},
 					InstallationSteps: []string{
-						"If you don't see an open dialog by the browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'>VS Code Insiders</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+						"If you don't see an open dialog in your browser, make sure you have <a target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'>VS Code Insiders</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
 					},
 				},
 				"jetbrains-gateway": {
 					DefaultDesktopIDE: intellij,
 					DesktopIDEs:       []string{intellij, goland, pycharm, phpstorm},
 					InstallationSteps: []string{
-						"If you don't see an open dialog by the browser, make sure you have <a target='_blank' class='gp-link' href='https://www.jetbrains.com/remote-development/gateway'>JetBrains Gateway</a> with <a target='_blank' class='gp-link' href='https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/doc/installing.md'>Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
+						"If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below.",
 					},
 				},
 			},


### PR DESCRIPTION
## Description

- Update gateway instructions from repo to main documentation
- Removed markdown documentation

## Related Issue(s)

N/A

## How to test

- Set JetBrains preferences
- Open workspace
- Links should be as expected (link to docs, not to GitHub / markdown)

## Release Notes

```release-note
NONE
```

## Documentation

N/A