### PR TITLE
[server][hotfix] Disable webhooks for github.com and GitHub Enterprise

### DIFF
--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -137,7 +137,7 @@ export class ProjectsService {
         const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         const hostContext = parsedUrl?.host ? this.hostContextProvider.get(parsedUrl?.host) : undefined;
         const type = hostContext && hostContext.authProvider.info.authProviderType;
-        if (type !== "github.com") {
+        if (type === "GitLab" || type === "Bitbucket") {
             const repositoryService = hostContext?.services?.repositoryService;
             if (repositoryService) {
                 // Note: For GitLab, we expect .canInstallAutomatedPrebuilds() to always return true, because earlier


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Very partial revert of https://github.com/gitpod-io/gitpod/pull/8574

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Hopefully fixes https://github.com/gitpod-io/gitpod/issues/8719

## How to test
<!-- Provide steps to test this PR -->

Already deployed in production as a hotfix to `server` pods

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
