### PR TITLE
Forcing the werft job to fail if the branch name is too long to support preview-environments

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -44,6 +44,19 @@ Tracing.initialize()
 async function run(context: any) {
     const config = jobConfig(werft, context)
 
+    //TODO: This is only a temporary solution and needs to be removed when we migrate to one prev-environment per cluster
+    // Because of a workspace label the branch name that can be used to create a preview environment is limited to 20 chars
+    // echo -n "gitpod.io/registry-facade_ready_ns_staging-" | wc -c
+    if (!config.noPreview) {
+        werft.phase("check-branchname","This checks if the branchname is to long to create a preview-environment successfully.")
+        const maxBranchNameLength = 20;
+        if (config.previewEnvironment.destname.length > maxBranchNameLength) {
+            werft.fail("check-branchname", `The branch name ${config.previewEnvironment.destname} is more than ${maxBranchNameLength} character. Please choose a shorter name!`)
+        }
+        werft.done("check-branchname")
+    }
+
+
     await validateChanges(werft)
     await prepare(werft)
     await buildAndPublish(werft, config)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR only replaces the branchname to be merged. The orginal PR is [here](https://github.com/gitpod-io/gitpod/pull/8316).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
