### PR TITLE
installer: clarify experimental config flag 

### DIFF
--- a/install/installer/cmd/render.go
+++ b/install/installer/cmd/render.go
@@ -46,9 +46,9 @@ A config file is required which can be generated with the init command.`,
 
 		if cfg.Experimental != nil {
 			if renderOpts.UseExperimentalConfig {
-				fmt.Fprintf(os.Stderr, "rendering using experimental config - here be dragons\n")
+				fmt.Fprintf(os.Stderr, "rendering using experimental config\n")
 			} else {
-				fmt.Fprintf(os.Stderr, "config contains experimental options - ignoring them\n")
+				fmt.Fprintf(os.Stderr, "ignoring experimental config. Use `--use-experimental-config` to include the experimental section in config\n")
 				cfg.Experimental = nil
 			}
 		}
@@ -190,5 +190,5 @@ func init() {
 	renderCmd.PersistentFlags().StringVarP(&renderOpts.ConfigFN, "config", "c", os.Getenv("GITPOD_INSTALLER_CONFIG"), "path to the config file")
 	renderCmd.PersistentFlags().StringVarP(&renderOpts.Namespace, "namespace", "n", "default", "namespace to deploy to")
 	renderCmd.Flags().BoolVar(&renderOpts.ValidateConfigDisabled, "no-validation", false, "if set, the config will not be validated before running")
-	renderCmd.Flags().BoolVar(&renderOpts.UseExperimentalConfig, "danger-use-unsupported-config", false, "enable use of unsupported config")
+	renderCmd.Flags().BoolVar(&renderOpts.UseExperimentalConfig, "use-experimental-config", false, "enable the use of experimental config that is prone to be changed")
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the flag descriptions, and the `render` display
notes to be more explicit on what experimental config is.

This flag is required, to make sure users are opting in explicitely/
knowlingly to use the experimental config.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8107

## How to test
<!-- Provide steps to test this PR -->
`render` cmd should have the renamed naming, and messages

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Renamed `danger-use-unsupported-config` flag in the installer to `use-experimental-config`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft no-preview