### PR TITLE
Make waiting for pods more robust

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -126,12 +126,12 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
         werft.done(vmSlices.KUBECONFIG)
 
         werft.log(vmSlices.WAIT_K3S, 'Wait for k3s')
-        await waitForApiserver({ slice:vmSlices.WAIT_K3S })
-        await waitUntilAllPodsAreReady("kube-system", { slice:vmSlices.WAIT_K3S } )
+        await waitForApiserver(vmSlices.WAIT_K3S)
+        await waitUntilAllPodsAreReady("kube-system", vmSlices.WAIT_K3S)
         werft.done(vmSlices.WAIT_K3S)
 
         werft.log(vmSlices.WAIT_CERTMANAGER, 'Wait for Cert-Manager')
-        await waitUntilAllPodsAreReady("cert-manager", { slice:vmSlices.WAIT_CERTMANAGER } )
+        await waitUntilAllPodsAreReady("cert-manager", vmSlices.WAIT_CERTMANAGER)
         werft.done(vmSlices.WAIT_CERTMANAGER)
 
         exec(`kubectl apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`, { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true })
@@ -448,7 +448,7 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
     }
 
     werft.log(installerSlices.DEPLOYMENT_WAITING, "Waiting until all pods are ready.");
-    await waitUntilAllPodsAreReady(deploymentConfig.namespace, { slice: installerSlices.DEPLOYMENT_WAITING })
+    await waitUntilAllPodsAreReady(deploymentConfig.namespace, installerSlices.DEPLOYMENT_WAITING)
     werft.done(installerSlices.DEPLOYMENT_WAITING);
 
     await addDNSRecord(werft, deploymentConfig.namespace, deploymentConfig.domain, !withVM)

--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -283,7 +283,7 @@ export async function waitUntilAllPodsAreReady(namespace: string, slice: string)
 
         await sleep(2 * 1000)
     }
-    exec(`kubectl get pods -n ${namespace}`, { ...shellOpts, async: false })
+    exec(`kubectl get pods -n ${namespace}`, { slice, async: false })
     throw new Error(`Not all pods in namespace ${namespace} transitioned to 'Running' or 'Succeeded/Completed' during the expected time.`)
 }
 


### PR DESCRIPTION
## Description
The new `kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=300s` fails with `error: no matching resources found` :astonished:
The api-server is already ready, but that does not seem to imply that there are pods in kube-system. 

This PR fixes the error by introducing more robust logic for waiting.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
