### PR TITLE
Bump to latest leeway release

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -68,7 +68,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/clean-up-werft-build-nodes.yaml
+++ b/.werft/clean-up-werft-build-nodes.yaml
@@ -16,7 +16,7 @@ pod:
         type: Directory
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/delete-preview-environments/delete-preview-environments-cron.yaml
+++ b/.werft/delete-preview-environments/delete-preview-environments-cron.yaml
@@ -18,7 +18,7 @@ pod:
       secretName: gcp-sa-gitpod-release-deployer
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/delete-preview-environments/delete-preview-environments.yaml
+++ b/.werft/delete-preview-environments/delete-preview-environments.yaml
@@ -18,7 +18,7 @@ pod:
       secretName: gcp-sa-gitpod-release-deployer
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bmp-leeway.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -59,7 +59,7 @@ RUN cd /usr/bin && curl -L https://github.com/praetorian-inc/gokart/releases/dow
 
 # leeway
 ENV LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE=8388608
-RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.16/leeway_0.2.16_Linux_x86_64.tar.gz | tar xz
+RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.17/leeway_0.2.17_Linux_x86_64.tar.gz | tar xz
 
 # dazzle
 RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.4/dazzle_0.1.4_Darwin_x86_64.tar.gz| tar xz


### PR DESCRIPTION
## Description
Bumps leeway to the [latest version](https://github.com/gitpod-io/leeway/releases/tag/v0.2.17).

## How to test
If it builds and the provenance shows that things were built from a clean git working copy, we're good.
```json
"materials": [
  {
    "uri": "git+https://github.com/gitpod-io/gitpod.git",
    "digest": {
      "sha256": "48315da8c73d17c25edc61e50cdd1296fb0edca9"
    }
  }
]
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
