### PR TITLE
[prebuilds] stopping prebuilds are not failed

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -90,13 +90,13 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
                         prebuild.error = status.conditions!.headlessTaskFailed;
                     prebuild.snapshot = status.conditions!.snapshot;
                     headlessUpdateType = HeadlessWorkspaceEventType.FinishedButFailed;
-                } else if (!status.conditions!.snapshot) {
-                    prebuild.state = "failed";
-                    headlessUpdateType = HeadlessWorkspaceEventType.Failed;
-                } else {
+                } else if (!!status.conditions!.snapshot) {
                     prebuild.state = "available";
                     prebuild.snapshot = status.conditions!.snapshot;
                     headlessUpdateType = HeadlessWorkspaceEventType.FinishedSuccessfully;
+                } else {
+                    // stopping event with no clear outcome (i.e. no snapshot yet)
+                    return;
                 }
 
                 if (writeToDB) {


### PR DESCRIPTION
## Description
Fixes a bug where stopping workspaces would be interpreted as failed because they don't yet have a snapshot attached.
This change makes it so we are ignoring such stopping events.

## Related Issue(s)
Fixes #8668

## How to test
Start a prebuild and see how it transition into "ready" without showing "system error" before.

## Release Notes
```release-note
NONE
```
