### PR TITLE
werft/build/prepare: Cleanup code

### DIFF
--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -1,24 +1,52 @@
-import * as shell from 'shelljs';
 import { exec } from '../../util/shell';
 import { Werft } from "../../util/werft";
 import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
 
+const phaseName = "prepare";
+
 export async function prepare(werft: Werft) {
-    werft.phase("prepare");
-
-    const werftImg = shell.exec("cat .werft/build.yaml | grep dev-environment").trim().split(": ")[1];
-    const devImg = shell.exec("yq r .gitpod.yml image").trim();
-    if (werftImg !== devImg) {
-        werft.fail('prep', `Werft job image (${werftImg}) and Gitpod dev image (${devImg}) do not match`);
-    }
-
+    werft.phase(phaseName);
     try {
-        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`);
-        exec("gcloud auth configure-docker --quiet");
-        exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet");
-        exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev');
-        werft.done('prep');
+        compareWerftAndGitpodImage()
+        activateCoreDevServiceAccount()
+        configureDocker()
+        configureCoreDevAccess()
     } catch (err) {
-        werft.fail('prep', err);
+        werft.fail(phaseName, err);
+    }
+    werft.done(phaseName);
+}
+
+// TODO: The reasoning behind this step should be clarified
+function compareWerftAndGitpodImage() {
+    const werftImg = exec("cat .werft/build.yaml | grep dev-environment", { silent: true }).trim().split(": ")[1];
+    const devImg = exec("yq r .gitpod.yml image", { silent: true }).trim();
+    if (werftImg !== devImg) {
+        throw new Error(`Werft job image (${werftImg}) and Gitpod dev image (${devImg}) do not match`);
+    }
+}
+
+function activateCoreDevServiceAccount() {
+    const rc = exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, { slice: phaseName }).code;
+
+    if (rc != 0) {
+        throw new Error("Failed to activate core-dev service account.")
+    }
+}
+
+function configureDocker() {
+    const rcDocker = exec("gcloud auth configure-docker --quiet", { slice: phaseName }).code;
+    const rcDockerRegistry = exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet", { slice: phaseName }).code;
+
+    if (rcDocker != 0 || rcDockerRegistry != 0) {
+        throw new Error("Failed to configure docker with gcloud.")
+    }
+}
+
+function configureCoreDevAccess() {
+    const rc = exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev', { slice: phaseName }).code;
+
+    if (rc != 0) {
+        throw new Error("Failed to get core-dev kubeconfig credentials.")
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A couple of changes to make code cleaner:

* Only uses `exec` from `util/shell` instead of using it from `shelljs` at some places.
* Refactor the `prepare` function to no longer hold any logic, only calling several smaller private functions.
* Write small functions following the ["Do one thing"](https://blog.codinghorror.com/curlys-law-do-one-thing/#:~:text=Curly's%20Law%20is%20about%20choosing,your%20code%20won't%20do.) pattern that replaces the previous logic inside the `prepare` function



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Start a new job, you shouldn't notice any difference

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
