### PR TITLE
.werft/build: Cleaning code

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -44,20 +44,7 @@ Tracing.initialize()
 async function run(context: any) {
     const config = jobConfig(werft, context)
 
-    //TODO: This is only a temporary solution and needs to be removed when we migrate to one prev-environment per cluster
-    // Because of a workspace label the branch name that can be used to create a preview environment is limited to 20 chars
-    // echo -n "gitpod.io/registry-facade_ready_ns_staging-" | wc -c
-    if (!config.noPreview) {
-        werft.phase("check-branchname","This checks if the branchname is to long to create a preview-environment successfully.")
-        const maxBranchNameLength = 20;
-        if (config.previewEnvironment.destname.length > maxBranchNameLength) {
-            werft.fail("check-branchname", `The branch name ${config.previewEnvironment.destname} is more than ${maxBranchNameLength} character. Please choose a shorter name!`)
-        }
-        werft.done("check-branchname")
-    }
-
-
-    await validateChanges(werft)
+    await validateChanges(werft, config)
     await prepare(werft)
     await buildAndPublish(werft, config)
     await coverage(werft, config)

--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -73,7 +73,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
     const url = `https://${domain}`;
     const imagePullAuth = exec(`printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
         | yq r - data['.dockerconfigjson'] \
-        | base64 -d)" | base64 -w 0`, { silent: true }).stdout.trim();
+        | base64 -d)" | base64 -w 0`, { silent: true}).stdout.trim();
 
     const sweeperImage = exec(`tar xfO /tmp/dev.tar.gz ./sweeper.txt`).stdout.trim();
 

--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -1,12 +1,38 @@
 import { exec } from "../../util/shell";
 import { Werft } from "../../util/werft";
+import { JobConfig } from "./job-config";
 
-export async function validateChanges(werft: Werft) {
+export async function validateChanges(werft: Werft, config: JobConfig) {
     werft.phase('validate-changes', 'validating changes');
     try {
-        exec(`pre-commit run --all-files --show-diff-on-failure`);
-        werft.done('validate-changes');
+        branchNameCheck(werft, config)
+        preCommitCheck(werft)
     } catch (err) {
         werft.fail('validate-changes', err);
     }
+    werft.done('validate-changes');
+}
+
+// Branch names cannot be longer than 20 characters.
+// We plan to remove this limitation once we move to previews on Harvester VMs.
+async function branchNameCheck(werft: Werft, config: JobConfig) {
+    if (!config.noPreview) {
+        const maxBranchNameLength = 20;
+        werft.log("check-branchname", `Checking if branch name is shorter than ${maxBranchNameLength} characters.`)
+
+        if (config.previewEnvironment.destname.length > maxBranchNameLength) {
+            throw new Error(`The branch name ${config.previewEnvironment.destname} is more than ${maxBranchNameLength} character. Please choose a shorter name!`)
+        }
+        werft.done("check-branchname")
+    }
+}
+
+async function preCommitCheck(werft: Werft) {
+    werft.log("pre-commit checks", "Running pre-commit hooks.")
+    const preCommitCmd = exec(`pre-commit run --all-files --show-diff-on-failure`, { slice: "pre-commit checks" });
+
+    if (preCommitCmd.code != 0) {
+        throw new Error(preCommitCmd.stderr.toString().trim())
+    }
+    werft.done("pre-commit checks")
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Keep built.ts cleaner by removing branch length check from it

Add branch length check to validation phase, as it seems more appropriate, while making logic clearer with better error handling

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```