### PR TITLE
Adds new foreign route for vscode webview/webworker resources

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 9592b83215333e2fd67c629847cdb0ade6dbfe59
+  codeCommit: 259579385f0059a940f49747bc221dc67c0da849
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz"

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -286,8 +286,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 		}
 	}
 
-	# remove (webview-|browser-|extensions-) after Theia removed and new VS Code is used by all workspaces
-	@workspace_port header_regexp host Host ^(webview-|browser-|extensions-)?(?P<workspacePort>[0-9]{2,5})-(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	@workspace_port header_regexp host Host ^(?P<workspacePort>[0-9]{2,5})-(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @workspace_port {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 			import workspace_transport
@@ -299,8 +298,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 		}
 	}
 
-	# remove (webview-|browser-|extensions-) after Theia removed and new VS Code is used by all workspaces
-	@workspace 	header_regexp host Host ^(webview-|browser-|extensions-)?(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	@workspace 	header_regexp host Host ^(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @workspace {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 			import workspace_transport
@@ -311,9 +309,27 @@ https://*.*.{$GITPOD_DOMAIN} {
 		}
 	}
 
-	# foreign content origin should be decoupled from the workspace (port) origin but the workspace (port) prefix should be the path root for routing
-	@foreign_content header_regexp host Host ^(.*)(foreign).ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	# REMOVE this once all workspaces have updated to new vscode version
+	# old foreign content route used by vscode to serve webview and webworker resources
+	# origin should be decoupled from the workspace (port) origin but the workspace (port) prefix should be the path root for routing
+	@foreign_content header_regexp host Host ^.+-foreign.ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @foreign_content {
+		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
+			import workspace_transport
+			import upstream_headers
+
+			header_up X-WSProxy-Host       {http.request.host}
+		}
+	}
+
+	# foreign content route used by vscode to serve webview and webworker resources of the form
+	# https://{{hash_base_32}}.<cluster>.<gitpod_domain> or https://v--{{hash_base_32}}.<cluster>.<gitpod_domain>
+	# e.g:
+	# https://0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-us34xl.gitpod.io (for webviews)
+	# https://v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-us34xl.gitpod.io (for webworker)
+	# origin should be decoupled from the workspace (port) origin but the workspace (port) prefix should be the path root for routing
+	@foreign_content2 header_regexp host Host ^(?:v--)?[0-9a-v]+.ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	handle @foreign_content2 {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 			import workspace_transport
 			import upstream_headers

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -167,17 +167,6 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			},
 		},
 		{
-			Name:       "webview workspace match",
-			HostHeader: "webview-amaranth-smelt-9ba20cc1" + wsHostSuffix,
-			Expected: matchResult{
-				MatchesWorkspace: true,
-				WorkspaceVars: map[string]string{
-					foreignOriginIdentifier: "webview-",
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-				},
-			},
-		},
-		{
 			Name:       "unique webview workspace match",
 			HostHeader: "ad859a83-b5a8-43ef-8e82-cfbf36cafacb-webview-foreign" + wsHostSuffix,
 			Path:       "/amaranth-smelt-9ba20cc1/index.html",
@@ -187,53 +176,6 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
 					foreignOriginIdentifier: "ad859a83-b5a8-43ef-8e82-cfbf36cafacb-webview-",
 					foreignPathIdentifier:   "/index.html",
-				},
-			},
-		},
-		{
-			Name:       "extension host workspace match",
-			HostHeader: "extensions-foreign" + wsHostSuffix,
-			Path:       "/amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesWorkspace: true,
-				WorkspaceVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					foreignOriginIdentifier: "extensions-",
-					foreignPathIdentifier:   "/index.html",
-				},
-			},
-		},
-		{
-			Name:       "mini browser workspace match",
-			HostHeader: "browser-amaranth-smelt-9ba20cc1" + wsHostSuffix,
-			Expected: matchResult{
-				MatchesWorkspace: true,
-				WorkspaceVars: map[string]string{
-					foreignOriginIdentifier: "browser-",
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-				},
-			},
-		},
-		{
-			Name:       "port match",
-			HostHeader: "8080-amaranth-smelt-9ba20cc1" + wsHostSuffix,
-			Expected: matchResult{
-				MatchesPort: true,
-				PortVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					workspacePortIdentifier: "8080",
-				},
-			},
-		},
-		{
-			Name:       "webview port match",
-			HostHeader: "webview-8080-amaranth-smelt-9ba20cc1" + wsHostSuffix,
-			Expected: matchResult{
-				MatchesPort: true,
-				PortVars: map[string]string{
-					foreignOriginIdentifier: "webview-",
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					workspacePortIdentifier: "8080",
 				},
 			},
 		},
@@ -252,26 +194,65 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			},
 		},
 		{
-			Name:       "extension host port match",
-			HostHeader: "extensions-foreign" + wsHostSuffix,
+			Name:       "unique webview workspace match 2",
+			HostHeader: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
+			Path:       "/amaranth-smelt-9ba20cc1/index.html",
+			Expected: matchResult{
+				MatchesWorkspace: true,
+				WorkspaceVars: map[string]string{
+					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
+					foreignOriginIdentifier: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
+					foreignPathIdentifier:   "/index.html",
+				},
+			},
+		},
+		{
+			Name:       "unique webview port match 2",
+			HostHeader: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
 			Path:       "/8080-amaranth-smelt-9ba20cc1/index.html",
 			Expected: matchResult{
 				MatchesPort: true,
 				PortVars: map[string]string{
 					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
 					workspacePortIdentifier: "8080",
-					foreignOriginIdentifier: "extensions-",
+					foreignOriginIdentifier: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
 					foreignPathIdentifier:   "/index.html",
 				},
 			},
 		},
 		{
-			Name:       "mini browser port match",
-			HostHeader: "browser-8080-amaranth-smelt-9ba20cc1" + wsHostSuffix,
+			Name:       "unique webworker workspace match",
+			HostHeader: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
+			Path:       "/amaranth-smelt-9ba20cc1/index.html",
+			Expected: matchResult{
+				MatchesWorkspace: true,
+				WorkspaceVars: map[string]string{
+					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
+					foreignOriginIdentifier: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
+					foreignPathIdentifier:   "/index.html",
+				},
+			},
+		},
+		{
+			Name:       "unique webworker port match",
+			HostHeader: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
+			Path:       "/8080-amaranth-smelt-9ba20cc1/index.html",
 			Expected: matchResult{
 				MatchesPort: true,
 				PortVars: map[string]string{
-					foreignOriginIdentifier: "browser-",
+					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
+					workspacePortIdentifier: "8080",
+					foreignOriginIdentifier: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
+					foreignPathIdentifier:   "/index.html",
+				},
+			},
+		},
+		{
+			Name:       "port match",
+			HostHeader: "8080-amaranth-smelt-9ba20cc1" + wsHostSuffix,
+			Expected: matchResult{
+				MatchesPort: true,
+				PortVars: map[string]string{
 					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
 					workspacePortIdentifier: "8080",
 				},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds new foreign route for vscode webview/weworker resources

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace
2. Select vscode insiders
3. Check that webviews load sucessfully (open simple browser, go to extensions view and click on some extension so the extension editor shows the readme file of the extension)
4. Check web worker extension host is running sucessfully (install vim extension and it works)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
