### PR TITLE
Link to privacy policy from login page

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -209,7 +209,8 @@ export function Login() {
                 </div>
                 <div className="flex-none mx-auto h-20 text-center">
                     <span className="text-gray-400">
-                        By signing in, you agree to our <a className="gp-link hover:text-gray-600" target="gitpod-terms" href="https://www.gitpod.io/terms/">terms of service</a>.
+                        By signing in, you agree to our <a className="gp-link hover:text-gray-600" target="gitpod-terms" href="https://www.gitpod.io/terms/">terms of service</a>
+                        and <a className="gp-link hover:text-gray-600" target="gitpod-privacy" href="https://www.gitpod.io/privacy/">privacy policy</a>.
                     </span>
                 </div>
             </div>

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -209,8 +209,7 @@ export function Login() {
                 </div>
                 <div className="flex-none mx-auto h-20 text-center">
                     <span className="text-gray-400">
-                        By signing in, you agree to our <a className="gp-link hover:text-gray-600" target="gitpod-terms" href="https://www.gitpod.io/terms/">terms of service</a>
-                        and <a className="gp-link hover:text-gray-600" target="gitpod-privacy" href="https://www.gitpod.io/privacy/">privacy policy</a>.
+                        By signing in, you agree to our <a className="gp-link hover:text-gray-600" target="gitpod-terms" href="https://www.gitpod.io/terms/">terms of service</a> and <a className="gp-link hover:text-gray-600" target="gitpod-privacy" href="https://www.gitpod.io/privacy/">privacy policy</a>.
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
## Description
Change login page to say: 

> By signing in, you agree to our [terms of service](https://www.gitpod.io/terms/) and [privacy policy](https://www.gitpod.io/privacy).

## Related Issue(s)
Fixes #8545

## How to test
- incognito window open https://jldec-privacy-8545.staging.gitpod-dev.com/login

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Link to privacy policy from login page
```