### PR TITLE
[installer]: correct the stored config to include apiVersion

### DIFF
--- a/install/installer/pkg/components/gitpod/configmap.go
+++ b/install/installer/pkg/components/gitpod/configmap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +25,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		VersionManifest: ctx.VersionManifest,
 	}
 
-	config, err := common.ToJSONString(ctx.Config)
+	cfg, err := config.Marshal(config.CurrentVersion, ctx.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal Gitpod config: %w", err)
 	}
@@ -43,7 +44,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.DefaultLabels(Component),
 			},
 			Data: map[string]string{
-				"config.json":   string(config),
+				"config.yaml":   string(cfg),
 				"versions.json": string(versions),
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The stored config was missing the `apiVersion` so was an invalid config. This also changes the format from JSON to YAML

This is useful when getting support bundles from KOTS so we can see the stored config to help with debugging

## How to test
<!-- Provide steps to test this PR -->
Deploy via the Installer and get the gitpod configmap

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: correct the stored config to include apiVersion
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
