### PR TITLE
.werft/build/prepare: Clarify why we compare workapce and job image

### DIFF
--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -27,7 +27,8 @@ export async function prepare(werft: Werft, config: JobConfig) {
     werft.done(phaseName);
 }
 
-// TODO: The reasoning behind this step should be clarified
+// We want to assure that our Workspace behaves the exactly same way as
+// it behaves when running a werft job. Therefore, we want them to always be equal.
 function compareWerftAndGitpodImage() {
     const werftImg = exec("cat .werft/build.yaml | grep dev-environment", { silent: true }).trim().split(": ")[1];
     const devImg = exec("yq r .gitpod.yml image", { silent: true }).trim();


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
