### PR TITLE
[code] codehelper exec replace process

### DIFF
--- a/components/ide/code/codehelper/main.go
+++ b/components/ide/code/codehelper/main.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"google.golang.org/grpc"
@@ -103,13 +104,11 @@ func main() {
 		log.WithField("cost", time.Now().Local().Sub(startTime).Milliseconds()).Info("extensions with path installed")
 	}
 
+	// install extensions and run code server with exec
 	args = append(args, os.Args[1:]...)
 	args = append(args, "--do-not-sync")
 	log.WithField("cost", time.Now().Local().Sub(startTime).Milliseconds()).Info("starting server")
-	cmd := exec.Command(Code, args...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	if err := cmd.Run(); err != nil {
+	if err := syscall.Exec(Code, append([]string{"gitpod-code"}, args...), os.Environ()); err != nil {
 		log.WithError(err).Error("install ext and start code server failed")
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use syscall.Exec to improve process tree

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Use insider
2. Start a workspace
3. Run `ps -efj fww`,  `/ide/bin/gitpod-code` must be direct children of supervisor
```
root           1       0       0       0  0 20:01 ?        Sl     0:00 supervisor init
root          26       1       0       0  0 20:01 ?        Sl     0:00 supervisor run
gitpod        47      26      47       0  0 20:01 ?        S      0:00  \_ sh /ide/bin/gitpod-code --start-server --install-builtin-extension github.vscode-pull-request-github --install-extension svelte.svelte-vscode --port 23000 --host 0.0.0.0 --without-connection-token --server-data-dir /workspace/.vscode-remote --do-not-sync
```

(We can remove this `gitpod-code` process too if we add exec to /ide/bin/gitpod-code. Or it's not necessary?)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
