### PR TITLE
 Make the licensing match what's advertised 

### DIFF
--- a/components/licensor/ee/cmd/validate.go
+++ b/components/licensor/ee/cmd/validate.go
@@ -25,7 +25,7 @@ var validateCmd = &cobra.Command{
 		domain, _ := cmd.Flags().GetString("domain")
 		licensorType, _ := cmd.Flags().GetString("licensor")
 
-		var e licensor.Evaluator
+		var e *licensor.Evaluator
 		switch licensorType {
 		case string(licensor.LicenseTypeReplicated):
 			e = licensor.NewReplicatedEvaluator(domain)

--- a/components/licensor/ee/pkg/licensor/gitpod.go
+++ b/components/licensor/ee/pkg/licensor/gitpod.go
@@ -61,6 +61,7 @@ func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 	}
 
 	return &Evaluator{
-		lic: lic.LicensePayload,
+		lic:           lic.LicensePayload,
+		allowFallback: false, // Gitpod licenses cannot fallback - assume these are always paid-for
 	}
 }

--- a/components/licensor/ee/pkg/licensor/gitpod.go
+++ b/components/licensor/ee/pkg/licensor/gitpod.go
@@ -14,53 +14,11 @@ import (
 	"time"
 )
 
-// GitpodEvaluator determines what a license allows for
-type GitpodEvaluator struct {
-	invalid string
-	lic     LicensePayload
-}
-
-// Validate returns false if the license isn't valid and a message explaining why that is.
-func (e *GitpodEvaluator) Validate() (msg string, valid bool) {
-	if e.invalid == "" {
-		return "", true
-	}
-
-	return e.invalid, false
-}
-
-// Enabled determines if a feature is enabled by the license
-func (e *GitpodEvaluator) Enabled(feature Feature) bool {
-	if e.invalid != "" {
-		return false
-	}
-
-	_, ok := e.lic.Level.allowance().Features[feature]
-	return ok
-}
-
-// HasEnoughSeats returns true if the license supports at least the give amount of seats
-func (e *GitpodEvaluator) HasEnoughSeats(seats int) bool {
-	if e.invalid != "" {
-		return false
-	}
-
-	return e.lic.Seats == 0 || seats <= e.lic.Seats
-}
-
-// Inspect returns the license information this evaluator holds.
-// This function is intended for transparency/debugging purposes only and must
-// never be used to determine feature eligibility under a license. All code making
-// those kinds of decisions must be part of the Evaluator.
-func (e *GitpodEvaluator) Inspect() LicensePayload {
-	return e.lic
-}
-
 // NewGitpodEvaluator produces a new license evaluator from a license key
-func NewGitpodEvaluator(key []byte, domain string) (res *GitpodEvaluator) {
+func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 	if len(key) == 0 {
 		// fallback to the default license
-		return &GitpodEvaluator{
+		return &Evaluator{
 			lic: defaultLicense,
 		}
 	}
@@ -68,19 +26,19 @@ func NewGitpodEvaluator(key []byte, domain string) (res *GitpodEvaluator) {
 	deckey := make([]byte, base64.StdEncoding.DecodedLen(len(key)))
 	n, err := base64.StdEncoding.Decode(deckey, key)
 	if err != nil {
-		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot decode key: %q", err)}
+		return &Evaluator{invalid: fmt.Sprintf("cannot decode key: %q", err)}
 	}
 	deckey = deckey[:n]
 
 	var lic licensePayload
 	err = json.Unmarshal(deckey, &lic)
 	if err != nil {
-		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot unmarshal key: %q", err)}
+		return &Evaluator{invalid: fmt.Sprintf("cannot unmarshal key: %q", err)}
 	}
 
 	keyWoSig, err := json.Marshal(lic.LicensePayload)
 	if err != nil {
-		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot remarshal key: %q", err)}
+		return &Evaluator{invalid: fmt.Sprintf("cannot remarshal key: %q", err)}
 	}
 	hashed := sha256.Sum256(keyWoSig)
 
@@ -91,18 +49,18 @@ func NewGitpodEvaluator(key []byte, domain string) (res *GitpodEvaluator) {
 		}
 	}
 	if err != nil {
-		return &GitpodEvaluator{invalid: fmt.Sprintf("cannot verify key: %q", err)}
+		return &Evaluator{invalid: fmt.Sprintf("cannot verify key: %q", err)}
 	}
 
 	if !matchesDomain(lic.Domain, domain) {
-		return &GitpodEvaluator{invalid: "wrong domain"}
+		return &Evaluator{invalid: "wrong domain"}
 	}
 
 	if lic.ValidUntil.Before(time.Now()) {
-		return &GitpodEvaluator{invalid: "not valid anymore"}
+		return &Evaluator{invalid: "not valid anymore"}
 	}
 
-	return &GitpodEvaluator{
+	return &Evaluator{
 		lic: lic.LicensePayload,
 	}
 }

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -87,10 +87,7 @@ type allowance struct {
 
 var allowanceMap = map[LicenseLevel]allowance{
 	LevelTeam: {
-		PrebuildTime: 50 * time.Hour,
 		Features: featureSet{
-			FeaturePrebuild: struct{}{},
-
 			FeatureAdminDashboard: struct{}{},
 		},
 	},

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -90,6 +90,8 @@ var allowanceMap = map[LicenseLevel]allowance{
 		PrebuildTime: 50 * time.Hour,
 		Features: featureSet{
 			FeaturePrebuild: struct{}{},
+
+			FeatureAdminDashboard: struct{}{},
 		},
 	},
 	LevelEnterprise: {

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -238,9 +238,7 @@ func TestFeatures(t *testing.T) {
 			FeaturePrebuild,
 		}, LicenseTypeGitpod, seats, nil},
 
-		{"Gitpod (over seats): no license", true, LicenseLevel(0), []Feature{
-			FeaturePrebuild,
-		}, LicenseTypeGitpod, 11, nil},
+		{"Gitpod (over seats): no license", true, LicenseLevel(0), []Feature{}, LicenseTypeGitpod, 11, nil},
 		{"Gitpod (over seats): invalid license level", false, LicenseLevel(666), []Feature{}, LicenseTypeGitpod, seats + 1, nil},
 		{"Gitpod (over seats): enterprise license", false, LevelEnterprise, []Feature{}, LicenseTypeGitpod, seats + 1, nil},
 
@@ -274,14 +272,8 @@ func TestFeatures(t *testing.T) {
 			FeaturePrebuild,
 		}, LicenseTypeReplicated, seats + 1, &replicatedPaid},
 
-		{"Replicated (over seats - fallback): invalid license level", false, LicenseLevel(666), []Feature{
-			FeatureAdminDashboard,
-			FeaturePrebuild,
-		}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
-		{"Replicated (over seats - fallback): enterprise license", false, LevelEnterprise, []Feature{
-			FeatureAdminDashboard,
-			FeaturePrebuild,
-		}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
+		{"Replicated (over seats - fallback): invalid license level", false, LicenseLevel(666), []Feature{FeatureAdminDashboard}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
+		{"Replicated (over seats - fallback): enterprise license", false, LevelEnterprise, []Feature{FeatureAdminDashboard}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
 	}
 
 	for _, test := range tests {

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -219,7 +219,7 @@ func TestFeatures(t *testing.T) {
 		Features       []Feature
 		LicenseType    LicenseType
 	}{
-		{"Gitpod: no license", true, LicenseLevel(0), []Feature{FeaturePrebuild}, LicenseTypeGitpod},
+		{"Gitpod: no license", true, LicenseLevel(0), []Feature{FeaturePrebuild, FeatureAdminDashboard}, LicenseTypeGitpod},
 		{"Gitpod: invalid license level", false, LicenseLevel(666), []Feature{}, LicenseTypeGitpod},
 		{"Gitpod: enterprise license", false, LevelEnterprise, []Feature{
 			FeatureAdminDashboard,

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -25,7 +25,7 @@ const (
 type licenseTest struct {
 	Name         string
 	License      *LicensePayload
-	Validate     func(t *testing.T, eval Evaluator)
+	Validate     func(t *testing.T, eval *Evaluator)
 	Type         LicenseType
 	NeverExpires bool
 }
@@ -47,7 +47,7 @@ func newTestClient(fn roundTripFunc) *http.Client {
 
 func (test *licenseTest) Run(t *testing.T) {
 	t.Run(test.Name, func(t *testing.T) {
-		var eval Evaluator
+		var eval *Evaluator
 		if test.Type == LicenseTypeGitpod {
 			if test.NeverExpires {
 				t.Fatal("gitpod licenses must have an expiry date")
@@ -195,7 +195,7 @@ func TestSeats(t *testing.T) {
 				Seats:      test.Licensed,
 				ValidUntil: validUntil,
 			},
-			Validate: func(t *testing.T, eval Evaluator) {
+			Validate: func(t *testing.T, eval *Evaluator) {
 				withinLimits := eval.HasEnoughSeats(test.Probe)
 				if withinLimits != test.WithinLimits {
 					t.Errorf("HasEnoughSeats did not behave as expected: lic=%d probe=%d expected=%v actual=%v", test.Licensed, test.Probe, test.WithinLimits, withinLimits)
@@ -253,7 +253,7 @@ func TestFeatures(t *testing.T) {
 		lt := licenseTest{
 			Name:    test.Name,
 			License: lic,
-			Validate: func(t *testing.T, eval Evaluator) {
+			Validate: func(t *testing.T, eval *Evaluator) {
 				unavailableFeatures := featureSet{}
 				for f := range allowanceMap[LevelEnterprise].Features {
 					unavailableFeatures[f] = struct{}{}

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -69,24 +69,24 @@ func (e *ReplicatedEvaluator) Validate() (msg string, valid bool) {
 }
 
 // defaultReplicatedLicense this is the default license if call fails
-func defaultReplicatedLicense() *ReplicatedEvaluator {
-	return &ReplicatedEvaluator{
+func defaultReplicatedLicense() *Evaluator {
+	return &Evaluator{
 		lic: defaultLicense,
 	}
 }
 
 // newReplicatedEvaluator exists to allow mocking of client
-func newReplicatedEvaluator(client *http.Client, domain string) (res *ReplicatedEvaluator) {
+func newReplicatedEvaluator(client *http.Client, domain string) (res *Evaluator) {
 	resp, err := client.Get(replicatedLicenseApiEndpoint)
 	if err != nil {
-		return &ReplicatedEvaluator{invalid: fmt.Sprintf("cannot query kots admin, %q", err)}
+		return &Evaluator{invalid: fmt.Sprintf("cannot query kots admin, %q", err)}
 	}
 	defer resp.Body.Close()
 
 	var replicatedPayload replicatedLicensePayload
 	err = json.NewDecoder(resp.Body).Decode(&replicatedPayload)
 	if err != nil {
-		return &ReplicatedEvaluator{invalid: fmt.Sprintf("cannot decode json data, %q", err)}
+		return &Evaluator{invalid: fmt.Sprintf("cannot decode json data, %q", err)}
 	}
 
 	lic := LicensePayload{
@@ -119,12 +119,12 @@ func newReplicatedEvaluator(client *http.Client, domain string) (res *Replicated
 		}
 	}
 
-	return &ReplicatedEvaluator{
+	return &Evaluator{
 		lic: lic,
 	}
 }
 
 // NewReplicatedEvaluator gets the license data from the kots admin panel
-func NewReplicatedEvaluator(domain string) (res *ReplicatedEvaluator) {
+func NewReplicatedEvaluator(domain string) (res *Evaluator) {
 	return newReplicatedEvaluator(&http.Client{Timeout: replicatedLicenseApiTimeout}, domain)
 }

--- a/components/licensor/typescript/ee/main.go
+++ b/components/licensor/typescript/ee/main.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	instances map[int]*licensor.Evaluator = make(map[int]*licensor.Evaluator)
-	nextID    int                        = 1
+	nextID    int                         = 1
 )
 
 // Init initializes the global license evaluator from an environment variable
@@ -49,13 +49,13 @@ func Validate(id int) (msg *C.char, valid bool) {
 
 // Enabled returns true if a license enables a feature
 //export Enabled
-func Enabled(id int, feature *C.char) (enabled, ok bool) {
+func Enabled(id int, feature *C.char, seats int) (enabled, ok bool) {
 	e, ok := instances[id]
 	if !ok {
 		return
 	}
 
-	return e.Enabled(licensor.Feature(C.GoString(feature))), true
+	return e.Enabled(licensor.Feature(C.GoString(feature)), seats), true
 }
 
 // HasEnoughSeats returns true if the license supports at least the given number of seats.

--- a/components/licensor/typescript/ee/main.go
+++ b/components/licensor/typescript/ee/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	instances map[int]licensor.Evaluator = make(map[int]licensor.Evaluator)
+	instances map[int]*licensor.Evaluator = make(map[int]*licensor.Evaluator)
 	nextID    int                        = 1
 )
 

--- a/components/licensor/typescript/ee/src/index.ts
+++ b/components/licensor/typescript/ee/src/index.ts
@@ -49,8 +49,8 @@ export class LicenseEvaluator {
         return { msg: v.msg, valid: false };
     }
 
-    public isEnabled(feature: Feature): boolean {
-        return isEnabled(this.instanceID, feature);
+    public isEnabled(feature: Feature, seats: number): boolean {
+        return isEnabled(this.instanceID, feature, seats);
     }
 
     public hasEnoughSeats(seats: number): boolean {

--- a/components/licensor/typescript/ee/src/nativemodule.d.ts
+++ b/components/licensor/typescript/ee/src/nativemodule.d.ts
@@ -9,7 +9,7 @@ export type Instance = number;
 
 export function init(key: string, domain: string): Instance;
 export function validate(id: Instance): { msg: string, valid: boolean };
-export function isEnabled(id: Instance, feature: Feature): boolean;
+export function isEnabled(id: Instance, feature: Feature, seats: int): boolean;
 export function hasEnoughSeats(id: Instance, seats: int): boolean;
 export function inspect(id: Instance): string;
 export function dispose(id: Instance);

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -49,6 +49,7 @@ import { GitLabAppSupport } from "./gitlab/gitlab-app-support";
 import { Config } from "../../src/config";
 import { SnapshotService } from "./workspace/snapshot-service";
 import { BitbucketAppSupport } from "./bitbucket/bitbucket-app-support";
+import { UserCounter } from "./user/user-counter";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -68,6 +69,8 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(BitbucketApp).toSelf().inSingletonScope();
     bind(BitbucketAppSupport).toSelf().inSingletonScope();
     bind(GitHubEnterpriseApp).toSelf().inSingletonScope();
+
+    bind(UserCounter).toSelf().inSingletonScope();
 
     bind(LicenseEvaluator).toSelf().inSingletonScope();
     bind(LicenseKeySource).to(DBLicenseKeySource).inSingletonScope();

--- a/components/server/ee/src/user/user-counter.ts
+++ b/components/server/ee/src/user/user-counter.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class UserCounter {
+    public expires: Date | null = null;
+
+    protected data: number | null = null;
+
+    protected readonly timeout: number = 60 * 1000; // Cache data for 1 minute
+
+    get count(): number | null {
+        if (this.expires !== null && Date.now() >= this.expires.getTime()) {
+            // The timestamp is in range - return the data
+            return this.data;
+        }
+        // Not in range - return null
+        return null;
+    }
+
+    set count(userCount: number | null) {
+        this.expires = new Date(Date.now() + this.timeout);
+
+        this.data = userCount;
+    }
+}

--- a/components/server/ee/src/user/user-service.ts
+++ b/components/server/ee/src/user/user-service.ts
@@ -28,8 +28,10 @@ export class UserServiceEE extends UserService {
             return this.eligibilityService.getDefaultWorkspaceTimeout(user, date);
         }
 
+        const userCount = await this.userDb.getUserCount(true);
+
         // the self-hosted case
-        if (!this.licenseEvaluator.isEnabled(Feature.FeatureSetTimeout)) {
+        if (!this.licenseEvaluator.isEnabled(Feature.FeatureSetTimeout, userCount)) {
             return "30m";
         }
 

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag - using this tag as need the license evaluator
-          image: 'eu.gcr.io/gitpod-core-dev/build/installer:main.2569'
+          image: 'eu.gcr.io/gitpod-core-dev/build/installer:sje-licensing.24'
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The self-hosted licensing now matches [what we advertise](https://www.gitpod.io/self-hosted), namely:

- Default to free/professional license which allows full access for a specific number of users. Free is for 10 users, pro is for however many their license allows. Internally, this is the "Enterprise" license.
- Fallback to community license, which allows for none of the EE features (except admin dashboard) for an unlimited number of users. Internally, this is the "Team" license.

This introduces the concept of a fallback license, in addition to the default license. It also adds the number of seats to the `Enabled` call in the licensor. As a workflow, if the license exceeds the number of seats requested in the call, it will try again with the fallback license, which is the community license.

### Fallback rules

| License type | Fallback allowed |
| --- | --- |
| No license (ie, installed via Installer) | Y |
| Gitpod paid license | N |
| Replicated community license | Y |
| Replicated paid license | N |

This table shows the fallback rules. It is done so that a user who is paying for Gitpod will have additional users rejected rather than having their service downgraded. It would be a pretty poor user experience if someone was paying for Gitpod, had an additional user sign up and then everyone lost all their premium services.

Gitpod licenses are always considered "paid". Now we are moving to Replicated for most licensing, Gitpod licenses will only be issued to paying customers who cannot use Replicated (eg, SaaS). Replicated has the concept of a community license - if their license is marked as "community", it will allow for fallback.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8328
Fixes #6932

## How to test
<!-- Provide steps to test this PR -->
Deploy to a self-hosted instance with a Replicated license. Tests already done:
 - Test prebuilds work with <=10 users
 - Test new user rejected when paid license has run out of seats
 - Test new user accepted when paid license changed to a community license
 - Test prebuilds rejected when on community license and > 10 users
 - Test prebuilds accepted when community license changed to a paid license with 20 users

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
 Make the licensing match what's advertised
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
