### PR TITLE
add docker image for gpctl and kubecdl

### DIFF
--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -26,8 +26,6 @@ packages:
       buildArgs:
         VERSION: ${version}
       dockerfile: leeway.Dockerfile
-      metadata:
-        helm-component: dev-utils
       image:
         - ${imageRepoBase}/dev-utils:${version}
         - ${imageRepoBase}/dev-utils:commit-${__git_commit}

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -5,6 +5,7 @@ packages:
       - dev/image:docker
       - dev/poolkeeper:docker
       - dev/sweeper:docker
+      - :dev-utils
     config:
       commands:
         - ["sh", "-c", "tail -n1 dev-sweeper--docker/imgnames.txt > sweeper.txt"]
@@ -14,3 +15,19 @@ packages:
       - dev/blowtorch:app
       - dev/gpctl:app
       - dev/loadgen:app
+  - name: dev-utils
+    type: docker
+    deps:
+      - dev/gpctl:app
+      - dev/kubecdl:app
+    argdeps:
+      - imageRepoBase
+    config:
+      buildArgs:
+        VERSION: ${version}
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: dev-utils
+      image:
+        - ${imageRepoBase}/dev-utils:${version}
+        - ${imageRepoBase}/dev-utils:commit-${__git_commit}

--- a/dev/gpctl/BUILD.yaml
+++ b/dev/gpctl/BUILD.yaml
@@ -18,4 +18,3 @@ packages:
     config:
       packaging: app
       dontTest: true
-

--- a/dev/kubecdl/BUILD.yaml
+++ b/dev/kubecdl/BUILD.yaml
@@ -10,4 +10,3 @@ packages:
     config:
       packaging: app
       dontTest: true
-

--- a/dev/leeway.Dockerfile
+++ b/dev/leeway.Dockerfile
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+FROM scratch
+
+COPY dev-gpctl--app/gpctl dev-kubecdl--app/kubecdl /app/


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add docker image for gpctl and kubecdl so that we don't need to build it in other werft jobs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/733

## How to test
<!-- Provide steps to test this PR -->
```
curl -L https://github.com/csweichel/oci-tool/releases/download/v0.2.0/oci-tool_0.2.0_linux_amd64.tar.gz | tar xz
chmod +x oci-tool

./oci-tool fetch file eu.gcr.io/gitpod-core-dev/dev/dev-utils:commit-d66b864f634482937265b3b7bfb1ed09df731bd7 app/gpctl
chmod +x gpctl

./gpctl --help
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add docker images for gpctl and kubecdl
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
