### PR TITLE
Update vscode stable with vscode_session fix

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 543d66ff57b0b01f48d6f66fc2fa2fc64d26a848
+  codeCommit: 55fa9977e29e52bb2fcafaa0ccc9dd1179b2c75a
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove track event vscode_session phase running and end, see changes here https://github.com/gitpod-io/openvscode-server/commit/a8cf2c01c89debd3fc8767176ad7ff2589ee12d4

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/8375

## How to test
<!-- Provide steps to test this PR -->
1. Use vscode insiders
2. Open a workspace
3. Go to segment `staging_untrusted` filter with `vscode_session`, you should see a track without `phase` and `focused` props

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

- [x] /werft version=staging-vscode-session
- [x] /werft namespace=staging-vscode-session