### PR TITLE
[dashboard] Don't always print 'Connecting to workspace logs...' (it's somewhat misleading)

### DIFF
--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -47,7 +47,6 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
     terminalRef.current = terminal;
     terminal.loadAddon(fitAddon);
     terminal.open(xTermParentRef.current);
-    terminal.write('Connecting to workspace logs...\r\n');
     props.logsEmitter.on('logs', logs => {
       if (terminal && logs) {
         terminal.write(logs);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Don't always print 'Connecting to workspace logs...' (it's somewhat misleading)

Context: We initially added it to show the user that the front-end is loaded, and now the backend is working to fetch what the user wants. However, we've observed that the backend is unreliable, and can fail in various different stages, so it's not always actually connecting (e.g. sometimes there is no workspace to connect to, other times it cannot find the logs for some reason).

Maybe showing a blank logs view is better than a somewhat misleading message.

A better, long-term fix would be to implement the [Headless Logs (again) RFC](https://www.notion.so/gitpod/Headless-Logs-again-a0dab5e5dd244feba5d147fca9fd29a4), i.e. "central log ingestion service to content-service, make supervisor a writing client to this service".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Cosmetic UI fix

## How to test
<!-- Provide steps to test this PR -->
1. Open any logs in the dashboard
2. The first line should not be "Connecting to workspace logs"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Don't always print 'Connecting to workspace logs...' (it's somewhat misleading)
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
