### PR TITLE
improve oom pod error handling

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -311,13 +311,14 @@ func podRunning(clientset client.Client, podName, namespace string) wait.Conditi
 		}
 
 		switch pod.Status.Phase {
-		case corev1.PodFailed, corev1.PodSucceeded:
-			return false, fmt.Errorf("pod ran to completion")
-		case corev1.PodPending:
+		case corev1.PodFailed:
 			if strings.HasPrefix(pod.Status.Reason, "OutOf") {
 				return false, xerrors.Errorf("cannot schedule pod due to out of resources, reason: %s", pod.Status.Reason)
 			}
-
+			return false, fmt.Errorf("pod failed with reason: %s", pod.Status.Reason)
+		case corev1.PodSucceeded:
+			return false, fmt.Errorf("pod ran to completion")
+		case corev1.PodPending:
 			for _, c := range pod.Status.Conditions {
 				if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionTrue {
 					// even if pod is pending but was scheduled already, it means kubelet is pulling images and running init containers


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Handle pod failed with out of memory error correctly.
This is the status of the pod with out of memory error:
```
status:
  message: 'Pod Node didn''t have enough resource: memory, requested: 2097152000,
    used: 65865462583, capacity: 66388008960'
  phase: Failed
  reason: OutOfmemory
  startTime: "2022-02-25T14:26:36Z"
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8238 
Improves #8372 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve handling of an error when pod fails to start due to out of memory error on the node
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
