### PR TITLE
[preview env] extend deny egress block

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -262,6 +262,13 @@ while [ "$i" -le "$DOCS" ]; do
       yq w -i k8s.yaml -d "$i" spec.ingress[0].ports[0].port "$WS_DAEMON_PORT"
    fi
 
+   # NetworkPolicy for workspace-default
+   if [[ "workspace-default" == "$NAME" ]] && [[ "$KIND" == "NetworkPolicy" ]]; then
+      WORK="overrides for $NAME $KIND"
+      echo "$WORK"
+      yq w -i k8s.yaml -d "$i" spec.egress[0].to[0].ipBlock.except[0] 169.254.169.254/30
+   fi
+
    # host ws-daemon on $WS_DAEMON_PORT
    if [[ "ws-daemon" == "$NAME" ]] && [[ "$KIND" == "ConfigMap" ]]; then
       WORK="overrides for $NAME $KIND"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
From https://github.com/gitpod-io/gitpod/pull/8336 We added GCP metadata security detection to the Preview environment, so that if GCP metadata is accessible in the workspace, the supervisor will immediately end the process to prevent sensitive information from being leaked.
 
But if we only block 169.254.169.254, it still can access by HTTP request, I don't know why

Perhaps in GKE, this IP is special and may not be controlled by the network policy

After testing, I found that changing the blocked IP to 169.254.169.254/30 solves the problem, I don't know the exact reason, but it does work

I am not sure this will affect any GKE cluster or just our preview environment, if all GKE clusters affect, I think changing installer network policy is a better way

We have two ways to temporarily alleviate this problem
1. disable metadata detection in the Preview environment
2. use 169.254.169.254/30 as a mitigation measure

This PR use option 2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Start a workspace, workspace can run

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
