### PR TITLE
[prebuilds] Introduce 'failed' state for prebuilds

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -248,6 +248,8 @@ export function prebuildStatusLabel(prebuild?: PrebuildWithStatus) {
             return (<span className="font-medium text-blue-500 uppercase">running</span>);
         case "aborted":
             return (<span className="font-medium text-gray-500 uppercase">canceled</span>);
+        case "failed":
+            return (<span className="font-medium text-red-500 uppercase">failed</span>);
         case "timeout":
             return (<span className="font-medium text-red-500 uppercase">failed</span>);
         case "available":

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -250,7 +250,7 @@ export default function () {
                                 <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
                                     <button className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}>New Workspace</button>
                                 </a>
-                                <ItemFieldContextMenu className="py-0.5" menuEntries={(!prebuild || prebuild.status === 'aborted' || prebuild.status === 'timeout' || !!prebuild.error)
+                                <ItemFieldContextMenu className="py-0.5" menuEntries={(!prebuild || prebuild.status === 'aborted' || prebuild.status === 'failed' || prebuild.status === 'timeout' || !!prebuild.error)
                                     ? [{
                                         title: `${prebuild ? 'Rerun' : 'Run'} Prebuild (${branch.name})`,
                                         onClick: () => triggerPrebuild(branch),

--- a/components/gitpod-protocol/src/headless-workspace-log.ts
+++ b/components/gitpod-protocol/src/headless-workspace-log.ts
@@ -11,6 +11,7 @@ export enum HeadlessWorkspaceEventType {
     FinishedButFailed = "finish-fail",
     AbortedTimedOut = "aborted-timeout",
     Aborted = "aborted",
+    Failed = "failed",
     Started = "started"
 }
 export namespace HeadlessWorkspaceEventType {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -650,7 +650,9 @@ export type PrebuiltWorkspaceState
     // the prebuild timed out
     | "timeout"
     // the prebuild has finished and a snapshot is available
-    | "available";
+    | "available"
+    //
+    | "failed";
 
 export interface PrebuiltWorkspace {
     id: string;

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -72,7 +72,7 @@ export class PrebuildManager {
             }
             const existingPB = await this.workspaceDB.trace({ span }).findPrebuiltWorkspaceByCommit(cloneURL, commit);
             // If the existing prebuild is failed, we want to retrigger it.
-            if (!!existingPB && existingPB.state !== 'aborted' && existingPB.state !== 'timeout' && !existingPB.error) {
+            if (!!existingPB && existingPB.state !== 'aborted' && existingPB.state !== 'failed' && existingPB.state !== 'timeout') {
                 // If the existing prebuild is based on an outdated project config, we also want to retrigger it.
                 const existingPBWS = await this.workspaceDB.trace({ span }).findById(existingPB.buildWorkspaceId);
                 const existingConfig = existingPBWS?.config;

--- a/components/server/ee/src/prebuilds/prebuilt-status-maintainer.ts
+++ b/components/server/ee/src/prebuilds/prebuilt-status-maintainer.ts
@@ -102,16 +102,18 @@ export class PrebuildStatusMaintainer implements Disposable {
     protected getConclusionFromPrebuildState(pws: PrebuiltWorkspace): "error" | "failure" | "pending" | "success" {
         if (pws.state === "aborted") {
             return "error";
-        } else if (pws.state === "queued") {
-            return "pending";
+        } else if (pws.state === "failed") {
+            return "error";
         } else if (pws.state === "timeout") {
             return "error";
+        } else if (pws.state === "queued") {
+            return "pending";
+        } else if (pws.state === "building") {
+            return "pending";
         } else if (pws.state === "available" && !pws.error) {
             return "success";
         } else if (pws.state === "available" && !!pws.error) {
             return "failure";
-        } else if (pws.state === "building") {
-            return "pending";
         } else {
             log.warn("Should have updated prebuilt workspace updatable, but don't know how. Resorting to error conclusion.", { pws });
             return "error";

--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -77,9 +77,9 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
                     prebuild.error = status.conditions!.timeout;
                     headlessUpdateType = HeadlessWorkspaceEventType.AbortedTimedOut;
                 } else if (!!status.conditions!.failed) {
-                    prebuild.state = "aborted";
+                    prebuild.state = "failed";
                     prebuild.error = status.conditions!.failed;
-                    headlessUpdateType = HeadlessWorkspaceEventType.Aborted;
+                    headlessUpdateType = HeadlessWorkspaceEventType.Failed;
                 } else if (!!status.conditions!.stoppedByRequest) {
                     prebuild.state = "aborted";
                     prebuild.error = "Cancelled";
@@ -89,6 +89,9 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
                     prebuild.error = status.conditions!.headlessTaskFailed;
                     prebuild.snapshot = status.conditions!.snapshot;
                     headlessUpdateType = HeadlessWorkspaceEventType.FinishedButFailed;
+                } else if (!status.conditions!.snapshot) {
+                    prebuild.state = "failed";
+                    headlessUpdateType = HeadlessWorkspaceEventType.Failed;
                 } else {
                     prebuild.state = "available";
                     prebuild.snapshot = status.conditions!.snapshot;


### PR DESCRIPTION
## Description

This PR introduces a "failure" state for prebuilds that have entirely failed to finish.
This is to distinguish them from failed tasks but finished rebuilds.

## Related Issue(s)
fixes https://github.com/gitpod-io/gitpod/issues/8592

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```