### PR TITLE
[preview-environments] Explicitly add statusfield of statefulset

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -6,6 +6,7 @@ package openvsx_proxy
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -101,6 +102,10 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					}},
 				},
 			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:          *pointer.Int32(1),
+			AvailableReplicas: *pointer.Int32(1),
 		},
 	}}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
While trying to spin up preview environments on Harvester, we were getting failures applying the gitpod config as shown [here](https://werft.gitpod-dev.com/job/gitpod-build-new-image-test-12.0):
![image](https://user-images.githubusercontent.com/24193764/156198800-c34fc7eb-8c91-4424-bd00-858c5c19bf0f.png)

It is a strange error since the status field of a stateful set should not be set before applying it, but should be populated and managed by the Kubernetes API.

If we decide to apply a statefulset with the status field though, there are some [required fields that need to be set](https://github.com/kubernetes/kubernetes/issues/78203).

I couldn't find a way to make the installer not render the openvsx-proxy statefulset without the status field, but managed to make CI pass if I add the required fields. **I'm opening this PR to ask for feedback, I'd rather prevent the status field from rendering altogether**

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create a fresh new environment from this PR

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
installer: Add required fields to openvsx statefulset manifests
```
