### PR TITLE
[server] remove setting sync record with limit

### DIFF
--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
@@ -122,10 +122,15 @@ export class CodeSyncResourceDBSpec {
     async roundRobinInsert(): Promise<void> {
         const kind = 'machines';
         const expectation: string[] = [];
-        const doInsert = async () => { };
+        const doInsert = async (rev: string, oldRevs: string[]) => {
+            for (let rev of oldRevs) {
+                await this.db.deleteResource(this.userId, kind, rev, async () => {});
+            }
+        }
         const revLimit = 3;
 
         const assertResources = async () => {
+
             const resources = await this.db.getResources(this.userId, kind);
             expect(resources.map(r => r.rev)).to.deep.eq(expectation);
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Origin code looks fine. So sync-data more than 20, maybe it's caused by `db-sync`.

This PR will alleviate this problem.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8589

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace
2. Adjust UI and toggle setting sync to reach config limit 2 (debug only)
3. Repeat prev step, watch minio files and DB record

### How to access minio with UI
```shell
# make sure using correct namespace
kubens staging-hw-fix-8589

# get user and psw
kubectl get secrets minio -oyaml | yq - r "data.root-user" | base64 -d
kubectl get secrets minio -oyaml | yq - r "data.root-password" | base64 -d

# port forward minio console to 1234 (whatever you want)
kubectl pord-forward service/minio 1234:9001

# open port in your browser!! 
```
How to access your configuration?

Buckets -> search with your userId (Chrome DevTools to get it) -> Browser details -> blobs -> code-data -> globalState(which store your UI setting)

### How to access setting sync table
```shell
# get psw
kubectl get secrets mysql -oyaml | yq - r "data.password" | base64 -d

# exec into mysql
kubectl exec -it mysql-0 -c mysql sh

# get your data
mysql -u gitpod -p # then enter your password
use gitpod;
SELECT * FROM d_b_code_sync_resource WHERE userId=<your_user_id>;
```

### How to trigger UI update request to server
Drag your *DEBUG CONSOLE* to *TERMINAL* (any of them)
|Image|
|:-:|
|<img width="1453" alt="image" src="https://user-images.githubusercontent.com/20944364/157595805-cc966d0c-5eef-4b33-92fe-503df9f78423.png">|

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix setting sync limit failure in some cases
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
