### PR TITLE
Log workspace starts and stop

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -145,6 +145,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
 
+	clog.Info("StartWorkspace")
 	reqs, _ := protojson.Marshal(req)
 	safeReqs, _ := log.RedactJSON(reqs)
 	log.WithField("req", string(safeReqs)).Debug("StartWorkspace request received")
@@ -417,8 +418,12 @@ func areValidFeatureFlags(value interface{}) error {
 // StopWorkspace stops a running workspace
 func (m *Manager) StopWorkspace(ctx context.Context, req *api.StopWorkspaceRequest) (res *api.StopWorkspaceResponse, err error) {
 	span, ctx := tracing.FromContext(ctx, "StopWorkspace")
-	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
+	owi := log.OWI("", "", req.Id)
+	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
+
+	clog := log.WithFields(owi)
+	clog.Info("StopWorkspace")
 
 	gracePeriod := stopWorkspaceNormallyGracePeriod
 	if req.Policy == api.StopWorkspacePolicy_IMMEDIATELY {


### PR DESCRIPTION
## Description
Logs workspace starts and stops which makes it easier to correlate log entries.

[StartWorkspace](https://console.cloud.google.com/logs/query;cursorTimestamp=2022-02-25T15:30:09Z;query=resource.labels.namespace_name%3D%22staging-fo-8449-2%22%0A%22StartWorkspace%22%0Atimestamp%3D%222022-02-25T15:30:09Z%22%0AinsertId%3D%22wua6ypzxdq9nmuau%22?project=gitpod-core-dev)

[StopWorkspace](https://console.cloud.google.com/logs/query;cursorTimestamp=2022-02-25T15:32:42Z;query=resource.labels.namespace_name%3D%22staging-fo-8449-2%22%0A%22StopWorkspace%22%0Atimestamp%3D%222022-02-25T15:32:42Z%22%0AinsertId%3D%22kji1fbekqocxa9di%22?project=gitpod-core-dev)

## Related Issue(s)
Fixes #8449

## How to test
- Start workspace
- Stop workspace
- Check logs

## Release Notes
```release-note
NONE
```