### PR TITLE
[ws-manager-bridge] Document ClusterService rpcs and messages

### DIFF
--- a/components/ws-manager-bridge-api/cluster-service.proto
+++ b/components/ws-manager-bridge-api/cluster-service.proto
@@ -8,10 +8,18 @@ package workspacemanagerbridge;
 
 option go_package = "github.com/gitpod-io/gitpod/workspace-manager-bridge/api";
 
+// ClusterService enables WorkspaceClusters to be dynamically managed.
 service ClusterService {
+  // Register registers a new WorkspaceCluster.
   rpc Register(RegisterRequest) returns (RegisterResponse) {}
+
+  // Update modififes properties of an already registered WorkspaceCluster.
   rpc Update(UpdateRequest) returns (UpdateResponse) {}
+
+  // Deregister removes a WorkspaceCluster from available clusters.
   rpc Deregister(DeregisterRequest) returns (DeregisterResponse) {}
+
+  // List returns the currently registered WorkspaceClusters.
   rpc List(ListRequest) returns (ListResponse) {}
 }
 
@@ -104,7 +112,10 @@ message ModifyAdmissionConstraint {
 message UpdateResponse {}
 
 message DeregisterRequest {
+  // name is the name of the WorkspaceCluster to deregister
   string name = 1;
+  // force causes the cluster to be deregistered even if there are
+  // intances still running on the cluster.
   bool force = 2;
 }
 

--- a/components/ws-manager-bridge-api/go/cluster-service.pb.go
+++ b/components/ws-manager-bridge-api/go/cluster-service.pb.go
@@ -793,8 +793,11 @@ type DeregisterRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name  string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Force bool   `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
+	// name is the name of the WorkspaceCluster to deregister
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// force causes the cluster to be deregistered even if there are
+	// intances still running on the cluster.
+	Force bool `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
 }
 
 func (x *DeregisterRequest) Reset() {

--- a/components/ws-manager-bridge-api/go/cluster-service_grpc.pb.go
+++ b/components/ws-manager-bridge-api/go/cluster-service_grpc.pb.go
@@ -22,9 +22,13 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ClusterServiceClient interface {
+	// Register registers a new WorkspaceCluster.
 	Register(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (*RegisterResponse, error)
+	// Update modififes properties of an already registered WorkspaceCluster.
 	Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateResponse, error)
+	// Deregister removes a WorkspaceCluster from available clusters.
 	Deregister(ctx context.Context, in *DeregisterRequest, opts ...grpc.CallOption) (*DeregisterResponse, error)
+	// List returns the currently registered WorkspaceClusters.
 	List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListResponse, error)
 }
 
@@ -76,9 +80,13 @@ func (c *clusterServiceClient) List(ctx context.Context, in *ListRequest, opts .
 // All implementations must embed UnimplementedClusterServiceServer
 // for forward compatibility
 type ClusterServiceServer interface {
+	// Register registers a new WorkspaceCluster.
 	Register(context.Context, *RegisterRequest) (*RegisterResponse, error)
+	// Update modififes properties of an already registered WorkspaceCluster.
 	Update(context.Context, *UpdateRequest) (*UpdateResponse, error)
+	// Deregister removes a WorkspaceCluster from available clusters.
 	Deregister(context.Context, *DeregisterRequest) (*DeregisterResponse, error)
+	// List returns the currently registered WorkspaceClusters.
 	List(context.Context, *ListRequest) (*ListResponse, error)
 	mustEmbedUnimplementedClusterServiceServer()
 }

--- a/components/ws-manager-bridge-api/typescript/src/cluster-service_grpc_pb.js
+++ b/components/ws-manager-bridge-api/typescript/src/cluster-service_grpc_pb.js
@@ -98,8 +98,10 @@ function deserialize_workspacemanagerbridge_UpdateResponse(buffer_arg) {
 }
 
 
+// ClusterService enables WorkspaceClusters to be dynamically managed.
 var ClusterServiceService = exports.ClusterServiceService = {
-  register: {
+  // Register registers a new WorkspaceCluster.
+register: {
     path: '/workspacemanagerbridge.ClusterService/Register',
     requestStream: false,
     responseStream: false,
@@ -110,7 +112,8 @@ var ClusterServiceService = exports.ClusterServiceService = {
     responseSerialize: serialize_workspacemanagerbridge_RegisterResponse,
     responseDeserialize: deserialize_workspacemanagerbridge_RegisterResponse,
   },
-  update: {
+  // Update modififes properties of an already registered WorkspaceCluster.
+update: {
     path: '/workspacemanagerbridge.ClusterService/Update',
     requestStream: false,
     responseStream: false,
@@ -121,7 +124,8 @@ var ClusterServiceService = exports.ClusterServiceService = {
     responseSerialize: serialize_workspacemanagerbridge_UpdateResponse,
     responseDeserialize: deserialize_workspacemanagerbridge_UpdateResponse,
   },
-  deregister: {
+  // Deregister removes a WorkspaceCluster from available clusters.
+deregister: {
     path: '/workspacemanagerbridge.ClusterService/Deregister',
     requestStream: false,
     responseStream: false,
@@ -132,7 +136,8 @@ var ClusterServiceService = exports.ClusterServiceService = {
     responseSerialize: serialize_workspacemanagerbridge_DeregisterResponse,
     responseDeserialize: deserialize_workspacemanagerbridge_DeregisterResponse,
   },
-  list: {
+  // List returns the currently registered WorkspaceClusters.
+list: {
     path: '/workspacemanagerbridge.ClusterService/List',
     requestStream: false,
     responseStream: false,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Because I had to reverse-engineer these from the code, and the design doc, and I feel like I shouldn't have to.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Document ClusterService rpcs and messages
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
