### PR TITLE
werft/build/job-config: Add withVM annotation if present on branch name

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -83,25 +83,23 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const withPayment = "with-payment" in buildConfig && !mainBuild;
     const withObservability = "with-observability" in buildConfig && !mainBuild;
     const withHelm = "with-helm" in buildConfig && !mainBuild;
-    const withVM = "with-vm" in buildConfig && !mainBuild;
-
-    const previewDestName = version.split(".")[0];
-    const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewDestName}`;
-    const previewEnvironment = {
-        destname: previewDestName,
-        namespace: previewEnvironmentNamespace
-    }
-
     const repository: Repository = {
         owner: context.Repository.owner,
         repo: context.Repository.repo,
         ref: context.Repository.ref,
         branch: context.Repository.ref,
     }
-
     const refsPrefix = "refs/heads/";
     if (repository.branch.startsWith(refsPrefix)) {
         repository.branch = repository.branch.substring(refsPrefix.length);
+    }
+    const withVM = ("with-vm" in buildConfig || repository.branch.includes("with-vm")) && !mainBuild;
+
+    const previewDestName = version.split(".")[0];
+    const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewDestName}`;
+    const previewEnvironment = {
+        destname: previewDestName,
+        namespace: previewEnvironmentNamespace
     }
 
     const observability: Observability = {

--- a/dev/preview/test/load-test.sh
+++ b/dev/preview/test/load-test.sh
@@ -21,7 +21,7 @@ BASE_BRANCH_NAME="vm-load-test"
 BRANCH_SUFFIX="with-vm"
 
 opts=$(getopt \
-  --longoptions "start:,end:,base-branch-name:" \
+  --longoptions "start:,end:,base-branch-name:,interval:" \
   --name "$(basename "$0")" \
   --options "" \
   -- "$@"

--- a/dev/preview/test/load-test.sh
+++ b/dev/preview/test/load-test.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   ./dev/preview/test/load-test.sh
-#   ./dev/preview/test/load-test.sh --base-branch-name my-load-test-base-branch-name --start 1 --end 5
+#   ./dev/preview/test/load-test.sh --base-branch-name test --start 1 --end 5 --interval 30
 #
 
 set -euo pipefail
@@ -16,7 +16,9 @@ function log {
 
 START=1
 END=15
+INTERVAL=30
 BASE_BRANCH_NAME="vm-load-test"
+BRANCH_SUFFIX="with-vm"
 
 opts=$(getopt \
   --longoptions "start:,end:,base-branch-name:" \
@@ -32,6 +34,7 @@ while [[ $# -gt 0 ]]; do
     --start) START=$2 ; shift 2 ;;
     --end) END=$2 ; shift 2 ;;
     --base-branch-name) BASE_BRANCH_NAME=$2 ;  shift 2 ;;
+    --interval) INTERVAL=$2 ; shift 2 ;;
     *) break ;;
   esac
 done
@@ -42,6 +45,7 @@ Are you sure you want to run the load test with the following configuration?
 
 START=${START}
 END=${END}
+INTERVAL=${INTERVAL}
 BASE_BRANCH_NAME=${BASE_BRANCH_NAME}
 
 y/n: " yn
@@ -52,20 +56,20 @@ y/n: " yn
     esac
 done
 
-log "Creating base branch ${BASE_BRANCH_NAME}"
-git checkout -b "${BASE_BRANCH_NAME}"
-git commit --allow-empty -m "Prepare load test" -m "/werft with-vm=true"
+FULL_BRANCH_NAME="${BASE_BRANCH_NAME}-${BRANCH_SUFFIX}"
+log "Creating base branch ${FULL_BRANCH_NAME}"
+git checkout -b "${FULL_BRANCH_NAME}"
 
 for number in $(seq "${START}" "${END}"); do
-    branch="${BASE_BRANCH_NAME}-${number}"
+    branch="${FULL_BRANCH_NAME}-${number}"
 
     log "Creating and pushing branch ${branch}"
     git checkout -b "${branch}"
     git push -u origin "${branch}"
 
-    log "Back to base branch ${BASE_BRANCH_NAME}"
-    git checkout "${BASE_BRANCH_NAME}"
+    log "Back to base branch ${FULL_BRANCH_NAME}"
+    git checkout "${FULL_BRANCH_NAME}"
 
-    log "Sleeping 30 seconds"
-    sleep 30
+    log "Sleeping ${INTERVAL} seconds"
+    sleep "$INTERVAL"
 done


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Since we can't pass annotations on commits anymore, this is needed to make Harvester load tests possible

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1444

## How to test
<!-- Provide steps to test this PR -->
Create a new branch from this PR with `with-vm` present on its name 

Start a new werft job, it should trigger the creation of a Harvester VM.

Or just run `./dev/preview/test/load-test.sh`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
