### PR TITLE
werft/deploy: Trigger VM creation before container builds

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -45,7 +45,7 @@ async function run(context: any) {
     const config = jobConfig(werft, context)
 
     await validateChanges(werft, config)
-    await prepare(werft)
+    await prepare(werft, config)
     await buildAndPublish(werft, config)
     await coverage(werft, config)
 

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -1,16 +1,26 @@
 import { exec } from '../../util/shell';
 import { Werft } from "../../util/werft";
+import * as VM from '../../vm/vm'
 import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
+import { JobConfig } from './job-config';
 
 const phaseName = "prepare";
+const prepareSlices = {
+    CONFIGURE_CORE_DEV: "Configuring core-dev access.",
+    BOOT_VM: "Booting VM."
+}
 
-export async function prepare(werft: Werft) {
+export async function prepare(werft: Werft, config: JobConfig) {
     werft.phase(phaseName);
     try {
+        werft.log(prepareSlices.CONFIGURE_CORE_DEV, prepareSlices.CONFIGURE_CORE_DEV)
         compareWerftAndGitpodImage()
         activateCoreDevServiceAccount()
         configureDocker()
         configureCoreDevAccess()
+        werft.done(prepareSlices.CONFIGURE_CORE_DEV)
+
+        decideHarvesterVMCreation(werft, config)
     } catch (err) {
         werft.fail(phaseName, err);
     }
@@ -27,7 +37,7 @@ function compareWerftAndGitpodImage() {
 }
 
 function activateCoreDevServiceAccount() {
-    const rc = exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, { slice: phaseName }).code;
+    const rc = exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, { slice: prepareSlices.CONFIGURE_CORE_DEV }).code;
 
     if (rc != 0) {
         throw new Error("Failed to activate core-dev service account.")
@@ -35,8 +45,8 @@ function activateCoreDevServiceAccount() {
 }
 
 function configureDocker() {
-    const rcDocker = exec("gcloud auth configure-docker --quiet", { slice: phaseName }).code;
-    const rcDockerRegistry = exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet", { slice: phaseName }).code;
+    const rcDocker = exec("gcloud auth configure-docker --quiet", { slice: prepareSlices.CONFIGURE_CORE_DEV }).code;
+    const rcDockerRegistry = exec("gcloud auth configure-docker europe-docker.pkg.dev --quiet", { slice: prepareSlices.CONFIGURE_CORE_DEV }).code;
 
     if (rcDocker != 0 || rcDockerRegistry != 0) {
         throw new Error("Failed to configure docker with gcloud.")
@@ -44,9 +54,34 @@ function configureDocker() {
 }
 
 function configureCoreDevAccess() {
-    const rc = exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev', { slice: phaseName }).code;
+    const rc = exec('gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev', { slice: prepareSlices.CONFIGURE_CORE_DEV }).code;
 
     if (rc != 0) {
         throw new Error("Failed to get core-dev kubeconfig credentials.")
     }
+}
+
+function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
+    if (config.withVM && !VM.vmExists({ name: config.previewEnvironment.destname })) {
+        prepareVM(werft, config)
+    } else {
+        werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", false)
+    }
+    werft.done(prepareSlices.BOOT_VM)
+}
+
+function prepareVM(werft: Werft, config: JobConfig) {
+    if (config.cleanSlateDeployment) {
+        werft.log(prepareSlices.BOOT_VM, "Cleaning previously created VM")
+        VM.deleteVM({ name: config.previewEnvironment.destname })
+    }
+    createVM(werft, config, prepareSlices.BOOT_VM)
+}
+
+// createVM only triggers the VM creation.
+// Readiness is not guaranted.
+function createVM(werft: Werft, config: JobConfig, slice: string) {
+    werft.log(slice, 'Booting  VM')
+    VM.startVM({ name: config.previewEnvironment.destname })
+    werft.currentPhaseSpan.setAttribute("werft.harvester.created_vm", true)
 }

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -123,7 +123,7 @@ export function vmExists(options: { name: string }) {
  * Wait until the VM Instance reaches the Running status.
  * If the VM Instance doesn't reach Running before the timeoutMS it will throw an Error.
  */
-export function waitForVM(options: { name: string, timeoutSeconds: number, slice: string }) {
+export function waitForVMReadiness(options: { name: string, timeoutSeconds: number, slice: string }) {
     const werft = getGlobalWerftInstance()
     const namespace = `preview-${options.name}`
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Triggers VM creation before we build our containers so it can boot in the background as we run `leeway build`.

This way we can make previews available faster 🔥 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8652

In the example below we made the whole pipeline 84 seconds faster
![image](https://user-images.githubusercontent.com/24193764/157230592-2709fb00-309d-4d2a-b4d8-243e92b769e7.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
