### PR TITLE
Allow for branch name lengths of 45

### DIFF
--- a/.werft/delete-preview-environments/delete-preview-environments-cron.ts
+++ b/.werft/delete-preview-environments/delete-preview-environments-cron.ts
@@ -3,6 +3,7 @@ import * as Tracing from '../observability/tracing';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { wipePreviewEnvironmentAndNamespace, helmInstallName, listAllPreviewNamespaces } from '../util/kubectl';
 import { exec } from '../util/shell';
+import { previewNameFromBranchName } from '../util/preview';
 
 // Will be set once tracing has been initialized
 let werft: Werft
@@ -12,12 +13,14 @@ Tracing.initialize()
         werft = new Werft("delete-preview-environment-cron")
     })
     .then(() => deletePreviewEnvironments())
-    .then(() => werft.endAllSpans())
     .catch((err) => {
         werft.rootSpan.setStatus({
             code: SpanStatusCode.ERROR,
             message: err
         })
+    })
+    .finally(() => {
+        werft.phase("Flushing telemetry", "Flushing telemetry before stopping job")
         werft.endAllSpans()
     })
 
@@ -35,25 +38,28 @@ async function deletePreviewEnvironments() {
 
     werft.phase("Fetching branches");
     const branches = getAllBranches();
-    const expectedPreviewEnvironmentNamespaces = new Set(branches.map(branch => parseBranch(branch)));
+    // During the transition from the old preview names to the new ones we have to check for the existence of both the old or new
+    // preview name patterns before it is safe to delete a namespace.
+    const expectedPreviewEnvironmentNamespaces = new Set(branches.flatMap(branch => [parseBranch(branch), expectedNamespaceFromBranch(branch)]));
     werft.done("Fetching branches");
 
     werft.phase("Fetching previews");
-    let previews
+    let previews: string[]
     try {
         previews = listAllPreviewNamespaces({});
+        previews.forEach(previewNs => werft.log("Fetching previews", previewNs))
     } catch (err) {
         werft.fail("Fetching previews", err)
     }
     werft.done("Fetching previews");
 
-
-    werft.phase("Mapping previews => branches")
-    const previewsToDelete = previews.filter(ns => !expectedPreviewEnvironmentNamespaces.has(ns))
-
     werft.phase("deleting previews")
     try {
-        previewsToDelete.forEach(preview => wipePreviewEnvironmentAndNamespace(helmInstallName, preview, { slice: `Deleting preview ${preview}` }));
+        const previewsToDelete = previews.filter(ns => !expectedPreviewEnvironmentNamespaces.has(ns))
+        // Trigger namespace deletion in parallel
+        const promises = previewsToDelete.map(preview => wipePreviewEnvironmentAndNamespace(helmInstallName, preview, { slice: `Deleting preview ${preview}` }));
+        // But wait for all of them to finish before (or one of them to fail) before we continue
+        await Promise.all(promises)
     } catch (err) {
         werft.fail("deleting previews", err)
     }
@@ -62,6 +68,11 @@ async function deletePreviewEnvironments() {
 
 function getAllBranches(): string[] {
     return exec(`git branch -r | grep -v '\\->' | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" | while read remote; do echo "\${remote#origin/}"; done`).stdout.trim().split('\n');
+}
+
+function expectedNamespaceFromBranch(branch: string): string {
+    const previewName = previewNameFromBranchName(branch)
+    return `staging-${previewName}`
 }
 
 function parseBranch(branch: string): string {

--- a/.werft/delete-preview-environments/delete-preview-environments.ts
+++ b/.werft/delete-preview-environments/delete-preview-environments.ts
@@ -26,6 +26,11 @@ Tracing.initialize()
 async function deletePreviewEnvironment() {
     werft.phase("preparing deletion")
     const version = parseVersion();
+
+    // TODO: This won't work, we need to compute the namespace using the function in
+    // .werft/util/preview.ts. As this job isn't executed yet I'm leaving it broken for
+    // now until we can test what information Werft makes available to the jobs that are
+    // triggered by branch deletions.
     const namespace = `staging-${version.split(".")[0]}`
     werft.log("preparing deletion", `Proceeding to delete the ${namespace} namespace`)
     werft.done("preparing deletion")

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -1,6 +1,6 @@
-import { config } from "process";
 import { exec } from "../../util/shell";
 import { Werft } from "../../util/werft";
+import { previewNameFromBranchName } from "../../util/preview";
 
 export interface JobConfig {
     analytics: string
@@ -95,10 +95,10 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     }
     const withVM = ("with-vm" in buildConfig || repository.branch.includes("with-vm")) && !mainBuild;
 
-    const previewDestName = version.split(".")[0];
-    const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewDestName}`;
+    const previewName = previewNameFromBranchName(repository.branch)
+    const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewName}`;
     const previewEnvironment = {
-        destname: previewDestName,
+        destname: previewName,
         namespace: previewEnvironmentNamespace
     }
 

--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -13,11 +13,15 @@ export async function validateChanges(werft: Werft, config: JobConfig) {
     werft.done('validate-changes');
 }
 
-// Branch names cannot be longer than 20 characters.
-// We plan to remove this limitation once we move to previews on Harvester VMs.
+// Branch names cannot be longer than 45 characters.
+//
+// The branch name is used as part of the Werft job name. The job name is used for the name of the pod
+// and k8s has a limit of 63 characters. We use 13 characters for the "gitpod-build-" prefix and 5
+// more for the ".<BUILD NUMBER>" ending. That leaves us 45 characters for the branch name.
+// See Werft source https://github.com/csweichel/werft/blob/057cfae0fd7bb1a7b05f89d1b162348378d74e71/pkg/werft/service.go#L376
 async function branchNameCheck(werft: Werft, config: JobConfig) {
     if (!config.noPreview) {
-        const maxBranchNameLength = 20;
+        const maxBranchNameLength = 45;
         werft.log("check-branchname", `Checking if branch name is shorter than ${maxBranchNameLength} characters.`)
 
         if (config.previewEnvironment.destname.length > maxBranchNameLength) {

--- a/.werft/util/preview.ts
+++ b/.werft/util/preview.ts
@@ -10,6 +10,10 @@ export function previewNameFromBranchName(branchName: string): string {
     // Due to various limitations we have to ensure that we only use 20 characters
     // for the preview environment name.
     //
+    // If the branch name is 20 characters or less we just use it.
+    //
+    // Otherwise:
+    //
     // We use the first 10 chars of the sanitized branch name
     // and then the 10 first chars of the hash of the sanitized branch name
     //
@@ -18,6 +22,11 @@ export function previewNameFromBranchName(branchName: string): string {
     //
     // see https://github.com/gitpod-io/ops/issues/1252 for details.
     const sanitizedBranchName = branchName.replace(/^refs\/heads\//, "").toLocaleLowerCase().replace(/[^-a-z0-9]/g, "-")
+
+    if (sanitizedBranchName.length <= 20) {
+        return sanitizedBranchName
+    }
+
     const hashed = createHash('sha256').update(sanitizedBranchName).digest('hex')
     return `${sanitizedBranchName.substring(0, 10)}${hashed.substring(0,10)}`
 }

--- a/.werft/util/preview.ts
+++ b/.werft/util/preview.ts
@@ -1,0 +1,23 @@
+import { createHash } from "crypto";
+
+/**
+ * Based on the current branch name this will compute the name of the associated
+ * preview environment.
+ *
+ * NOTE: This needs to produce the same result as the function in dev/preview/util/preview-name-from-branch.sh
+ */
+export function previewNameFromBranchName(branchName: string): string {
+    // Due to various limitations we have to ensure that we only use 20 characters
+    // for the preview environment name.
+    //
+    // We use the first 10 chars of the sanitized branch name
+    // and then the 10 first chars of the hash of the sanitized branch name
+    //
+    // That means collisions can happen. If they do, two jobs would try to deploy to the same
+    // environment.
+    //
+    // see https://github.com/gitpod-io/ops/issues/1252 for details.
+    const sanitizedBranchName = branchName.replace(/^refs\/heads\//, "").toLocaleLowerCase().replace(/[^-a-z0-9]/g, "-")
+    const hashed = createHash('sha256').update(sanitizedBranchName).digest('hex')
+    return `${sanitizedBranchName.substring(0, 10)}${hashed.substring(0,10)}`
+}

--- a/dev/preview/install-k3s-kubeconfig.sh
+++ b/dev/preview/install-k3s-kubeconfig.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+source ./dev/preview/util/preview-name-from-branch.sh
+
+VM_NAME="$(preview-name-from-branch)"
 
 PRIVATE_KEY=$HOME/.ssh/vm_id_rsa
 PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub

--- a/dev/preview/portforward-monitoring-satellite-core-dev.sh
+++ b/dev/preview/portforward-monitoring-satellite-core-dev.sh
@@ -3,8 +3,10 @@
 # Exposes Prometheus and Grafana's UI
 #
 
-VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
-NAMESPACE="staging-${VM_NAME}"
+source ./dev/preview/util/preview-name-from-branch.sh
+
+PREVIEW_NAME="$(preview-name-from-branch)"
+NAMESPACE="staging-${PREVIEW_NAME}"
 
 function log {
     echo "[$(date)] $*"

--- a/dev/preview/portforward-monitoring-satellite-harvester.sh
+++ b/dev/preview/portforward-monitoring-satellite-harvester.sh
@@ -3,7 +3,9 @@
 # Exposes Prometheus and Grafana's UI
 #
 
-VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+source ./dev/preview/util/preview-name-from-branch.sh
+
+VM_NAME="$(preview-name-from-branch)"
 NAMESPACE="preview-${VM_NAME}"
 
 function log {

--- a/dev/preview/ssh-proxy-command.sh
+++ b/dev/preview/ssh-proxy-command.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+source ./dev/preview/util/preview-name-from-branch.sh
+
+VM_NAME="$(preview-name-from-branch)"
 NAMESPACE="preview-${VM_NAME}"
 
 while getopts n:p: flag

--- a/dev/preview/ssh-vm.sh
+++ b/dev/preview/ssh-vm.sh
@@ -5,7 +5,9 @@
 
 set -euo pipefail
 
-VM_NAME="$(git symbolic-ref HEAD 2>&1 | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')"
+source ./dev/preview/util/preview-name-from-branch.sh
+
+VM_NAME="$(preview-name-from-branch)"
 NAMESPACE="preview-${VM_NAME}"
 
 PRIVATE_KEY=$HOME/.ssh/vm_id_rsa

--- a/dev/preview/util/preview-name-from-branch.sh
+++ b/dev/preview/util/preview-name-from-branch.sh
@@ -10,6 +10,12 @@
 function preview-name-from-branch {
     branch_name=$(git symbolic-ref HEAD 2>&1) || error "Cannot get current branch"
     sanitizedd_branch_name=$(echo "$branch_name" | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')
-    hashed=$(echo -n "${sanitizedd_branch_name}" | sha256sum)
-    echo "${sanitizedd_branch_name:0:10}${hashed:0:10}"
+    length=$(echo -n "$sanitizedd_branch_name" | wc -c)
+
+    if [ "$length" -gt 20 ]; then
+        hashed=$(echo -n "${sanitizedd_branch_name}" | sha256sum)
+        echo "${sanitizedd_branch_name:0:10}${hashed:0:10}"
+    else
+        echo "${sanitizedd_branch_name}"
+    fi
 }

--- a/dev/preview/util/preview-name-from-branch.sh
+++ b/dev/preview/util/preview-name-from-branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#
+# Based on the name of the current branch this will compute the name of the associated
+# preview environment.
+#
+# NOTE: This needs to produce the same result as the function in .werft/util/preview.ts
+#        See the file for implementation notes.
+#
+function preview-name-from-branch {
+    branch_name=$(git symbolic-ref HEAD 2>&1) || error "Cannot get current branch"
+    sanitizedd_branch_name=$(echo "$branch_name" | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')
+    hashed=$(echo -n "${sanitizedd_branch_name}" | sha256sum)
+    echo "${sanitizedd_branch_name:0:10}${hashed:0:10}"
+}

--- a/scripts/branch-namespace.sh
+++ b/scripts/branch-namespace.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-branch=$(git symbolic-ref HEAD 2>&1) || error "cannot set kubectl namespace: no branch"
+source ./dev/preview/util/preview-name-from-branch.sh
+
 currentContext=$(kubectl config current-context 2>&1) || error "cannot set kubectl namespace: no current context"
-namespace=staging-$(echo "$branch" | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')
+namespace="staging-$(preview-name-from-branch)"
 
 echo "Setting kubectl namespace: $namespace"
 kubectl config set-context "$currentContext" --namespace "$namespace"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This relaxes the branch name restriction from 20 characters to 45. This is achieved by constructing the preview name based on the first 10 characters of the branch name and then the first 10 characters of the hashed value of the branch name if the branch name is longer than 20 characters. Once we move to Harvester we can likely increase the preview name to be longer than 20 characters but still not arbitrarily long - see [this issue](https://github.com/gitpod-io/ops/issues/1252) and the comments therein for more details on where these restrictions are coming from. The purpose of making it longer than 20 characters would be to have more readable preview names - e.g. https://mads-a-lond78d730379.staging.gitpod-dev.com isn't the most readable thing in the world.

The 45 limit of the branch name is now based on an implementation detail in Werft. The Werft Job name is used as the name of the pod. Kubernetes has a pod name limit of 63 characters. For the build job we use 13 chars for "gitpod-build-" prefix and 5 for the ".<job count>" ending (as there's a max supported of 9999 jobs for the same branch)  - see [Werft source](https://github.com/csweichel/werft/blob/main/pkg/werft/service.go#L376) - this leaves 45 characters for the branch name. We could decide to just not care, as there would only be a collision if the first 45 characters are the same. For this PR I decided to care.

Some implementation details

- This PR decouples the Werft job name from the preview name. The preview name is now computed on the full branch name and not the sanitized and shortened version that Werft provides (otherwise the hashed value would only be based on the first 45 characters of the branch name which would reduce the effect it has on avoiding collisions). It also gives us the benefit that we control the preview name regardless of underlying changes to Werft.
- Ensures that the preview name is generated a single place pr. language (ts, bash) - previously we computed the preview name from the branch name in quite a lot of places.
- The delete-preview-environment-cron Werft has been updated to be able to deal with both the new and old preview name patterns (and I have added some minor improvements to it).

Some consequences of merging this PR

- If you have a branch that was started before this PR was merged, and you rebase on main, you'll effectively get a "clean-slate-deployment" as the name of the preview environment will be different.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1252

## How to test
<!-- Provide steps to test this PR -->

- I have verified that preview environments with both with and without VM
- I have verified that `scripts/branch-namespace.sh` works correctly
- I have verified that the VM-related scripts still work (install k3s kubeconfig, ssh, grafana, etc.)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A