### PR TITLE
[installer] Add network policy for registry-facade access to coredns

### DIFF
--- a/install/installer/pkg/common/networkpolicies.go
+++ b/install/installer/pkg/common/networkpolicies.go
@@ -30,14 +30,24 @@ func AllowKubeDnsEgressRule() v1.NetworkPolicyEgressRule {
 				},
 			},
 		},
-		To: []v1.NetworkPolicyPeer{{
-			PodSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"k8s-app": "kube-dns",
+		// Enable access to DNS service in the cluster: kube-dns or coredns
+		To: []v1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"k8s-app": "kube-dns",
+					},
 				},
+				NamespaceSelector: &metav1.LabelSelector{},
+			}, {
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"k8s-app": "coredns",
+					},
+				},
+				NamespaceSelector: &metav1.LabelSelector{},
 			},
-			NamespaceSelector: &metav1.LabelSelector{},
-		}},
+		},
 	}
 
 	return dnsEgressRule


### PR DESCRIPTION
## Description

kube-dns and coredns (helm chart) use different labels.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Add network policy for registry-facade access to coredns
```
