### PR TITLE
[kots]: switch azure cluster issuer to issuer

### DIFF
--- a/install/kots/manifests/gitpod-certificate.yaml
+++ b/install/kots/manifests/gitpod-certificate.yaml
@@ -8,7 +8,7 @@ spec:
   secretName: https-certificates
   issuerRef:
     name: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}ca-issuer{{repl else }}gitpod-issuer{{repl end }}'
-    kind: '{{repl if or (ConfigOptionEquals "tls_self_signed_enabled" "1") (ConfigOptionNotEquals "cert_manager_provider" "azure") }}Issuer{{repl else }}ClusterIssuer{{repl end }}'
+    kind: Issuer
   dnsNames:
     - '{{repl ConfigOption "domain" }}'
     - '*.{{repl ConfigOption "domain" }}'

--- a/install/kots/manifests/gitpod-issuer-azure.yaml
+++ b/install/kots/manifests/gitpod-issuer-azure.yaml
@@ -1,7 +1,5 @@
-# Azure doesn't seem to like using an Issuer
-# @link https://github.com/cert-manager/cert-manager/issues/4867c
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: gitpod-issuer
   annotations:

--- a/install/kots/manifests/helm-cert-manager.yaml
+++ b/install/kots/manifests/helm-cert-manager.yaml
@@ -9,3 +9,12 @@ spec:
     chartVersion: 1.7.0
   helmVersion: v3
   useHelmInstall: true
+  optionalValues:
+    # Azure must have issuer-ambient-credentials set to true
+    # @link https://github.com/cert-manager/cert-manager/issues/4867
+    - when: "repl{{ and (ConfigOptionEquals `tls_self_signed_enabled` `0`) (ConfigOptionEquals `cert_manager_provider` `azure`) }}"
+      recursiveMerge: true
+      values:
+        cert-manager:
+          extraArgs:
+            - '--issuer-ambient-credentials=true'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Related to a [cert-manager issue](https://github.com/cert-manager/cert-manager/issues/4867), in order for Azure issuers to use the ambient credentials an additional argument is required to be passed in.

This changes the Azure `ClusterIssuer` to an `Issuer`

## How to test
<!-- Provide steps to test this PR -->
Deploy to Azure via KOTS. Search for:

```shell
kubectl get deployments.apps -n gitpod cert-manager -o yaml | grep '\-\-issuer-ambient-credentials=true'
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: switch azure cluster issuer to issuer
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
