### PR TITLE
[installer]: update release download URL to latest

### DIFF
--- a/install/installer/README.md
+++ b/install/installer/README.md
@@ -39,7 +39,7 @@ Select your desired binary, download and install
 1. Download the latest release with the command:
 
 ```shell
-curl -fsSLO https://github.com/gitpod-io/gitpod/releases/download/2022.01/gitpod-installer-linux-amd64
+curl -fsSLO https://github.com/gitpod-io/gitpod/releases/latest/download/gitpod-installer-linux-amd64
 ```
 
 2. Validate the binary (optional)
@@ -47,7 +47,7 @@ curl -fsSLO https://github.com/gitpod-io/gitpod/releases/download/2022.01/gitpod
 Download the checksum file:
 
 ```shell
-curl -fsSLO https://github.com/gitpod-io/gitpod/releases/download/2022.01/gitpod-installer-linux-amd64.sha256
+curl -fsSLO https://github.com/gitpod-io/gitpod/releases/latest/download/gitpod-installer-linux-amd64.sha256
 ```
 
 Validate the binary against the checksum file:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change the download URL so it refers to the latest release - saves us having to change this each time we do a release

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
