### PR TITLE
werft/vm/manifest: Disable google cloud agent

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -146,7 +146,7 @@ type UserDataSecretManifestOptions = {
   secretName: string
 }
 
-export function UserDataSecretManifest({vmName, namespace, secretName }: UserDataSecretManifestOptions) {
+export function UserDataSecretManifest({ vmName, namespace, secretName }: UserDataSecretManifestOptions) {
   const userdata = Buffer.from(`#cloud-config
 users:
 - name: ubuntu
@@ -158,6 +158,20 @@ chpasswd:
     ubuntu:ubuntu
   expire: False
 write_files:
+  - path: /etc/disable-services.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      systemctl disable google-guest-agent &
+      systemctl disable google-startup-scripts &
+      systemctl disable google-osconfig-agent &
+      systemctl disable google-oslogin-cache.timer &
+      systemctl disable google-shutdown-scripts &
+      systemctl stop google-guest-agent &
+      systemctl stop google-startup-scripts &
+      systemctl stop google-osconfig-agent &
+      systemctl stop google-oslogin-cache.timer &
+      systemctl stop google-shutdown-scripts &
   - path: /etc/ssh/sshd_config.d/101-change-ssh-port.conf
     permission: 0644
     owner: root
@@ -213,6 +227,7 @@ write_files:
       export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
       EOF
 runcmd:
+ - bash /etc/disable-services.sh
  - bash /usr/local/bin/bootstrap-k3s.sh`).toString("base64")
   return `
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Disabling google-cloud agent during boot time aiming for faster boot

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1443

## How to test
<!-- Provide steps to test this PR -->


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
