### PR TITLE
Fix launch-dev-server script to work also from VS Code

### DIFF
--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -32,4 +32,11 @@ fi
 export JB_DEV=true
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0"
 
+# Set default config and system directories under /workspace to preserve between restarts
+export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains
+export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
+
+# Enable host status endpoint
+export CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod
+
 $TEST_BACKEND_DIR/bin/remote-dev-server.sh run $TEST_DIR

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/ControllerStatusService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/ControllerStatusService.kt
@@ -17,7 +17,6 @@ import java.net.http.HttpResponse
 import java.time.Duration
 
 object ControllerStatusService {
-    private val port = BuiltInServerManager.getInstance().port
     private val cwmToken = System.getenv("CWM_HOST_STATUS_OVER_HTTP_TOKEN")
     private val httpClient = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.ALWAYS)
         .connectTimeout(Duration.ofSeconds(2))
@@ -33,6 +32,7 @@ object ControllerStatusService {
     suspend fun fetch(): ControllerStatus =
         @Suppress("MagicNumber")
         retry(3) {
+            val port = BuiltInServerManager.getInstance().waitForStart().port
             val httpRequest = HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:$port/codeWithMe/unattendedHostStatus?token=$cwmToken"))
                 .header("Content-Type", "application/json")


### PR DESCRIPTION
## Description

Fix launch-dev-server script to work also from VS Code.

There were some missing environment variables in the script.

Also, we now set the port in a later moment, in [ControllerStatusService.kt](https://github.com/gitpod-io/gitpod/pull/8544/files#diff-d153ea9286fb391f993f849a5883a05ef9669a2b095ada06e7f1a5f7204cdda0).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
