### PR TITLE
change alert period for ws stuck on starting or stopping to 20m

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -14,11 +14,11 @@
             labels: {
               severity: 'critical',
             },
-            'for': '1h',
+            'for': '20m',
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStarting.md',
               summary: '5 or more workspaces are stuck on starting',
-              description: '{{ printf "%.2f" $value }} regular workspaces are stuck on starting for more than 1 hour. Current status: "{{ $labels.reason }}"',
+              description: '{{ printf "%.2f" $value }} regular workspaces are stuck on starting for more than 20 minutes. Current status: "{{ $labels.reason }}"',
             },
             expr: |||
               count(
@@ -31,11 +31,11 @@
             labels: {
               severity: 'critical',
             },
-            'for': '1h',
+            'for': '20m',
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md',
               summary: '5 or more workspaces are stuck on stopping',
-              description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 1 hour.',
+              description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes.',
             },
             expr: |||
               sum(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Reduce alert period from 1h to 20m for `GitpodWorkspaceStuckOnStarting` and `GitpodWorkspaceStuckOnStopping`.
Reasoning:
Currently it takes one hour of that alert firing before pager duty gets issued. This is not great customer experience.
I checked in grafana for the last 7 days and that change should not produce any false positives.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
