### PR TITLE
[jb] warm up IntelliJ backend

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,6 +31,7 @@ tasks:
       exit 0
   - name: Java
     init: |
+      scripts/intellij-warm-up.sh
       leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
       leeway exec --package components/ide/jetbrains/backend-plugin:plugin -- ./gradlew buildPlugin
       leeway exec --package components/ide/jetbrains/gateway-plugin:publish -- ./gradlew buildPlugin

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="maven" />
       <option name="url" value="https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/snapshots" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/releases" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/gitpod.iml" filepath="$PROJECT_DIR$/.idea/gitpod.iml" />
-    </modules>
-  </component>
-</project>

--- a/scripts/intellij-warm-up.sh
+++ b/scripts/intellij-warm-up.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# only run as a part of prebuild
+if [ ! "$GITPOD_HEADLESS" = "true" ] ; then exit ; fi
+
+# donwload released IntelliJ backend supported by Gitpod
+INTELLIJ_DOWNLOAD_URL=$(yq read WORKSPACE.yaml 'defaultArgs.intellijDownloadUrl')
+echo "$INTELLIJ_DOWNLOAD_URL"
+mkdir /tmp/backend
+cd /tmp/backend || exit
+curl -sSLo backend.tar.gz "$INTELLIJ_DOWNLOAD_URL" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
+
+# see https://github.com/gitpod-io/gitpod/blob/eaa440f09c144611d1ac3a2734dcb681617c3f5f/components/ide/jetbrains/image/leeway.Dockerfile#L12
+printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend/bin/idea.properties"
+# see https://github.com/gitpod-io/gitpod/blob/2bd00a2afaea61b38da6df5e8d2b400641713e38/components/ide/jetbrains/image/startup.sh#L19-L23
+unset JAVA_TOOL_OPTIONS
+# see https://github.com/gitpod-io/gitpod/blob/2bd00a2afaea61b38da6df5e8d2b400641713e38/components/ide/jetbrains/image/startup.sh#L29
+export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains
+export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
+
+# run indexing
+/tmp/backend/bin/remote-dev-server.sh warmup /workspace/gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It should enable faster turn around to develop JB backend plugin.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Enable IntelliJ in [preferences](https://gitpod.io/preferences).
- [Start a workspace on this PR](https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/8480), wait for the prebuild, open in IntelliJ, open java code in the backend plugin and check that smartness is already available.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
