### PR TITLE
Show git providers

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -25,6 +25,7 @@ export default function UserDetail(p: { user: User }) {
     const [isStudent, setIsStudent] = useState<boolean>();
     const [editFeatureFlags, setEditFeatureFlags] = useState(false);
     const [editRoles, setEditRoles] = useState(false);
+    const [authProviders, setAuthProviders] = useState<string[]>();
     const userRef = useRef(user);
 
     const isProfessionalOpenSource = accountStatement && accountStatement.subscriptions.some(s => s.planId === Plans.FREE_OPEN_SOURCE.chargebeeId)
@@ -39,6 +40,9 @@ export default function UserDetail(p: { user: User }) {
         });
         getGitpodService().server.adminIsStudent(p.user.id).then(
             isStud => setIsStudent(isStud)
+        );
+        getGitpodService().server.adminGetAuthProviderIdsOfUser(p.user.id).then(
+            result => setAuthProviders(result.map(r => r.authProviderId))
         );
     }, [p.user]);
 
@@ -168,6 +172,12 @@ export default function UserDetail(p: { user: User }) {
                                 onClick: addStudentDomain
                             }] :  undefined}
                         >{isStudent === undefined ? '---' : (isStudent ? 'Enabled' : 'Disabled')}</Property>
+                    </div>
+                    <div className="flex w-full mt-6 overflow-scroll">
+                        {authProviders && authProviders.length > 0 &&
+                            <Property name="Git providers">
+                                <div className="overflow-scroll">{authProviders?.join(", ")}</div>
+                            </Property>}
                     </div>
                 </div>
             </div>

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -187,6 +187,13 @@ export class TypeORMUserDBImpl implements UserDB {
         return qBuilder.getOne();
     }
 
+    public async findAuthProviderIdsOfUser(userId: string): Promise<Identity[]> {
+        const repo = await this.getIdentitiesRepo();
+        const queryBuilder = repo.createQueryBuilder('identity')
+            .where('identity.userId', { userId });
+        return queryBuilder.getMany();
+    }
+
     public async findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]> {
         const repo = await this.getGitpodTokenRepo()
         const qBuilder = repo.createQueryBuilder('gitpodToken')

--- a/components/gitpod-db/src/user-db.spec.db.ts
+++ b/components/gitpod-db/src/user-db.spec.db.ts
@@ -153,6 +153,16 @@ const WRONG_ID = '123';    // no uuid
         expect(r1).to.be.not.undefined;
         expect(r1!.name).to.be.eq("XYZ");
     }
+
+    @test(timeout(10000))
+    public async findAuthProviderIdsByUserId() {
+        let user = await this.db.newUser();
+        user.identities.push(this.IDENTITY1);
+        user = await this.db.storeUser(user);
+
+        const identity = await this.db.findAuthProviderIdsOfUser(user.id);
+        expect(identity[0].authProviderId).to.eq("GitHub");
+    }
 }
 
 namespace TestData {

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -112,6 +112,7 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
 
     findUserByGitpodToken(tokenHash: string, tokenType?: GitpodTokenType): Promise<{ user: User, token: GitpodToken } | undefined>;
     findGitpodTokensOfUser(userId: string, tokenHash: string): Promise<GitpodToken | undefined>;
+    findAuthProviderIdsOfUser(userId: string): Promise<Identity[]>;
     findAllGitpodTokensOfUser(userId: string): Promise<GitpodToken[]>;
     storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void>;
     deleteGitpodToken(tokenHash: string): Promise<void>;

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { User, Workspace, NamedWorkspaceFeatureFlag } from "./protocol";
+import { User, Workspace, NamedWorkspaceFeatureFlag, Identity } from "./protocol";
 import { FindPrebuildsParams } from "./gitpod-service";
 import { Project, Team, PrebuildWithStatus, TeamMemberInfo, TeamMemberRole } from "./teams-projects-protocol"
 import { WorkspaceInstance, WorkspaceInstancePhase } from "./workspace-instance";
@@ -17,6 +17,7 @@ export interface AdminServer {
     adminGetUser(id: string): Promise<User>;
     adminBlockUser(req: AdminBlockUserRequest): Promise<User>;
     adminDeleteUser(id: string): Promise<void>;
+    adminGetAuthProviderIdsOfUser(userId: string): Promise<Identity[]>;
     adminModifyRoleOrPermission(req: AdminModifyRoleOrPermissionRequest): Promise<User>;
     adminModifyPermanentWorkspaceFeatureFlag(req: AdminModifyPermanentWorkspaceFeatureFlagRequest): Promise<User>;
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -7,7 +7,7 @@
 import { injectable, inject } from "inversify";
 import { GitpodServerImpl, traceAPIParams, traceWI, censor } from "../../../src/workspace/gitpod-server-impl";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
-import { GitpodServer, GitpodClient, AdminGetListRequest, User, Team, TeamMemberInfo, AdminGetListResult, Permission, AdminBlockUserRequest, AdminModifyRoleOrPermissionRequest, RoleOrPermission, AdminModifyPermanentWorkspaceFeatureFlagRequest, UserFeatureSettings, AdminGetWorkspacesRequest, WorkspaceAndInstance, GetWorkspaceTimeoutResult, WorkspaceTimeoutDuration, WorkspaceTimeoutValues, SetWorkspaceTimeoutResult, WorkspaceContext, CreateWorkspaceMode, WorkspaceCreationResult, PrebuiltWorkspaceContext, CommitContext, PrebuiltWorkspace, WorkspaceInstance, EduEmailDomain, ProviderRepository, Queue, PrebuildWithStatus, CreateProjectParams, Project, StartPrebuildResult, ClientHeaderFields, Workspace, FindPrebuildsParams, TeamMemberRole } from "@gitpod/gitpod-protocol";
+import { GitpodServer, GitpodClient, AdminGetListRequest, User, Team, TeamMemberInfo, AdminGetListResult, Permission, AdminBlockUserRequest, AdminModifyRoleOrPermissionRequest, RoleOrPermission, AdminModifyPermanentWorkspaceFeatureFlagRequest, UserFeatureSettings, AdminGetWorkspacesRequest, WorkspaceAndInstance, GetWorkspaceTimeoutResult, WorkspaceTimeoutDuration, WorkspaceTimeoutValues, SetWorkspaceTimeoutResult, WorkspaceContext, CreateWorkspaceMode, WorkspaceCreationResult, PrebuiltWorkspaceContext, CommitContext, PrebuiltWorkspace, WorkspaceInstance, EduEmailDomain, ProviderRepository, Queue, PrebuildWithStatus, CreateProjectParams, Project, StartPrebuildResult, ClientHeaderFields, Workspace, FindPrebuildsParams, TeamMemberRole, Identity } from "@gitpod/gitpod-protocol";
 import { ResponseError } from "vscode-jsonrpc";
 import { TakeSnapshotRequest, AdmissionLevel, ControlAdmissionRequest, StopWorkspacePolicy, DescribeWorkspaceRequest, SetTimeoutRequest } from "@gitpod/ws-manager/lib";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -487,6 +487,14 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         } catch (e) {
             throw new ResponseError(500, e.toString());
         }
+    }
+
+    async adminGetAuthProviderIdsOfUser(ctx: TraceContext, userId: string): Promise<Identity[]> {
+        traceAPIParams(ctx, { userId });
+        this.requireEELicense(Feature.FeatureAdminDashboard);
+        await this.guardAdminAccess("adminGetAuthProviderIdsOfUser", { userId }, Permission.ADMIN_USERS);
+
+        return await this.userDB.findAuthProviderIdsOfUser(userId);
     }
 
     async adminModifyRoleOrPermission(ctx: TraceContext, req: AdminModifyRoleOrPermissionRequest): Promise<User> {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -135,6 +135,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         "adminGetUser": { group: "default", points: 1 },
         "adminBlockUser": { group: "default", points: 1 },
         "adminDeleteUser": { group: "default", points: 1 },
+        "adminGetAuthProviderIdsOfUser": { group: "default", points: 1 },
         "adminModifyRoleOrPermission": { group: "default", points: 1 },
         "adminModifyPermanentWorkspaceFeatureFlag": { group: "default", points: 1 },
         "adminGetTeams": { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -6,7 +6,7 @@
 
 import { DownloadUrlRequest, DownloadUrlResponse, UploadUrlRequest, UploadUrlResponse } from '@gitpod/content-service/lib/blobs_pb';
 import { AppInstallationDB, UserDB, UserMessageViewsDB, WorkspaceDB, DBWithTracing, TracedWorkspaceDB, DBGitpodToken, DBUser, UserStorageResourcesDB, TeamDB, InstallationAdminDB, ProjectDB } from '@gitpod/gitpod-db/lib';
-import { AuthProviderEntry, AuthProviderInfo, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient as GitpodApiClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, Project, ProviderRepository, TeamMemberRole, WithDefaultConfig, FindPrebuildsParams, PrebuildWithStatus, StartPrebuildResult, ClientHeaderFields, Permission, SnapshotContext } from '@gitpod/gitpod-protocol';
+import { AuthProviderEntry, AuthProviderInfo, CommitContext, Configuration, CreateWorkspaceMode, DisposableCollection, GetWorkspaceTimeoutResult, GitpodClient as GitpodApiClient, GitpodServer, GitpodToken, GitpodTokenType, InstallPluginsParams, PermissionName, PortVisibility, PrebuiltWorkspace, PrebuiltWorkspaceContext, PreparePluginUploadParams, ResolvedPlugins, ResolvePluginsParams, SetWorkspaceTimeoutResult, StartPrebuildContext, StartWorkspaceResult, Terms, Token, UninstallPluginParams, User, UserEnvVar, UserEnvVarValue, UserInfo, WhitelistedRepository, Workspace, WorkspaceContext, WorkspaceCreationResult, WorkspaceImageBuild, WorkspaceInfo, WorkspaceInstance, WorkspaceInstancePort, WorkspaceInstanceUser, WorkspaceTimeoutDuration, GuessGitTokenScopesParams, GuessedGitTokenScopes, Team, TeamMemberInfo, TeamMembershipInvite, CreateProjectParams, Project, ProviderRepository, TeamMemberRole, WithDefaultConfig, FindPrebuildsParams, PrebuildWithStatus, StartPrebuildResult, ClientHeaderFields, Permission, SnapshotContext, Identity } from '@gitpod/gitpod-protocol';
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { AdminBlockUserRequest, AdminGetListRequest, AdminGetListResult, AdminGetWorkspacesRequest, AdminModifyPermanentWorkspaceFeatureFlagRequest, AdminModifyRoleOrPermissionRequest, WorkspaceAndInstance } from '@gitpod/gitpod-protocol/lib/admin-protocol';
 import { GetLicenseInfoResult, LicenseFeature, LicenseValidationResult } from '@gitpod/gitpod-protocol/lib/license-protocol';
@@ -2168,6 +2168,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     async adminDeleteUser(ctx: TraceContext, _id: string): Promise<void> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
+    async adminGetAuthProviderIdsOfUser(ctx: TraceContext, userId: string): Promise<Identity[]> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }
 


### PR DESCRIPTION
## Description
[WIP] This shows the list of git providers of a user.

<img width="426" alt="Screenshot 2022-03-07 at 19 43 16" src="https://user-images.githubusercontent.com/8015191/157098864-5416e82c-2601-4e80-8c62-5ebbeda65111.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8451

## How to test
https://lm-git-integ-8451.staging.gitpod-dev.com/admin/users

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Shows git providers of a user in the admin user detail.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
