### PR TITLE
Pass auth cookie as env variable

### DIFF
--- a/test/pkg/agent/workspace/api/api.go
+++ b/test/pkg/agent/workspace/api/api.go
@@ -31,6 +31,7 @@ type ExecRequest struct {
 	Dir     string
 	Command string
 	Args    []string
+	Env     []string
 }
 
 type ExecResponse struct {

--- a/test/pkg/agent/workspace/main.go
+++ b/test/pkg/agent/workspace/main.go
@@ -123,13 +123,15 @@ func (*WorkspaceAgent) WriteFile(req *api.WriteFileRequest, resp *api.WriteFileR
 // Exec executes a command in the workspace
 func (*WorkspaceAgent) Exec(req *api.ExecRequest, resp *api.ExecResponse) (err error) {
 	cmd := exec.Command(req.Command, req.Args...)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, req.Env...)
+	if req.Dir != "" {
+		cmd.Dir = req.Dir
+	}
 	var (
 		stdout bytes.Buffer
 		stderr bytes.Buffer
 	)
-	if req.Dir != "" {
-		cmd.Dir = req.Dir
-	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -127,13 +127,14 @@ func TestPythonExtWorkspace(t *testing.T) {
 				Dir:     "/workspace/python-test-workspace",
 				Command: "yarn",
 				Args: []string{
-					"--silent",
 					"gp-code-server-test",
 					fmt.Sprintf("--endpoint=%s", nfo.LatestInstance.IdeURL),
-					fmt.Sprintf("--authCookie=%s", base64.StdEncoding.EncodeToString([]byte(jsonCookie))),
 					"--workspacePath=./src/testWorkspace",
 					"--extensionDevelopmentPath=./out",
 					"--extensionTestsPath=./out/test/suite",
+				},
+				Env: []string{
+					fmt.Sprintf("AUTH_COOKIE=%s", base64.StdEncoding.EncodeToString([]byte(jsonCookie))),
 				},
 			}, &resp)
 
@@ -141,8 +142,8 @@ func TestPythonExtWorkspace(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			t.Log("Ide integration stdout:\n", resp.Stdout)
 			if resp.ExitCode != 0 {
-				t.Log("Ide integration stdout:\n", resp.Stdout)
 				t.Log("Ide integration stderr:\n", resp.Stderr)
 				t.Fatal("There was an error running ide test")
 			}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Pass auth cookie as env variable in ide tests

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Run in terminal `werft run github -j .werft/integration-tests-startup.yaml -f.` (not working for now, wait till next stable on Friday) or run test manually `go test -v github.com/gitpod-io/gitpod/test/tests/ide/vscode -kubeconfig=/home/gitpod/.kube/config -namespace=staging-jp-cookie-as-env -username=<username>` (select insiders first in dashboard->preferences)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
