### PR TITLE
werft/deploy/post-process: Remove openvsx statefulsetstatus

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -218,6 +218,15 @@ while [ "$i" -le "$DOCS" ]; do
       yq m -x -i k8s.yaml -d "$i" /tmp/"$NAME"overrides.yaml
    fi
 
+   if [[ "openvsx-proxy" == "$NAME" ]] && [[ "$KIND" == "StatefulSet" ]]; then
+      # Our installer is rendering StatefulSet Status field although it is not a necessary field.
+      # In fact, the fields under StatefulSet status has changed over the last Kubernetes versions,
+      # We're being hit by this while trying to install Gitpod on GKE and k3s running different versions
+      # where 'availableReplicas' is unkown in GKE while being required on k3s.
+      # This workaround should be deleted when https://github.com/gitpod-io/gitpod/issues/8529 gets fixed.
+      yq d -i k8s.yaml -d "$i" 'status'
+   fi
+
     if [[ ! -v WITH_VM ]] && [[ "ws-proxy" == "$NAME" ]] && [[ "$KIND" == "Service" ]]; then
       WORK="overrides for $NAME $KIND"
       echo "$WORK"

--- a/install/installer/README.md
+++ b/install/installer/README.md
@@ -163,6 +163,24 @@ yq eval-all --inplace \
   gitpod.yaml
 ```
 
+## Error validating `StatefulSet.status`
+
+```shell
+error: error validating "gitpod.yaml": error validating data: ValidationError(StatefulSet.status): missing required field "availableReplicas" in io.k8s.api.apps.v1.StatefulSetStatus; if you choose to ignore these errors, turn validation off with --validate=false
+```
+
+Depending upon your Kubernetes implementation, you may receive this error. This is
+due to a bug in the underlying StatefulSet dependency, which is used to generate the
+OpenVSX proxy (see [#8529](https://github.com/gitpod-io/gitpod/issues/8529)).
+
+To fix this, you will need to post-process the rendered YAML to remove the `status` field.
+
+```shell
+yq eval-all --inplace \
+  'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
+  gitpod.yaml
+```
+
 ---
 
 # What is installed


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
While https://github.com/gitpod-io/gitpod/issues/8529 is not fixed, we're adding a workaround to remove the status field from OpenVSX-Proxy statefulset, to make sure our deployment works on both core-dev and harvester.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Start a preview on core-dev and harvester

Docs change tested with https://www.yamldiff.com/

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
