### PR TITLE
Only allow exact-matching of workspace search

### DIFF
--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -16,6 +16,7 @@ import { UserContext } from "../user-context";
 import { getProject, WorkspaceStatusIndicator } from "../workspaces/WorkspaceEntry";
 import { adminMenu } from "./admin-menu";
 import WorkspaceDetail from "./WorkspaceDetail";
+import info from '../images/info.svg';
 
 interface Props {
     user?: User
@@ -66,6 +67,11 @@ export function WorkspaceSearch(props: Props) {
     }
 
     const search = async () => {
+        // Disables empty search on the workspace search page
+        if (!props.user && queryTerm.length === 0) {
+            return;
+        }
+
         setSearching(true);
         try {
             const query: AdminGetWorkspacesQuery = {
@@ -75,6 +81,9 @@ export function WorkspaceSearch(props: Props) {
                 query.instanceIdOrWorkspaceId = queryTerm;
             } else if (matchesNewWorkspaceIdExactly(queryTerm)) {
                 query.workspaceId = queryTerm;
+            }
+            if (!query.ownerId && !query.instanceIdOrWorkspaceId && !query.workspaceId) {
+                return;
             }
 
             const result = await getGitpodService().server.adminGetWorkspaces({
@@ -104,6 +113,10 @@ export function WorkspaceSearch(props: Props) {
                 </div>
                 <button disabled={searching} onClick={search}>Search</button>
             </div>
+        </div>
+        <div className={'flex rounded-xl bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 p-2 w-2/3 mb-2'}>
+            <img className="w-4 h-4 m-1 ml-2 mr-4" alt="info" src={info} />
+            <span>Please enter complete IDs - this search does not perform partial-matching.</span>
         </div>
         <div className="flex flex-col space-y-2">
             <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">


### PR DESCRIPTION
## Description
This PR disables empty string and partial match search.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8614

## How to test
1. Go to https://lm-empty-8614.staging.gitpod-dev.com/admin/workspaces
2. Click the Search button without any search queries. It should not do anything.
3. Enter a partial match of a workspace ID. It should not do anything.
4. Enter exact match of a workspace ID. It should return a result.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Admins cannot search empty strings or partial matches on workspace search.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
