### PR TITLE
[kots]: add standard labels to KOTS manifests

### DIFF
--- a/install/kots/manifests/gitpod-certificate-secret.yaml
+++ b/install/kots/manifests/gitpod-certificate-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: https-certificates
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl ConfigOptionEquals "cert_manager_enabled" "0" }}'
 type: kubernetes.io/tls

--- a/install/kots/manifests/gitpod-certificate.yaml
+++ b/install/kots/manifests/gitpod-certificate.yaml
@@ -2,6 +2,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: https-certificates
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl or (ConfigOptionEquals "tls_self_signed_enabled" "1") (ConfigOptionEquals "cert_manager_enabled" "1") }}'
 spec:

--- a/install/kots/manifests/gitpod-cloudsql-secret.yaml
+++ b/install/kots/manifests/gitpod-cloudsql-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudsql
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl and (ConfigOptionEquals "db_incluster" "0") (ConfigOptionEquals "db_cloudsql_enabled" "1") }}'
 data:

--- a/install/kots/manifests/gitpod-config-patch.yaml
+++ b/install/kots/manifests/gitpod-config-patch.yaml
@@ -4,5 +4,6 @@ metadata:
   name: gitpod-config-patch
   labels:
     app: gitpod
+    component: gitpod-installer
 data:
   gitpod-config-patch.yaml: '{{repl if and (ConfigOptionEquals "advanced_mode_enabled" "1") (ConfigOptionNotEquals "config_patch" "") }}{{repl ConfigOption "config_patch" }}{{repl else }}{{repl printf "{}" | Base64Encode }}{{repl end }}'

--- a/install/kots/manifests/gitpod-database-secret.yaml
+++ b/install/kots/manifests/gitpod-database-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: database
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl and (ConfigOptionEquals "db_incluster" "0") (ConfigOptionEquals "db_cloudsql_enabled" "0") }}'
 data:

--- a/install/kots/manifests/gitpod-dns-gcp-secret.yaml
+++ b/install/kots/manifests/gitpod-dns-gcp-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cert-manager-gcp-dns-solver
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl and (ConfigOptionEquals "cert_manager_enabled" "1") (ConfigOptionEquals "cert_manager_provider" "gcp") }}'
 data:

--- a/install/kots/manifests/gitpod-installation.yaml
+++ b/install/kots/manifests/gitpod-installation.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gitpod-installation
+  labels:
+    app: gitpod
+    component: gitpod-installer
 data:
   channelName: '{{repl ChannelName }}'
   cursor: '{{repl Cursor }}'

--- a/install/kots/manifests/gitpod-issuer-azure.yaml
+++ b/install/kots/manifests/gitpod-issuer-azure.yaml
@@ -4,6 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: gitpod-issuer
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl and (ConfigOptionEquals "cert_manager_enabled" "1") (ConfigOptionEquals "cert_manager_provider" "azure") }}'
 spec:

--- a/install/kots/manifests/gitpod-issuer-gcp.yaml
+++ b/install/kots/manifests/gitpod-issuer-gcp.yaml
@@ -2,6 +2,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: gitpod-issuer
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl and (ConfigOptionEquals "cert_manager_enabled" "1") (ConfigOptionEquals "cert_manager_provider" "gcp") }}'
 spec:

--- a/install/kots/manifests/gitpod-license.yaml
+++ b/install/kots/manifests/gitpod-license.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gitpod-license
+  labels:
+    app: gitpod
+    component: gitpod-installer
 data:
   license: '{{repl LicenseFieldValue "signature" | Base64Encode }}'
   type: '{{repl printf "replicated" | Base64Encode }}'

--- a/install/kots/manifests/gitpod-registry-s3-backend.yaml
+++ b/install/kots/manifests/gitpod-registry-s3-backend.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: container-registry-s3-backend
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl and (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_s3storage" "1") }}'
 data:

--- a/install/kots/manifests/gitpod-storage-azure-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-azure-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: storage-azure
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl ConfigOptionEquals "store_provider" "azure" }}'
 data:

--- a/install/kots/manifests/gitpod-storage-gcp-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-gcp-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: storage-gcp
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl ConfigOptionEquals "store_provider" "gcp" }}'
 data:

--- a/install/kots/manifests/gitpod-storage-s3-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-s3-secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: storage-azure
+  labels:
+    app: gitpod
+    component: gitpod-installer
   annotations:
     kots.io/when: '{{repl ConfigOptionEquals "store_provider" "s3" }}'
 data:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add labels to the `gitpod-` KOTS resources. Notice these were missing during this morning's demo. This will allow for KOTS support bundles to pick these resources up.

## How to test
<!-- Provide steps to test this PR -->
Deploy to KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add standard labels to KOTS manifests
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
