### PR TITLE
Remove free text search on contextURL

### DIFF
--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -97,7 +97,7 @@ export function ProjectsSearch() {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search Projects" onKeyDown={(k) => k.key === 'Enter' && search()} onChange={(v) => { setSearchTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search Projects" onKeyDown={(k) => k.key === 'Enter' && search()} onChange={(v) => { setSearchTerm((v.target.value).trim()) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/dashboard/src/admin/TeamsSearch.tsx
+++ b/components/dashboard/src/admin/TeamsSearch.tsx
@@ -81,7 +81,7 @@ export function TeamsSearch() {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search Teams" onKeyDown={(k) => k.key === 'Enter' && search()} onChange={(v) => { setSearchTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search Teams" onKeyDown={(k) => k.key === 'Enter' && search()} onChange={(v) => { setSearchTerm((v.target.value).trim()) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -72,7 +72,7 @@ export default function UserSearch() {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search Users" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search Users" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm((v.target.value).trim()) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -68,27 +68,19 @@ export function WorkspaceSearch(props: Props) {
     const search = async () => {
         setSearching(true);
         try {
-            let searchTerm: string | undefined = queryTerm;
-            const query: AdminGetWorkspacesQuery = {
-                ownerId: props?.user?.id,
-            };
-            if (matchesInstanceIdOrLegacyWorkspaceIdExactly(searchTerm)) {
-                query.instanceIdOrWorkspaceId = searchTerm;
-            } else if (matchesNewWorkspaceIdExactly(searchTerm)) {
-                query.workspaceId = searchTerm;
-            }
-            if (query.workspaceId || query.instanceId || query.instanceIdOrWorkspaceId) {
-                searchTerm = undefined;
+            const query: AdminGetWorkspacesQuery = {};
+            if (matchesInstanceIdOrLegacyWorkspaceIdExactly(queryTerm)) {
+                query.instanceIdOrWorkspaceId = queryTerm;
+            } else if (matchesNewWorkspaceIdExactly(queryTerm)) {
+                query.workspaceId = queryTerm;
             }
 
-            // const searchTerm = searchTerm;
             const result = await getGitpodService().server.adminGetWorkspaces({
                 limit: 100,
                 orderBy: 'instanceCreationTime',
                 offset: 0,
                 orderDir: "desc",
                 ...query,
-                searchTerm,
             });
             setSearchResult(result);
         } finally {
@@ -104,7 +96,9 @@ export function WorkspaceSearch(props: Props) {
                             <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search Workspaces" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setQueryTerm(v.target.value) }} />
+                    <input type="search" placeholder="Search Workspace IDs"
+                        onKeyDown={(ke) => ke.key === 'Enter' && search() }
+                        onChange={(v) => { setQueryTerm((v.target.value).trim()) }} />
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -315,28 +315,6 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
     }
 
     @test(timeout(10000))
-    public async testFindAllWorkspaceAndInstances_contextUrl() {
-        await Promise.all([
-            this.db.store(this.ws),
-            this.db.storeInstance(this.wsi1),
-            this.db.storeInstance(this.wsi2),
-            this.db.store(this.ws2),
-            this.db.storeInstance(this.ws2i1),
-        ]);
-        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "contextURL", "DESC", undefined, this.ws.contextURL);
-        // It should only find one workspace instance
-        expect(dbResult.total).to.eq(1);
-
-        const workspaceAndInstance = dbResult.rows[0]
-
-        // It should find the workspace that uses the queried context url
-        expect(workspaceAndInstance.workspaceId).to.eq(this.ws.id)
-
-        // It should select the workspace instance that was most recently created
-        expect(workspaceAndInstance.instanceId).to.eq(this.wsi2.id)
-    }
-
-    @test(timeout(10000))
     public async testFindAllWorkspaceAndInstances_workspaceId() {
         await Promise.all([
             this.db.store(this.ws),
@@ -344,7 +322,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             this.db.store(this.ws2),
             this.db.storeInstance(this.ws2i1),
         ]);
-        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "workspaceId", "DESC", { workspaceId: this.ws2.id }, undefined);
+        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "workspaceId", "DESC", { workspaceId: this.ws2.id });
         // It should only find one workspace instance
         expect(dbResult.total).to.eq(1);
 
@@ -361,7 +339,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             this.db.store(this.ws2),
             this.db.storeInstance(this.ws2i1),
         ]);
-        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "workspaceId", "DESC", { instanceIdOrWorkspaceId: this.ws2.id }, undefined);
+        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "workspaceId", "DESC", { instanceIdOrWorkspaceId: this.ws2.id });
         // It should only find one workspace instance
         expect(dbResult.total).to.eq(1);
 
@@ -379,7 +357,7 @@ import { DBWorkspaceInstance } from './typeorm/entity/db-workspace-instance';
             this.db.store(this.ws2),
             this.db.storeInstance(this.ws2i1),
         ]);
-        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "instanceId", "DESC", { instanceId: this.wsi1.id }, undefined);
+        const dbResult = await this.db.findAllWorkspaceAndInstances(0, 10, "instanceId", "DESC", { instanceId: this.wsi1.id });
 
         // It should only find one workspace instance
         expect(dbResult.total).to.eq(1);

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -81,7 +81,7 @@ export interface WorkspaceDB {
     findWorkspacesForContentDeletion(minSoftDeletedTimeInDays: number, limit: number): Promise<WorkspaceOwnerAndSoftDeleted[]>;
     findPrebuiltWorkspacesForGC(daysUnused: number, limit: number): Promise<WorkspaceAndOwner[]>;
     findAllWorkspaces(offset: number, limit: number, orderBy: keyof Workspace, orderDir: "ASC" | "DESC", ownerId?: string, searchTerm?: string, minCreationTime?: Date, maxCreationDateTime?: Date, type?: WorkspaceType): Promise<{ total: number, rows: Workspace[] }>;
-    findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof WorkspaceAndInstance, orderDir: "ASC" | "DESC", query?: AdminGetWorkspacesQuery, searchTerm?: string): Promise<{ total: number, rows: WorkspaceAndInstance[] }>;
+    findAllWorkspaceAndInstances(offset: number, limit: number, orderBy: keyof WorkspaceAndInstance, orderDir: "ASC" | "DESC", query?: AdminGetWorkspacesQuery): Promise<{ total: number, rows: WorkspaceAndInstance[] }>;
     findWorkspaceAndInstance(id: string): Promise<WorkspaceAndInstance | undefined>;
     findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
 

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -116,5 +116,4 @@ export type AdminGetWorkspacesQuery = {
     instanceIdOrWorkspaceId?: string;
     instanceId?: string;
     workspaceId?: string;
-    ownerId?: string;
 };

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -586,7 +586,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         await this.guardAdminAccess("adminGetWorkspaces", { req }, Permission.ADMIN_WORKSPACES);
 
-        return await this.workspaceDb.trace(ctx).findAllWorkspaceAndInstances(req.offset, req.limit, req.orderBy, req.orderDir === "asc" ? "ASC" : "DESC", req, req.searchTerm);
+        return await this.workspaceDb.trace(ctx).findAllWorkspaceAndInstances(req.offset, req.limit, req.orderBy, req.orderDir === "asc" ? "ASC" : "DESC", req);
     }
 
     async adminGetWorkspace(ctx: TraceContext, workspaceId: string): Promise<WorkspaceAndInstance> {


### PR DESCRIPTION
## Description
This change disables the free text search, and encourages searching on workspace IDs.  
It's a minimum change for now - there will be follow-up tasks to improve the search[[1](https://github.com/gitpod-io/gitpod/issues/8453#issuecomment-1050875763)][[2](https://github.com/gitpod-io/gitpod/issues/8453#issuecomment-1054716890)].
It also includes drive-by changes of removing whitespace from searches[[1](https://github.com/gitpod-io/gitpod/issues/8454)].

<img width="601" alt="Screenshot 2022-03-02 at 00 54 02" src="https://user-images.githubusercontent.com/8015191/156268601-ae4a447d-0a46-4a46-b2f1-b0c903e8fd12.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8453
Fixes #8454 

## How to test
1. Go to https://lm-search-ws-8453.staging.gitpod-dev.com/admin/workspaces
2. Search part of a contextURL - it should not work.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Free text search on workspace admin dashboard is not enabled anymore.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
