### PR TITLE
[installer] Allow to set default workspace timeout

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -321,7 +321,16 @@ export interface ClientHeaderFields {
     clientRegion?: string;
 }
 
-export const WorkspaceTimeoutValues = ["30m", "60m", "180m"] as const;
+export const WORKSPACE_TIMEOUT_DEFAULT_SHORT = "short";
+export const WORKSPACE_TIMEOUT_DEFAULT_LONG = "long";
+export const WORKSPACE_TIMEOUT_EXTENDED = "extended";
+export const WORKSPACE_TIMEOUT_EXTENDED_ALT = "180m"; // for backwards compatibility since the IDE uses this
+export const WorkspaceTimeoutValues = [
+    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
+    WORKSPACE_TIMEOUT_DEFAULT_LONG,
+    WORKSPACE_TIMEOUT_EXTENDED,
+    WORKSPACE_TIMEOUT_EXTENDED_ALT,
+] as const;
 
 export const createServiceMock = function <C extends GitpodClient, S extends GitpodServer>(
     methods: Partial<JsonRpcProxy<S>>,

--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -7,7 +7,7 @@
 import { inject, injectable } from "inversify";
 import { TeamSubscriptionDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { TokenProvider } from "../../../src/user/token-provider";
-import { User, WorkspaceTimeoutDuration, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { User, WorkspaceTimeoutDuration, WorkspaceInstance, WORKSPACE_TIMEOUT_DEFAULT_LONG, WORKSPACE_TIMEOUT_DEFAULT_SHORT } from "@gitpod/gitpod-protocol";
 import { RemainingHours } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Plans, MAX_PARALLEL_WORKSPACES } from "@gitpod/gitpod-protocol/lib/plans";
@@ -251,9 +251,9 @@ export class EligibilityService {
      */
     async getDefaultWorkspaceTimeout(user: User, date: Date = new Date()): Promise<WorkspaceTimeoutDuration> {
         if (await this.maySetTimeout(user, date)) {
-            return "60m";
+            return WORKSPACE_TIMEOUT_DEFAULT_LONG;
         } else {
-            return "30m";
+            return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
         }
     }
 

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -29,6 +29,8 @@ export interface WorkspaceDefaults {
     workspaceImage: string;
     previewFeatureFlags: NamedWorkspaceFeatureFlag[];
     defaultFeatureFlags: NamedWorkspaceFeatureFlag[];
+    timeoutDefault?: string;
+    timeoutExtended?: string;
 }
 
 export interface WorkspaceGarbageCollection {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import { User, Identity, WorkspaceTimeoutDuration, UserEnvVarValue, Token } from "@gitpod/gitpod-protocol";
+import { User, Identity, WorkspaceTimeoutDuration, UserEnvVarValue, Token, WORKSPACE_TIMEOUT_DEFAULT_SHORT, WORKSPACE_TIMEOUT_DEFAULT_LONG, WORKSPACE_TIMEOUT_EXTENDED, WORKSPACE_TIMEOUT_EXTENDED_ALT } from "@gitpod/gitpod-protocol";
 import { TermsAcceptanceDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
@@ -155,7 +155,32 @@ export class UserService {
      * @param date The date for which we want to know the default workspace timeout
      */
     async getDefaultWorkspaceTimeout(user: User, date: Date = new Date()): Promise<WorkspaceTimeoutDuration> {
-        return "30m";
+        return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
+    }
+
+    public workspaceTimeoutToDuration(timeout: WorkspaceTimeoutDuration): string {
+        switch (timeout) {
+            case WORKSPACE_TIMEOUT_DEFAULT_SHORT:
+                return "30m";
+            case WORKSPACE_TIMEOUT_DEFAULT_LONG:
+                return "60m";
+            case WORKSPACE_TIMEOUT_EXTENDED:
+            case WORKSPACE_TIMEOUT_EXTENDED_ALT:
+                return "180m";
+        }
+    }
+
+    public durationToWorkspaceTimeout(duration: string): WorkspaceTimeoutDuration {
+        switch (duration) {
+            case "30m":
+                return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
+            case "60m":
+                return WORKSPACE_TIMEOUT_DEFAULT_LONG;
+            case "180m":
+                return WORKSPACE_TIMEOUT_EXTENDED_ALT;
+            default:
+                return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
+        }
     }
 
     /**

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1191,7 +1191,7 @@ export class WorkspaceStarter {
         spec.setWorkspaceLocation(workspace.config.workspaceLocation || spec.getCheckoutLocation());
         spec.setFeatureFlagsList(this.toWorkspaceFeatureFlags(featureFlags));
         if (workspace.type === "regular") {
-            spec.setTimeout(await userTimeoutPromise);
+            spec.setTimeout(this.userService.workspaceTimeoutToDuration(await userTimeoutPromise));
         }
         spec.setAdmission(admissionLevel);
         return spec;

--- a/install/installer/example-config.yaml
+++ b/install/installer/example-config.yaml
@@ -23,6 +23,7 @@ openVSX:
   url: https://open-vsx.org
 repository: eu.gcr.io/gitpod-core-dev/build
 workspace:
+  maxLifetime: 36h0m0s
   resources:
     requests:
       cpu: "1"

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -40,6 +40,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			WorkspaceImage:      common.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, ""), workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
 			PreviewFeatureFlags: []NamedWorkspaceFeatureFlag{},
 			DefaultFeatureFlags: []NamedWorkspaceFeatureFlag{},
+			TimeoutDefault:      ctx.Config.Workspace.TimeoutDefault,
+			TimeoutExtended:     ctx.Config.Workspace.TimeoutExtended,
 		},
 		Session: Session{
 			MaxAgeMs: 259200000,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -4,7 +4,10 @@
 
 package server
 
-import "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+import (
+	"github.com/gitpod-io/gitpod/common-go/util"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+)
 
 // These types are from TypeScript files
 
@@ -120,6 +123,8 @@ type WorkspaceDefaults struct {
 	WorkspaceImage      string                      `json:"workspaceImage"`
 	PreviewFeatureFlags []NamedWorkspaceFeatureFlag `json:"previewFeatureFlags"`
 	DefaultFeatureFlags []NamedWorkspaceFeatureFlag `json:"defaultFeatureFlags"`
+	TimeoutDefault      *util.Duration              `json:"timeoutDefault,omitempty"`
+	TimeoutExtended     *util.Duration              `json:"timeoutExtended,omitempty"`
 }
 
 type NamedWorkspaceFeatureFlag string

--- a/install/installer/pkg/components/ws-manager/configmap.go
+++ b/install/installer/pkg/components/ws-manager/configmap.go
@@ -38,6 +38,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return (&q).String()
 	}
 
+	timeoutAfterClose := util.Duration(2 * time.Minute)
+	if ctx.Config.Workspace.TimeoutAfterClose != nil {
+		timeoutAfterClose = *ctx.Config.Workspace.TimeoutAfterClose
+	}
+
 	wsmcfg := config.ServiceConfiguration{
 		Manager: config.Configuration{
 			Namespace:      ctx.Namespace,
@@ -81,11 +86,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			WorkspaceHostPath:        wsdaemon.HostWorkingArea,
 			WorkspacePodTemplate:     templatesCfg,
 			Timeouts: config.WorkspaceTimeoutConfiguration{
-				AfterClose:          util.Duration(2 * time.Minute),
+				AfterClose:          timeoutAfterClose,
 				HeadlessWorkspace:   util.Duration(1 * time.Hour),
 				Initialization:      util.Duration(30 * time.Minute),
 				RegularWorkspace:    util.Duration(30 * time.Minute),
-				MaxLifetime:         util.Duration(36 * time.Hour),
+				MaxLifetime:         ctx.Config.Workspace.MaxLifetime,
 				TotalStartup:        util.Duration(1 * time.Hour),
 				ContentFinalization: util.Duration(1 * time.Hour),
 				Stopping:            util.Duration(1 * time.Hour),

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -5,6 +5,9 @@
 package config
 
 import (
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/cpulimit"
@@ -53,6 +56,7 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Workspace.Runtime.FSShiftMethod = FSShiftFuseFS
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
+	cfg.Workspace.MaxLifetime = util.Duration(36 * time.Hour)
 	cfg.OpenVSX.URL = "https://open-vsx.org"
 	cfg.DisableDefinitelyGP = false
 
@@ -224,6 +228,18 @@ type Workspace struct {
 	Runtime   WorkspaceRuntime    `json:"runtime" validate:"required"`
 	Resources Resources           `json:"resources" validate:"required"`
 	Templates *WorkspaceTemplates `json:"templates,omitempty"`
+
+	// MaxLifetime is the maximum time a workspace is allowed to run. After that, the workspace times out despite activity
+	MaxLifetime util.Duration `json:"maxLifetime" validate:"required"`
+
+	// TimeoutDefault is the default timeout of a regular workspace
+	TimeoutDefault *util.Duration `json:"timeoutDefault,omitempty"`
+
+	// TimeoutExtended is the workspace timeout that a user can extend to for one workspace
+	TimeoutExtended *util.Duration `json:"timeoutExtended,omitempty"`
+
+	// TimeoutAfterClose is the time a workspace timed out after it has been closed (“closed” means that it does not get a heartbeat from an IDE anymore)
+	TimeoutAfterClose *util.Duration `json:"timeoutAfterClose,omitempty"`
 }
 
 type OpenVSX struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a proposal that allows to set custom timeouts for the workspaces. It adds the following config values:
```yaml
workspace:
  timeoutDefault: 30m
  timeoutExtended: 60m
  maxLifetime: 36h
  timeoutAfterClose: 2m
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8528

## How to test
<!-- Provide steps to test this PR -->

Add the following patch to `deploy-to-preview-environment.ts`:
```diff
diff --git a/.werft/jobs/build/deploy-to-preview-environment.ts b/.werft/jobs/build/deploy-to-preview-environment.ts
index 4c82fa8d..b963703a 100644
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -392,6 +392,12 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
             exec('exit 0')
         }
 
+        // TODO: remove me – just for testing purposes
+        exec(`yq w -i ./config.yaml workspace.timeoutDefault "3m"`);
+        exec(`yq w -i ./config.yaml workspace.timeoutExtended "6m"`);
+        exec(`yq w -i ./config.yaml workspace.maxLifetime "9m"`);
+        exec(`yq w -i ./config.yaml workspace.timeoutAfterClose "10s"`);
+
         // validate the config
         exec(`/tmp/installer validate config -c config.yaml`, { slice: installerSlices.INSTALLER_RENDER });
```

And run a werft build like this:
```
$ werft run github -s .werft/jobs/build/deploy-to-preview-environment.ts
```
**NOTE:** I did this already. As long as the preview env hasn't been removed in the meantime, the preview should be deployed like this.

With this configuration you can observe the following timeouts:
- When you start a workspace, it times out after 3 minutes of inactivity. You can see this value when you run (change your workspace ID):
   ```
   $ kubectl describe pod ws-50950ba6-eea9-4d06-8aa9-a98f6a19811d  | grep customTimeout
                 gitpod/customTimeout: 3m0s
   ```
  You'll also see the current timeout when you hover over the clock in your workspace status bar:
![image](https://user-images.githubusercontent.com/24960040/157894524-b64ea44b-3c02-44af-971c-6d636afeba9d.png)

- When you extend your workspace timeout (click on the clock), the new timeout will be 6 minutes (check again with `kubectl` or the hover message).
- When you close the browser, the workspace times out after 10 seconds. (Note: The value that you see with `kubectl` will not change but you can see that the pod disappears after 10 seconds and the Gitpod dashboard shows stopping.)
- The workspace will be stopped after 9 minutes. Even if there is activity. It will stop in every case.


## Discussion and Limitations

- I tried to eliminate the hard-coded values in the code and add “classes” of timeouts (short, long, and extended). However, [the VS Code IDE sends always `180m` as a timeout value](https://github.com/gitpod-io/openvscode-server/blob/5658446f7bef3662e805df93669b0b4cb79349c5/extensions/gitpod-shared/src/features.ts#L598) when a user clicks on the clock. That's why I kept the `180m` constant as an alternative value for `extended`. In the long term, it would make sense to send `extended` instead.

- When the user extends the workspace, the message always says [it's extended to “three hours”](https://github.com/gitpod-io/openvscode-server/blob/5658446f7bef3662e805df93669b0b4cb79349c5/extensions/gitpod-shared/src/features.ts#L599-L602). That should be changed to a more general wording.

- The hover text always shows the proper timeout value but the color of the clock is checked by comparing it [with the hard-coded value of `180m`](https://github.com/gitpod-io/openvscode-server/blob/5658446f7bef3662e805df93669b0b4cb79349c5/extensions/gitpod-shared/src/features.ts#L627). The problem is, that we don't know at this point what the extended timeout value is. Instead of [reading `listener.info.latestInstance`](https://github.com/gitpod-io/openvscode-server/blob/5658446f7bef3662e805df93669b0b4cb79349c5/extensions/gitpod-shared/src/features.ts#L621), we could also call 
   ```
  const workspaceTimeout = await context.gitpod.server.getWorkspaceTimeout(context.info.getWorkspaceId());
  ```
   instead. That [always returns `180m` as timeout as constant for the extended value](https://github.com/gitpod-io/gitpod/blob/9e736913586482b75d43cc68454304e1e7ac477a/components/server/src/user/user-service.ts#L167-L169) (should be probably changed to `extended` in the long term, see above). However, I don't know if that has a performance impact.

All of these are little UI flaws that shouldn't be real blockers, in my opinion.

/cc @akosyakov 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow setting custom workspace timeouts in the Gitpod Installer for self-hosted installations.
```