### PR TITLE
Rate-limit new prebuilds to 50 / user / minute to prevent incidents

### DIFF
--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -40,6 +40,10 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
             points: 1,  // 1 workspace start per user per 10s
             durationsSec: 10
         },
+        startPrebuild: {
+            points: 50,  // 50 prebuild starts per user per minute
+            durationsSec: 60
+        },
     }
     const defaultFunctions: FunctionsConfig = {
         "getLoggedInUser": { group: "default", points: 1 },
@@ -105,7 +109,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "deleteProject":  { group: "default", points: 1 },
         "findPrebuilds":  { group: "default", points: 1 },
         "getProjectOverview":  { group: "default", points: 1 },
-        "triggerPrebuild":  { group: "default", points: 1 },
+        "triggerPrebuild":  { group: "startPrebuild", points: 1 },
         "cancelPrebuild":  { group: "default", points: 1 },
         "fetchProjectRepositoryConfiguration":  { group: "default", points: 1 },
         "guessProjectConfiguration":  { group: "default", points: 1 },

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -11,8 +11,9 @@ import { RateLimiterMemory, RateLimiterRes } from "rate-limiter-flexible";
 
 export const accessCodeSyncStorage = 'accessCodeSyncStorage';
 export const accessHeadlessLogs = 'accessHeadlessLogs';
-type GitpodServerMethodType = keyof Omit<GitpodServer, "dispose" | "setClient"> | typeof accessCodeSyncStorage | typeof accessHeadlessLogs;
-type GroupKey = "default" | "startWorkspace";
+export const startPrebuild = 'startPrebuild';
+type GitpodServerMethodType = keyof Omit<GitpodServer, "dispose" | "setClient"> | typeof accessCodeSyncStorage | typeof accessHeadlessLogs | typeof startPrebuild;
+type GroupKey = "default" | "startWorkspace" | "startPrebuild";
 type GroupsConfig = {
     [key: string]: {
         points: number,
@@ -161,10 +162,6 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "getLicenseInfo": { group: "default", points: 1 },
         "licenseIncludesFeature": { group: "default", points: 1 },
 
-        "accessCodeSyncStorage": { group: "default", points: 1 },
-
-        accessHeadlessLogs: { group: "default", points: 1 },
-
         "adminAddStudentEmailDomain":  { group: "default", points: 1 },
         "adminGetAccountStatement":  { group: "default", points: 1 },
         "adminIsStudent":  { group: "default", points: 1 },
@@ -197,6 +194,11 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "trackLocation": { group: "default", points: 1},
         "identifyUser": { group: "default", points: 1},
         "getIDEOptions": { group: "default", points: 1 },
+
+        // Non-server methods
+        "accessCodeSyncStorage": { group: "default", points: 1 },
+        "accessHeadlessLogs": { group: "default", points: 1 },
+        "startPrebuild":  { group: "startPrebuild", points: 1 },
     };
 
     return {

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -358,7 +358,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
                     throw rlRejected;
                 }
                 log.warn({ userId }, "Rate limiter prevents accessing method due to too many requests.", rlRejected, { method });
-                throw new ResponseError<RateLimiterError>(ErrorCodes.TOO_MANY_REQUESTS, "too many requests", { method, retryAfter: Math.round(rlRejected.msBeforeNext / 1000) || 1 });
+                throw new ResponseError<RateLimiterError>(ErrorCodes.TOO_MANY_REQUESTS, "too many requests", { method, retryAfter: Math.ceil(rlRejected.msBeforeNext / 1000) || 1 });
             }
 
             // access guard


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Rate-limit new prebuilds to 50 / user / minute to prevent incidents

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5176

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Rate-limit new prebuilds to 50 / user / minute to prevent incidents
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
