### PR TITLE
Update to vscode 1.65

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: bdb931480bacaac62d7c8aed5c59badfd2ea4c0d
+  codeCommit: 96fc3d8b50d203c4b12aa0722aacc653208cedcc
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"


### PR DESCRIPTION
## Description
Update code to [1.65](https://github.com/microsoft/vscode/releases/tag/1.65.0).

## How to test

- Switch to VS Code Insiders in settings.
- Start a workspace.
- Test following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data are sync across workspaces as well as on workspace restart, especially for extensions
   - [x] extensions from .gitpod.yml are not installed as sync
   - [x] extensions installed as sync are actually sync in new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - websockets and workers are properly proxied
    - [x] diff editor should be operatable
    - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old websockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. F1 → type Gitpod prefix
  - [x] that a PR view is preloaded on the PR url
  - [x] test gp open and preview
  - [x] test open in VS Code Desktop, check gp open and preview in task/user terminals
  - [x] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe
/werft no-preview