### PR TITLE
[kots]: use Helm for the Installer job

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -3,6 +3,7 @@
 # See License-AGPL.txt in the project root for license information.
 
 FROM alpine:3.15
+COPY --from=alpine/helm:3.8.0 /usr/bin/helm /usr/bin/helm
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
 RUN apk add --no-cache curl yq  \
     && curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag - using this tag as need the license evaluator
-          image: 'eu.gcr.io/gitpod-core-dev/build/installer:sje-licensing.24'
+          image: 'eu.gcr.io/gitpod-core-dev/build/installer:sje-kots-helm.7'
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -182,16 +182,39 @@ spec:
               config=$(cat "${CONFIG_FILE}")
               echo "Gitpod: ${CONFIG_FILE}=${config}"
 
-              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} > /tmp/gitpod.yaml
+              echo "Gitpod: Create a Helm template directory"
+              rm -Rf "${GITPOD_OBJECTS}"
+              mkdir -p "${GITPOD_OBJECTS}/templates"
+              cat <<EOF >> "${GITPOD_OBJECTS}/Chart.yaml"
+              apiVersion: v2
+              name: gitpod-kots
+              description: Always ready-to-code
+              Version: "1.0.0"
+              appVersion: "$(/app/installer version | yq e '.version' -)"
+              EOF
+
+              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} > "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
               # Workaround for #8532 and #8529
               echo "Gitpod: Remove the StatefulSet status object for OpenVSX Proxy"
               yq eval-all --inplace \
                 'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
-                /tmp/gitpod.yaml
+                "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
+              # The long timeout is to ensure the TLS cert is created (if required)
               echo "Gitpod: Apply the Kubernetes objects"
-              kubectl apply -f /tmp/gitpod.yaml
+              helm upgrade \
+                --atomic \
+                --cleanup-on-fail \
+                --create-namespace \
+                --install \
+                --namespace="{{repl Namespace }}" \
+                --reset-values \
+                --timeout 1h \
+                --wait \
+                --wait-for-jobs \
+                gitpod \
+                "${GITPOD_OBJECTS}"
 
               echo "Gitpod: Installer job finished - goodbye"
       volumes:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This changes the KOTS Installer job to use Helm for the installation of Gitpod rather than `kubectl apply`. **IMPORTANT** this still uses the Gitpod Installer for generating the Kubernetes YAML and is not in any way us going back to using Helm for installing Gitpod.

One thing we have to be aware of with KOTS is that we control what resources third-parties/customers have installed on their clusters under the umbrella of "Gitpod". It is key that we should remove resources when they've been finished with.

An example of this:
- day 1: a user installs Gitpod with in-cluster database/registry/object storage as a way of getting up and running quickly. They use this to get familiar with Gitpod and the installation process
- day 2: once they've decided they're happy, they change their KOTS configuration to migrate to external (and more performant) database/registry/object storage.

If we use `kubectl apply`, there is no history and any resources that are no longer required (eg, the `mysql-0` statefulset) remain in the cluster. As they are no longer being used, they become orphaned from Gitpod installation YAML. More importantly, any persistent volume claims remain and the costs therein.

By switching to `helm upgrade`, we hook into Helm's history. Any resources that are removed between the previous and current installations are deleted.

Helm can be thought of as fulfilling two jobs:
1. generating the YAML from templates
2. deploying and managing resources

As we are still using the Installer to generate the YAML (ie, part 1), we're only using Helm for part 2.

The alternative way of doing this is to implement our own version of this. In reality, we'd likely end up building something very similar to how Helm works. By doing it this way, we reduce the time involved and benefit from all their testing.

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS:
 - install with in-cluster dependencies
 - upgrade to external dependencies - watch the old resources disappear

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: use Helm for the Installer job
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
