### PR TITLE
Fix workspace search under user detail

### DIFF
--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -68,7 +68,9 @@ export function WorkspaceSearch(props: Props) {
     const search = async () => {
         setSearching(true);
         try {
-            const query: AdminGetWorkspacesQuery = {};
+            const query: AdminGetWorkspacesQuery = {
+                ownerId: props?.user?.id, // Workspace search in admin user detail
+            };
             if (matchesInstanceIdOrLegacyWorkspaceIdExactly(queryTerm)) {
                 query.instanceIdOrWorkspaceId = queryTerm;
             } else if (matchesNewWorkspaceIdExactly(queryTerm)) {

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -768,6 +768,10 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
             } else if (query.workspaceId) {
                 whereConditions.push("ws.id = :workspaceId");
                 whereConditionParams.workspaceId = query.workspaceId;
+            } else if (query.ownerId) {
+                // If an owner id is provided only search for workspaces belonging to that user.
+                whereConditions.push("ws.ownerId = :ownerId");
+                whereConditionParams.ownerId = query.ownerId;
             } else if (query.instanceId) {
                 // in addition to adding "instanceId" to the "WHERE" clause like for the other workspace-guided queries,
                 // we modify the JOIN condition below to a) select the correct instance and b) make the query faster

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -116,4 +116,5 @@ export type AdminGetWorkspacesQuery = {
     instanceIdOrWorkspaceId?: string;
     instanceId?: string;
     workspaceId?: string;
+    ownerId?: string;
 };


### PR DESCRIPTION
## Description
Fixes the bug where a user detail fetches all workspaces instead of only their own.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8561 

## How to test
1. Have more than one user in the preview env[[1](https://lm-ws-user-list-8651.staging.gitpod-dev.com/)]
2. Go to user detail - the workspaces list should only show the user's workspaces.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix user detail bug that fetches all workspaces.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
