### PR TITLE
Set the timeout for the server deployment to 10min

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -456,7 +456,7 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
 
     try {
         werft.log(installerSlices.DEPLOYMENT_WAITING, "Server not ready. Let the waiting...commence!");
-        exec(`kubectl -n ${namespace} rollout status deployment/server --timeout=5m`, { slice: installerSlices.DEPLOYMENT_WAITING });
+        exec(`kubectl -n ${namespace} rollout status deployment/server --timeout=10m`, { slice: installerSlices.DEPLOYMENT_WAITING });
         werft.done(installerSlices.DEPLOYMENT_WAITING);
     } catch (err) {
         if (!jobConfig.mainBuild) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Installing Gitpod in a VM on Harvester lead to a timeout during the server deployment. Using twice the time should prevent the deployment from failing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create a new VM using werft.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
