### PR TITLE
[Analytics] Track current user's subscription(s) at login

### DIFF
--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -6,10 +6,11 @@
 import { User } from '@gitpod/gitpod-protocol';
 import { Request } from 'express';
 import { IAnalyticsWriter } from '@gitpod/gitpod-protocol/lib/analytics';
+import { SubscriptionService } from '@gitpod/gitpod-payment-endpoint/lib/accounting';
 
-export async function trackLogin(user: User, request: Request, authHost: string, analytics: IAnalyticsWriter) {
+export async function trackLogin(user: User, request: Request, authHost: string, analytics: IAnalyticsWriter, subscriptionService: SubscriptionService) {
     //make new complete identify call for each login
-    fullIdentify(user, request, analytics);
+    fullIdentify(user, request, analytics, subscriptionService);
 
     //track the login
     analytics.track({
@@ -23,25 +24,26 @@ export async function trackLogin(user: User, request: Request, authHost: string,
 }
 
 export async function trackSignup(user: User, request: Request, analytics: IAnalyticsWriter) {
-        //make new complete identify call for each signup
-        fullIdentify(user,request,analytics);
+    //make new complete identify call for each signup
+    fullIdentify(user,request,analytics);
 
-        //track the signup
-        analytics.track({
-            userId: user.id,
-            anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
-            event: "signup",
-            properties: {
-                "auth_provider": user.identities[0].authProviderId,
-                "qualified": !!request.cookies["gitpod-marketing-website-visited"]
-            }
-        });
+    //track the signup
+    analytics.track({
+        userId: user.id,
+        anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
+        event: "signup",
+        properties: {
+            "auth_provider": user.identities[0].authProviderId,
+            "qualified": !!request.cookies["gitpod-marketing-website-visited"]
+        }
+    });
 }
 
-function fullIdentify(user: User, request: Request, analytics: IAnalyticsWriter) {
+function fullIdentify(user: User, request: Request, analytics: IAnalyticsWriter, subscriptionService?: SubscriptionService) {
     //makes a full identify call for authenticated users
     const coords = request.get("x-glb-client-city-lat-long")?.split(", ");
     const ip = request.get("x-forwarded-for")?.split(",")[0];
+    const subscriptions = subscriptionService ? subscriptionService.getNotYetCancelledSubscriptions(user,new Date(Date.now()).toISOString()) : undefined;
     analytics.identify({
         anonymousId: stripCookie(request.cookies.ajs_anonymous_id),
         userId:user.id,
@@ -63,7 +65,8 @@ function fullIdentify(user: User, request: Request, analytics: IAnalyticsWriter)
             "created_at": user.creationDate,
             "unsubscribed_onboarding": !user.additionalData?.emailNotificationSettings?.allowsOnboardingMail,
             "unsubscribed_changelog": !user.additionalData?.emailNotificationSettings?.allowsChangelogMail,
-            "unsubscribed_devx": !user.additionalData?.emailNotificationSettings?.allowsDevXMail
+            "unsubscribed_devx": !user.additionalData?.emailNotificationSettings?.allowsDevXMail,
+            "subscriptions": subscriptions
         }
     });
 }

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -82,8 +82,8 @@ export class LoginCompletionHandler {
 
             increaseLoginCounter("succeeded", authHost);
 
-            /** no await */ trackLogin(user, request, authHost, this.analytics)
-                .catch(err => log.error({ userId: user.id }, err));
+            /** no await */ trackLogin(user, request, authHost, this.analytics,this.subscriptionService)
+            .catch(err => log.error({ userId: user.id }, err));
         }
 
         // Check for and automatically subscribe to Professional OpenSource subscription


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
tracks the current subscription(s) of a user at each login
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe