### PR TITLE
[dashboard] Further disambiguate 'Team Plans' vs 'Teams' based on user feedback (title, button, invite modal)

### DIFF
--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -24,7 +24,7 @@ import { Disposable } from "@gitpod/gitpod-protocol";
 export default function Teams() {
 
     return (<div>
-        <PageWithSubMenu subMenu={settingsMenu} title='Teams' subtitle='View and manage subscriptions for your team with one centralized billing.'>
+        <PageWithSubMenu subMenu={settingsMenu} title='Team Plans' subtitle='View and manage subscriptions for your team with one centralized billing.'>
             <AllTeams />
         </PageWithSubMenu>
     </div>);
@@ -435,7 +435,7 @@ function AllTeams() {
                     <button className="self-end my-auto secondary" onClick={() => showBilling()}>Billing</button>
                 )}
                 {getActiveSubs().length > 0 && (
-                    <button className="self-end my-auto" disabled={!!pendingPlanPurchase || getAvailableSubTypes().length === 0} onClick={() => showCreateTeamModal()}>Create Team</button>
+                    <button className="self-end my-auto" disabled={!!pendingPlanPurchase || getAvailableSubTypes().length === 0} onClick={() => showCreateTeamModal()}>Create Team Plan</button>
                 )}
             </div>
         </div>
@@ -564,7 +564,7 @@ function InviteMembersModal(props: {
     return (<Modal visible={true} onClose={props.onClose}>
         <h3 className="pb-2">Invite Members</h3>
         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-            <p className="pb-2 text-gray-500 text-base">Invite members to the team using the URL below.</p>
+            <p className="pb-2 text-gray-500 text-base">Invite members to the team plan using the URL below.</p>
 
             <div className="flex flex-col space-y-2">
                 <label htmlFor="inviteUrl" className="font-medium">Invite URL</label>
@@ -574,7 +574,7 @@ function InviteMembersModal(props: {
                         <img src={copy} title="Copy Invite URL" className="absolute top-1/3 right-3" />
                     </div>
                 </div>
-                <p className="pb-4 text-gray-500 text-sm">{copied ? "Copied to clipboard!" : "Use this URL to join this team."}</p>
+                <p className="pb-4 text-gray-500 text-sm">{copied ? "Copied to clipboard!" : "Use this URL to join this team plan."}</p>
             </div>
 
         </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Further disambiguate 'Team Plans' vs 'Teams' based on user feedback (title, button, invite modal).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes legacy Team Plans UI by adding the word "plan" in relevant places

## How to test
<!-- Provide steps to test this PR -->

1. Open `/teams`
2. Be slightly less confused

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
