### PR TITLE
[kots]: add workaround for #8529

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -178,11 +178,20 @@ spec:
               echo "Gitpod: ${CONFIG_PATCH_FILE}=${config_patch}"
               yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' "${CONFIG_FILE}" /tmp/patch.yaml
 
-              echo "Gitpod: Generate the Kubernetes objects and apply"
+              echo "Gitpod: Generate the Kubernetes objects"
               config=$(cat "${CONFIG_FILE}")
               echo "Gitpod: ${CONFIG_FILE}=${config}"
 
-              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} | kubectl apply -f -
+              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} > /tmp/gitpod.yaml
+
+              # Workaround for #8532 and #8529
+              echo "Gitpod: Remove the StatefulSet status object for OpenVSX Proxy"
+              yq eval-all --inplace \
+                'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
+                /tmp/gitpod.yaml
+
+              echo "Gitpod: Apply the Kubernetes objects"
+              kubectl apply -f /tmp/gitpod.yaml
 
               echo "Gitpod: Installer job finished - goodbye"
       volumes:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Workaround for #8529, using the advice of #8532

The Go library has a misconfiguration which adds in `replicas` and `availableReplicas` to the OpenVSX Proxy StatefulSet. This can cause validation issues dependent upon the version of Kubernetes that's being used.

This removes the block from the rendered Kubernetes objects which is the expected behaviour.

## How to test
<!-- Provide steps to test this PR -->
Run via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
