### PR TITLE
[ws-daemon] Fix CPU limit annotation

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -98,9 +98,11 @@ type DispatchListener struct {
 }
 
 type workspace struct {
-	CFS       CFSController
-	OWI       logrus.Fields
-	HardLimit ResourceLimiter
+	CFS        CgroupCFSController
+	OWI        logrus.Fields
+	BaseLimit  Bandwidth
+	BurstLimit Bandwidth
+	HardLimit  ResourceLimiter
 
 	lastThrottled uint64
 }
@@ -135,6 +137,8 @@ func (d *DispatchListener) source(context.Context) ([]Workspace, error) {
 			ID:          id,
 			NrThrottled: throttled,
 			Usage:       usage,
+			BaseLimit:   w.BaseLimit,
+			BurstLimit:  w.BurstLimit,
 		})
 	}
 	return res, nil
@@ -215,7 +219,8 @@ func (d *DispatchListener) WorkspaceUpdated(ctx context.Context, ws *dispatch.Wo
 		if err != nil {
 			return xerrors.Errorf("cannot enforce fixed CPU limit: %w", err)
 		}
-		wsinfo.HardLimit = FixedLimiter(BandwidthFromQuantity(limit))
+		wsinfo.BaseLimit = BandwidthFromQuantity(limit)
+		wsinfo.BurstLimit = BandwidthFromQuantity(limit)
 	}
 
 	return nil

--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -98,7 +98,7 @@ type DispatchListener struct {
 }
 
 type workspace struct {
-	CFS        CgroupCFSController
+	CFS        CFSController
 	OWI        logrus.Fields
 	BaseLimit  Bandwidth
 	BurstLimit Bandwidth


### PR DESCRIPTION
## Description
When we updated the CPU limiting mechanism, we broke the `gitpod.io/cpuLimit` annotation. This PR makes that annotation work again. It effectively controls the base and burst limits of a workspace.

## How to test
1. Start a workspace
2. Set the `gitpod.io/cpuLimit` annotation on that workspace
3. Observe how the workspace's cfs quota gets set to that value

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Made the `gitpod.io/cpuLimit` annotation work again
```
