### PR TITLE
chore(server): add github app install script for dev iteration against staging github app

### DIFF
--- a/components/server/install-gh-app.sh
+++ b/components/server/install-gh-app.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script will patch the servers config map, install the app cert and restart the server components
+# It is best to add the envs to your environment variables using `gp env GH_APP_ID=....` and `gp env GH_APP_KEY="..."`.
+# See https://www.notion.so/gitpod/How-to-deploy-a-PR-with-a-working-GitHub-App-integration-d297a1ef2f7b4b3aa8483b2ae9b47da2 (internal) for more details.
+
+# GH_APP_ID=<app-id>
+# GH_APP_KEY="-----BEGIN RSA PRIVATE KEY-----
+# ...
+# -----END RSA PRIVATE KEY-----"
+#############################
+
+if [ -z "$GH_APP_ID" ]; then
+  echo "Missing env GH_APP_ID"
+  return
+fi
+
+if [ -z "${GH_APP_KEY}" ]; then
+  echo "Missing env GH_APP_KEY"
+  return
+fi
+
+# turn spaces into newlines, in case the key got pasted in on the env var dashboard interface
+TMP=${GH_APP_KEY// RSA PRIVATE /RSA_PRIVATE}
+TMP2=${TMP// /$'\n'}
+GH_APP_KEY=${TMP2//RSA_PRIVATE/ RSA PRIVATE }
+
+
+echo 'patching configmap server-config'
+LINE="\"githubApp\": \{\"appId\":${GH_APP_ID},\"authProviderId\":\"Public-GitHub\",\"certPath\":\"\/github-app-cert\/cert\",\"certSecretName\":\"server-github-app-cert\",\"enabled\":true,\"marketplaceName\":\"gitpod-io\",\"webhookSecret\":\"omgsecret\"}"
+kubectl get cm server-config -o yaml > server-config.yml
+perl -0777 -i.original -pe "s/\"githubApp\":.+?\}/$LINE/igs" server-config.yml
+kubectl apply -f server-config.yml
+rm server-config.yml
+
+echo 'updating the secret'
+kubectl delete secret server-github-app-cert
+kubectl create secret generic server-github-app-cert --from-literal=cert="$GH_APP_KEY"
+
+if kubectl get deployment server -o json | grep -q 'github-app-cert-secret'; then
+  echo 'deployment already contains github-app-cert-volume. Skipping patching server deployment.'
+else
+  echo 'updating server deployment'
+  kubectl get deployment server -o json | \
+    sed -E "s|\"volumeMounts\": \[|\"volumeMounts\": \[ {\"name\": \"github-app-cert-secret\", \"readOnly\": true, \"mountPath\": \"/github-app-cert\"},|" | \
+    sed -E "s|\"volumes\": \[|\"volumes\": \[ {\"name\": \"github-app-cert-secret\", \"secret\": { \"secretName\": \"server-github-app-cert\"}},|" | \
+    kubectl apply -f -
+fi
+echo 'restarting server deployment'
+kubectl rollout restart deployment server


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Moves the script from internal documentation into the repository for ease of use. This is needed to be able to iterate on github app integration locally/in dev.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
