### PR TITLE
[code] update stable to 1.65

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -356,7 +356,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-890de80174c7dd9d073d63ef2b1f9eac68f063c1"
+      stableVersion: "commit-a5d259949a3fa8d3bbfbb4cb19fd2c3fb0cdf00b"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-890de80174c7dd9d073d63ef2b1f9eac68f063c1" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-a5d259949a3fa8d3bbfbb4cb19fd2c3fb0cdf00b" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates stable VS Code Web to 1.65
VSCode Endgame: https://github.com/microsoft/vscode/issues/143606

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Select vscode stable in dashboard settings
- Start a workspace.
- Use about dialog to check that version is 1.65.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
/werft no-preview