### PR TITLE
Namespace prebuild tracing tags

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -69,9 +69,11 @@ export class PrebuildManager {
 
     async startPrebuild(ctx: TraceContext, { contextURL, cloneURL, commit, branch, project, user }: StartPrebuildParams): Promise<StartPrebuildResult> {
         const span = TraceContext.startSpan("startPrebuild", ctx);
-        span.setTag("contextURL", contextURL);
-        span.setTag("cloneURL", cloneURL);
-        span.setTag("commit", commit);
+        span.setTag("prebuild.contextURL", contextURL);
+        span.setTag("prebuild.cloneURL", cloneURL);
+        span.setTag("prebuild.commit", commit);
+        span.setTag("prebuild.branch", branch);
+        span.setTag("prebuild.project", project);
 
         try {
             if (user.blocked) {
@@ -134,8 +136,8 @@ export class PrebuildManager {
                 prebuild.error = "Prebuild is rate limited. Please contact Gitpod if you believe this happened in error.";
 
                 await this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild);
-                span.setTag("starting", false);
-                span.setTag("ratelimited", true);
+                span.setTag("prebuild.starting", false);
+                span.setTag("prebuild.ratelimited", true);
                 return {
                     wsid: workspace.id,
                     prebuildId: prebuild.id,
@@ -143,7 +145,7 @@ export class PrebuildManager {
                 };
             }
 
-            span.setTag("starting", true);
+            span.setTag("prebuild.starting", true);
             const projectEnvVars = await projectEnvVarsPromise;
             await this.workspaceStarter.startWorkspace({ span }, workspace, user, [], projectEnvVars, {excludeFeatureFlags: ['full_workspace_backup']});
             return { prebuildId: prebuild.id, wsid: workspace.id, done: false };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Namespace `startPrebuild` tags as mentioned in https://github.com/gitpod-io/gitpod/pull/8568#discussion_r820887740

## Open Questions
* Fields like `contextURL`, `project` and few others feel like shared domain tags between many RPCs - do we have any unified tagging for domain properties which are wide-reaching? In practice, we want to be able to find relevant traces for any of these properties and for that we need a common tag schema.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Namespace prebuild tags
```