### PR TITLE
 Add some tests for cgroup v2

### DIFF
--- a/test/integration.yaml
+++ b/test/integration.yaml
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: integration-svc
       containers:
       - name: tests
-        image: eu.gcr.io/gitpod-core-dev/build/integration-tests:kyleb-installer-integration.24
+        image: eu.gcr.io/gitpod-core-dev/build/integration-tests:to-cgv2-itest.39
         imagePullPolicy: Always
         #args: ["-username=sagor999"]
         #args: ["-enterprise=true"]

--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/tests/workspace/common"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCgroupV2(t *testing.T) {
+	f := features.New("cgroup v2").
+		WithLabel("component", "workspace").
+		Assess("it should create a new cgroup when cgroup v2 is enabled", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			ws, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				err = integration.DeleteWorkspace(ctx, api, ws.Req.Id)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(ws.Req.Id), integration.WithWorkspacekitLift(true))
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting workspace: %v", err)
+			}
+			defer rsa.Close()
+			integration.DeferCloser(t, closer)
+
+			cgv2, err := common.IsCgroupV2(rsa)
+			if err != nil {
+				t.Fatalf("unexpected error checking cgroup v2: %v", err)
+			}
+			if !cgv2 {
+				t.Skip("This test only works for cgroup v2")
+			}
+
+			cgroupBase := "/sys/fs/cgroup/test"
+			var respNewCgroup agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/",
+				Command: "bash",
+				Args: []string{
+					"-c",
+					fmt.Sprintf("sudo mkdir %s", cgroupBase),
+				},
+			}, &respNewCgroup)
+			if err != nil {
+				t.Fatalf("new cgroup create failed: %v\n%s\n%s", err, respNewCgroup.Stdout, respNewCgroup.Stderr)
+			}
+
+			if respNewCgroup.ExitCode != 0 {
+				t.Fatalf("new cgroup create failed: %s\n%s", respNewCgroup.Stdout, respNewCgroup.Stderr)
+			}
+
+			var respCheckControllers agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/",
+				Command: "bash",
+				Args: []string{
+					"-c",
+					fmt.Sprintf("cat %s", filepath.Join(cgroupBase, "cgroup.controllers")),
+				},
+			}, &respCheckControllers)
+			if err != nil {
+				t.Fatalf("cgroup v2 controllers check failed: %v\n%s\n%s", err, respCheckControllers.Stdout, respCheckControllers.Stderr)
+			}
+
+			if respCheckControllers.ExitCode != 0 {
+				t.Fatalf("cgroup v2 controllers check failed: %s\n%s", respCheckControllers.Stdout, respCheckControllers.Stderr)
+			}
+
+			expect := []string{
+				"cpuset",
+				"cpu",
+				"io",
+				"memory",
+				"hugetlb",
+				"pids",
+				"rdma",
+			}
+			sort.Strings(expect)
+			act := strings.Split(strings.TrimSuffix(respCheckControllers.Stdout, "\n"), " ")
+			sort.Strings(act)
+			if diff := cmp.Diff(act, expect); len(diff) != 0 {
+				t.Errorf("cgroup v2 controllers mismatch (-want +got):\n%s", diff)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}

--- a/test/tests/workspace/common/cgroup.go
+++ b/test/tests/workspace/common/cgroup.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package common
+
+import (
+	"net/rpc"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+)
+
+func IsCgroupV2(rsa *rpc.Client) (bool, error) {
+	var resp agent.ExecResponse
+	err := rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     "/",
+		Command: "bash",
+		Args: []string{
+			"-c",
+			"test -f /sys/fs/cgroup/cgroup.controllers",
+		},
+	}, &resp)
+	if resp.ExitCode == 1 {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return resp.ExitCode == 0, nil
+}

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/tests/workspace/common"
+)
+
+func TestK3s(t *testing.T) {
+	f := features.New("k3s").
+		WithLabel("component", "workspace").
+		Assess("it should start a k3s when cgroup v2 enable", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			ws, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				err = integration.DeleteWorkspace(ctx, api, ws.Req.Id)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(ws.Req.Id), integration.WithWorkspacekitLift(true))
+			if err != nil {
+				t.Fatalf("unexpected error instrumenting workspace: %v", err)
+			}
+			defer rsa.Close()
+			integration.DeferCloser(t, closer)
+
+			cgv2, err := common.IsCgroupV2(rsa)
+			if err != nil {
+				t.Fatalf("unexpected error checking cgroup v2: %v", err)
+			}
+
+			if !cgv2 {
+				t.Skip("This test only works for cgroup v2")
+			}
+
+			go func() {
+				var respReadyForK3s agent.ExecResponse
+				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+					Dir:     "/",
+					Command: "bash",
+					Args: []string{
+						"-c",
+						"curl -L https://github.com/k3s-io/k3s/releases/download/v1.23.4%2Bk3s1/k3s -o /workspace/k3s && sudo chmod +x /workspace/k3s && sudo /workspace/k3s server -d /workspace/data --flannel-backend=host-gw > /dev/null 2>&1",
+					},
+				}, &respReadyForK3s)
+			}()
+
+			kubeEnv := []string{
+				"KUBECONFIG=/etc/rancher/k3s/k3s.yaml",
+			}
+			var respWaitForK3s agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/",
+				Command: "bash",
+				Env:     kubeEnv,
+				Args: []string{
+					"-c",
+					"timeout 30s bash -c 'while [ ! -e /etc/rancher/k3s/k3s.yaml ]; do sleep 1; done' && sudo chmod +r /etc/rancher/k3s/k3s.yaml && timeout 1m bash -c 'until /workspace/k3s kubectl wait --for=condition=Ready nodes -l node-role.kubernetes.io/master=true --timeout 30s; do sleep 1; done'",
+				},
+			}, &respWaitForK3s)
+			if err != nil {
+				t.Fatalf("failed to wait for starting k3s: %v\n%s\n%s", err, respWaitForK3s.Stdout, respWaitForK3s.Stderr)
+			}
+
+			if respWaitForK3s.ExitCode != 0 {
+				t.Fatalf("failed to wait for starting k3s: %s\n%s", respWaitForK3s.Stdout, respWaitForK3s.Stderr)
+			}
+
+			var respGetPods agent.ExecResponse
+			err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+				Dir:     "/",
+				Command: "bash",
+				Env:     kubeEnv,
+				Args: []string{
+					"-c",
+					"/workspace/k3s kubectl get nodes",
+				},
+			}, &respGetPods)
+			if err != nil {
+				t.Fatalf("failed to get nodes: %v\n%s\n%s", err, respGetPods.Stdout, respGetPods.Stderr)
+			}
+
+			if respGetPods.ExitCode != 0 {
+				t.Fatalf("failed to get nodes: %s\n%s", respGetPods.Stdout, respGetPods.Stderr)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description

- Add a test for cgroup v2
- Add a test for k3s

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8627

## How to test
<!-- Provide steps to test this PR -->
Run the integration test following README of tests.
(e.g. https://werft.gitpod-dev.com/job/gitpod-custom-to-cgv2-itest.2/logs)
For cgroup v2, you need to prepare a dedicated image to build the environment. core-dev is cgoup v1, so the test for cgroup v2 is skipped. `gitpod-k3s-202203090157-cgv2` is the image that set the cgroup v2 setting.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
