### PR TITLE
Enable changing default editor in integration tests

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -2056,6 +2056,15 @@ type UpdateUserStorageResourceOptions struct {
 type AdditionalUserData struct {
 	EmailNotificationSettings *EmailNotificationSettings `json:"emailNotificationSettings,omitempty"`
 	Platforms                 []*UserPlatform            `json:"platforms,omitempty"`
+	IdeSettings               *IDESettings               `json:"ideSettings,omitempty"`
+}
+
+// IDESettings is the IDESettings message type
+type IDESettings struct {
+	DefaultIde        string `json:"defaultIde,omitempty"`
+	UseDesktopIde     bool   `json:"useDesktopIde,omitempty"`
+	DefaultDesktopIde string `json:"defaultDesktopIde,omitempty"`
+	UseLatestVersion  bool   `json:"useLatestVersion,omitempty"`
 }
 
 // EmailNotificationSettings is the EmailNotificationSettings message type

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
 )
@@ -58,6 +59,23 @@ func TestPythonExtWorkspace(t *testing.T) {
 			userId, err := api.CreateUser(username, userToken)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			serverOpts := []integration.GitpodServerOpt{integration.WithGitpodUser(username)}
+			server, err := api.GitpodServer(serverOpts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = server.UpdateLoggedInUser(ctx, &protocol.User{
+				AdditionalData: &protocol.AdditionalUserData{
+					IdeSettings: &protocol.IDESettings{
+						DefaultIde: "code-latest",
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("cannot set ide to vscode insiders: %q", err)
 			}
 
 			nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(ctx, "github.com/jeanp413/python-test-workspace", username, api)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Enable changing default editor in integration tests

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
related #3065

## How to test
<!-- Provide steps to test this PR -->
1. Open preview environment and login
2. In workspace `cd ./test/tests/ide/`
3. Run `export USER_TOKEN=foo`
4. Run test manually `go test -v github.com/gitpod-io/gitpod/test/tests/ide/vscode -kubeconfig=/home/gitpod/.kube/config -namespace=staging-jp-set-editor-test -username=<username>`
5. Open prev env dashboard and see you default ide is vscode insiders

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
