### PR TITLE
.werft/vm/manifest: Faster boots by requiring less readiness probes

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -48,7 +48,7 @@ spec:
         periodSeconds: 20
         timeoutSeconds: 10
         failureThreshold: 10
-        successThreshold: 10
+        successThreshold: 1
       domain:
         hostname: ${vmName}
         machine:

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -44,10 +44,10 @@ spec:
       readinessProbe:
         tcpSocket:
           port: 2200
-        initialDelaySeconds: 120
-        periodSeconds: 20
-        timeoutSeconds: 10
-        failureThreshold: 10
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 60
         successThreshold: 1
       domain:
         hostname: ${vmName}


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->
After reading [k8s docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes):
```
successThreshold: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.
```

It looks like we're shooting ourselves in the foot by requiring way too many successful probes before setting VMs to ready state. Since we probe every 20 seconds, this change should reduce readiness by 200~ seconds 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/8662

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
