### PR TITLE
align dashboard plans page wording on website 

### DIFF
--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -333,7 +333,7 @@ export default function () {
     const openSourceFeatures = <>
         <p className="truncate" title="Public Repositories">✓ Public &amp; Private Repositories</p>
         <p className="truncate" title="4 Parallel Workspaces">✓ 4 Parallel Workspaces</p>
-        <p className="truncate" title="30 min Timeout">✓ 30 min Timeout</p>
+        <p className="truncate" title="30 min Inactivity  Timeout">✓ 30 min Inactivity Timeout</p>
     </>;
     if (currentPlan.chargebeeId === freePlan.chargebeeId) {
         planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={freePlan} isCurrent={!!accountStatement}>{openSourceFeatures}</PlanCard>);
@@ -405,7 +405,7 @@ export default function () {
     const unleashedFeatures = <>
         <p className="truncate" title={'Everything in ' + professionalPlan.name}>← Everything in {professionalPlan.name}</p>
         <p className="truncate" title="16 Parallel Workspaces">✓ 16 Parallel Workspaces</p>
-        <p className="truncate" title="1h Timeout">✓ 1h Timeout</p>
+        <p className="truncate" title="1h Inactivity Timeout">✓ 1h Inactivity Timeout</p>
         <p className="truncate" title="3h Timeout Boost">✓ 3h Timeout Boost</p>
     </>;
     const isUnleashedTsAssigned = !!assignedStudentUnleashedTs || !!assignedUnleashedTs;

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -333,7 +333,7 @@ export default function () {
     const openSourceFeatures = <>
         <p className="truncate" title="Public Repositories">✓ Public &amp; Private Repositories</p>
         <p className="truncate" title="4 Parallel Workspaces">✓ 4 Parallel Workspaces</p>
-        <p className="truncate" title="30 min Inactivity  Timeout">✓ 30 min Inactivity Timeout</p>
+        <p className="truncate" title="30 min Inactivity Timeout">✓ 30 min Inactivity Timeout</p>
     </>;
     if (currentPlan.chargebeeId === freePlan.chargebeeId) {
         planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={freePlan} isCurrent={!!accountStatement}>{openSourceFeatures}</PlanCard>);


### PR DESCRIPTION
## Description
 After watching a YouTube review of gitpod, I noticed the wording around Timeouts on the dashboard/settings/plans page is inconsistent with the wording on our website/pricing page. It can lead to the reader assuming that on the free plan you workspace automatically times out after 30 mins, not that it times out after 30 mins of inactivity. This was also assumed by the reviewer. Hence I added "inactivity" as a qualifier before "timeout" to clarify this. This is also the wording used on the pricing page.

## How to test
Run gitpod, look at the dashboards/settings/plans page to see that the changes came through

## Release Notes
```release-note
Clarified wording of "timeout" feature on the settings/plans page
```
