### PR TITLE
.werft/vm/manifests: Replace docker.io with quay.io

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -218,6 +218,8 @@ write_files:
       # apply fix from https://github.com/k3s-io/klipper-lb/issues/6 so we can use the klipper servicelb
       # this can be removed if https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/20 gets merged
       cat /var/lib/gitpod/manifests/calico.yaml | sed s/__KUBERNETES_NODE_NAME__\\"\\,/__KUBERNETES_NODE_NAME__\\",\\ \\"container_settings\\"\\:\\ \\{\\ \\"allow_ip_forwarding\\"\\:\\ true\\ \\}\\,/ > /var/lib/gitpod/manifests/calico2.yaml
+
+      sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico2.yaml
       kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml
 
       kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
We're being rate limited by Docker hub when pulling calico container images.

We're switching to quay.io to avoid that.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
