### PR TITLE
Update stable with vscode_session telemetry fix

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -356,7 +356,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-9216e2bf490666d468012ab797ecc2703968da47"
+      stableVersion: "commit-890de80174c7dd9d073d63ef2b1f9eac68f063c1"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-9216e2bf490666d468012ab797ecc2703968da47" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-890de80174c7dd9d073d63ef2b1f9eac68f063c1" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove track event vscode_session phase running and end, see changes here https://github.com/gitpod-io/openvscode-server/commit/a8cf2c01c89debd3fc8767176ad7ff2589ee12d4

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/8375

## How to test
<!-- Provide steps to test this PR -->
1. Use vscode stable
2. Open a workspace
3. Open about dialog anf check commit is https://github.com/gitpod-io/openvscode-server/commit/55fa9977e29e52bb2fcafaa0ccc9dd1179b2c75a

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```