### PR TITLE
add warning when all attempts to download OTS have failed

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -315,6 +315,7 @@ func downloadOTS(ctx context.Context, url string) (user, pwd string, err error) 
 		log.WithError(err).WithField("attempt", i).Warn("cannot download OTS")
 	}
 	if err != nil {
+		log.WithError(err).Warn("failed to download OTS")
 		return "", "", err
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add warning when all attempts to download OTS have failed.
To help distinguish failed attempt and when all attempts have failed.
See this: https://github.com/gitpod-io/gitpod/issues/8096#issuecomment-1058678985

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
