### PR TITLE
[installer] Tidy up `omitempty` in config

### DIFF
--- a/install/installer/example-config.yaml
+++ b/install/installer/example-config.yaml
@@ -10,8 +10,8 @@ containerRegistry:
   inCluster: true
 database:
   inCluster: true
-domain: gitpod.example.com
-imagePullSecrets: null
+disableDefinitelyGp: false
+domain: ""
 jaegerOperator:
   inCluster: true
 kind: Full
@@ -21,6 +21,8 @@ objectStorage:
   inCluster: true
 observability:
   logLevel: info
+openVSX:
+  url: https://open-vsx.org
 repository: eu.gcr.io/gitpod-core-dev/build
 workspace:
   resources:
@@ -28,6 +30,6 @@ workspace:
       cpu: "1"
       memory: 2Gi
   runtime:
-    containerdRuntimeDir: /run/containerd/io.containerd.runtime.v2.task/k8s.io
+    containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
     containerdSocket: /run/containerd/containerd.sock
     fsShiftMethod: fuse

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -55,6 +55,7 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
 	cfg.OpenVSX.URL = "https://open-vsx.org"
+	cfg.DisableDefinitelyGP = false
 
 	return nil
 }
@@ -78,7 +79,7 @@ type Config struct {
 
 	Certificate ObjectRef `json:"certificate" validate:"required"`
 
-	ImagePullSecrets []ObjectRef `json:"imagePullSecrets"`
+	ImagePullSecrets []ObjectRef `json:"imagePullSecrets,omitempty"`
 
 	Workspace Workspace `json:"workspace" validate:"required"`
 
@@ -90,7 +91,7 @@ type Config struct {
 
 	SSHGatewayHostKey *ObjectRef `json:"sshGatewayHostKey,omitempty"`
 
-	DisableDefinitelyGP bool `json:"disableDefinitelyGp,omitempty"`
+	DisableDefinitelyGP bool `json:"disableDefinitelyGp"`
 
 	Experimental *experimental.Config `json:"experimental,omitempty"`
 }
@@ -172,7 +173,7 @@ const (
 type ContainerRegistry struct {
 	InCluster *bool                      `json:"inCluster,omitempty" validate:"required"`
 	External  *ContainerRegistryExternal `json:"external,omitempty" validate:"required_if=InCluster false"`
-	S3Storage *S3Storage                 `json:"s3storage"`
+	S3Storage *S3Storage                 `json:"s3storage,omitempty"`
 }
 
 type ContainerRegistryExternal struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -40,7 +40,7 @@ type TracingSampleType string
 
 type Tracing struct {
 	SamplerType  *TracingSampleType `json:"samplerType,omitempty" validate:"omitempty,tracing_sampler_type"`
-	SamplerParam *float64           `json:"samplerParam,omitEmpty" validate:"required_with=SamplerType"`
+	SamplerParam *float64           `json:"samplerParam,omitempty" validate:"required_with=SamplerType"`
 }
 
 // Values taken from https://github.com/jaegertracing/jaeger-client-go/blob/967f9c36f0fa5a2617c9a0993b03f9a3279fadc8/config/config.go#L71


### PR DESCRIPTION
## Description
This change is a tidy-up of what is generated with `installer init`. It ...
- adds a default value to `disableDefinitelyGp`
- adds `omitempty` for values that are `null` by default (be more consistent, **alternative**: remove `omitemtpy` more or less everywhere and render all `null` values)
- updates the `example-config.yaml` file

## How to test
<!-- Provide steps to test this PR -->
Nothing to do, just look at the updated `example-config.yaml` file and express your feelings about this change.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Meta
/werft no-preview