### PR TITLE
[dashboard] address lint warnings

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,15 +14,15 @@ ports:
     onOpen: ignore
   - port: 9229
     onOpen: ignore
-  # Go proxy
+# Go proxy
   - port: 9999
     onOpen: ignore
   - port: 13001
     onOpen: ignore
-  # Werft
+# Werft
   - port: 7777
     onOpen: ignore
-  # Dev Theia
+# Dev Theia
   - port: 13444
 tasks:
   - name: Add Harvester kubeconfig
@@ -56,3 +56,5 @@ vscode:
     - timonwong.shellcheck
     - vscjava.vscode-java-pack
     - fwcd.kotlin
+    - dbaeumer.vscode-eslint
+    - esbenp.prettier-vscode

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -4,103 +4,123 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import React, { Suspense, useContext, useEffect, useState } from 'react';
-import Menu from './Menu';
+import React, { Suspense, useContext, useEffect, useState } from "react";
+import Menu from "./Menu";
 import { Redirect, Route, Switch } from "react-router";
 
-import { Login } from './Login';
-import { UserContext } from './user-context';
-import { TeamsContext } from './teams/teams-context';
-import { ThemeContext } from './theme-context';
-import { AdminContext } from './admin-context';
-import { getGitpodService } from './service/service';
-import { shouldSeeWhatsNew, WhatsNew } from './whatsnew/WhatsNew';
-import gitpodIcon from './icons/gitpod.svg';
-import { ErrorCodes } from '@gitpod/gitpod-protocol/lib/messaging/error';
-import { useHistory } from 'react-router-dom';
-import { trackButtonOrAnchor, trackPathChange, trackLocation } from './Analytics';
-import { User } from '@gitpod/gitpod-protocol';
-import * as GitpodCookie from '@gitpod/gitpod-protocol/lib/util/gitpod-cookie';
-import { Experiment } from './experiments';
-import { workspacesPathMain } from './workspaces/workspaces.routes';
-import { settingsPathAccount, settingsPathIntegrations, settingsPathMain, settingsPathNotifications, settingsPathPlans, settingsPathPreferences, settingsPathTeams, settingsPathTeamsJoin, settingsPathTeamsNew, settingsPathVariables } from './settings/settings.routes';
-import { projectsPathInstallGitHubApp, projectsPathMain, projectsPathMainWithParams, projectsPathNew } from './projects/projects.routes';
-import { refreshSearchData } from './components/RepositoryFinder';
-import { StartWorkspaceModal } from './workspaces/StartWorkspaceModal';
-import { parseProps } from './start/StartWorkspace';
+import { Login } from "./Login";
+import { UserContext } from "./user-context";
+import { TeamsContext } from "./teams/teams-context";
+import { ThemeContext } from "./theme-context";
+import { AdminContext } from "./admin-context";
+import { getGitpodService } from "./service/service";
+import { shouldSeeWhatsNew, WhatsNew } from "./whatsnew/WhatsNew";
+import gitpodIcon from "./icons/gitpod.svg";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { useHistory } from "react-router-dom";
+import { trackButtonOrAnchor, trackPathChange, trackLocation } from "./Analytics";
+import { User } from "@gitpod/gitpod-protocol";
+import * as GitpodCookie from "@gitpod/gitpod-protocol/lib/util/gitpod-cookie";
+import { Experiment } from "./experiments";
+import { workspacesPathMain } from "./workspaces/workspaces.routes";
+import {
+    settingsPathAccount,
+    settingsPathIntegrations,
+    settingsPathMain,
+    settingsPathNotifications,
+    settingsPathPlans,
+    settingsPathPreferences,
+    settingsPathTeams,
+    settingsPathTeamsJoin,
+    settingsPathTeamsNew,
+    settingsPathVariables,
+} from "./settings/settings.routes";
+import {
+    projectsPathInstallGitHubApp,
+    projectsPathMain,
+    projectsPathMainWithParams,
+    projectsPathNew,
+} from "./projects/projects.routes";
+import { refreshSearchData } from "./components/RepositoryFinder";
+import { StartWorkspaceModal } from "./workspaces/StartWorkspaceModal";
+import { parseProps } from "./start/StartWorkspace";
 
-const Setup = React.lazy(() => import(/* webpackPrefetch: true */ './Setup'));
-const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ './workspaces/Workspaces'));
-const Account = React.lazy(() => import(/* webpackPrefetch: true */ './settings/Account'));
-const Notifications = React.lazy(() => import(/* webpackPrefetch: true */ './settings/Notifications'));
-const Plans = React.lazy(() => import(/* webpackPrefetch: true */ './settings/Plans'));
-const Teams = React.lazy(() => import(/* webpackPrefetch: true */ './settings/Teams'));
-const EnvironmentVariables = React.lazy(() => import(/* webpackPrefetch: true */ './settings/EnvironmentVariables'));
-const Integrations = React.lazy(() => import(/* webpackPrefetch: true */ './settings/Integrations'));
-const Preferences = React.lazy(() => import(/* webpackPrefetch: true */ './settings/Preferences'));
-const Open = React.lazy(() => import(/* webpackPrefetch: true */ './start/Open'));
-const StartWorkspace = React.lazy(() => import(/* webpackPrefetch: true */ './start/StartWorkspace'));
-const CreateWorkspace = React.lazy(() => import(/* webpackPrefetch: true */ './start/CreateWorkspace'));
-const NewTeam = React.lazy(() => import(/* webpackPrefetch: true */ './teams/NewTeam'));
-const JoinTeam = React.lazy(() => import(/* webpackPrefetch: true */ './teams/JoinTeam'));
-const Members = React.lazy(() => import(/* webpackPrefetch: true */ './teams/Members'));
-const TeamSettings = React.lazy(() => import(/* webpackPrefetch: true */ './teams/TeamSettings'));
-const NewProject = React.lazy(() => import(/* webpackPrefetch: true */ './projects/NewProject'));
-const ConfigureProject = React.lazy(() => import(/* webpackPrefetch: true */ './projects/ConfigureProject'));
-const Projects = React.lazy(() => import(/* webpackPrefetch: true */ './projects/Projects'));
-const Project = React.lazy(() => import(/* webpackPrefetch: true */ './projects/Project'));
-const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ './projects/ProjectSettings'));
-const ProjectVariables = React.lazy(() => import(/* webpackPrefetch: true */ './projects/ProjectVariables'));
-const Prebuilds = React.lazy(() => import(/* webpackPrefetch: true */ './projects/Prebuilds'));
-const Prebuild = React.lazy(() => import(/* webpackPrefetch: true */ './projects/Prebuild'));
-const InstallGitHubApp = React.lazy(() => import(/* webpackPrefetch: true */ './projects/InstallGitHubApp'));
-const FromReferrer = React.lazy(() => import(/* webpackPrefetch: true */ './FromReferrer'));
-const UserSearch = React.lazy(() => import(/* webpackPrefetch: true */ './admin/UserSearch'));
-const WorkspacesSearch = React.lazy(() => import(/* webpackPrefetch: true */ './admin/WorkspacesSearch'));
-const AdminSettings = React.lazy(() => import(/* webpackPrefetch: true */ './admin/Settings'));
-const ProjectsSearch = React.lazy(() => import(/* webpackPrefetch: true */ './admin/ProjectsSearch'));
-const TeamsSearch = React.lazy(() => import(/* webpackPrefetch: true */ './admin/TeamsSearch'));
-const OAuthClientApproval = React.lazy(() => import(/* webpackPrefetch: true */ './OauthClientApproval'));
+const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
+const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "./workspaces/Workspaces"));
+const Account = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Account"));
+const Notifications = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Notifications"));
+const Plans = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Plans"));
+const Teams = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Teams"));
+const EnvironmentVariables = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/EnvironmentVariables"));
+const Integrations = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Integrations"));
+const Preferences = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Preferences"));
+const Open = React.lazy(() => import(/* webpackPrefetch: true */ "./start/Open"));
+const StartWorkspace = React.lazy(() => import(/* webpackPrefetch: true */ "./start/StartWorkspace"));
+const CreateWorkspace = React.lazy(() => import(/* webpackPrefetch: true */ "./start/CreateWorkspace"));
+const NewTeam = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/NewTeam"));
+const JoinTeam = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/JoinTeam"));
+const Members = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/Members"));
+const TeamSettings = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/TeamSettings"));
+const NewProject = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/NewProject"));
+const ConfigureProject = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ConfigureProject"));
+const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Projects"));
+const Project = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Project"));
+const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ProjectSettings"));
+const ProjectVariables = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ProjectVariables"));
+const Prebuilds = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Prebuilds"));
+const Prebuild = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Prebuild"));
+const InstallGitHubApp = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/InstallGitHubApp"));
+const FromReferrer = React.lazy(() => import(/* webpackPrefetch: true */ "./FromReferrer"));
+const UserSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/UserSearch"));
+const WorkspacesSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/WorkspacesSearch"));
+const AdminSettings = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/Settings"));
+const ProjectsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/ProjectsSearch"));
+const TeamsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/TeamsSearch"));
+const OAuthClientApproval = React.lazy(() => import(/* webpackPrefetch: true */ "./OauthClientApproval"));
 
 function Loading() {
-    return <>
-    </>;
+    return <></>;
 }
 
 function isGitpodIo() {
-    return window.location.hostname === 'gitpod.io' || window.location.hostname === 'gitpod-staging.com' || window.location.hostname.endsWith('gitpod-dev.com') || window.location.hostname.endsWith('gitpod-io-dev.com')
+    return (
+        window.location.hostname === "gitpod.io" ||
+        window.location.hostname === "gitpod-staging.com" ||
+        window.location.hostname.endsWith("gitpod-dev.com") ||
+        window.location.hostname.endsWith("gitpod-io-dev.com")
+    );
 }
 
 function isWebsiteSlug(pathName: string) {
     const slugs = [
-        'about',
-        'blog',
-        'careers',
-        'changelog',
-        'chat',
-        'code-of-conduct',
-        'contact',
-        'docs',
-        'features',
-        'for',
-        'gitpod-vs-github-codespaces',
-        'imprint',
-        'media-kit',
-        'memes',
-        'pricing',
-        'privacy',
-        'security',
-        'screencasts',
-        'self-hosted',
-        'support',
-        'terms',
-        'values'
-    ]
-    return slugs.some(slug => pathName.startsWith('/' + slug + '/') || pathName === ('/' + slug));
+        "about",
+        "blog",
+        "careers",
+        "changelog",
+        "chat",
+        "code-of-conduct",
+        "contact",
+        "docs",
+        "features",
+        "for",
+        "gitpod-vs-github-codespaces",
+        "imprint",
+        "media-kit",
+        "memes",
+        "pricing",
+        "privacy",
+        "security",
+        "screencasts",
+        "self-hosted",
+        "support",
+        "terms",
+        "values",
+    ];
+    return slugs.some((slug) => pathName.startsWith("/" + slug + "/") || pathName === "/" + slug);
 }
 
 export function getURLHash() {
-    return window.location.hash.replace(/^[#/]+/, '');
+    return window.location.hash.replace(/^[#/]+/, "");
 }
 
 function App() {
@@ -129,20 +149,19 @@ function App() {
                     // if a team was selected previously and we call the root URL (e.g. "gitpod.io"),
                     // let's continue with the team page
                     const hash = getURLHash();
-                    const isRoot = window.location.pathname === '/' && hash === '';
+                    const isRoot = window.location.pathname === "/" && hash === "";
                     if (isRoot) {
                         try {
-                            const teamSlug = localStorage.getItem('team-selection');
-                            if (teams.some(t => t.slug === teamSlug)) {
+                            const teamSlug = localStorage.getItem("team-selection");
+                            if (teams.some((t) => t.slug === teamSlug)) {
                                 history.push(`/t/${teamSlug}`);
                             }
-                        } catch {
-                        }
+                        } catch {}
                     }
                 }
                 setTeams(teams);
 
-                if (user?.rolesOrPermissions?.includes('admin')) {
+                if (user?.rolesOrPermissions?.includes("admin")) {
                     const adminSettings = await getGitpodService().server.adminGetSettings();
                     setAdminSettings(adminSettings);
                 }
@@ -159,32 +178,34 @@ function App() {
             setLoading(false);
             (window as any)._gp.path = window.location.pathname; //store current path to have access to previous when path changes
         })();
-    }, []);
+    }, [history, setAdminSettings, setTeams, setUser]);
 
     useEffect(() => {
         const updateTheme = () => {
-            const isDark = localStorage.theme === 'dark' || (localStorage.theme !== 'light' && window.matchMedia("(prefers-color-scheme: dark)").matches);
+            const isDark =
+                localStorage.theme === "dark" ||
+                (localStorage.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
             setIsDark(isDark);
-        }
+        };
         updateTheme();
         const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
         if (mediaQuery instanceof EventTarget) {
-            mediaQuery.addEventListener('change', updateTheme);
+            mediaQuery.addEventListener("change", updateTheme);
         } else {
             // backward compatibility for Safari < 14
             (mediaQuery as MediaQueryList).addListener(updateTheme);
         }
-        window.addEventListener('storage', updateTheme);
+        window.addEventListener("storage", updateTheme);
         return function cleanup() {
             if (mediaQuery instanceof EventTarget) {
-                mediaQuery.removeEventListener('change', updateTheme);
+                mediaQuery.removeEventListener("change", updateTheme);
             } else {
                 // backward compatibility for Safari < 14
                 (mediaQuery as MediaQueryList).removeListener(updateTheme);
             }
-            window.removeEventListener('storage', updateTheme);
-        }
-    }, []);
+            window.removeEventListener("storage", updateTheme);
+        };
+    }, [setIsDark]);
 
     // listen and notify Segment of client-side path updates
     useEffect(() => {
@@ -192,81 +213,97 @@ function App() {
             // Choose which experiments to run for this session/user
             Experiment.set(Experiment.seed(true));
         }
-    })
+    });
 
     useEffect(() => {
         return history.listen((location: any) => {
             const path = window.location.pathname;
             trackPathChange({
                 prev: (window as any)._gp.path,
-                path: path
+                path: path,
             });
             (window as any)._gp.path = path;
-        })
-    }, [history])
+        });
+    }, [history]);
 
     useEffect(() => {
         const handleButtonOrAnchorTracking = (props: MouseEvent) => {
             var curr = props.target as HTMLElement;
             //check if current target or any ancestor up to document is button or anchor
             while (!(curr instanceof Document)) {
-                if (curr instanceof HTMLButtonElement || curr instanceof HTMLAnchorElement || (curr instanceof HTMLDivElement && curr.onclick)) {
+                if (
+                    curr instanceof HTMLButtonElement ||
+                    curr instanceof HTMLAnchorElement ||
+                    (curr instanceof HTMLDivElement && curr.onclick)
+                ) {
                     trackButtonOrAnchor(curr);
                     break; //finding first ancestor is sufficient
                 }
                 curr = curr.parentNode as HTMLElement;
             }
-        }
+        };
         window.addEventListener("click", handleButtonOrAnchorTracking, true);
         return () => window.removeEventListener("click", handleButtonOrAnchorTracking, true);
     }, []);
 
     useEffect(() => {
         if (user) {
-            refreshSearchData('', user);
+            refreshSearchData("", user);
         }
     }, [user]);
 
     // redirect to website for any website slugs
     if (isGitpodIo() && isWebsiteSlug(window.location.pathname)) {
-        window.location.host = 'www.gitpod.io';
+        window.location.host = "www.gitpod.io";
         return <div></div>;
     }
 
-    if (isGitpodIo() && window.location.pathname === '/' && window.location.hash === '' && !loading && !user) {
+    if (isGitpodIo() && window.location.pathname === "/" && window.location.hash === "" && !loading && !user) {
         if (!GitpodCookie.isPresent(document.cookie)) {
             window.location.href = `https://www.gitpod.io`;
             return <div></div>;
         } else {
             // explicitly render the Login page when the session is out-of-sync with the Gitpod cookie
-            return (<Login />);
+            return <Login />;
         }
     }
 
     if (loading) {
-        return (<Loading />);
+        return <Loading />;
     }
     if (isSetupRequired) {
-        return (<Suspense fallback={<Loading />}>
-            <Setup />
-        </Suspense>);
+        return (
+            <Suspense fallback={<Loading />}>
+                <Setup />
+            </Suspense>
+        );
     }
     if (!user) {
-        return (<Login />);
+        return <Login />;
     }
-    if (window.location.pathname.startsWith('/blocked')) {
-        return <div className="mt-48 text-center">
-            <img src={gitpodIcon} className="h-16 mx-auto" alt="Gitpod's logo" />
-            <h1 className="mt-12 text-gray-500 text-3xl">Your account has been blocked.</h1>
-            <p className="mt-4 mb-8 text-lg w-96 mx-auto">Please contact support if you think this is an error. See also <a className="hover:text-blue-600 dark:hover:text-blue-400" href="https://www.gitpod.io/terms/">terms of service</a>.</p>
-            <a className="mx-auto" href="mailto:support@gitpod.io?Subject=Blocked"><button className="secondary">Contact Support</button></a>
-        </div>;
+    if (window.location.pathname.startsWith("/blocked")) {
+        return (
+            <div className="mt-48 text-center">
+                <img src={gitpodIcon} className="h-16 mx-auto" alt="Gitpod's logo" />
+                <h1 className="mt-12 text-gray-500 text-3xl">Your account has been blocked.</h1>
+                <p className="mt-4 mb-8 text-lg w-96 mx-auto">
+                    Please contact support if you think this is an error. See also{" "}
+                    <a className="hover:text-blue-600 dark:hover:text-blue-400" href="https://www.gitpod.io/terms/">
+                        terms of service
+                    </a>
+                    .
+                </p>
+                <a className="mx-auto" href="mailto:support@gitpod.io?Subject=Blocked">
+                    <button className="secondary">Contact Support</button>
+                </a>
+            </div>
+        );
     }
-    const shouldWhatsNewShown = shouldSeeWhatsNew(user)
+    const shouldWhatsNewShown = shouldSeeWhatsNew(user);
     if (shouldWhatsNewShown !== isWhatsNewShown) {
         setWhatsNewShown(shouldWhatsNewShown);
     }
-    if (window.location.pathname.startsWith('/oauth-approval')) {
+    if (window.location.pathname.startsWith("/oauth-approval")) {
         return (
             <Suspense fallback={<Loading />}>
                 <OAuthClientApproval />
@@ -274,142 +311,162 @@ function App() {
         );
     }
 
-    window.addEventListener("hashchange", () => {
-        // Refresh on hash change if the path is '/' (new context URL)
-        if (window.location.pathname === '/') {
-            window.location.reload();
-        }
-    }, false);
+    window.addEventListener(
+        "hashchange",
+        () => {
+            // Refresh on hash change if the path is '/' (new context URL)
+            if (window.location.pathname === "/") {
+                window.location.reload();
+            }
+        },
+        false,
+    );
 
-    let toRender: React.ReactElement = <Route>
-        <div className="container">
-            <Menu />
-            <Switch>
-                <Route path={projectsPathNew} exact component={NewProject} />
-                <Route path="/open" exact component={Open} />
-                <Route path="/setup" exact component={Setup} />
-                <Route path={workspacesPathMain} exact component={Workspaces} />
-                <Route path={settingsPathAccount} exact component={Account} />
-                <Route path={settingsPathIntegrations} exact component={Integrations} />
-                <Route path={settingsPathNotifications} exact component={Notifications} />
-                <Route path={settingsPathPlans} exact component={Plans} />
-                <Route path={settingsPathVariables} exact component={EnvironmentVariables} />
-                <Route path={settingsPathPreferences} exact component={Preferences} />
-                <Route path={projectsPathInstallGitHubApp} exact component={InstallGitHubApp} />
-                <Route path="/from-referrer" exact component={FromReferrer} />
+    let toRender: React.ReactElement = (
+        <Route>
+            <div className="container">
+                <Menu />
+                <Switch>
+                    <Route path={projectsPathNew} exact component={NewProject} />
+                    <Route path="/open" exact component={Open} />
+                    <Route path="/setup" exact component={Setup} />
+                    <Route path={workspacesPathMain} exact component={Workspaces} />
+                    <Route path={settingsPathAccount} exact component={Account} />
+                    <Route path={settingsPathIntegrations} exact component={Integrations} />
+                    <Route path={settingsPathNotifications} exact component={Notifications} />
+                    <Route path={settingsPathPlans} exact component={Plans} />
+                    <Route path={settingsPathVariables} exact component={EnvironmentVariables} />
+                    <Route path={settingsPathPreferences} exact component={Preferences} />
+                    <Route path={projectsPathInstallGitHubApp} exact component={InstallGitHubApp} />
+                    <Route path="/from-referrer" exact component={FromReferrer} />
 
-                <Route path="/admin/users" component={UserSearch} />
-                <Route path="/admin/teams" component={TeamsSearch} />
-                <Route path="/admin/workspaces" component={WorkspacesSearch} />
-                <Route path="/admin/settings" component={AdminSettings} />
-                <Route path="/admin/projects" component={ProjectsSearch} />
+                    <Route path="/admin/users" component={UserSearch} />
+                    <Route path="/admin/teams" component={TeamsSearch} />
+                    <Route path="/admin/workspaces" component={WorkspacesSearch} />
+                    <Route path="/admin/settings" component={AdminSettings} />
+                    <Route path="/admin/projects" component={ProjectsSearch} />
 
-                <Route path={["/", "/login"]} exact>
-                    <Redirect to={workspacesPathMain} />
-                </Route>
-                <Route path={[settingsPathMain]} exact>
-                    <Redirect to={settingsPathAccount} />
-                </Route>
-                <Route path={["/access-control"]} exact>
-                    <Redirect to={settingsPathIntegrations} />
-                </Route>
-                <Route path={["/subscription", "/usage", "/upgrade-subscription"]} exact>
-                    <Redirect to={settingsPathPlans} />
-                </Route>
-                <Route path={["/admin"]} exact>
-                    <Redirect to="/admin/users" />
-                </Route>
-                <Route path="/sorry" exact>
-                    <div className="mt-48 text-center">
-                        <h1 className="text-gray-500 text-3xl">Oh, no! Something went wrong!</h1>
-                        <p className="mt-4 text-lg text-gitpod-red">{decodeURIComponent(getURLHash())}</p>
-                    </div>
-                </Route>
-                <Route path={projectsPathMain}>
-                    <Route exact path={projectsPathMain} component={Projects} />
-                    <Route exact path={projectsPathMainWithParams} render={(props) => {
-                        const { resourceOrPrebuild } = props.match.params;
-                        if (resourceOrPrebuild === "settings") {
-                            return <ProjectSettings />;
-                        }
-                        if (resourceOrPrebuild === "configure") {
-                            return <ConfigureProject />;
-                        }
-                        if (resourceOrPrebuild === "variables") {
-                            return <ProjectVariables />;
-                        }
-                        if (resourceOrPrebuild === "prebuilds") {
-                            return <Prebuilds />;
-                        }
-                        return resourceOrPrebuild ? <Prebuild /> : <Project />;
-                    }} />
-                </Route>
-                <Route path={settingsPathTeams}>
-                    <Route exact path={settingsPathTeams} component={Teams} />
-                    <Route exact path={settingsPathTeamsNew} component={NewTeam} />
-                    <Route exact path={settingsPathTeamsJoin} component={JoinTeam} />
-                </Route>
-                {(teams || []).map(team =>
-                    <Route path={`/t/${team.slug}`} key={team.slug}>
-                        <Route exact path={`/t/${team.slug}`}>
-                            <Redirect to={`/t/${team.slug}/projects`} />
+                    <Route path={["/", "/login"]} exact>
+                        <Redirect to={workspacesPathMain} />
+                    </Route>
+                    <Route path={[settingsPathMain]} exact>
+                        <Redirect to={settingsPathAccount} />
+                    </Route>
+                    <Route path={["/access-control"]} exact>
+                        <Redirect to={settingsPathIntegrations} />
+                    </Route>
+                    <Route path={["/subscription", "/usage", "/upgrade-subscription"]} exact>
+                        <Redirect to={settingsPathPlans} />
+                    </Route>
+                    <Route path={["/admin"]} exact>
+                        <Redirect to="/admin/users" />
+                    </Route>
+                    <Route path="/sorry" exact>
+                        <div className="mt-48 text-center">
+                            <h1 className="text-gray-500 text-3xl">Oh, no! Something went wrong!</h1>
+                            <p className="mt-4 text-lg text-gitpod-red">{decodeURIComponent(getURLHash())}</p>
+                        </div>
+                    </Route>
+                    <Route path={projectsPathMain}>
+                        <Route exact path={projectsPathMain} component={Projects} />
+                        <Route
+                            exact
+                            path={projectsPathMainWithParams}
+                            render={(props) => {
+                                const { resourceOrPrebuild } = props.match.params;
+                                if (resourceOrPrebuild === "settings") {
+                                    return <ProjectSettings />;
+                                }
+                                if (resourceOrPrebuild === "configure") {
+                                    return <ConfigureProject />;
+                                }
+                                if (resourceOrPrebuild === "variables") {
+                                    return <ProjectVariables />;
+                                }
+                                if (resourceOrPrebuild === "prebuilds") {
+                                    return <Prebuilds />;
+                                }
+                                return resourceOrPrebuild ? <Prebuild /> : <Project />;
+                            }}
+                        />
+                    </Route>
+                    <Route path={settingsPathTeams}>
+                        <Route exact path={settingsPathTeams} component={Teams} />
+                        <Route exact path={settingsPathTeamsNew} component={NewTeam} />
+                        <Route exact path={settingsPathTeamsJoin} component={JoinTeam} />
+                    </Route>
+                    {(teams || []).map((team) => (
+                        <Route path={`/t/${team.slug}`} key={team.slug}>
+                            <Route exact path={`/t/${team.slug}`}>
+                                <Redirect to={`/t/${team.slug}/projects`} />
+                            </Route>
+                            <Route
+                                exact
+                                path={`/t/${team.slug}/:maybeProject/:resourceOrPrebuild?`}
+                                render={(props) => {
+                                    const { maybeProject, resourceOrPrebuild } = props.match.params;
+                                    if (maybeProject === "projects") {
+                                        return <Projects />;
+                                    }
+                                    if (maybeProject === "workspaces") {
+                                        return <Workspaces />;
+                                    }
+                                    if (maybeProject === "members") {
+                                        return <Members />;
+                                    }
+                                    if (maybeProject === "settings") {
+                                        return <TeamSettings />;
+                                    }
+                                    if (resourceOrPrebuild === "settings") {
+                                        return <ProjectSettings />;
+                                    }
+                                    if (resourceOrPrebuild === "configure") {
+                                        return <ConfigureProject />;
+                                    }
+                                    if (resourceOrPrebuild === "variables") {
+                                        return <ProjectVariables />;
+                                    }
+                                    if (resourceOrPrebuild === "prebuilds") {
+                                        return <Prebuilds />;
+                                    }
+                                    return resourceOrPrebuild ? <Prebuild /> : <Project />;
+                                }}
+                            />
                         </Route>
-                        <Route exact path={`/t/${team.slug}/:maybeProject/:resourceOrPrebuild?`} render={(props) => {
-                            const { maybeProject, resourceOrPrebuild } = props.match.params;
-                            if (maybeProject === "projects") {
-                                return <Projects />;
-                            }
-                            if (maybeProject === "workspaces") {
-                                return <Workspaces />;
-                            }
-                            if (maybeProject === "members") {
-                                return <Members />;
-                            }
-                            if (maybeProject === "settings") {
-                                return <TeamSettings />;
-                            }
-                            if (resourceOrPrebuild === "settings") {
-                                return <ProjectSettings />;
-                            }
-                            if (resourceOrPrebuild === "configure") {
-                                return <ConfigureProject />;
-                            }
-                            if (resourceOrPrebuild === "variables") {
-                                return <ProjectVariables />;
-                            }
-                            if (resourceOrPrebuild === "prebuilds") {
-                                return <Prebuilds />;
-                            }
-                            return resourceOrPrebuild ? <Prebuild /> : <Project />;
-                        }} />
-                    </Route>)}
-                <Route path="*" render={
-                    (_match) => {
-
-                        return isGitpodIo() ?
-                            // delegate to our website to handle the request
-                            (window.location.host = 'www.gitpod.io') :
-                            <div className="mt-48 text-center">
-                                <h1 className="text-gray-500 text-3xl">404</h1>
-                                <p className="mt-4 text-lg">Page not found.</p>
-                            </div>;
-                    }}>
-                </Route>
-            </Switch>
-            <StartWorkspaceModal />
-        </div>
-    </Route>;
+                    ))}
+                    <Route
+                        path="*"
+                        render={(_match) => {
+                            return isGitpodIo() ? (
+                                // delegate to our website to handle the request
+                                (window.location.host = "www.gitpod.io")
+                            ) : (
+                                <div className="mt-48 text-center">
+                                    <h1 className="text-gray-500 text-3xl">404</h1>
+                                    <p className="mt-4 text-lg">Page not found.</p>
+                                </div>
+                            );
+                        }}
+                    ></Route>
+                </Switch>
+                <StartWorkspaceModal />
+            </div>
+        </Route>
+    );
 
     const hash = getURLHash();
     if (/^(https:\/\/)?github\.dev\//i.test(hash)) {
-        window.location.hash = hash.replace(/^(https:\/\/)?github\.dev\//i, 'https://github.com/')
-        return <div></div>
-    } else if (/^([^\/]+?=[^\/]*?|prebuild)\/(https:\/\/)?github\.dev\//i.test(hash)) {
-        window.location.hash = hash.replace(/^([^\/]+?=[^\/]*?|prebuild)\/(https:\/\/)?github\.dev\//i, '$1/https://github.com/')
-        return <div></div>
+        window.location.hash = hash.replace(/^(https:\/\/)?github\.dev\//i, "https://github.com/");
+        return <div></div>;
+    } else if (/^([^/]+?=[^/]*?|prebuild)\/(https:\/\/)?github\.dev\//i.test(hash)) {
+        window.location.hash = hash.replace(
+            /^([^/]+?=[^/]*?|prebuild)\/(https:\/\/)?github\.dev\//i,
+            "$1/https://github.com/",
+        );
+        return <div></div>;
     }
-    const isCreation = window.location.pathname === '/' && hash !== '';
-    const isWsStart = /\/start\/?/.test(window.location.pathname) && hash !== '';
+    const isCreation = window.location.pathname === "/" && hash !== "";
+    const isWsStart = /\/start\/?/.test(window.location.pathname) && hash !== "";
     if (isWhatsNewShown) {
         toRender = <WhatsNew onClose={() => setWhatsNewShown(false)} />;
     } else if (isCreation) {
@@ -417,18 +474,14 @@ function App() {
     } else if (isWsStart) {
         toRender = <StartWorkspace {...parseProps(hash, window.location.search)} />;
     } else if (/^(github|gitlab)\.com\/.+?/i.test(window.location.pathname)) {
-        let url = new URL(window.location.href)
-        url.hash = url.pathname
-        url.pathname = '/'
-        window.location.replace(url)
-        return <div></div>
+        let url = new URL(window.location.href);
+        url.hash = url.pathname;
+        url.pathname = "/";
+        window.location.replace(url);
+        return <div></div>;
     }
 
-    return (
-        <Suspense fallback={<Loading />}>
-            {toRender}
-        </Suspense>
-    );
+    return <Suspense fallback={<Loading />}>{toRender}</Suspense>;
 }
 
 export default App;

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -5,15 +5,15 @@
  */
 
 import { AuthProviderInfo } from "@gitpod/gitpod-protocol";
-import * as GitpodCookie from '@gitpod/gitpod-protocol/lib/util/gitpod-cookie';
+import * as GitpodCookie from "@gitpod/gitpod-protocol/lib/util/gitpod-cookie";
 import { useContext, useEffect, useState } from "react";
 import { UserContext } from "./user-context";
 import { TeamsContext } from "./teams/teams-context";
 import { getGitpodService } from "./service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName, getSafeURLRedirect } from "./provider-utils";
-import gitpod from './images/gitpod.svg';
-import gitpodDark from './images/gitpod-dark.svg';
-import gitpodIcon from './icons/gitpod.svg';
+import gitpod from "./images/gitpod.svg";
+import gitpodDark from "./images/gitpod-dark.svg";
+import gitpodIcon from "./icons/gitpod.svg";
 import automate from "./images/welcome/automate.svg";
 import code from "./images/welcome/code.svg";
 import collaborate from "./images/welcome/collaborate.svg";
@@ -23,13 +23,14 @@ import prebuild from "./images/welcome/prebuild.svg";
 import exclamation from "./images/exclamation.svg";
 import { getURLHash } from "./App";
 
-
-function Item(props: { icon: string, iconSize?: string, text: string }) {
+function Item(props: { icon: string; iconSize?: string; text: string }) {
     const iconSize = props.iconSize || 28;
-    return <div className="flex-col items-center w-1/3 px-3">
-        <img src={props.icon} className={`w-${iconSize} m-auto h-24`} />
-        <div className="text-gray-400 text-sm w-36 h-20 text-center">{props.text}</div>
-    </div>;
+    return (
+        <div className="flex-col items-center w-1/3 px-3">
+            <img src={props.icon} className={`w-${iconSize} m-auto h-24`} alt="" />
+            <div className="text-gray-400 text-sm w-36 h-20 text-center">{props.text}</div>
+        </div>
+    );
 }
 
 export function markLoggedIn() {
@@ -72,14 +73,14 @@ export function Login() {
         (async () => {
             setAuthProviders(await getGitpodService().server.getAuthProviders());
         })();
-    }, [])
+    }, []);
 
     useEffect(() => {
         if (hostFromContext && authProviders) {
-            const providerFromContext = authProviders.find(provider => provider.host === hostFromContext);
+            const providerFromContext = authProviders.find((provider) => provider.host === hostFromContext);
             setProviderFromContext(providerFromContext);
         }
-    }, [authProviders]);
+    }, [authProviders, hostFromContext]);
 
     const authorizeSuccessful = async (payload?: string) => {
         updateUser().catch(console.error);
@@ -90,7 +91,7 @@ export function Login() {
             // ... and if it is, redirect to it
             window.location.replace(safeReturnTo);
         }
-    }
+    };
 
     const updateUser = async () => {
         await getGitpodService().reconnect();
@@ -101,7 +102,7 @@ export function Login() {
         setUser(user);
         setTeams(teams);
         markLoggedIn();
-    }
+    };
 
     const openLogin = async (host: string) => {
         setErrorMessage(undefined);
@@ -118,102 +119,148 @@ export function Login() {
                     } else {
                         errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
                         if (payload.error === "email_taken") {
-                            errorMessage = `Email address already used in another account. Please log in with ${(payload as any).host}.`;
+                            errorMessage = `Email address already used in another account. Please log in with ${
+                                (payload as any).host
+                            }.`;
                         }
                     }
                     setErrorMessage(errorMessage);
-                }
+                },
             });
         } catch (error) {
-            console.log(error)
+            console.log(error);
         }
-    }
+    };
 
-    return (<div id="login-container" className="z-50 flex w-screen h-screen">
-        {showWelcome ? <div id="feature-section" className="flex-grow bg-gray-100 dark:bg-gray-800 w-1/2 hidden lg:block">
-            <div id="feature-section-column" className="flex max-w-xl h-full mx-auto pt-6">
-                <div className="flex flex-col px-8 my-auto ml-auto">
-                    <div className="mb-12">
-                        <img src={gitpod} className="h-8 block dark:hidden" alt="Gitpod light theme logo" />
-                        <img src={gitpodDark} className="h-8 hidden dark:block" alt="Gitpod dark theme logo" />
-                    </div>
-                    <div className="mb-10">
-                        <h1 className="text-5xl mb-3">Welcome to Gitpod</h1>
-                        <div className="text-gray-400 text-lg">
-                            Spin up fresh, automated dev environments for each task in the cloud, in seconds.
-                        </div>
-                    </div>
-                    <div className="flex mb-10">
-                        <Item icon={code} iconSize="16" text="Always Ready&#x2011;To&#x2011;Code" />
-                        <Item icon={customize} text="Personalize your Workspace" />
-                        <Item icon={automate} text="Automate Your Development Setup" />
-                    </div>
-                    <div className="flex">
-                        <Item icon={prebuild} text="Continuously Prebuild Your Project" />
-                        <Item icon={collaborate} text="Collaborate With Your Team" />
-                        <Item icon={fresh} text="Fresh Workspace For Each New Task" />
-                    </div>
-                </div>
-            </div>
-        </div> : null}
-        <div id="login-section" className={"flex-grow flex w-full" + (showWelcome ? " lg:w-1/2" : "")}>
-            <div id="login-section-column" className={"flex-grow max-w-2xl flex flex-col h-100 mx-auto" + (showWelcome ? " lg:my-0" : "")}>
-                <div className="flex-grow h-100 flex flex-row items-center justify-center" >
-                    <div className="rounded-xl px-10 py-10 mx-auto">
-                        <div className="mx-auto pb-8">
-                            <img src={providerFromContext ? gitpod : gitpodIcon} className="h-14 mx-auto block dark:hidden" alt="Gitpod's logo" />
-                            <img src={providerFromContext ? gitpodDark : gitpodIcon} className="h-14 hidden mx-auto dark:block" alt="Gitpod dark theme logo" />
-                        </div>
-
-                        <div className="mx-auto text-center pb-8 space-y-2">
-                            {providerFromContext
-                                ? <>
-                                    <h2 className="text-xl text-black dark:text-gray-50 font-semibold">Open a cloud-based developer environment</h2>
-                                    <h2 className="text-xl">for the repository {repoPathname?.slice(1)}</h2>
-                                </>
-                                : <>
-                                    <h1 className="text-3xl">Log in{showWelcome ? '' : ' to Gitpod'}</h1>
-                                    <h2 className="uppercase text-sm text-gray-400">ALWAYS READY-TO-CODE</h2>
-                                </>}
-                        </div>
-
-
-                        <div className="flex flex-col space-y-3 items-center">
-                            {providerFromContext
-                                ?
-                                <button key={"button" + providerFromContext.host} className="btn-login flex-none w-56 h-10 p-0 inline-flex" onClick={() => openLogin(providerFromContext.host)}>
-                                    {iconForAuthProvider(providerFromContext.authProviderType)}
-                                    <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">Continue with {simplifyProviderName(providerFromContext.host)}</span>
-                                </button>
-                                :
-                                authProviders.map(ap =>
-                                    <button key={"button" + ap.host} className="btn-login flex-none w-56 h-10 p-0 inline-flex" onClick={() => openLogin(ap.host)}>
-                                        {iconForAuthProvider(ap.authProviderType)}
-                                        <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">Continue with {simplifyProviderName(ap.host)}</span>
-                                    </button>)
-                            }
-                        </div>
-
-                        {errorMessage && (
-                            <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
-                                <div className="pr-3 self-center w-6">
-                                    <img src={exclamation} />
-                                </div>
-                                <div className="flex-1 flex flex-col">
-                                    <p className="text-gitpod-red text-sm">{errorMessage}</p>
+    return (
+        <div id="login-container" className="z-50 flex w-screen h-screen">
+            {showWelcome ? (
+                <div id="feature-section" className="flex-grow bg-gray-100 dark:bg-gray-800 w-1/2 hidden lg:block">
+                    <div id="feature-section-column" className="flex max-w-xl h-full mx-auto pt-6">
+                        <div className="flex flex-col px-8 my-auto ml-auto">
+                            <div className="mb-12">
+                                <img src={gitpod} className="h-8 block dark:hidden" alt="Gitpod light theme logo" />
+                                <img src={gitpodDark} className="h-8 hidden dark:block" alt="Gitpod dark theme logo" />
+                            </div>
+                            <div className="mb-10">
+                                <h1 className="text-5xl mb-3">Welcome to Gitpod</h1>
+                                <div className="text-gray-400 text-lg">
+                                    Spin up fresh, automated dev environments for each task in the cloud, in seconds.
                                 </div>
                             </div>
-                        )}
-
+                            <div className="flex mb-10">
+                                <Item icon={code} iconSize="16" text="Always Ready&#x2011;To&#x2011;Code" />
+                                <Item icon={customize} text="Personalize your Workspace" />
+                                <Item icon={automate} text="Automate Your Development Setup" />
+                            </div>
+                            <div className="flex">
+                                <Item icon={prebuild} text="Continuously Prebuild Your Project" />
+                                <Item icon={collaborate} text="Collaborate With Your Team" />
+                                <Item icon={fresh} text="Fresh Workspace For Each New Task" />
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div className="flex-none mx-auto h-20 text-center">
-                    <span className="text-gray-400">
-                        By signing in, you agree to our <a className="gp-link hover:text-gray-600" target="gitpod-terms" href="https://www.gitpod.io/terms/">terms of service</a> and <a className="gp-link hover:text-gray-600" target="gitpod-privacy" href="https://www.gitpod.io/privacy/">privacy policy</a>.
-                    </span>
+            ) : null}
+            <div id="login-section" className={"flex-grow flex w-full" + (showWelcome ? " lg:w-1/2" : "")}>
+                <div
+                    id="login-section-column"
+                    className={"flex-grow max-w-2xl flex flex-col h-100 mx-auto" + (showWelcome ? " lg:my-0" : "")}
+                >
+                    <div className="flex-grow h-100 flex flex-row items-center justify-center">
+                        <div className="rounded-xl px-10 py-10 mx-auto">
+                            <div className="mx-auto pb-8">
+                                <img
+                                    src={providerFromContext ? gitpod : gitpodIcon}
+                                    className="h-14 mx-auto block dark:hidden"
+                                    alt="Gitpod's logo"
+                                />
+                                <img
+                                    src={providerFromContext ? gitpodDark : gitpodIcon}
+                                    className="h-14 hidden mx-auto dark:block"
+                                    alt="Gitpod dark theme logo"
+                                />
+                            </div>
+
+                            <div className="mx-auto text-center pb-8 space-y-2">
+                                {providerFromContext ? (
+                                    <>
+                                        <h2 className="text-xl text-black dark:text-gray-50 font-semibold">
+                                            Open a cloud-based developer environment
+                                        </h2>
+                                        <h2 className="text-xl">for the repository {repoPathname?.slice(1)}</h2>
+                                    </>
+                                ) : (
+                                    <>
+                                        <h1 className="text-3xl">Log in{showWelcome ? "" : " to Gitpod"}</h1>
+                                        <h2 className="uppercase text-sm text-gray-400">ALWAYS READY-TO-CODE</h2>
+                                    </>
+                                )}
+                            </div>
+
+                            <div className="flex flex-col space-y-3 items-center">
+                                {providerFromContext ? (
+                                    <button
+                                        key={"button" + providerFromContext.host}
+                                        className="btn-login flex-none w-56 h-10 p-0 inline-flex"
+                                        onClick={() => openLogin(providerFromContext.host)}
+                                    >
+                                        {iconForAuthProvider(providerFromContext.authProviderType)}
+                                        <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">
+                                            Continue with {simplifyProviderName(providerFromContext.host)}
+                                        </span>
+                                    </button>
+                                ) : (
+                                    authProviders.map((ap) => (
+                                        <button
+                                            key={"button" + ap.host}
+                                            className="btn-login flex-none w-56 h-10 p-0 inline-flex"
+                                            onClick={() => openLogin(ap.host)}
+                                        >
+                                            {iconForAuthProvider(ap.authProviderType)}
+                                            <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">
+                                                Continue with {simplifyProviderName(ap.host)}
+                                            </span>
+                                        </button>
+                                    ))
+                                )}
+                            </div>
+
+                            {errorMessage && (
+                                <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
+                                    <div className="pr-3 self-center w-6">
+                                        <img src={exclamation} alt="Error:" />
+                                    </div>
+                                    <div className="flex-1 flex flex-col">
+                                        <p className="text-gitpod-red text-sm">{errorMessage}</p>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                    <div className="flex-none mx-auto h-20 text-center">
+                        <span className="text-gray-400">
+                            By signing in, you agree to our{" "}
+                            <a
+                                className="gp-link hover:text-gray-600"
+                                target="gitpod-terms"
+                                href="https://www.gitpod.io/terms/"
+                            >
+                                terms of service
+                            </a>{" "}
+                            and{" "}
+                            <a
+                                className="gp-link hover:text-gray-600"
+                                target="gitpod-privacy"
+                                href="https://www.gitpod.io/privacy/"
+                            >
+                                privacy policy
+                            </a>
+                            .
+                        </span>
+                    </div>
                 </div>
             </div>
-
         </div>
-    </div>);
+    );
 }

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -9,14 +9,14 @@ import { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useLocation, useRouteMatch } from "react-router";
 import { Location } from "history";
-import gitpodIcon from './icons/gitpod.svg';
+import gitpodIcon from "./icons/gitpod.svg";
 import CaretDown from "./icons/CaretDown.svg";
 import CaretUpDown from "./icons/CaretUpDown.svg";
 import { getGitpodService, gitpodHostUrl } from "./service/service";
 import { UserContext } from "./user-context";
 import { TeamsContext, getCurrentTeam } from "./teams/teams-context";
-import settingsMenu from './settings/settings-menu';
-import { adminMenu } from './admin/admin-menu';
+import settingsMenu from "./settings/settings-menu";
+import { adminMenu } from "./admin/admin-menu";
 import ContextMenu from "./components/ContextMenu";
 import Separator from "./components/Separator";
 import PillMenuItem from "./components/PillMenuItem";
@@ -26,9 +26,9 @@ import { getProjectSettingsMenu } from "./projects/ProjectSettings";
 import { ProjectContext } from "./projects/project-context";
 
 interface Entry {
-    title: string,
-    link: string,
-    alternatives?: string[]
+    title: string;
+    link: string;
+    alternatives?: string[];
 }
 
 export default function Menu() {
@@ -38,7 +38,9 @@ export default function Menu() {
     const team = getCurrentTeam(location, teams);
     const { project, setProject } = useContext(ProjectContext);
 
-    const match = useRouteMatch<{ segment1?: string, segment2?: string, segment3?: string }>("/(t/)?:segment1/:segment2?/:segment3?");
+    const match = useRouteMatch<{ segment1?: string; segment2?: string; segment3?: string }>(
+        "/(t/)?:segment1/:segment2?/:segment3?",
+    );
     const projectSlug = (() => {
         const resource = match?.params?.segment2;
         if (resource && !["projects", "members", "users", "workspaces", "settings", "teams"].includes(resource)) {
@@ -47,59 +49,71 @@ export default function Menu() {
     })();
     const prebuildId = (() => {
         const resource = projectSlug && match?.params?.segment3;
-        if (resource !== "workspaces" && resource !== "prebuilds" && resource !== "settings" && resource !== "configure" && resource !== "variables") {
+        if (
+            resource !== "workspaces" &&
+            resource !== "prebuilds" &&
+            resource !== "settings" &&
+            resource !== "configure" &&
+            resource !== "variables"
+        ) {
             return resource;
         }
     })();
 
     function isSelected(entry: Entry, location: Location<any>) {
-        const all = [entry.link, ...(entry.alternatives||[])].map(l => l.toLowerCase());
+        const all = [entry.link, ...(entry.alternatives || [])].map((l) => l.toLowerCase());
         const path = location.pathname.toLowerCase();
-        return all.some(n => n === path || n+'/' === path);
+        return all.some((n) => n === path || n + "/" === path);
     }
 
-    const userFullName = user?.fullName || user?.name || '...';
+    const userFullName = user?.fullName || user?.name || "...";
 
+    // TODO: This one smells like it could be some clever trickery,
+    // so opting for keeping it and disabling linting until
+    // Alex Tugarev chimes-in
+    // eslint-disable-next-line no-lone-blocks
     {
         // updating last team selection
         try {
-            localStorage.setItem('team-selection', team ? team.slug : "");
-        } catch {
-        }
+            localStorage.setItem("team-selection", team ? team.slug : "");
+        } catch {}
     }
 
     // Hide most of the top menu when in a full-page form.
-    const isMinimalUI = ['/new', '/teams/new', '/open'].includes(location.pathname);
+    const isMinimalUI = ["/new", "/teams/new", "/open"].includes(location.pathname);
 
-    const [ teamMembers, setTeamMembers ] = useState<Record<string, TeamMemberInfo[]>>({});
+    const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
     useEffect(() => {
         if (!teams) {
             return;
         }
         (async () => {
             const members: Record<string, TeamMemberInfo[]> = {};
-            await Promise.all(teams.map(async (team) => {
-                try {
-                    members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
-                } catch (error) {
-                    console.error('Could not get members of team', team, error);
-                }
-            }));
+            await Promise.all(
+                teams.map(async (team) => {
+                    try {
+                        members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
+                    } catch (error) {
+                        console.error("Could not get members of team", team, error);
+                    }
+                }),
+            );
             setTeamMembers(members);
         })();
-    }, [ teams ]);
+    }, [teams]);
 
     useEffect(() => {
         if (!teams || !projectSlug) {
             return;
         }
         (async () => {
-            const projects = (!!team
+            const projects = !!team
                 ? await getGitpodService().server.getTeamProjects(team.id)
-                : await getGitpodService().server.getUserProjects());
+                : await getGitpodService().server.getUserProjects();
 
             // Find project matching with slug, otherwise with name
-            const project = projectSlug && projects.find(p => p.slug ? p.slug === projectSlug : p.name === projectSlug);
+            const project =
+                projectSlug && projects.find((p) => (p.slug ? p.slug === projectSlug : p.name === projectSlug));
             if (!project) {
                 return;
             }
@@ -107,47 +121,47 @@ export default function Menu() {
         })();
     }, [projectSlug, setProject, team, teams]);
 
-    const teamOrUserSlug = !!team ? '/t/' + team.slug : '/projects';
+    const teamOrUserSlug = !!team ? "/t/" + team.slug : "/projects";
     const leftMenu: Entry[] = (() => {
         // Project menu
         if (projectSlug) {
             return [
                 {
-                    title: 'Branches',
+                    title: "Branches",
                     link: `${teamOrUserSlug}/${projectSlug}`,
                 },
                 {
-                    title: 'Prebuilds',
+                    title: "Prebuilds",
                     link: `${teamOrUserSlug}/${projectSlug}/prebuilds`,
                 },
                 {
-                    title: 'Settings',
+                    title: "Settings",
                     link: `${teamOrUserSlug}/${projectSlug}/settings`,
-                    alternatives: getProjectSettingsMenu({ slug: projectSlug } as Project, team).flatMap(e => e.link),
+                    alternatives: getProjectSettingsMenu({ slug: projectSlug } as Project, team).flatMap((e) => e.link),
                 },
             ];
         }
         // Team menu
         if (team) {
-            const currentUserInTeam = (teamMembers[team.id] || []).find(m => m.userId === user?.id);
+            const currentUserInTeam = (teamMembers[team.id] || []).find((m) => m.userId === user?.id);
 
             const teamSettingsList = [
                 {
-                    title: 'Projects',
+                    title: "Projects",
                     link: `/t/${team.slug}/projects`,
-                    alternatives: ([] as string[])
+                    alternatives: [] as string[],
                 },
                 {
-                    title: 'Members',
-                    link: `/t/${team.slug}/members`
-                }
+                    title: "Members",
+                    link: `/t/${team.slug}/members`,
+                },
             ];
             if (currentUserInTeam?.role === "owner") {
                 teamSettingsList.push({
-                    title: 'Settings',
+                    title: "Settings",
                     link: `/t/${team.slug}/settings`,
-                    alternatives: getTeamSettingsMenu(team).flatMap(e => e.link),
-                })
+                    alternatives: getTeamSettingsMenu(team).flatMap((e) => e.link),
+                });
             }
 
             return teamSettingsList;
@@ -155,148 +169,226 @@ export default function Menu() {
         // User menu
         return [
             {
-                title: 'Workspaces',
-                link: '/workspaces',
-                alternatives: ['/']
+                title: "Workspaces",
+                link: "/workspaces",
+                alternatives: ["/"],
             },
             {
-                title: 'Projects',
-                link: '/projects'
+                title: "Projects",
+                link: "/projects",
             },
             {
-                title: 'Settings',
-                link: '/settings',
-                alternatives: settingsMenu.flatMap(e => e.link)
-            }
+                title: "Settings",
+                link: "/settings",
+                alternatives: settingsMenu.flatMap((e) => e.link),
+            },
         ];
     })();
     const rightMenu: Entry[] = [
-        ...(user?.rolesOrPermissions?.includes('admin') ? [{
-            title: 'Admin',
-            link: '/admin',
-            alternatives: adminMenu.flatMap(e => e.link)
-        }] : []),
+        ...(user?.rolesOrPermissions?.includes("admin")
+            ? [
+                  {
+                      title: "Admin",
+                      link: "/admin",
+                      alternatives: adminMenu.flatMap((e) => e.link),
+                  },
+              ]
+            : []),
         {
-            title: 'Docs',
-            link: 'https://www.gitpod.io/docs/',
+            title: "Docs",
+            link: "https://www.gitpod.io/docs/",
         },
         {
-            title: 'Help',
-            link: 'https://www.gitpod.io/support',
-        }
+            title: "Help",
+            link: "https://www.gitpod.io/support",
+        },
     ];
 
     const renderTeamMenu = () => {
         return (
             <div className="flex p-1 pl-3 ">
-                { projectSlug && <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1">
-                    <Link to={team ? `/t/${team.slug}/projects` : `/projects`}>
-                        <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">{team?.name || userFullName}</span>
-                    </Link>
-                </div> }
-                <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800">
-                    <ContextMenu classes="w-64 left-0" menuEntries={[
-                        {
-                            title: userFullName,
-                            customContent: <div className="w-full text-gray-400 flex flex-col">
-                                <span className="text-gray-800 dark:text-gray-100 text-base font-semibold">{userFullName}</span>
-                                <span className="">Personal Account</span>
-                            </div>,
-                            active: !team,
-                            separator: true,
-                            link: '/',
-                        },
-                        ...(teams || []).map(t => ({
-                            title: t.name,
-                            customContent: <div className="w-full text-gray-400 flex flex-col">
-                                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{t.name}</span>
-                                <span className="">{!!teamMembers[t.id]
-                                    ? `${teamMembers[t.id].length} member${teamMembers[t.id].length === 1 ? '' : 's'}`
-                                    : '...'
-                                }</span>
-                            </div>,
-                            active: team && team.id === t.id,
-                            separator: true,
-                            link: `/t/${t.slug}`,
-                        })).sort((a, b) => a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1),
-                        {
-                            title: 'Create a new team',
-                            customContent: <div className="w-full text-gray-400 flex items-center">
-                                <span className="flex-1 font-semibold">New Team</span>
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5"><path fill="currentColor" fill-rule="evenodd" d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z" clip-rule="evenodd" /></svg>
-                            </div>,
-                            link: '/teams/new',
-                        }
-                    ]}>
-                        <div className="flex h-full px-2 py-1 space-x-3.5">
-                            { !projectSlug && <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">{team?.name || userFullName}</span>}
-                            <img alt="" aria-label="Toggle team selection menu" className="filter-grayscale" style={{marginTop: 5, marginBottom: 5}} src={CaretUpDown} />
-                        </div>
-                    </ContextMenu>
-                </div>
-                { projectSlug && (
+                {projectSlug && (
                     <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1">
-                        <Link to={`${teamOrUserSlug}/${projectSlug}${prebuildId ? "/prebuilds" : ""}`}>
-                            <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">{project?.name}</span>
+                        <Link to={team ? `/t/${team.slug}/projects` : `/projects`}>
+                            <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">
+                                {team?.name || userFullName}
+                            </span>
                         </Link>
                     </div>
                 )}
-                { prebuildId && (
+                <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800">
+                    <ContextMenu
+                        classes="w-64 left-0"
+                        menuEntries={[
+                            {
+                                title: userFullName,
+                                customContent: (
+                                    <div className="w-full text-gray-400 flex flex-col">
+                                        <span className="text-gray-800 dark:text-gray-100 text-base font-semibold">
+                                            {userFullName}
+                                        </span>
+                                        <span className="">Personal Account</span>
+                                    </div>
+                                ),
+                                active: !team,
+                                separator: true,
+                                link: "/",
+                            },
+                            ...(teams || [])
+                                .map((t) => ({
+                                    title: t.name,
+                                    customContent: (
+                                        <div className="w-full text-gray-400 flex flex-col">
+                                            <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">
+                                                {t.name}
+                                            </span>
+                                            <span className="">
+                                                {!!teamMembers[t.id]
+                                                    ? `${teamMembers[t.id].length} member${
+                                                          teamMembers[t.id].length === 1 ? "" : "s"
+                                                      }`
+                                                    : "..."}
+                                            </span>
+                                        </div>
+                                    ),
+                                    active: team && team.id === t.id,
+                                    separator: true,
+                                    link: `/t/${t.slug}`,
+                                }))
+                                .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1)),
+                            {
+                                title: "Create a new team",
+                                customContent: (
+                                    <div className="w-full text-gray-400 flex items-center">
+                                        <span className="flex-1 font-semibold">New Team</span>
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            fill="none"
+                                            viewBox="0 0 14 14"
+                                            className="w-3.5"
+                                        >
+                                            <path
+                                                fill="currentColor"
+                                                fill-rule="evenodd"
+                                                d="M7 0a1 1 0 011 1v5h5a1 1 0 110 2H8v5a1 1 0 11-2 0V8H1a1 1 0 010-2h5V1a1 1 0 011-1z"
+                                                clip-rule="evenodd"
+                                            />
+                                        </svg>
+                                    </div>
+                                ),
+                                link: "/teams/new",
+                            },
+                        ]}
+                    >
+                        <div className="flex h-full px-2 py-1 space-x-3.5">
+                            {!projectSlug && (
+                                <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">
+                                    {team?.name || userFullName}
+                                </span>
+                            )}
+                            <img
+                                alt=""
+                                aria-label="Toggle team selection menu"
+                                className="filter-grayscale"
+                                style={{ marginTop: 5, marginBottom: 5 }}
+                                src={CaretUpDown}
+                            />
+                        </div>
+                    </ContextMenu>
+                </div>
+                {projectSlug && (
+                    <div className="flex h-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1">
+                        <Link to={`${teamOrUserSlug}/${projectSlug}${prebuildId ? "/prebuilds" : ""}`}>
+                            <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">
+                                {project?.name}
+                            </span>
+                        </Link>
+                    </div>
+                )}
+                {prebuildId && (
                     <div className="flex h-full ml-2 py-1">
                         <img alt="" className="mr-3 filter-grayscale m-auto transform -rotate-90" src={CaretDown} />
                         <span className="text-base text-gray-600 dark:text-gray-400 font-semibold">{prebuildId}</span>
                     </div>
                 )}
             </div>
-        )
-    }
+        );
+    };
 
-    return <>
-        <header className={`app-container flex flex-col pt-4 space-y-4 ${isMinimalUI || !!prebuildId ? 'pb-4' : ''}`} data-analytics='{"button_type":"menu"}'>
-            <div className="flex h-10">
-                <div className="flex justify-between items-center pr-3">
-                    <Link to="/">
-                        <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
-                    </Link>
-                    {!isMinimalUI && <div className="ml-2 text-base">
-                        {renderTeamMenu()}
-                    </div>}
-                </div>
-                <div className="flex flex-1 items-center w-auto" id="menu">
-                    <nav className="flex-1">
-                        <ul className="flex flex-1 items-center justify-between text-base text-gray-700 space-x-2">
-                            <li className="flex-1"></li>
-                            {!isMinimalUI && rightMenu.map(entry => <li key={entry.title}>
-                                <PillMenuItem name={entry.title} selected={isSelected(entry, location)} link={entry.link}/>
-                            </li>)}
-                        </ul>
-                    </nav>
-                    <div className="ml-3 flex items-center justify-start mb-0 pointer-cursor m-l-auto rounded-full border-2 border-transparent hover:border-gray-200 dark:hover:border-gray-700 p-0.5 font-medium" data-analytics='{"label":"Account"}'>
-                        <ContextMenu menuEntries={[
-                            {
-                                title: (user && User.getPrimaryEmail(user)) || '',
-                                customFontStyle: 'text-gray-400',
-                                separator: true
-                            },
-                            {
-                                title: 'Settings',
-                                link: '/settings',
-                                separator: true
-                            },
-                            {
-                                title: 'Logout',
-                                href: gitpodHostUrl.asApiLogout().toString()
-                            },
-                        ]}>
-                            <img className="rounded-full w-6 h-6" src={user?.avatarUrl || ''} alt={user?.name || 'Anonymous'} />
-                        </ContextMenu>
+    return (
+        <>
+            <header
+                className={`app-container flex flex-col pt-4 space-y-4 ${isMinimalUI || !!prebuildId ? "pb-4" : ""}`}
+                data-analytics='{"button_type":"menu"}'
+            >
+                <div className="flex h-10">
+                    <div className="flex justify-between items-center pr-3">
+                        <Link to="/">
+                            <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
+                        </Link>
+                        {!isMinimalUI && <div className="ml-2 text-base">{renderTeamMenu()}</div>}
+                    </div>
+                    <div className="flex flex-1 items-center w-auto" id="menu">
+                        <nav className="flex-1">
+                            <ul className="flex flex-1 items-center justify-between text-base text-gray-700 space-x-2">
+                                <li className="flex-1"></li>
+                                {!isMinimalUI &&
+                                    rightMenu.map((entry) => (
+                                        <li key={entry.title}>
+                                            <PillMenuItem
+                                                name={entry.title}
+                                                selected={isSelected(entry, location)}
+                                                link={entry.link}
+                                            />
+                                        </li>
+                                    ))}
+                            </ul>
+                        </nav>
+                        <div
+                            className="ml-3 flex items-center justify-start mb-0 pointer-cursor m-l-auto rounded-full border-2 border-transparent hover:border-gray-200 dark:hover:border-gray-700 p-0.5 font-medium"
+                            data-analytics='{"label":"Account"}'
+                        >
+                            <ContextMenu
+                                menuEntries={[
+                                    {
+                                        title: (user && User.getPrimaryEmail(user)) || "",
+                                        customFontStyle: "text-gray-400",
+                                        separator: true,
+                                    },
+                                    {
+                                        title: "Settings",
+                                        link: "/settings",
+                                        separator: true,
+                                    },
+                                    {
+                                        title: "Logout",
+                                        href: gitpodHostUrl.asApiLogout().toString(),
+                                    },
+                                ]}
+                            >
+                                <img
+                                    className="rounded-full w-6 h-6"
+                                    src={user?.avatarUrl || ""}
+                                    alt={user?.name || "Anonymous"}
+                                />
+                            </ContextMenu>
+                        </div>
                     </div>
                 </div>
-            </div>
-            {!isMinimalUI && !prebuildId && <nav className="flex">
-                {leftMenu.map((entry: Entry) => <TabMenuItem key={entry.title} name={entry.title} selected={isSelected(entry, location)} link={entry.link}/>)}
-            </nav>}
-        </header>
-        <Separator />
-    </>;
+                {!isMinimalUI && !prebuildId && (
+                    <nav className="flex">
+                        {leftMenu.map((entry: Entry) => (
+                            <TabMenuItem
+                                key={entry.title}
+                                name={entry.title}
+                                selected={isSelected(entry, location)}
+                                link={entry.link}
+                            />
+                        ))}
+                    </nav>
+                )}
+            </header>
+            <Separator />
+        </>
+    );
 }

--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -21,51 +21,56 @@ export default function ProjectsSearchPage() {
         <PageWithSubMenu subMenu={adminMenu} title="Projects" subtitle="Search and manage all projects.">
             <ProjectsSearch />
         </PageWithSubMenu>
-    )
+    );
 }
 
 export function ProjectsSearch() {
     const location = useLocation();
     const { user } = useContext(UserContext);
-    const [searchTerm, setSearchTerm] = useState('');
+    const [searchTerm, setSearchTerm] = useState("");
     const [searching, setSearching] = useState(false);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<Project>>({ total: 0, rows: [] });
     const [currentProject, setCurrentProject] = useState<Project | undefined>(undefined);
     const [currentProjectOwner, setCurrentProjectOwner] = useState<string | undefined>("");
 
     useEffect(() => {
-        const projectId = location.pathname.split('/')[3];
+        const projectId = location.pathname.split("/")[3];
         if (projectId && searchResult) {
-            let currentProject = searchResult.rows.find(project => project.id === projectId);
+            let currentProject = searchResult.rows.find((project) => project.id === projectId);
             if (currentProject) {
                 setCurrentProject(currentProject);
             } else {
-                getGitpodService().server.adminGetProjectById(projectId)
-                    .then(project => setCurrentProject(project))
-                    .catch(e => console.error(e));
+                getGitpodService()
+                    .server.adminGetProjectById(projectId)
+                    .then((project) => setCurrentProject(project))
+                    .catch((e) => console.error(e));
             }
         } else {
             setCurrentProject(undefined);
         }
-    }, [location]);
+    }, [location, searchResult]);
 
     useEffect(() => {
         (async () => {
             if (currentProject) {
                 if (currentProject.userId) {
                     const owner = await getGitpodService().server.adminGetUser(currentProject.userId);
-                    if (owner) { setCurrentProjectOwner(owner?.name) }
+                    if (owner) {
+                        setCurrentProjectOwner(owner?.name);
+                    }
                 }
                 if (currentProject.teamId) {
                     const owner = await getGitpodService().server.adminGetTeamById(currentProject.teamId);
-                    if (owner) { setCurrentProjectOwner(owner?.name) }
+                    if (owner) {
+                        setCurrentProjectOwner(owner?.name);
+                    }
                 }
             }
         })();
-    }, [currentProject])
+    }, [currentProject]);
 
-    if (!user || !user?.rolesOrPermissions?.includes('admin')) {
-        return <Redirect to="/" />
+    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
+        return <Redirect to="/" />;
     }
 
     if (currentProject) {
@@ -78,43 +83,71 @@ export function ProjectsSearch() {
             const result = await getGitpodService().server.adminGetProjectsBySearchTerm({
                 searchTerm,
                 limit: 50,
-                orderBy: 'creationTime',
+                orderBy: "creationTime",
                 offset: 0,
-                orderDir: "desc"
-            })
+                orderDir: "desc",
+            });
             setSearchResult(result);
         } finally {
             setSearching(false);
         }
-    }
+    };
 
-    return <>
-        <div className="pt-8 flex">
-            <div className="flex justify-between w-full">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg className={searching ? 'animate-spin' : ''} width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
-                        </svg>
+    return (
+        <>
+            <div className="pt-8 flex">
+                <div className="flex justify-between w-full">
+                    <div className="flex">
+                        <div className="py-4">
+                            <svg
+                                className={searching ? "animate-spin" : ""}
+                                width="16"
+                                height="16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path
+                                    fillRule="evenodd"
+                                    clipRule="evenodd"
+                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                    fill="#A8A29E"
+                                />
+                            </svg>
+                        </div>
+                        <input
+                            type="search"
+                            placeholder="Search Projects"
+                            onKeyDown={(k) => k.key === "Enter" && search()}
+                            onChange={(v) => {
+                                setSearchTerm(v.target.value.trim());
+                            }}
+                        />
                     </div>
-                    <input type="search" placeholder="Search Projects" onKeyDown={(k) => k.key === 'Enter' && search()} onChange={(v) => { setSearchTerm((v.target.value).trim()) }} />
+                    <button disabled={searching} onClick={search}>
+                        Search
+                    </button>
                 </div>
-                <button disabled={searching} onClick={search}>Search</button>
             </div>
-        </div>
-        <div className="flex flex-col space-y-2">
-            <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
-                <div className="w-4/12">Name</div>
-                <div className="w-6/12">Clone URL</div>
-                <div className="w-2/12">Created</div>
+            <div className="flex flex-col space-y-2">
+                <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
+                    <div className="w-4/12">Name</div>
+                    <div className="w-6/12">Clone URL</div>
+                    <div className="w-2/12">Created</div>
+                </div>
+                {searchResult.rows.map((project) => (
+                    <ProjectResultItem project={project} />
+                ))}
             </div>
-            {searchResult.rows.map(project => <ProjectResultItem project={project} />)}
-        </div>
-    </>
+        </>
+    );
 
     function ProjectResultItem(p: { project: Project }) {
         return (
-            <Link key={'pr-' + p.project.name} to={'/admin/projects/' + p.project.id} data-analytics='{"button_type":"sidebar_menu"}'>
+            <Link
+                key={"pr-" + p.project.name}
+                to={"/admin/projects/" + p.project.id}
+                data-analytics='{"button_type":"sidebar_menu"}'
+            >
                 <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
                     <div className="flex flex-col w-4/12 truncate">
                         <div className="font-medium text-gray-800 dark:text-gray-100 truncate">{p.project.name}</div>
@@ -123,10 +156,12 @@ export function ProjectsSearch() {
                         <div className="text-gray-500 dark:text-gray-100 truncate">{p.project.cloneUrl}</div>
                     </div>
                     <div className="flex w-2/12 self-center">
-                        <div className="text-sm w-full text-gray-400 truncate">{moment(p.project.creationTime).fromNow()}</div>
+                        <div className="text-sm w-full text-gray-400 truncate">
+                            {moment(p.project.creationTime).fromNow()}
+                        </div>
                     </div>
                 </div>
             </Link>
-        )
+        );
     }
 }

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -27,39 +27,56 @@ export default function Settings() {
         }
         (async () => {
             const data = await getGitpodService().server.adminGetTelemetryData();
-            setTelemetryData(data)
+            setTelemetryData(data);
 
             const setting = await getGitpodService().server.adminGetSettings();
-            setAdminSettings(setting)
+            setAdminSettings(setting);
         })();
-    }, []);
+    }, [setAdminSettings]);
 
-    if (!user || !user?.rolesOrPermissions?.includes('admin')) {
-        return <Redirect to="/"/>
+    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
+        return <Redirect to="/" />;
     }
 
     const actuallySetTelemetryPrefs = async (value: InstallationAdminSettings) => {
         await getGitpodService().server.adminUpdateSettings(value);
         setAdminSettings(value);
-    }
+    };
 
     return (
         <div>
-            <PageWithSubMenu subMenu={adminMenu} title="Settings" subtitle="Configure settings for your Gitpod cluster.">
+            <PageWithSubMenu
+                subMenu={adminMenu}
+                title="Settings"
+                subtitle="Configure settings for your Gitpod cluster."
+            >
                 <h3>Usage Statistics</h3>
                 <CheckBox
                     title="Enable Service Ping"
-                    desc={<span>The following usage data is sent to provide insights on how you use your Gitpod instance, so we can provide a better overall experience. <a className="gp-link" href="https://www.gitpod.io/privacy">Read our Privacy Policy</a></span>}
+                    desc={
+                        <span>
+                            The following usage data is sent to provide insights on how you use your Gitpod instance, so
+                            we can provide a better overall experience.{" "}
+                            <a className="gp-link" href="https://www.gitpod.io/privacy">
+                                Read our Privacy Policy
+                            </a>
+                        </span>
+                    }
                     checked={adminSettings?.sendTelemetry ?? false}
-                    onChange={(evt) => actuallySetTelemetryPrefs({
-                        sendTelemetry: evt.target.checked,
-                    })} />
-                <InfoBox><pre>{JSON.stringify(telemetryData, null, 2)}</pre></InfoBox>
-            </PageWithSubMenu >
-        </div >
-    )
+                    onChange={(evt) =>
+                        actuallySetTelemetryPrefs({
+                            sendTelemetry: evt.target.checked,
+                        })
+                    }
+                />
+                <InfoBox>
+                    <pre>{JSON.stringify(telemetryData, null, 2)}</pre>
+                </InfoBox>
+            </PageWithSubMenu>
+        </div>
+    );
 }
 
 function isGitpodIo() {
-    return window.location.hostname === 'gitpod.io' || window.location.hostname === 'gitpod-staging.com';
+    return window.location.hostname === "gitpod.io" || window.location.hostname === "gitpod-staging.com";
 }

--- a/components/dashboard/src/admin/TeamsSearch.tsx
+++ b/components/dashboard/src/admin/TeamsSearch.tsx
@@ -22,35 +22,36 @@ export default function TeamsSearchPage() {
         <PageWithSubMenu subMenu={adminMenu} title="Teams" subtitle="Search and manage teams.">
             <TeamsSearch />
         </PageWithSubMenu>
-    )
+    );
 }
 
 export function TeamsSearch() {
     const location = useLocation();
     const { user } = useContext(UserContext);
     const [searching, setSearching] = useState(false);
-    const [searchTerm, setSearchTerm] = useState('');
+    const [searchTerm, setSearchTerm] = useState("");
     const [currentTeam, setCurrentTeam] = useState<Team | undefined>(undefined);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<Team>>({ total: 0, rows: [] });
 
     useEffect(() => {
-        const teamId = location.pathname.split('/')[3];
+        const teamId = location.pathname.split("/")[3];
         if (teamId && searchResult) {
-            let foundTeam = searchResult.rows.find(team => team.id === teamId);
+            let foundTeam = searchResult.rows.find((team) => team.id === teamId);
             if (foundTeam) {
                 setCurrentTeam(foundTeam);
             } else {
-                getGitpodService().server.adminGetTeamById(teamId)
-                    .then(team => setCurrentTeam(team))
-                    .catch(e => console.error(e));
+                getGitpodService()
+                    .server.adminGetTeamById(teamId)
+                    .then((team) => setCurrentTeam(team))
+                    .catch((e) => console.error(e));
             }
         } else {
             setCurrentTeam(undefined);
         }
-    }, [location]);
+    }, [location, searchResult]);
 
-    if (!user || !user?.rolesOrPermissions?.includes('admin')) {
-        return <Redirect to="/"/>
+    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
+        return <Redirect to="/" />;
     }
 
     if (currentTeam) {
@@ -63,56 +64,93 @@ export function TeamsSearch() {
             const result = await getGitpodService().server.adminGetTeams({
                 searchTerm,
                 limit: 100,
-                orderBy: 'creationTime',
+                orderBy: "creationTime",
                 offset: 0,
-                orderDir: "desc"
-            })
+                orderDir: "desc",
+            });
             setSearchResult(result);
         } finally {
             setSearching(false);
         }
-    }
-    return <>
-        <div className="pt-8 flex">
-            <div className="flex justify-between w-full">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg className={searching ? 'animate-spin' : ''} width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
+    };
+    return (
+        <>
+            <div className="pt-8 flex">
+                <div className="flex justify-between w-full">
+                    <div className="flex">
+                        <div className="py-4">
+                            <svg
+                                className={searching ? "animate-spin" : ""}
+                                width="16"
+                                height="16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path
+                                    fillRule="evenodd"
+                                    clipRule="evenodd"
+                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                    fill="#A8A29E"
+                                />
+                            </svg>
+                        </div>
+                        <input
+                            type="search"
+                            placeholder="Search Teams"
+                            onKeyDown={(k) => k.key === "Enter" && search()}
+                            onChange={(v) => {
+                                setSearchTerm(v.target.value.trim());
+                            }}
+                        />
+                    </div>
+                    <button disabled={searching} onClick={search}>
+                        Search
+                    </button>
+                </div>
+            </div>
+            <div className="flex flex-col space-y-2">
+                <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
+                    <div className="w-7/12">Name</div>
+                    <div className="w-5/12 flex items-center">
+                        <span>Created</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" className="h-4 w-4" viewBox="0 0 16 16">
+                            <path
+                                fill="#A8A29E"
+                                fill-rule="evenodd"
+                                d="M13.366 8.234a.8.8 0 010 1.132l-4.8 4.8a.8.8 0 01-1.132 0l-4.8-4.8a.8.8 0 111.132-1.132L7.2 11.67V2.4a.8.8 0 111.6 0v9.269l3.434-3.435a.8.8 0 011.132 0z"
+                                clip-rule="evenodd"
+                            />
                         </svg>
                     </div>
-                    <input type="search" placeholder="Search Teams" onKeyDown={(k) => k.key === 'Enter' && search()} onChange={(v) => { setSearchTerm((v.target.value).trim()) }} />
                 </div>
-                <button disabled={searching} onClick={search}>Search</button>
+                {searchResult.rows.map((team) => (
+                    <TeamResultItem team={team} />
+                ))}
             </div>
-        </div>
-        <div className="flex flex-col space-y-2">
-            <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
-                <div className="w-7/12">Name</div>
-                <div className="w-5/12 flex items-center"><span>Created</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" className="h-4 w-4" viewBox="0 0 16 16"><path fill="#A8A29E" fill-rule="evenodd" d="M13.366 8.234a.8.8 0 010 1.132l-4.8 4.8a.8.8 0 01-1.132 0l-4.8-4.8a.8.8 0 111.132-1.132L7.2 11.67V2.4a.8.8 0 111.6 0v9.269l3.434-3.435a.8.8 0 011.132 0z" clip-rule="evenodd" /></svg>
-                </div>
+        </>
+    );
 
-
-            </div>
-            {searchResult.rows.map(team => <TeamResultItem team={team} />)}
-        </div>
-    </>
-
-function TeamResultItem(props: { team: Team }) {
-    return (
-        <Link key={'pr-' + props.team.name} to={'/admin/teams/' + props.team.id} data-analytics='{"button_type":"sidebar_menu"}'>
-            <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
-                <div className="flex flex-col w-7/12 truncate">
-                    <div className="font-medium text-gray-800 dark:text-gray-100 truncate max-w-sm">{props.team.name}
-                    {props.team.markedDeleted && <Label text='Deleted' color="red"/>}
+    function TeamResultItem(props: { team: Team }) {
+        return (
+            <Link
+                key={"pr-" + props.team.name}
+                to={"/admin/teams/" + props.team.id}
+                data-analytics='{"button_type":"sidebar_menu"}'
+            >
+                <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+                    <div className="flex flex-col w-7/12 truncate">
+                        <div className="font-medium text-gray-800 dark:text-gray-100 truncate max-w-sm">
+                            {props.team.name}
+                            {props.team.markedDeleted && <Label text="Deleted" color="red" />}
+                        </div>
+                    </div>
+                    <div className="flex w-5/12 self-center">
+                        <div className="text-sm w-full text-gray-400 truncate">
+                            {moment(props.team.creationTime).format("MMM D, YYYY")}
+                        </div>
                     </div>
                 </div>
-                <div className="flex w-5/12 self-center">
-                    <div className="text-sm w-full text-gray-400 truncate">{moment(props.team.creationTime).format('MMM D, YYYY')}</div>
-                </div>
-            </div>
-        </Link>
-    )
-}
+            </Link>
+        );
+    }
 }

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -20,32 +20,33 @@ export default function UserSearch() {
     const location = useLocation();
     const { user } = useContext(UserContext);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<User>>({ rows: [], total: 0 });
-    const [searchTerm, setSearchTerm] = useState('');
+    const [searchTerm, setSearchTerm] = useState("");
     const [searching, setSearching] = useState(false);
-    const [currentUser, setCurrentUserState] = useState<User|undefined>(undefined);
+    const [currentUser, setCurrentUserState] = useState<User | undefined>(undefined);
 
     useEffect(() => {
-        const userId = location.pathname.split('/')[3];
+        const userId = location.pathname.split("/")[3];
         if (userId) {
-            let user = searchResult.rows.find(u => u.id === userId);
+            let user = searchResult.rows.find((u) => u.id === userId);
             if (user) {
                 setCurrentUserState(user);
             } else {
-                getGitpodService().server.adminGetUser(userId).then(
-                    user => setCurrentUserState(user)
-                ).catch(e => console.error(e));
+                getGitpodService()
+                    .server.adminGetUser(userId)
+                    .then((user) => setCurrentUserState(user))
+                    .catch((e) => console.error(e));
             }
         } else {
             setCurrentUserState(undefined);
         }
-    }, [location]);
+    }, [location, searchResult.rows]);
 
-    if (!user || !user?.rolesOrPermissions?.includes('admin')) {
-        return <Redirect to="/"/>
+    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
+        return <Redirect to="/" />;
     }
 
     if (currentUser) {
-        return <UserDetail user={currentUser}/>;
+        return <UserDetail user={currentUser} />;
     }
 
     const search = async () => {
@@ -54,62 +55,94 @@ export default function UserSearch() {
             const result = await getGitpodService().server.adminGetUsers({
                 searchTerm,
                 limit: 50,
-                orderBy: 'creationDate',
+                orderBy: "creationDate",
                 offset: 0,
-                orderDir: "desc"
+                orderDir: "desc",
             });
             setSearchResult(result);
         } finally {
             setSearching(false);
         }
-    }
-    return <PageWithSubMenu subMenu={adminMenu} title="Users" subtitle="Search and manage all users.">
-        <div className="pt-8 flex">
-            <div className="flex justify-between w-full">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg className={searching ? 'animate-spin' : ''} width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
-                        </svg>
+    };
+    return (
+        <PageWithSubMenu subMenu={adminMenu} title="Users" subtitle="Search and manage all users.">
+            <div className="pt-8 flex">
+                <div className="flex justify-between w-full">
+                    <div className="flex">
+                        <div className="py-4">
+                            <svg
+                                className={searching ? "animate-spin" : ""}
+                                width="16"
+                                height="16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path
+                                    fillRule="evenodd"
+                                    clipRule="evenodd"
+                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                    fill="#A8A29E"
+                                />
+                            </svg>
+                        </div>
+                        <input
+                            type="search"
+                            placeholder="Search Users"
+                            onKeyDown={(ke) => ke.key === "Enter" && search()}
+                            onChange={(v) => {
+                                setSearchTerm(v.target.value.trim());
+                            }}
+                        />
                     </div>
-                    <input type="search" placeholder="Search Users" onKeyDown={(ke) => ke.key === 'Enter' && search() } onChange={(v) => { setSearchTerm((v.target.value).trim()) }} />
+                    <button disabled={searching} onClick={search}>
+                        Search
+                    </button>
                 </div>
-                <button disabled={searching} onClick={search}>Search</button>
             </div>
-        </div>
-        <div className="flex flex-col space-y-2">
-            <div className="px-6 py-3 flex justify-between space-x-2 text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
-                <div className="w-1/12"></div>
-                <div className="w-6/12">Name</div>
-                <div className="w-5/12">Created</div>
+            <div className="flex flex-col space-y-2">
+                <div className="px-6 py-3 flex justify-between space-x-2 text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
+                    <div className="w-1/12"></div>
+                    <div className="w-6/12">Name</div>
+                    <div className="w-5/12">Created</div>
+                </div>
+                {searchResult.rows
+                    .filter((u) => u.identities.length > 0)
+                    .map((u) => (
+                        <UserEntry user={u} />
+                    ))}
             </div>
-            {searchResult.rows.filter(u => u.identities.length > 0).map(u => <UserEntry user={u} />)}
-        </div>
-    </PageWithSubMenu>
+        </PageWithSubMenu>
+    );
 }
 
 function UserEntry(p: { user: User }) {
     if (!p) {
         return <></>;
     }
-    let email = '---';
+    let email = "---";
     try {
         email = User.getPrimaryEmail(p.user);
     } catch (e) {
         log.error(e);
     }
-    return <Link key={p.user.id} to={'/admin/users/' + p.user.id} data-analytics='{"button_type":"sidebar_menu"}'>
-        <div className="rounded-xl whitespace-nowrap flex space-x-2 py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
-            <div className="pr-3 self-center w-1/12">
-                <img className="rounded-full" src={p.user.avatarUrl} alt={p.user.fullName || p.user.name}/>
+    return (
+        <Link key={p.user.id} to={"/admin/users/" + p.user.id} data-analytics='{"button_type":"sidebar_menu"}'>
+            <div className="rounded-xl whitespace-nowrap flex space-x-2 py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+                <div className="pr-3 self-center w-1/12">
+                    <img className="rounded-full" src={p.user.avatarUrl} alt={p.user.fullName || p.user.name} />
+                </div>
+                <div className="flex flex-col w-6/12">
+                    <div className="font-medium text-gray-800 dark:text-gray-100 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                        {p.user.fullName}
+                    </div>
+                    <div className="text-sm overflow-ellipsis truncate text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">
+                        {email}
+                    </div>
+                </div>
+                <div className="flex w-5/12 self-center">
+                    <div className="text-sm w-full text-gray-400 truncate">{moment(p.user.creationDate).fromNow()}</div>
+                </div>
             </div>
-            <div className="flex flex-col w-6/12">
-                <div className="font-medium text-gray-800 dark:text-gray-100 truncate hover:text-blue-600 dark:hover:text-blue-400">{p.user.fullName}</div>
-                <div className="text-sm overflow-ellipsis truncate text-gray-400 hover:text-blue-600 dark:hover:text-blue-400">{email}</div>
-            </div>
-            <div className="flex w-5/12 self-center">
-                <div className="text-sm w-full text-gray-400 truncate">{moment(p.user.creationDate).fromNow()}</div>
-            </div>
-        </div>
-    </Link>;
+        </Link>
+    );
 }

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -4,10 +4,19 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { AdminGetListResult, AdminGetWorkspacesQuery, ContextURL, User, WorkspaceAndInstance } from "@gitpod/gitpod-protocol";
-import { matchesInstanceIdOrLegacyWorkspaceIdExactly, matchesNewWorkspaceIdExactly } from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
+import {
+    AdminGetListResult,
+    AdminGetWorkspacesQuery,
+    ContextURL,
+    User,
+    WorkspaceAndInstance,
+} from "@gitpod/gitpod-protocol";
+import {
+    matchesInstanceIdOrLegacyWorkspaceIdExactly,
+    matchesNewWorkspaceIdExactly,
+} from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
 import moment from "moment";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { Link, Redirect } from "react-router-dom";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
@@ -16,57 +25,29 @@ import { UserContext } from "../user-context";
 import { getProject, WorkspaceStatusIndicator } from "../workspaces/WorkspaceEntry";
 import { adminMenu } from "./admin-menu";
 import WorkspaceDetail from "./WorkspaceDetail";
-import info from '../images/info.svg';
+import info from "../images/info.svg";
 
 interface Props {
-    user?: User
+    user?: User;
 }
 
 export default function WorkspaceSearchPage() {
-    return <PageWithSubMenu subMenu={adminMenu} title="Workspaces" subtitle="Search and manage all workspaces.">
-        <WorkspaceSearch />
-    </PageWithSubMenu>;
+    return (
+        <PageWithSubMenu subMenu={adminMenu} title="Workspaces" subtitle="Search and manage all workspaces.">
+            <WorkspaceSearch />
+        </PageWithSubMenu>
+    );
 }
 
 export function WorkspaceSearch(props: Props) {
     const location = useLocation();
     const { user } = useContext(UserContext);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<WorkspaceAndInstance>>({ rows: [], total: 0 });
-    const [queryTerm, setQueryTerm] = useState('');
+    const [queryTerm, setQueryTerm] = useState("");
     const [searching, setSearching] = useState(false);
-    const [currentWorkspace, setCurrentWorkspaceState] = useState<WorkspaceAndInstance|undefined>(undefined);
+    const [currentWorkspace, setCurrentWorkspaceState] = useState<WorkspaceAndInstance | undefined>(undefined);
 
-    useEffect(() => {
-        const workspaceId = location.pathname.split('/')[3];
-        if (workspaceId) {
-            let user = searchResult.rows.find(ws => ws.workspaceId === workspaceId);
-            if (user) {
-                setCurrentWorkspaceState(user);
-            } else {
-                getGitpodService().server.adminGetWorkspace(workspaceId).then(
-                    ws => setCurrentWorkspaceState(ws)
-                ).catch(e => console.error(e));
-            }
-        } else {
-            setCurrentWorkspaceState(undefined);
-        }
-    }, [location]);
-
-    useEffect(() => {
-        if (props.user) {
-            search();
-        }
-    }, [props.user]);
-
-    if (!user || !user?.rolesOrPermissions?.includes('admin')) {
-        return <Redirect to="/"/>
-    }
-
-    if (currentWorkspace) {
-        return <WorkspaceDetail workspace={currentWorkspace}/>;
-    }
-
-    const search = async () => {
+    const search = useCallback(async () => {
         // Disables empty search on the workspace search page
         if (!props.user && queryTerm.length === 0) {
             return;
@@ -88,7 +69,7 @@ export function WorkspaceSearch(props: Props) {
 
             const result = await getGitpodService().server.adminGetWorkspaces({
                 limit: 100,
-                orderBy: 'instanceCreationTime',
+                orderBy: "instanceCreationTime",
                 offset: 0,
                 orderDir: "desc",
                 ...query,
@@ -97,56 +78,128 @@ export function WorkspaceSearch(props: Props) {
         } finally {
             setSearching(false);
         }
+    }, [props.user, queryTerm]);
+
+    useEffect(() => {
+        const workspaceId = location.pathname.split("/")[3];
+        if (workspaceId) {
+            let user = searchResult.rows.find((ws) => ws.workspaceId === workspaceId);
+            if (user) {
+                setCurrentWorkspaceState(user);
+            } else {
+                getGitpodService()
+                    .server.adminGetWorkspace(workspaceId)
+                    .then((ws) => setCurrentWorkspaceState(ws))
+                    .catch((e) => console.error(e));
+            }
+        } else {
+            setCurrentWorkspaceState(undefined);
+        }
+    }, [location, searchResult.rows]);
+
+    useEffect(() => {
+        if (props.user) {
+            search();
+        }
+    }, [props.user, search]);
+
+    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
+        return <Redirect to="/" />;
     }
-    return <>
-        <div className="pt-8 flex">
-            <div className="flex justify-between w-full">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg className={searching ? 'animate-spin' : ''} width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path fillRule="evenodd" clipRule="evenodd" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" fill="#A8A29E" />
-                        </svg>
+
+    if (currentWorkspace) {
+        return <WorkspaceDetail workspace={currentWorkspace} />;
+    }
+
+    return (
+        <>
+            <div className="pt-8 flex">
+                <div className="flex justify-between w-full">
+                    <div className="flex">
+                        <div className="py-4">
+                            <svg
+                                className={searching ? "animate-spin" : ""}
+                                width="16"
+                                height="16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path
+                                    fillRule="evenodd"
+                                    clipRule="evenodd"
+                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                    fill="#A8A29E"
+                                />
+                            </svg>
+                        </div>
+                        <input
+                            type="search"
+                            placeholder="Search Workspace IDs"
+                            onKeyDown={(ke) => ke.key === "Enter" && search()}
+                            onChange={(v) => {
+                                setQueryTerm(v.target.value.trim());
+                            }}
+                        />
                     </div>
-                    <input type="search" placeholder="Search Workspace IDs"
-                        onKeyDown={(ke) => ke.key === 'Enter' && search() }
-                        onChange={(v) => { setQueryTerm((v.target.value).trim()) }} />
+                    <button disabled={searching} onClick={search}>
+                        Search
+                    </button>
                 </div>
-                <button disabled={searching} onClick={search}>Search</button>
             </div>
-        </div>
-        <div className={'flex rounded-xl bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 p-2 w-2/3 mb-2'}>
-            <img className="w-4 h-4 m-1 ml-2 mr-4" alt="info" src={info} />
-            <span>Please enter complete IDs - this search does not perform partial-matching.</span>
-        </div>
-        <div className="flex flex-col space-y-2">
-            <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
-                <div className="w-8"></div>
-                <div className="w-5/12">Name</div>
-                <div className="w-5/12">Context</div>
-                <div className="w-2/12">Last Started</div>
+            <div
+                className={
+                    "flex rounded-xl bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 p-2 w-2/3 mb-2"
+                }
+            >
+                <img className="w-4 h-4 m-1 ml-2 mr-4" alt="info" src={info} />
+                <span>Please enter complete IDs - this search does not perform partial-matching.</span>
             </div>
-            {searchResult.rows.map(ws => <WorkspaceEntry ws={ws} />)}
-        </div>
-    </>
+            <div className="flex flex-col space-y-2">
+                <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
+                    <div className="w-8"></div>
+                    <div className="w-5/12">Name</div>
+                    <div className="w-5/12">Context</div>
+                    <div className="w-2/12">Last Started</div>
+                </div>
+                {searchResult.rows.map((ws) => (
+                    <WorkspaceEntry ws={ws} />
+                ))}
+            </div>
+        </>
+    );
 }
 
 function WorkspaceEntry(p: { ws: WorkspaceAndInstance }) {
-    return <Link key={'ws-' + p.ws.workspaceId} to={'/admin/workspaces/' + p.ws.workspaceId} data-analytics='{"button_type":"sidebar_menu"}'>
-        <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
-            <div className="pr-3 self-center w-8">
-                <WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(p.ws)}/>
+    return (
+        <Link
+            key={"ws-" + p.ws.workspaceId}
+            to={"/admin/workspaces/" + p.ws.workspaceId}
+            data-analytics='{"button_type":"sidebar_menu"}'
+        >
+            <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+                <div className="pr-3 self-center w-8">
+                    <WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(p.ws)} />
+                </div>
+                <div className="flex flex-col w-5/12 truncate">
+                    <div className="font-medium text-gray-800 dark:text-gray-100 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                        {p.ws.workspaceId}
+                    </div>
+                    <div className="text-sm overflow-ellipsis truncate text-gray-400">
+                        {getProject(WorkspaceAndInstance.toWorkspace(p.ws))}
+                    </div>
+                </div>
+                <div className="flex flex-col w-5/12 self-center truncate">
+                    <div className="text-gray-500 overflow-ellipsis truncate">{p.ws.description}</div>
+                    <div className="text-sm text-gray-400 overflow-ellipsis truncate">
+                        {ContextURL.getNormalizedURL(p.ws)?.toString()}
+                    </div>
+                </div>
+                <div className="flex w-2/12 self-center">
+                    <div className="text-sm w-full text-gray-400 truncate">
+                        {moment(p.ws.instanceCreationTime || p.ws.workspaceCreationTime).fromNow()}
+                    </div>
+                </div>
             </div>
-            <div className="flex flex-col w-5/12 truncate">
-                <div className="font-medium text-gray-800 dark:text-gray-100 truncate hover:text-blue-600 dark:hover:text-blue-400 truncate">{p.ws.workspaceId}</div>
-                <div className="text-sm overflow-ellipsis truncate text-gray-400 truncate">{getProject(WorkspaceAndInstance.toWorkspace(p.ws))}</div>
-            </div>
-            <div className="flex flex-col w-5/12 self-center truncate">
-                <div className="text-gray-500 overflow-ellipsis truncate">{p.ws.description}</div>
-                <div className="text-sm text-gray-400 overflow-ellipsis truncate">{ContextURL.getNormalizedURL(p.ws)?.toString()}</div>
-            </div>
-            <div className="flex w-2/12 self-center">
-                <div className="text-sm w-full text-gray-400 truncate">{moment(p.ws.instanceCreationTime || p.ws.workspaceCreationTime).fromNow()}</div>
-            </div>
-        </div>
-    </Link>;
+        </Link>
+    );
 }

--- a/components/dashboard/src/components/AlertBox.tsx
+++ b/components/dashboard/src/components/AlertBox.tsx
@@ -4,11 +4,13 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import exclamation from '../images/exclamation.svg';
+import exclamation from "../images/exclamation.svg";
 
-export default function AlertBox(p: { className?: string, children?: React.ReactNode }) {
-    return <div className={'flex rounded-xl bg-gitpod-kumquat-light text-gitpod-red p-4 ' + (p.className || '')}>
-        <img className="w-4 h-4 m-1 ml-2 mr-4" src={exclamation} />
-        <span>{p.children}</span>
-    </div>;
+export default function AlertBox(p: { className?: string; children?: React.ReactNode }) {
+    return (
+        <div className={"flex rounded-xl bg-gitpod-kumquat-light text-gitpod-red p-4 " + (p.className || "")}>
+            <img className="w-4 h-4 m-1 ml-2 mr-4" src={exclamation} alt="Heads up!" />
+            <span>{p.children}</span>
+        </div>
+    );
 }

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -10,19 +10,18 @@ import { useRef, useEffect } from "react";
 
 export default function ConfirmationModal(props: {
     title?: string;
-    areYouSureText?: string,
-    children?: Entity | React.ReactChild[] | React.ReactChild
-    buttonText?: string,
-    buttonDisabled?: boolean,
-    visible?: boolean,
-    warningText?: string,
-    onClose: () => void,
-    onConfirm: () => void,
+    areYouSureText?: string;
+    children?: Entity | React.ReactChild[] | React.ReactChild;
+    buttonText?: string;
+    buttonDisabled?: boolean;
+    visible?: boolean;
+    warningText?: string;
+    onClose: () => void;
+    onConfirm: () => void;
 }) {
-
-    const child: React.ReactChild[] = [
-        <p className="mt-3 mb-3 text-base text-gray-500">{props.areYouSureText}</p>,
-    ]
+    // TODO: preparing an array of children like this, generates the famous "every item needs a key" React error at runtime.
+    // Needs a bit of refactoring, moving all the conditions directly inside the returned Modal content.
+    const child: React.ReactChild[] = [<p className="mt-3 mb-3 text-base text-gray-500">{props.areYouSureText}</p>];
 
     if (props.warningText) {
         child.unshift(<AlertBox>{props.warningText}</AlertBox>);
@@ -34,9 +33,11 @@ export default function ConfirmationModal(props: {
             child.push(
                 <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
                     <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.name}</p>
-                    {props.children.description && <p className="text-gray-500 truncate">{props.children.description}</p>}
-                </div>
-            )
+                    {props.children.description && (
+                        <p className="text-gray-500 truncate">{props.children.description}</p>
+                    )}
+                </div>,
+            );
         } else if (Array.isArray(props.children)) {
             child.push(...props.children);
         } else {
@@ -46,16 +47,18 @@ export default function ConfirmationModal(props: {
     const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
     const buttons = [
-        <button className="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>Cancel</button>,
+        <button className="secondary" onClick={props.onClose} autoFocus ref={cancelButtonRef}>
+            Cancel
+        </button>,
         <button className="ml-2 danger" onClick={props.onConfirm} disabled={props.buttonDisabled}>
             {props.buttonText || "Yes, I'm Sure"}
         </button>,
-    ]
+    ];
 
     const buttonDisabled = useRef(props.buttonDisabled);
     useEffect(() => {
         buttonDisabled.current = props.buttonDisabled;
-    })
+    });
 
     return (
         <Modal
@@ -69,7 +72,7 @@ export default function ConfirmationModal(props: {
                     return false;
                 }
                 if (buttonDisabled.current) {
-                    return false
+                    return false;
                 }
                 props.onConfirm();
                 return true;
@@ -81,6 +84,6 @@ export default function ConfirmationModal(props: {
 }
 
 export interface Entity {
-    name: string,
-    description?: string,
+    name: string;
+    description?: string;
 }

--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -4,9 +4,9 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import React, { HTMLAttributeAnchorTarget } from 'react';
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { HTMLAttributeAnchorTarget } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 export interface ContextMenuProps {
     children?: React.ReactChild[] | React.ReactChild;
@@ -33,82 +33,127 @@ function ContextMenu(props: ContextMenuProps) {
     const [expanded, setExpanded] = useState(false);
     const toggleExpanded = () => {
         setExpanded(!expanded);
-    }
+    };
 
     const handler = (evt: KeyboardEvent) => {
-        if (evt.key === 'Escape') {
+        if (evt.key === "Escape") {
             setExpanded(false);
         }
-    }
+    };
 
     const skipClickHandlerRef = React.useRef(false);
     const setSkipClickHandler = (data: boolean) => {
         skipClickHandlerRef.current = data;
-    }
-    const clickHandler = (evt: MouseEvent) => {
-        if (skipClickHandlerRef.current) {
-            // skip only once
-            setSkipClickHandler(false);
-        } else {
-            setExpanded(false);
-        }
-    }
+    };
 
     useEffect(() => {
-        window.addEventListener('keydown', handler);
-        window.addEventListener('click', clickHandler);
+        const clickHandler = () => {
+            if (skipClickHandlerRef.current) {
+                // skip only once
+                setSkipClickHandler(false);
+            } else {
+                setExpanded(false);
+            }
+        };
+
+        window.addEventListener("keydown", handler);
+        window.addEventListener("click", clickHandler);
         // Remove event listeners on cleanup
         return () => {
-            window.removeEventListener('keydown', handler);
-            window.removeEventListener('click', clickHandler);
+            window.removeEventListener("keydown", handler);
+            window.removeEventListener("click", clickHandler);
         };
     }, []); // Empty array ensures that effect is only run on mount and unmount
 
-
-    const font = "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100"
+    const font = "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100";
 
     const menuId = String(Math.random());
 
     // Default 'children' is the three dots hamburger button.
-    const children = props.children || <svg className="w-8 h-8 p-1 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Actions</title><g fill="currentColor" transform="rotate(90 12 12)"><circle cx="1" cy="1" r="2" transform="translate(5 11)" /><circle cx="1" cy="1" r="2" transform="translate(11 11)" /><circle cx="1" cy="1" r="2" transform="translate(17 11)" /></g></svg>;
+    const children = props.children || (
+        <svg
+            className="w-8 h-8 p-1 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+        >
+            <title>Actions</title>
+            <g fill="currentColor" transform="rotate(90 12 12)">
+                <circle cx="1" cy="1" r="2" transform="translate(5 11)" />
+                <circle cx="1" cy="1" r="2" transform="translate(11 11)" />
+                <circle cx="1" cy="1" r="2" transform="translate(17 11)" />
+            </g>
+        </svg>
+    );
 
     return (
         <div className="relative cursor-pointer">
-            <div onClick={(e) => {
-                toggleExpanded();
-                // Don't use `e.stopPropagation();` because that prevents that clicks on other context menus closes this one.
-                setSkipClickHandler(true);
-            }}>
+            <div
+                onClick={(e) => {
+                    toggleExpanded();
+                    // Don't use `e.stopPropagation();` because that prevents that clicks on other context menus closes this one.
+                    setSkipClickHandler(true);
+                }}
+            >
                 {children}
             </div>
-            {expanded ?
-                <div className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${props.classes || 'w-48 right-0'}`} data-analytics='{"button_type":"context_menu"}'>
-                    {props.menuEntries.length === 0
-                        ? <p className="px-4 py-3">No actions available</p>
-                        : props.menuEntries.map((e, index) => {
+            {expanded ? (
+                <div
+                    className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${
+                        props.classes || "w-48 right-0"
+                    }`}
+                    data-analytics='{"button_type":"context_menu"}'
+                >
+                    {props.menuEntries.length === 0 ? (
+                        <p className="px-4 py-3">No actions available</p>
+                    ) : (
+                        props.menuEntries.map((e, index) => {
                             const clickable = e.href || e.onClick || e.link;
-                            const entry = <div className={`px-4 flex py-3 ${clickable ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : ''} ${e.active ? 'bg-gray-50 dark:bg-gray-800' : ''} ${index === 0 ? 'rounded-t-lg' : ''} ${index === props.menuEntries.length - 1 ? 'rounded-b-lg' : ''} text-sm leading-1 ${e.customFontStyle || font} ${e.separator ? ' border-b border-gray-200 dark:border-gray-800' : ''}`} title={e.title}>
-                                {e.customContent || <><div className="truncate w-52">{e.title}</div><div className="flex-1"></div>{e.active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}</>}
-                            </div>
+                            const entry = (
+                                <div
+                                    className={`px-4 flex py-3 ${
+                                        clickable ? "hover:bg-gray-100 dark:hover:bg-gray-700" : ""
+                                    } ${e.active ? "bg-gray-50 dark:bg-gray-800" : ""} ${
+                                        index === 0 ? "rounded-t-lg" : ""
+                                    } ${
+                                        index === props.menuEntries.length - 1 ? "rounded-b-lg" : ""
+                                    } text-sm leading-1 ${e.customFontStyle || font} ${
+                                        e.separator ? " border-b border-gray-200 dark:border-gray-800" : ""
+                                    }`}
+                                    title={e.title}
+                                >
+                                    {e.customContent || (
+                                        <>
+                                            <div className="truncate w-52">{e.title}</div>
+                                            <div className="flex-1"></div>
+                                            {e.active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}
+                                        </>
+                                    )}
+                                </div>
+                            );
                             const key = `entry-${menuId}-${index}-${e.title}`;
                             if (e.link) {
-                                return <Link key={key} to={e.link} onClick={e.onClick} target={e.target}>
-                                    {entry}
-                                </Link>;
+                                return (
+                                    <Link key={key} to={e.link} onClick={e.onClick} target={e.target}>
+                                        {entry}
+                                    </Link>
+                                );
                             } else if (e.href) {
-                                return <a key={key} href={e.href} onClick={e.onClick} target={e.target}>
-                                    {entry}
-                                </a>;
+                                return (
+                                    <a key={key} href={e.href} onClick={e.onClick} target={e.target}>
+                                        {entry}
+                                    </a>
+                                );
                             } else {
-                                return <div key={key} onClick={e.onClick}>
-                                    {entry}
-                                </div>
+                                return (
+                                    <div key={key} onClick={e.onClick}>
+                                        {entry}
+                                    </div>
+                                );
                             }
-                        })}
+                        })
+                    )}
                 </div>
-                :
-                null
-            }
+            ) : null}
         </div>
     );
 }

--- a/components/dashboard/src/components/Header.tsx
+++ b/components/dashboard/src/components/Header.tsx
@@ -18,14 +18,16 @@ export default function Header(p: HeaderProps) {
             return;
         }
         document.title = `${p.title} — Gitpod`;
-    }, []);
-    return <div className="app-container border-gray-200 dark:border-gray-800">
-        <div className="flex pb-8 pt-6">
-            <div className="">
-                {typeof p.title === "string" ? (<h1 className="tracking-tight">{p.title}</h1>) : p.title}
-                {typeof p.subtitle === "string" ? (<h2 className="tracking-wide">{p.subtitle}</h2>) : p.subtitle}
+    }, [p.title]);
+    return (
+        <div className="app-container border-gray-200 dark:border-gray-800">
+            <div className="flex pb-8 pt-6">
+                <div className="">
+                    {typeof p.title === "string" ? <h1 className="tracking-tight">{p.title}</h1> : p.title}
+                    {typeof p.subtitle === "string" ? <h2 className="tracking-wide">{p.subtitle}</h2> : p.subtitle}
+                </div>
             </div>
+            <Separator />
         </div>
-        <Separator />
-    </div>;
+    );
 }

--- a/components/dashboard/src/components/InfoBox.tsx
+++ b/components/dashboard/src/components/InfoBox.tsx
@@ -4,11 +4,18 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import info from '../images/info.svg';
+import info from "../images/info.svg";
 
-export default function InfoBox(p: { className?: string, children?: React.ReactNode }) {
-    return <div className={'flex rounded-xl bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 p-4 ' + (p.className || '')}>
-        <img className="w-4 h-4 m-1 ml-2 mr-4" src={info} />
-        <span>{p.children}</span>
-    </div>;
+export default function InfoBox(p: { className?: string; children?: React.ReactNode }) {
+    return (
+        <div
+            className={
+                "flex rounded-xl bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 p-4 " +
+                (p.className || "")
+            }
+        >
+            <img className="w-4 h-4 m-1 ml-2 mr-4" src={info} alt="" />
+            <span>{p.children}</span>
+        </div>
+    );
 }

--- a/components/dashboard/src/components/MonacoEditor.tsx
+++ b/components/dashboard/src/components/MonacoEditor.tsx
@@ -8,92 +8,92 @@ import { useContext, useEffect, useRef } from "react";
 import * as monaco from "monaco-editor";
 import { ThemeContext } from "../theme-context";
 
-monaco.editor.defineTheme('gitpod', {
-  base: 'vs',
-  inherit: true,
-  rules: [],
-  colors: {},
+monaco.editor.defineTheme("gitpod", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {},
 });
-monaco.editor.defineTheme('gitpod-disabled', {
-  base: 'vs',
-  inherit: true,
-  rules: [],
-  colors: {
-    'editor.background': '#F5F5F4', // Tailwind's warmGray 100 https://tailwindcss.com/docs/customizing-colors
-  },
+monaco.editor.defineTheme("gitpod-disabled", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {
+        "editor.background": "#F5F5F4", // Tailwind's warmGray 100 https://tailwindcss.com/docs/customizing-colors
+    },
 });
-monaco.editor.defineTheme('gitpod-dark', {
-  base: 'vs-dark',
-  inherit: true,
-  rules: [],
-  colors: {
-    'editor.background': '#292524', // Tailwind's warmGray 800 https://tailwindcss.com/docs/customizing-colors
-  },
+monaco.editor.defineTheme("gitpod-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+        "editor.background": "#292524", // Tailwind's warmGray 800 https://tailwindcss.com/docs/customizing-colors
+    },
 });
-monaco.editor.defineTheme('gitpod-dark-disabled', {
-  base: 'vs-dark',
-  inherit: true,
-  rules: [],
-  colors: {
-    'editor.background': '#44403C', // Tailwind's warmGray 700 https://tailwindcss.com/docs/customizing-colors
-  },
+monaco.editor.defineTheme("gitpod-dark-disabled", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+        "editor.background": "#44403C", // Tailwind's warmGray 700 https://tailwindcss.com/docs/customizing-colors
+    },
 });
 
 export interface MonacoEditorProps {
-  classes: string;
-  disabled?: boolean;
-  language: string;
-  value: string;
-  onChange: (value: string) => void;
+    classes: string;
+    disabled?: boolean;
+    language: string;
+    value: string;
+    onChange: (value: string) => void;
 }
 
 export default function MonacoEditor(props: MonacoEditorProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
-  const { isDark } = useContext(ThemeContext);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
+    const { isDark } = useContext(ThemeContext);
 
-  useEffect(() => {
-    if (containerRef.current) {
-      editorRef.current = monaco.editor.create(containerRef.current, {
-        value: props.value,
-        language: props.language,
-        minimap: {
-          enabled: false,
-        },
-        renderLineHighlight: 'none',
-        lineNumbers: 'off',
-        glyphMargin: false,
-        folding: false,
-      });
-      editorRef.current.onDidChangeModelContent(() => {
-        props.onChange(editorRef.current!.getValue());
-      });
-      // 8px top margin: https://github.com/Microsoft/monaco-editor/issues/1333
-      editorRef.current.changeViewZones(accessor => {
-        accessor.addZone({
-          afterLineNumber: 0,
-          heightInPx: 8,
-          domNode: document.createElement('div'),
-        });
-      });
-    }
-    return () => editorRef.current?.dispose();
-  }, []);
+    useEffect(() => {
+        if (containerRef.current) {
+            editorRef.current = monaco.editor.create(containerRef.current, {
+                value: props.value,
+                language: props.language,
+                minimap: {
+                    enabled: false,
+                },
+                renderLineHighlight: "none",
+                lineNumbers: "off",
+                glyphMargin: false,
+                folding: false,
+            });
+            editorRef.current.onDidChangeModelContent(() => {
+                props.onChange(editorRef.current!.getValue());
+            });
+            // 8px top margin: https://github.com/Microsoft/monaco-editor/issues/1333
+            editorRef.current.changeViewZones((accessor) => {
+                accessor.addZone({
+                    afterLineNumber: 0,
+                    heightInPx: 8,
+                    domNode: document.createElement("div"),
+                });
+            });
+        }
+        return () => editorRef.current?.dispose();
+    }, [props]);
 
-  useEffect(() => {
-    if (editorRef.current && editorRef.current.getValue() !== props.value) {
-      editorRef.current.setValue(props.value);
-    }
-  }, [ props.value ]);
+    useEffect(() => {
+        if (editorRef.current && editorRef.current.getValue() !== props.value) {
+            editorRef.current.setValue(props.value);
+        }
+    }, [props.value]);
 
-  useEffect(() => {
-    monaco.editor.setTheme(props.disabled
-      ? (isDark ? 'gitpod-dark-disabled' : 'gitpod-disabled')
-      : (isDark ? 'gitpod-dark' : 'gitpod'));
-    if (editorRef.current) {
-      editorRef.current.updateOptions({ readOnly: props.disabled });
-    }
-  }, [ props.disabled, isDark ]);
+    useEffect(() => {
+        monaco.editor.setTheme(
+            props.disabled ? (isDark ? "gitpod-dark-disabled" : "gitpod-disabled") : isDark ? "gitpod-dark" : "gitpod",
+        );
+        if (editorRef.current) {
+            editorRef.current.updateOptions({ readOnly: props.disabled });
+        }
+    }, [props.disabled, isDark]);
 
-  return <div className={props.classes} ref={containerRef} />;
+    return <div className={props.classes} ref={containerRef} />;
 }

--- a/components/dashboard/src/components/PendingChangesDropdown.tsx
+++ b/components/dashboard/src/components/PendingChangesDropdown.tsx
@@ -9,35 +9,45 @@ import ContextMenu, { ContextMenuEntry } from "./ContextMenu";
 import CaretDown from "../icons/CaretDown.svg";
 
 export default function PendingChangesDropdown(props: { workspaceInstance?: WorkspaceInstance }) {
-  const repo = props.workspaceInstance?.status?.repo;
-  const headingStyle = 'text-gray-500 dark:text-gray-400 text-left';
-  const itemStyle = 'text-gray-400 dark:text-gray-500 text-left -mt-5';
-  const menuEntries: ContextMenuEntry[] = [];
-  let totalChanges = 0;
-  if (repo) {
-    if ((repo.totalUntrackedFiles || 0) > 0) {
-      totalChanges += repo.totalUntrackedFiles || 0;
-      menuEntries.push({ title: 'Untracked Files', customFontStyle: headingStyle });
-      (repo.untrackedFiles || []).forEach(item => menuEntries.push({ title: item, customFontStyle: itemStyle }));
+    const repo = props.workspaceInstance?.status?.repo;
+    const headingStyle = "text-gray-500 dark:text-gray-400 text-left";
+    const itemStyle = "text-gray-400 dark:text-gray-500 text-left -mt-5";
+    const menuEntries: ContextMenuEntry[] = [];
+    let totalChanges = 0;
+    if (repo) {
+        if ((repo.totalUntrackedFiles || 0) > 0) {
+            totalChanges += repo.totalUntrackedFiles || 0;
+            menuEntries.push({ title: "Untracked Files", customFontStyle: headingStyle });
+            (repo.untrackedFiles || []).forEach((item) =>
+                menuEntries.push({ title: item, customFontStyle: itemStyle }),
+            );
+        }
+        if ((repo.totalUncommitedFiles || 0) > 0) {
+            totalChanges += repo.totalUncommitedFiles || 0;
+            menuEntries.push({ title: "Uncommitted Files", customFontStyle: headingStyle });
+            (repo.uncommitedFiles || []).forEach((item) =>
+                menuEntries.push({ title: item, customFontStyle: itemStyle }),
+            );
+        }
+        if ((repo.totalUnpushedCommits || 0) > 0) {
+            totalChanges += repo.totalUnpushedCommits || 0;
+            menuEntries.push({ title: "Unpushed Commits", customFontStyle: headingStyle });
+            (repo.unpushedCommits || []).forEach((item) =>
+                menuEntries.push({ title: item, customFontStyle: itemStyle }),
+            );
+        }
     }
-    if ((repo.totalUncommitedFiles || 0) > 0) {
-      totalChanges += repo.totalUncommitedFiles || 0;
-      menuEntries.push({ title: 'Uncommitted Files', customFontStyle: headingStyle });
-      (repo.uncommitedFiles || []).forEach(item => menuEntries.push({ title: item, customFontStyle: itemStyle }));
+    if (totalChanges <= 0) {
+        return <div className="text-sm text-gray-400 dark:text-gray-500">No Changes</div>;
     }
-    if ((repo.totalUnpushedCommits || 0) > 0) {
-      totalChanges += repo.totalUnpushedCommits || 0;
-      menuEntries.push({ title: 'Unpushed Commits', customFontStyle: headingStyle });
-      (repo.unpushedCommits || []).forEach(item => menuEntries.push({ title: item, customFontStyle: itemStyle }));
-    }
-  }
-  if (totalChanges <= 0) {
-    return <div className="text-sm text-gray-400 dark:text-gray-500">No Changes</div>;
-  }
-  return <ContextMenu menuEntries={menuEntries} classes="w-64 max-h-48 overflow-scroll mx-auto left-0 right-0">
-    <p className="flex justify-center text-gitpod-red">
-      <span>{totalChanges} Change{totalChanges === 1 ? '' : 's'}</span>
-      <img className="m-2" src={CaretDown}/>
-    </p>
-  </ContextMenu>;
+    return (
+        <ContextMenu menuEntries={menuEntries} classes="w-64 max-h-48 overflow-scroll mx-auto left-0 right-0">
+            <p className="flex justify-center text-gitpod-red">
+                <span>
+                    {totalChanges} Change{totalChanges === 1 ? "" : "s"}
+                </span>
+                <img className="m-2" src={CaretDown} alt="" />
+            </p>
+        </ContextMenu>
+    );
 }

--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -6,235 +6,258 @@
 
 import EventEmitter from "events";
 import React, { Suspense, useEffect, useState } from "react";
-import { Workspace, WorkspaceInstance, DisposableCollection, WorkspaceImageBuild, HEADLESS_LOG_STREAM_STATUS_CODE_REGEX } from "@gitpod/gitpod-protocol";
+import {
+    Workspace,
+    WorkspaceInstance,
+    DisposableCollection,
+    WorkspaceImageBuild,
+    HEADLESS_LOG_STREAM_STATUS_CODE_REGEX,
+} from "@gitpod/gitpod-protocol";
 import { getGitpodService } from "../service/service";
 
-const WorkspaceLogs = React.lazy(() => import('./WorkspaceLogs'));
+const WorkspaceLogs = React.lazy(() => import("./WorkspaceLogs"));
 
 export interface PrebuildLogsProps {
-  workspaceId?: string;
-  onInstanceUpdate?: (instance: WorkspaceInstance) => void;
+    workspaceId?: string;
+    onInstanceUpdate?: (instance: WorkspaceInstance) => void;
 }
 
 export default function PrebuildLogs(props: PrebuildLogsProps) {
-  const [ workspace, setWorkspace ] = useState<Workspace | undefined>();
-  const [ workspaceInstance, setWorkspaceInstance ] = useState<WorkspaceInstance | undefined>();
-  const [ error, setError ] = useState<Error | undefined>();
-  const [ logsEmitter ] = useState(new EventEmitter());
+    const [workspace, setWorkspace] = useState<Workspace | undefined>();
+    const [workspaceInstance, setWorkspaceInstance] = useState<WorkspaceInstance | undefined>();
+    const [error, setError] = useState<Error | undefined>();
+    const [logsEmitter] = useState(new EventEmitter());
 
-  useEffect(() => {
-    const disposables = new DisposableCollection();
-    setWorkspaceInstance(undefined);
-    (async () => {
-      if (!props.workspaceId) {
-        return;
-      }
-      try {
-        const info = await getGitpodService().server.getWorkspace(props.workspaceId);
-        if (info.latestInstance) {
-          setWorkspace(info.workspace);
-          setWorkspaceInstance(info.latestInstance);
-        }
-        disposables.push(getGitpodService().registerClient({
-          onInstanceUpdate: (instance) => {
-            if (props.workspaceId === instance.workspaceId) {
-              setWorkspaceInstance(instance);
+    useEffect(() => {
+        const disposables = new DisposableCollection();
+        setWorkspaceInstance(undefined);
+        (async () => {
+            if (!props.workspaceId) {
+                return;
             }
-          },
-          onWorkspaceImageBuildLogs: (info: WorkspaceImageBuild.StateInfo, content?: WorkspaceImageBuild.LogContent) => {
-            if (!content) {
-              return;
+            try {
+                const info = await getGitpodService().server.getWorkspace(props.workspaceId);
+                if (info.latestInstance) {
+                    setWorkspace(info.workspace);
+                    setWorkspaceInstance(info.latestInstance);
+                }
+                disposables.push(
+                    getGitpodService().registerClient({
+                        onInstanceUpdate: (instance) => {
+                            if (props.workspaceId === instance.workspaceId) {
+                                setWorkspaceInstance(instance);
+                            }
+                        },
+                        onWorkspaceImageBuildLogs: (
+                            info: WorkspaceImageBuild.StateInfo,
+                            content?: WorkspaceImageBuild.LogContent,
+                        ) => {
+                            if (!content) {
+                                return;
+                            }
+                            logsEmitter.emit("logs", content.text);
+                        },
+                    }),
+                );
+                if (info.latestInstance) {
+                    disposables.push(
+                        watchHeadlessLogs(
+                            info.latestInstance.id,
+                            (chunk) => {
+                                logsEmitter.emit("logs", chunk);
+                            },
+                            async () => workspaceInstance?.status.phase === "stopped",
+                        ),
+                    );
+                }
+            } catch (err) {
+                console.error(err);
+                setError(err);
             }
-            logsEmitter.emit('logs', content.text);
-          },
-        }));
-        if (info.latestInstance) {
-          disposables.push(watchHeadlessLogs(info.latestInstance.id, chunk => {
-            logsEmitter.emit('logs', chunk);
-          }, async () => workspaceInstance?.status.phase === 'stopped'));
+        })();
+        return function cleanUp() {
+            disposables.dispose();
+        };
+    }, [logsEmitter, props.workspaceId, workspaceInstance?.status.phase]);
+
+    useEffect(() => {
+        if (props.onInstanceUpdate && workspaceInstance) {
+            props.onInstanceUpdate(workspaceInstance);
         }
-      } catch (err) {
-        console.error(err);
-        setError(err);
-      }
-    })();
-    return function cleanUp() {
-      disposables.dispose();
-    }
-  }, [ props.workspaceId ]);
+        switch (workspaceInstance?.status.phase) {
+            // unknown indicates an issue within the system in that it cannot determine the actual phase of
+            // a workspace. This phase is usually accompanied by an error.
+            case "unknown":
+                break;
 
-  useEffect(() => {
-    if (props.onInstanceUpdate && workspaceInstance) {
-      props.onInstanceUpdate(workspaceInstance);
-    }
-    switch (workspaceInstance?.status.phase) {
-      // unknown indicates an issue within the system in that it cannot determine the actual phase of
-      // a workspace. This phase is usually accompanied by an error.
-      case "unknown":
-        break;
+            // Preparing means that we haven't actually started the workspace instance just yet, but rather
+            // are still preparing for launch. This means we're building the Docker image for the workspace.
+            case "preparing":
+                getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
+                break;
 
-      // Preparing means that we haven't actually started the workspace instance just yet, but rather
-      // are still preparing for launch. This means we're building the Docker image for the workspace.
-      case "preparing":
-        getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
-        break;
+            // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
+            // some space within the cluster. If for example the cluster needs to scale up to accomodate the
+            // workspace, the workspace will be in Pending state until that happened.
+            case "pending":
+                break;
 
-      // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
-      // some space within the cluster. If for example the cluster needs to scale up to accomodate the
-      // workspace, the workspace will be in Pending state until that happened.
-      case "pending":
-        break;
+            // Creating means the workspace is currently being created. That includes downloading the images required
+            // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
+            // network speed, image size and cache states.
+            case "creating":
+                break;
 
-      // Creating means the workspace is currently being created. That includes downloading the images required
-      // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
-      // network speed, image size and cache states.
-      case "creating":
-        break;
+            // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
+            // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
+            case "initializing":
+                break;
 
-      // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
-      // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
-      case "initializing":
-        break;
+            // Running means the workspace is able to actively perform work, either by serving a user through Theia,
+            // or as a headless workspace.
+            case "running":
+                break;
 
-      // Running means the workspace is able to actively perform work, either by serving a user through Theia,
-      // or as a headless workspace.
-      case "running":
-        break;
+            // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
+            // When in this state, we expect it to become running or stopping anytime soon.
+            case "interrupted":
+                break;
 
-      // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
-      // When in this state, we expect it to become running or stopping anytime soon.
-      case "interrupted":
-        break;
+            // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
+            case "stopping":
+                break;
 
-      // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
-      case "stopping":
-        break;
+            // Stopped means the workspace ended regularly because it was shut down.
+            case "stopped":
+                getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
+                break;
+        }
+        if (workspaceInstance?.status.conditions.headlessTaskFailed) {
+            setError(new Error(workspaceInstance.status.conditions.headlessTaskFailed));
+        }
+        if (workspaceInstance?.status.conditions.failed) {
+            setError(new Error(workspaceInstance.status.conditions.failed));
+        }
+    }, [props, props.workspaceId, workspace, workspaceInstance, workspaceInstance?.status.phase]);
 
-      // Stopped means the workspace ended regularly because it was shut down.
-      case "stopped":
-        getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
-        break;
-    }
-    if (workspaceInstance?.status.conditions.headlessTaskFailed) {
-      setError(new Error(workspaceInstance.status.conditions.headlessTaskFailed));
-    }
-    if (workspaceInstance?.status.conditions.failed) {
-      setError(new Error(workspaceInstance.status.conditions.failed));
-    }
-  }, [ props.workspaceId, workspaceInstance?.status.phase ]);
-
-  return <Suspense fallback={<div />}>
-    <WorkspaceLogs classes="h-full w-full" logsEmitter={logsEmitter} errorMessage={error?.message} />
-  </Suspense>;
+    return (
+        <Suspense fallback={<div />}>
+            <WorkspaceLogs classes="h-full w-full" logsEmitter={logsEmitter} errorMessage={error?.message} />
+        </Suspense>
+    );
 }
 
-export function watchHeadlessLogs(instanceId: string, onLog: (chunk: string) => void, checkIsDone: () => Promise<boolean>): DisposableCollection {
-  const disposables = new DisposableCollection();
+export function watchHeadlessLogs(
+    instanceId: string,
+    onLog: (chunk: string) => void,
+    checkIsDone: () => Promise<boolean>,
+): DisposableCollection {
+    const disposables = new DisposableCollection();
 
-  const startWatchingLogs = async () => {
-    if (await checkIsDone()) {
-      return;
-    }
-
-    const initialDelaySeconds = 1;
-    let delayInSeconds = initialDelaySeconds;
-    const retryBackoff = async (reason: string, err?: Error) => {
-      const backoffFactor = 1.2;
-      const maxBackoffSeconds = 5;
-      delayInSeconds = Math.min(delayInSeconds * backoffFactor, maxBackoffSeconds);
-
-      console.debug("re-trying headless-logs because: " + reason, err);
-      await new Promise((resolve) => {
-        setTimeout(resolve, delayInSeconds * 1000);
-      });
-      startWatchingLogs().catch(console.error);
-    };
-
-    let response: Response | undefined = undefined;
-    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined = undefined;
-    try {
-      const logSources = await getGitpodService().server.getHeadlessLog(instanceId);
-      // TODO(gpl) Only listening on first stream for now
-      const streamIds = Object.keys(logSources.streams);
-      if (streamIds.length < 1) {
-        await retryBackoff("no streams");
-        return;
-      }
-
-      const streamUrl = logSources.streams[streamIds[0]];
-      console.log("fetching from streamUrl: " + streamUrl);
-      response = await fetch(streamUrl, {
-        method: 'GET',
-        cache: 'no-cache',
-        credentials: 'include',
-        keepalive: true,
-        headers: {
-          'TE': 'trailers', // necessary to receive stream status code
-        },
-      });
-      reader = response.body?.getReader();
-      if (!reader) {
-        await retryBackoff("no reader");
-        return;
-      }
-      disposables.push({ dispose: () => reader?.cancel() });
-
-      const decoder = new TextDecoder('utf-8');
-      let chunk = await reader.read();
-      while (!chunk.done) {
-        const msg = decoder.decode(chunk.value, { stream: true });
-
-        // In an ideal world, we'd use res.addTrailers()/response.trailer here. But despite being introduced with HTTP/1.1 in 1999, trailers are not supported by popular proxies (nginx, for example).
-        // So we resort to this hand-written solution:
-        const matches = msg.match(HEADLESS_LOG_STREAM_STATUS_CODE_REGEX);
-        if (matches) {
-          if (matches.length < 2) {
-            console.debug("error parsing log stream status code. msg: " + msg);
-          } else {
-            const code = parseStatusCode(matches[1]);
-            if (code !== 200) {
-              throw new StreamError(code);
-            }
-          }
-        } else {
-          onLog(msg);
+    const startWatchingLogs = async () => {
+        if (await checkIsDone()) {
+            return;
         }
 
-        chunk = await reader.read();
-      }
-      reader.cancel()
+        const initialDelaySeconds = 1;
+        let delayInSeconds = initialDelaySeconds;
+        const retryBackoff = async (reason: string, err?: Error) => {
+            const backoffFactor = 1.2;
+            const maxBackoffSeconds = 5;
+            delayInSeconds = Math.min(delayInSeconds * backoffFactor, maxBackoffSeconds);
 
-      if (await checkIsDone()) {
-        return;
-      }
-    } catch(err) {
-      reader?.cancel().catch(console.debug);
-      if (err.code === 400) {
-        // sth is really off, and we _should not_ retry
-        console.error("stopped watching headless logs", err);
-        return;
-      }
-      await retryBackoff("error while listening to stream", err);
-    }
-  };
-  startWatchingLogs().catch(console.error);
+            console.debug("re-trying headless-logs because: " + reason, err);
+            await new Promise((resolve) => {
+                setTimeout(resolve, delayInSeconds * 1000);
+            });
+            startWatchingLogs().catch(console.error);
+        };
 
-  return disposables;
+        let response: Response | undefined = undefined;
+        let reader: ReadableStreamDefaultReader<Uint8Array> | undefined = undefined;
+        try {
+            const logSources = await getGitpodService().server.getHeadlessLog(instanceId);
+            // TODO(gpl) Only listening on first stream for now
+            const streamIds = Object.keys(logSources.streams);
+            if (streamIds.length < 1) {
+                await retryBackoff("no streams");
+                return;
+            }
+
+            const streamUrl = logSources.streams[streamIds[0]];
+            console.log("fetching from streamUrl: " + streamUrl);
+            response = await fetch(streamUrl, {
+                method: "GET",
+                cache: "no-cache",
+                credentials: "include",
+                keepalive: true,
+                headers: {
+                    TE: "trailers", // necessary to receive stream status code
+                },
+            });
+            reader = response.body?.getReader();
+            if (!reader) {
+                await retryBackoff("no reader");
+                return;
+            }
+            disposables.push({ dispose: () => reader?.cancel() });
+
+            const decoder = new TextDecoder("utf-8");
+            let chunk = await reader.read();
+            while (!chunk.done) {
+                const msg = decoder.decode(chunk.value, { stream: true });
+
+                // In an ideal world, we'd use res.addTrailers()/response.trailer here. But despite being introduced with HTTP/1.1 in 1999, trailers are not supported by popular proxies (nginx, for example).
+                // So we resort to this hand-written solution:
+                const matches = msg.match(HEADLESS_LOG_STREAM_STATUS_CODE_REGEX);
+                if (matches) {
+                    if (matches.length < 2) {
+                        console.debug("error parsing log stream status code. msg: " + msg);
+                    } else {
+                        const code = parseStatusCode(matches[1]);
+                        if (code !== 200) {
+                            throw new StreamError(code);
+                        }
+                    }
+                } else {
+                    onLog(msg);
+                }
+
+                chunk = await reader.read();
+            }
+            reader.cancel();
+
+            if (await checkIsDone()) {
+                return;
+            }
+        } catch (err) {
+            reader?.cancel().catch(console.debug);
+            if (err.code === 400) {
+                // sth is really off, and we _should not_ retry
+                console.error("stopped watching headless logs", err);
+                return;
+            }
+            await retryBackoff("error while listening to stream", err);
+        }
+    };
+    startWatchingLogs().catch(console.error);
+
+    return disposables;
 }
 
 class StreamError extends Error {
-  constructor(readonly code?: number) {
-    super(`stream status code: ${code}`)
-  }
+    constructor(readonly code?: number) {
+        super(`stream status code: ${code}`);
+    }
 }
 
 function parseStatusCode(code: string | undefined): number | undefined {
-  try {
-    if (!code) {
-      return undefined;
+    try {
+        if (!code) {
+            return undefined;
+        }
+        return Number.parseInt(code);
+    } catch (err) {
+        return undefined;
     }
-    return Number.parseInt(code);
-  } catch(err) {
-    return undefined;
-  }
 }

--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -5,41 +5,44 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 
 type SearchResult = string;
 type SearchData = SearchResult[];
 
-const LOCAL_STORAGE_KEY = 'open-in-gitpod-search-data';
+const LOCAL_STORAGE_KEY = "open-in-gitpod-search-data";
 const MAX_DISPLAYED_ITEMS = 20;
 
 export default function RepositoryFinder(props: { initialQuery?: string }) {
     const { user } = useContext(UserContext);
-    const [searchQuery, setSearchQuery] = useState<string>(props.initialQuery || '');
+    const [searchQuery, setSearchQuery] = useState<string>(props.initialQuery || "");
     const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
     const [selectedSearchResult, setSelectedSearchResult] = useState<SearchResult | undefined>();
 
-    const onResults = (results: SearchResult[]) => {
-        if (JSON.stringify(results) !== JSON.stringify(searchResults)) {
-            setSearchResults(results);
-            setSelectedSearchResult(results[0]);
-        }
-    }
+    const search = useCallback(
+        async (query: string) => {
+            const onResults = (results: SearchResult[]) => {
+                if (JSON.stringify(results) !== JSON.stringify(searchResults)) {
+                    setSearchResults(results);
+                    setSelectedSearchResult(results[0]);
+                }
+            };
 
-    const search = async (query: string) => {
-        setSearchQuery(query);
-        await findResults(query, onResults);
-        if (await refreshSearchData(query, user)) {
-            // Re-run search if the underlying search data has changed
+            setSearchQuery(query);
             await findResults(query, onResults);
-        }
-    }
+            if (await refreshSearchData(query, user)) {
+                // Re-run search if the underlying search data has changed
+                await findResults(query, onResults);
+            }
+        },
+        [searchResults, user],
+    );
 
     useEffect(() => {
-        search('');
-    }, []);
+        search("");
+    }, [search]);
 
     // Up/Down keyboard navigation between results
     const onKeyDown = (event: React.KeyboardEvent) => {
@@ -52,55 +55,86 @@ export default function RepositoryFinder(props: { initialQuery?: string }) {
             // Source: https://stackoverflow.com/a/4467559/3461173
             const n = Math.min(searchResults.length, MAX_DISPLAYED_ITEMS);
             setSelectedSearchResult(searchResults[((index % n) + n) % n]);
-        }
-        if (event.key === 'ArrowDown') {
+        };
+        if (event.key === "ArrowDown") {
             event.preventDefault();
             select(selectedIndex + 1);
             return;
         }
-        if (event.key === 'ArrowUp') {
+        if (event.key === "ArrowUp") {
             event.preventDefault();
             select(selectedIndex - 1);
             return;
         }
-    }
+    };
 
     useEffect(() => {
         const element = document.querySelector(`a[href='/#${selectedSearchResult}']`);
         if (element) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            element.scrollIntoView({ behavior: "smooth", block: "nearest" });
         }
     }, [selectedSearchResult]);
 
     const onSubmit = (event: React.FormEvent) => {
         event.preventDefault();
         if (selectedSearchResult) {
-            window.location.href = '/#' + selectedSearchResult;
+            window.location.href = "/#" + selectedSearchResult;
         }
-    }
+    };
 
-    return <form onSubmit={onSubmit}>
-        <div className="flex px-4 rounded-xl border border-gray-300 dark:border-gray-500">
-            <div className="py-4">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" /></svg>
+    return (
+        <form onSubmit={onSubmit}>
+            <div className="flex px-4 rounded-xl border border-gray-300 dark:border-gray-500">
+                <div className="py-4">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
+                        <path
+                            fill="#A8A29E"
+                            d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                        />
+                    </svg>
+                </div>
+                <input
+                    type="search"
+                    className="flex-grow"
+                    placeholder="Paste repository URL or type to find suggestions"
+                    autoFocus
+                    value={searchQuery}
+                    onChange={(e) => search(e.target.value)}
+                    onKeyDown={onKeyDown}
+                />
             </div>
-            <input type="search" className="flex-grow" placeholder="Paste repository URL or type to find suggestions" autoFocus value={searchQuery} onChange={e => search(e.target.value)} onKeyDown={onKeyDown} />
-        </div>
-        <div className="mt-3 -mx-5 px-5 flex flex-col space-y-2 h-64 overflow-y-auto">
-            {searchResults.slice(0, MAX_DISPLAYED_ITEMS).map((result, index) =>
-                <a className={`px-4 py-3 rounded-xl` + (result === selectedSearchResult ? ' bg-gray-600 text-gray-50 dark:bg-gray-700' : '')} href={`/#${result}`} key={`search-result-${index}`} onMouseEnter={() => setSelectedSearchResult(result)}>
-                    {searchQuery.length < 2
-                        ? <span>{result}</span>
-                        : result.split(searchQuery).map((segment, index) => <span>
-                            {index === 0 ? <></> : <strong>{searchQuery}</strong>}
-                            {segment}
-                        </span>)}
-                </a>
-            )}
-            {searchResults.length > MAX_DISPLAYED_ITEMS &&
-                <span className="mt-3 px-4 py-2 text-sm text-gray-400 dark:text-gray-500">{searchResults.length - MAX_DISPLAYED_ITEMS} more result{(searchResults.length - MAX_DISPLAYED_ITEMS) === 1 ? '' : 's'} found</span>}
-        </div>
-    </form>;
+            <div className="mt-3 -mx-5 px-5 flex flex-col space-y-2 h-64 overflow-y-auto">
+                {searchResults.slice(0, MAX_DISPLAYED_ITEMS).map((result, index) => (
+                    <a
+                        className={
+                            `px-4 py-3 rounded-xl` +
+                            (result === selectedSearchResult ? " bg-gray-600 text-gray-50 dark:bg-gray-700" : "")
+                        }
+                        href={`/#${result}`}
+                        key={`search-result-${index}`}
+                        onMouseEnter={() => setSelectedSearchResult(result)}
+                    >
+                        {searchQuery.length < 2 ? (
+                            <span>{result}</span>
+                        ) : (
+                            result.split(searchQuery).map((segment, index) => (
+                                <span>
+                                    {index === 0 ? <></> : <strong>{searchQuery}</strong>}
+                                    {segment}
+                                </span>
+                            ))
+                        )}
+                    </a>
+                ))}
+                {searchResults.length > MAX_DISPLAYED_ITEMS && (
+                    <span className="mt-3 px-4 py-2 text-sm text-gray-400 dark:text-gray-500">
+                        {searchResults.length - MAX_DISPLAYED_ITEMS} more result
+                        {searchResults.length - MAX_DISPLAYED_ITEMS === 1 ? "" : "s"} found
+                    </span>
+                )}
+            </div>
+        </form>
+    );
 }
 
 function loadSearchData(): SearchData {
@@ -112,7 +146,7 @@ function loadSearchData(): SearchData {
         const data = JSON.parse(string);
         return data;
     } catch (error) {
-        console.warn('Could not load search data from local storage', error);
+        console.warn("Could not load search data from local storage", error);
         return [];
     }
 }
@@ -121,7 +155,7 @@ function saveSearchData(searchData: SearchData): void {
     try {
         window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(searchData));
     } catch (error) {
-        console.warn('Could not save search data into local storage', error);
+        console.warn("Could not save search data into local storage", error);
     }
 }
 
@@ -139,11 +173,11 @@ export async function refreshSearchData(query: string, user: User | undefined): 
 
 // Fetch all possible search results and cache them into local storage
 async function actuallyRefreshSearchData(query: string, user: User | undefined): Promise<boolean> {
-    console.log('refreshing search data');
+    console.log("refreshing search data");
     const oldData = loadSearchData();
     const newData = await getGitpodService().server.getSuggestedContextURLs();
     if (JSON.stringify(oldData) !== JSON.stringify(newData)) {
-        console.log('new data:', newData);
+        console.log("new data:", newData);
         saveSearchData(newData);
         return true;
     }
@@ -158,8 +192,7 @@ async function findResults(query: string, onResults: (results: string[]) => void
         if (!searchData.includes(query)) {
             searchData.push(query);
         }
-    } catch {
-    }
+    } catch {}
     // console.log('searching', query, 'in', searchData);
-    onResults(searchData.filter(result => result.toLowerCase().includes(query.toLowerCase())));
+    onResults(searchData.filter((result) => result.toLowerCase().includes(query.toLowerCase())));
 }

--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -4,88 +4,94 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import EventEmitter from 'events';
-import { useContext, useEffect, useRef } from 'react';
-import { Terminal, ITerminalOptions, ITheme } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit'
-import 'xterm/css/xterm.css';
-import { ThemeContext } from '../theme-context';
+import EventEmitter from "events";
+import { useContext, useEffect, useMemo, useRef } from "react";
+import { Terminal, ITerminalOptions, ITheme } from "xterm";
+import { FitAddon } from "xterm-addon-fit";
+import "xterm/css/xterm.css";
+import { ThemeContext } from "../theme-context";
 
 const darkTheme: ITheme = {
-  background: '#292524', // Tailwind's warmGray 800 https://tailwindcss.com/docs/customizing-colors
+    background: "#292524", // Tailwind's warmGray 800 https://tailwindcss.com/docs/customizing-colors
 };
 const lightTheme: ITheme = {
-  background: '#F5F5F4', // Tailwind's warmGray 100 https://tailwindcss.com/docs/customizing-colors
-  foreground: '#78716C', // Tailwind's warmGray 500 https://tailwindcss.com/docs/customizing-colors
-  cursor: '#78716C', // Tailwind's warmGray 500 https://tailwindcss.com/docs/customizing-colors
-}
+    background: "#F5F5F4", // Tailwind's warmGray 100 https://tailwindcss.com/docs/customizing-colors
+    foreground: "#78716C", // Tailwind's warmGray 500 https://tailwindcss.com/docs/customizing-colors
+    cursor: "#78716C", // Tailwind's warmGray 500 https://tailwindcss.com/docs/customizing-colors
+};
 
 export interface WorkspaceLogsProps {
-  logsEmitter: EventEmitter;
-  errorMessage?: string;
-  classes?: string;
+    logsEmitter: EventEmitter;
+    errorMessage?: string;
+    classes?: string;
 }
 
 export default function WorkspaceLogs(props: WorkspaceLogsProps) {
-  const xTermParentRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<Terminal>();
-  const fitAddon = new FitAddon();
-  const { isDark } = useContext(ThemeContext);
+    const xTermParentRef = useRef<HTMLDivElement>(null);
+    const terminalRef = useRef<Terminal>();
+    const fitAddon = useMemo(() => new FitAddon(), []);
+    const { isDark } = useContext(ThemeContext);
 
-  useEffect(() => {
-    if (!xTermParentRef.current) {
-      return;
-    }
-    const options: ITerminalOptions = {
-      cursorBlink: false,
-      disableStdin: true,
-      fontSize: 14,
-      theme: darkTheme,
-      scrollback: 9999999,
-    };
-    const terminal = new Terminal(options);
-    terminalRef.current = terminal;
-    terminal.loadAddon(fitAddon);
-    terminal.open(xTermParentRef.current);
-    props.logsEmitter.on('logs', logs => {
-      if (terminal && logs) {
-        terminal.write(logs);
-      }
-    });
-    fitAddon.fit();
-    return function cleanUp() {
-      terminal.dispose();
-    }
-  }, []);
+    useEffect(() => {
+        if (!xTermParentRef.current) {
+            return;
+        }
+        const options: ITerminalOptions = {
+            cursorBlink: false,
+            disableStdin: true,
+            fontSize: 14,
+            theme: darkTheme,
+            scrollback: 9999999,
+        };
+        const terminal = new Terminal(options);
+        terminalRef.current = terminal;
+        terminal.loadAddon(fitAddon);
+        terminal.open(xTermParentRef.current);
+        props.logsEmitter.on("logs", (logs) => {
+            if (terminal && logs) {
+                terminal.write(logs);
+            }
+        });
+        fitAddon.fit();
+        return function cleanUp() {
+            terminal.dispose();
+        };
+    }, [fitAddon, props.logsEmitter]);
 
-  useEffect(() => {
-    // Fit terminal on window resize (debounced)
-    let timeout: NodeJS.Timeout | undefined;
-    const onWindowResize = () => {
-      clearTimeout(timeout!);
-      timeout = setTimeout(() => fitAddon.fit(), 20);
-    };
-    window.addEventListener('resize', onWindowResize);
-    return function cleanUp() {
-      clearTimeout(timeout!);
-      window.removeEventListener('resize', onWindowResize);
-    }
-  }, []);
+    useEffect(() => {
+        // Fit terminal on window resize (debounced)
+        let timeout: NodeJS.Timeout | undefined;
+        const onWindowResize = () => {
+            clearTimeout(timeout!);
+            timeout = setTimeout(() => fitAddon.fit(), 20);
+        };
+        window.addEventListener("resize", onWindowResize);
+        return function cleanUp() {
+            clearTimeout(timeout!);
+            window.removeEventListener("resize", onWindowResize);
+        };
+    }, [fitAddon]);
 
-  useEffect(() => {
-    if (terminalRef.current && props.errorMessage) {
-      terminalRef.current.write(`\r\n\u001b[38;5;196m${props.errorMessage}\u001b[0m\r\n`);
-    }
-  }, [ terminalRef.current, props.errorMessage ]);
+    useEffect(() => {
+        if (terminalRef.current && props.errorMessage) {
+            terminalRef.current.write(`\r\n\u001b[38;5;196m${props.errorMessage}\u001b[0m\r\n`);
+        }
+    }, [props.errorMessage]);
 
-  useEffect(() => {
-    if (!terminalRef.current) {
-      return;
-    }
-    terminalRef.current.setOption('theme', isDark ? darkTheme : lightTheme);
-  }, [ terminalRef.current, isDark ]);
+    useEffect(() => {
+        if (!terminalRef.current) {
+            return;
+        }
+        terminalRef.current.setOption("theme", isDark ? darkTheme : lightTheme);
+    }, [isDark]);
 
-  return <div className={`${props.classes || 'mt-6 h-72 w-11/12 lg:w-3/5 rounded-xl overflow-hidden'} bg-gray-100 dark:bg-gray-800 relative`}>
-    <div className="absolute top-0 left-0 bottom-0 right-0 m-6" ref={xTermParentRef}></div>
-  </div>;
+    return (
+        <div
+            className={`${
+                props.classes || "mt-6 h-72 w-11/12 lg:w-3/5 rounded-xl overflow-hidden"
+            } bg-gray-100 dark:bg-gray-800 relative`}
+        >
+            <div className="absolute top-0 left-0 bottom-0 right-0 m-6" ref={xTermParentRef}></div>
+        </div>
+    );
 }

--- a/components/dashboard/src/experiments.ts
+++ b/components/dashboard/src/experiments.ts
@@ -27,11 +27,18 @@ const Experiments = {
     /**
      * Experiment "example" will be activate on login for 10% of all clients.
      */
-    "example": 0.1,
+    example: 0.1,
 };
-type Experiments = Partial<{ [e in Experiment]: boolean }>;
-export type Experiment = keyof (typeof Experiments);
 
+// TODO: Both Experiment and Experiments are used for both code and typings here.
+// Not sure if it's safe to rename either, so I'm disabling linting while
+// I wait for Gero Posmyk-Leinemann to chime in.
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+type Experiments = Partial<{ [e in Experiment]: boolean }>;
+export type Experiment = keyof typeof Experiments;
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 export namespace Experiment {
     /**
      * Randomly decides what the set of Experiments is the user participates in

--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -9,7 +9,8 @@
 @tailwind utilities;
 
 @layer base {
-    html, body {
+    html,
+    body {
         @apply h-full;
     }
     body {
@@ -61,30 +62,42 @@
         @apply cursor-default opacity-50 pointer-events-none;
     }
 
-    a.gp-link {
+    button.gp-link {
+        @apply bg-transparent hover:bg-transparent p-0 rounded-none;
+    }
+
+    a.gp-link,
+    button.gp-link {
         @apply text-blue-500 hover:text-blue-600  dark:text-blue-400 dark:hover:text-blue-500;
     }
 
-    input[type=text], input[type=search], input[type=password], select {
+    input[type="text"],
+    input[type="search"],
+    input[type="password"],
+    select {
         @apply block w-56 text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 rounded-md border border-gray-300 dark:border-gray-500 focus:border-gray-400 dark:focus:border-gray-400 focus:ring-0;
     }
-    input[type=text]::placeholder, input[type=search]::placeholder, input[type=password]::placeholder {
+    input[type="text"]::placeholder,
+    input[type="search"]::placeholder,
+    input[type="password"]::placeholder {
         @apply text-gray-400 dark:text-gray-500;
     }
-    input[type=text].error, input[type=password].error, select.error {
+    input[type="text"].error,
+    input[type="password"].error,
+    select.error {
         @apply border-gitpod-red dark:border-gitpod-red focus:border-gitpod-red dark:focus:border-gitpod-red;
     }
     input[disabled] {
         @apply bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500;
     }
-    input[type=radio] {
+    input[type="radio"] {
         @apply border border-gray-300 focus:border-gray-400 focus:bg-white focus:ring-0;
     }
-    input[type=search] {
+    input[type="search"] {
         @apply border-0 dark:bg-transparent;
     }
-    input[type=checkbox] {
-        @apply disabled:opacity-50
+    input[type="checkbox"] {
+        @apply disabled:opacity-50;
     }
 
     progress {

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "../provider-utils";
 import { AuthProviderInfo, Project, ProviderRepository, Team, TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
@@ -42,49 +42,74 @@ export default function NewProject() {
 
     const [authProviders, setAuthProviders] = useState<AuthProviderInfo[]>([]);
 
+    const updateReposInAccounts = useCallback(
+        async (installationId?: string) => {
+            setLoaded(false);
+            setReposInAccounts([]);
+            if (!selectedProviderHost) {
+                return [];
+            }
+            try {
+                const repos = await getGitpodService().server.getProviderRepositoriesForUser({
+                    provider: selectedProviderHost,
+                    hints: { installationId },
+                });
+                setReposInAccounts(repos);
+                setLoaded(true);
+                return repos;
+            } catch (error) {
+                console.log(error);
+            }
+            return [];
+        },
+        [selectedProviderHost],
+    );
+
     useEffect(() => {
         if (user && selectedProviderHost === undefined) {
-            if (user.identities.find(i => i.authProviderId === "Public-GitLab")) {
+            if (user.identities.find((i) => i.authProviderId === "Public-GitLab")) {
                 setSelectedProviderHost("gitlab.com");
-            } else if (user.identities.find(i => i.authProviderId === "Public-GitHub")) {
+            } else if (user.identities.find((i) => i.authProviderId === "Public-GitHub")) {
                 setSelectedProviderHost("github.com");
-            } else if (user.identities.find(i => i.authProviderId === "Public-Bitbucket")) {
+            } else if (user.identities.find((i) => i.authProviderId === "Public-Bitbucket")) {
                 setSelectedProviderHost("bitbucket.org");
             }
             (async () => {
                 setAuthProviders(await getGitpodService().server.getAuthProviders());
             })();
         }
-    }, [user]);
+    }, [selectedProviderHost, user]);
 
     useEffect(() => {
         const params = new URLSearchParams(location.search);
         const teamParam = params.get("team");
         if (teamParam) {
-            window.history.replaceState({}, '', window.location.pathname);
-            const team = teams?.find(t => t.slug === teamParam);
+            window.history.replaceState({}, "", window.location.pathname);
+            const team = teams?.find((t) => t.slug === teamParam);
             setSelectedTeamOrUser(team);
         }
         if (params.get("user")) {
-            window.history.replaceState({}, '', window.location.pathname);
+            window.history.replaceState({}, "", window.location.pathname);
             setSelectedTeamOrUser(user);
         }
-    }, []);
+    }, [location.search, teams, user]);
 
-    const [ teamMembers, setTeamMembers ] = useState<Record<string, TeamMemberInfo[]>>({});
+    const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
     useEffect(() => {
         if (!teams) {
             return;
         }
         (async () => {
             const members: Record<string, TeamMemberInfo[]> = {};
-            await Promise.all(teams.map(async (team) => {
-                try {
-                    members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
-                } catch (error) {
-                    console.error('Could not get members of team', team, error);
-                }
-            }));
+            await Promise.all(
+                teams.map(async (team) => {
+                    try {
+                        members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
+                    } catch (error) {
+                        console.error("Could not get members of team", team, error);
+                    }
+                }),
+            );
             setTeamMembers(members);
         })();
     }, [teams]);
@@ -92,34 +117,63 @@ export default function NewProject() {
     useEffect(() => {
         if (selectedRepo) {
             (async () => {
-
                 try {
-                    const guessedConfigStringPromise = getGitpodService().server.guessRepositoryConfiguration(selectedRepo.cloneUrl);
-                    const repoConfigString = await getGitpodService().server.fetchRepositoryConfiguration(selectedRepo.cloneUrl);
+                    const guessedConfigStringPromise = getGitpodService().server.guessRepositoryConfiguration(
+                        selectedRepo.cloneUrl,
+                    );
+                    const repoConfigString = await getGitpodService().server.fetchRepositoryConfiguration(
+                        selectedRepo.cloneUrl,
+                    );
                     if (repoConfigString) {
                         setSourceOfConfig("repo");
                     } else {
-                        setGuessedConfigString(await guessedConfigStringPromise || `tasks:
+                        setGuessedConfigString(
+                            (await guessedConfigStringPromise) ||
+                                `tasks:
   - init: |
       echo 'TODO: build project'
     command: |
-      echo 'TODO: start app'`);
+      echo 'TODO: start app'`,
+                        );
                         setSourceOfConfig("db");
                     }
                 } catch (error) {
-                    console.error('Getting project configuration failed', error);
+                    console.error("Getting project configuration failed", error);
                     setSourceOfConfig(undefined);
                 }
-
             })();
         }
     }, [selectedRepo]);
 
     useEffect(() => {
+        const createProject = async (teamOrUser: Team | User, repo: ProviderRepository) => {
+            if (!selectedProviderHost) {
+                return;
+            }
+            const repoSlug = repo.path || repo.name;
+
+            try {
+                const project = await getGitpodService().server.createProject({
+                    name: repo.name,
+                    slug: repoSlug,
+                    cloneUrl: repo.cloneUrl,
+                    account: repo.account,
+                    provider: selectedProviderHost,
+                    ...(User.is(teamOrUser) ? { userId: teamOrUser.id } : { teamId: teamOrUser.id }),
+                    appInstallationId: String(repo.installationId),
+                });
+
+                setProject(project);
+            } catch (error) {
+                const message = (error && error?.message) || "Failed to create new project.";
+                window.alert(message);
+            }
+        };
+
         if (selectedTeamOrUser && selectedRepo) {
             createProject(selectedTeamOrUser, selectedRepo);
         }
-    }, [selectedTeamOrUser, selectedRepo]);
+    }, [selectedTeamOrUser, selectedRepo, selectedProviderHost]);
 
     useEffect(() => {
         if (reposInAccounts.length === 0) {
@@ -127,13 +181,14 @@ export default function NewProject() {
         } else {
             const first = reposInAccounts[0];
             if (!!first.installationUpdatedAt) {
-                const mostRecent = reposInAccounts.reduce((prev, current) => (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current);
+                const mostRecent = reposInAccounts.reduce((prev, current) =>
+                    (prev.installationUpdatedAt || 0) > (current.installationUpdatedAt || 0) ? prev : current,
+                );
                 setSelectedAccount(mostRecent.account);
             } else {
                 setSelectedAccount(first.account);
             }
         }
-
     }, [reposInAccounts]);
 
     useEffect(() => {
@@ -147,7 +202,7 @@ export default function NewProject() {
         (async () => {
             await updateReposInAccounts();
         })();
-    }, [selectedProviderHost]);
+    }, [selectedProviderHost, updateReposInAccounts]);
 
     useEffect(() => {
         if (project && sourceOfConfig) {
@@ -158,63 +213,22 @@ export default function NewProject() {
                 await getGitpodService().server.triggerPrebuild(project.id, null);
             })();
         }
-    }, [project, sourceOfConfig]);
+    }, [guessedConfigString, project, sourceOfConfig]);
 
     const isGitHub = () => selectedProviderHost === "github.com";
-
-    const updateReposInAccounts = async (installationId?: string) => {
-        setLoaded(false);
-        setReposInAccounts([]);
-        if (!selectedProviderHost) {
-            return [];
-        }
-        try {
-            const repos = await getGitpodService().server.getProviderRepositoriesForUser({ provider: selectedProviderHost, hints: { installationId } });
-            setReposInAccounts(repos);
-            setLoaded(true);
-            return repos;
-        } catch (error) {
-            console.log(error);
-        }
-        return [];
-    }
 
     const reconfigure = () => {
         openReconfigureWindow({
             account: selectedAccount,
-            onSuccess: (p: { installationId: string, setupAction?: string }) => {
+            onSuccess: (p: { installationId: string; setupAction?: string }) => {
                 updateReposInAccounts(p.installationId);
                 trackEvent("organisation_authorised", {
                     installation_id: p.installationId,
-                    setup_action: p.setupAction
+                    setup_action: p.setupAction,
                 });
-            }
+            },
         });
-    }
-
-    const createProject = async (teamOrUser: Team | User, repo: ProviderRepository) => {
-        if (!selectedProviderHost) {
-            return;
-        }
-        const repoSlug = repo.path || repo.name;
-
-        try {
-            const project = await getGitpodService().server.createProject({
-                name: repo.name,
-                slug: repoSlug,
-                cloneUrl: repo.cloneUrl,
-                account: repo.account,
-                provider: selectedProviderHost,
-                ...(User.is(teamOrUser) ? { userId: teamOrUser.id } : { teamId: teamOrUser.id }),
-                appInstallationId: String(repo.installationId),
-            });
-
-            setProject(project);
-        } catch (error) {
-            const message = (error && error?.message) || "Failed to create new project."
-            window.alert(message);
-        }
-    }
+    };
 
     const toSimpleName = (fullName: string) => {
         const splitted = fullName.split("/");
@@ -222,16 +236,20 @@ export default function NewProject() {
             return fullName;
         }
         return splitted.shift() && splitted.join("/");
-    }
+    };
 
     const accounts = new Map<string, { avatarUrl: string }>();
-    reposInAccounts.forEach(r => { if (!accounts.has(r.account)) accounts.set(r.account, { avatarUrl: r.accountAvatarUrl }) });
+    reposInAccounts.forEach((r) => {
+        if (!accounts.has(r.account)) accounts.set(r.account, { avatarUrl: r.accountAvatarUrl });
+    });
 
     const getDropDownEntries = (accounts: Map<string, { avatarUrl: string }>) => {
-        const renderItemContent = (label: string, icon: string, addClasses?: string) => (<div className="w-full flex">
-            <img src={icon} className="rounded-full w-6 h-6 my-auto" />
-            <span className={"pl-2 text-gray-600 dark:text-gray-100 text-base " + (addClasses || "")}>{label}</span>
-        </div>)
+        const renderItemContent = (label: string, icon: string, addClasses?: string) => (
+            <div className="w-full flex">
+                <img src={icon} className="rounded-full w-6 h-6 my-auto" alt="" />
+                <span className={"pl-2 text-gray-600 dark:text-gray-100 text-base " + (addClasses || "")}>{label}</span>
+            </div>
+        );
         const result: ContextMenuEntry[] = [];
 
         if (!selectedAccount && user && user.name && user.avatarUrl) {
@@ -239,7 +257,7 @@ export default function NewProject() {
                 title: "user",
                 customContent: renderItemContent(user?.name, user?.avatarUrl),
                 separator: true,
-            })
+            });
         }
         for (const [account, props] of accounts.entries()) {
             result.push({
@@ -247,7 +265,7 @@ export default function NewProject() {
                 customContent: renderItemContent(account, props.avatarUrl, "font-semibold"),
                 separator: true,
                 onClick: () => setSelectedAccount(account),
-            })
+            });
         }
         if (isGitHub()) {
             result.push({
@@ -255,114 +273,195 @@ export default function NewProject() {
                 customContent: renderItemContent("Add GitHub Orgs or Account", Plus),
                 separator: true,
                 onClick: () => reconfigure(),
-            })
+            });
         }
         result.push({
             title: "Select another Git Provider to continue with",
             customContent: renderItemContent("Select Git Provider", Switch),
             onClick: () => setShowGitProviders(true),
-        })
+        });
 
         return result;
-    }
+    };
 
     const renderSelectRepository = () => {
-
         const noReposAvailable = reposInAccounts.length === 0;
-        const filteredRepos = Array.from(reposInAccounts).filter(r => r.account === selectedAccount && `${r.name}`.toLowerCase().includes(repoSearchFilter.toLowerCase()));
+        const filteredRepos = Array.from(reposInAccounts).filter(
+            (r) => r.account === selectedAccount && `${r.name}`.toLowerCase().includes(repoSearchFilter.toLowerCase()),
+        );
         const icon = selectedAccount && accounts.get(selectedAccount)?.avatarUrl;
 
         const showSearchInput = !!repoSearchFilter || filteredRepos.length > 0;
 
         const userLink = (r: ProviderRepository) => {
-            return `https://${new URL(r.cloneUrl).host}/${r.inUse?.userName}`
-        }
+            return `https://${new URL(r.cloneUrl).host}/${r.inUse?.userName}`;
+        };
 
         const projectText = () => {
-            return <p className="text-gray-500 text-center text-base">Projects allow you to manage prebuilds and workspaces for your repository. <a href="https://www.gitpod.io/docs/teams-and-projects" rel="noopener" className="gp-link">Learn more</a></p>
-        }
+            return (
+                <p className="text-gray-500 text-center text-base">
+                    Projects allow you to manage prebuilds and workspaces for your repository.{" "}
+                    <a href="https://www.gitpod.io/docs/teams-and-projects" rel="noopener" className="gp-link">
+                        Learn more
+                    </a>
+                </p>
+            );
+        };
 
-        const renderRepos = () => (<>
-            {projectText()}
-            <p className="text-gray-500 text-center text-base mt-12">{loaded && noReposAvailable ? 'Select account on ' : 'Select a Git repository on '}<b>{selectedProviderHost}</b> (<a className="gp-link cursor-pointer" onClick={() => setShowGitProviders(true)}>change</a>)</p>
-            <div className={`mt-2 flex-col ${noReposAvailable && isGitHub() ? 'w-96' : ''}`}>
-                <div className="px-8 flex flex-col space-y-2" data-analytics='{"label":"Identity"}'>
-                    <ContextMenu classes="w-full left-0 cursor-pointer" menuEntries={getDropDownEntries(accounts)}>
-                        <div className="w-full">
-                            {!selectedAccount && user && user.name && user.avatarUrl && (
-                                <>
-                                    <img src={user?.avatarUrl} className="rounded-full w-6 h-6 absolute my-2.5 left-3" />
-                                    <input className="w-full px-12 cursor-pointer font-semibold" readOnly type="text" value={user?.name}></input>
-                                </>
-                            )}
-                            {selectedAccount && (
-                                <>
-                                    <img src={icon ? icon : ""} className="rounded-full w-6 h-6 absolute my-2.5 left-3" />
-                                    <input className="w-full px-12 cursor-pointer font-semibold" readOnly type="text" value={selectedAccount}></input>
-                                </>
-                            )}
-                            <img src={CaretDown} title="Select Account" className="filter-grayscale absolute top-1/2 right-3" />
-                        </div>
-                    </ContextMenu>
-                    {showSearchInput && (
-                        <div className="w-full relative ">
-                            <img src={search} title="Search" className="filter-grayscale absolute top-1/3 left-3" />
-                            <input className="w-96 pl-10 border-0" type="text" placeholder="Search Repositories" value={repoSearchFilter}
-                                onChange={(e) => setRepoSearchFilter(e.target.value)}></input>
-                        </div>
-                    )}
-                </div>
-                <div className="p-6 flex-col">
-                    {filteredRepos.length > 0 && (
-                        <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
-                            {filteredRepos.map((r, index) => (
-                                <div key={`repo-${index}-${r.account}-${r.name}`} className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group" >
-
-                                    <div className="flex-grow">
-                                        <div className={"text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap" + (r.inUse ? " text-gray-400 dark:text-gray-500" : "text-gray-700")}>{toSimpleName(r.name)}</div>
-                                        <p>Updated {moment(r.updatedAt).fromNow()}</p>
-                                    </div>
-                                    <div className="flex justify-end">
-                                        <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100 items-center mr-2 text-right">
-                                            {!r.inUse ? (
-                                                <button className="primary" onClick={() => setSelectedRepo(r)}>Select</button>
-                                            ) : (
-                                                <p className="text-gray-500 font-medium">
-                                                    <a rel="noopener" className="gp-link" href={userLink(r)}>@{r.inUse.userName}</a> already<br/>added this repo
-                                                </p>
-                                            )}
+        const renderRepos = () => (
+            <>
+                {projectText()}
+                <p className="text-gray-500 text-center text-base mt-12">
+                    {loaded && noReposAvailable ? "Select account on " : "Select a Git repository on "}
+                    <b>{selectedProviderHost}</b> (
+                    <button className="gp-link cursor-pointer" onClick={() => setShowGitProviders(true)}>
+                        change
+                    </button>
+                    )
+                </p>
+                <div className={`mt-2 flex-col ${noReposAvailable && isGitHub() ? "w-96" : ""}`}>
+                    <div className="px-8 flex flex-col space-y-2" data-analytics='{"label":"Identity"}'>
+                        <ContextMenu classes="w-full left-0 cursor-pointer" menuEntries={getDropDownEntries(accounts)}>
+                            <div className="w-full">
+                                {!selectedAccount && user && user.name && user.avatarUrl && (
+                                    <>
+                                        <img
+                                            src={user?.avatarUrl}
+                                            className="rounded-full w-6 h-6 absolute my-2.5 left-3"
+                                            alt=""
+                                        />
+                                        <input
+                                            className="w-full px-12 cursor-pointer font-semibold"
+                                            readOnly
+                                            type="text"
+                                            value={user?.name}
+                                        ></input>
+                                    </>
+                                )}
+                                {selectedAccount && (
+                                    <>
+                                        <img
+                                            src={icon ? icon : ""}
+                                            className="rounded-full w-6 h-6 absolute my-2.5 left-3"
+                                            alt=""
+                                        />
+                                        <input
+                                            className="w-full px-12 cursor-pointer font-semibold"
+                                            readOnly
+                                            type="text"
+                                            value={selectedAccount}
+                                        ></input>
+                                    </>
+                                )}
+                                <img
+                                    src={CaretDown}
+                                    title="Select Account"
+                                    className="filter-grayscale absolute top-1/2 right-3"
+                                    alt=""
+                                />
+                            </div>
+                        </ContextMenu>
+                        {showSearchInput && (
+                            <div className="w-full relative ">
+                                <img
+                                    src={search}
+                                    title="Search"
+                                    className="filter-grayscale absolute top-1/3 left-3"
+                                    alt=""
+                                />
+                                <input
+                                    className="w-96 pl-10 border-0"
+                                    type="text"
+                                    placeholder="Search Repositories"
+                                    value={repoSearchFilter}
+                                    onChange={(e) => setRepoSearchFilter(e.target.value)}
+                                ></input>
+                            </div>
+                        )}
+                    </div>
+                    <div className="p-6 flex-col">
+                        {filteredRepos.length > 0 && (
+                            <div className="overscroll-contain max-h-80 overflow-y-auto pr-2">
+                                {filteredRepos.map((r, index) => (
+                                    <div
+                                        key={`repo-${index}-${r.account}-${r.name}`}
+                                        className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group"
+                                    >
+                                        <div className="flex-grow">
+                                            <div
+                                                className={
+                                                    "text-base text-gray-900 dark:text-gray-50 font-medium rounded-xl whitespace-nowrap" +
+                                                    (r.inUse ? " text-gray-400 dark:text-gray-500" : "text-gray-700")
+                                                }
+                                            >
+                                                {toSimpleName(r.name)}
+                                            </div>
+                                            <p>Updated {moment(r.updatedAt).fromNow()}</p>
+                                        </div>
+                                        <div className="flex justify-end">
+                                            <div className="h-full my-auto flex self-center opacity-0 group-hover:opacity-100 items-center mr-2 text-right">
+                                                {!r.inUse ? (
+                                                    <button className="primary" onClick={() => setSelectedRepo(r)}>
+                                                        Select
+                                                    </button>
+                                                ) : (
+                                                    <p className="text-gray-500 font-medium">
+                                                        <a rel="noopener" className="gp-link" href={userLink(r)}>
+                                                            @{r.inUse.userName}
+                                                        </a>{" "}
+                                                        already
+                                                        <br />
+                                                        added this repo
+                                                    </p>
+                                                )}
+                                            </div>
                                         </div>
                                     </div>
+                                ))}
+                            </div>
+                        )}
+                        {!noReposAvailable && filteredRepos.length === 0 && <p className="text-center">No Results</p>}
+                        {loaded && noReposAvailable && isGitHub() && (
+                            <div>
+                                <div className="px-12 py-20 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl">
+                                    <span className="dark:text-gray-400">
+                                        Additional authorization is required for our GitHub App to watch your
+                                        repositories and trigger prebuilds.
+                                    </span>
+                                    <br />
+                                    <button className="mt-6" onClick={() => reconfigure()}>
+                                        Configure Gitpod App
+                                    </button>
                                 </div>
-                            ))}
-                        </div>
-                    )}
-                    {!noReposAvailable && filteredRepos.length === 0 && (
-                        <p className="text-center">No Results</p>
-                    )}
-                    {loaded && noReposAvailable && isGitHub() && (<div>
-                        <div className="px-12 py-20 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl">
-                            <span className="dark:text-gray-400">
-                                Additional authorization is required for our GitHub App to watch your repositories and trigger prebuilds.
-                            </span>
-                            <br />
-                            <button className="mt-6" onClick={() => reconfigure()}>Configure Gitpod App</button>
-                        </div>
-                    </div>)}
-                </div>
-
-            </div>
-            {reposInAccounts.length > 0 && isGitHub() && (
-                <div>
-                    <div className="text-gray-500 text-center w-96 mx-8">
-                        Repository not found? <a href="javascript:void(0)" onClick={e => reconfigure()} className="text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600">Reconfigure</a>
+                            </div>
+                        )}
                     </div>
                 </div>
-            )}
-            <p className="text-center w-full mt-12 text-gray-500">
-                <strong>Teams &amp; Projects</strong> are currently in Beta. <a href="https://github.com/gitpod-io/gitpod/issues/5095" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a>
-            </p>
-        </>
+                {reposInAccounts.length > 0 && isGitHub() && (
+                    <div>
+                        <div className="text-gray-500 text-center w-96 mx-8">
+                            Repository not found?{" "}
+                            <button
+                                onClick={(e) => reconfigure()}
+                                className="gp-link text-gray-400 underline underline-thickness-thin underline-offset-small hover:text-gray-600"
+                            >
+                                Reconfigure
+                            </button>
+                        </div>
+                    </div>
+                )}
+                <p className="text-center w-full mt-12 text-gray-500">
+                    <strong>Teams &amp; Projects</strong> are currently in Beta.{" "}
+                    <a
+                        href="https://github.com/gitpod-io/gitpod/issues/5095"
+                        target="gitpod-feedback-issue"
+                        rel="noopener"
+                        className="gp-link"
+                    >
+                        Send feedback
+                    </a>
+                </p>
+            </>
         );
 
         const renderLoadingState = () => (
@@ -371,13 +470,12 @@ export default function NewProject() {
                 <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
                     <div>
                         <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
-                            <h3 className="mb-2 text-gray-400 dark:text-gray-600 animate-pulse">
-                                Loading ...
-                            </h3>
+                            <h3 className="mb-2 text-gray-400 dark:text-gray-600 animate-pulse">Loading ...</h3>
                         </div>
                     </div>
                 </div>
-            </div>)
+            </div>
+        );
 
         const onGitProviderSeleted = async (host: string, updateUser?: boolean) => {
             if (updateUser) {
@@ -385,61 +483,81 @@ export default function NewProject() {
             }
             setShowGitProviders(false);
             setSelectedProviderHost(host);
-        }
+        };
 
         if (!loaded) {
             return renderLoadingState();
         }
 
         if (showGitProviders) {
-            return (<GitProviders onHostSelected={onGitProviderSeleted} authProviders={authProviders} />);
+            return <GitProviders onHostSelected={onGitProviderSeleted} authProviders={authProviders} />;
         }
 
         return renderRepos();
     };
 
     const renderSelectTeam = () => {
-        const userFullName = user?.fullName || user?.name || '...';
+        const userFullName = user?.fullName || user?.name || "...";
         const teamsToRender = teams || [];
-        return (<>
-            <p className="mt-2 text-gray-500 text-center text-base">Select team or personal account</p>
-            <div className="mt-14 flex flex-col space-y-2">
-                <label key={`user-${userFullName}`} className={`w-80 px-4 py-3 flex space-x-3 items-center cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800`} onClick={() => setSelectedTeamOrUser(user)}>
-                    <input type="radio" />
-                    <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                        <span className="font-semibold">{userFullName}</span>
-                        <span className="text-sm text-gray-400">Personal account</span>
-                    </div>
-                </label>
-                {teamsToRender.map((t) => (
-                    <label key={`team-${t.name}`} className={`w-80 px-4 py-3 flex space-x-3 items-center cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800`} onClick={() => setSelectedTeamOrUser(t)}>
+        return (
+            <>
+                <p className="mt-2 text-gray-500 text-center text-base">Select team or personal account</p>
+                <div className="mt-14 flex flex-col space-y-2">
+                    <label
+                        key={`user-${userFullName}`}
+                        className={`w-80 px-4 py-3 flex space-x-3 items-center cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800`}
+                        onClick={() => setSelectedTeamOrUser(user)}
+                    >
                         <input type="radio" />
                         <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                            <span className="font-semibold">{t.name}</span>
-                            <span className="text-sm text-gray-400">{!!teamMembers[t.id]
-                                ? `${teamMembers[t.id].length} member${teamMembers[t.id].length === 1 ? '' : 's'}`
-                                : 'Team'
-                            }</span>
+                            <span className="font-semibold">{userFullName}</span>
+                            <span className="text-sm text-gray-400">Personal account</span>
                         </div>
                     </label>
-                ))}
-                <label className="w-80 px-4 py-3 flex flex-col cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800">
-                    <div className="flex space-x-3 items-center relative">
-                        <input type="radio" onChange={() => setShowNewTeam(!showNewTeam)} />
-                        <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                            <span className="font-semibold">Create new team</span>
-                            <span className="text-sm text-gray-400">Collaborate with others</span>
+                    {teamsToRender.map((t) => (
+                        <label
+                            key={`team-${t.name}`}
+                            className={`w-80 px-4 py-3 flex space-x-3 items-center cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800`}
+                            onClick={() => setSelectedTeamOrUser(t)}
+                        >
+                            <input type="radio" />
+                            <div className="flex-grow overflow-ellipsis truncate flex flex-col">
+                                <span className="font-semibold">{t.name}</span>
+                                <span className="text-sm text-gray-400">
+                                    {!!teamMembers[t.id]
+                                        ? `${teamMembers[t.id].length} member${
+                                              teamMembers[t.id].length === 1 ? "" : "s"
+                                          }`
+                                        : "Team"}
+                                </span>
+                            </div>
+                        </label>
+                    ))}
+                    <label className="w-80 px-4 py-3 flex flex-col cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800">
+                        <div className="flex space-x-3 items-center relative">
+                            <input type="radio" onChange={() => setShowNewTeam(!showNewTeam)} />
+                            <div className="flex-grow overflow-ellipsis truncate flex flex-col">
+                                <span className="font-semibold">Create new team</span>
+                                <span className="text-sm text-gray-400">Collaborate with others</span>
+                            </div>
+                            {teamsToRender.length > 0 && (
+                                <img
+                                    alt=""
+                                    src={CaretDown}
+                                    title="Select Account"
+                                    className={`${
+                                        showNewTeam ? "transform rotate-180" : ""
+                                    } filter-grayscale absolute top-1/2 right-3 cursor-pointer`}
+                                />
+                            )}
                         </div>
-                        {teamsToRender.length > 0 && (
-                            <img alt="" src={CaretDown} title="Select Account" className={`${showNewTeam ? "transform rotate-180" : ""} filter-grayscale absolute top-1/2 right-3 cursor-pointer`} />
+                        {(showNewTeam || teamsToRender.length === 0) && (
+                            <NewTeam onSuccess={(t) => setSelectedTeamOrUser(t)} />
                         )}
-                    </div>
-                    {(showNewTeam || teamsToRender.length === 0) && (
-                        <NewTeam onSuccess={(t) => setSelectedTeamOrUser(t)} />
-                    )}
-                </label>
-            </div>
-        </>)
+                    </label>
+                </div>
+            </>
+        );
     };
 
     const onNewWorkspace = async () => {
@@ -449,52 +567,67 @@ export default function NewProject() {
             url.pathname = "/";
             url.hash = project?.cloneUrl!;
             window.location.href = url.toString();
-        }
+        };
         redirectToNewWorkspace();
-    }
+    };
 
     if (!project) {
-        return (<div className="flex flex-col w-96 mt-24 mx-auto items-center">
+        return (
+            <div className="flex flex-col w-96 mt-24 mx-auto items-center">
+                <>
+                    <h1>New Project</h1>
 
-            <>
-                <h1>New Project</h1>
+                    {!selectedRepo && renderSelectRepository()}
 
-                {!selectedRepo && renderSelectRepository()}
+                    {selectedRepo && !selectedTeamOrUser && renderSelectTeam()}
 
-                {selectedRepo && !selectedTeamOrUser && renderSelectTeam()}
-
-                {selectedRepo && selectedTeamOrUser && (<div></div>)}
-            </>
-
-        </div>);
+                    {selectedRepo && selectedTeamOrUser && <div></div>}
+                </>
+            </div>
+        );
     } else {
-        const projectLink = User.is(selectedTeamOrUser) ? `/projects/${project.slug}` : `/t/${selectedTeamOrUser?.slug}/${project.slug}`;
-        const location = User.is(selectedTeamOrUser) ? "" : (<> in team <a className="gp-link" href={`/t/${selectedTeamOrUser?.slug}/projects`}>{selectedTeamOrUser?.name}</a></>);
-
-        return (<div className="flex flex-col w-96 mt-24 mx-auto items-center">
-
+        const projectLink = User.is(selectedTeamOrUser)
+            ? `/projects/${project.slug}`
+            : `/t/${selectedTeamOrUser?.slug}/${project.slug}`;
+        const location = User.is(selectedTeamOrUser) ? (
+            ""
+        ) : (
             <>
-                <h1>Project Created</h1>
-
-                <p className="mt-2 text-gray-500 text-center text-base">Created <a className="gp-link" href={projectLink}>{project.name}</a> {location}
-                </p>
-
-                <div className="mt-12">
-                    <button onClick={onNewWorkspace}>New Workspace</button>
-                </div>
-
+                {" "}
+                in team{" "}
+                <a className="gp-link" href={`/t/${selectedTeamOrUser?.slug}/projects`}>
+                    {selectedTeamOrUser?.name}
+                </a>
             </>
+        );
 
-        </div>);
+        return (
+            <div className="flex flex-col w-96 mt-24 mx-auto items-center">
+                <>
+                    <h1>Project Created</h1>
+
+                    <p className="mt-2 text-gray-500 text-center text-base">
+                        Created{" "}
+                        <a className="gp-link" href={projectLink}>
+                            {project.name}
+                        </a>{" "}
+                        {location}
+                    </p>
+
+                    <div className="mt-12">
+                        <button onClick={onNewWorkspace}>New Workspace</button>
+                    </div>
+                </>
+            </div>
+        );
     }
-
 }
 
 function GitProviders(props: {
-    authProviders: AuthProviderInfo[],
-    onHostSelected: (host: string, updateUser?: boolean) => void
+    authProviders: AuthProviderInfo[];
+    onHostSelected: (host: string, updateUser?: boolean) => void;
 }) {
-    const [ errorMessage, setErrorMessage ] = useState<string | undefined>(undefined);
+    const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
     const selectProvider = async (ap: AuthProviderInfo) => {
         setErrorMessage(undefined);
@@ -517,15 +650,20 @@ function GitProviders(props: {
                 } else {
                     errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
                     if (payload.error === "email_taken") {
-                        errorMessage = `Email address already used in another account. Please log in with ${(payload as any).host}.`;
+                        errorMessage = `Email address already used in another account. Please log in with ${
+                            (payload as any).host
+                        }.`;
                     }
                 }
                 setErrorMessage(errorMessage);
-            }
+            },
         });
-    }
+    };
 
-    const filteredProviders = () => props.authProviders.filter(p => p.authProviderType === "GitHub" || p.host === "bitbucket.org" || p.authProviderType === "GitLab");
+    const filteredProviders = () =>
+        props.authProviders.filter(
+            (p) => p.authProviderType === "GitHub" || p.host === "bitbucket.org" || p.authProviderType === "GitLab",
+        );
 
     return (
         <div className="mt-8 border rounded-t-xl border-gray-100 dark:border-gray-800 flex-col">
@@ -534,11 +672,17 @@ function GitProviders(props: {
                     Select a Git provider first and continue with your repositories.
                 </div>
                 <div className="mt-6 flex flex-col space-y-3 items-center pb-8">
-                    {filteredProviders().map(ap => {
+                    {filteredProviders().map((ap) => {
                         return (
-                            <button key={"button" + ap.host} className="btn-login flex-none w-56 h-10 p-0 inline-flex" onClick={() => selectProvider(ap)}>
+                            <button
+                                key={"button" + ap.host}
+                                className="btn-login flex-none w-56 h-10 p-0 inline-flex"
+                                onClick={() => selectProvider(ap)}
+                            >
                                 {iconForAuthProvider(ap.authProviderType)}
-                                <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">Continue with {simplifyProviderName(ap.host)}</span>
+                                <span className="pt-2 pb-2 mr-3 text-sm my-auto font-medium truncate overflow-ellipsis">
+                                    Continue with {simplifyProviderName(ap.host)}
+                                </span>
                             </button>
                         );
                     })}
@@ -547,22 +691,19 @@ function GitProviders(props: {
                 {errorMessage && (
                     <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
                         <div className="pr-3 self-center w-6">
-                            <img src={exclamation} />
+                            <img src={exclamation} alt="Heads up!" />
                         </div>
                         <div className="flex-1 flex flex-col">
                             <p className="text-gitpod-red text-sm">{errorMessage}</p>
                         </div>
                     </div>
                 )}
-
             </div>
         </div>
-    )
+    );
 }
 
-function NewTeam(props: {
-    onSuccess: (team: Team) => void,
-}) {
+function NewTeam(props: { onSuccess: (team: Team) => void }) {
     const { setTeams } = useContext(TeamsContext);
 
     const [teamName, setTeamName] = useState<string | undefined>();
@@ -580,37 +721,53 @@ function NewTeam(props: {
             console.error(error);
             setError(error?.message || "Failed to create new team!");
         }
-    }
+    };
 
     const onTeamNameChanged = (name: string) => {
         setTeamName(name);
         setError(undefined);
-    }
+    };
 
-    return <>
-        <div className="mt-6 mb-1 flex flex-row space-x-2">
-            <input type="text" className="py-1 min-w-0" name="new-team-inline" value={teamName} onChange={(e) => onTeamNameChanged(e.target.value)} />
-            <button key={`new-team-inline-create`} disabled={!teamName} onClick={() => onNewTeam()}>Continue</button>
-        </div>
-        {error && <p className="text-gitpod-red">{error}</p>}
-    </>;
+    return (
+        <>
+            <div className="mt-6 mb-1 flex flex-row space-x-2">
+                <input
+                    type="text"
+                    className="py-1 min-w-0"
+                    name="new-team-inline"
+                    value={teamName}
+                    onChange={(e) => onTeamNameChanged(e.target.value)}
+                />
+                <button key={`new-team-inline-create`} disabled={!teamName} onClick={() => onNewTeam()}>
+                    Continue
+                </button>
+            </div>
+            {error && <p className="text-gitpod-red">{error}</p>}
+        </>
+    );
 }
 
-async function openReconfigureWindow(params: { account?: string, onSuccess: (p: any) => void }) {
+async function openReconfigureWindow(params: { account?: string; onSuccess: (p: any) => void }) {
     const { account, onSuccess } = params;
     const state = btoa(JSON.stringify({ from: "/reconfigure", next: "/new" }));
-    const url = gitpodHostUrl.withApi({
-        pathname: '/apps/github/reconfigure',
-        search: `account=${account}&state=${encodeURIComponent(state)}`
-    }).toString();
+    const url = gitpodHostUrl
+        .withApi({
+            pathname: "/apps/github/reconfigure",
+            search: `account=${account}&state=${encodeURIComponent(state)}`,
+        })
+        .toString();
 
     const width = 800;
     const height = 800;
-    const left = (window.screen.width / 2) - (width / 2);
-    const top = (window.screen.height / 2) - (height / 2);
+    const left = window.screen.width / 2 - width / 2;
+    const top = window.screen.height / 2 - height / 2;
 
     // Optimistically assume that the new window was opened.
-    window.open(url, "gitpod-github-window", `width=${width},height=${height},top=${top},left=${left}status=yes,scrollbars=yes,resizable=yes`);
+    window.open(
+        url,
+        "gitpod-github-window",
+        `width=${width},height=${height},top=${top},left=${left}status=yes,scrollbars=yes,resizable=yes`,
+    );
 
     const eventListener = (event: MessageEvent) => {
         // todo: check event.origin
@@ -622,19 +779,21 @@ async function openReconfigureWindow(params: { account?: string, onSuccess: (p: 
                 console.log(`Received Window Result. Closing Window.`);
                 event.source.close();
             }
-        }
+        };
 
         if (typeof event.data === "string" && event.data.startsWith("payload:")) {
             killWindow();
             try {
-                let payload: { installationId: string, setupAction?: string } = JSON.parse(atob(event.data.substring("payload:".length)));
+                let payload: { installationId: string; setupAction?: string } = JSON.parse(
+                    atob(event.data.substring("payload:".length)),
+                );
                 onSuccess && onSuccess(payload);
             } catch (error) {
                 console.log(error);
             }
         }
         if (typeof event.data === "string" && event.data.startsWith("error:")) {
-            let error: string | { error: string, description?: string } = atob(event.data.substring("error:".length));
+            let error: string | { error: string; description?: string } = atob(event.data.substring("error:".length));
             try {
                 const payload = JSON.parse(error);
                 if (typeof payload === "object" && payload.error) {

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -23,27 +23,28 @@ export default function () {
     const { teams } = useContext(TeamsContext);
     const team = getCurrentTeam(location, teams);
 
-    const match = useRouteMatch<{ team: string, project: string, prebuildId: string }>("/(t/)?:team/:project/:prebuildId");
+    const match = useRouteMatch<{ team: string; project: string; prebuildId: string }>(
+        "/(t/)?:team/:project/:prebuildId",
+    );
     const projectSlug = match?.params?.project;
     const prebuildId = match?.params?.prebuildId;
 
-    const [ prebuild, setPrebuild ] = useState<PrebuildWithStatus | undefined>();
-    const [ prebuildInstance, setPrebuildInstance ] = useState<WorkspaceInstance | undefined>();
-    const [ isRerunningPrebuild, setIsRerunningPrebuild ] = useState<boolean>(false);
-    const [ isCancellingPrebuild, setIsCancellingPrebuild ] = useState<boolean>(false);
+    const [prebuild, setPrebuild] = useState<PrebuildWithStatus | undefined>();
+    const [prebuildInstance, setPrebuildInstance] = useState<WorkspaceInstance | undefined>();
+    const [isRerunningPrebuild, setIsRerunningPrebuild] = useState<boolean>(false);
+    const [isCancellingPrebuild, setIsCancellingPrebuild] = useState<boolean>(false);
 
     useEffect(() => {
         if (!teams || !projectSlug || !prebuildId) {
             return;
         }
         (async () => {
-            const projects = (!!team
+            const projects = !!team
                 ? await getGitpodService().server.getTeamProjects(team.id)
-                : await getGitpodService().server.getUserProjects());
+                : await getGitpodService().server.getUserProjects();
 
-            const project = projectSlug && projects.find(p => !!p.slug
-                ? p.slug === projectSlug
-                : p.name === projectSlug);
+            const project =
+                projectSlug && projects.find((p) => (!!p.slug ? p.slug === projectSlug : p.name === projectSlug));
             if (!project) {
                 console.error(new Error(`Project not found! (teamId: ${team?.id}, projectName: ${projectSlug})`));
                 return;
@@ -51,7 +52,7 @@ export default function () {
 
             const prebuilds = await getGitpodService().server.findPrebuilds({
                 projectId: project.id,
-                prebuildId
+                prebuildId,
             });
             setPrebuild(prebuilds[0]);
         })();
@@ -61,29 +62,51 @@ export default function () {
         if (!prebuild) {
             return "unknown prebuild";
         }
-        return (<h1 className="tracking-tight">{prebuild.info.branch} </h1>);
+        return <h1 className="tracking-tight">{prebuild.info.branch} </h1>;
     };
 
     const renderSubtitle = () => {
         if (!prebuild) {
             return "";
         }
-        const startedByAvatar = prebuild.info.startedByAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={prebuild.info.startedByAvatar || ''} alt={prebuild.info.startedBy} />;
-        return (<div className="flex">
-            <div className="my-auto">
-                <p>{startedByAvatar}Triggered {moment(prebuild.info.startedAt).fromNow()}</p>
-            </div>
-            <p className="mx-2 my-auto">·</p>
-            <div className="my-auto">
-                <p className="text-gray-500 dark:text-gray-50">{shortCommitMessage(prebuild.info.changeTitle)}</p>
-            </div>
-            {!!prebuild.info.basedOnPrebuildId && <>
+        const startedByAvatar = prebuild.info.startedByAvatar && (
+            <img
+                className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2"
+                src={prebuild.info.startedByAvatar || ""}
+                alt={prebuild.info.startedBy}
+            />
+        );
+        return (
+            <div className="flex">
+                <div className="my-auto">
+                    <p>
+                        {startedByAvatar}Triggered {moment(prebuild.info.startedAt).fromNow()}
+                    </p>
+                </div>
                 <p className="mx-2 my-auto">·</p>
                 <div className="my-auto">
-                    <p className="text-gray-500 dark:text-gray-50">Incremental Prebuild (<a className="gp-link" title={prebuild.info.basedOnPrebuildId} href={`./${prebuild.info.basedOnPrebuildId}`}>base</a>)</p>
+                    <p className="text-gray-500 dark:text-gray-50">{shortCommitMessage(prebuild.info.changeTitle)}</p>
                 </div>
-            </>}
-        </div>)
+                {!!prebuild.info.basedOnPrebuildId && (
+                    <>
+                        <p className="mx-2 my-auto">·</p>
+                        <div className="my-auto">
+                            <p className="text-gray-500 dark:text-gray-50">
+                                Incremental Prebuild (
+                                <a
+                                    className="gp-link"
+                                    title={prebuild.info.basedOnPrebuildId}
+                                    href={`./${prebuild.info.basedOnPrebuildId}`}
+                                >
+                                    base
+                                </a>
+                                )
+                            </p>
+                        </div>
+                    </>
+                )}
+            </div>
+        );
     };
 
     const onInstanceUpdate = async (instance: WorkspaceInstance) => {
@@ -93,10 +116,10 @@ export default function () {
         }
         const prebuilds = await getGitpodService().server.findPrebuilds({
             projectId: prebuild.info.projectId,
-            prebuildId
+            prebuildId,
         });
         setPrebuild(prebuilds[0]);
-    }
+    };
 
     const rerunPrebuild = async () => {
         if (!prebuild) {
@@ -106,13 +129,13 @@ export default function () {
             setIsRerunningPrebuild(true);
             await getGitpodService().server.triggerPrebuild(prebuild.info.projectId, prebuild.info.branch);
             // TODO: Open a Prebuilds page that's specific to `prebuild.info.branch`?
-            history.push(`/${!!team ? 't/'+team.slug : 'projects'}/${projectSlug}/prebuilds`);
+            history.push(`/${!!team ? "t/" + team.slug : "projects"}/${projectSlug}/prebuilds`);
         } catch (error) {
-            console.error('Could not rerun prebuild', error);
+            console.error("Could not rerun prebuild", error);
         } finally {
             setIsRerunningPrebuild(false);
         }
-    }
+    };
 
     const cancelPrebuild = async () => {
         if (!prebuild) {
@@ -122,40 +145,69 @@ export default function () {
             setIsCancellingPrebuild(true);
             await getGitpodService().server.cancelPrebuild(prebuild.info.projectId, prebuild.info.id);
         } catch (error) {
-            console.error('Could not cancel prebuild', error);
+            console.error("Could not cancel prebuild", error);
         } finally {
             setIsCancellingPrebuild(false);
         }
-    }
+    };
 
-    useEffect(() => { document.title = 'Prebuild — Gitpod' }, []);
+    useEffect(() => {
+        document.title = "Prebuild — Gitpod";
+    }, []);
 
-    return <>
-        <Header title={renderTitle()} subtitle={renderSubtitle()} />
-        <div className="app-container mt-8">
-            <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
-                <div className="h-96 flex">
-                    <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId} onInstanceUpdate={onInstanceUpdate} />
-                </div>
-                <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
-                    {prebuildInstance && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} />}
-                    <div className="flex-grow" />
-                    {(prebuild?.status === 'aborted' || prebuild?.status === 'timeout' || !!prebuild?.error)
-                        ? <button className="flex items-center space-x-2" disabled={isRerunningPrebuild} onClick={rerunPrebuild}>
-                            {isRerunningPrebuild && <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />}
-                            <span>Rerun Prebuild ({prebuild.info.branch})</span>
-                        </button>
-                        : (prebuild?.status === 'building'
-                            ? <button className="danger flex items-center space-x-2" disabled={isCancellingPrebuild || (prebuildInstance?.status.phase !== "initializing" && prebuildInstance?.status.phase !== "running")} onClick={cancelPrebuild}>
-                                {isCancellingPrebuild && <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />}
+    return (
+        <>
+            <Header title={renderTitle()} subtitle={renderSubtitle()} />
+            <div className="app-container mt-8">
+                <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
+                    <div className="h-96 flex">
+                        <PrebuildLogs
+                            workspaceId={prebuild?.info?.buildWorkspaceId}
+                            onInstanceUpdate={onInstanceUpdate}
+                        />
+                    </div>
+                    <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
+                        {prebuildInstance && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} />}
+                        <div className="flex-grow" />
+                        {prebuild?.status === "aborted" || prebuild?.status === "timeout" || !!prebuild?.error ? (
+                            <button
+                                className="flex items-center space-x-2"
+                                disabled={isRerunningPrebuild}
+                                onClick={rerunPrebuild}
+                            >
+                                {isRerunningPrebuild && (
+                                    <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} alt="" />
+                                )}
+                                <span>Rerun Prebuild ({prebuild.info.branch})</span>
+                            </button>
+                        ) : prebuild?.status === "building" ? (
+                            <button
+                                className="danger flex items-center space-x-2"
+                                disabled={
+                                    isCancellingPrebuild ||
+                                    (prebuildInstance?.status.phase !== "initializing" &&
+                                        prebuildInstance?.status.phase !== "running")
+                                }
+                                onClick={cancelPrebuild}
+                            >
+                                {isCancellingPrebuild && (
+                                    <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} alt="" />
+                                )}
                                 <span>Cancel Prebuild</span>
                             </button>
-                            : (prebuild?.status === 'available'
-                                ? <a className="my-auto" href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}><button>New Workspace ({prebuild?.info.branch})</button></a>
-                                : <button disabled={true}>New Workspace ({prebuild?.info.branch})</button>))}
+                        ) : prebuild?.status === "available" ? (
+                            <a
+                                className="my-auto"
+                                href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}
+                            >
+                                <button>New Workspace ({prebuild?.info.branch})</button>
+                            </a>
+                        ) : (
+                            <button disabled={true}>New Workspace ({prebuild?.info.branch})</button>
+                        )}
+                    </div>
                 </div>
             </div>
-        </div>
-    </>;
-
+        </>
+    );
 }

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -24,13 +24,13 @@ import { shortCommitMessage } from "./render-utils";
 import { Link } from "react-router-dom";
 import { Disposable } from "vscode-jsonrpc";
 
-export default function (props: { project?: Project, isAdminDashboard?: boolean }) {
+export default function (props: { project?: Project; isAdminDashboard?: boolean }) {
     const location = useLocation();
 
     const { teams } = useContext(TeamsContext);
     const team = getCurrentTeam(location, teams);
 
-    const match = useRouteMatch<{ team: string, resource: string }>("/(t/)?:team/:resource");
+    const match = useRouteMatch<{ team: string; resource: string }>("/(t/)?:team/:resource");
     const projectSlug = props.isAdminDashboard ? props.project?.slug : match?.params?.resource;
 
     const [project, setProject] = useState<Project | undefined>();
@@ -56,39 +56,41 @@ export default function (props: { project?: Project, isAdminDashboard?: boolean 
             registration = getGitpodService().registerClient({
                 onPrebuildUpdate: (update: PrebuildWithStatus) => {
                     if (update.info.projectId === project.id) {
-                        setPrebuilds(prev => [update, ...prev.filter(p => p.info.id !== update.info.id)]);
+                        setPrebuilds((prev) => [update, ...prev.filter((p) => p.info.id !== update.info.id)]);
                         setIsLoadingPrebuilds(false);
                     }
-                }
+                },
             });
         }
 
         (async () => {
             setIsLoadingPrebuilds(true);
-            const prebuilds = props && props.isAdminDashboard ?
-                await getGitpodService().server.adminFindPrebuilds({ projectId: project.id })
-                : await getGitpodService().server.findPrebuilds({ projectId: project.id });
+            const prebuilds =
+                props && props.isAdminDashboard
+                    ? await getGitpodService().server.adminFindPrebuilds({ projectId: project.id })
+                    : await getGitpodService().server.findPrebuilds({ projectId: project.id });
             setPrebuilds(prebuilds);
             setIsLoadingPrebuilds(false);
         })();
 
         if (!props.isAdminDashboard) {
-            return () => { registration.dispose(); }
+            return () => {
+                registration.dispose();
+            };
         }
-    }, [project]);
+    }, [project, props]);
 
     useEffect(() => {
         if (!teams) {
             return;
         }
         (async () => {
-            const projects = (!!team
+            const projects = !!team
                 ? await getGitpodService().server.getTeamProjects(team.id)
-                : await getGitpodService().server.getUserProjects());
+                : await getGitpodService().server.getUserProjects();
 
-            const newProject = projectSlug && projects.find(
-                p => p.slug ? p.slug === projectSlug :
-                    p.name === projectSlug);
+            const newProject =
+                projectSlug && projects.find((p) => (p.slug ? p.slug === projectSlug : p.name === projectSlug));
 
             if (newProject) {
                 setProject(newProject);
@@ -100,51 +102,54 @@ export default function (props: { project?: Project, isAdminDashboard?: boolean 
         if (prebuilds.length === 0) {
             setIsLoadingPrebuilds(false);
         }
-    }, [prebuilds])
+    }, [prebuilds]);
 
     const prebuildContextMenu = (p: PrebuildWithStatus) => {
-        const isFailed = p.status === "aborted" || p.status === "timeout" || p.status === "failed"|| !!p.error;
+        const isFailed = p.status === "aborted" || p.status === "timeout" || p.status === "failed" || !!p.error;
         const isRunning = p.status === "building";
         const entries: ContextMenuEntry[] = [];
         if (isFailed) {
             entries.push({
                 title: `Rerun Prebuild (${p.info.branch})`,
                 onClick: () => triggerPrebuild(p.info.branch),
-                separator: isRunning
+                separator: isRunning,
             });
         }
         if (isRunning) {
             entries.push({
                 title: "Cancel Prebuild",
-                customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
+                customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
                 onClick: () => cancelPrebuild(p.info.id),
-            })
+            });
         }
         return entries;
-    }
+    };
 
     const statusFilterEntries = () => {
         const entries: DropDownEntry[] = [];
         entries.push({
-            title: 'All',
-            onClick: () => setStatusFilter(undefined)
+            title: "All",
+            onClick: () => setStatusFilter(undefined),
         });
         entries.push({
-            title: 'READY',
-            onClick: () => setStatusFilter("available")
+            title: "READY",
+            onClick: () => setStatusFilter("available"),
         });
         return entries;
-    }
+    };
 
     const filter = (p: PrebuildWithStatus) => {
         if (statusFilter && statusFilter !== p.status) {
             return false;
         }
-        if (searchFilter && `${p.info.changeTitle} ${p.info.branch}`.toLowerCase().includes(searchFilter.toLowerCase()) === false) {
+        if (
+            searchFilter &&
+            `${p.info.changeTitle} ${p.info.branch}`.toLowerCase().includes(searchFilter.toLowerCase()) === false
+        ) {
             return false;
         }
         return true;
-    }
+    };
 
     const prebuildSorter = (a: PrebuildWithStatus, b: PrebuildWithStatus) => {
         if (a.info.startedAt < b.info.startedAt) {
@@ -154,113 +159,182 @@ export default function (props: { project?: Project, isAdminDashboard?: boolean 
             return 0;
         }
         return -1;
-    }
+    };
 
     const triggerPrebuild = (branchName: string | null) => {
         if (!project) {
             return;
         }
         getGitpodService().server.triggerPrebuild(project.id, branchName);
-    }
+    };
 
     const cancelPrebuild = (prebuildId: string) => {
         if (!project) {
             return;
         }
         getGitpodService().server.cancelPrebuild(project.id, prebuildId);
-    }
+    };
 
     const formatDate = (date: string | undefined) => {
         return date ? moment(date).fromNow() : "";
-    }
+    };
 
-    return <>
-        {!props.isAdminDashboard && <Header title="Prebuilds" subtitle={`View recent prebuilds for active branches.`} />}
-        <div className={props.isAdminDashboard ? "" : "app-container"}>
-            <div className={props.isAdminDashboard ? "flex" : "flex mt-8"} >
-                <div className="flex">
-                    <div className="py-4">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" /></svg>
-                    </div>
-                    <input type="search" placeholder="Search Prebuilds" onChange={e => setSearchFilter(e.target.value)} />
-                </div>
-                <div className="flex-1" />
-                <div className="py-3 pl-3">
-                    <DropDown prefix="Prebuild Status: " contextMenuWidth="w-32" entries={statusFilterEntries()} />
-                </div>
-                {(!isLoadingPrebuilds && prebuilds.length === 0 && !props.isAdminDashboard) &&
-                    <button onClick={() => triggerPrebuild(null)} className="ml-2">Run Prebuild</button>}
-            </div>
-            <ItemsList className="mt-2">
-                <Item header={true} className="grid grid-cols-3">
-                    <ItemField className="my-auto">
-                        <span>Prebuild</span>
-                    </ItemField>
-                    <ItemField className="my-auto">
-                        <span>Commit</span>
-                    </ItemField>
-                    <ItemField className="my-auto">
-                        <span>Branch</span>
-                    </ItemField>
-                </Item>
-                {isLoadingPrebuilds && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
-                    <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
-                    <span>Fetching prebuilds...</span>
-                </div>}
-                {prebuilds.filter(filter).sort(prebuildSorter).map((p, index) => <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">
-                    <ItemField className={`flex items-center my-auto ${props.isAdminDashboard ? "pointer-events-none" : ""}`}>
-                        <Link to={`/${!!team ? 't/' + team.slug : 'projects'}/${projectSlug}/${p.info.id}`} className="cursor-pointer">
-                            <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1">
-                                <div className="inline-block align-text-bottom mr-2 w-4 h-4">{prebuildStatusIcon(p)}</div>
-                                {prebuildStatusLabel(p)}
-                            </div>
-                            <p>{p.info.startedByAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={p.info.startedByAvatar || ''} alt={p.info.startedBy} />}Triggered {formatDate(p.info.startedAt)}</p>
-                        </Link>
-                    </ItemField>
-                    <ItemField className="flex items-center my-auto">
-                        <div className="truncate">
-                            <a href={p.info.changeUrl} className="cursor-pointer">
-                                <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate" title={shortCommitMessage(p.info.changeTitle)}>{shortCommitMessage(p.info.changeTitle)}</div>
-                            </a>
-                            <p>{p.info.changeAuthorAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={p.info.changeAuthorAvatar || ''} alt={p.info.changeAuthor} />}Authored {formatDate(p.info.changeDate)} · {p.info.changeHash?.substring(0, 8)}</p>
+    return (
+        <>
+            {!props.isAdminDashboard && (
+                <Header title="Prebuilds" subtitle={`View recent prebuilds for active branches.`} />
+            )}
+            <div className={props.isAdminDashboard ? "" : "app-container"}>
+                <div className={props.isAdminDashboard ? "flex" : "flex mt-8"}>
+                    <div className="flex">
+                        <div className="py-4">
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                height="16"
+                            >
+                                <path
+                                    fill="#A8A29E"
+                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                />
+                            </svg>
                         </div>
-                    </ItemField>
-                    <ItemField className="flex">
-                        <a href={p.info.changeUrl} className="cursor-pointer">
-                            <div className="flex space-x-2 truncate">
-                                <span className="font-medium text-gray-500 dark:text-gray-50 truncate" title={p.info.branch}>{p.info.branch}</span>
-                            </div>
-                        </a>
-                        <span className="flex-grow" />
-                        {!props.isAdminDashboard && <ItemFieldContextMenu menuEntries={prebuildContextMenu(p)} />}
-                    </ItemField>
-                </Item>)}
-            </ItemsList>
-            {(!isLoadingPrebuilds && prebuilds.length === 0) &&
-                <div className="p-3 text-gray-400 rounded-xl text-sm text-center">No prebuilds found.</div>}
-        </div>
-
-    </>;
+                        <input
+                            type="search"
+                            placeholder="Search Prebuilds"
+                            onChange={(e) => setSearchFilter(e.target.value)}
+                        />
+                    </div>
+                    <div className="flex-1" />
+                    <div className="py-3 pl-3">
+                        <DropDown prefix="Prebuild Status: " contextMenuWidth="w-32" entries={statusFilterEntries()} />
+                    </div>
+                    {!isLoadingPrebuilds && prebuilds.length === 0 && !props.isAdminDashboard && (
+                        <button onClick={() => triggerPrebuild(null)} className="ml-2">
+                            Run Prebuild
+                        </button>
+                    )}
+                </div>
+                <ItemsList className="mt-2">
+                    <Item header={true} className="grid grid-cols-3">
+                        <ItemField className="my-auto">
+                            <span>Prebuild</span>
+                        </ItemField>
+                        <ItemField className="my-auto">
+                            <span>Commit</span>
+                        </ItemField>
+                        <ItemField className="my-auto">
+                            <span>Branch</span>
+                        </ItemField>
+                    </Item>
+                    {isLoadingPrebuilds && (
+                        <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
+                            <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
+                            <span>Fetching prebuilds...</span>
+                        </div>
+                    )}
+                    {prebuilds
+                        .filter(filter)
+                        .sort(prebuildSorter)
+                        .map((p, index) => (
+                            <Item key={`prebuild-${p.info.id}`} className="grid grid-cols-3">
+                                <ItemField
+                                    className={`flex items-center my-auto ${
+                                        props.isAdminDashboard ? "pointer-events-none" : ""
+                                    }`}
+                                >
+                                    <Link
+                                        to={`/${!!team ? "t/" + team.slug : "projects"}/${projectSlug}/${p.info.id}`}
+                                        className="cursor-pointer"
+                                    >
+                                        <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1">
+                                            <div className="inline-block align-text-bottom mr-2 w-4 h-4">
+                                                {prebuildStatusIcon(p)}
+                                            </div>
+                                            {prebuildStatusLabel(p)}
+                                        </div>
+                                        <p>
+                                            {p.info.startedByAvatar && (
+                                                <img
+                                                    className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2"
+                                                    src={p.info.startedByAvatar || ""}
+                                                    alt={p.info.startedBy}
+                                                />
+                                            )}
+                                            Triggered {formatDate(p.info.startedAt)}
+                                        </p>
+                                    </Link>
+                                </ItemField>
+                                <ItemField className="flex items-center my-auto">
+                                    <div className="truncate">
+                                        <a href={p.info.changeUrl} className="cursor-pointer">
+                                            <div
+                                                className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate"
+                                                title={shortCommitMessage(p.info.changeTitle)}
+                                            >
+                                                {shortCommitMessage(p.info.changeTitle)}
+                                            </div>
+                                        </a>
+                                        <p>
+                                            {p.info.changeAuthorAvatar && (
+                                                <img
+                                                    className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2"
+                                                    src={p.info.changeAuthorAvatar || ""}
+                                                    alt={p.info.changeAuthor}
+                                                />
+                                            )}
+                                            Authored {formatDate(p.info.changeDate)} ·{" "}
+                                            {p.info.changeHash?.substring(0, 8)}
+                                        </p>
+                                    </div>
+                                </ItemField>
+                                <ItemField className="flex">
+                                    <a href={p.info.changeUrl} className="cursor-pointer">
+                                        <div className="flex space-x-2 truncate">
+                                            <span
+                                                className="font-medium text-gray-500 dark:text-gray-50 truncate"
+                                                title={p.info.branch}
+                                            >
+                                                {p.info.branch}
+                                            </span>
+                                        </div>
+                                    </a>
+                                    <span className="flex-grow" />
+                                    {!props.isAdminDashboard && (
+                                        <ItemFieldContextMenu menuEntries={prebuildContextMenu(p)} />
+                                    )}
+                                </ItemField>
+                            </Item>
+                        ))}
+                </ItemsList>
+                {!isLoadingPrebuilds && prebuilds.length === 0 && (
+                    <div className="p-3 text-gray-400 rounded-xl text-sm text-center">No prebuilds found.</div>
+                )}
+            </div>
+        </>
+    );
 }
 
 export function prebuildStatusLabel(prebuild?: PrebuildWithStatus) {
     switch (prebuild?.status) {
         case undefined: // Fall through
         case "queued":
-            return (<span className="font-medium text-orange-500 uppercase">pending</span>);
+            return <span className="font-medium text-orange-500 uppercase">pending</span>;
         case "building":
-            return (<span className="font-medium text-blue-500 uppercase">running</span>);
+            return <span className="font-medium text-blue-500 uppercase">running</span>;
         case "aborted":
-            return (<span className="font-medium text-gray-500 uppercase">canceled</span>);
+            return <span className="font-medium text-gray-500 uppercase">canceled</span>;
         case "failed":
-            return (<span className="font-medium text-red-500 uppercase">system error</span>);
+            return <span className="font-medium text-red-500 uppercase">system error</span>;
         case "timeout":
-            return (<span className="font-medium text-red-500 uppercase">timed out</span>);
+            return <span className="font-medium text-red-500 uppercase">timed out</span>;
         case "available":
             if (prebuild?.error) {
-                return (<span className="font-medium text-red-500 uppercase">failed</span>);
+                return <span className="font-medium text-red-500 uppercase">failed</span>;
             }
-            return (<span className="font-medium text-green-500 uppercase">ready</span>);
+            return <span className="font-medium text-green-500 uppercase">ready</span>;
     }
 }
 
@@ -287,7 +361,7 @@ export function prebuildStatusIcon(prebuild?: PrebuildWithStatus) {
 
 function formatDuration(milliseconds: number) {
     const hours = Math.floor(milliseconds / (1000 * 60 * 60));
-    return (hours > 0 ? `${hours}:` : '') + moment(milliseconds).format('mm:ss');
+    return (hours > 0 ? `${hours}:` : "") + moment(milliseconds).format("mm:ss");
 }
 
 export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInstance }) {
@@ -295,72 +369,106 @@ export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInst
     let details = <></>;
     switch (props.prebuildInstance?.status.phase) {
         case undefined: // Fall through
-        case 'preparing': // Fall through
-        case 'pending': // Fall through
-        case 'creating': // Fall through
-        case 'unknown':
-            status = <div className="flex space-x-1 items-center text-yellow-600">
-                <img alt="" className="h-4 w-4" src={StatusPaused} />
-                <span>PENDING</span>
-                </div>;
-            details = <div className="flex space-x-1 items-center text-gray-400">
-                <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
-                <span>Preparing prebuild ...</span>
-                </div>;
+        case "preparing": // Fall through
+        case "pending": // Fall through
+        case "creating": // Fall through
+        case "unknown":
+            status = (
+                <div className="flex space-x-1 items-center text-yellow-600">
+                    <img alt="" className="h-4 w-4" src={StatusPaused} />
+                    <span>PENDING</span>
+                </div>
+            );
+            details = (
+                <div className="flex space-x-1 items-center text-gray-400">
+                    <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
+                    <span>Preparing prebuild ...</span>
+                </div>
+            );
             break;
-        case 'initializing': // Fall  through
-        case 'running': // Fall through
-        case 'interrupted': // Fall through
-        case 'stopping':
-            status = <div className="flex space-x-1 items-center text-blue-600">
-                <img alt="" className="h-4 w-4" src={StatusRunning} />
-                <span>RUNNING</span>
-                </div>;
-            details = <div className="flex space-x-1 items-center text-gray-400">
-                <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
-                <span>Prebuild in progress ...</span>
-                </div>;
+        case "initializing": // Fall  through
+        case "running": // Fall through
+        case "interrupted": // Fall through
+        case "stopping":
+            status = (
+                <div className="flex space-x-1 items-center text-blue-600">
+                    <img alt="" className="h-4 w-4" src={StatusRunning} />
+                    <span>RUNNING</span>
+                </div>
+            );
+            details = (
+                <div className="flex space-x-1 items-center text-gray-400">
+                    <img alt="" className="h-4 w-4 animate-spin" src={Spinner} />
+                    <span>Prebuild in progress ...</span>
+                </div>
+            );
             break;
-        case 'stopped':
-            status = <div className="flex space-x-1 items-center text-green-600">
-                <img alt="" className="h-4 w-4" src={StatusDone} />
-                <span>READY</span>
-                </div>;
-            details = <div className="flex space-x-1 items-center text-gray-400">
-                <img alt="" className="h-4 w-4 filter-grayscale" src={StatusRunning} />
-                <span>{!!props.prebuildInstance?.stoppedTime
-                    ? formatDuration((new Date(props.prebuildInstance.stoppedTime).getTime()) - (new Date(props.prebuildInstance.creationTime).getTime()))
-                    : '...'}</span>
-                </div>;
+        case "stopped":
+            status = (
+                <div className="flex space-x-1 items-center text-green-600">
+                    <img alt="" className="h-4 w-4" src={StatusDone} />
+                    <span>READY</span>
+                </div>
+            );
+            details = (
+                <div className="flex space-x-1 items-center text-gray-400">
+                    <img alt="" className="h-4 w-4 filter-grayscale" src={StatusRunning} />
+                    <span>
+                        {!!props.prebuildInstance?.stoppedTime
+                            ? formatDuration(
+                                  new Date(props.prebuildInstance.stoppedTime).getTime() -
+                                      new Date(props.prebuildInstance.creationTime).getTime(),
+                              )
+                            : "..."}
+                    </span>
+                </div>
+            );
             break;
     }
     if (props.prebuildInstance?.status.conditions.stoppedByRequest) {
-        status = <div className="flex space-x-1 items-center text-gray-500">
-            <img alt="" className="h-4 w-4" src={StatusCanceled} />
-            <span>CANCELED</span>
-        </div>;
-        details = <div className="flex space-x-1 items-center text-gray-400">
-            <span>Prebuild canceled</span>
-        </div>;
-    } else if (props.prebuildInstance?.status.conditions.failed || props.prebuildInstance?.status.conditions.headlessTaskFailed) {
-        status = <div className="flex space-x-1 items-center text-gitpod-red">
-            <img alt="" className="h-4 w-4" src={StatusFailed} />
-            <span>FAILED</span>
-        </div>;
-        details = <div className="flex space-x-1 items-center text-gray-400">
-            <span>Prebuild failed</span>
-        </div>;
+        status = (
+            <div className="flex space-x-1 items-center text-gray-500">
+                <img alt="" className="h-4 w-4" src={StatusCanceled} />
+                <span>CANCELED</span>
+            </div>
+        );
+        details = (
+            <div className="flex space-x-1 items-center text-gray-400">
+                <span>Prebuild canceled</span>
+            </div>
+        );
+    } else if (
+        props.prebuildInstance?.status.conditions.failed ||
+        props.prebuildInstance?.status.conditions.headlessTaskFailed
+    ) {
+        status = (
+            <div className="flex space-x-1 items-center text-gitpod-red">
+                <img alt="" className="h-4 w-4" src={StatusFailed} />
+                <span>FAILED</span>
+            </div>
+        );
+        details = (
+            <div className="flex space-x-1 items-center text-gray-400">
+                <span>Prebuild failed</span>
+            </div>
+        );
     } else if (props.prebuildInstance?.status.conditions.timeout) {
-        status = <div className="flex space-x-1 items-center text-gitpod-red">
-            <img alt="" className="h-4 w-4" src={StatusFailed} />
-            <span>FAILED</span>
-        </div>;
-        details = <div className="flex space-x-1 items-center text-gray-400">
-            <span>Prebuild timed out</span>
-        </div>;
+        status = (
+            <div className="flex space-x-1 items-center text-gitpod-red">
+                <img alt="" className="h-4 w-4" src={StatusFailed} />
+                <span>FAILED</span>
+            </div>
+        );
+        details = (
+            <div className="flex space-x-1 items-center text-gray-400">
+                <span>Prebuild timed out</span>
+            </div>
+        );
     }
-    return <div className="flex flex-col space-y-1 justify-center text-sm font-semibold">
-        <div>{status}</div>
-        <div>{details}</div>
-    </div>;
+    return (
+        <div className="flex flex-col space-y-1 justify-center text-sm font-semibold">
+            <div>{status}</div>
+            <div>{details}</div>
+        </div>
+    );
 }

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -6,7 +6,7 @@
 
 import moment from "moment";
 import { PrebuildWithStatus, Project } from "@gitpod/gitpod-protocol";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { useLocation, useRouteMatch } from "react-router";
 import Header from "../components/Header";
 import { ItemsList, Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
@@ -25,7 +25,7 @@ export default function () {
     const { teams } = useContext(TeamsContext);
     const team = getCurrentTeam(location, teams);
 
-    const match = useRouteMatch<{ team: string, resource: string }>("/(t/)?:team/:resource");
+    const match = useRouteMatch<{ team: string; resource: string }>("/(t/)?:team/:resource");
     const projectSlug = match?.params?.resource;
 
     const [project, setProject] = useState<Project | undefined>();
@@ -39,48 +39,7 @@ export default function () {
 
     const [showAuthBanner, setShowAuthBanner] = useState<{ host: string } | undefined>(undefined);
 
-    useEffect(() => {
-        updateProject();
-    }, [teams]);
-
-    useEffect(() => {
-        if (!project) {
-            return;
-        }
-        (async () => {
-            try {
-                await updateBranches();
-            } catch (error) {
-                if (error && error.code === ErrorCodes.NOT_AUTHENTICATED) {
-                    setShowAuthBanner({ host: new URL(project.cloneUrl).hostname });
-                } else {
-                    console.error('Getting branches failed', error);
-                }
-            }
-        })();
-    }, [project]);
-
-    const updateProject = async () => {
-        if (!teams || !projectSlug) {
-            return;
-        }
-        const projects = (!!team
-            ? await getGitpodService().server.getTeamProjects(team.id)
-            : await getGitpodService().server.getUserProjects());
-
-        // Find project matching with slug, otherwise with name
-        const project = projectSlug && projects.find(
-            p => p.slug ? p.slug === projectSlug :
-            p.name === projectSlug);
-
-        if (!project) {
-            return;
-        }
-
-        setProject(project);
-    }
-
-    const updateBranches = async () => {
+    const updateBranches = useCallback(async () => {
         if (!project) {
             return;
         }
@@ -95,7 +54,47 @@ export default function () {
         } finally {
             setIsLoadingBranches(false);
         }
-    }
+    }, [project]);
+
+    useEffect(() => {
+        const updateProject = async () => {
+            if (!teams || !projectSlug) {
+                return;
+            }
+            const projects = !!team
+                ? await getGitpodService().server.getTeamProjects(team.id)
+                : await getGitpodService().server.getUserProjects();
+
+            // Find project matching with slug, otherwise with name
+            const project =
+                projectSlug && projects.find((p) => (p.slug ? p.slug === projectSlug : p.name === projectSlug));
+
+            if (!project) {
+                return;
+            }
+
+            setProject(project);
+        };
+
+        updateProject();
+    }, [projectSlug, team, teams]);
+
+    useEffect(() => {
+        if (!project) {
+            return;
+        }
+        (async () => {
+            try {
+                await updateBranches();
+            } catch (error) {
+                if (error && error.code === ErrorCodes.NOT_AUTHENTICATED) {
+                    setShowAuthBanner({ host: new URL(project.cloneUrl).hostname });
+                } else {
+                    console.error("Getting branches failed", error);
+                }
+            }
+        })();
+    }, [project, updateBranches]);
 
     const tryAuthorize = async (host: string, onSuccess: () => void) => {
         try {
@@ -104,7 +103,7 @@ export default function () {
                 onSuccess,
                 onError: (error) => {
                     console.log(error);
-                }
+                },
             });
         } catch (error) {
             console.log(error);
@@ -118,7 +117,7 @@ export default function () {
             await getGitpodService().reconnect();
 
             // retry fetching branches
-            updateBranches().catch(e => console.log(e));
+            updateBranches().catch((e) => console.log(e));
         });
     };
 
@@ -129,7 +128,7 @@ export default function () {
             loadPrebuild(branch);
         }
         return lastPrebuild;
-    }
+    };
 
     const loadPrebuild = async (branch: Project.BranchDetails) => {
         if (prebuildLoaders.has(branch.name) || lastPrebuilds.has(branch.name)) {
@@ -146,129 +145,216 @@ export default function () {
             branch: branch.name,
             latest: true,
         });
-        setLastPrebuilds(prev => new Map(prev).set(branch.name, lastPrebuild[0]));
+        setLastPrebuilds((prev) => new Map(prev).set(branch.name, lastPrebuild[0]));
         prebuildLoaders.delete(branch.name);
-    }
+    };
 
     const filter = (branch: Project.BranchDetails) => {
-        if (searchFilter && `${branch.changeTitle} ${branch.name}`.toLowerCase().includes(searchFilter.toLowerCase()) === false) {
+        if (
+            searchFilter &&
+            `${branch.changeTitle} ${branch.name}`.toLowerCase().includes(searchFilter.toLowerCase()) === false
+        ) {
             return false;
         }
         return true;
-    }
+    };
 
     const triggerPrebuild = (branch: Project.BranchDetails) => {
         if (!project) {
             return;
         }
         getGitpodService().server.triggerPrebuild(project.id, branch.name);
-    }
+    };
 
     const cancelPrebuild = (prebuildId: string) => {
         if (!project) {
             return;
         }
         getGitpodService().server.cancelPrebuild(project.id, prebuildId);
-    }
+    };
 
     const formatDate = (date: string | undefined) => {
         return date ? moment(date).fromNow() : "";
-    }
+    };
 
-    return <>
-        <Header title="Branches" subtitle={<h2 className="tracking-wide">View recent active branches for <a className="gp-link" href={project?.cloneUrl!}>{toRemoteURL(project?.cloneUrl || '')}</a>.</h2>} />
-        <div className="app-container">
-            {showAuthBanner ? (
-                <div className="mt-8 rounded-xl text-gray-500 bg-gray-50 dark:bg-gray-800 flex-col">
-                    <div className="p-8 text-center">
-                        <img src={NoAccess} alt="" title="No Access" className="m-auto mb-4" />
-                        <div className="text-center text-gray-600 dark:text-gray-50 pb-3 font-bold">
-                            No Access
+    return (
+        <>
+            <Header
+                title="Branches"
+                subtitle={
+                    <h2 className="tracking-wide">
+                        View recent active branches for{" "}
+                        <a className="gp-link" href={project?.cloneUrl!}>
+                            {toRemoteURL(project?.cloneUrl || "")}
+                        </a>
+                        .
+                    </h2>
+                }
+            />
+            <div className="app-container">
+                {showAuthBanner ? (
+                    <div className="mt-8 rounded-xl text-gray-500 bg-gray-50 dark:bg-gray-800 flex-col">
+                        <div className="p-8 text-center">
+                            <img src={NoAccess} alt="" title="No Access" className="m-auto mb-4" />
+                            <div className="text-center text-gray-600 dark:text-gray-50 pb-3 font-bold">No Access</div>
+                            <div className="text-center dark:text-gray-400 pb-3">
+                                Authorize {showAuthBanner.host} <br />
+                                to access branch information.
+                            </div>
+                            <button
+                                className={`primary mr-2 py-2`}
+                                onClick={() => onConfirmShowAuthModal(showAuthBanner.host)}
+                            >
+                                Authorize Provider
+                            </button>
                         </div>
-                        <div className="text-center dark:text-gray-400 pb-3">
-                            Authorize {showAuthBanner.host} <br />to access branch information.
-                        </div>
-                        <button className={`primary mr-2 py-2`} onClick={() => onConfirmShowAuthModal(showAuthBanner.host)}>Authorize Provider</button>
                     </div>
-                </div>
-            ) : (<>
-                <div className="flex mt-8">
-                    <div className="flex">
-                        <div className="py-4">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" /></svg>
-                        </div>
-                        <input type="search" placeholder="Search Active Branches" onChange={e => setSearchFilter(e.target.value)} />
-                    </div>
-                    <div className="flex-1" />
-                    <div className="py-3 pl-3">
-                    </div>
-                </div>
-                <ItemsList className="mt-2">
-                    <Item header={true} className="grid grid-cols-3">
-                        <ItemField className="my-auto">
-                            <span>Branch</span>
-                        </ItemField>
-                        <ItemField className="my-auto">
-                            <span>Commit</span>
-                        </ItemField>
-                        <ItemField className="my-auto">
-                            <span>Prebuild</span>
-                        </ItemField>
-                    </Item>
-                    {isLoadingBranches && <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
-                        <img className="h-4 w-4 animate-spin" src={Spinner} />
-                        <span>Fetching repository branches...</span>
-                    </div>}
-                    {branches.filter(filter).slice(0, 10).map((branch, index) => {
-
-                        const prebuild = lastPrebuild(branch); // this might lazily trigger fetching of prebuild details
-
-                        const avatar = branch.changeAuthorAvatar && <img className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2" src={branch.changeAuthorAvatar || ''} alt={branch.changeAuthor} />;
-                        const statusIcon = prebuildStatusIcon(prebuild);
-                        const status = prebuildStatusLabel(prebuild);
-
-                        return <Item key={`branch-${index}-${branch.name}`} className="grid grid-cols-3 group">
-                            <ItemField className="flex items-center my-auto">
-                                <div>
-                                    <a href={branch.url}><div className="text-base text-gray-600 hover:text-gray-800 dark:text-gray-50 dark:hover:text-gray-200 font-medium mb-1">
-                                        {branch.name}
-                                        {branch.isDefault && (<span className="ml-2 self-center rounded-xl py-0.5 px-2 text-sm bg-blue-50 text-blue-40 dark:bg-blue-500 dark:text-blue-100">DEFAULT</span>)}
-                                    </div></a>
+                ) : (
+                    <>
+                        <div className="flex mt-8">
+                            <div className="flex">
+                                <div className="py-4">
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        height="16"
+                                    >
+                                        <path
+                                            fill="#A8A29E"
+                                            d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                        />
+                                    </svg>
                                 </div>
-                            </ItemField>
-                            <ItemField className="flex items-center my-auto">
-                                <div className="truncate">
-                                    <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate">{shortCommitMessage(branch.changeTitle)}</div>
-                                    <p>{avatar}Authored {formatDate(branch.changeDate)} · {branch.changeHash?.substring(0, 8)}</p>
+                                <input
+                                    type="search"
+                                    placeholder="Search Active Branches"
+                                    onChange={(e) => setSearchFilter(e.target.value)}
+                                />
+                            </div>
+                            <div className="flex-1" />
+                            <div className="py-3 pl-3"></div>
+                        </div>
+                        <ItemsList className="mt-2">
+                            <Item header={true} className="grid grid-cols-3">
+                                <ItemField className="my-auto">
+                                    <span>Branch</span>
+                                </ItemField>
+                                <ItemField className="my-auto">
+                                    <span>Commit</span>
+                                </ItemField>
+                                <ItemField className="my-auto">
+                                    <span>Prebuild</span>
+                                </ItemField>
+                            </Item>
+                            {isLoadingBranches && (
+                                <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
+                                    <img className="h-4 w-4 animate-spin" src={Spinner} alt="" />
+                                    <span>Fetching repository branches...</span>
                                 </div>
-                            </ItemField>
-                            <ItemField className="flex items-center my-auto">
-                                <a className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1 cursor-pointer" href={prebuild ? `/${!!team ? 't/' + team.slug : 'projects'}/${projectSlug}/${prebuild.info.id}` : 'javascript:void(0)'}>
-                                    {prebuild ? (<><div className="inline-block align-text-bottom mr-2 w-4 h-4">{statusIcon}</div>{status}</>) : (<span> </span>)}
-                                </a>
-                                <span className="flex-grow" />
-                                <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
-                                    <button className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}>New Workspace</button>
-                                </a>
-                                <ItemFieldContextMenu className="py-0.5" menuEntries={(!prebuild || prebuild.status === 'aborted' || prebuild.status === 'failed' || prebuild.status === 'timeout' || !!prebuild.error)
-                                    ? [{
-                                        title: `${prebuild ? 'Rerun' : 'Run'} Prebuild (${branch.name})`,
-                                        onClick: () => triggerPrebuild(branch),
-                                    }]
-                                    : (prebuild.status === 'building'
-                                        ? [{
-                                            title: 'Cancel Prebuild',
-                                            customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
-                                            onClick: () => cancelPrebuild(prebuild.info.id),
-                                        }]
-                                        : [])} />
-                            </ItemField>
-                        </Item>
-                    }
-                    )}
-                </ItemsList>
-            </>)}
-        </div>
+                            )}
+                            {branches
+                                .filter(filter)
+                                .slice(0, 10)
+                                .map((branch, index) => {
+                                    const prebuild = lastPrebuild(branch); // this might lazily trigger fetching of prebuild details
 
-    </>;
+                                    const avatar = branch.changeAuthorAvatar && (
+                                        <img
+                                            className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2"
+                                            src={branch.changeAuthorAvatar || ""}
+                                            alt={branch.changeAuthor}
+                                        />
+                                    );
+                                    const statusIcon = prebuildStatusIcon(prebuild);
+                                    const status = prebuildStatusLabel(prebuild);
+
+                                    return (
+                                        <Item key={`branch-${index}-${branch.name}`} className="grid grid-cols-3 group">
+                                            <ItemField className="flex items-center my-auto">
+                                                <div>
+                                                    <a href={branch.url}>
+                                                        <div className="text-base text-gray-600 hover:text-gray-800 dark:text-gray-50 dark:hover:text-gray-200 font-medium mb-1">
+                                                            {branch.name}
+                                                            {branch.isDefault && (
+                                                                <span className="ml-2 self-center rounded-xl py-0.5 px-2 text-sm bg-blue-50 text-blue-40 dark:bg-blue-500 dark:text-blue-100">
+                                                                    DEFAULT
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </a>
+                                                </div>
+                                            </ItemField>
+                                            <ItemField className="flex items-center my-auto">
+                                                <div className="truncate">
+                                                    <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate">
+                                                        {shortCommitMessage(branch.changeTitle)}
+                                                    </div>
+                                                    <p>
+                                                        {avatar}Authored {formatDate(branch.changeDate)} ·{" "}
+                                                        {branch.changeHash?.substring(0, 8)}
+                                                    </p>
+                                                </div>
+                                            </ItemField>
+                                            <ItemField className="flex items-center my-auto">
+                                                {prebuild ? (
+                                                    <a
+                                                        className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1 cursor-pointer"
+                                                        href={`/${
+                                                            !!team ? "t/" + team.slug : "projects"
+                                                        }/${projectSlug}/${prebuild.info.id}`}
+                                                    >
+                                                        <div className="inline-block align-text-bottom mr-2 w-4 h-4">
+                                                            {statusIcon}
+                                                        </div>
+                                                        {status}
+                                                    </a>
+                                                ) : null}
+                                                <span className="flex-grow" />
+                                                <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
+                                                    <button
+                                                        className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}
+                                                    >
+                                                        New Workspace
+                                                    </button>
+                                                </a>
+                                                <ItemFieldContextMenu
+                                                    className="py-0.5"
+                                                    menuEntries={
+                                                        !prebuild ||
+                                                        prebuild.status === "aborted" ||
+                                                        prebuild.status === "failed" ||
+                                                        prebuild.status === "timeout" ||
+                                                        !!prebuild.error
+                                                            ? [
+                                                                  {
+                                                                      title: `${prebuild ? "Rerun" : "Run"} Prebuild (${
+                                                                          branch.name
+                                                                      })`,
+                                                                      onClick: () => triggerPrebuild(branch),
+                                                                  },
+                                                              ]
+                                                            : prebuild.status === "building"
+                                                            ? [
+                                                                  {
+                                                                      title: "Cancel Prebuild",
+                                                                      customFontStyle:
+                                                                          "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                                                                      onClick: () => cancelPrebuild(prebuild.info.id),
+                                                                  },
+                                                              ]
+                                                            : []
+                                                    }
+                                                />
+                                            </ItemField>
+                                        </Item>
+                                    );
+                                })}
+                        </ItemsList>
+                    </>
+                )}
+            </div>
+        </>
+    );
 }

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -7,17 +7,17 @@
 import moment from "moment";
 import { Link } from "react-router-dom";
 import Header from "../components/Header";
-import projectsEmpty from '../images/projects-empty.svg';
-import projectsEmptyDark from '../images/projects-empty-dark.svg';
+import projectsEmpty from "../images/projects-empty.svg";
+import projectsEmptyDark from "../images/projects-empty-dark.svg";
 import { useHistory, useLocation } from "react-router";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
 import { ThemeContext } from "../theme-context";
 import { PrebuildWithStatus, Project } from "@gitpod/gitpod-protocol";
 import { toRemoteURL } from "./render-utils";
 import ContextMenu from "../components/ContextMenu";
-import ConfirmationModal from "../components/ConfirmationModal"
+import ConfirmationModal from "../components/ConfirmationModal";
 import { prebuildStatusIcon } from "./Prebuilds";
 
 export default function () {
@@ -26,71 +26,75 @@ export default function () {
 
     const { teams } = useContext(TeamsContext);
     const team = getCurrentTeam(location, teams);
-    const [ projects, setProjects ] = useState<Project[]>([]);
-    const [ lastPrebuilds, setLastPrebuilds ] = useState<Map<string, PrebuildWithStatus>>(new Map());
+    const [projects, setProjects] = useState<Project[]>([]);
+    const [lastPrebuilds, setLastPrebuilds] = useState<Map<string, PrebuildWithStatus>>(new Map());
 
     const { isDark } = useContext(ThemeContext);
 
     const [searchFilter, setSearchFilter] = useState<string | undefined>();
 
-    useEffect(() => {
-        updateProjects();
-    }, [ teams ]);
-
-    const updateProjects = async () => {
+    const updateProjects = useCallback(async () => {
         if (!teams) {
             return;
         }
-        const infos = (!!team
+        const infos = !!team
             ? await getGitpodService().server.getTeamProjects(team.id)
-            : await getGitpodService().server.getUserProjects());
+            : await getGitpodService().server.getUserProjects();
         setProjects(infos);
 
         const map = new Map();
-        await Promise.all(infos.map(async (p) => {
-            try {
-                const lastPrebuild = await getGitpodService().server.findPrebuilds({
-                    projectId: p.id,
-                    latest: true,
-                });
-                if (lastPrebuild[0]) {
-                    map.set(p.id, lastPrebuild[0]);
+        await Promise.all(
+            infos.map(async (p) => {
+                try {
+                    const lastPrebuild = await getGitpodService().server.findPrebuilds({
+                        projectId: p.id,
+                        latest: true,
+                    });
+                    if (lastPrebuild[0]) {
+                        map.set(p.id, lastPrebuild[0]);
+                    }
+                } catch (error) {
+                    console.error("Failed to load prebuilds for project", p, error);
                 }
-            } catch (error) {
-                console.error('Failed to load prebuilds for project', p, error);
-            }
-        }));
+            }),
+        );
         setLastPrebuilds(map);
-    }
+    }, [team, teams]);
 
-    const newProjectUrl = !!team ? `/new?team=${team.slug}` : '/new?user=1';
+    useEffect(() => {
+        updateProjects();
+    }, [teams, updateProjects]);
+
+    const newProjectUrl = !!team ? `/new?team=${team.slug}` : "/new?user=1";
     const onNewProject = () => {
         history.push(newProjectUrl);
-    }
+    };
 
     const onRemoveProject = async (p: Project) => {
-        setRemoveModalVisible(false)
+        setRemoveModalVisible(false);
         await getGitpodService().server.deleteProject(p.id);
         await updateProjects();
-    }
+    };
 
     const filter = (project: Project) => {
         if (searchFilter && `${project.name}`.toLowerCase().includes(searchFilter.toLowerCase()) === false) {
             return false;
         }
         return true;
-    }
+    };
 
     function hasNewerPrebuild(p0: Project, p1: Project): number {
-        return moment(lastPrebuilds.get(p1.id)?.info?.startedAt || '1970-01-01').diff(moment(lastPrebuilds.get(p0.id)?.info?.startedAt || '1970-01-01'));
+        return moment(lastPrebuilds.get(p1.id)?.info?.startedAt || "1970-01-01").diff(
+            moment(lastPrebuilds.get(p0.id)?.info?.startedAt || "1970-01-01"),
+        );
     }
 
-    let [ isRemoveModalVisible, setRemoveModalVisible ] = useState(false);
-    let [ removeProjectHandler, setRemoveProjectHandler ] = useState<() => void>(()=> () => {})
-    let [ willRemoveProject, setWillRemoveProject ] = useState<Project>()
+    let [isRemoveModalVisible, setRemoveModalVisible] = useState(false);
+    let [removeProjectHandler, setRemoveProjectHandler] = useState<() => void>(() => () => {});
+    let [willRemoveProject, setWillRemoveProject] = useState<Project>();
 
     function renderProjectLink(project: Project): React.ReactElement {
-        let slug = '';
+        let slug = "";
         const name = project.name;
 
         if (project.slug) {
@@ -103,127 +107,198 @@ export default function () {
         return (
             <Link to={`/${teamOrUserSlug}/${slug}`}>
                 <span className="text-xl font-semibold">{name}</span>
-            </Link>)
+            </Link>
+        );
     }
 
-    const teamOrUserSlug = !!team ? 't/' + team.slug : 'projects';
+    const teamOrUserSlug = !!team ? "t/" + team.slug : "projects";
 
-    return <>
-
-        {isRemoveModalVisible && <ConfirmationModal
-            title="Remove Project"
-            areYouSureText="Are you sure you want to remove this project from this team? Team members will also lose access to this project."
-            children={{
-                name: willRemoveProject?.name ?? "",
-                description: willRemoveProject?.cloneUrl ?? "",
-            }}
-            buttonText="Remove Project"
-            visible={isRemoveModalVisible}
-            onClose={() => setRemoveModalVisible(false)}
-            onConfirm={removeProjectHandler}
-        />}
-        <Header title="Projects" subtitle="Manage recently added projects." />
-        {projects.length === 0 && (
-            <div>
-                <img alt="Projects (empty)" className="h-44 mt-24 mx-auto" role="presentation" src={isDark ? projectsEmptyDark : projectsEmpty} />
-                <h3 className="text-center text-gray-500 mt-8">No Recent Projects</h3>
-                <p className="text-center text-base text-gray-500 mt-4">Add projects to enable and manage Prebuilds.<br /><a className="gp-link" href="https://www.gitpod.io/docs/prebuilds/">Learn more about Prebuilds</a></p>
-                <div className="flex space-x-2 justify-center mt-7">
-                    <Link to={newProjectUrl}><button>New Project</button></Link>
-                    {team && <Link to="./members"><button className="secondary">Invite Members</button></Link>}
+    return (
+        <>
+            {isRemoveModalVisible && (
+                <ConfirmationModal
+                    title="Remove Project"
+                    areYouSureText="Are you sure you want to remove this project from this team? Team members will also lose access to this project."
+                    children={{
+                        name: willRemoveProject?.name ?? "",
+                        description: willRemoveProject?.cloneUrl ?? "",
+                    }}
+                    buttonText="Remove Project"
+                    visible={isRemoveModalVisible}
+                    onClose={() => setRemoveModalVisible(false)}
+                    onConfirm={removeProjectHandler}
+                />
+            )}
+            <Header title="Projects" subtitle="Manage recently added projects." />
+            {projects.length === 0 && (
+                <div>
+                    <img
+                        alt="Projects (empty)"
+                        className="h-44 mt-24 mx-auto"
+                        role="presentation"
+                        src={isDark ? projectsEmptyDark : projectsEmpty}
+                    />
+                    <h3 className="text-center text-gray-500 mt-8">No Recent Projects</h3>
+                    <p className="text-center text-base text-gray-500 mt-4">
+                        Add projects to enable and manage Prebuilds.
+                        <br />
+                        <a className="gp-link" href="https://www.gitpod.io/docs/prebuilds/">
+                            Learn more about Prebuilds
+                        </a>
+                    </p>
+                    <div className="flex space-x-2 justify-center mt-7">
+                        <Link to={newProjectUrl}>
+                            <button>New Project</button>
+                        </Link>
+                        {team && (
+                            <Link to="./members">
+                                <button className="secondary">Invite Members</button>
+                            </Link>
+                        )}
+                    </div>
                 </div>
-            </div>
-
-        )}
-        {projects.length > 0 && (
-            <div className="app-container">
-                <div className="mt-8 pb-2 flex border-b border-gray-200 dark:border-gray-800">
-                    <div className="flex">
-                        <div className="py-4">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z" /></svg>
+            )}
+            {projects.length > 0 && (
+                <div className="app-container">
+                    <div className="mt-8 pb-2 flex border-b border-gray-200 dark:border-gray-800">
+                        <div className="flex">
+                            <div className="py-4">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    height="16"
+                                >
+                                    <path
+                                        fill="#A8A29E"
+                                        d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                    />
+                                </svg>
+                            </div>
+                            <input
+                                type="search"
+                                placeholder="Search Projects"
+                                onChange={(e) => setSearchFilter(e.target.value)}
+                            />
                         </div>
-                        <input type="search" placeholder="Search Projects" onChange={e => setSearchFilter(e.target.value)} />
+                        <div className="flex-1" />
+                        <div className="py-3 pl-3"></div>
+                        {team && (
+                            <Link to="./members" className="flex">
+                                <button className="ml-2 secondary">Invite Members</button>
+                            </Link>
+                        )}
+                        <button className="ml-2" onClick={() => onNewProject()}>
+                            New Project
+                        </button>
                     </div>
-                    <div className="flex-1" />
-                    <div className="py-3 pl-3">
-                    </div>
-                    {team && <Link to="./members" className="flex"><button className="ml-2 secondary">Invite Members</button></Link>}
-                    <button className="ml-2" onClick={() => onNewProject()}>New Project</button>
-                </div>
-                <div className="mt-4 grid lg:grid-cols-3 md:grid-cols-2 grid-cols-1 gap-4 pb-40">
-                    {projects.filter(filter).sort(hasNewerPrebuild).map(p => (<div key={`project-${p.id}`} className="h-52">
-                        <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
-                            <div className="h-32 p-6">
-                                <div className="flex text-gray-700 dark:text-gray-200 font-medium">
-                                    {renderProjectLink(p)}
-                                    <span className="flex-grow" />
-                                    <div className="justify-end">
-                                        <ContextMenu menuEntries={[
-                                            {
-                                                title: "New Workspace",
-                                                href: `/#${p.cloneUrl}`,
-                                                separator: true,
-                                            },
-                                            {
-                                                title: "Remove Project",
-                                                customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
-                                                onClick: () => {
-                                                    setWillRemoveProject(p)
-                                                    setRemoveProjectHandler(() => () => {
-                                                        onRemoveProject(p)
-                                                    })
-                                                    setRemoveModalVisible(true)
-                                                }
-                                            },
-                                        ]} />
+                    <div className="mt-4 grid lg:grid-cols-3 md:grid-cols-2 grid-cols-1 gap-4 pb-40">
+                        {projects
+                            .filter(filter)
+                            .sort(hasNewerPrebuild)
+                            .map((p) => (
+                                <div key={`project-${p.id}`} className="h-52">
+                                    <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
+                                        <div className="h-32 p-6">
+                                            <div className="flex text-gray-700 dark:text-gray-200 font-medium">
+                                                {renderProjectLink(p)}
+                                                <span className="flex-grow" />
+                                                <div className="justify-end">
+                                                    <ContextMenu
+                                                        menuEntries={[
+                                                            {
+                                                                title: "New Workspace",
+                                                                href: `/#${p.cloneUrl}`,
+                                                                separator: true,
+                                                            },
+                                                            {
+                                                                title: "Remove Project",
+                                                                customFontStyle:
+                                                                    "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                                                                onClick: () => {
+                                                                    setWillRemoveProject(p);
+                                                                    setRemoveProjectHandler(() => () => {
+                                                                        onRemoveProject(p);
+                                                                    });
+                                                                    setRemoveModalVisible(true);
+                                                                },
+                                                            },
+                                                        ]}
+                                                    />
+                                                </div>
+                                            </div>
+                                            <a href={p.cloneUrl.replace(/\.git$/, "")}>
+                                                <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500 pr-10 truncate">
+                                                    {toRemoteURL(p.cloneUrl)}
+                                                </p>
+                                            </a>
+                                        </div>
+                                        <div className="h-10 px-6 py-1 text-gray-400 text-sm">
+                                            <span className="hover:text-gray-600 dark:hover:text-gray-300">
+                                                <Link to={`/${teamOrUserSlug}/${p.slug || p.name}`}>Branches</Link>
+                                            </span>
+                                            <span className="mx-2 my-auto">·</span>
+                                            <span className="hover:text-gray-600 dark:hover:text-gray-300">
+                                                <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`}>
+                                                    Prebuilds
+                                                </Link>
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div className="h-10 px-4 border rounded-b-xl dark:border-gray-800 bg-gray-100 border-gray-100 dark:bg-gray-800">
+                                        {lastPrebuilds.get(p.id) ? (
+                                            <div className="flex flex-row h-full text-sm space-x-4">
+                                                <Link
+                                                    to={`/${teamOrUserSlug}/${p.slug || p.name}/${
+                                                        lastPrebuilds.get(p.id)?.info?.id
+                                                    }`}
+                                                    className="flex-grow flex items-center group space-x-2 truncate"
+                                                >
+                                                    {prebuildStatusIcon(lastPrebuilds.get(p.id))}
+                                                    <div
+                                                        className="font-semibold text-gray-500 dark:text-gray-400 truncate"
+                                                        title={lastPrebuilds.get(p.id)?.info?.branch}
+                                                    >
+                                                        {lastPrebuilds.get(p.id)?.info?.branch}
+                                                    </div>
+                                                    <span className="flex-shrink-0 mx-1 text-gray-400 dark:text-gray-600">
+                                                        ·
+                                                    </span>
+                                                    <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">
+                                                        {moment(lastPrebuilds.get(p.id)?.info?.startedAt).fromNow()}
+                                                    </div>
+                                                </Link>
+                                                <Link
+                                                    to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`}
+                                                    className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                                                >
+                                                    View All &rarr;
+                                                </Link>
+                                            </div>
+                                        ) : (
+                                            <div className="flex h-full text-md">
+                                                <p className="my-auto ">No recent prebuilds</p>
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
-                                <a href={p.cloneUrl.replace(/\.git$/, '')}>
-                                    <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500 pr-10 truncate">{toRemoteURL(p.cloneUrl)}</p>
-                                </a>
+                            ))}
+                        {!searchFilter && (
+                            <div
+                                key="new-project"
+                                className="h-52 border-dashed border-2 border-gray-100 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl focus:bg-gitpod-kumquat-light transition ease-in-out group"
+                            >
+                                <Link to={newProjectUrl} data-analytics='{"button_type":"card"}'>
+                                    <div className="flex h-full">
+                                        <div className="m-auto text-gray-400 dark:text-gray-600">New Project</div>
+                                    </div>
+                                </Link>
                             </div>
-                            <div className="h-10 px-6 py-1 text-gray-400 text-sm">
-                                <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}`}>
-                                        Branches
-                                    </Link>
-                                </span>
-                                <span className="mx-2 my-auto">·</span>
-                                <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`}>
-                                        Prebuilds
-                                    </Link>
-                                </span>
-                            </div>
-                        </div>
-                        <div className="h-10 px-4 border rounded-b-xl dark:border-gray-800 bg-gray-100 border-gray-100 dark:bg-gray-800">
-                            {lastPrebuilds.get(p.id)
-                                ? (<div className="flex flex-row h-full text-sm space-x-4">
-                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/${lastPrebuilds.get(p.id)?.info?.id}`} className="flex-grow flex items-center group space-x-2 truncate">
-                                        {prebuildStatusIcon(lastPrebuilds.get(p.id))}
-                                        <div className="font-semibold text-gray-500 dark:text-gray-400 truncate" title={lastPrebuilds.get(p.id)?.info?.branch}>{lastPrebuilds.get(p.id)?.info?.branch}</div>
-                                        <span className="flex-shrink-0 mx-1 text-gray-400 dark:text-gray-600">·</span>
-                                        <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">{moment(lastPrebuilds.get(p.id)?.info?.startedAt).fromNow()}</div>
-                                    </Link>
-                                    <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`} className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">View All &rarr;</Link>
-                                </div>)
-                                : (<div className="flex h-full text-md">
-                                    <p className="my-auto ">No recent prebuilds</p>
-                                </div>)}
-                        </div>
-                    </div>))}
-                    {!searchFilter && (
-                        <div key="new-project"
-                            className="h-52 border-dashed border-2 border-gray-100 dark:border-gray-800 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl focus:bg-gitpod-kumquat-light transition ease-in-out group">
-                            <Link to={newProjectUrl} data-analytics='{"button_type":"card"}'>
-                                <div className="flex h-full">
-                                    <div className="m-auto text-gray-400 dark:text-gray-600">New Project</div>
-                                </div>
-                            </Link>
-                        </div>
-                    )}
+                        )}
+                    </div>
                 </div>
-            </div>
-        )}
-    </>;
+            )}
+        </>
+    );
 }

--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -4,19 +4,19 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import bitbucket from './images/bitbucket.svg';
-import github from './images/github.svg';
-import gitlab from './images/gitlab.svg';
+import bitbucket from "./images/bitbucket.svg";
+import github from "./images/github.svg";
+import gitlab from "./images/gitlab.svg";
 import { gitpodHostUrl } from "./service/service";
 
 function iconForAuthProvider(type: string) {
     switch (type) {
         case "GitHub":
-            return <img className="fill-current dark:filter-invert w-5 h-5 ml-3 mr-3 my-auto" src={github} />;
+            return <img className="fill-current dark:filter-invert w-5 h-5 ml-3 mr-3 my-auto" src={github} alt="" />;
         case "GitLab":
-            return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={gitlab} />;
+            return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={gitlab} alt="" />;
         case "Bitbucket":
-            return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={bitbucket} />;
+            return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={bitbucket} alt="" />;
         default:
             return <></>;
     }
@@ -25,11 +25,11 @@ function iconForAuthProvider(type: string) {
 function simplifyProviderName(host: string) {
     switch (host) {
         case "github.com":
-            return "GitHub"
+            return "GitHub";
         case "gitlab.com":
-            return "GitLab"
+            return "GitLab";
         case "bitbucket.org":
-            return "Bitbucket"
+            return "Bitbucket";
         default:
             return host;
     }
@@ -42,35 +42,45 @@ interface OpenAuthorizeWindowParams {
     overrideScopes?: boolean;
     overrideReturn?: string;
     onSuccess?: (payload?: string) => void;
-    onError?: (error: string | { error: string, description?: string }) => void;
+    onError?: (error: string | { error: string; description?: string }) => void;
 }
 
 async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
     const { login, host, scopes, overrideScopes, onSuccess, onError } = params;
-    let search = 'message=success';
+    let search = "message=success";
     const redirectURL = getSafeURLRedirect();
     if (redirectURL) {
-        search = `${search}&returnTo=${encodeURIComponent(redirectURL)}`
+        search = `${search}&returnTo=${encodeURIComponent(redirectURL)}`;
     }
-    const returnTo = gitpodHostUrl.with({ pathname: 'complete-auth', search: search }).toString();
+    const returnTo = gitpodHostUrl.with({ pathname: "complete-auth", search: search }).toString();
     const requestedScopes = scopes || [];
     const url = login
-        ? gitpodHostUrl.withApi({
-            pathname: '/login',
-            search: `host=${host}&returnTo=${encodeURIComponent(returnTo)}`
-        }).toString()
-        : gitpodHostUrl.withApi({
-            pathname: '/authorize',
-            search: `returnTo=${encodeURIComponent(returnTo)}&host=${host}${overrideScopes ? "&override=true" : ""}&scopes=${requestedScopes.join(',')}`
-        }).toString();
+        ? gitpodHostUrl
+              .withApi({
+                  pathname: "/login",
+                  search: `host=${host}&returnTo=${encodeURIComponent(returnTo)}`,
+              })
+              .toString()
+        : gitpodHostUrl
+              .withApi({
+                  pathname: "/authorize",
+                  search: `returnTo=${encodeURIComponent(returnTo)}&host=${host}${
+                      overrideScopes ? "&override=true" : ""
+                  }&scopes=${requestedScopes.join(",")}`,
+              })
+              .toString();
 
     const width = 800;
     const height = 800;
-    const left = (window.screen.width / 2) - (width / 2);
-    const top = (window.screen.height / 2) - (height / 2);
+    const left = window.screen.width / 2 - width / 2;
+    const top = window.screen.height / 2 - height / 2;
 
     // Optimistically assume that the new window was opened.
-    window.open(url, "gitpod-auth-window", `width=${width},height=${height},top=${top},left=${left}status=yes,scrollbars=yes,resizable=yes`);
+    window.open(
+        url,
+        "gitpod-auth-window",
+        `width=${width},height=${height},top=${top},left=${left}status=yes,scrollbars=yes,resizable=yes`,
+    );
 
     const eventListener = (event: MessageEvent) => {
         // todo: check event.origin
@@ -82,14 +92,14 @@ async function openAuthorizeWindow(params: OpenAuthorizeWindowParams) {
                 console.log(`Received Auth Window Result. Closing Window.`);
                 event.source.close();
             }
-        }
+        };
 
         if (typeof event.data === "string" && event.data.startsWith("success")) {
             killAuthWindow();
             onSuccess && onSuccess(event.data);
         }
         if (typeof event.data === "string" && event.data.startsWith("error:")) {
-            let error: string | { error: string, description?: string } = atob(event.data.substring("error:".length));
+            let error: string | { error: string; description?: string } = atob(event.data.substring("error:".length));
             try {
                 const payload = JSON.parse(error);
                 if (typeof payload === "object" && payload.error) {
@@ -109,11 +119,14 @@ const getSafeURLRedirect = (source?: string) => {
     const returnToURL: string | null = new URLSearchParams(source ? source : window.location.search).get("returnTo");
     if (returnToURL) {
         // Only allow oauth on the same host
-        if (returnToURL.toLowerCase().startsWith(`${window.location.protocol}//${window.location.host}/api/oauth/`.toLowerCase())) {
+        if (
+            returnToURL
+                .toLowerCase()
+                .startsWith(`${window.location.protocol}//${window.location.host}/api/oauth/`.toLowerCase())
+        ) {
             return returnToURL;
         }
     }
-}
+};
 
-
-export { iconForAuthProvider, simplifyProviderName, openAuthorizeWindow, getSafeURLRedirect }
+export { iconForAuthProvider, simplifyProviderName, openAuthorizeWindow, getSafeURLRedirect };

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -22,26 +22,26 @@ interface EnvVarModalProps {
 }
 
 function AddEnvVarModal(p: EnvVarModalProps) {
-    const [ev, setEv] = useState({...p.envVar});
-    const [error, setError] = useState('');
+    const [ev, setEv] = useState({ ...p.envVar });
+    const [error, setError] = useState("");
     const ref = useRef(ev);
 
     const update = (pev: Partial<UserEnvVarValue>) => {
-        const newEnv = { ...ref.current, ... pev};
+        const newEnv = { ...ref.current, ...pev };
         setEv(newEnv);
         ref.current = newEnv;
     };
 
     useEffect(() => {
-        setEv({...p.envVar});
-        setError('');
+        setEv({ ...p.envVar });
+        setError("");
     }, [p.envVar]);
 
     const isNew = !p.envVar.id;
     let save = () => {
         const v = ref.current;
         const errorMsg = p.validate(v);
-        if (errorMsg !== '') {
+        if (errorMsg !== "") {
             setError(errorMsg);
             return false;
         } else {
@@ -51,45 +51,80 @@ function AddEnvVarModal(p: EnvVarModalProps) {
         }
     };
 
-    return <Modal visible={true} onClose={p.onClose} onEnter={save}>
-        <h3 className="mb-4">{isNew ? 'New' : 'Edit'} Variable</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
-            {error ? <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">
-                {error}
-            </div> : null}
-            <div>
-                <h4>Name</h4>
-                <input autoFocus className="w-full" type="text" value={ev.name} onChange={(v) => { update({name: v.target.value}) }} />
+    return (
+        <Modal visible={true} onClose={p.onClose} onEnter={save}>
+            <h3 className="mb-4">{isNew ? "New" : "Edit"} Variable</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
+                {error ? (
+                    <div className="bg-gitpod-kumquat-light rounded-md p-3 text-gitpod-red text-sm mb-2">{error}</div>
+                ) : null}
+                <div>
+                    <h4>Name</h4>
+                    <input
+                        autoFocus
+                        className="w-full"
+                        type="text"
+                        value={ev.name}
+                        onChange={(v) => {
+                            update({ name: v.target.value });
+                        }}
+                    />
+                </div>
+                <div className="mt-4">
+                    <h4>Value</h4>
+                    <input
+                        className="w-full"
+                        type="text"
+                        value={ev.value}
+                        onChange={(v) => {
+                            update({ value: v.target.value });
+                        }}
+                    />
+                </div>
+                <div className="mt-4">
+                    <h4>Scope</h4>
+                    <input
+                        className="w-full"
+                        type="text"
+                        value={ev.repositoryPattern}
+                        placeholder="e.g. owner/repository"
+                        onChange={(v) => {
+                            update({ repositoryPattern: v.target.value });
+                        }}
+                    />
+                </div>
+                <div className="mt-1">
+                    <p className="text-gray-500">
+                        You can pass a variable for a specific project or use wildcard character (
+                        <CodeText>*/*</CodeText>) to make it available in more projects.
+                    </p>
+                </div>
             </div>
-            <div className="mt-4">
-                <h4>Value</h4>
-                <input className="w-full" type="text" value={ev.value} onChange={(v) => { update({value: v.target.value}) }} />
+            <div className="flex justify-end mt-6">
+                <button className="secondary" onClick={p.onClose}>
+                    Cancel
+                </button>
+                <button className="ml-2" onClick={save}>
+                    {isNew ? "Add" : "Update"} Variable
+                </button>
             </div>
-            <div className="mt-4">
-                <h4>Scope</h4>
-                <input className="w-full" type="text" value={ev.repositoryPattern} placeholder="e.g. owner/repository"
-                    onChange={(v) => { update({repositoryPattern: v.target.value}) }} />
-            </div>
-            <div className="mt-1">
-                <p className="text-gray-500">You can pass a variable for a specific project or use wildcard character (<CodeText>*/*</CodeText>) to make it available in more projects.</p>
-            </div>
-        </div>
-        <div className="flex justify-end mt-6">
-            <button className="secondary" onClick={p.onClose}>Cancel</button>
-            <button className="ml-2" onClick={save} >{isNew ? 'Add' : 'Update'} Variable</button>
-        </div>
-    </Modal>
+        </Modal>
+    );
 }
 
-function DeleteEnvVarModal(p: { variable: UserEnvVarValue, deleteVariable: () => void, onClose: () => void }) {
-    return <ConfirmationModal
-        title="Delete Variable"
-        areYouSureText="Are you sure you want to delete this variable?"
-        buttonText="Delete Variable"
-        onClose={p.onClose}
-        onConfirm={() => { p.deleteVariable(); p.onClose(); }}
-    >
-        <div className="grid grid-cols-2 gap-4 px-3 text-sm text-gray-400">
+function DeleteEnvVarModal(p: { variable: UserEnvVarValue; deleteVariable: () => void; onClose: () => void }) {
+    return (
+        <ConfirmationModal
+            title="Delete Variable"
+            areYouSureText="Are you sure you want to delete this variable?"
+            buttonText="Delete Variable"
+            onClose={p.onClose}
+            onConfirm={() => {
+                p.deleteVariable();
+                p.onClose();
+            }}
+        >
+            <div className="grid grid-cols-2 gap-4 px-3 text-sm text-gray-400">
                 <span className="truncate">Name</span>
                 <span className="truncate">Scope</span>
             </div>
@@ -97,7 +132,8 @@ function DeleteEnvVarModal(p: { variable: UserEnvVarValue, deleteVariable: () =>
                 <span className="truncate text-gray-900 dark:text-gray-50">{p.variable.name}</span>
                 <span className="truncate text-sm">{p.variable.repositoryPattern}</span>
             </div>
-    </ConfirmationModal>;
+        </ConfirmationModal>
+    );
 }
 
 function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
@@ -109,35 +145,40 @@ function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
 
 export default function EnvVars() {
     const [envVars, setEnvVars] = useState([] as UserEnvVarValue[]);
-    const [currentEnvVar, setCurrentEnvVar] = useState({ name: '', value: '', repositoryPattern: '' } as UserEnvVarValue);
+    const [currentEnvVar, setCurrentEnvVar] = useState({
+        name: "",
+        value: "",
+        repositoryPattern: "",
+    } as UserEnvVarValue);
     const [isAddEnvVarModalVisible, setAddEnvVarModalVisible] = useState(false);
     const [isDeleteEnvVarModalVisible, setDeleteEnvVarModalVisible] = useState(false);
     const update = async () => {
-        await getGitpodService().server.getAllEnvVars().then(r => setEnvVars(r.sort(sortEnvVars)));
-    }
+        await getGitpodService()
+            .server.getAllEnvVars()
+            .then((r) => setEnvVars(r.sort(sortEnvVars)));
+    };
 
     useEffect(() => {
-        update()
+        update();
     }, []);
 
-
     const add = () => {
-        setCurrentEnvVar({ name: '', value: '', repositoryPattern: '' });
+        setCurrentEnvVar({ name: "", value: "", repositoryPattern: "" });
         setAddEnvVarModalVisible(true);
         setDeleteEnvVarModalVisible(false);
-    }
+    };
 
     const edit = (variable: UserEnvVarValue) => {
         setCurrentEnvVar(variable);
         setAddEnvVarModalVisible(true);
         setDeleteEnvVarModalVisible(false);
-    }
+    };
 
     const confirmDeleteVariable = (variable: UserEnvVarValue) => {
         setCurrentEnvVar(variable);
         setAddEnvVarModalVisible(false);
         setDeleteEnvVarModalVisible(true);
-    }
+    };
 
     const save = async (variable: UserEnvVarValue) => {
         await getGitpodService().server.setEnvVar(variable);
@@ -152,88 +193,121 @@ export default function EnvVars() {
     const validate = (variable: UserEnvVarValue) => {
         const name = variable.name;
         const pattern = variable.repositoryPattern;
-        if (name.trim() === '') {
-            return 'Name must not be empty.';
+        if (name.trim() === "") {
+            return "Name must not be empty.";
         }
         if (!/^[a-zA-Z0-9_]*$/.test(name)) {
-            return 'Name must match /[a-zA-Z_]+[a-zA-Z0-9_]*/.';
+            return "Name must match /[a-zA-Z_]+[a-zA-Z0-9_]*/.";
         }
-        if (variable.value.trim() === '') {
-            return 'Value must not be empty.';
+        if (variable.value.trim() === "") {
+            return "Value must not be empty.";
         }
-        if (pattern.trim() === '') {
-            return 'Scope must not be empty.';
+        if (pattern.trim() === "") {
+            return "Scope must not be empty.";
         }
-        const split = pattern.split('/');
+        const split = pattern.split("/");
         if (split.length < 2) {
             return "A scope must use the form 'organization/repo'.";
         }
         for (const name of split) {
-            if (name !== '*') {
-                if (!/^[a-zA-Z0-9_\-.\*]+$/.test(name)) {
-                    return 'Invalid scope segment. Only ASCII characters, numbers, -, _, . or * are allowed.';
+            if (name !== "*") {
+                if (!/^[a-zA-Z0-9_\-.*]+$/.test(name)) {
+                    return "Invalid scope segment. Only ASCII characters, numbers, -, _, . or * are allowed.";
                 }
             }
         }
-        if (!variable.id && envVars.some(v => v.name === name && v.repositoryPattern === pattern)) {
-            return 'A variable with this name and scope already exists';
+        if (!variable.id && envVars.some((v) => v.name === name && v.repositoryPattern === pattern)) {
+            return "A variable with this name and scope already exists";
         }
-        return '';
+        return "";
     };
 
-    return <PageWithSubMenu subMenu={settingsMenu} title='Variables' subtitle='Configure environment variables for all workspaces.'>
-        {isAddEnvVarModalVisible && <AddEnvVarModal
-            save={save}
-            envVar={currentEnvVar}
-            validate={validate}
-            onClose={() => setAddEnvVarModalVisible(false)} />}
-        {isDeleteEnvVarModalVisible && <DeleteEnvVarModal
-            variable={currentEnvVar}
-            deleteVariable={() => deleteVariable(currentEnvVar)}
-            onClose={() => setDeleteEnvVarModalVisible(false)} />}
-        <div className="flex items-start sm:justify-between mb-2">
-            <div>
-                <h3>Environment Variables</h3>
-                <h2 className="text-gray-500">Variables are used to store information like passwords.</h2>
-            </div>
-            {envVars.length !== 0
-                ? <div className="mt-3 flex mt-0">
-                    <button onClick={add} className="ml-2">New Variable</button>
+    return (
+        <PageWithSubMenu
+            subMenu={settingsMenu}
+            title="Variables"
+            subtitle="Configure environment variables for all workspaces."
+        >
+            {isAddEnvVarModalVisible && (
+                <AddEnvVarModal
+                    save={save}
+                    envVar={currentEnvVar}
+                    validate={validate}
+                    onClose={() => setAddEnvVarModalVisible(false)}
+                />
+            )}
+            {isDeleteEnvVarModalVisible && (
+                <DeleteEnvVarModal
+                    variable={currentEnvVar}
+                    deleteVariable={() => deleteVariable(currentEnvVar)}
+                    onClose={() => setDeleteEnvVarModalVisible(false)}
+                />
+            )}
+            <div className="flex items-start sm:justify-between mb-2">
+                <div>
+                    <h3>Environment Variables</h3>
+                    <h2 className="text-gray-500">Variables are used to store information like passwords.</h2>
                 </div>
-                : null}
-        </div>
-        {envVars.length === 0
-            ? <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full h-96">
-                <div className="pt-28 flex flex-col items-center w-96 m-auto">
-                    <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Environment Variables</h3>
-                    <div className="text-center pb-6 text-gray-500">In addition to user-specific environment variables you can also pass variables through a workspace creation URL. <a className="gp-link" href="https://www.gitpod.io/docs/environment-variables/#using-the-account-settings">Learn more</a></div>
-                    <button onClick={add}>New Variable</button>
-                </div>
+                {envVars.length !== 0 ? (
+                    <div className="mt-3 flex">
+                        <button onClick={add} className="ml-2">
+                            New Variable
+                        </button>
+                    </div>
+                ) : null}
             </div>
-            : <ItemsList>
-                <Item header={true}>
-                    <ItemField className="w-5/12 my-auto">Name</ItemField>
-                    <ItemField className="w-5/12 my-auto">Scope</ItemField>
-                </Item>
-                {envVars.map(variable => {
-                    return <Item className="whitespace-nowrap">
-                        <ItemField className="w-5/12 overflow-ellipsis truncate my-auto">{variable.name}</ItemField>
-                        <ItemField className="w-5/12 overflow-ellipsis truncate text-sm text-gray-400 my-auto">{variable.repositoryPattern}</ItemField>
-                        <ItemFieldContextMenu menuEntries={[
-                            {
-                                title: 'Edit',
-                                onClick: () => edit(variable),
-                                separator: true
-                            },
-                            {
-                                title: 'Delete',
-                                customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
-                                onClick: () => confirmDeleteVariable(variable)
-                            },
-                        ]} />
+            {envVars.length === 0 ? (
+                <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full h-96">
+                    <div className="pt-28 flex flex-col items-center w-96 m-auto">
+                        <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Environment Variables</h3>
+                        <div className="text-center pb-6 text-gray-500">
+                            In addition to user-specific environment variables you can also pass variables through a
+                            workspace creation URL.{" "}
+                            <a
+                                className="gp-link"
+                                href="https://www.gitpod.io/docs/environment-variables/#using-the-account-settings"
+                            >
+                                Learn more
+                            </a>
+                        </div>
+                        <button onClick={add}>New Variable</button>
+                    </div>
+                </div>
+            ) : (
+                <ItemsList>
+                    <Item header={true}>
+                        <ItemField className="w-5/12 my-auto">Name</ItemField>
+                        <ItemField className="w-5/12 my-auto">Scope</ItemField>
                     </Item>
-                })}
-            </ItemsList>
-        }
-    </PageWithSubMenu>;
+                    {envVars.map((variable) => {
+                        return (
+                            <Item className="whitespace-nowrap">
+                                <ItemField className="w-5/12 overflow-ellipsis truncate my-auto">
+                                    {variable.name}
+                                </ItemField>
+                                <ItemField className="w-5/12 overflow-ellipsis truncate text-sm text-gray-400 my-auto">
+                                    {variable.repositoryPattern}
+                                </ItemField>
+                                <ItemFieldContextMenu
+                                    menuEntries={[
+                                        {
+                                            title: "Edit",
+                                            onClick: () => edit(variable),
+                                            separator: true,
+                                        },
+                                        {
+                                            title: "Delete",
+                                            customFontStyle:
+                                                "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                                            onClick: () => confirmDeleteVariable(variable),
+                                        },
+                                    ]}
+                                />
+                            </Item>
+                        );
+                    })}
+                </ItemsList>
+            )}
+        </PageWithSubMenu>
+    );
 }

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -6,16 +6,16 @@
 
 import { AuthProviderEntry, AuthProviderInfo } from "@gitpod/gitpod-protocol";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import AlertBox from "../components/AlertBox";
-import CheckBox from '../components/CheckBox';
+import CheckBox from "../components/CheckBox";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon, ItemsList } from "../components/ItemsList";
 import Modal from "../components/Modal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import copy from '../images/copy.svg';
-import exclamation from '../images/exclamation.svg';
+import copy from "../images/copy.svg";
+import exclamation from "../images/exclamation.svg";
 import { openAuthorizeWindow } from "../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
@@ -23,27 +23,49 @@ import { SelectAccountModal } from "./SelectAccountModal";
 import settingsMenu from "./settings-menu";
 
 export default function Integrations() {
-
-    return (<div>
-        <PageWithSubMenu subMenu={settingsMenu} title='Integrations' subtitle='Manage permissions for Git providers and integrations.'>
-            <GitProviders />
-            <div className="h-12"></div>
-            <GitIntegrations />
-        </PageWithSubMenu>
-    </div>);
+    return (
+        <div>
+            <PageWithSubMenu
+                subMenu={settingsMenu}
+                title="Integrations"
+                subtitle="Manage permissions for Git providers and integrations."
+            >
+                <GitProviders />
+                <div className="h-12"></div>
+                <GitIntegrations />
+            </PageWithSubMenu>
+        </div>
+    );
 }
 
-
 function GitProviders() {
-
     const { user, setUser } = useContext(UserContext);
 
     const [authProviders, setAuthProviders] = useState<AuthProviderInfo[]>([]);
     const [allScopes, setAllScopes] = useState<Map<string, string[]>>(new Map());
     const [disconnectModal, setDisconnectModal] = useState<{ provider: AuthProviderInfo } | undefined>(undefined);
-    const [editModal, setEditModal] = useState<{ provider: AuthProviderInfo, prevScopes: Set<string>, nextScopes: Set<string> } | undefined>(undefined);
+    const [editModal, setEditModal] = useState<
+        { provider: AuthProviderInfo; prevScopes: Set<string>; nextScopes: Set<string> } | undefined
+    >(undefined);
     const [selectAccountModal, setSelectAccountModal] = useState<SelectAccountPayload | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+    const updateCurrentScopes = useCallback(async () => {
+        if (user) {
+            const scopesByProvider = new Map<string, string[]>();
+            const connectedProviders = user.identities.map((i) =>
+                authProviders.find((ap) => ap.authProviderId === i.authProviderId),
+            );
+            for (let provider of connectedProviders) {
+                if (!provider) {
+                    continue;
+                }
+                const token = await getGitpodService().server.getToken({ host: provider.host });
+                scopesByProvider.set(provider.authProviderId, token?.scopes?.slice() || []);
+            }
+            setAllScopes(scopesByProvider);
+        }
+    }, [authProviders, user]);
 
     useEffect(() => {
         updateAuthProviders();
@@ -51,29 +73,14 @@ function GitProviders() {
 
     useEffect(() => {
         updateCurrentScopes();
-    }, [user, authProviders]);
+    }, [user, authProviders, updateCurrentScopes]);
 
     const updateAuthProviders = async () => {
         setAuthProviders(await getGitpodService().server.getAuthProviders());
-    }
-
-    const updateCurrentScopes = async () => {
-        if (user) {
-            const scopesByProvider = new Map<string, string[]>();
-            const connectedProviders = user.identities.map(i => authProviders.find(ap => ap.authProviderId === i.authProviderId));
-            for (let provider of connectedProviders) {
-                if (!provider) {
-                    continue;
-                }
-                const token = await getGitpodService().server.getToken({ host: provider.host });
-                scopesByProvider.set(provider.authProviderId, (token?.scopes?.slice() || []));
-            }
-            setAllScopes(scopesByProvider);
-        }
-    }
+    };
 
     const isConnected = (authProviderId: string) => {
-        return !!user?.identities?.find(i => i.authProviderId === authProviderId);
+        return !!user?.identities?.find((i) => i.authProviderId === authProviderId);
     };
 
     const gitProviderMenu = (provider: AuthProviderInfo) => {
@@ -81,7 +88,7 @@ function GitProviders() {
         const connected = isConnected(provider.authProviderId);
         if (connected) {
             result.push({
-                title: 'Edit Permissions',
+                title: "Edit Permissions",
                 onClick: () => startEditPermissions(provider),
                 separator: !provider.settingsUrl,
             });
@@ -94,26 +101,28 @@ function GitProviders() {
                     separator: true,
                 });
             }
-            const connectedWithSecondProvider = authProviders.some(p => p.authProviderId !== provider.authProviderId && isConnected(p.authProviderId))
+            const connectedWithSecondProvider = authProviders.some(
+                (p) => p.authProviderId !== provider.authProviderId && isConnected(p.authProviderId),
+            );
             if (connectedWithSecondProvider) {
                 result.push({
-                    title: 'Disconnect',
-                    customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
-                    onClick: () => setDisconnectModal({ provider })
+                    title: "Disconnect",
+                    customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                    onClick: () => setDisconnectModal({ provider }),
                 });
             }
         } else {
             result.push({
-                title: 'Connect',
-                customFontStyle: 'text-green-600',
-                onClick: () => connect(provider)
-            })
+                title: "Connect",
+                customFontStyle: "text-green-600",
+                onClick: () => connect(provider),
+            });
         }
         return result;
     };
 
     const getUsername = (authProviderId: string) => {
-        return user?.identities?.find(i => i.authProviderId === authProviderId)?.authName;
+        return user?.identities?.find((i) => i.authProviderId === authProviderId)?.authName;
     };
 
     const getPermissions = (authProviderId: string) => {
@@ -122,15 +131,17 @@ function GitProviders() {
 
     const connect = async (ap: AuthProviderInfo) => {
         await doAuthorize(ap.host, ap.requirements?.default);
-    }
+    };
 
     const disconnect = async (ap: AuthProviderInfo) => {
         setDisconnectModal(undefined);
-        const returnTo = gitpodHostUrl.with({ pathname: 'complete-auth', search: 'message=success' }).toString();
-        const deauthorizeUrl = gitpodHostUrl.withApi({
-            pathname: '/deauthorize',
-            search: `returnTo=${returnTo}&host=${ap.host}`
-        }).toString();
+        const returnTo = gitpodHostUrl.with({ pathname: "complete-auth", search: "message=success" }).toString();
+        const deauthorizeUrl = gitpodHostUrl
+            .withApi({
+                pathname: "/deauthorize",
+                search: `returnTo=${returnTo}&host=${ap.host}`,
+            })
+            .toString();
 
         fetch(deauthorizeUrl)
             .then((res) => {
@@ -140,8 +151,12 @@ function GitProviders() {
                 return res;
             })
             .then((response) => updateUser())
-            .catch((error) => setErrorMessage("You cannot disconnect this integration because it is required for authentication and logging in with this account."))
-    }
+            .catch((error) =>
+                setErrorMessage(
+                    "You cannot disconnect this integration because it is required for authentication and logging in with this account.",
+                ),
+            );
+    };
 
     const startEditPermissions = async (provider: AuthProviderInfo) => {
         // todo: add spinner
@@ -150,12 +165,12 @@ function GitProviders() {
         if (token) {
             setEditModal({ provider, prevScopes: new Set(token.scopes), nextScopes: new Set(token.scopes) });
         }
-    }
+    };
 
     const updateUser = async () => {
         const user = await getGitpodService().server.getLoggedInUser();
         setUser(user);
-    }
+    };
 
     const doAuthorize = async (host: string, scopes?: string[]) => {
         try {
@@ -169,18 +184,18 @@ function GitProviders() {
                         try {
                             const payload = JSON.parse(error);
                             if (SelectAccountPayload.is(payload)) {
-                                setSelectAccountModal(payload)
+                                setSelectAccountModal(payload);
                             }
                         } catch (error) {
                             console.log(error);
                         }
                     }
-                }
+                },
             });
         } catch (error) {
-            console.log(error)
+            console.log(error);
         }
-    }
+    };
 
     const updatePermissions = async () => {
         if (!editModal) {
@@ -192,7 +207,7 @@ function GitProviders() {
             console.log(error);
         }
         setEditModal(undefined);
-    }
+    };
     const onChangeScopeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (!editModal) {
             return;
@@ -205,125 +220,159 @@ function GitProviders() {
             nextScopes.delete(scope);
         }
         setEditModal({ ...editModal, nextScopes });
-    }
+    };
 
     const getDescriptionForScope = (scope: string) => {
         switch (scope) {
-            case "user:email": return "Read-only access to your email addresses";
-            case "read:user": return "Read-only access to your profile information";
-            case "public_repo": return "Write access to code in public repositories and organizations";
-            case "repo": return "Read/write access to code in private repositories and organizations";
-            case "read:org": return "Read-only access to organizations (used to suggest organizations when forking a repository)";
-            case "workflow": return "Allow updating GitHub Actions workflow files";
+            case "user:email":
+                return "Read-only access to your email addresses";
+            case "read:user":
+                return "Read-only access to your profile information";
+            case "public_repo":
+                return "Write access to code in public repositories and organizations";
+            case "repo":
+                return "Read/write access to code in private repositories and organizations";
+            case "read:org":
+                return "Read-only access to organizations (used to suggest organizations when forking a repository)";
+            case "workflow":
+                return "Allow updating GitHub Actions workflow files";
             // GitLab
-            case "read_user": return "Read-only access to your email addresses";
-            case "api": return "Allow making API calls (used to set up a webhook when enabling prebuilds for a repository)";
-            case "read_repository": return "Read/write access to your repositories";
+            case "read_user":
+                return "Read-only access to your email addresses";
+            case "api":
+                return "Allow making API calls (used to set up a webhook when enabling prebuilds for a repository)";
+            case "read_repository":
+                return "Read/write access to your repositories";
             // Bitbucket
-            case "account": return "Read-only access to your account information";
-            case "repository": return "Read-only access to your repositories (note: Bitbucket doesn't support revoking scopes)";
-            case "repository:write": return "Read/write access to your repositories (note: Bitbucket doesn't support revoking scopes)";
-            case "pullrequest": return "Read access to pull requests and ability to collaborate via comments, tasks, and approvals (note: Bitbucket doesn't support revoking scopes)";
-            case "pullrequest:write": return "Allow creating, merging and declining pull requests (note: Bitbucket doesn't support revoking scopes)";
-            case "webhook": return "Allow installing webhooks (used when enabling prebuilds for a repository, note: Bitbucket doesn't support revoking scopes)";
-            default: return "";
+            case "account":
+                return "Read-only access to your account information";
+            case "repository":
+                return "Read-only access to your repositories (note: Bitbucket doesn't support revoking scopes)";
+            case "repository:write":
+                return "Read/write access to your repositories (note: Bitbucket doesn't support revoking scopes)";
+            case "pullrequest":
+                return "Read access to pull requests and ability to collaborate via comments, tasks, and approvals (note: Bitbucket doesn't support revoking scopes)";
+            case "pullrequest:write":
+                return "Allow creating, merging and declining pull requests (note: Bitbucket doesn't support revoking scopes)";
+            case "webhook":
+                return "Allow installing webhooks (used when enabling prebuilds for a repository, note: Bitbucket doesn't support revoking scopes)";
+            default:
+                return "";
         }
-    }
+    };
 
-    return (<div>
+    return (
+        <div>
+            {selectAccountModal && (
+                <SelectAccountModal {...selectAccountModal} close={() => setSelectAccountModal(undefined)} />
+            )}
 
-        {selectAccountModal && (
-            <SelectAccountModal {...selectAccountModal} close={() => setSelectAccountModal(undefined)} />
-        )}
+            {disconnectModal && (
+                <ConfirmationModal
+                    title="Disconnect Provider"
+                    areYouSureText="Are you sure you want to disconnect the following provider?"
+                    children={{
+                        name: disconnectModal.provider.authProviderType,
+                        description: disconnectModal.provider.host,
+                    }}
+                    buttonText="Disconnect Provider"
+                    onClose={() => setDisconnectModal(undefined)}
+                    onConfirm={() => disconnect(disconnectModal.provider)}
+                />
+            )}
 
-        {disconnectModal && (
-            <ConfirmationModal
-                title="Disconnect Provider"
-                areYouSureText="Are you sure you want to disconnect the following provider?"
-                children={{
-                    name: disconnectModal.provider.authProviderType,
-                    description: disconnectModal.provider.host,
-                }}
-                buttonText="Disconnect Provider"
-                onClose={() => setDisconnectModal(undefined)}
-                onConfirm={() => disconnect(disconnectModal.provider)}
-            />
-        )}
+            {errorMessage && (
+                <div className="flex rounded-md bg-red-600 p-3 mb-4">
+                    <img className="w-4 h-4 mx-2 my-auto filter-brightness-10" src={exclamation} alt="Heads up!" />
+                    <span className="text-white">{errorMessage}</span>
+                </div>
+            )}
 
-        {errorMessage && (
-            <div className="flex rounded-md bg-red-600 p-3 mb-4">
-                <img className="w-4 h-4 mx-2 my-auto filter-brightness-10" src={exclamation} />
-                <span className="text-white">{errorMessage}</span>
-            </div>
-        )}
-
-        {editModal && (
-            <Modal visible={true} onClose={() => setEditModal(undefined)}>
-                <h3 className="pb-2">Edit Permissions</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                    <div className="text-gray-500">
-                        Configure provider permissions.
+            {editModal && (
+                <Modal visible={true} onClose={() => setEditModal(undefined)}>
+                    <h3 className="pb-2">Edit Permissions</h3>
+                    <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
+                        <div className="text-gray-500">Configure provider permissions.</div>
+                        {(editModal.provider.scopes || []).map((scope) => (
+                            <div key={`scope-${scope}`}>
+                                <CheckBox
+                                    name={scope}
+                                    desc={getDescriptionForScope(scope)}
+                                    title={scope}
+                                    key={`scope-checkbox-${scope}`}
+                                    checked={editModal.nextScopes.has(scope)}
+                                    disabled={editModal.provider.requirements?.default.includes(scope)}
+                                    onChange={onChangeScopeHandler}
+                                ></CheckBox>
+                            </div>
+                        ))}
                     </div>
-                    {(editModal.provider.scopes || []).map(scope => (
-                        <div key={`scope-${scope}`}>
-                            <CheckBox
-                                name={scope}
-                                desc={getDescriptionForScope(scope)}
-                                title={scope}
-                                key={`scope-checkbox-${scope}`}
-                                checked={editModal.nextScopes.has(scope)}
-                                disabled={editModal.provider.requirements?.default.includes(scope)}
-                                onChange={onChangeScopeHandler}
-                            ></CheckBox>
-                        </div>
-                    ))}
-                </div>
-                <div className="flex justify-end mt-6">
-                    <button onClick={() => updatePermissions()}
-                        disabled={equals(editModal.nextScopes, editModal.prevScopes)}
-                    >
-                        Update Permissions
-                    </button>
-                </div>
-            </Modal>
-        )}
+                    <div className="flex justify-end mt-6">
+                        <button
+                            onClick={() => updatePermissions()}
+                            disabled={equals(editModal.nextScopes, editModal.prevScopes)}
+                        >
+                            Update Permissions
+                        </button>
+                    </div>
+                </Modal>
+            )}
 
-        <h3>Git Providers</h3>
-        <h2>Manage permissions for Git providers.</h2>
-        <ItemsList className="pt-6">
-            {authProviders && authProviders.map(ap => (
-                <Item key={"ap-" + ap.authProviderId} className="h-16">
-                    <ItemFieldIcon>
-                        <div className={"rounded-full w-3 h-3 text-sm align-middle m-auto " + (isConnected(ap.authProviderId) ? "bg-green-500" : "bg-gray-400")}>
-                            &nbsp;
-                        </div>
-                    </ItemFieldIcon>
-                    <ItemField className="w-4/12 xl:w-3/12 flex flex-col my-auto">
-                        <span className="my-auto font-medium truncate overflow-ellipsis">{ap.authProviderType}</span>
-                        <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis dark:text-gray-500">{ap.host}</span>
-                    </ItemField>
-                    <ItemField className="w-6/12 xl:w-3/12 flex flex-col my-auto">
-                        <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">{getUsername(ap.authProviderId) || "–"}</span>
-                        <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Username</span>
-                    </ItemField>
-                    <ItemField className="hidden xl:w-5/12 xl:flex xl:flex-col my-auto">
-                        <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">{getPermissions(ap.authProviderId)?.join(", ") || "–"}</span>
-                        <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Permissions</span>
-                    </ItemField>
-                    <ItemFieldContextMenu menuEntries={gitProviderMenu(ap)} />
-                </Item>
-            ))}
-        </ItemsList>
-    </div>);
+            <h3>Git Providers</h3>
+            <h2>Manage permissions for Git providers.</h2>
+            <ItemsList className="pt-6">
+                {authProviders &&
+                    authProviders.map((ap) => (
+                        <Item key={"ap-" + ap.authProviderId} className="h-16">
+                            <ItemFieldIcon>
+                                <div
+                                    className={
+                                        "rounded-full w-3 h-3 text-sm align-middle m-auto " +
+                                        (isConnected(ap.authProviderId) ? "bg-green-500" : "bg-gray-400")
+                                    }
+                                >
+                                    &nbsp;
+                                </div>
+                            </ItemFieldIcon>
+                            <ItemField className="w-4/12 xl:w-3/12 flex flex-col my-auto">
+                                <span className="my-auto font-medium truncate overflow-ellipsis">
+                                    {ap.authProviderType}
+                                </span>
+                                <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis dark:text-gray-500">
+                                    {ap.host}
+                                </span>
+                            </ItemField>
+                            <ItemField className="w-6/12 xl:w-3/12 flex flex-col my-auto">
+                                <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">
+                                    {getUsername(ap.authProviderId) || "–"}
+                                </span>
+                                <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Username</span>
+                            </ItemField>
+                            <ItemField className="hidden xl:w-5/12 xl:flex xl:flex-col my-auto">
+                                <span className="my-auto truncate text-gray-500 overflow-ellipsis dark:text-gray-400">
+                                    {getPermissions(ap.authProviderId)?.join(", ") || "–"}
+                                </span>
+                                <span className="text-sm my-auto text-gray-400 dark:text-gray-500">Permissions</span>
+                            </ItemField>
+                            <ItemFieldContextMenu menuEntries={gitProviderMenu(ap)} />
+                        </Item>
+                    ))}
+            </ItemsList>
+        </div>
+    );
 }
 
 function GitIntegrations() {
-
     const { user } = useContext(UserContext);
 
     const [providers, setProviders] = useState<AuthProviderEntry[]>([]);
 
-    const [modal, setModal] = useState<{ mode: "new" } | { mode: "edit", provider: AuthProviderEntry } | { mode: "delete", provider: AuthProviderEntry } | undefined>(undefined);
+    const [modal, setModal] = useState<
+        | { mode: "new" }
+        | { mode: "edit"; provider: AuthProviderEntry }
+        | { mode: "delete"; provider: AuthProviderEntry }
+        | undefined
+    >(undefined);
 
     useEffect(() => {
         updateOwnAuthProviders();
@@ -331,7 +380,7 @@ function GitIntegrations() {
 
     const updateOwnAuthProviders = async () => {
         setProviders(await getGitpodService().server.getOwnAuthProviders());
-    }
+    };
 
     const deleteProvider = async (provider: AuthProviderEntry) => {
         try {
@@ -341,7 +390,7 @@ function GitIntegrations() {
         }
         setModal(undefined);
         updateOwnAuthProviders();
-    }
+    };
 
     const gitProviderMenu = (provider: AuthProviderEntry) => {
         const result: ContextMenuEntry[] = [];
@@ -349,100 +398,127 @@ function GitIntegrations() {
             title: provider.status === "verified" ? "Edit Configuration" : "Activate Integration",
             onClick: () => setModal({ mode: "edit", provider }),
             separator: true,
-        })
+        });
         result.push({
-            title: 'Remove',
-            customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
-            onClick: () => setModal({ mode: "delete", provider })
+            title: "Remove",
+            customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+            onClick: () => setModal({ mode: "delete", provider }),
         });
         return result;
     };
 
-    return (<div>
+    return (
+        <div>
+            {modal?.mode === "new" && (
+                <GitIntegrationModal
+                    mode={modal.mode}
+                    userId={user?.id || "no-user"}
+                    onClose={() => setModal(undefined)}
+                    onUpdate={updateOwnAuthProviders}
+                />
+            )}
+            {modal?.mode === "edit" && (
+                <GitIntegrationModal
+                    mode={modal.mode}
+                    userId={user?.id || "no-user"}
+                    provider={modal.provider}
+                    onClose={() => setModal(undefined)}
+                    onUpdate={updateOwnAuthProviders}
+                />
+            )}
+            {modal?.mode === "delete" && (
+                <ConfirmationModal
+                    title="Remove Integration"
+                    areYouSureText="Are you sure you want to remove the following Git integration?"
+                    children={{
+                        name: modal.provider.type,
+                        description: modal.provider.host,
+                    }}
+                    buttonText="Remove Integration"
+                    onClose={() => setModal(undefined)}
+                    onConfirm={() => deleteProvider(modal.provider)}
+                />
+            )}
 
-        {modal?.mode === "new" && (
-            <GitIntegrationModal mode={modal.mode} userId={user?.id || "no-user"} onClose={() => setModal(undefined)} onUpdate={updateOwnAuthProviders} />
-        )}
-        {modal?.mode === "edit" && (
-            <GitIntegrationModal mode={modal.mode} userId={user?.id || "no-user"} provider={modal.provider} onClose={() => setModal(undefined)} onUpdate={updateOwnAuthProviders} />
-        )}
-        {modal?.mode === "delete" && (
-            <ConfirmationModal
-                title="Remove Integration"
-                areYouSureText="Are you sure you want to remove the following Git integration?"
-                children={{
-                    name: modal.provider.type,
-                    description: modal.provider.host,
-                }}
-                buttonText="Remove Integration"
-                onClose={() => setModal(undefined)}
-                onConfirm={() => deleteProvider(modal.provider)}
-            />
-
-        )}
-
-        <div className="flex items-start sm:justify-between mb-2">
-            <div>
-                <h3>Git Integrations</h3>
-                <h2>Manage Git integrations for GitLab or GitHub self-hosted instances.</h2>
-            </div>
-            {providers.length !== 0
-                ?
-                <div className="mt-3 flex mt-0">
-                    <button onClick={() => setModal({ mode: "new" })} className="ml-2">New Integration</button>
+            <div className="flex items-start sm:justify-between mb-2">
+                <div>
+                    <h3>Git Integrations</h3>
+                    <h2>Manage Git integrations for GitLab or GitHub self-hosted instances.</h2>
                 </div>
-                : null}
-        </div>
-
-        {providers && providers.length === 0 && (
-            <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
-                <div className="m-auto text-center">
-                    <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Git Integrations</h3>
-                    <div className="text-gray-500 mb-6">In addition to the default Git Providers you can authorize<br /> with a self-hosted instance of a provider.</div>
-                    <button className="self-center" onClick={() => setModal({ mode: "new" })}>New Integration</button>
-                </div>
+                {providers.length !== 0 ? (
+                    <div className="mt-3 flex">
+                        <button onClick={() => setModal({ mode: "new" })} className="ml-2">
+                            New Integration
+                        </button>
+                    </div>
+                ) : null}
             </div>
-        )}
-        <ItemsList className="pt-6">
-            {providers && providers.map(ap => (
-                <Item key={"ap-" + ap.id} className="h-16">
-                    <ItemFieldIcon>
-                        <div className={"rounded-full w-3 h-3 text-sm align-middle m-auto " + (ap.status === "verified" ? "bg-green-500" : "bg-gray-400")}>
-                            &nbsp;
+
+            {providers && providers.length === 0 && (
+                <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
+                    <div className="m-auto text-center">
+                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Git Integrations</h3>
+                        <div className="text-gray-500 mb-6">
+                            In addition to the default Git Providers you can authorize
+                            <br /> with a self-hosted instance of a provider.
                         </div>
-                    </ItemFieldIcon>
-                    <ItemField className="w-3/12 flex flex-col my-auto">
-                        <span className="font-medium truncate overflow-ellipsis">{ap.type}</span>
-                    </ItemField>
-                    <ItemField className="w-7/12 flex flex-col my-auto">
-                        <span className="my-auto truncate text-gray-500 overflow-ellipsis">{ap.host}</span>
-                    </ItemField>
-                    <ItemFieldContextMenu menuEntries={gitProviderMenu(ap)} />
-                </Item>
-            ))}
-        </ItemsList>
-    </div>);
+                        <button className="self-center" onClick={() => setModal({ mode: "new" })}>
+                            New Integration
+                        </button>
+                    </div>
+                </div>
+            )}
+            <ItemsList className="pt-6">
+                {providers &&
+                    providers.map((ap) => (
+                        <Item key={"ap-" + ap.id} className="h-16">
+                            <ItemFieldIcon>
+                                <div
+                                    className={
+                                        "rounded-full w-3 h-3 text-sm align-middle m-auto " +
+                                        (ap.status === "verified" ? "bg-green-500" : "bg-gray-400")
+                                    }
+                                >
+                                    &nbsp;
+                                </div>
+                            </ItemFieldIcon>
+                            <ItemField className="w-3/12 flex flex-col my-auto">
+                                <span className="font-medium truncate overflow-ellipsis">{ap.type}</span>
+                            </ItemField>
+                            <ItemField className="w-7/12 flex flex-col my-auto">
+                                <span className="my-auto truncate text-gray-500 overflow-ellipsis">{ap.host}</span>
+                            </ItemField>
+                            <ItemFieldContextMenu menuEntries={gitProviderMenu(ap)} />
+                        </Item>
+                    ))}
+            </ItemsList>
+        </div>
+    );
 }
 
-export function GitIntegrationModal(props: ({
-    mode: "new",
-} | {
-    mode: "edit",
-    provider: AuthProviderEntry
-}) & {
-    login?: boolean,
-    headerText?: string,
-    userId: string,
-    onClose?: () => void,
-    closeable?: boolean,
-    onUpdate?: () => void,
-    onAuthorize?: (payload?: string) => void
-}) {
-
+export function GitIntegrationModal(
+    props: (
+        | {
+              mode: "new";
+          }
+        | {
+              mode: "edit";
+              provider: AuthProviderEntry;
+          }
+    ) & {
+        login?: boolean;
+        headerText?: string;
+        userId: string;
+        onClose?: () => void;
+        closeable?: boolean;
+        onUpdate?: () => void;
+        onAuthorize?: (payload?: string) => void;
+    },
+) {
     const callbackUrl = (host: string) => {
         const pathname = `/auth/${host}/callback`;
         return gitpodHostUrl.with({ pathname }).toString();
-    }
+    };
 
     const [mode, setMode] = useState<"new" | "edit">("new");
     const [providerEntry, setProviderEntry] = useState<AuthProviderEntry | undefined>(undefined);
@@ -456,6 +532,40 @@ export function GitIntegrationModal(props: ({
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
     const [validationError, setValidationError] = useState<string | undefined>();
 
+    const validate = useCallback(() => {
+        const errors: string[] = [];
+        if (clientId.trim().length === 0) {
+            errors.push(`${type === "GitLab" ? "Application ID" : "Client ID"} is missing.`);
+        }
+        if (clientSecret.trim().length === 0) {
+            errors.push(`${type === "GitLab" ? "Secret" : "Client Secret"} is missing.`);
+        }
+        if (errors.length === 0) {
+            setValidationError(undefined);
+            return true;
+        } else {
+            setValidationError(errors.join("\n"));
+            return false;
+        }
+    }, [clientId, clientSecret, type]);
+
+    const updateHostValue = useCallback(
+        (host: string) => {
+            if (mode === "new") {
+                let newHostValue = host;
+
+                if (host.startsWith("https://")) {
+                    newHostValue = host.replace("https://", "");
+                }
+
+                setHost(newHostValue);
+                setRedirectURL(callbackUrl(newHostValue));
+                setErrorMessage(undefined);
+            }
+        },
+        [mode],
+    );
+
     useEffect(() => {
         setMode(props.mode);
         if (props.mode === "edit") {
@@ -466,12 +576,16 @@ export function GitIntegrationModal(props: ({
             setClientSecret(props.provider.oauth.clientSecret);
             setRedirectURL(props.provider.oauth.callBackUrl);
         }
+        // TODO: the correct dependency array here would be [props.mode, props.provider]
+        // but the inferred type doesn't include props.provider (see the union in the function declaration above).
+        // So this needs to be refactored into something less clever, or even more clever (maybe with a type guard?)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {
         setErrorMessage(undefined);
         validate();
-    }, [clientId, clientSecret, type])
+    }, [clientId, clientSecret, type, validate]);
 
     useEffect(() => {
         if (props.mode === "new") {
@@ -480,24 +594,27 @@ export function GitIntegrationModal(props: ({
             const exampleHostname = `${type.toLowerCase()}.example.com`;
             updateHostValue(exampleHostname);
         }
-    }, [type]);
+    }, [host, props.mode, type, updateHostValue]);
 
     const onClose = () => props.onClose && props.onClose();
     const onUpdate = () => props.onUpdate && props.onUpdate();
 
     const activate = async () => {
-        let entry = (mode === "new") ? {
-            host,
-            type,
-            clientId,
-            clientSecret,
-            ownerId: props.userId
-        } as AuthProviderEntry.NewEntry : {
-            id: providerEntry?.id,
-            ownerId: props.userId,
-            clientId,
-            clientSecret: clientSecret === "redacted" ? undefined : clientSecret
-        } as AuthProviderEntry.UpdateEntry;
+        let entry =
+            mode === "new"
+                ? ({
+                      host,
+                      type,
+                      clientId,
+                      clientSecret,
+                      ownerId: props.userId,
+                  } as AuthProviderEntry.NewEntry)
+                : ({
+                      id: providerEntry?.id,
+                      ownerId: props.userId,
+                      clientId,
+                      clientSecret: clientSecret === "redacted" ? undefined : clientSecret,
+                  } as AuthProviderEntry.UpdateEntry);
 
         setBusy(true);
         setErrorMessage(undefined);
@@ -506,16 +623,18 @@ export function GitIntegrationModal(props: ({
 
             // the server is checking periodically for updates of dynamic providers, thus we need to
             // wait at least 2 seconds for the changes to be propagated before we try to use this provider.
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise((resolve) => setTimeout(resolve, 2000));
 
             onUpdate();
 
             const updateProviderEntry = async () => {
-                const provider = (await getGitpodService().server.getOwnAuthProviders()).find(ap => ap.id === newProvider.id);
+                const provider = (await getGitpodService().server.getOwnAuthProviders()).find(
+                    (ap) => ap.id === newProvider.id,
+                );
                 if (provider) {
                     setProviderEntry(provider);
                 }
-            }
+            };
 
             // just open the authorization window and do *not* await
             openAuthorizeWindow({
@@ -536,7 +655,7 @@ export function GitIntegrationModal(props: ({
                         errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
                     }
                     setErrorMessage(errorMessage);
-                }
+                },
             });
 
             if (props.closeable) {
@@ -553,46 +672,14 @@ export function GitIntegrationModal(props: ({
             setErrorMessage("message" in error ? error.message : "Failed to update Git provider");
         }
         setBusy(false);
-    }
-
-    const updateHostValue = (host: string) => {
-        if (mode === "new") {
-
-            let newHostValue = host;
-
-            if (host.startsWith("https://")) {
-                newHostValue = host.replace("https://","");
-            }
-
-            setHost(newHostValue);
-            setRedirectURL(callbackUrl(newHostValue));
-            setErrorMessage(undefined);
-        }
-    }
+    };
 
     const updateClientId = (value: string) => {
         setClientId(value.trim());
-    }
+    };
     const updateClientSecret = (value: string) => {
         setClientSecret(value.trim());
-    }
-
-    const validate = () => {
-        const errors: string[] = [];
-        if (clientId.trim().length === 0) {
-            errors.push(`${type === "GitLab" ? "Application ID" : "Client ID"} is missing.`);
-        }
-        if (clientSecret.trim().length === 0) {
-            errors.push(`${type === "GitLab" ? "Secret" : "Client Secret"} is missing.`);
-        }
-        if (errors.length === 0) {
-            setValidationError(undefined);
-            return true;
-        } else {
-            setValidationError(errors.join("\n"));
-            return false;
-        }
-    }
+    };
 
     const getRedirectUrlDescription = (type: string, host: string) => {
         let settingsUrl = ``;
@@ -603,7 +690,8 @@ export function GitIntegrationModal(props: ({
             case "GitLab":
                 settingsUrl = `${host}/-/profile/applications`;
                 break;
-            default: return undefined;
+            default:
+                return undefined;
         }
         let docsUrl = ``;
         switch (type) {
@@ -613,15 +701,24 @@ export function GitIntegrationModal(props: ({
             case "GitLab":
                 docsUrl = `https://www.gitpod.io/docs/gitlab-integration/#oauth-application`;
                 break;
-            default: return undefined;
+            default:
+                return undefined;
         }
 
-        return (<span>
-            Use this redirect URL to update the OAuth application.
-            Go to <a href={`https://${settingsUrl}`} target="_blank" rel="noopener" className="gp-link">developer settings</a> and setup the OAuth application.&nbsp;
-            <a href={docsUrl} target="_blank" rel="noopener" className="gp-link">Learn more</a>.
-        </span>);
-    }
+        return (
+            <span>
+                Use this redirect URL to update the OAuth application. Go to{" "}
+                <a href={`https://${settingsUrl}`} target="_blank" rel="noopener noreferrer" className="gp-link">
+                    developer settings
+                </a>{" "}
+                and setup the OAuth application.&nbsp;
+                <a href={docsUrl} target="_blank" rel="noopener noreferrer" className="gp-link">
+                    Learn more
+                </a>
+                .
+            </span>
+        );
+    };
 
     const copyRedirectUrl = () => {
         const el = document.createElement("textarea");
@@ -635,67 +732,117 @@ export function GitIntegrationModal(props: ({
         }
     };
 
-    return (<Modal visible={!!props} onClose={onClose} closeable={props.closeable}>
-        <h3 className="pb-2">{mode === "new" ? "New Git Integration" : "Git Integration"}</h3>
-        <div className="space-y-4 border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-            {mode === "edit" && providerEntry?.status !== "verified" && (
-                <AlertBox>You need to activate this integration.</AlertBox>
-            )}
-            <div className="flex flex-col">
-                <span className="text-gray-500">{props.headerText || "Configure a Git integration with a GitLab or GitHub self-hosted instance."}</span>
-            </div>
+    return (
+        <Modal visible={!!props} onClose={onClose} closeable={props.closeable}>
+            <h3 className="pb-2">{mode === "new" ? "New Git Integration" : "Git Integration"}</h3>
+            <div className="space-y-4 border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
+                {mode === "edit" && providerEntry?.status !== "verified" && (
+                    <AlertBox>You need to activate this integration.</AlertBox>
+                )}
+                <div className="flex flex-col">
+                    <span className="text-gray-500">
+                        {props.headerText ||
+                            "Configure a Git integration with a GitLab or GitHub self-hosted instance."}
+                    </span>
+                </div>
 
-            <div className="overscroll-contain max-h-96 overflow-y-auto pr-2">
-                {mode === "new" && (
+                <div className="overscroll-contain max-h-96 overflow-y-auto pr-2">
+                    {mode === "new" && (
+                        <div className="flex flex-col space-y-2">
+                            <label htmlFor="type" className="font-medium">
+                                Provider Type
+                            </label>
+                            <select
+                                name="type"
+                                value={type}
+                                disabled={mode !== "new"}
+                                className="w-full"
+                                onChange={(e) => setType(e.target.value)}
+                            >
+                                <option value="GitHub">GitHub</option>
+                                <option value="GitLab">GitLab</option>
+                            </select>
+                        </div>
+                    )}
                     <div className="flex flex-col space-y-2">
-                        <label htmlFor="type" className="font-medium">Provider Type</label>
-                        <select name="type" value={type} disabled={mode !== "new"} className="w-full"
-                            onChange={(e) => setType(e.target.value)}>
-                            <option value="GitHub">GitHub</option>
-                            <option value="GitLab">GitLab</option>
-                        </select>
+                        <label htmlFor="hostName" className="font-medium">
+                            Provider Host Name
+                        </label>
+                        <input
+                            name="hostName"
+                            disabled={mode === "edit"}
+                            type="text"
+                            value={host}
+                            className="w-full"
+                            onChange={(e) => updateHostValue(e.target.value)}
+                        />
+                    </div>
+                    <div className="flex flex-col space-y-2">
+                        <label htmlFor="redirectURL" className="font-medium">
+                            Redirect URL
+                        </label>
+                        <div className="w-full relative">
+                            <input
+                                name="redirectURL"
+                                disabled={true}
+                                readOnly={true}
+                                type="text"
+                                value={redirectURL}
+                                className="w-full pr-8"
+                            />
+                            <div className="cursor-pointer" onClick={() => copyRedirectUrl()}>
+                                <img
+                                    src={copy}
+                                    title="Copy the Redirect URL to clipboard"
+                                    alt="Copy the Redirect URL to clipboard"
+                                    className="absolute top-1/3 right-3"
+                                />
+                            </div>
+                        </div>
+                        <span className="text-gray-500 text-sm">{getRedirectUrlDescription(type, host)}</span>
+                    </div>
+                    <div className="flex flex-col space-y-2">
+                        <label htmlFor="clientId" className="font-medium">{`${
+                            type === "GitLab" ? "Application ID" : "Client ID"
+                        }`}</label>
+                        <input
+                            name="clientId"
+                            type="text"
+                            value={clientId}
+                            className="w-full"
+                            onChange={(e) => updateClientId(e.target.value)}
+                        />
+                    </div>
+                    <div className="flex flex-col space-y-2">
+                        <label htmlFor="clientSecret" className="font-medium">{`${
+                            type === "GitLab" ? "Secret" : "Client Secret"
+                        }`}</label>
+                        <input
+                            name="clientSecret"
+                            type="password"
+                            value={clientSecret}
+                            className="w-full"
+                            onChange={(e) => updateClientSecret(e.target.value)}
+                        />
+                    </div>
+                </div>
+
+                {(errorMessage || validationError) && (
+                    <div className="flex rounded-md bg-red-600 p-3">
+                        <img className="w-4 h-4 mx-2 my-auto filter-brightness-10" src={exclamation} alt="Heads up!" />
+                        <span className="text-white">{errorMessage || validationError}</span>
                     </div>
                 )}
-                <div className="flex flex-col space-y-2">
-                    <label htmlFor="hostName" className="font-medium">Provider Host Name</label>
-                    <input name="hostName" disabled={mode === "edit"} type="text" value={host} className="w-full"
-                        onChange={(e) => updateHostValue(e.target.value)} />
-                </div>
-                <div className="flex flex-col space-y-2">
-                    <label htmlFor="redirectURL" className="font-medium">Redirect URL</label>
-                    <div className="w-full relative">
-                        <input name="redirectURL" disabled={true} readOnly={true} type="text" value={redirectURL} className="w-full pr-8" />
-                        <div className="cursor-pointer" onClick={() => copyRedirectUrl()}>
-                            <img src={copy} title="Copy the Redirect URL to clipboard" className="absolute top-1/3 right-3" />
-                        </div>
-                    </div>
-                    <span className="text-gray-500 text-sm">{getRedirectUrlDescription(type, host)}</span>
-                </div>
-                <div className="flex flex-col space-y-2">
-                    <label htmlFor="clientId" className="font-medium">{`${type === "GitLab" ? "Application ID" : "Client ID"}`}</label>
-                    <input name="clientId" type="text" value={clientId} className="w-full"
-                        onChange={(e) => updateClientId(e.target.value)} />
-                </div>
-                <div className="flex flex-col space-y-2">
-                    <label htmlFor="clientSecret" className="font-medium">{`${type === "GitLab" ? "Secret" : "Client Secret"}`}</label>
-                    <input name="clientSecret" type="password" value={clientSecret} className="w-full"
-                        onChange={(e) => updateClientSecret(e.target.value)} />
-                </div>
             </div>
-
-            {(errorMessage || validationError) && (
-                <div className="flex rounded-md bg-red-600 p-3">
-                    <img className="w-4 h-4 mx-2 my-auto filter-brightness-10" src={exclamation} />
-                    <span className="text-white">{errorMessage || validationError}</span>
-                </div>
-            )}
-        </div>
-        <div className="flex justify-end mt-6">
-            <button onClick={() => validate() && activate()} disabled={!!validationError || busy}>Activate Integration</button>
-        </div>
-    </Modal>);
+            <div className="flex justify-end mt-6">
+                <button onClick={() => validate() && activate()} disabled={!!validationError || busy}>
+                    Activate Integration
+                </button>
+            </div>
+        </Modal>
+    );
 }
 
 function equals(a: Set<string>, b: Set<string>): boolean {
-    return a.size === b.size && Array.from(a).every(e => b.has(e));
+    return a.size === b.size && Array.from(a).every((e) => b.has(e));
 }

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -4,9 +4,24 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+// TODO: there's a number of <a /> elements used as a <button />
+// together with href="javascript:void(0)"
+// They should all be changed to <button className="gp-link [etc etc]" />
+// but at this time I don't know how to test them without tripping up my
+// personal subscription plan.
+// Hence I'm disabling the relative linting rules and writing this TODO.
+/* eslint-disable no-script-url */
+/* eslint-disable jsx-a11y/anchor-is-valid */
+
 import React, { useState, useEffect, useContext } from "react";
-import { countries } from 'countries-list';
-import { AccountStatement, Subscription, UserPaidSubscription, AssignedTeamSubscription, CreditDescription } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
+import { countries } from "countries-list";
+import {
+    AccountStatement,
+    Subscription,
+    UserPaidSubscription,
+    AssignedTeamSubscription,
+    CreditDescription,
+} from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { PlanCoupon, GithubUpgradeURL } from "@gitpod/gitpod-protocol/lib/payment-protocol";
 import { Plans, Plan, Currency, PlanType } from "@gitpod/gitpod-protocol/lib/plans";
 import { ChargebeeClient } from "../chargebee/chargebee-client";
@@ -24,107 +39,121 @@ type PlanWithOriginalPrice = Plan & { originalPrice?: number };
 type Pending = { pendingSince: number };
 type PendingPlan = PlanWithOriginalPrice & Pending;
 
-type TeamClaimModal = {
-    errorText: string;
-    mode: "error";
-} | {
-    text: string;
-    teamId: string;
-    slotId: string;
-    mode: "confirmation";
-}
+type TeamClaimModal =
+    | {
+          errorText: string;
+          mode: "error";
+      }
+    | {
+          text: string;
+          teamId: string;
+          slotId: string;
+          mode: "confirmation";
+      };
 
 export default function () {
     const { user } = useContext(UserContext);
-    const [ showPaymentUI, setShowPaymentUI ] = useState<boolean>(false);
-    const [ accountStatement, setAccountStatement ] = useState<AccountStatement>();
-    const [ isChargebeeCustomer, setIsChargebeeCustomer ] = useState<boolean>();
-    const [ isStudent, setIsStudent ] = useState<boolean>();
-    const [ currency, setCurrency ] = useState<Currency>('USD');
-    const [ availableCoupons, setAvailableCoupons ] = useState<PlanCoupon[]>();
-    const [ appliedCoupons, setAppliedCoupons ] = useState<PlanCoupon[]>();
-    const [ gitHubUpgradeUrls, setGitHubUpgradeUrls ] = useState<GithubUpgradeURL[]>();
+    const [showPaymentUI, setShowPaymentUI] = useState<boolean>(false);
+    const [accountStatement, setAccountStatement] = useState<AccountStatement>();
+    const [isChargebeeCustomer, setIsChargebeeCustomer] = useState<boolean>();
+    const [isStudent, setIsStudent] = useState<boolean>();
+    const [currency, setCurrency] = useState<Currency>("USD");
+    const [availableCoupons, setAvailableCoupons] = useState<PlanCoupon[]>();
+    const [appliedCoupons, setAppliedCoupons] = useState<PlanCoupon[]>();
+    const [gitHubUpgradeUrls, setGitHubUpgradeUrls] = useState<GithubUpgradeURL[]>();
 
-    const [ teamClaimModal, setTeamClaimModal ] = useState<TeamClaimModal | undefined>(undefined);
+    const [teamClaimModal, setTeamClaimModal] = useState<TeamClaimModal | undefined>(undefined);
 
     let pollAccountStatementTimeout: NodeJS.Timeout | undefined;
 
     useEffect(() => {
         const { server } = getGitpodService();
         Promise.all([
-            server.getShowPaymentUI().then(v => () => setShowPaymentUI(v)),
-            server.getAccountStatement({}).then(v => () => setAccountStatement(v)),
-            server.isChargebeeCustomer().then(v => () => setIsChargebeeCustomer(v)),
-            server.isStudent().then(v => () => setIsStudent(v)),
-            server.getClientRegion().then(v => () => {
-                // @ts-ignore
-                setCurrency(countries[v]?.currency === 'EUR' ? 'EUR' : 'USD');
+            server.getShowPaymentUI().then((v) => () => setShowPaymentUI(v)),
+            server.getAccountStatement({}).then((v) => () => setAccountStatement(v)),
+            server.isChargebeeCustomer().then((v) => () => setIsChargebeeCustomer(v)),
+            server.isStudent().then((v) => () => setIsStudent(v)),
+            server.getClientRegion().then((v) => () => {
+                setCurrency(countries[v as keyof typeof countries]?.currency === "EUR" ? "EUR" : "USD");
             }),
-            server.getAvailableCoupons().then(v => () => setAvailableCoupons(v)),
-            server.getAppliedCoupons().then(v => () => setAppliedCoupons(v)),
-            server.getGithubUpgradeUrls().then(v => () => setGitHubUpgradeUrls(v))
-        ]).then(setters => setters.forEach(s => s()));
+            server.getAvailableCoupons().then((v) => () => setAvailableCoupons(v)),
+            server.getAppliedCoupons().then((v) => () => setAppliedCoupons(v)),
+            server.getGithubUpgradeUrls().then((v) => () => setGitHubUpgradeUrls(v)),
+        ]).then((setters) => setters.forEach((s) => s()));
 
         return function cleanup() {
             clearTimeout(pollAccountStatementTimeout!);
-        }
-    }, []);
+        };
+    }, [pollAccountStatementTimeout]);
 
-    const activeSubscriptions = (accountStatement?.subscriptions || []).filter(s => Subscription.isActive(s, new Date().toISOString()));
+    const activeSubscriptions = (accountStatement?.subscriptions || []).filter((s) =>
+        Subscription.isActive(s, new Date().toISOString()),
+    );
     const freeSubscription =
-        activeSubscriptions.find(s => s.planId === Plans.FREE_OPEN_SOURCE.chargebeeId) // Prefer Pro Open Source plan
-        || activeSubscriptions.find(s => Plans.isFreePlan(s.planId)); // Any active free plan
-    const freePlan = freeSubscription && Plans.getById(freeSubscription.planId) || Plans.getFreePlan(user?.creationDate || new Date().toISOString());
-    const paidSubscription = activeSubscriptions.find(s => UserPaidSubscription.is(s));
+        activeSubscriptions.find((s) => s.planId === Plans.FREE_OPEN_SOURCE.chargebeeId) || // Prefer Pro Open Source plan
+        activeSubscriptions.find((s) => Plans.isFreePlan(s.planId)); // Any active free plan
+    const freePlan =
+        (freeSubscription && Plans.getById(freeSubscription.planId)) ||
+        Plans.getFreePlan(user?.creationDate || new Date().toISOString());
+    const paidSubscription = activeSubscriptions.find((s) => UserPaidSubscription.is(s));
     const paidPlan = paidSubscription && Plans.getById(paidSubscription.planId);
 
-    const assignedTeamSubscriptions = activeSubscriptions.filter(s => AssignedTeamSubscription.is(s));
-    const getAssignedTs = (type: PlanType) => assignedTeamSubscriptions.find(s => {
-        const p = Plans.getById(s.planId);
-        return !!p && p.type === type
-    });
-    const assignedProfessionalTs = getAssignedTs('professional-new');
-    const assignedUnleashedTs = getAssignedTs('professional');
-    const assignedStudentUnleashedTs = getAssignedTs('student');
+    const assignedTeamSubscriptions = activeSubscriptions.filter((s) => AssignedTeamSubscription.is(s));
+    const getAssignedTs = (type: PlanType) =>
+        assignedTeamSubscriptions.find((s) => {
+            const p = Plans.getById(s.planId);
+            return !!p && p.type === type;
+        });
+    const assignedProfessionalTs = getAssignedTs("professional-new");
+    const assignedUnleashedTs = getAssignedTs("professional");
+    const assignedStudentUnleashedTs = getAssignedTs("student");
     const assignedTs = assignedProfessionalTs || assignedUnleashedTs || assignedStudentUnleashedTs;
 
-    const claimedTeamSubscriptionId = new URL(window.location.href).searchParams.get('teamid');
-    if (!!accountStatement && !!claimedTeamSubscriptionId && !assignedTeamSubscriptions.some(s => !!s.teamSubscriptionSlotId)) {
+    const claimedTeamSubscriptionId = new URL(window.location.href).searchParams.get("teamid");
+    if (
+        !!accountStatement &&
+        !!claimedTeamSubscriptionId &&
+        !assignedTeamSubscriptions.some((s) => !!s.teamSubscriptionSlotId)
+    ) {
         // Remove all query parameters from the current URL, without actually navigating anywhere
-        window.history.replaceState({}, '', window.location.pathname);
-        getGitpodService().server.tsGetUnassignedSlot(claimedTeamSubscriptionId).then(freeSlot => {
-            if (!freeSlot) {
-                setTeamClaimModal({
-                    mode: "error",
-                    errorText: "This invitation is no longer valid. Please contact the team owner.",
-                });
-            } else {
-                setTeamClaimModal({
-                    mode: "confirmation",
-                    teamId: claimedTeamSubscriptionId,
-                    slotId: freeSlot.id,
-                    text: "You are about to claim a seat in a team.",
-                });
-            }
-        });
+        window.history.replaceState({}, "", window.location.pathname);
+        getGitpodService()
+            .server.tsGetUnassignedSlot(claimedTeamSubscriptionId)
+            .then((freeSlot) => {
+                if (!freeSlot) {
+                    setTeamClaimModal({
+                        mode: "error",
+                        errorText: "This invitation is no longer valid. Please contact the team owner.",
+                    });
+                } else {
+                    setTeamClaimModal({
+                        mode: "confirmation",
+                        teamId: claimedTeamSubscriptionId,
+                        slotId: freeSlot.id,
+                        text: "You are about to claim a seat in a team.",
+                    });
+                }
+            });
     }
 
-    const [ pendingUpgradePlan, setPendingUpgradePlan ] = useState<PendingPlan | undefined>(getLocalStorageObject('pendingUpgradePlan'));
+    const [pendingUpgradePlan, setPendingUpgradePlan] = useState<PendingPlan | undefined>(
+        getLocalStorageObject("pendingUpgradePlan"),
+    );
     const setPendingUpgrade = (to: PendingPlan) => {
         clearTimeout(pollAccountStatementTimeout!);
-        setLocalStorageObject('pendingUpgradePlan', to);
+        setLocalStorageObject("pendingUpgradePlan", to);
         setPendingUpgradePlan(to);
     };
     const removePendingUpgrade = () => {
         clearTimeout(pollAccountStatementTimeout!);
-        removeLocalStorageObject('pendingUpgradePlan');
+        removeLocalStorageObject("pendingUpgradePlan");
         setPendingUpgradePlan(undefined);
-    }
+    };
     if (!!pendingUpgradePlan) {
-        if (!!accountStatement && (paidPlan?.chargebeeId === pendingUpgradePlan.chargebeeId)) {
+        if (!!accountStatement && paidPlan?.chargebeeId === pendingUpgradePlan.chargebeeId) {
             // The upgrade already worked
             removePendingUpgrade();
-        } else if ((pendingUpgradePlan.pendingSince + 1000 * 60 * 5) < Date.now()) {
+        } else if (pendingUpgradePlan.pendingSince + 1000 * 60 * 5 < Date.now()) {
             // Pending upgrades expire after 5 minutes
             removePendingUpgrade();
         } else if (!pollAccountStatementTimeout) {
@@ -149,21 +178,23 @@ export default function () {
     const unleashedPlan = Plans.getProPlan(currency);
     const studentUnleashedPlan = Plans.getStudentProPlan(currency);
 
-    const scheduledDowngradePlanId = !!(paidSubscription?.paymentData?.downgradeDate)
+    const scheduledDowngradePlanId = !!paidSubscription?.paymentData?.downgradeDate
         ? paidSubscription.paymentData.newPlan || personalPlan.chargebeeId
         : undefined;
 
-    const [ pendingDowngradePlan, setPendingDowngradePlan ] = useState<PendingPlan | undefined>(getLocalStorageObject('pendingDowngradePlan'));
+    const [pendingDowngradePlan, setPendingDowngradePlan] = useState<PendingPlan | undefined>(
+        getLocalStorageObject("pendingDowngradePlan"),
+    );
     const setPendingDowngrade = (to: PendingPlan) => {
         clearTimeout(pollAccountStatementTimeout!);
-        setLocalStorageObject('pendingDowngradePlan', to);
+        setLocalStorageObject("pendingDowngradePlan", to);
         setPendingDowngradePlan(to);
     };
     const removePendingDowngrade = () => {
         clearTimeout(pollAccountStatementTimeout!);
-        removeLocalStorageObject('pendingDowngradePlan');
+        removeLocalStorageObject("pendingDowngradePlan");
         setPendingDowngradePlan(undefined);
-    }
+    };
     if (!!pendingDowngradePlan) {
         if (!!accountStatement && (paidPlan || freePlan).chargebeeId === pendingDowngradePlan.chargebeeId) {
             // The Downgrade already worked
@@ -171,7 +202,7 @@ export default function () {
         } else if (scheduledDowngradePlanId === pendingDowngradePlan.chargebeeId) {
             // The Downgrade is already scheduled
             removePendingDowngrade();
-        } else if ((pendingDowngradePlan.pendingSince + 1000 * 60 * 5) < Date.now()) {
+        } else if (pendingDowngradePlan.pendingSince + 1000 * 60 * 5 < Date.now()) {
             // Pending downgrades expire after 5 minutes
             removePendingDowngrade();
         } else if (!pollAccountStatementTimeout) {
@@ -183,22 +214,24 @@ export default function () {
         }
     }
 
-    const [ pendingDowngradeCancellation, setPendingDowngradeCancellation ] = useState<Pending | undefined>(getLocalStorageObject('pendingDowngradeCancellation'));
+    const [pendingDowngradeCancellation, setPendingDowngradeCancellation] = useState<Pending | undefined>(
+        getLocalStorageObject("pendingDowngradeCancellation"),
+    );
     const setPendingCancelDowngrade = (cancellation: Pending) => {
         clearTimeout(pollAccountStatementTimeout!);
-        setLocalStorageObject('pendingDowngradeCancellation', cancellation);
+        setLocalStorageObject("pendingDowngradeCancellation", cancellation);
         setPendingDowngradeCancellation(cancellation);
     };
     const removePendingCancelDowngrade = () => {
         clearTimeout(pollAccountStatementTimeout!);
-        removeLocalStorageObject('pendingDowngradeCancellation');
+        removeLocalStorageObject("pendingDowngradeCancellation");
         setPendingDowngradeCancellation(undefined);
-    }
+    };
     if (!!pendingDowngradeCancellation) {
         if (!!accountStatement && !scheduledDowngradePlanId) {
             // The downgrade cancellation worked
             removePendingCancelDowngrade();
-        } else if ((pendingDowngradeCancellation.pendingSince + 1000 * 60 * 5) < Date.now()) {
+        } else if (pendingDowngradeCancellation.pendingSince + 1000 * 60 * 5 < Date.now()) {
             // Pending downgrade cancellations expire after 5 minutes
             removePendingCancelDowngrade();
         } else if (!pollAccountStatementTimeout) {
@@ -212,23 +245,23 @@ export default function () {
 
     const pendingChargebeeCallback = !!pendingUpgradePlan || !!pendingDowngradePlan || !!pendingDowngradeCancellation;
 
-    const [ confirmUpgradeToPlan, setConfirmUpgradeToPlan ] = useState<Plan>();
-    const [ confirmDowngradeToPlan, setConfirmDowngradeToPlan ] = useState<Plan>();
-    const [ isConfirmCancelDowngrade, setIsConfirmCancelDowngrade ] = useState<boolean>(false);
+    const [confirmUpgradeToPlan, setConfirmUpgradeToPlan] = useState<Plan>();
+    const [confirmDowngradeToPlan, setConfirmDowngradeToPlan] = useState<Plan>();
+    const [isConfirmCancelDowngrade, setIsConfirmCancelDowngrade] = useState<boolean>(false);
     const confirmUpgrade = (to: Plan) => {
         if (pendingChargebeeCallback) {
             // Don't upgrade if we're still waiting for a Chargebee callback
             return;
         }
-        if ((paidSubscription?.paymentReference || '').startsWith("github:")) {
-            const url = (gitHubUpgradeUrls || []).find(u => u.planID == to.githubId);
+        if ((paidSubscription?.paymentReference || "").startsWith("github:")) {
+            const url = (gitHubUpgradeUrls || []).find((u) => u.planID === to.githubId);
             if (url) {
                 window.location.href = url.url;
             }
             return;
         }
         setConfirmUpgradeToPlan(to);
-    }
+    };
     const doUpgrade = async (event: React.MouseEvent) => {
         if (!confirmUpgradeToPlan) {
             return;
@@ -237,26 +270,34 @@ export default function () {
             (event.target as HTMLButtonElement).disabled = true;
             if (!paidSubscription) {
                 await new Promise((resolve, reject) => {
-                    ChargebeeClient.getOrCreate().then(chargebeeClient => {
-                        chargebeeClient.checkout(paymentServer => paymentServer.checkout(confirmUpgradeToPlan.chargebeeId), {
-                            success: resolve,
-                            error: reject,
-                        });
-                    }).catch(reject);
+                    ChargebeeClient.getOrCreate()
+                        .then((chargebeeClient) => {
+                            chargebeeClient.checkout(
+                                (paymentServer) => paymentServer.checkout(confirmUpgradeToPlan.chargebeeId),
+                                {
+                                    success: resolve,
+                                    error: reject,
+                                },
+                            );
+                        })
+                        .catch(reject);
                 });
             } else {
-                await getGitpodService().server.subscriptionUpgradeTo(paidSubscription.uid, confirmUpgradeToPlan.chargebeeId);
+                await getGitpodService().server.subscriptionUpgradeTo(
+                    paidSubscription.uid,
+                    confirmUpgradeToPlan.chargebeeId,
+                );
             }
             setPendingUpgrade({
-              ... confirmUpgradeToPlan,
-              pendingSince: Date.now(),
+                ...confirmUpgradeToPlan,
+                pendingSince: Date.now(),
             });
         } catch (error) {
-            console.error('Upgrade Error', error);
+            console.error("Upgrade Error", error);
         } finally {
             setConfirmUpgradeToPlan(undefined);
         }
-    }
+    };
     const confirmDowngrade = (to: Plan) => {
         if (pendingChargebeeCallback) {
             // Don't downgrade if we're still waiting for a Chargebee callback
@@ -266,8 +307,8 @@ export default function () {
             // Don't downgrade if another downgrade is already scheduled (first that one should happen or be be cancelled)
             return;
         }
-        if ((paidSubscription?.paymentReference || '').startsWith("github:")) {
-            const url = (gitHubUpgradeUrls || []).find(u => u.planID == to.githubId);
+        if ((paidSubscription?.paymentReference || "").startsWith("github:")) {
+            const url = (gitHubUpgradeUrls || []).find((u) => u.planID === to.githubId);
             if (!url) {
                 return;
             }
@@ -275,7 +316,7 @@ export default function () {
             return;
         }
         setConfirmDowngradeToPlan(to);
-    }
+    };
     const doDowngrade = async (event: React.MouseEvent) => {
         if (!confirmDowngradeToPlan || !paidSubscription) {
             return;
@@ -285,18 +326,21 @@ export default function () {
             if (Plans.isFreePlan(confirmDowngradeToPlan.chargebeeId)) {
                 await getGitpodService().server.subscriptionCancel(paidSubscription.uid);
             } else {
-                await getGitpodService().server.subscriptionDowngradeTo(paidSubscription.uid, confirmDowngradeToPlan.chargebeeId);
+                await getGitpodService().server.subscriptionDowngradeTo(
+                    paidSubscription.uid,
+                    confirmDowngradeToPlan.chargebeeId,
+                );
             }
             setPendingDowngrade({
-              ... confirmDowngradeToPlan,
-              pendingSince: Date.now(),
+                ...confirmDowngradeToPlan,
+                pendingSince: Date.now(),
             });
         } catch (error) {
-            console.error('Downgrade Error', error);
+            console.error("Downgrade Error", error);
         } finally {
             setConfirmDowngradeToPlan(undefined);
         }
-    }
+    };
     const confirmCancelDowngrade = () => {
         if (pendingChargebeeCallback) {
             // Don't cancel downgrade if we're still waiting for a Chargebee callback
@@ -306,11 +350,11 @@ export default function () {
             // No scheduled downgrade to be cancelled?
             return;
         }
-        if ((paidSubscription?.paymentReference || '').startsWith("github:")) {
+        if ((paidSubscription?.paymentReference || "").startsWith("github:")) {
             return;
         }
         setIsConfirmCancelDowngrade(true);
-    }
+    };
     const doCancelDowngrade = async (event: React.MouseEvent) => {
         if (!isConfirmCancelDowngrade || !paidSubscription) {
             return;
@@ -319,249 +363,585 @@ export default function () {
             await getGitpodService().server.subscriptionCancelDowngrade(paidSubscription.uid);
             setPendingCancelDowngrade({
                 pendingSince: Date.now(),
-            })
+            });
         } catch (error) {
-            console.error('Cancel Downgrade Error', error);
+            console.error("Cancel Downgrade Error", error);
         } finally {
             setIsConfirmCancelDowngrade(false);
         }
-    }
+    };
 
     const planCards = [];
 
     // Plan card: Free a.k.a. Open Source (or Professional Open Source)
-    const openSourceFeatures = <>
-        <p className="truncate" title="Public Repositories">✓ Public &amp; Private Repositories</p>
-        <p className="truncate" title="4 Parallel Workspaces">✓ 4 Parallel Workspaces</p>
-        <p className="truncate" title="30 min Timeout">✓ 30 min Timeout</p>
-    </>;
+    const openSourceFeatures = (
+        <>
+            <p className="truncate" title="Public Repositories">
+                ✓ Public &amp; Private Repositories
+            </p>
+            <p className="truncate" title="4 Parallel Workspaces">
+                ✓ 4 Parallel Workspaces
+            </p>
+            <p className="truncate" title="30 min Timeout">
+                ✓ 30 min Timeout
+            </p>
+        </>
+    );
     if (currentPlan.chargebeeId === freePlan.chargebeeId) {
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={freePlan} isCurrent={!!accountStatement}>{openSourceFeatures}</PlanCard>);
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={freePlan}
+                isCurrent={!!accountStatement}
+            >
+                {openSourceFeatures}
+            </PlanCard>,
+        );
     } else {
         const targetPlan = freePlan;
         let bottomLabel;
         if (scheduledDowngradePlanId === targetPlan.chargebeeId && !pendingDowngradeCancellation) {
-            bottomLabel = <p className="text-green-600">Downgrade scheduled<br/><a className="text-blue-light leading-6" href="javascript:void(0)" onClick={() => confirmCancelDowngrade()}>Cancel</a></p>;
+            bottomLabel = (
+                <p className="text-green-600">
+                    Downgrade scheduled
+                    <br />
+                    <a
+                        className="text-blue-light leading-6"
+                        href="javascrip::void(0)"
+                        // They should all be changed to <button className="gp-link [etc etc]" />
+                        // but at this time I don't know how to test them without tripping up my
+                        // personal subscription plan.
+                        // Hence I'm disabling the relative linting rules and writing this TODO.
+                        onClick={() => confirmCancelDowngrade()}
+                    >
+                        Cancel
+                    </a>
+                </p>
+            );
         } else if (pendingDowngradePlan?.chargebeeId === targetPlan.chargebeeId) {
             bottomLabel = <p className="text-green-600 animate-pulse">Downgrade scheduled</p>;
         }
         let onDowngrade;
         switch (Plans.subscriptionChange(currentPlan.type, targetPlan.type)) {
-            case 'downgrade': onDowngrade = () => confirmDowngrade(targetPlan); break;
+            case "downgrade":
+                onDowngrade = () => confirmDowngrade(targetPlan);
+                break;
         }
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={targetPlan} isCurrent={false} onDowngrade={onDowngrade} bottomLabel={bottomLabel}>{openSourceFeatures}</PlanCard>);
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={targetPlan}
+                isCurrent={false}
+                onDowngrade={onDowngrade}
+                bottomLabel={bottomLabel}
+            >
+                {openSourceFeatures}
+            </PlanCard>,
+        );
     }
 
     // Plan card: Personal
-    const personalFeatures = <>
-        <p className="truncate" title={'Everything in ' + freePlan.name}>← Everything in {freePlan.name}</p>
-    </>;
+    const personalFeatures = (
+        <>
+            <p className="truncate" title={"Everything in " + freePlan.name}>
+                ← Everything in {freePlan.name}
+            </p>
+        </>
+    );
     if (currentPlan.chargebeeId === personalPlan.chargebeeId) {
-        const bottomLabel = ('pendingSince' in currentPlan) ? <p className="text-green-600 animate-pulse">Upgrade in progress</p> : undefined;
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={applyCoupons(personalPlan, appliedCoupons)} isCurrent={true} bottomLabel={bottomLabel}>{personalFeatures}</PlanCard>);
+        const bottomLabel =
+            "pendingSince" in currentPlan ? (
+                <p className="text-green-600 animate-pulse">Upgrade in progress</p>
+            ) : undefined;
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={applyCoupons(personalPlan, appliedCoupons)}
+                isCurrent={true}
+                bottomLabel={bottomLabel}
+            >
+                {personalFeatures}
+            </PlanCard>,
+        );
     } else {
         const targetPlan = applyCoupons(personalPlan, availableCoupons);
         let bottomLabel;
         if (scheduledDowngradePlanId === targetPlan.chargebeeId && !pendingDowngradeCancellation) {
-            bottomLabel = <p className="text-green-600">Downgrade scheduled<br/><a className="text-blue-light leading-6" href="javascript:void(0)"  onClick={() => confirmCancelDowngrade()}>Cancel</a></p>;
+            bottomLabel = (
+                <p className="text-green-600">
+                    Downgrade scheduled
+                    <br />
+                    <a
+                        className="text-blue-light leading-6"
+                        href="javascript:void(0)"
+                        onClick={() => confirmCancelDowngrade()}
+                    >
+                        Cancel
+                    </a>
+                </p>
+            );
         } else if (pendingDowngradePlan?.chargebeeId === targetPlan.chargebeeId) {
             bottomLabel = <p className="text-green-600">Downgrade scheduled</p>;
         }
         let onUpgrade, onDowngrade;
         switch (Plans.subscriptionChange(currentPlan.type, targetPlan.type)) {
-            case 'upgrade': onUpgrade = () => confirmUpgrade(targetPlan); break;
-            case 'downgrade': onDowngrade = () => confirmDowngrade(targetPlan); break;
+            case "upgrade":
+                onUpgrade = () => confirmUpgrade(targetPlan);
+                break;
+            case "downgrade":
+                onDowngrade = () => confirmDowngrade(targetPlan);
+                break;
         }
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={targetPlan} isCurrent={false} onUpgrade={onUpgrade} onDowngrade={onDowngrade} bottomLabel={bottomLabel}>{personalFeatures}</PlanCard>);
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={targetPlan}
+                isCurrent={false}
+                onUpgrade={onUpgrade}
+                onDowngrade={onDowngrade}
+                bottomLabel={bottomLabel}
+            >
+                {personalFeatures}
+            </PlanCard>,
+        );
     }
 
     // Plan card: Professional
-    const professionalFeatures = <>
-        <p className="truncate" title={'Everything in ' + personalPlan.name}>← Everything in {personalPlan.name}</p>
-        <p className="truncate" title="8 Parallel Workspaces">✓ 8 Parallel Workspaces</p>
-        <p className="truncate" title="Teams">✓ Teams</p>
-    </>;
+    const professionalFeatures = (
+        <>
+            <p className="truncate" title={"Everything in " + personalPlan.name}>
+                ← Everything in {personalPlan.name}
+            </p>
+            <p className="truncate" title="8 Parallel Workspaces">
+                ✓ 8 Parallel Workspaces
+            </p>
+            <p className="truncate" title="Teams">
+                ✓ Teams
+            </p>
+        </>
+    );
 
     if (currentPlan.chargebeeId === professionalPlan.chargebeeId) {
-        const bottomLabel = ('pendingSince' in currentPlan) ? <p className="text-green-600 animate-pulse">Upgrade in progress</p> : undefined;
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={applyCoupons(professionalPlan, appliedCoupons)} isCurrent={true} bottomLabel={bottomLabel} isTsAssigned={!!assignedProfessionalTs}>{professionalFeatures}</PlanCard>);
+        const bottomLabel =
+            "pendingSince" in currentPlan ? (
+                <p className="text-green-600 animate-pulse">Upgrade in progress</p>
+            ) : undefined;
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={applyCoupons(professionalPlan, appliedCoupons)}
+                isCurrent={true}
+                bottomLabel={bottomLabel}
+                isTsAssigned={!!assignedProfessionalTs}
+            >
+                {professionalFeatures}
+            </PlanCard>,
+        );
     } else {
         const targetPlan = applyCoupons(professionalPlan, availableCoupons);
         let bottomLabel;
         if (scheduledDowngradePlanId === targetPlan.chargebeeId && !pendingDowngradeCancellation) {
-            bottomLabel = <p className="text-green-600">Downgrade scheduled<br/><a className="text-blue-light leading-6" href="javascript:void(0)" onClick={() => confirmCancelDowngrade()}>Cancel</a></p>;
+            bottomLabel = (
+                <p className="text-green-600">
+                    Downgrade scheduled
+                    <br />
+                    <a
+                        className="text-blue-light leading-6"
+                        href="javascript:void(0)"
+                        onClick={() => confirmCancelDowngrade()}
+                    >
+                        Cancel
+                    </a>
+                </p>
+            );
         } else if (pendingDowngradePlan?.chargebeeId === targetPlan.chargebeeId) {
             bottomLabel = <p className="text-green-600">Downgrade scheduled</p>;
         }
         let onUpgrade, onDowngrade;
         switch (Plans.subscriptionChange(currentPlan.type, targetPlan.type)) {
-            case 'upgrade': onUpgrade = () => confirmUpgrade(targetPlan); break;
-            case 'downgrade': onDowngrade = () => confirmDowngrade(targetPlan); break;
+            case "upgrade":
+                onUpgrade = () => confirmUpgrade(targetPlan);
+                break;
+            case "downgrade":
+                onDowngrade = () => confirmDowngrade(targetPlan);
+                break;
         }
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={targetPlan} isCurrent={!!assignedProfessionalTs} onUpgrade={onUpgrade} onDowngrade={onDowngrade} bottomLabel={bottomLabel} isTsAssigned={!!assignedProfessionalTs}>{professionalFeatures}</PlanCard>);
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={targetPlan}
+                isCurrent={!!assignedProfessionalTs}
+                onUpgrade={onUpgrade}
+                onDowngrade={onDowngrade}
+                bottomLabel={bottomLabel}
+                isTsAssigned={!!assignedProfessionalTs}
+            >
+                {professionalFeatures}
+            </PlanCard>,
+        );
     }
 
     // Plan card: Unleashed (or Student Unleashed)
-    const unleashedFeatures = <>
-        <p className="truncate" title={'Everything in ' + professionalPlan.name}>← Everything in {professionalPlan.name}</p>
-        <p className="truncate" title="16 Parallel Workspaces">✓ 16 Parallel Workspaces</p>
-        <p className="truncate" title="1h Timeout">✓ 1h Timeout</p>
-        <p className="truncate" title="3h Timeout Boost">✓ 3h Timeout Boost</p>
-    </>;
+    const unleashedFeatures = (
+        <>
+            <p className="truncate" title={"Everything in " + professionalPlan.name}>
+                ← Everything in {professionalPlan.name}
+            </p>
+            <p className="truncate" title="16 Parallel Workspaces">
+                ✓ 16 Parallel Workspaces
+            </p>
+            <p className="truncate" title="1h Timeout">
+                ✓ 1h Timeout
+            </p>
+            <p className="truncate" title="3h Timeout Boost">
+                ✓ 3h Timeout Boost
+            </p>
+        </>
+    );
     const isUnleashedTsAssigned = !!assignedStudentUnleashedTs || !!assignedUnleashedTs;
     if (currentPlan.chargebeeId === studentUnleashedPlan.chargebeeId) {
-        const bottomLabel = ('pendingSince' in currentPlan) ? <p className="text-green-600 animate-pulse">Upgrade in progress</p> : undefined;
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={applyCoupons(studentUnleashedPlan, appliedCoupons)} isCurrent={true} bottomLabel={bottomLabel} isTsAssigned={isUnleashedTsAssigned}>{unleashedFeatures}</PlanCard>);
+        const bottomLabel =
+            "pendingSince" in currentPlan ? (
+                <p className="text-green-600 animate-pulse">Upgrade in progress</p>
+            ) : undefined;
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={applyCoupons(studentUnleashedPlan, appliedCoupons)}
+                isCurrent={true}
+                bottomLabel={bottomLabel}
+                isTsAssigned={isUnleashedTsAssigned}
+            >
+                {unleashedFeatures}
+            </PlanCard>,
+        );
     } else if (currentPlan.chargebeeId === unleashedPlan.chargebeeId) {
-        const bottomLabel = ('pendingSince' in currentPlan) ? <p className="text-green-600 animate-pulse">Upgrade in progress</p> : undefined;
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={applyCoupons(unleashedPlan, appliedCoupons)} isCurrent={true} bottomLabel={bottomLabel} isTsAssigned={isUnleashedTsAssigned}>{unleashedFeatures}</PlanCard>);
+        const bottomLabel =
+            "pendingSince" in currentPlan ? (
+                <p className="text-green-600 animate-pulse">Upgrade in progress</p>
+            ) : undefined;
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={applyCoupons(unleashedPlan, appliedCoupons)}
+                isCurrent={true}
+                bottomLabel={bottomLabel}
+                isTsAssigned={isUnleashedTsAssigned}
+            >
+                {unleashedFeatures}
+            </PlanCard>,
+        );
     } else {
         const targetPlan = applyCoupons(isStudent ? studentUnleashedPlan : unleashedPlan, availableCoupons);
         let onUpgrade;
         switch (Plans.subscriptionChange(currentPlan.type, targetPlan.type)) {
-            case 'upgrade': onUpgrade = () => confirmUpgrade(targetPlan); break;
+            case "upgrade":
+                onUpgrade = () => confirmUpgrade(targetPlan);
+                break;
         }
-        planCards.push(<PlanCard isDisabled={!!assignedTs || pendingChargebeeCallback} plan={targetPlan} isCurrent={!!isUnleashedTsAssigned} onUpgrade={onUpgrade} isTsAssigned={isUnleashedTsAssigned}>{unleashedFeatures}</PlanCard>);
+        planCards.push(
+            <PlanCard
+                isDisabled={!!assignedTs || pendingChargebeeCallback}
+                plan={targetPlan}
+                isCurrent={!!isUnleashedTsAssigned}
+                onUpgrade={onUpgrade}
+                isTsAssigned={isUnleashedTsAssigned}
+            >
+                {unleashedFeatures}
+            </PlanCard>,
+        );
     }
 
-    return <div>
-        <PageWithSubMenu subMenu={settingsMenu}  title='Plans' subtitle='Manage account usage and billing.'>
-            {showPaymentUI && <div className="w-full text-center">
-                <p className="text-xl text-gray-500">You are currently using the <span className="font-bold">{Plans.getById(assignedTs?.planId)?.name || currentPlan.name}</span> plan.</p>
-                {!assignedTs && (
-                    <p className="text-base w-96 m-auto">Upgrade your plan to get more hours and more parallel workspaces.</p>
+    return (
+        <div>
+            <PageWithSubMenu subMenu={settingsMenu} title="Plans" subtitle="Manage account usage and billing.">
+                {showPaymentUI && (
+                    <div className="w-full text-center">
+                        <p className="text-xl text-gray-500">
+                            You are currently using the{" "}
+                            <span className="font-bold">
+                                {Plans.getById(assignedTs?.planId)?.name || currentPlan.name}
+                            </span>{" "}
+                            plan.
+                        </p>
+                        {!assignedTs && (
+                            <p className="text-base w-96 m-auto">
+                                Upgrade your plan to get more hours and more parallel workspaces.
+                            </p>
+                        )}
+                        <Tooltip
+                            content={`Current billing cycle: ${guessCurrentBillingCycle(currentPlan, accountStatement)
+                                .map((d) => d.toLocaleDateString())
+                                .join(" - ")}`}
+                        >
+                            <p className="mt-2 font-semibold text-gray-500">
+                                Remaining hours:{" "}
+                                {typeof accountStatement?.remainingHours === "number"
+                                    ? Math.floor(accountStatement.remainingHours * 10) / 10
+                                    : accountStatement?.remainingHours}
+                            </p>
+                        </Tooltip>
+                        {typeof accountStatement?.remainingHours === "number" &&
+                        typeof currentPlan.hoursPerMonth === "number" ? (
+                            <progress
+                                value={currentPlan.hoursPerMonth - accountStatement.remainingHours}
+                                max={currentPlan.hoursPerMonth}
+                            />
+                        ) : (
+                            <progress value="0" max="100" />
+                        )}
+                        <p className="text-sm">
+                            <a
+                                className={`text-blue-light hover:underline" ${isChargebeeCustomer ? "" : "invisible"}`}
+                                href="javascript:void(0)"
+                                onClick={() => {
+                                    ChargebeeClient.getOrCreate().then((chargebeeClient) =>
+                                        chargebeeClient.openPortal(),
+                                    );
+                                }}
+                            >
+                                Billing
+                            </a>
+                            {!!accountStatement && Plans.isFreePlan(currentPlan.chargebeeId) && (
+                                <span className="pl-6">
+                                    {currency === "EUR" ? (
+                                        <>
+                                            € /{" "}
+                                            <a
+                                                className="text-blue-light hover:underline"
+                                                href="javascript:void(0)"
+                                                onClick={() => setCurrency("USD")}
+                                            >
+                                                $
+                                            </a>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <a
+                                                className="text-blue-light hover:underline"
+                                                href="javascript:void(0)"
+                                                onClick={() => setCurrency("EUR")}
+                                            >
+                                                €
+                                            </a>{" "}
+                                            / $
+                                        </>
+                                    )}
+                                </span>
+                            )}
+                        </p>
+                    </div>
                 )}
-                <Tooltip content={`Current billing cycle: ${guessCurrentBillingCycle(currentPlan, accountStatement).map(d => d.toLocaleDateString()).join(' - ')}`}>
-                    <p className="mt-2 font-semibold text-gray-500">Remaining hours: {typeof(accountStatement?.remainingHours) === 'number'
-                        ? Math.floor(accountStatement.remainingHours * 10) / 10
-                        : accountStatement?.remainingHours}</p>
-                </Tooltip>
-                {(typeof(accountStatement?.remainingHours) === 'number' && typeof(currentPlan.hoursPerMonth) === 'number')
-                    ? <progress value={currentPlan.hoursPerMonth - accountStatement.remainingHours} max={currentPlan.hoursPerMonth} />
-                    : <progress value="0" max="100" />}
-                <p className="text-sm">
-                    <a className={`text-blue-light hover:underline" ${isChargebeeCustomer ? '' : 'invisible'}`} href="javascript:void(0)" onClick={() => { ChargebeeClient.getOrCreate().then(chargebeeClient => chargebeeClient.openPortal()); }}>Billing</a>
-                    {!!accountStatement && Plans.isFreePlan(currentPlan.chargebeeId) && <span className="pl-6">{currency === 'EUR'
-                        ? <>€ / <a className="text-blue-light hover:underline" href="javascript:void(0)" onClick={() => setCurrency('USD')}>$</a></>
-                        : <><a className="text-blue-light hover:underline" href="javascript:void(0)" onClick={() => setCurrency('EUR')}>€</a> / $</>}
-                    </span>}
-                </p>
-            </div>}
-            <div className="mt-4 flex justify-center space-x-3 2xl:space-x-7">{planCards}</div>
-            <InfoBox className="w-2/3 mt-14 mx-auto">
-                If you are interested in purchasing a plan for a team, purchase a Team plan with one centralized billing. <a className="underline" href="https://www.gitpod.io/docs/teams/">Learn more</a>
-            </InfoBox>
-            {!!confirmUpgradeToPlan && <Modal visible={true} onClose={() => setConfirmUpgradeToPlan(undefined)}>
-                <h3>Upgrade to {confirmUpgradeToPlan.name}</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
-                    <p className="mt-1 mb-4 text-gray-500 text-base">You are about to upgrade to {confirmUpgradeToPlan.name}.</p>
-                    {!Plans.isFreePlan(currentPlan.chargebeeId) && <InfoBox className="mb-4">
-                        For this billing cycle you will be charged only the total difference ({(confirmUpgradeToPlan.currency === 'EUR' ? '€' : '$') + (confirmUpgradeToPlan.pricePerMonth - applyCoupons(currentPlan, appliedCoupons).pricePerMonth)}). The new total will be effective from the next billing cycle.
-                    </InfoBox>}
-                    <AlertBox className="mb-4">
-                        Total: {(confirmUpgradeToPlan.currency === 'EUR' ? '€' : '$') + confirmUpgradeToPlan.pricePerMonth} per month
-                    </AlertBox>
-                </div>
-                <div className="flex justify-end mt-6">
-                    <button onClick={doUpgrade}>Upgrade Plan</button>
-                </div>
-            </Modal>}
-            {!!confirmDowngradeToPlan && <Modal visible={true} onClose={() => setConfirmDowngradeToPlan(undefined)}>
-                <h3>Downgrade to {confirmDowngradeToPlan.name}</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
-                    <p className="mt-1 mb-4 text-base">You are about to downgrade to {confirmDowngradeToPlan.name}.</p>
-                    <InfoBox className="mb-4">
-                        {!Plans.isFreePlan(confirmDowngradeToPlan.chargebeeId)
-                            ? <span>Your account will downgrade to {confirmDowngradeToPlan.name} on the next billing cycle.</span>
-                            : <span>Your account will downgrade to {confirmDowngradeToPlan.name}. The remaining hours in your current plan will be available to use until the next billing cycle.</span>}
-                    </InfoBox>
-                </div>
-                <div className="flex justify-end mt-6">
-                    <button className="danger" onClick={doDowngrade}>Downgrade Plan</button>
-                </div>
-            </Modal>}
-            {isConfirmCancelDowngrade && <Modal visible={true} onClose={() => setIsConfirmCancelDowngrade(false)}>
-                <h3>Cancel downgrade and stay with {currentPlan.name}</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
-                    <p className="mt-1 mb-4 text-base">You are about to cancel the scheduled downgrade and stay with {currentPlan.name}.</p>
-                    <InfoBox className="mb-4">You can continue using it right away.</InfoBox>
-                </div>
-                <div className="flex justify-end mt-6">
-                    <button className="bg-red-600 border-red-800" onClick={doCancelDowngrade}>Cancel Downgrade</button>
-                </div>
-            </Modal>}
-            {!!teamClaimModal && (<Modal visible={true} onClose={() => setTeamClaimModal(undefined)}>
-                <h3 className="pb-2">Team Invitation</h3>
-                <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                    <p className="pb-4 text-gray-500 text-base">{teamClaimModal.mode === "error" ? teamClaimModal.errorText : teamClaimModal.text}</p>
-                </div>
-                <div className="flex justify-end mt-6">
-                    {teamClaimModal.mode === "confirmation" && (
-                        <>
-                            <button className="secondary" onClick={() => setTeamClaimModal(undefined)}>Cancel</button>
-                            <button className="ml-2" onClick={async () => {
-                                try {
-                                    await getGitpodService().server.tsAssignSlot(teamClaimModal.teamId, teamClaimModal.slotId, undefined);
-                                    window.history.replaceState({}, window.document.title, window.location.href.replace(window.location.search, ''));
+                <div className="mt-4 flex justify-center space-x-3 2xl:space-x-7">{planCards}</div>
+                <InfoBox className="w-2/3 mt-14 mx-auto">
+                    If you are interested in purchasing a plan for a team, purchase a Team plan with one centralized
+                    billing.{" "}
+                    <a className="underline" href="https://www.gitpod.io/docs/teams/">
+                        Learn more
+                    </a>
+                </InfoBox>
+                {!!confirmUpgradeToPlan && (
+                    <Modal visible={true} onClose={() => setConfirmUpgradeToPlan(undefined)}>
+                        <h3>Upgrade to {confirmUpgradeToPlan.name}</h3>
+                        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+                            <p className="mt-1 mb-4 text-gray-500 text-base">
+                                You are about to upgrade to {confirmUpgradeToPlan.name}.
+                            </p>
+                            {!Plans.isFreePlan(currentPlan.chargebeeId) && (
+                                <InfoBox className="mb-4">
+                                    For this billing cycle you will be charged only the total difference (
+                                    {(confirmUpgradeToPlan.currency === "EUR" ? "€" : "$") +
+                                        (confirmUpgradeToPlan.pricePerMonth -
+                                            applyCoupons(currentPlan, appliedCoupons).pricePerMonth)}
+                                    ). The new total will be effective from the next billing cycle.
+                                </InfoBox>
+                            )}
+                            <AlertBox className="mb-4">
+                                Total:{" "}
+                                {(confirmUpgradeToPlan.currency === "EUR" ? "€" : "$") +
+                                    confirmUpgradeToPlan.pricePerMonth}{" "}
+                                per month
+                            </AlertBox>
+                        </div>
+                        <div className="flex justify-end mt-6">
+                            <button onClick={doUpgrade}>Upgrade Plan</button>
+                        </div>
+                    </Modal>
+                )}
+                {!!confirmDowngradeToPlan && (
+                    <Modal visible={true} onClose={() => setConfirmDowngradeToPlan(undefined)}>
+                        <h3>Downgrade to {confirmDowngradeToPlan.name}</h3>
+                        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+                            <p className="mt-1 mb-4 text-base">
+                                You are about to downgrade to {confirmDowngradeToPlan.name}.
+                            </p>
+                            <InfoBox className="mb-4">
+                                {!Plans.isFreePlan(confirmDowngradeToPlan.chargebeeId) ? (
+                                    <span>
+                                        Your account will downgrade to {confirmDowngradeToPlan.name} on the next billing
+                                        cycle.
+                                    </span>
+                                ) : (
+                                    <span>
+                                        Your account will downgrade to {confirmDowngradeToPlan.name}. The remaining
+                                        hours in your current plan will be available to use until the next billing
+                                        cycle.
+                                    </span>
+                                )}
+                            </InfoBox>
+                        </div>
+                        <div className="flex justify-end mt-6">
+                            <button className="danger" onClick={doDowngrade}>
+                                Downgrade Plan
+                            </button>
+                        </div>
+                    </Modal>
+                )}
+                {isConfirmCancelDowngrade && (
+                    <Modal visible={true} onClose={() => setIsConfirmCancelDowngrade(false)}>
+                        <h3>Cancel downgrade and stay with {currentPlan.name}</h3>
+                        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+                            <p className="mt-1 mb-4 text-base">
+                                You are about to cancel the scheduled downgrade and stay with {currentPlan.name}.
+                            </p>
+                            <InfoBox className="mb-4">You can continue using it right away.</InfoBox>
+                        </div>
+                        <div className="flex justify-end mt-6">
+                            <button className="bg-red-600 border-red-800" onClick={doCancelDowngrade}>
+                                Cancel Downgrade
+                            </button>
+                        </div>
+                    </Modal>
+                )}
+                {!!teamClaimModal && (
+                    <Modal visible={true} onClose={() => setTeamClaimModal(undefined)}>
+                        <h3 className="pb-2">Team Invitation</h3>
+                        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
+                            <p className="pb-4 text-gray-500 text-base">
+                                {teamClaimModal.mode === "error" ? teamClaimModal.errorText : teamClaimModal.text}
+                            </p>
+                        </div>
+                        <div className="flex justify-end mt-6">
+                            {teamClaimModal.mode === "confirmation" && (
+                                <>
+                                    <button className="secondary" onClick={() => setTeamClaimModal(undefined)}>
+                                        Cancel
+                                    </button>
+                                    <button
+                                        className="ml-2"
+                                        onClick={async () => {
+                                            try {
+                                                await getGitpodService().server.tsAssignSlot(
+                                                    teamClaimModal.teamId,
+                                                    teamClaimModal.slotId,
+                                                    undefined,
+                                                );
+                                                window.history.replaceState(
+                                                    {},
+                                                    window.document.title,
+                                                    window.location.href.replace(window.location.search, ""),
+                                                );
 
-                                    setTeamClaimModal(undefined);
+                                                setTeamClaimModal(undefined);
 
-                                    const statement = await getGitpodService().server.getAccountStatement({});
-                                    setAccountStatement(statement);
-                                } catch (error) {
-                                    setTeamClaimModal({
-                                        mode: "error",
-                                        errorText: `Error: ${error.message}`,
-                                    })
-                                }
-                            }}>Accept Invitation</button>
-                        </>
-                    )}
-                    {teamClaimModal.mode === "error" && (
-                        <button className="secondary" onClick={() => setTeamClaimModal(undefined)}>Close</button>
-                    )}
-                </div>
-            </Modal>)}
-        </PageWithSubMenu>
-    </div>;
+                                                const statement = await getGitpodService().server.getAccountStatement(
+                                                    {},
+                                                );
+                                                setAccountStatement(statement);
+                                            } catch (error) {
+                                                setTeamClaimModal({
+                                                    mode: "error",
+                                                    errorText: `Error: ${error.message}`,
+                                                });
+                                            }
+                                        }}
+                                    >
+                                        Accept Invitation
+                                    </button>
+                                </>
+                            )}
+                            {teamClaimModal.mode === "error" && (
+                                <button className="secondary" onClick={() => setTeamClaimModal(undefined)}>
+                                    Close
+                                </button>
+                            )}
+                        </div>
+                    </Modal>
+                )}
+            </PageWithSubMenu>
+        </div>
+    );
 }
 
 interface PlanCardProps {
-  plan: PlanWithOriginalPrice;
-  isCurrent: boolean;
-  children: React.ReactNode;
-  onUpgrade?: () => void;
-  onDowngrade?: () => void;
-  bottomLabel?: React.ReactNode;
-  isDisabled?: boolean;
-  isTsAssigned?: boolean;
+    plan: PlanWithOriginalPrice;
+    isCurrent: boolean;
+    children: React.ReactNode;
+    onUpgrade?: () => void;
+    onDowngrade?: () => void;
+    bottomLabel?: React.ReactNode;
+    isDisabled?: boolean;
+    isTsAssigned?: boolean;
 }
 
 function PlanCard(p: PlanCardProps) {
-    return <SelectableCard className="w-44 2xl:w-56" title={p.plan.name.toUpperCase()} selected={p.isCurrent} onClick={() => {}}>
-        <div className="mt-5 mb-5 flex flex-col items-center justify-center">
-            <p className="text-3xl text-gray-500 font-bold">{p.plan.hoursPerMonth}</p>
-            <p className="text-base text-gray-500 font-bold">hours</p>
-        </div>
-        <div className="flex-grow flex flex-col space-y-2">{p.children}</div>
-        <div>
-        <p className="text-center text-gray-500 font-semibold mb-2 mt-4">{p.plan.pricePerMonth <= 0.001
-            ? 'FREE'
-            : (p.plan.currency === 'EUR' ? '€' : '$') + p.plan.pricePerMonth + ' per month'
-        }</p>
-        {p.isCurrent
-            ? <button className="w-full" disabled={true}>Current Plan</button>
-            : ((p.onUpgrade && <button disabled={p.isDisabled} className="w-full secondary group-hover:bg-green-600 group-hover:text-gray-100" onClick={p.onUpgrade}>Upgrade</button>)
-                || (p.onDowngrade && <button disabled={p.isDisabled} className="w-full secondary group-hover:bg-green-600 group-hover:text-gray-100" onClick={p.onDowngrade}>Downgrade</button>)
-                || <button className="w-full secondary" disabled={true}>&nbsp;</button>)}
-        </div>
-        <div className="relative w-full">
-            {p.isTsAssigned && (
-                <div className="absolute w-full mt-5 text-center font-semibold cursor-default">Team seat assigned</div>
-            )}
-            <div className="absolute w-full mt-5 text-center font-semibold cursor-default">{p.bottomLabel}</div>
-        </div>
-    </SelectableCard>;
+    return (
+        <SelectableCard
+            className="w-44 2xl:w-56"
+            title={p.plan.name.toUpperCase()}
+            selected={p.isCurrent}
+            onClick={() => {}}
+        >
+            <div className="mt-5 mb-5 flex flex-col items-center justify-center">
+                <p className="text-3xl text-gray-500 font-bold">{p.plan.hoursPerMonth}</p>
+                <p className="text-base text-gray-500 font-bold">hours</p>
+            </div>
+            <div className="flex-grow flex flex-col space-y-2">{p.children}</div>
+            <div>
+                <p className="text-center text-gray-500 font-semibold mb-2 mt-4">
+                    {p.plan.pricePerMonth <= 0.001
+                        ? "FREE"
+                        : (p.plan.currency === "EUR" ? "€" : "$") + p.plan.pricePerMonth + " per month"}
+                </p>
+                {p.isCurrent ? (
+                    <button className="w-full" disabled={true}>
+                        Current Plan
+                    </button>
+                ) : (
+                    (p.onUpgrade && (
+                        <button
+                            disabled={p.isDisabled}
+                            className="w-full secondary group-hover:bg-green-600 group-hover:text-gray-100"
+                            onClick={p.onUpgrade}
+                        >
+                            Upgrade
+                        </button>
+                    )) ||
+                    (p.onDowngrade && (
+                        <button
+                            disabled={p.isDisabled}
+                            className="w-full secondary group-hover:bg-green-600 group-hover:text-gray-100"
+                            onClick={p.onDowngrade}
+                        >
+                            Downgrade
+                        </button>
+                    )) || (
+                        <button className="w-full secondary" disabled={true}>
+                            &nbsp;
+                        </button>
+                    )
+                )}
+            </div>
+            <div className="relative w-full">
+                {p.isTsAssigned && (
+                    <div className="absolute w-full mt-5 text-center font-semibold cursor-default">
+                        Team seat assigned
+                    </div>
+                )}
+                <div className="absolute w-full mt-5 text-center font-semibold cursor-default">{p.bottomLabel}</div>
+            </div>
+        </SelectableCard>
+    );
 }
 
 function getLocalStorageObject(key: string): PendingPlan | undefined {
@@ -584,20 +964,20 @@ function setLocalStorageObject(key: string, object: Object): void {
     try {
         window.localStorage.setItem(key, JSON.stringify(object));
     } catch (error) {
-        console.error('Setting localstorage item failed', key, object, error);
+        console.error("Setting localstorage item failed", key, object, error);
     }
 }
 
 function applyCoupons(plan: Plan, coupons: PlanCoupon[] | undefined): PlanWithOriginalPrice {
-    let coupon = (coupons || []).find(c => c.chargebeePlanID == plan.chargebeeId);
+    let coupon = (coupons || []).find((c) => c.chargebeePlanID === plan.chargebeeId);
     if (!coupon) {
         return plan;
     }
     return {
         ...plan,
         pricePerMonth: coupon.newPrice || 0,
-        originalPrice: plan.pricePerMonth
-    }
+        originalPrice: plan.pricePerMonth,
+    };
 }
 
 // Look for relevant billing cycle dates in the account statement's computed credits.
@@ -607,7 +987,12 @@ function guessCurrentBillingCycle(currentPlan: Plan, accountStatement?: AccountS
     }
     try {
         const now = new Date().toISOString();
-        const credit = accountStatement.credits.find(c => c.date < now && c.expiryDate >= now && (c.description as CreditDescription)?.planId === currentPlan.chargebeeId);
+        const credit = accountStatement.credits.find(
+            (c) =>
+                c.date < now &&
+                c.expiryDate >= now &&
+                (c.description as CreditDescription)?.planId === currentPlan.chargebeeId,
+        );
         if (!!credit) {
             return [new Date(credit.date), new Date(credit.expiryDate)];
         }

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -15,19 +15,19 @@ import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
 import settingsMenu from "./settings-menu";
-import IDENone from '../icons/IDENone.svg';
-import IDENoneDark from '../icons/IDENoneDark.svg';
+import IDENone from "../icons/IDENone.svg";
+import IDENoneDark from "../icons/IDENoneDark.svg";
 import CheckBox from "../components/CheckBox";
 
-type Theme = 'light' | 'dark' | 'system';
+type Theme = "light" | "dark" | "system";
 
 const DesktopNoneId = "none";
 const DesktopNone: IDEOption = {
-    "image": "",
-    "logo": IDENone,
-    "orderKey": "-1",
-    "title": "None",
-    "type": "desktop"
+    image: "",
+    logo: IDENone,
+    orderKey: "-1",
+    title: "None",
+    type: "desktop",
 };
 
 export default function Preferences() {
@@ -44,36 +44,43 @@ export default function Preferences() {
         settings.defaultDesktopIde = desktopIde;
         settings.useLatestVersion = useLatestVersion;
         additionalData.ideSettings = settings;
-        getGitpodService().server.trackEvent({
-            event: "ide_configuration_changed",
-            properties: {
-                useDesktopIde,
-                defaultIde,
-                defaultDesktopIde: desktopIde,
-                useLatestVersion,
-            },
-        }).then().catch(console.error);
+        getGitpodService()
+            .server.trackEvent({
+                event: "ide_configuration_changed",
+                properties: {
+                    useDesktopIde,
+                    defaultIde,
+                    defaultDesktopIde: desktopIde,
+                    useLatestVersion,
+                },
+            })
+            .then()
+            .catch(console.error);
         await getGitpodService().server.updateLoggedInUser({ additionalData });
-    }
+    };
 
     const [defaultIde, setDefaultIde] = useState<string>(user?.additionalData?.ideSettings?.defaultIde || "");
     const actuallySetDefaultIde = async (value: string) => {
         await updateUserIDEInfo(defaultDesktopIde, value, useLatestVersion);
         setDefaultIde(value);
-    }
+    };
 
-    const [defaultDesktopIde, setDefaultDesktopIde] = useState<string>((user?.additionalData?.ideSettings?.useDesktopIde && user?.additionalData?.ideSettings?.defaultDesktopIde) || DesktopNoneId);
+    const [defaultDesktopIde, setDefaultDesktopIde] = useState<string>(
+        (user?.additionalData?.ideSettings?.useDesktopIde && user?.additionalData?.ideSettings?.defaultDesktopIde) ||
+            DesktopNoneId,
+    );
     const actuallySetDefaultDesktopIde = async (value: string) => {
         await updateUserIDEInfo(value, defaultIde, useLatestVersion);
         setDefaultDesktopIde(value);
-    }
+    };
 
-    const [useLatestVersion, setUseLatestVersion] = useState<boolean>(user?.additionalData?.ideSettings?.useLatestVersion ?? false);
+    const [useLatestVersion, setUseLatestVersion] = useState<boolean>(
+        user?.additionalData?.ideSettings?.useLatestVersion ?? false,
+    );
     const actuallySetUseLatestVersion = async (value: boolean) => {
         await updateUserIDEInfo(defaultDesktopIde, defaultIde, value);
         setUseLatestVersion(value);
-    }
-
+    };
 
     const [ideOptions, setIdeOptions] = useState<IDEOptions | undefined>(undefined);
     useEffect(() => {
@@ -81,26 +88,28 @@ export default function Preferences() {
             const ideopts = await getGitpodService().server.getIDEOptions();
             ideopts.options[DesktopNoneId] = DesktopNone;
             setIdeOptions(ideopts);
-            if (!(defaultIde)) {
+            if (!defaultIde) {
                 setDefaultIde(ideopts.defaultIde);
             }
             if (!defaultDesktopIde) {
                 setDefaultDesktopIde(ideopts.defaultDesktopIde);
             }
         })();
-    }, []);
+    }, [defaultDesktopIde, defaultIde]);
 
-    const [theme, setTheme] = useState<Theme>(localStorage.theme || 'system');
+    const [theme, setTheme] = useState<Theme>(localStorage.theme || "system");
     const actuallySetTheme = (theme: Theme) => {
-        if (theme === 'dark' || theme === 'light') {
+        if (theme === "dark" || theme === "light") {
             localStorage.theme = theme;
         } else {
-            localStorage.removeItem('theme');
+            localStorage.removeItem("theme");
         }
-        const isDark = localStorage.theme === 'dark' || (localStorage.theme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        const isDark =
+            localStorage.theme === "dark" ||
+            (localStorage.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
         setIsDark(isDark);
         setTheme(theme);
-    }
+    };
 
     const browserIdeOptions = ideOptions && orderedIdeOptions(ideOptions, "browser");
     const desktopIdeOptions = ideOptions && orderedIdeOptions(ideOptions, "desktop");
@@ -112,90 +121,178 @@ export default function Preferences() {
         await getGitpodService().server.updateLoggedInUser({ additionalData });
     };
 
-    return <div>
-        <PageWithSubMenu subMenu={settingsMenu} title='Preferences' subtitle='Configure user preferences.'>
-            {ideOptions && <>
-                {browserIdeOptions && <>
-                    <h3>Browser Editor</h3>
-                    <p className="text-base text-gray-500 dark:text-gray-400">Choose the default editor for opening workspaces in the browser.</p>
-                    <div className="my-4 gap-4 flex flex-wrap">
-                        {
-                            browserIdeOptions.map(([id, option]) => {
-                                const selected = defaultIde === id;
-                                const onSelect = () => actuallySetDefaultIde(id);
-                                return renderIdeOption(option, selected, onSelect);
-                            })
-                        }
-                    </div>
-                    {ideOptions.options[defaultIde]?.notes &&
-                        <InfoBox className="my-5 max-w-2xl"><ul>
-                            {ideOptions.options[defaultIde].notes?.map((x, idx) => <li className={idx > 0 ? "mt-2" : ""}>{x}</li>)}
-                        </ul></InfoBox>
-                    }
-                </>}
-                {desktopIdeOptions && <>
-                    <h3 className="mt-12 flex">
-                        Desktop Editor
-                      <PillLabel type="warn" className="font-semibold py-0.5 px-2 self-center">Beta</PillLabel>
-                    </h3>
-                    <p className="text-base text-gray-500 dark:text-gray-400">Optionally, choose the default desktop editor for opening workspaces.</p>
-                    <div className="my-4 gap-4 flex flex-wrap max-w-2xl">
-                        {
-                            desktopIdeOptions.map(([id, option]) => {
-                                const selected = defaultDesktopIde === id;
-                                const onSelect = () => actuallySetDefaultDesktopIde(id);
-                                if (id === DesktopNoneId) {
-                                    option.logo = isDark ? IDENoneDark : IDENone
-                                }
-                                return renderIdeOption(option, selected, onSelect);
-                            })
-                        }
-                    </div>
-                    {ideOptions.options[defaultDesktopIde]?.notes &&
-                        <InfoBox className="my-5 max-w-2xl"><ul>
-                            {ideOptions.options[defaultDesktopIde].notes?.map((x, idx) => <li className={idx > 0 ? "mt-2" : ""}>{x}</li>)}
-                        </ul></InfoBox>
-                    }
-                    <p className="text-left w-full text-gray-500">
-                        The <strong>JetBrains desktop IDEs</strong> are currently in beta. <a href="https://github.com/gitpod-io/gitpod/issues/6576" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a> · <a href="https://www.gitpod.io/docs/integrations/jetbrains" target="_blank" rel="noopener noreferrer" className="gp-link">Documentation</a>
-                    </p>
-                </>}
-                <CheckBox title="Latest Release" desc="Include the latest Early Access Program (EAP) version for each JetBrains IDE." checked={useLatestVersion} onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}/>
-            </>}
-            <h3 className="mt-12">Theme</h3>
-            <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
-            <div className="mt-4 space-x-4 flex">
-                <SelectableCard className="w-36 h-32" title="Light" selected={theme === 'light'} onClick={() => actuallySetTheme('light')}>
-                    <div className="flex-grow flex justify-center items-end">
-                        <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" /><rect width="32" height="16" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="24" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" /></svg>
-                    </div>
-                </SelectableCard>
-                <SelectableCard className="w-36 h-32" title="Dark" selected={theme === 'dark'} onClick={() => actuallySetTheme('dark')}>
-                    <div className="flex-grow flex justify-center items-end">
-                        <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#737373" rx="8" /><rect width="32" height="16" fill="#737373" rx="8" /><rect width="32" height="16" y="24" fill="#737373" rx="8" /><rect width="32" height="16" y="48" fill="#737373" rx="8" /></svg>
-                    </div>
-                </SelectableCard>
-                <SelectableCard className="w-36 h-32" title="System" selected={theme === 'system'} onClick={() => actuallySetTheme('system')}>
-                    <div className="flex-grow flex justify-center items-end">
-                        <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" /><path fill="#737373" d="M74.111 3.412A8 8 0 0180.665 0H100a8 8 0 018 8v24a8 8 0 01-8 8H48.5L74.111 3.412z" /><rect width="32" height="16" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="24" fill="#737373" rx="8" /><rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" /></svg>
-                    </div>
-                </SelectableCard>
-            </div>
+    return (
+        <div>
+            <PageWithSubMenu subMenu={settingsMenu} title="Preferences" subtitle="Configure user preferences.">
+                {ideOptions && (
+                    <>
+                        {browserIdeOptions && (
+                            <>
+                                <h3>Browser Editor</h3>
+                                <p className="text-base text-gray-500 dark:text-gray-400">
+                                    Choose the default editor for opening workspaces in the browser.
+                                </p>
+                                <div className="my-4 gap-4 flex flex-wrap">
+                                    {browserIdeOptions.map(([id, option]) => {
+                                        const selected = defaultIde === id;
+                                        const onSelect = () => actuallySetDefaultIde(id);
+                                        return renderIdeOption(option, selected, onSelect);
+                                    })}
+                                </div>
+                                {ideOptions.options[defaultIde]?.notes && (
+                                    <InfoBox className="my-5 max-w-2xl">
+                                        <ul>
+                                            {ideOptions.options[defaultIde].notes?.map((x, idx) => (
+                                                <li className={idx > 0 ? "mt-2" : ""}>{x}</li>
+                                            ))}
+                                        </ul>
+                                    </InfoBox>
+                                )}
+                            </>
+                        )}
+                        {desktopIdeOptions && (
+                            <>
+                                <h3 className="mt-12 flex">
+                                    Desktop Editor
+                                    <PillLabel type="warn" className="font-semibold py-0.5 px-2 self-center">
+                                        Beta
+                                    </PillLabel>
+                                </h3>
+                                <p className="text-base text-gray-500 dark:text-gray-400">
+                                    Optionally, choose the default desktop editor for opening workspaces.
+                                </p>
+                                <div className="my-4 gap-4 flex flex-wrap max-w-2xl">
+                                    {desktopIdeOptions.map(([id, option]) => {
+                                        const selected = defaultDesktopIde === id;
+                                        const onSelect = () => actuallySetDefaultDesktopIde(id);
+                                        if (id === DesktopNoneId) {
+                                            option.logo = isDark ? IDENoneDark : IDENone;
+                                        }
+                                        return renderIdeOption(option, selected, onSelect);
+                                    })}
+                                </div>
+                                {ideOptions.options[defaultDesktopIde]?.notes && (
+                                    <InfoBox className="my-5 max-w-2xl">
+                                        <ul>
+                                            {ideOptions.options[defaultDesktopIde].notes?.map((x, idx) => (
+                                                <li className={idx > 0 ? "mt-2" : ""}>{x}</li>
+                                            ))}
+                                        </ul>
+                                    </InfoBox>
+                                )}
+                                <p className="text-left w-full text-gray-500">
+                                    The <strong>JetBrains desktop IDEs</strong> are currently in beta.{" "}
+                                    <a
+                                        href="https://github.com/gitpod-io/gitpod/issues/6576"
+                                        target="gitpod-feedback-issue"
+                                        rel="noopener"
+                                        className="gp-link"
+                                    >
+                                        Send feedback
+                                    </a>{" "}
+                                    ·{" "}
+                                    <a
+                                        href="https://www.gitpod.io/docs/integrations/jetbrains"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="gp-link"
+                                    >
+                                        Documentation
+                                    </a>
+                                </p>
+                            </>
+                        )}
+                        <CheckBox
+                            title="Latest Release"
+                            desc="Include the latest Early Access Program (EAP) version for each JetBrains IDE."
+                            checked={useLatestVersion}
+                            onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}
+                        />
+                    </>
+                )}
+                <h3 className="mt-12">Theme</h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
+                <div className="mt-4 space-x-4 flex">
+                    <SelectableCard
+                        className="w-36 h-32"
+                        title="Light"
+                        selected={theme === "light"}
+                        onClick={() => actuallySetTheme("light")}
+                    >
+                        <div className="flex-grow flex justify-center items-end">
+                            <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64">
+                                <rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" y="24" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" />
+                            </svg>
+                        </div>
+                    </SelectableCard>
+                    <SelectableCard
+                        className="w-36 h-32"
+                        title="Dark"
+                        selected={theme === "dark"}
+                        onClick={() => actuallySetTheme("dark")}
+                    >
+                        <div className="flex-grow flex justify-center items-end">
+                            <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64">
+                                <rect width="68" height="40" x="40" fill="#737373" rx="8" />
+                                <rect width="32" height="16" fill="#737373" rx="8" />
+                                <rect width="32" height="16" y="24" fill="#737373" rx="8" />
+                                <rect width="32" height="16" y="48" fill="#737373" rx="8" />
+                            </svg>
+                        </div>
+                    </SelectableCard>
+                    <SelectableCard
+                        className="w-36 h-32"
+                        title="System"
+                        selected={theme === "system"}
+                        onClick={() => actuallySetTheme("system")}
+                    >
+                        <div className="flex-grow flex justify-center items-end">
+                            <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64">
+                                <rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" />
+                                <path
+                                    fill="#737373"
+                                    d="M74.111 3.412A8 8 0 0180.665 0H100a8 8 0 018 8v24a8 8 0 01-8 8H48.5L74.111 3.412z"
+                                />
+                                <rect width="32" height="16" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" y="24" fill="#737373" rx="8" />
+                                <rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" />
+                            </svg>
+                        </div>
+                    </SelectableCard>
+                </div>
 
-            <h3 className="mt-12">Dotfiles <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel></h3>
-            <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
-            <div className="mt-4 max-w-md">
-                <h4>Repository URL</h4>
-                <input type="text" value={dotfileRepo} className="w-full" placeholder="e.g. https://github.com/username/dotfiles" onChange={(e) => setDotfileRepo(e.target.value)} />
-                <div className="mt-1">
-                    <p className="text-gray-500 dark:text-gray-400">Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for every new workspace.</p>
-                </div>
+                <h3 className="mt-12">
+                    Dotfiles{" "}
+                    <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">
+                        Beta
+                    </PillLabel>
+                </h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
                 <div className="mt-4 max-w-md">
-                    <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
+                    <h4>Repository URL</h4>
+                    <input
+                        type="text"
+                        value={dotfileRepo}
+                        className="w-full"
+                        placeholder="e.g. https://github.com/username/dotfiles"
+                        onChange={(e) => setDotfileRepo(e.target.value)}
+                    />
+                    <div className="mt-1">
+                        <p className="text-gray-500 dark:text-gray-400">
+                            Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for
+                            every new workspace.
+                        </p>
+                    </div>
+                    <div className="mt-4 max-w-md">
+                        <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
+                    </div>
                 </div>
-            </div>
-        </PageWithSubMenu>
-    </div>;
+            </PageWithSubMenu>
+        </div>
+    );
 }
 
 function orderedIdeOptions(ideOptions: IDEOptions, type: "browser" | "desktop") {
@@ -210,18 +307,27 @@ function orderedIdeOptions(ideOptions: IDEOptions, type: "browser" | "desktop") 
 }
 
 function renderIdeOption(option: IDEOption, selected: boolean, onSelect: () => void): JSX.Element {
-    const card = <SelectableCard className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
-        <div className="flex justify-center mt-3">
-            <img className="w-16 filter-grayscale self-center"
-                src={option.logo} alt="logo" />
-        </div>
-        {option.label ? <div className={`font-semibold text-sm ${selected ? 'text-green-500' : 'text-gray-500 dark:text-gray-400'} uppercase mt-2 px-3 py-1 self-center`}>{option.label}</div> : <></>}
-    </SelectableCard>;
+    const card = (
+        <SelectableCard className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
+            <div className="flex justify-center mt-3">
+                <img className="w-16 filter-grayscale self-center" src={option.logo} alt="logo" />
+            </div>
+            {option.label ? (
+                <div
+                    className={`font-semibold text-sm ${
+                        selected ? "text-green-500" : "text-gray-500 dark:text-gray-400"
+                    } uppercase mt-2 px-3 py-1 self-center`}
+                >
+                    {option.label}
+                </div>
+            ) : (
+                <></>
+            )}
+        </SelectableCard>
+    );
 
     if (option.tooltip) {
-        return <Tooltip content={option.tooltip} >
-            {card}
-        </Tooltip>;
+        return <Tooltip content={option.tooltip}>{card}</Tooltip>;
     }
     return card;
 }

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -4,30 +4,39 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import React, { useEffect, useRef, useState } from "react";
-import { countries } from 'countries-list';
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { countries } from "countries-list";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
 import AlertBox from "../components/AlertBox";
 import Modal from "../components/Modal";
-import { AssigneeIdentifier, TeamSubscription, TeamSubscriptionSlotResolved } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
+import {
+    AssigneeIdentifier,
+    TeamSubscription,
+    TeamSubscriptionSlotResolved,
+} from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
 import { Currency, Plan, Plans } from "@gitpod/gitpod-protocol/lib/plans";
 import { ChargebeeClient } from "../chargebee/chargebee-client";
-import copy from '../images/copy.svg';
-import exclamation from '../images/exclamation.svg';
+import copy from "../images/copy.svg";
+import exclamation from "../images/exclamation.svg";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { poll, PollOptions } from "../utils";
 import settingsMenu from "./settings-menu";
 import { Disposable } from "@gitpod/gitpod-protocol";
 
 export default function Teams() {
-
-    return (<div>
-        <PageWithSubMenu subMenu={settingsMenu} title='Team Plans' subtitle='View and manage subscriptions for your team with one centralized billing.'>
-            <AllTeams />
-        </PageWithSubMenu>
-    </div>);
+    return (
+        <div>
+            <PageWithSubMenu
+                subMenu={settingsMenu}
+                title="Team Plans"
+                subtitle="View and manage subscriptions for your team with one centralized billing."
+            >
+                <AllTeams />
+            </PageWithSubMenu>
+        </div>
+    );
 }
 
 interface Slot extends TeamSubscriptionSlotResolved {
@@ -36,7 +45,6 @@ interface Slot extends TeamSubscriptionSlotResolved {
 }
 
 function AllTeams() {
-
     const [defaultCurrency, setDefaultCurrency] = useState<string>("USD");
 
     const [slots, setSlots] = useState<Slot[]>([]);
@@ -45,7 +53,9 @@ function AllTeams() {
     const [isStudent, setIsStudent] = useState<boolean>(false);
     const [teamSubscriptions, setTeamSubscriptions] = useState<TeamSubscription[]>([]);
 
-    const [createTeamModal, setCreateTeamModal] = useState<{ types: string[], defaultCurrency: string } | undefined>(undefined);
+    const [createTeamModal, setCreateTeamModal] = useState<{ types: string[]; defaultCurrency: string } | undefined>(
+        undefined,
+    );
     const [manageTeamModal, setManageTeamModal] = useState<{ sub: TeamSubscription } | undefined>(undefined);
     const [inviteMembersModal, setInviteMembersModal] = useState<{ sub: TeamSubscription } | undefined>(undefined);
     const [addMembersModal, setAddMembersModal] = useState<{ sub: TeamSubscription } | undefined>(undefined);
@@ -53,12 +63,12 @@ function AllTeams() {
     const restorePendingPlanPurchase = () => {
         const pendingState = restorePendingState("pendingPlanPurchase") as { planId: string } | undefined;
         return pendingState;
-    }
+    };
 
     const restorePendingSlotsPurchase = () => {
         const pendingState = restorePendingState("pendingSlotsPurchase") as { tsId: string } | undefined;
         return pendingState;
-    }
+    };
 
     const restorePendingState = (key: string) => {
         const obj = getLocalStorageObject(key);
@@ -70,14 +80,18 @@ function AllTeams() {
                 removeLocalStorageObject(key);
             }
         }
-    }
+    };
     const storePendingState = (key: string, obj: any) => {
-        const expirationDate = new Date(Date.now() + 5 * 60 * 1000).toISOString()
+        const expirationDate = new Date(Date.now() + 5 * 60 * 1000).toISOString();
         setLocalStorageObject(key, { ...obj, expirationDate });
-    }
+    };
 
-    const [pendingPlanPurchase, setPendingPlanPurchase] = useState<{ planId: string } | undefined>(restorePendingPlanPurchase());
-    const [pendingSlotsPurchase, setPendingSlotsPurchase] = useState<{ tsId: string } | undefined>(restorePendingSlotsPurchase());
+    const [pendingPlanPurchase, setPendingPlanPurchase] = useState<{ planId: string } | undefined>(
+        restorePendingPlanPurchase(),
+    );
+    const [pendingSlotsPurchase, setPendingSlotsPurchase] = useState<{ tsId: string } | undefined>(
+        restorePendingSlotsPurchase(),
+    );
 
     const pendingPlanPurchasePoller = useRef<Disposable>();
     const pendingSlotsPurchasePoller = useRef<Disposable>();
@@ -85,12 +99,45 @@ function AllTeams() {
     const cancelPollers = () => {
         pendingPlanPurchasePoller.current?.dispose();
         pendingSlotsPurchasePoller.current?.dispose();
-    }
+    };
+
+    const pollForAdditionalSlotsBought = useCallback(() => {
+        let token: { cancelled?: boolean } = {};
+        pendingSlotsPurchasePoller.current?.dispose();
+        pendingSlotsPurchasePoller.current = Disposable.create(() => {
+            token.cancelled = true;
+        });
+
+        const opts: PollOptions<TeamSubscriptionSlotResolved[]> = {
+            token,
+            backoffFactor: 1.4,
+            retryUntilSeconds: 240,
+            success: (result) => {
+                setSlots(result || []);
+
+                setPendingSlotsPurchase(undefined);
+            },
+            stop: () => {},
+        };
+        poll<TeamSubscriptionSlotResolved[]>(
+            2,
+            async () => {
+                const freshSlots = await getGitpodService().server.tsGetSlots();
+                if (freshSlots.length > slots.length) {
+                    return { done: true, result: freshSlots };
+                }
+                return { done: false };
+            },
+            opts,
+        );
+    }, [slots.length]);
 
     useEffect(() => {
         if (pendingPlanPurchase) {
             storePendingState("pendingPlanPurchase", pendingPlanPurchase);
-            pollForPlanPurchased(Plans.getAvailableTeamPlans().filter(p => p.chargebeeId === pendingPlanPurchase.planId)[0])
+            pollForPlanPurchased(
+                Plans.getAvailableTeamPlans().filter((p) => p.chargebeeId === pendingPlanPurchase.planId)[0],
+            );
         } else {
             pendingPlanPurchasePoller.current?.dispose();
             removeLocalStorageObject("pendingPlanPurchase");
@@ -105,14 +152,14 @@ function AllTeams() {
             pendingSlotsPurchasePoller.current?.dispose();
             removeLocalStorageObject("pendingSlotsPurchase");
         }
-    }, [pendingSlotsPurchase]);
+    }, [pendingSlotsPurchase, pollForAdditionalSlotsBought]);
 
     useEffect(() => {
         queryState();
 
         return function cleanup() {
             cancelPollers();
-        }
+        };
     }, []);
 
     const queryState = async () => {
@@ -125,7 +172,7 @@ function AllTeams() {
                 getGitpodService().server.isStudent(),
             ]);
 
-            setDefaultCurrency((clientRegion && (countries as any)[clientRegion]?.currency === 'EUR') ? 'EUR' : 'USD');
+            setDefaultCurrency(clientRegion && (countries as any)[clientRegion]?.currency === "EUR" ? "EUR" : "USD");
             setIsStudent(isStudent);
 
             setSlots(slots);
@@ -134,7 +181,7 @@ function AllTeams() {
         } catch (error) {
             console.log(error);
         }
-    }
+    };
 
     useEffect(() => {
         if (!isChargebeeCustomer) {
@@ -144,53 +191,54 @@ function AllTeams() {
                 } catch (error) {
                     console.log(error);
                 }
-            })()
+            })();
         }
         if (pendingPlanPurchase) {
-            if (teamSubscriptions.some(ts => ts.planId === pendingPlanPurchase.planId)) {
+            if (teamSubscriptions.some((ts) => ts.planId === pendingPlanPurchase.planId)) {
                 setPendingPlanPurchase(undefined);
             }
         }
-    }, [teamSubscriptions]);
+    }, [isChargebeeCustomer, pendingPlanPurchase, teamSubscriptions]);
 
     useEffect(() => {
         if (pendingSlotsPurchase) {
-            if (slots.some(s => s.teamSubscription.id === pendingSlotsPurchase.tsId)) {
+            if (slots.some((s) => s.teamSubscription.id === pendingSlotsPurchase.tsId)) {
                 setPendingSlotsPurchase(undefined);
             }
         }
-    }, [slots]);
+    }, [pendingSlotsPurchase, slots]);
 
-    const getSubscriptionTypes = () => isStudent ? ['professional', 'professional-new', 'student'] : ['professional', 'professional-new'];
+    const getSubscriptionTypes = () =>
+        isStudent ? ["professional", "professional-new", "student"] : ["professional", "professional-new"];
 
     const getActiveSubs = () => {
         const now = new Date().toISOString();
-        const activeSubs = (teamSubscriptions || []).filter(ts => TeamSubscription.isActive(ts, now));
+        const activeSubs = (teamSubscriptions || []).filter((ts) => TeamSubscription.isActive(ts, now));
         return activeSubs;
-    }
+    };
 
     const getAvailableSubTypes = () => {
-        const usedTypes = getActiveSubs().map(sub => getPlan(sub)?.type as string);
-        const types = getSubscriptionTypes().filter(t => !usedTypes.includes(t));
+        const usedTypes = getActiveSubs().map((sub) => getPlan(sub)?.type as string);
+        const types = getSubscriptionTypes().filter((t) => !usedTypes.includes(t));
         return types;
-    }
+    };
 
     const getSlotsForSub = (sub: TeamSubscription) => {
         const result: Slot[] = [];
         const plan = getPlan(sub);
-        slots.forEach(s => {
+        slots.forEach((s) => {
             if (s.teamSubscription.planId === plan.chargebeeId) {
                 result.push(s);
             }
-        })
+        });
         return result;
-    }
+    };
 
     const onBuy = (plan: Plan, quantity: number, sub?: TeamSubscription) => {
         inputHandler(sub).buySlots(plan, quantity);
         setCreateTeamModal(undefined);
         setAddMembersModal(undefined);
-    }
+    };
 
     const slotDoPoll = (slot: TeamSubscriptionSlotResolved) => () => pollForSlotUpdate(slot);
 
@@ -201,46 +249,49 @@ function AllTeams() {
             success: (result) => {
                 if (result) {
                     updateSlot(slot, (s) => {
-                        return { ...result, loading: false }
-                    })
+                        return { ...result, loading: false };
+                    });
                 }
             },
             stop: () => {
-                updateSlot(slot, (s) => ({ ...s, loading: false }))
+                updateSlot(slot, (s) => ({ ...s, loading: false }));
             },
-
         };
-        poll<TeamSubscriptionSlotResolved>(1, async () => {
-            const freshSlots = await getGitpodService().server.tsGetSlots();
-            const freshSlot = freshSlots.find(s => s.id === slot.id);
-            if (!freshSlot) {
-                // Our slot is not included any more: looks like an update, better fetch complete state
-                queryState();
-                return { done: true };
-            }
+        poll<TeamSubscriptionSlotResolved>(
+            1,
+            async () => {
+                const freshSlots = await getGitpodService().server.tsGetSlots();
+                const freshSlot = freshSlots.find((s) => s.id === slot.id);
+                if (!freshSlot) {
+                    // Our slot is not included any more: looks like an update, better fetch complete state
+                    queryState();
+                    return { done: true };
+                }
 
-            return {
-                done: freshSlot.state !== slot.state || freshSlot.assigneeId !== slot.assigneeId,
-                result: freshSlot
-            };
-            // tslint:disable-next-line:align
-        }, opts);
-    }
+                return {
+                    done: freshSlot.state !== slot.state || freshSlot.assigneeId !== slot.assigneeId,
+                    result: freshSlot,
+                };
+                // tslint:disable-next-line:align
+            },
+            opts,
+        );
+    };
 
     const updateSlot = (slot: TeamSubscriptionSlotResolved, update: (s: Slot) => Slot) => {
         setSlots((prevState) => {
-            const next = [...prevState]
-            const i = next.findIndex(s => s.id === slot.id);
+            const next = [...prevState];
+            const i = next.findIndex((s) => s.id === slot.id);
             if (i >= 0) {
                 next[i] = update(next[i]);
             }
             return next;
-        })
-    }
+        });
+    };
 
     const slotSetErrorMessage = (slot: TeamSubscriptionSlotResolved) => (err: any) => {
         updateSlot(slot, (s) => {
-            const result = { ...s }
+            const result = { ...s };
             result.errorMsg = err && ((err.data && err.data.msg) || err.message || String(err));
             result.loading = false;
             return result;
@@ -250,28 +301,32 @@ function AllTeams() {
     const slotInputHandler = {
         assign: (slot: TeamSubscriptionSlotResolved, assigneeIdentifier: string) => {
             updateSlot(slot, (s) => ({ ...s, loading: true }));
-            getGitpodService().server.tsAssignSlot(slot.teamSubscription.id, slot.id, assigneeIdentifier)
+            getGitpodService()
+                .server.tsAssignSlot(slot.teamSubscription.id, slot.id, assigneeIdentifier)
                 .then(slotDoPoll(slot))
                 .catch(slotSetErrorMessage(slot));
         },
         reassign: (slot: TeamSubscriptionSlotResolved, newAssigneeIdentifier: string) => {
             updateSlot(slot, (s) => ({ ...s, loading: true }));
-            getGitpodService().server.tsReassignSlot(slot.teamSubscription.id, slot.id, newAssigneeIdentifier)
+            getGitpodService()
+                .server.tsReassignSlot(slot.teamSubscription.id, slot.id, newAssigneeIdentifier)
                 .then(slotDoPoll(slot))
                 .catch(slotSetErrorMessage(slot));
         },
         deactivate: (slot: TeamSubscriptionSlotResolved) => {
             updateSlot(slot, (s) => ({ ...s, loading: true }));
-            getGitpodService().server.tsDeactivateSlot(slot.teamSubscription.id, slot.id)
+            getGitpodService()
+                .server.tsDeactivateSlot(slot.teamSubscription.id, slot.id)
                 .then(slotDoPoll(slot))
                 .catch(slotSetErrorMessage(slot));
         },
         reactivate: (slot: TeamSubscriptionSlotResolved) => {
             updateSlot(slot, (s) => ({ ...s, loading: true }));
-            getGitpodService().server.tsReactivateSlot(slot.teamSubscription.id, slot.id)
+            getGitpodService()
+                .server.tsReactivateSlot(slot.teamSubscription.id, slot.id)
                 .then(slotDoPoll(slot))
                 .catch(slotSetErrorMessage(slot));
-        }
+        },
     };
 
     const inputHandler = (ts: TeamSubscription | undefined) => {
@@ -284,12 +339,13 @@ function AllTeams() {
                         return;
                     }
 
+                    getGitpodService()
+                        .server.tsAddSlots(ts.id, quantity)
+                        .then(() => {
+                            setPendingSlotsPurchase({ tsId: ts.id });
 
-                    getGitpodService().server.tsAddSlots(ts.id, quantity).then(() => {
-                        setPendingSlotsPurchase({ tsId: ts.id });
-
-                        pollForAdditionalSlotsBought();
-                    })
+                            pollForAdditionalSlotsBought();
+                        })
                         .catch((err) => {
                             setPendingSlotsPurchase(undefined);
 
@@ -301,30 +357,35 @@ function AllTeams() {
                     // Buy new subscription + initial slots
 
                     let successful = false;
-                    (await ChargebeeClient.getOrCreate()).checkout(async (server) => {
-                        setPendingPlanPurchase({ planId: plan.chargebeeId });
+                    (await ChargebeeClient.getOrCreate()).checkout(
+                        async (server) => {
+                            setPendingPlanPurchase({ planId: plan.chargebeeId });
 
-                        return server.checkout(plan.chargebeeId, quantity)
-                    }, {
-                        success: () => {
-                            successful = true;
-                            pollForPlanPurchased(plan);
+                            return server.checkout(plan.chargebeeId, quantity);
                         },
-                        close: () => {
-                            if (!successful) {
-                                // Close gets triggered after success, too: Only close if necessary
-                                setPendingPlanPurchase(undefined);
-                            }
-                        }
-                    });
+                        {
+                            success: () => {
+                                successful = true;
+                                pollForPlanPurchased(plan);
+                            },
+                            close: () => {
+                                if (!successful) {
+                                    // Close gets triggered after success, too: Only close if necessary
+                                    setPendingPlanPurchase(undefined);
+                                }
+                            },
+                        },
+                    );
                 }
-            }
+            },
         };
     };
     const pollForPlanPurchased = (plan: Plan) => {
         let token: { cancelled?: boolean } = {};
         pendingPlanPurchasePoller.current?.dispose();
-        pendingPlanPurchasePoller.current = Disposable.create(() => { token.cancelled = true });
+        pendingPlanPurchasePoller.current = Disposable.create(() => {
+            token.cancelled = true;
+        });
 
         const opts: PollOptions<TeamSubscription[]> = {
             token,
@@ -337,215 +398,249 @@ function AllTeams() {
                 setTeamSubscriptions(result || []);
 
                 setPendingPlanPurchase(undefined);
-            }
-        };
-        poll<TeamSubscription[]>(2, async () => {
-            const now = new Date().toISOString();
-            const teamSubscriptions = await getGitpodService().server.tsGet();
-            // Has active subscription with given plan?
-            if (teamSubscriptions.some(t => TeamSubscription.isActive(t, now) && t.planId === plan.chargebeeId)) {
-                return { done: true, result: teamSubscriptions };
-            } else {
-                return { done: false };
-            }
-        }, opts);
-    }
-    const pollForAdditionalSlotsBought = () => {
-        let token: { cancelled?: boolean } = {};
-        pendingSlotsPurchasePoller.current?.dispose();
-        pendingSlotsPurchasePoller.current = Disposable.create(() => { token.cancelled = true });
-
-        const opts: PollOptions<TeamSubscriptionSlotResolved[]> = {
-            token,
-            backoffFactor: 1.4,
-            retryUntilSeconds: 240,
-            success: (result) => {
-                setSlots(result || []);
-
-                setPendingSlotsPurchase(undefined);
             },
-            stop: () => {
-            }
         };
-        poll<TeamSubscriptionSlotResolved[]>(2, async () => {
-            const freshSlots = await getGitpodService().server.tsGetSlots();
-            if (freshSlots.length > slots.length) {
-                return { done: true, result: freshSlots };
-            }
-            return { done: false };
-        }, opts);
-    }
+        poll<TeamSubscription[]>(
+            2,
+            async () => {
+                const now = new Date().toISOString();
+                const teamSubscriptions = await getGitpodService().server.tsGet();
+                // Has active subscription with given plan?
+                if (teamSubscriptions.some((t) => TeamSubscription.isActive(t, now) && t.planId === plan.chargebeeId)) {
+                    return { done: true, result: teamSubscriptions };
+                } else {
+                    return { done: false };
+                }
+            },
+            opts,
+        );
+    };
 
     const getPlan = (sub: TeamSubscription) => {
-        return Plans.getAvailableTeamPlans().filter(p => p.chargebeeId === sub.planId)[0];
-    }
+        return Plans.getAvailableTeamPlans().filter((p) => p.chargebeeId === sub.planId)[0];
+    };
 
     const subscriptionMenu = (sub: TeamSubscription) => {
         const result: ContextMenuEntry[] = [];
         result.push({
-            title: 'Manage Members',
-            onClick: () => manageMembers(sub)
-        })
+            title: "Manage Members",
+            onClick: () => manageMembers(sub),
+        });
         result.push({
-            title: 'Add Members',
-            onClick: () => addMembers(sub)
-        })
+            title: "Add Members",
+            onClick: () => addMembers(sub),
+        });
         result.push({
-            title: 'Invite Members',
-            onClick: () => inviteMembers(sub)
-        })
+            title: "Invite Members",
+            onClick: () => inviteMembers(sub),
+        });
         return result;
     };
 
     const showCreateTeamModal = () => {
         const types = getAvailableSubTypes();
         if (types && types.length > 0) {
-            setCreateTeamModal({ types, defaultCurrency })
+            setCreateTeamModal({ types, defaultCurrency });
         }
-    }
+    };
 
     const manageMembers = (sub: TeamSubscription) => {
         setManageTeamModal({ sub });
-    }
+    };
 
     const addMembers = (sub: TeamSubscription) => {
         setAddMembersModal({ sub });
-    }
+    };
 
     const inviteMembers = (sub: TeamSubscription) => {
         setInviteMembersModal({ sub });
-    }
+    };
 
     const showBilling = async () => {
         (await ChargebeeClient.getOrCreate()).openPortal();
-    }
+    };
 
     const isPaymentInProgress = (ts: TeamSubscription) => {
-        return pendingSlotsPurchase && pendingSlotsPurchase.tsId === ts.id
-    }
+        return pendingSlotsPurchase && pendingSlotsPurchase.tsId === ts.id;
+    };
 
-    const renderTeams = () => (<React.Fragment>
-        <div className="flex flex-row">
-            <div className="flex-grow ">
-                <h3 className="self-center">All Team Plans</h3>
-                <h2>Manage team plans and team members.</h2>
-            </div>
-            <div className="flex flex-end space-x-3">
-                {isChargebeeCustomer && (
-                    <button className="self-end my-auto secondary" onClick={() => showBilling()}>Billing</button>
-                )}
-                {getActiveSubs().length > 0 && (
-                    <button className="self-end my-auto" disabled={!!pendingPlanPurchase || getAvailableSubTypes().length === 0} onClick={() => showCreateTeamModal()}>Create Team Plan</button>
-                )}
-            </div>
-        </div>
-
-        {createTeamModal && (
-            <NewTeamModal onClose={() => setCreateTeamModal(undefined)} onBuy={onBuy} {...createTeamModal} />
-        )}
-
-        {manageTeamModal && (
-            <ManageTeamModal onClose={() => { queryState(); setManageTeamModal(undefined) }} slotInputHandler={slotInputHandler} slots={getSlotsForSub(manageTeamModal.sub)} />
-        )}
-
-        {inviteMembersModal && (
-            <InviteMembersModal onClose={() => setInviteMembersModal(undefined)} {...inviteMembersModal} />
-        )}
-
-        {addMembersModal && (
-            <AddMembersModal onClose={() => setAddMembersModal(undefined)} onBuy={onBuy} {...addMembersModal} />
-        )}
-
-        {(getActiveSubs().length === 0 && !pendingPlanPurchase) && (
-            <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
-                <div className="m-auto text-center">
-                    <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Team Plans</h3>
-                    <div className="text-gray-500 mb-6">Get started by creating a team plan<br /> and adding team members. <a href="https://www.gitpod.io/docs/teams/" target="_blank" rel="noopener" className="gp-link">Learn more</a></div>
-                    <button className="self-center" onClick={() => showCreateTeamModal()}>Create Team Plan</button>
-                </div>
-            </div>
-        )}
-
-        {(getActiveSubs().length > 0 || !!pendingPlanPurchase) && (
-            <div className="flex flex-col pt-6 space-y-2">
-                {pendingPlanPurchase && (
-                    <div key={"team-sub-" + pendingPlanPurchase.planId} className="flex-grow flex flex-row hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl h-16 w-full group">
-                        <div className="px-4 self-center w-1/12">
-                            <div className={"rounded-full w-3 h-3 text-sm align-middle bg-gitpod-kumquat"}>
-                                &nbsp;
-                        </div>
-                        </div>
-                        <div className="p-0 my-auto flex flex-col w-6/12">
-                            <span className="my-auto font-medium truncate overflow-ellipsis">{Plans.getAvailableTeamPlans().filter(p => p.chargebeeId === pendingPlanPurchase.planId)[0]?.name}</span>
-                            <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis">Purchased on {formatDate(new Date().toString())}</span>
-                        </div>
-                        <div className="p-0 my-auto flex w-4/12">
-                            <div className="ml-auto self-center rounded-xl bg-orange-300 font-medium text-sm text-orange-700 py-1 px-2 animate-pulse">
-                                Payment in Progress
-                            </div>
-                        </div>
-                        <div className="my-auto flex w-1/12 opacity-0 group-hover:opacity-100 justify-end">
-                        </div>
-                    </div>
-                )}
-                {getActiveSubs().map((sub, index) => (
-                    <div key={"team-sub-" + sub.id} className="flex-grow flex flex-row hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl h-16 w-full group">
-                        <div className="px-4 self-center w-1/12">
-                            <div className={"rounded-full w-3 h-3 text-sm align-middle " + (isPaymentInProgress(sub) ? "bg-gitpod-kumquat" : "bg-green-500")}>
-                                &nbsp;
-                        </div>
-                        </div>
-                        <div className="p-0 my-auto flex flex-col w-4/12">
-                            <span className="my-auto font-medium truncate overflow-ellipsis">{getPlan(sub)?.name}</span>
-                            <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis">Purchased on {formatDate(sub?.startDate)}</span>
-                        </div>
-                        <div className="p-0 my-auto flex flex-col w-2/12">
-                            <span className="my-auto truncate text-gray-500 overflow-ellipsis">{slots.filter(s => s.state !== 'cancelled' && s.teamSubscription.id === sub.id).length || "–"}</span>
-                            <span className="text-sm my-auto text-gray-400">Members</span>
-                        </div>
-                        <div className="p-0 my-auto flex w-4/12">
-                            {isPaymentInProgress(sub) && (
-                                <div className="ml-auto self-center rounded-xl bg-orange-300 font-medium text-sm text-orange-700 py-1 px-2 animate-pulse">
-                                    Payment in Progress
-                                </div>
-                            )}
-                        </div>
-                        <div className="my-auto flex w-1/12 mr-4 opacity-0 group-hover:opacity-100 justify-end">
-                            <div className="self-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer w-8">
-                                <ContextMenu menuEntries={subscriptionMenu(sub)} />
-                            </div>
-                        </div>
-                    </div>
-                ))}
-            </div>
-        )}
-    </React.Fragment>);
-
-    return (<div>
-        {showPaymentUI ? renderTeams() : (
+    const renderTeams = () => (
+        <React.Fragment>
             <div className="flex flex-row">
                 <div className="flex-grow ">
                     <h3 className="self-center">All Team Plans</h3>
                     <h2>Manage team plans and team members.</h2>
                 </div>
+                <div className="flex flex-end space-x-3">
+                    {isChargebeeCustomer && (
+                        <button className="self-end my-auto secondary" onClick={() => showBilling()}>
+                            Billing
+                        </button>
+                    )}
+                    {getActiveSubs().length > 0 && (
+                        <button
+                            className="self-end my-auto"
+                            disabled={!!pendingPlanPurchase || getAvailableSubTypes().length === 0}
+                            onClick={() => showCreateTeamModal()}
+                        >
+                            Create Team Plan
+                        </button>
+                    )}
+                </div>
             </div>
-        )}
-    </div>);
+
+            {createTeamModal && (
+                <NewTeamModal onClose={() => setCreateTeamModal(undefined)} onBuy={onBuy} {...createTeamModal} />
+            )}
+
+            {manageTeamModal && (
+                <ManageTeamModal
+                    onClose={() => {
+                        queryState();
+                        setManageTeamModal(undefined);
+                    }}
+                    slotInputHandler={slotInputHandler}
+                    slots={getSlotsForSub(manageTeamModal.sub)}
+                />
+            )}
+
+            {inviteMembersModal && (
+                <InviteMembersModal onClose={() => setInviteMembersModal(undefined)} {...inviteMembersModal} />
+            )}
+
+            {addMembersModal && (
+                <AddMembersModal onClose={() => setAddMembersModal(undefined)} onBuy={onBuy} {...addMembersModal} />
+            )}
+
+            {getActiveSubs().length === 0 && !pendingPlanPurchase && (
+                <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
+                    <div className="m-auto text-center">
+                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Team Plans</h3>
+                        <div className="text-gray-500 mb-6">
+                            Get started by creating a team plan
+                            <br /> and adding team members.{" "}
+                            <a
+                                href="https://www.gitpod.io/docs/teams/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="gp-link"
+                            >
+                                Learn more
+                            </a>
+                        </div>
+                        <button className="self-center" onClick={() => showCreateTeamModal()}>
+                            Create Team Plan
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {(getActiveSubs().length > 0 || !!pendingPlanPurchase) && (
+                <div className="flex flex-col pt-6 space-y-2">
+                    {pendingPlanPurchase && (
+                        <div
+                            key={"team-sub-" + pendingPlanPurchase.planId}
+                            className="flex-grow flex flex-row hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl h-16 w-full group"
+                        >
+                            <div className="px-4 self-center w-1/12">
+                                <div className={"rounded-full w-3 h-3 text-sm align-middle bg-gitpod-kumquat"}>
+                                    &nbsp;
+                                </div>
+                            </div>
+                            <div className="p-0 my-auto flex flex-col w-6/12">
+                                <span className="my-auto font-medium truncate overflow-ellipsis">
+                                    {
+                                        Plans.getAvailableTeamPlans().filter(
+                                            (p) => p.chargebeeId === pendingPlanPurchase.planId,
+                                        )[0]?.name
+                                    }
+                                </span>
+                                <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis">
+                                    Purchased on {formatDate(new Date().toString())}
+                                </span>
+                            </div>
+                            <div className="p-0 my-auto flex w-4/12">
+                                <div className="ml-auto self-center rounded-xl bg-orange-300 font-medium text-sm text-orange-700 py-1 px-2 animate-pulse">
+                                    Payment in Progress
+                                </div>
+                            </div>
+                            <div className="my-auto flex w-1/12 opacity-0 group-hover:opacity-100 justify-end"></div>
+                        </div>
+                    )}
+                    {getActiveSubs().map((sub, index) => (
+                        <div
+                            key={"team-sub-" + sub.id}
+                            className="flex-grow flex flex-row hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl h-16 w-full group"
+                        >
+                            <div className="px-4 self-center w-1/12">
+                                <div
+                                    className={
+                                        "rounded-full w-3 h-3 text-sm align-middle " +
+                                        (isPaymentInProgress(sub) ? "bg-gitpod-kumquat" : "bg-green-500")
+                                    }
+                                >
+                                    &nbsp;
+                                </div>
+                            </div>
+                            <div className="p-0 my-auto flex flex-col w-4/12">
+                                <span className="my-auto font-medium truncate overflow-ellipsis">
+                                    {getPlan(sub)?.name}
+                                </span>
+                                <span className="text-sm my-auto text-gray-400 truncate overflow-ellipsis">
+                                    Purchased on {formatDate(sub?.startDate)}
+                                </span>
+                            </div>
+                            <div className="p-0 my-auto flex flex-col w-2/12">
+                                <span className="my-auto truncate text-gray-500 overflow-ellipsis">
+                                    {slots.filter((s) => s.state !== "cancelled" && s.teamSubscription.id === sub.id)
+                                        .length || "–"}
+                                </span>
+                                <span className="text-sm my-auto text-gray-400">Members</span>
+                            </div>
+                            <div className="p-0 my-auto flex w-4/12">
+                                {isPaymentInProgress(sub) && (
+                                    <div className="ml-auto self-center rounded-xl bg-orange-300 font-medium text-sm text-orange-700 py-1 px-2 animate-pulse">
+                                        Payment in Progress
+                                    </div>
+                                )}
+                            </div>
+                            <div className="my-auto flex w-1/12 mr-4 opacity-0 group-hover:opacity-100 justify-end">
+                                <div className="self-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer w-8">
+                                    <ContextMenu menuEntries={subscriptionMenu(sub)} />
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </React.Fragment>
+    );
+
+    return (
+        <div>
+            {showPaymentUI ? (
+                renderTeams()
+            ) : (
+                <div className="flex flex-row">
+                    <div className="flex-grow ">
+                        <h3 className="self-center">All Team Plans</h3>
+                        <h2>Manage team plans and team members.</h2>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
 }
 
-function InviteMembersModal(props: {
-    sub: TeamSubscription,
-    onClose: () => void
-}) {
-
+function InviteMembersModal(props: { sub: TeamSubscription; onClose: () => void }) {
     const [copied, setCopied] = useState<boolean>(false);
 
     const getInviteURL = () => {
         const link = new URL(window.location.href);
-        link.pathname = '/plans'
-        link.search = '?teamid=' + props.sub.id;
+        link.pathname = "/plans";
+        link.search = "?teamid=" + props.sub.id;
         return link.href;
-    }
+    };
 
     const copyToClipboard = (text: string) => {
         const el = document.createElement("textarea");
@@ -561,85 +656,113 @@ function InviteMembersModal(props: {
         setTimeout(() => setCopied(false), 2000);
     };
 
-    return (<Modal visible={true} onClose={props.onClose}>
-        <h3 className="pb-2">Invite Members</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-            <p className="pb-2 text-gray-500 text-base">Invite members to the team plan using the URL below.</p>
+    return (
+        <Modal visible={true} onClose={props.onClose}>
+            <h3 className="pb-2">Invite Members</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
+                <p className="pb-2 text-gray-500 text-base">Invite members to the team plan using the URL below.</p>
 
-            <div className="flex flex-col space-y-2">
-                <label htmlFor="inviteUrl" className="font-medium">Invite URL</label>
-                <div className="w-full relative">
-                    <input name="inviteUrl" disabled={true} readOnly={true} type="text" value={getInviteURL()} className="rounded-md w-full truncate pr-8" />
-                    <div className="cursor-pointer" onClick={() => copyToClipboard(getInviteURL())}>
-                        <img src={copy} title="Copy Invite URL" className="absolute top-1/3 right-3" />
+                <div className="flex flex-col space-y-2">
+                    <label htmlFor="inviteUrl" className="font-medium">
+                        Invite URL
+                    </label>
+                    <div className="w-full relative">
+                        <input
+                            name="inviteUrl"
+                            disabled={true}
+                            readOnly={true}
+                            type="text"
+                            value={getInviteURL()}
+                            className="rounded-md w-full truncate pr-8"
+                        />
+                        <div className="cursor-pointer" onClick={() => copyToClipboard(getInviteURL())}>
+                            <img
+                                src={copy}
+                                title="Copy Invite URL"
+                                alt="Copy Invite URL"
+                                className="absolute top-1/3 right-3"
+                            />
+                        </div>
                     </div>
+                    <p className="pb-4 text-gray-500 text-sm">
+                        {copied ? "Copied to clipboard!" : "Use this URL to join this team plan."}
+                    </p>
                 </div>
-                <p className="pb-4 text-gray-500 text-sm">{copied ? "Copied to clipboard!" : "Use this URL to join this team plan."}</p>
             </div>
-
-        </div>
-        <div className="flex justify-end mt-6">
-            <button className={"ml-2 secondary"} onClick={() => props.onClose()}>Close</button>
-        </div>
-    </Modal>);
+            <div className="flex justify-end mt-6">
+                <button className={"ml-2 secondary"} onClick={() => props.onClose()}>
+                    Close
+                </button>
+            </div>
+        </Modal>
+    );
 }
 
 const quantities = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
 function AddMembersModal(props: {
-    sub: TeamSubscription,
-    onBuy: (plan: Plan, quantity: number, sub: TeamSubscription) => void,
-    onClose: () => void
+    sub: TeamSubscription;
+    onBuy: (plan: Plan, quantity: number, sub: TeamSubscription) => void;
+    onClose: () => void;
 }) {
-
     const [quantity, setQuantity] = useState<number>(5);
 
     const [expectedPrice, setExpectedPrice] = useState<string>("");
+
+    const getPlan = useCallback(() => {
+        return Plans.getAvailableTeamPlans().filter((p) => p.chargebeeId === props.sub.planId)[0];
+    }, [props.sub.planId]);
 
     useEffect(() => {
         const plan = getPlan();
         const expectedPrice = quantity * plan.pricePerMonth;
         setExpectedPrice(`${Currency.getSymbol(plan.currency)}${expectedPrice}`);
-    }, [quantity])
+    }, [getPlan, quantity]);
 
-    const getPlan = () => {
-        return Plans.getAvailableTeamPlans().filter(p => p.chargebeeId === props.sub.planId)[0];
-    }
+    return (
+        <Modal visible={true} onClose={props.onClose}>
+            <h3 className="pb-2">Add Members</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
+                <p className="pb-4 text-gray-500 text-base">Select the number of members to add to the team plan.</p>
 
-    return (<Modal visible={true} onClose={props.onClose}>
-        <h3 className="pb-2">Add Members</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-            <p className="pb-4 text-gray-500 text-base">Select the number of members to add to the team plan.</p>
+                <div className="flex flex-col space-y-2 pb-4">
+                    <label htmlFor="quantity" className="font-medium">
+                        Additional Members
+                    </label>
+                    <select
+                        name="quantity"
+                        value={quantity}
+                        className="rounded-md w-full"
+                        onChange={(e) => setQuantity(parseInt(e.target.value || "1", 10))}
+                    >
+                        {quantities.map((n) => (
+                            <option key={`quantity-${n}`} value={n}>
+                                {n}
+                            </option>
+                        ))}
+                    </select>
+                </div>
 
-            <div className="flex flex-col space-y-2 pb-4">
-                <label htmlFor="quantity" className="font-medium">Additional Members</label>
-                <select name="quantity" value={quantity} className="rounded-md w-full"
-                    onChange={(e) => setQuantity(parseInt(e.target.value || '1', 10))}>
-                    {quantities.map(n => (
-                        <option key={`quantity-${n}`} value={n}>{n}</option>
-                    ))}
-                </select>
+                <AlertBox>Additional Charge: {expectedPrice} per month</AlertBox>
             </div>
-
-            <AlertBox>Additional Charge: {expectedPrice} per month</AlertBox>
-
-        </div>
-        <div className="flex justify-end mt-6">
-            <button className={"ml-2"} onClick={() => props.onBuy(getPlan(), quantity, props.sub)}>Continue</button>
-        </div>
-    </Modal>);
+            <div className="flex justify-end mt-6">
+                <button className={"ml-2"} onClick={() => props.onBuy(getPlan(), quantity, props.sub)}>
+                    Continue
+                </button>
+            </div>
+        </Modal>
+    );
 }
 
 function NewTeamModal(props: {
-    types: string[],
+    types: string[];
     defaultCurrency: string;
-    onBuy: (plan: Plan, quantity: number) => void,
-    onClose: () => void,
+    onBuy: (plan: Plan, quantity: number) => void;
+    onClose: () => void;
 }) {
-
     const getPlan = (type: string, currency: string) => {
-        return Plans.getAvailableTeamPlans().filter(p => p.type === type && p.currency === currency)[0];
-    }
+        return Plans.getAvailableTeamPlans().filter((p) => p.type === type && p.currency === currency)[0];
+    };
 
     const [currency, setCurrency] = useState<string>(props.defaultCurrency);
     const [type, setType] = useState<string>(props.types[0]);
@@ -655,86 +778,112 @@ function NewTeamModal(props: {
         }
         const expectedPrice = quantity * newPlan.pricePerMonth;
         setExpectedPrice(`${Currency.getSymbol(newPlan.currency)}${expectedPrice}`);
-    }, [currency, type, quantity])
+    }, [currency, type, quantity, plan.chargebeeId]);
 
     const teamTypeLabel = (type: string) => {
         return getPlan(type, currency)?.name;
-    }
+    };
 
-    return (<Modal visible={true} onClose={props.onClose}>
-        <h3 className="pb-2">New Team Plan</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-            <p className="pb-4 text-gray-500 text-base">Create a team plan and add team members.</p>
+    return (
+        <Modal visible={true} onClose={props.onClose}>
+            <h3 className="pb-2">New Team Plan</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
+                <p className="pb-4 text-gray-500 text-base">Create a team plan and add team members.</p>
 
-            <div className="flex flex-col space-y-2">
-                <label htmlFor="type" className="font-medium">Team</label>
-                <select name="type" value={type} className="rounded-md w-full"
-                    onChange={(e) => setType(e.target.value)}>
-                    {props.types.map(type => (
-                        <option key={`type-option-${type}`} value={type}>{teamTypeLabel(type)}</option>
-                    ))}
-                </select>
+                <div className="flex flex-col space-y-2">
+                    <label htmlFor="type" className="font-medium">
+                        Team
+                    </label>
+                    <select
+                        name="type"
+                        value={type}
+                        className="rounded-md w-full"
+                        onChange={(e) => setType(e.target.value)}
+                    >
+                        {props.types.map((type) => (
+                            <option key={`type-option-${type}`} value={type}>
+                                {teamTypeLabel(type)}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                    <label htmlFor="quantity" className="font-medium">
+                        Members
+                    </label>
+                    <select
+                        name="quantity"
+                        value={quantity}
+                        className="rounded-md w-full"
+                        onChange={(e) => setQuantity(parseInt(e.target.value || "1", 10))}
+                    >
+                        {quantities.map((n) => (
+                            <option key={`quantity-${n}`} value={n}>
+                                {n}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                    <label htmlFor="currency" className="font-medium">
+                        Currency
+                    </label>
+                    <select
+                        name="currency"
+                        value={currency}
+                        className="rounded-md w-full"
+                        onChange={(e) => setCurrency(e.target.value as any)}
+                    >
+                        {Currency.getAll().map((c) => (
+                            <option key={`currency-${c}`} value={c}>
+                                {c}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <AlertBox className="mt-2">Total: {expectedPrice} per month</AlertBox>
             </div>
-
-            <div className="flex flex-col space-y-2">
-                <label htmlFor="quantity" className="font-medium">Members</label>
-                <select name="quantity" value={quantity} className="rounded-md w-full"
-                    onChange={(e) => setQuantity(parseInt(e.target.value || '1', 10))}>
-                    {quantities.map(n => (
-                        <option key={`quantity-${n}`} value={n}>{n}</option>
-                    ))}
-                </select>
+            <div className="flex justify-end mt-6">
+                <button className={"ml-2"} onClick={() => props.onBuy(plan, quantity)}>
+                    Continue to Billing
+                </button>
             </div>
-
-            <div className="flex flex-col space-y-2">
-                <label htmlFor="currency" className="font-medium">Currency</label>
-                <select name="currency" value={currency} className="rounded-md w-full"
-                    onChange={(e) => setCurrency(e.target.value as any)}>
-                    {Currency.getAll().map(c => (
-                        <option key={`currency-${c}`} value={c}>{c}</option>
-                    ))}
-                </select>
-            </div>
-
-            <AlertBox className="mt-2">Total: {expectedPrice} per month</AlertBox>
-
-        </div>
-        <div className="flex justify-end mt-6">
-            <button className={"ml-2"} onClick={() => props.onBuy(plan, quantity)}>Continue to Billing</button>
-        </div>
-    </Modal>);
+        </Modal>
+    );
 }
 
-function ManageTeamModal(props: {
-    slots: Slot[],
-    slotInputHandler: SlotInputHandler,
-    onClose: () => void,
-}) {
-
+function ManageTeamModal(props: { slots: Slot[]; slotInputHandler: SlotInputHandler; onClose: () => void }) {
     const [slots, setSlots] = useState<Slot[]>([]);
 
     useEffect(() => {
-        const activeSlots = props.slots.filter(s => s.state !== 'cancelled');
+        const activeSlots = props.slots.filter((s) => s.state !== "cancelled");
         setSlots(activeSlots);
-    }, [props.slots])
+    }, [props.slots]);
 
-    return (<Modal visible={true} onClose={props.onClose}>
-        <h3 className="pb-2">Manage Team</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-            <p className="pb-4 text-gray-500 text-base">Add members using their username prefixed by the Git Provider's host.</p>
+    return (
+        <Modal visible={true} onClose={props.onClose}>
+            <h3 className="pb-2">Manage Team</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
+                <p className="pb-4 text-gray-500 text-base">
+                    Add members using their username prefixed by the Git Provider's host.
+                </p>
 
-            <div className="overscroll-contain max-h-96 overflow-y-auto">
-                {slots.map((slot, index) => {
-                    return (
-                        <SlotInput key={slot.id} slot={slot} inputHandler={props.slotInputHandler} />
-                    )
-                })}
+                <div className="overscroll-contain max-h-96 overflow-y-auto">
+                    {slots.map((slot, index) => {
+                        return <SlotInput key={slot.id} slot={slot} inputHandler={props.slotInputHandler} />;
+                    })}
+                </div>
             </div>
-        </div>
-        <div className="flex justify-end mt-6">
-            <button className={"ml-2 secondary"} onClick={() => props.onClose()}>Close</button>
-        </div>
-    </Modal>);
+            <div className="flex justify-end mt-6">
+                <button className={"ml-2 secondary"} onClick={() => props.onClose()}>
+                    Close
+                </button>
+            </div>
+        </Modal>
+    );
 }
 
 interface SlotInputHandler {
@@ -744,11 +893,7 @@ interface SlotInputHandler {
     reactivate: (slot: TeamSubscriptionSlotResolved) => void;
 }
 
-function SlotInput(props: {
-    slot: Slot,
-    inputHandler: SlotInputHandler;
-}) {
-
+function SlotInput(props: { slot: Slot; inputHandler: SlotInputHandler }) {
     const [slot, setSlot] = useState<Slot>(props.slot);
     const [editMode, setEditMode] = useState<boolean>(false);
     const [assigneeIdentifier, setAssigneeIdentifier] = useState<string | undefined>();
@@ -758,14 +903,14 @@ function SlotInput(props: {
         setEditMode((prev) => {
             const newEditMode = (prev && !!props.slot.loading) || !!props.slot.errorMsg;
             return newEditMode;
-        })
+        });
 
-        setSlot(props.slot)
-    }, [props.slot])
+        setSlot(props.slot);
+    }, [props.slot]);
 
     useEffect(() => {
         setErrorMsg(slot.errorMsg);
-    }, [slot])
+    }, [slot]);
 
     const key = `assignee-${props.slot.id}`;
 
@@ -776,10 +921,10 @@ function SlotInput(props: {
     };
 
     const handleAssignment = () => {
-        if (slot.state === 'assigned') {
-            props.inputHandler.reassign(slot, assigneeIdentifier || '');
+        if (slot.state === "assigned") {
+            props.inputHandler.reassign(slot, assigneeIdentifier || "");
         } else {
-            props.inputHandler.assign(slot, assigneeIdentifier || '');
+            props.inputHandler.assign(slot, assigneeIdentifier || "");
         }
     };
 
@@ -792,83 +937,128 @@ function SlotInput(props: {
     const handleEdit = () => {
         setEditMode(true);
         setErrorMsg(undefined);
-        setAssigneeIdentifier('');
+        setAssigneeIdentifier("");
     };
 
     const handleDeactivation = () => {
         props.inputHandler.deactivate(slot);
-    }
+    };
 
     const handleReactivation = () => {
         props.inputHandler.reactivate(slot);
-    }
-
+    };
 
     const getActions = (slot: Slot) => {
         const actions: JSX.Element[] = [];
 
         if (editMode) {
-            actions.push((<button key={`slot-action-ok-${slot.id}`} className={"ml-2 disabled:opacity-50"} disabled={slot.loading} onClick={() => handleAssignment()}>OK</button>));
-            actions.push((<button key={`slot-action-cancel-${slot.id}`} className={"ml-2 disabled:opacity-50 secondary"} disabled={slot.loading} onClick={() => handleCancel()}>Cancel</button>));
+            actions.push(
+                <button
+                    key={`slot-action-ok-${slot.id}`}
+                    className={"ml-2 disabled:opacity-50"}
+                    disabled={slot.loading}
+                    onClick={() => handleAssignment()}
+                >
+                    OK
+                </button>,
+            );
+            actions.push(
+                <button
+                    key={`slot-action-cancel-${slot.id}`}
+                    className={"ml-2 disabled:opacity-50 secondary"}
+                    disabled={slot.loading}
+                    onClick={() => handleCancel()}
+                >
+                    Cancel
+                </button>,
+            );
         } else {
             switch (slot.state) {
-                case 'unassigned':
-                case 'assigned':
-                    actions.push(<button key={`slot-action-deactivate-${slot.id}`} className={"ml-2 disabled:opacity-50 danger secondary"} disabled={slot.loading} onClick={() => handleDeactivation()}>Deactivate</button>);
+                case "unassigned":
+                case "assigned":
+                    actions.push(
+                        <button
+                            key={`slot-action-deactivate-${slot.id}`}
+                            className={"ml-2 disabled:opacity-50 danger secondary"}
+                            disabled={slot.loading}
+                            onClick={() => handleDeactivation()}
+                        >
+                            Deactivate
+                        </button>,
+                    );
                     break;
 
-                case 'deactivated':
-                    actions.push(<button key={`slot-action-reactivate-${slot.id}`} className={"ml-2 disabled:opacity-50"} disabled={slot.loading} onClick={() => handleReactivation()}>Reactivate</button>);
+                case "deactivated":
+                    actions.push(
+                        <button
+                            key={`slot-action-reactivate-${slot.id}`}
+                            className={"ml-2 disabled:opacity-50"}
+                            disabled={slot.loading}
+                            onClick={() => handleReactivation()}
+                        >
+                            Reactivate
+                        </button>,
+                    );
                     break;
             }
         }
         return actions;
-    }
+    };
 
     return (
         <div key={key} className="flex flex-col space-y-2 pt-2">
             {/* <label htmlFor={key} className="font-medium">Username</label> */}
             <div className="flex flex-grow flex-row space-x-2">
-                <input name={key} value={editMode ? (assigneeIdentifier || "") : (renderIdentifier(slot.assigneeIdentifier) || "")} className="rounded-md w-full pl-2 bg-gray-200 focus:bg-white dark:bg-gray-700 dark:focus:bg-gray-800 "
+                <input
+                    name={key}
+                    value={editMode ? assigneeIdentifier || "" : renderIdentifier(slot.assigneeIdentifier) || ""}
+                    className="rounded-md w-full pl-2 bg-gray-200 focus:bg-white dark:bg-gray-700 dark:focus:bg-gray-800 "
                     readOnly={!editMode}
-                    placeholder={!editMode && (renderIdentifier(slot.assigneeIdentifier) || "e.g. github.com/username") || undefined}
+                    placeholder={
+                        (!editMode && (renderIdentifier(slot.assigneeIdentifier) || "e.g. github.com/username")) ||
+                        undefined
+                    }
                     onChange={(e) => editMode && setAssigneeIdentifier(e.target.value)}
                     onClick={() => !editMode && handleEdit()}
                     onKeyDown={(e) => {
                         if (e.key === "Enter") {
-                            e.preventDefault()
-                            handleAssignment()
+                            e.preventDefault();
+                            handleAssignment();
                         }
                         if (e.key === "Escape") {
-                            e.preventDefault()
-                            handleCancel()
+                            e.preventDefault();
+                            handleCancel();
                         }
                     }}
                 />
                 {getActions(slot)}
             </div>
-            {slot.state === 'deactivated' && (
-                <p className="pb-4 text-gray-500 text-sm">You will no longer be billed for this seat starting {formatDate(slot.cancellationDate)}.</p>
+            {slot.state === "deactivated" && (
+                <p className="pb-4 text-gray-500 text-sm">
+                    You will no longer be billed for this seat starting {formatDate(slot.cancellationDate)}.
+                </p>
             )}
             {errorMsg && (
                 <div className="flex rounded-md bg-red-600 p-3">
-                    <img className="w-4 h-4 mx-2 my-auto filter-brightness-10" src={exclamation} />
+                    <img className="w-4 h-4 mx-2 my-auto filter-brightness-10" src={exclamation} alt="Heads up!" />
                     <span className="text-white text-sm">{errorMsg}</span>
                 </div>
             )}
         </div>
-    )
-
+    );
 }
 
 function formatDate(date?: string) {
     try {
         if (date) {
-            return new Date(Date.parse(date)).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+            return new Date(Date.parse(date)).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+            });
         }
-    } catch {
-    }
-    return ""
+    } catch {}
+    return "";
 }
 
 function getLocalStorageObject(key: string) {
@@ -878,20 +1068,17 @@ function getLocalStorageObject(key: string) {
             return;
         }
         return JSON.parse(string);
-    } catch {
-    }
+    } catch {}
 }
 
 function removeLocalStorageObject(key: string): void {
     try {
         window.localStorage.removeItem(key);
-    } catch {
-    }
+    } catch {}
 }
 
 function setLocalStorageObject(key: string, object: Object): void {
     try {
         window.localStorage.setItem(key, JSON.stringify(object));
-    } catch {
-    }
+    } catch {}
 }

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -6,7 +6,12 @@
 
 import EventEmitter from "events";
 import React, { useEffect, Suspense, useContext, useState } from "react";
-import { CreateWorkspaceMode, WorkspaceCreationResult, RunningWorkspacePrebuildStarting, ContextURL } from "@gitpod/gitpod-protocol";
+import {
+    CreateWorkspaceMode,
+    WorkspaceCreationResult,
+    RunningWorkspacePrebuildStarting,
+    ContextURL,
+} from "@gitpod/gitpod-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import Modal from "../components/Modal";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
@@ -19,352 +24,489 @@ import { SelectAccountModal } from "../settings/SelectAccountModal";
 import { watchHeadlessLogs } from "../components/PrebuildLogs";
 import CodeText from "../components/CodeText";
 
-const WorkspaceLogs = React.lazy(() => import('../components/WorkspaceLogs'));
+const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
 
 export interface CreateWorkspaceProps {
-  contextUrl: string;
+    contextUrl: string;
 }
 
 export interface CreateWorkspaceState {
-  result?: WorkspaceCreationResult;
-  error?: StartWorkspaceError;
-  selectAccountError?: SelectAccountPayload;
-  stillParsing: boolean;
+    result?: WorkspaceCreationResult;
+    error?: StartWorkspaceError;
+    selectAccountError?: SelectAccountPayload;
+    stillParsing: boolean;
 }
 
 export default class CreateWorkspace extends React.Component<CreateWorkspaceProps, CreateWorkspaceState> {
-
-  constructor(props: CreateWorkspaceProps) {
-    super(props);
-    this.state = { stillParsing: true };
-  }
-
-  componentDidMount() {
-    this.createWorkspace();
-  }
-
-  async createWorkspace(mode = CreateWorkspaceMode.SelectIfRunning, forceDefaultConfig = false) {
-    // Invalidate any previous result.
-    this.setState({ result: undefined, stillParsing: true });
-
-    // We assume anything longer than 3 seconds is no longer just parsing the context URL (i.e. it's now creating a workspace).
-    let timeout = setTimeout(() => this.setState({ stillParsing: false }), 3000);
-
-    try {
-      const result = await getGitpodService().server.createWorkspace({
-        contextUrl: this.props.contextUrl,
-        mode,
-        forceDefaultConfig
-      });
-      if (result.workspaceURL) {
-        window.location.href = result.workspaceURL;
-        return;
-      }
-      clearTimeout(timeout);
-      this.setState({ result, stillParsing: false });
-    } catch (error) {
-      clearTimeout(timeout);
-      console.error(error);
-      this.setState({ error, stillParsing: false });
+    constructor(props: CreateWorkspaceProps) {
+        super(props);
+        this.state = { stillParsing: true };
     }
-  }
 
-  async tryAuthorize(host: string, scopes?: string[]) {
-    try {
-      await openAuthorizeWindow({
-        host,
-        scopes,
-        onSuccess: () => {
-          window.location.reload();
-        },
-        onError: (error) => {
-          if (typeof error === "string") {
-            try {
-              const payload = JSON.parse(error);
-              if (SelectAccountPayload.is(payload)) {
-                this.setState({ selectAccountError: payload });
-              }
-            } catch (error) {
-              console.log(error);
+    componentDidMount() {
+        this.createWorkspace();
+    }
+
+    async createWorkspace(mode = CreateWorkspaceMode.SelectIfRunning, forceDefaultConfig = false) {
+        // Invalidate any previous result.
+        this.setState({ result: undefined, stillParsing: true });
+
+        // We assume anything longer than 3 seconds is no longer just parsing the context URL (i.e. it's now creating a workspace).
+        let timeout = setTimeout(() => this.setState({ stillParsing: false }), 3000);
+
+        try {
+            const result = await getGitpodService().server.createWorkspace({
+                contextUrl: this.props.contextUrl,
+                mode,
+                forceDefaultConfig,
+            });
+            if (result.workspaceURL) {
+                window.location.href = result.workspaceURL;
+                return;
             }
-          }
+            clearTimeout(timeout);
+            this.setState({ result, stillParsing: false });
+        } catch (error) {
+            clearTimeout(timeout);
+            console.error(error);
+            this.setState({ error, stillParsing: false });
         }
-      });
-    } catch (error) {
-      console.log(error)
-    }
-  };
-
-  render() {
-    if (SelectAccountPayload.is(this.state.selectAccountError)) {
-      return (<StartPage phase={StartPhase.Checking}>
-        <div className="mt-2 flex flex-col space-y-8">
-          <SelectAccountModal {...this.state.selectAccountError} close={() => {
-            window.location.href = gitpodHostUrl.asAccessControl().toString();
-          }} />
-        </div>
-      </StartPage>);
     }
 
-    let phase = StartPhase.Checking;
-    let statusMessage = <p className="text-base text-gray-400">{this.state.stillParsing ? 'Parsing context …' : 'Preparing workspace …'}</p>;
-
-    let error = this.state?.error;
-    if (error) {
-      switch (error.code) {
-        case ErrorCodes.CONTEXT_PARSE_ERROR:
-          statusMessage = <div className="text-center">
-            <p className="text-base mt-2">Are you trying to open a Git repository from a self-hosted instance? <a className="text-blue" href={gitpodHostUrl.asAccessControl().toString()}>Add integration</a></p>
-          </div>;
-          break;
-        case ErrorCodes.INVALID_GITPOD_YML:
-          statusMessage = <div className="mt-2 flex flex-col space-y-8">
-            <button className="" onClick={() => { this.createWorkspace(CreateWorkspaceMode.Default, true) }}>Continue with default configuration</button>
-          </div>;
-          break;
-        case ErrorCodes.NOT_AUTHENTICATED:
-          statusMessage = <div className="mt-2 flex flex-col space-y-8">
-            <button className="" onClick={() => {
-              this.tryAuthorize(error?.data.host, error?.data.scopes)
-            }}>Authorize with {error.data.host}</button>
-          </div>;
-          break;
-        case ErrorCodes.PERMISSION_DENIED:
-          statusMessage = <p className="text-base text-gitpod-red w-96">Access is not allowed</p>;
-          break;
-        case ErrorCodes.USER_BLOCKED:
-          window.location.href = '/blocked';
-          return;
-        case ErrorCodes.NOT_FOUND:
-          return <RepositoryNotFoundView error={error} />;
-        case ErrorCodes.TOO_MANY_RUNNING_WORKSPACES:
-          // HACK: Hide the error (behind the modal)
-          error = undefined;
-          phase = StartPhase.Stopped;
-          statusMessage = <LimitReachedParallelWorkspacesModal />;
-          break;
-        case ErrorCodes.NOT_ENOUGH_CREDIT:
-          // HACK: Hide the error (behind the modal)
-          error = undefined;
-          phase = StartPhase.Stopped;
-          statusMessage = <LimitReachedOutOfHours />;
-          break;
-        default:
-          statusMessage = <p className="text-base text-gitpod-red w-96">Unknown Error: {JSON.stringify(this.state?.error, null, 2)}</p>;
-          break;
-      }
+    async tryAuthorize(host: string, scopes?: string[]) {
+        try {
+            await openAuthorizeWindow({
+                host,
+                scopes,
+                onSuccess: () => {
+                    window.location.reload();
+                },
+                onError: (error) => {
+                    if (typeof error === "string") {
+                        try {
+                            const payload = JSON.parse(error);
+                            if (SelectAccountPayload.is(payload)) {
+                                this.setState({ selectAccountError: payload });
+                            }
+                        } catch (error) {
+                            console.log(error);
+                        }
+                    }
+                },
+            });
+        } catch (error) {
+            console.log(error);
+        }
     }
 
-    const result = this.state?.result;
-    if (result?.createdWorkspaceId) {
-      return <StartWorkspace {...parseProps(result?.createdWorkspaceId, window.location.search)} />;
-    }
+    render() {
+        if (SelectAccountPayload.is(this.state.selectAccountError)) {
+            return (
+                <StartPage phase={StartPhase.Checking}>
+                    <div className="mt-2 flex flex-col space-y-8">
+                        <SelectAccountModal
+                            {...this.state.selectAccountError}
+                            close={() => {
+                                window.location.href = gitpodHostUrl.asAccessControl().toString();
+                            }}
+                        />
+                    </div>
+                </StartPage>
+            );
+        }
 
-    else if (result?.existingWorkspaces) {
-      statusMessage = <Modal visible={true} closeable={false} onClose={() => { }}>
-        <h3>Running Workspaces</h3>
-        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
-          <p className="mt-1 mb-2 text-base">You already have running workspaces with the same context. You can open an existing one or open a new workspace.</p>
-          <>
-            {result?.existingWorkspaces?.map(w => {
-              const normalizedContextUrl = ContextURL.getNormalizedURL(w.workspace)?.toString() || "undefined";
-              return (
-                <a href={w.latestInstance?.ideUrl || gitpodHostUrl.with({ pathname: '/start/', hash: '#' + w.latestInstance?.workspaceId }).toString()} className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-3 my-1">
-                  <div className="w-full">
-                    <p className="text-base text-black dark:text-gray-100 font-bold">{w.workspace.id}</p>
-                    <p className="truncate" title={normalizedContextUrl}>{normalizedContextUrl}</p>
-                  </div>
-                </a>
-              );
-            })}
-          </>
-        </div>
-        <div className="flex justify-end mt-6">
-          <button onClick={() => this.createWorkspace(CreateWorkspaceMode.Default)}>New Workspace</button>
-        </div>
-      </Modal>;
-    }
+        let phase = StartPhase.Checking;
+        let statusMessage = (
+            <p className="text-base text-gray-400">
+                {this.state.stillParsing ? "Parsing context …" : "Preparing workspace …"}
+            </p>
+        );
 
-    else if (result?.runningWorkspacePrebuild) {
-      return <RunningPrebuildView
-        runningPrebuild={result.runningWorkspacePrebuild}
-        onIgnorePrebuild={() => this.createWorkspace(CreateWorkspaceMode.ForceNew)}
-        onPrebuildSucceeded={() => this.createWorkspace(CreateWorkspaceMode.UsePrebuild)}
-      />;
-    }
+        let error = this.state?.error;
+        if (error) {
+            switch (error.code) {
+                case ErrorCodes.CONTEXT_PARSE_ERROR:
+                    statusMessage = (
+                        <div className="text-center">
+                            <p className="text-base mt-2">
+                                Are you trying to open a Git repository from a self-hosted instance?{" "}
+                                <a className="text-blue" href={gitpodHostUrl.asAccessControl().toString()}>
+                                    Add integration
+                                </a>
+                            </p>
+                        </div>
+                    );
+                    break;
+                case ErrorCodes.INVALID_GITPOD_YML:
+                    statusMessage = (
+                        <div className="mt-2 flex flex-col space-y-8">
+                            <button
+                                className=""
+                                onClick={() => {
+                                    this.createWorkspace(CreateWorkspaceMode.Default, true);
+                                }}
+                            >
+                                Continue with default configuration
+                            </button>
+                        </div>
+                    );
+                    break;
+                case ErrorCodes.NOT_AUTHENTICATED:
+                    statusMessage = (
+                        <div className="mt-2 flex flex-col space-y-8">
+                            <button
+                                className=""
+                                onClick={() => {
+                                    this.tryAuthorize(error?.data.host, error?.data.scopes);
+                                }}
+                            >
+                                Authorize with {error.data.host}
+                            </button>
+                        </div>
+                    );
+                    break;
+                case ErrorCodes.PERMISSION_DENIED:
+                    statusMessage = <p className="text-base text-gitpod-red w-96">Access is not allowed</p>;
+                    break;
+                case ErrorCodes.USER_BLOCKED:
+                    window.location.href = "/blocked";
+                    return;
+                case ErrorCodes.NOT_FOUND:
+                    return <RepositoryNotFoundView error={error} />;
+                case ErrorCodes.TOO_MANY_RUNNING_WORKSPACES:
+                    // HACK: Hide the error (behind the modal)
+                    error = undefined;
+                    phase = StartPhase.Stopped;
+                    statusMessage = <LimitReachedParallelWorkspacesModal />;
+                    break;
+                case ErrorCodes.NOT_ENOUGH_CREDIT:
+                    // HACK: Hide the error (behind the modal)
+                    error = undefined;
+                    phase = StartPhase.Stopped;
+                    statusMessage = <LimitReachedOutOfHours />;
+                    break;
+                default:
+                    statusMessage = (
+                        <p className="text-base text-gitpod-red w-96">
+                            Unknown Error: {JSON.stringify(this.state?.error, null, 2)}
+                        </p>
+                    );
+                    break;
+            }
+        }
 
-    return <StartPage phase={phase} error={error}>
-      {statusMessage}
-      {error && <div>
-        <a href={gitpodHostUrl.asDashboard().toString()}><button className="mt-8 secondary">Go to Dashboard</button></a>
-        <p className="mt-14 text-base text-gray-400 flex space-x-2">
-          <a className="hover:text-blue-600 dark:hover:text-blue-400" href="https://www.gitpod.io/docs/">Docs</a>
-          <span>—</span>
-          <a className="hover:text-blue-600 dark:hover:text-blue-400" href="https://status.gitpod.io/">Status</a>
-          <span>—</span>
-          <a className="hover:text-blue-600 dark:hover:text-blue-400" href="https://www.gitpod.io/blog/">Blog</a>
-        </p>
-      </div>}
-    </StartPage>;
-  }
+        const result = this.state?.result;
+        if (result?.createdWorkspaceId) {
+            return <StartWorkspace {...parseProps(result?.createdWorkspaceId, window.location.search)} />;
+        } else if (result?.existingWorkspaces) {
+            statusMessage = (
+                <Modal visible={true} closeable={false} onClose={() => {}}>
+                    <h3>Running Workspaces</h3>
+                    <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+                        <p className="mt-1 mb-2 text-base">
+                            You already have running workspaces with the same context. You can open an existing one or
+                            open a new workspace.
+                        </p>
+                        <>
+                            {result?.existingWorkspaces?.map((w) => {
+                                const normalizedContextUrl =
+                                    ContextURL.getNormalizedURL(w.workspace)?.toString() || "undefined";
+                                return (
+                                    <a
+                                        href={
+                                            w.latestInstance?.ideUrl ||
+                                            gitpodHostUrl
+                                                .with({
+                                                    pathname: "/start/",
+                                                    hash: "#" + w.latestInstance?.workspaceId,
+                                                })
+                                                .toString()
+                                        }
+                                        className="rounded-xl group hover:bg-gray-100 dark:hover:bg-gray-800 flex p-3 my-1"
+                                    >
+                                        <div className="w-full">
+                                            <p className="text-base text-black dark:text-gray-100 font-bold">
+                                                {w.workspace.id}
+                                            </p>
+                                            <p className="truncate" title={normalizedContextUrl}>
+                                                {normalizedContextUrl}
+                                            </p>
+                                        </div>
+                                    </a>
+                                );
+                            })}
+                        </>
+                    </div>
+                    <div className="flex justify-end mt-6">
+                        <button onClick={() => this.createWorkspace(CreateWorkspaceMode.Default)}>New Workspace</button>
+                    </div>
+                </Modal>
+            );
+        } else if (result?.runningWorkspacePrebuild) {
+            return (
+                <RunningPrebuildView
+                    runningPrebuild={result.runningWorkspacePrebuild}
+                    onIgnorePrebuild={() => this.createWorkspace(CreateWorkspaceMode.ForceNew)}
+                    onPrebuildSucceeded={() => this.createWorkspace(CreateWorkspaceMode.UsePrebuild)}
+                />
+            );
+        }
+
+        return (
+            <StartPage phase={phase} error={error}>
+                {statusMessage}
+                {error && (
+                    <div>
+                        <a href={gitpodHostUrl.asDashboard().toString()}>
+                            <button className="mt-8 secondary">Go to Dashboard</button>
+                        </a>
+                        <p className="mt-14 text-base text-gray-400 flex space-x-2">
+                            <a
+                                className="hover:text-blue-600 dark:hover:text-blue-400"
+                                href="https://www.gitpod.io/docs/"
+                            >
+                                Docs
+                            </a>
+                            <span>—</span>
+                            <a
+                                className="hover:text-blue-600 dark:hover:text-blue-400"
+                                href="https://status.gitpod.io/"
+                            >
+                                Status
+                            </a>
+                            <span>—</span>
+                            <a
+                                className="hover:text-blue-600 dark:hover:text-blue-400"
+                                href="https://www.gitpod.io/blog/"
+                            >
+                                Blog
+                            </a>
+                        </p>
+                    </div>
+                )}
+            </StartPage>
+        );
+    }
 }
 
 function LimitReachedModal(p: { children: React.ReactNode }) {
-  const { user } = useContext(UserContext);
-  return <Modal visible={true} closeable={false} onClose={() => { }}>
-    <h3 className="flex">
-      <span className="flex-grow">Limit Reached</span>
-      <img className="rounded-full w-8 h-8" src={user?.avatarUrl || ''} alt={user?.name || 'Anonymous'} />
-    </h3>
-    <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
-      {p.children}
-    </div>
-    <div className="flex justify-end mt-6">
-      <a href={gitpodHostUrl.asDashboard().toString()}><button className="secondary">Go to Dashboard</button></a>
-      <a href={gitpodHostUrl.with({ pathname: 'plans' }).toString()} className="ml-2"><button>Upgrade</button></a>
-    </div>
-  </Modal>;
+    const { user } = useContext(UserContext);
+    return (
+        <Modal visible={true} closeable={false} onClose={() => {}}>
+            <h3 className="flex">
+                <span className="flex-grow">Limit Reached</span>
+                <img className="rounded-full w-8 h-8" src={user?.avatarUrl || ""} alt={user?.name || "Anonymous"} />
+            </h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+                {p.children}
+            </div>
+            <div className="flex justify-end mt-6">
+                <a href={gitpodHostUrl.asDashboard().toString()}>
+                    <button className="secondary">Go to Dashboard</button>
+                </a>
+                <a href={gitpodHostUrl.with({ pathname: "plans" }).toString()} className="ml-2">
+                    <button>Upgrade</button>
+                </a>
+            </div>
+        </Modal>
+    );
 }
 
 function LimitReachedParallelWorkspacesModal() {
-  return <LimitReachedModal>
-    <p className="mt-1 mb-2 text-base dark:text-gray-400">You have reached the limit of parallel running workspaces for your account. Please, upgrade or stop one of the running workspaces.</p>
-  </LimitReachedModal>;
+    return (
+        <LimitReachedModal>
+            <p className="mt-1 mb-2 text-base dark:text-gray-400">
+                You have reached the limit of parallel running workspaces for your account. Please, upgrade or stop one
+                of the running workspaces.
+            </p>
+        </LimitReachedModal>
+    );
 }
 
 function LimitReachedOutOfHours() {
-  return <LimitReachedModal>
-    <p className="mt-1 mb-2 text-base dark:text-gray-400">You have reached the limit of monthly workspace hours for your account. Please upgrade to get more hours for your workspaces.</p>
-  </LimitReachedModal>;
+    return (
+        <LimitReachedModal>
+            <p className="mt-1 mb-2 text-base dark:text-gray-400">
+                You have reached the limit of monthly workspace hours for your account. Please upgrade to get more hours
+                for your workspaces.
+            </p>
+        </LimitReachedModal>
+    );
 }
 
 function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
-  const [statusMessage, setStatusMessage] = useState<React.ReactNode>();
-  const { host, owner, repoName, userIsOwner, userScopes, lastUpdate } = p.error.data;
-  const repoFullName = (owner && repoName) ? `${owner}/${repoName}` : '';
+    const [statusMessage, setStatusMessage] = useState<React.ReactNode>();
+    const { host, owner, repoName, userIsOwner, userScopes, lastUpdate } = p.error.data;
+    const repoFullName = owner && repoName ? `${owner}/${repoName}` : "";
 
-  useEffect(() => {
-    (async () => {
-      console.log('host', host);
-      console.log('owner', owner);
-      console.log('repoName', repoName);
-      console.log('userIsOwner', userIsOwner);
-      console.log('userScopes', userScopes);
-      console.log('lastUpdate', lastUpdate);
+    useEffect(() => {
+        (async () => {
+            console.log("host", host);
+            console.log("owner", owner);
+            console.log("repoName", repoName);
+            console.log("userIsOwner", userIsOwner);
+            console.log("userScopes", userScopes);
+            console.log("lastUpdate", lastUpdate);
 
-      const authProvider = (await getGitpodService().server.getAuthProviders()).find(p => p.host === host);
-      if (!authProvider) {
-        return;
-      }
+            const authProvider = (await getGitpodService().server.getAuthProviders()).find((p) => p.host === host);
+            if (!authProvider) {
+                return;
+            }
 
-      // TODO: this should be aware of already granted permissions
-      const missingScope = authProvider.authProviderType === 'GitHub' ? 'repo' : 'read_repository';
-      const authorizeURL = gitpodHostUrl.withApi({
-        pathname: '/authorize',
-        search: `returnTo=${encodeURIComponent(window.location.toString())}&host=${host}&scopes=${missingScope}`
-      }).toString();
+            // TODO: this should be aware of already granted permissions
+            const missingScope = authProvider.authProviderType === "GitHub" ? "repo" : "read_repository";
+            const authorizeURL = gitpodHostUrl
+                .withApi({
+                    pathname: "/authorize",
+                    search: `returnTo=${encodeURIComponent(
+                        window.location.toString(),
+                    )}&host=${host}&scopes=${missingScope}`,
+                })
+                .toString();
 
-      if (!userScopes.includes(missingScope)) {
-        setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
-          <p className="text-base text-gray-400 w-96">The repository may be private. Please authorize Gitpod to access to private repositories.</p>
-          <a className="mx-auto" href={authorizeURL}><button>Grant Access</button></a>
-        </div>);
-        return;
-      }
+            if (!userScopes.includes(missingScope)) {
+                setStatusMessage(
+                    <div className="mt-2 flex flex-col space-y-8">
+                        <p className="text-base text-gray-400 w-96">
+                            The repository may be private. Please authorize Gitpod to access to private repositories.
+                        </p>
+                        <a className="mx-auto" href={authorizeURL}>
+                            <button>Grant Access</button>
+                        </a>
+                    </div>,
+                );
+                return;
+            }
 
-      if (userIsOwner) {
-        setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
-          <p className="text-base text-gray-400 w-96">The repository was not found in your account.</p>
-        </div>);
-        return;
-      }
+            if (userIsOwner) {
+                setStatusMessage(
+                    <div className="mt-2 flex flex-col space-y-8">
+                        <p className="text-base text-gray-400 w-96">The repository was not found in your account.</p>
+                    </div>,
+                );
+                return;
+            }
 
-      let updatedRecently = false;
-      if (lastUpdate && typeof lastUpdate === 'string') {
-        try {
-          const minutes = (Date.now() - Date.parse(lastUpdate)) / 1000 / 60;
-          updatedRecently = minutes < 5;
-        } catch {
-          // ignore
-        }
-      }
+            let updatedRecently = false;
+            if (lastUpdate && typeof lastUpdate === "string") {
+                try {
+                    const minutes = (Date.now() - Date.parse(lastUpdate)) / 1000 / 60;
+                    updatedRecently = minutes < 5;
+                } catch {
+                    // ignore
+                }
+            }
 
-      if (!updatedRecently) {
-        setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
-          <p className="text-base text-gray-400 w-96">Permission to access private repositories has been granted. If you are a member of <CodeText>{owner}</CodeText>, please try to request access for Gitpod.</p>
-          <a className="mx-auto" href={authorizeURL}><button>Request Access for Gitpod</button></a>
-        </div>);
-        return;
-      }
+            if (!updatedRecently) {
+                setStatusMessage(
+                    <div className="mt-2 flex flex-col space-y-8">
+                        <p className="text-base text-gray-400 w-96">
+                            Permission to access private repositories has been granted. If you are a member of{" "}
+                            <CodeText>{owner}</CodeText>, please try to request access for Gitpod.
+                        </p>
+                        <a className="mx-auto" href={authorizeURL}>
+                            <button>Request Access for Gitpod</button>
+                        </a>
+                    </div>,
+                );
+                return;
+            }
 
-      setStatusMessage(<div className="mt-2 flex flex-col space-y-8">
-        <p className="text-base text-gray-400 w-96">Your access token was updated recently. Please try again if the repository exists and Gitpod was approved for <CodeText>{owner}</CodeText>.</p>
-        <a className="mx-auto" href={authorizeURL}><button>Try Again</button></a>
-      </div>);
-    })();
-  }, []);
+            setStatusMessage(
+                <div className="mt-2 flex flex-col space-y-8">
+                    <p className="text-base text-gray-400 w-96">
+                        Your access token was updated recently. Please try again if the repository exists and Gitpod was
+                        approved for <CodeText>{owner}</CodeText>.
+                    </p>
+                    <a className="mx-auto" href={authorizeURL}>
+                        <button>Try Again</button>
+                    </a>
+                </div>,
+            );
+        })();
+    }, [host, lastUpdate, owner, repoName, userIsOwner, userScopes]);
 
-  return (
-    <StartPage phase={StartPhase.Checking} error={p.error}>
-      <p className="text-base text-gray-400 mt-2">
-        <CodeText>{repoFullName}</CodeText>
-      </p>
-      {statusMessage}
-    </StartPage>
-  );
+    return (
+        <StartPage phase={StartPhase.Checking} error={p.error}>
+            <p className="text-base text-gray-400 mt-2">
+                <CodeText>{repoFullName}</CodeText>
+            </p>
+            {statusMessage}
+        </StartPage>
+    );
 }
 
 interface RunningPrebuildViewProps {
-  runningPrebuild: {
-    prebuildID: string
-    workspaceID: string
-    instanceID: string
-    starting: RunningWorkspacePrebuildStarting
-    sameCluster: boolean
-  };
-  onIgnorePrebuild: () => void;
-  onPrebuildSucceeded: () => void;
+    runningPrebuild: {
+        prebuildID: string;
+        workspaceID: string;
+        instanceID: string;
+        starting: RunningWorkspacePrebuildStarting;
+        sameCluster: boolean;
+    };
+    onIgnorePrebuild: () => void;
+    onPrebuildSucceeded: () => void;
 }
 
 function RunningPrebuildView(props: RunningPrebuildViewProps) {
-  const logsEmitter = new EventEmitter();
-  let pollTimeout: NodeJS.Timeout | undefined;
-  let prebuildDoneTriggered: boolean = false;
+    const logsEmitter = new EventEmitter();
+    let pollTimeout: NodeJS.Timeout | undefined;
+    let prebuildDoneTriggered: boolean = false;
 
-  useEffect(() => {
-    const checkIsPrebuildDone = async (): Promise<boolean> => {
-      if (prebuildDoneTriggered) {
-        console.debug("prebuild done already triggered, doing nothing");
-        return true;
-      }
+    useEffect(() => {
+        const checkIsPrebuildDone = async (): Promise<boolean> => {
+            if (prebuildDoneTriggered) {
+                console.debug("prebuild done already triggered, doing nothing");
+                return true;
+            }
 
-      const done = await getGitpodService().server.isPrebuildDone(props.runningPrebuild.prebuildID);
-      if (done) {
-        // note: this treats "done" as "available" which is not equivalent.
-        // This works because the backend ignores prebuilds which are not "available", and happily starts a workspace as if there was no prebuild at all.
-        prebuildDoneTriggered = true;
-        props.onPrebuildSucceeded();
-        return true;
-      }
-      return false;
-    };
-    const pollIsPrebuildDone = async () => {
-      clearTimeout(pollTimeout!);
-      await checkIsPrebuildDone();
-      pollTimeout = setTimeout(pollIsPrebuildDone, 10000);
-    };
+            const done = await getGitpodService().server.isPrebuildDone(props.runningPrebuild.prebuildID);
+            if (done) {
+                // note: this treats "done" as "available" which is not equivalent.
+                // This works because the backend ignores prebuilds which are not "available", and happily starts a workspace as if there was no prebuild at all.
+                // TODO: this doesn't really work, or it works by chance, because the following assignment
+                // will be lost on each re-render.
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+                prebuildDoneTriggered = true;
+                props.onPrebuildSucceeded();
+                return true;
+            }
+            return false;
+        };
+        const pollIsPrebuildDone = async () => {
+            clearTimeout(pollTimeout!);
+            await checkIsPrebuildDone();
+            // TODO: this doesn't really work, or it works by chance, because the following assignment
+            // will be lost on each re-render.
+            // eslint-disable-next-line react-hooks/exhaustive-deps, @typescript-eslint/no-unused-vars
+            pollTimeout = setTimeout(pollIsPrebuildDone, 10000);
+        };
 
-    const disposables = watchHeadlessLogs(props.runningPrebuild.instanceID, (chunk) => logsEmitter.emit('logs', chunk), checkIsPrebuildDone);
-    return function cleanup() {
-      clearTimeout(pollTimeout!);
-      disposables.dispose();
-    };
-  }, []);
+        const disposables = watchHeadlessLogs(
+            props.runningPrebuild.instanceID,
+            (chunk) => logsEmitter.emit("logs", chunk),
+            checkIsPrebuildDone,
+        );
+        return function cleanup() {
+            clearTimeout(pollTimeout!);
+            disposables.dispose();
+        };
+    }, []);
 
-  return <StartPage title="Prebuild in Progress">
-    <Suspense fallback={<div />}>
-      <WorkspaceLogs logsEmitter={logsEmitter} />
-    </Suspense>
-    <button className="mt-6 secondary" onClick={() => { clearTimeout(pollTimeout!); props.onIgnorePrebuild(); }}>Don't Wait for Prebuild</button>
-  </StartPage>;
+    return (
+        <StartPage title="Prebuild in Progress">
+            <Suspense fallback={<div />}>
+                <WorkspaceLogs logsEmitter={logsEmitter} />
+            </Suspense>
+            <button
+                className="mt-6 secondary"
+                onClick={() => {
+                    clearTimeout(pollTimeout!);
+                    props.onIgnorePrebuild();
+                }}
+            >
+                Don't Wait for Prebuild
+            </button>
+        </StartPage>
+    );
 }

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -4,13 +4,23 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { ContextURL, DisposableCollection, GitpodServer, RateLimiterError, StartWorkspaceResult, WithPrebuild, Workspace, WorkspaceImageBuild, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import {
+    ContextURL,
+    DisposableCollection,
+    GitpodServer,
+    RateLimiterError,
+    StartWorkspaceResult,
+    WithPrebuild,
+    Workspace,
+    WorkspaceImageBuild,
+    WorkspaceInstance,
+} from "@gitpod/gitpod-protocol";
 import { IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import EventEmitter from "events";
 import * as queryString from "query-string";
-import React, { Suspense, useEffect } from "react";
-import { v4 } from 'uuid';
+import React, { Suspense, useEffect, useMemo } from "react";
+import { v4 } from "uuid";
 import Arrow from "../components/Arrow";
 import ContextMenu from "../components/ContextMenu";
 import PendingChangesDropdown from "../components/PendingChangesDropdown";
@@ -19,604 +29,729 @@ import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
 const sessionId = v4();
 
-const WorkspaceLogs = React.lazy(() => import('../components/WorkspaceLogs'));
+const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
 
 export interface StartWorkspaceProps {
-  workspaceId: string,
-  runsInIFrame: boolean,
-  /**
-   * This flag is used to break the autostart-cycle explained in https://github.com/gitpod-io/gitpod/issues/8043
-   */
-  dontAutostart: boolean,
+    workspaceId: string;
+    runsInIFrame: boolean;
+    /**
+     * This flag is used to break the autostart-cycle explained in https://github.com/gitpod-io/gitpod/issues/8043
+     */
+    dontAutostart: boolean;
 }
 
 export function parseProps(workspaceId: string, search?: string): StartWorkspaceProps {
-  const params = parseParameters(search);
-  const runsInIFrame = window.top !== window.self;
-  return {
-    workspaceId,
-    runsInIFrame: window.top !== window.self,
-    // Either:
-    //  - not_found: we were sent back from a workspace cluster/IDE URL where we expected a workspace to be running but it wasn't because either:
-    //    - this is a (very) old tab and the workspace already timed out
-    //    - due to a start error our workspace terminated very quickly between:
-    //      a) us being redirected to that IDEUrl (based on the first ws-manager update) and
-    //      b) our requests being validated by ws-proxy
-    //  - runsInIFrame (IDE case):
-    //    - we assume the workspace has already been started for us
-    //    - we don't know it's instanceId
-    dontAutostart: params.notFound || runsInIFrame,
-  }
+    const params = parseParameters(search);
+    const runsInIFrame = window.top !== window.self;
+    return {
+        workspaceId,
+        runsInIFrame: window.top !== window.self,
+        // Either:
+        //  - not_found: we were sent back from a workspace cluster/IDE URL where we expected a workspace to be running but it wasn't because either:
+        //    - this is a (very) old tab and the workspace already timed out
+        //    - due to a start error our workspace terminated very quickly between:
+        //      a) us being redirected to that IDEUrl (based on the first ws-manager update) and
+        //      b) our requests being validated by ws-proxy
+        //  - runsInIFrame (IDE case):
+        //    - we assume the workspace has already been started for us
+        //    - we don't know it's instanceId
+        dontAutostart: params.notFound || runsInIFrame,
+    };
 }
 
 function parseParameters(search?: string): { notFound?: boolean } {
-  try {
-    if (search === undefined) {
-      return {};
+    try {
+        if (search === undefined) {
+            return {};
+        }
+        const params = queryString.parse(search, { parseBooleans: true });
+        const notFound = !!(params && params["not_found"]);
+        return {
+            notFound,
+        };
+    } catch (err) {
+        console.error("/start: error parsing search params", err);
+        return {};
     }
-    const params = queryString.parse(search, {parseBooleans: true});
-    const notFound = !!(params && params["not_found"]);
-    return {
-      notFound,
-    };
-  } catch (err) {
-    console.error("/start: error parsing search params", err);
-    return {};
-  }
 }
 
 export interface StartWorkspaceState {
-  /**
-   * This is set to the istanceId we started (think we started on).
-   * We only receive updates for this particular instance, or none if not set.
-  */
-  startedInstanceId?: string;
-  workspaceInstance?: WorkspaceInstance;
-  workspace?: Workspace;
-  hasImageBuildLogs?: boolean;
-  error?: StartWorkspaceError;
-  desktopIde?: {
-    link: string
-    label: string
-    clientID?: string
-  };
-  ideOptions?: IDEOptions;
+    /**
+     * This is set to the istanceId we started (think we started on).
+     * We only receive updates for this particular instance, or none if not set.
+     */
+    startedInstanceId?: string;
+    workspaceInstance?: WorkspaceInstance;
+    workspace?: Workspace;
+    hasImageBuildLogs?: boolean;
+    error?: StartWorkspaceError;
+    desktopIde?: {
+        link: string;
+        label: string;
+        clientID?: string;
+    };
+    ideOptions?: IDEOptions;
 }
 
 export default class StartWorkspace extends React.Component<StartWorkspaceProps, StartWorkspaceState> {
-
-  constructor(props: StartWorkspaceProps) {
-    super(props);
-    this.state = {};
-  }
-
-  private readonly toDispose = new DisposableCollection();
-  componentWillMount() {
-    if (this.props.runsInIFrame) {
-      window.parent.postMessage({ type: '$setSessionId', sessionId }, '*');
-      const setStateEventListener = (event: MessageEvent) => {
-        if (event.data.type === 'setState' && 'state' in event.data && typeof event.data['state'] === 'object') {
-          if (event.data.state.ideFrontendFailureCause) {
-            const error = { message: event.data.state.ideFrontendFailureCause };
-            this.setState({ error });
-          }
-          if (event.data.state.desktopIdeLink) {
-            const label = event.data.state.desktopIdeLabel || "Open Desktop IDE";
-            const clientID = event.data.state.desktopIdeClientID;
-            this.setState({ desktopIde: { link: event.data.state.desktopIdeLink, label, clientID } });
-          }
-        }
-      }
-      window.addEventListener('message', setStateEventListener, false);
-      this.toDispose.push({
-        dispose: () => window.removeEventListener('message', setStateEventListener)
-      });
+    constructor(props: StartWorkspaceProps) {
+        super(props);
+        this.state = {};
     }
 
-    try {
-      this.toDispose.push(getGitpodService().registerClient(this));
-    } catch (error) {
-      console.error(error);
-      this.setState({ error });
-    }
-
-    if (this.props.dontAutostart) {
-      // we saw errors previously, or run in-frame
-      this.fetchWorkspaceInfo(undefined);
-    } else {
-      // dashboard case (w/o previous errors): start workspace as quickly as possible
-      this.startWorkspace();
-    }
-
-    // query IDE options so we can show them if necessary once the workspace is running
-    this.fetchIDEOptions();
-  }
-
-  componentWillUnmount() {
-    this.toDispose.dispose();
-  }
-
-  componentDidUpdate(prevPros: StartWorkspaceProps, prevState: StartWorkspaceState) {
-    const newPhase = this.state?.workspaceInstance?.status.phase;
-    const oldPhase = prevState.workspaceInstance?.status.phase;
-    if (newPhase !== oldPhase) {
-      getGitpodService().server.trackEvent({
-        event: "status_rendered",
-        properties: {
-          sessionId,
-          instanceId: this.state.workspaceInstance?.id,
-          workspaceId: this.props.workspaceId,
-          type: this.state.workspace?.type,
-          phase: newPhase
-        },
-      });
-    }
-
-    if (!!this.state.error && this.state.error !== prevState.error) {
-      getGitpodService().server.trackEvent({
-        event: "error_rendered",
-        properties: {
-          sessionId,
-          instanceId: this.state.workspaceInstance?.id,
-          workspaceId: this.state?.workspace?.id,
-          type: this.state.workspace?.type,
-          error: this.state.error
-        },
-      });
-    }
-  }
-
-  async startWorkspace(restart = false, forceDefaultImage = false) {
-    const state = this.state;
-    if (state) {
-      if (!restart && (state.startedInstanceId /* || state.errorMessage */)) {
-        // We stick with a started instance until we're explicitly told not to
-        return;
-      }
-    }
-
-    const { workspaceId } = this.props;
-    try {
-      const result = await this.startWorkspaceRateLimited(workspaceId, { forceDefaultImage });
-      if (!result) {
-        throw new Error("No result!");
-      }
-      console.log("/start: started workspace instance: " + result.instanceID);
-      // redirect to workspaceURL if we are not yet running in an iframe
-      if (!this.props.runsInIFrame && result.workspaceURL) {
-        this.redirectTo(result.workspaceURL);
-        return;
-      }
-      // Start listening too instance updates - and explicitly query state once to guarantee we get at least one update
-      // (needed for already started workspaces, and not hanging in 'Starting ...' for too long)
-      this.fetchWorkspaceInfo(result.instanceID);
-    } catch (error) {
-      console.error(error);
-      if (typeof error === 'string') {
-        error = { message: error };
-      }
-      if (error?.code === ErrorCodes.USER_BLOCKED) {
-        this.redirectTo(gitpodHostUrl.with({ pathname: '/blocked' }).toString());
-        return;
-      }
-      this.setState({ error });
-    }
-  }
-
-  /**
-   * TODO(gpl) Ideally this can be pushed into the GitpodService implementation. But to get started we hand-roll it here.
-   * @param workspaceId
-   * @param options
-   * @returns
-   */
-  protected async startWorkspaceRateLimited(workspaceId: string, options: GitpodServer.StartWorkspaceOptions): Promise<StartWorkspaceResult> {
-    let retries = 0;
-    while (true) {
-      try {
-        return await getGitpodService().server.startWorkspace(workspaceId, options);
-      } catch (err) {
-        if (err?.code !== ErrorCodes.TOO_MANY_REQUESTS) {
-          throw err;
-        }
-
-        if (retries >= 10) {
-          throw err;
-        }
-        retries++;
-
-        const data = err?.data as RateLimiterError | undefined;
-        const timeoutSeconds = data?.retryAfter || 5;
-        console.log(`startWorkspace was rate-limited: waiting for ${timeoutSeconds}s before doing ${retries}nd retry...`)
-        await new Promise(resolve => setTimeout(resolve, timeoutSeconds * 1000));
-      }
-    }
-  }
-
-  /**
-   * Fetches initial WorkspaceInfo from the server. If there is a WorkspaceInstance for workspaceId, we feed it
-   * into "onInstanceUpdate" and start accepting further updates.
-   *
-   * @param startedInstanceId The instanceId we want to listen on
-   */
-  async fetchWorkspaceInfo(startedInstanceId: string | undefined) {
-    // this ensures we're receiving updates for this instance
-    if (startedInstanceId) {
-      this.setState({ startedInstanceId });
-    }
-
-    const { workspaceId } = this.props;
-    try {
-      const info = await getGitpodService().server.getWorkspace(workspaceId);
-      if (info.latestInstance) {
-        const instance = info.latestInstance;
-        this.setState((s) => ({
-          workspace: info.workspace,
-          startedInstanceId: s.startedInstanceId || instance.id,  // note: here's a potential mismatch between startedInstanceId and instance.id. TODO(gpl) How to handle this?
-        }));
-        this.onInstanceUpdate(instance);
-      }
-    } catch (error) {
-      console.error(error);
-      this.setState({ error });
-    }
-  }
-
-  /**
-   * Fetches the current IDEOptions config for this user
-   *
-   * TODO(gpl) Ideally this would be part of the WorkspaceInstance shape, really. And we'd display options based on
-   * what support it was started with.
-   */
-  protected async fetchIDEOptions() {
-    const ideOptions = await getGitpodService().server.getIDEOptions();
-    this.setState({ ideOptions });
-  }
-
-  notifyDidOpenConnection() {
-    this.fetchWorkspaceInfo(undefined);
-  }
-
-  async onInstanceUpdate(workspaceInstance: WorkspaceInstance) {
-    if (workspaceInstance.workspaceId !== this.props.workspaceId) {
-      return;
-    }
-
-    // Here we filter out updates to instances we haven't started to avoid issues with updates coming in out-of-order
-    // (e.g., multiple "stopped" events from the older instance, where we already started a fresh one after the first)
-    // Only exception is when we do the switch from the "old" to the "new" one.
-    const startedInstanceId = this.state?.startedInstanceId;
-    if (startedInstanceId !== workspaceInstance.id) {
-      // do we want to switch to "new" instance we just received an update for?
-      const switchToNewInstance = this.state.workspaceInstance?.status.phase === "stopped" && workspaceInstance.status.phase !== "stopped";
-      if (!switchToNewInstance) {
-        return;
-      }
-      this.setState({
-        startedInstanceId: workspaceInstance.id,
-        workspaceInstance,
-      });
-
-      // now we're listening to a new instance, which might have been started with other IDEoptions
-      this.fetchIDEOptions();
-    }
-
-    await this.ensureWorkspaceAuth(workspaceInstance.id);
-
-    // Redirect to workspaceURL if we are not yet running in an iframe.
-    // It happens this late if we were waiting for a docker build.
-    if (!this.props.runsInIFrame && workspaceInstance.ideUrl && !this.props.dontAutostart) {
-      this.redirectTo(workspaceInstance.ideUrl);
-      return;
-    }
-
-    if (workspaceInstance.status.phase === 'preparing') {
-      this.setState({ hasImageBuildLogs: true });
-    }
-
-    let error: StartWorkspaceError | undefined;
-    if (workspaceInstance.status.conditions.failed) {
-      error = { message: workspaceInstance.status.conditions.failed };
-    }
-
-    // Successfully stopped and headless: the prebuild is done, let's try to use it!
-    if (!error && workspaceInstance.status.phase === 'stopped' && this.state.workspace?.type !== 'regular') {
-      // here we want to point to the original context, w/o any modifiers "workspace" was started with (as this might have been a manually triggered prebuild!)
-      const contextURL = ContextURL.getNormalizedURL(this.state.workspace);
-      if (contextURL) {
-        this.redirectTo(gitpodHostUrl.withContext(contextURL.toString()).toString());
-      } else {
-        console.error(`unable to parse contextURL: ${contextURL}`);
-      }
-    }
-
-    this.setState({ workspaceInstance, error });
-  }
-
-  async ensureWorkspaceAuth(instanceID: string) {
-    if (!document.cookie.includes(`${instanceID}_owner_`)) {
-      const authURL = gitpodHostUrl.asWorkspaceAuth(instanceID);
-      const response = await fetch(authURL.toString());
-      if (response.redirected) {
-        this.redirectTo(response.url);
-        return;
-      }
-      if (!response.ok) {
-        // getting workspace auth didn't work as planned - redirect
-        this.redirectTo(authURL.asWorkspaceAuth(instanceID, true).toString());
-        return;
-      }
-    }
-  }
-
-  redirectTo(url: string) {
-    if (this.props.runsInIFrame) {
-      window.parent.postMessage({ type: 'relocate', url }, '*');
-    } else {
-      window.location.href = url;
-    }
-  }
-
-  render() {
-    const { error } = this.state;
-    const isHeadless = this.state.workspace?.type !== 'regular';
-    const isPrebuilt = WithPrebuild.is(this.state.workspace?.context);
-    let phase: StartPhase | undefined = StartPhase.Preparing;
-    let title = undefined;
-    let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
-    const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
-
-    switch (this.state?.workspaceInstance?.status.phase) {
-      // unknown indicates an issue within the system in that it cannot determine the actual phase of
-      // a workspace. This phase is usually accompanied by an error.
-      case "unknown":
-        break;
-
-      // Preparing means that we haven't actually started the workspace instance just yet, but rather
-      // are still preparing for launch. This means we're building the Docker image for the workspace.
-      case "preparing":
-        return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} />;
-
-      // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
-      // some space within the cluster. If for example the cluster needs to scale up to accomodate the
-      // workspace, the workspace will be in Pending state until that happened.
-      case "pending":
-        phase = StartPhase.Preparing;
-        statusMessage = <p className="text-base text-gray-400">Allocating resources …</p>;
-        break;
-
-      // Creating means the workspace is currently being created. That includes downloading the images required
-      // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
-      // network speed, image size and cache states.
-      case "creating":
-        phase = StartPhase.Creating;
-        statusMessage = <p className="text-base text-gray-400">Pulling container image …</p>;
-        break;
-
-      // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
-      // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
-      case "initializing":
-        phase = StartPhase.Starting;
-        statusMessage = <p className="text-base text-gray-400">{isPrebuilt ? 'Loading prebuild …' : 'Initializing content …'}</p>;
-        break;
-
-      // Running means the workspace is able to actively perform work, either by serving a user through Theia,
-      // or as a headless workspace.
-      case "running":
-        if (isHeadless) {
-          return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
-        }
-        if (!this.state.desktopIde) {
-          phase = StartPhase.Running;
-
-          if (this.props.dontAutostart) {
-            // hide the progress bar, as we're already running
-            phase = undefined;
-            title = 'Running';
-
-            // in case we dontAutostart the IDE we have to provide controls to do so
-            statusMessage = <div>
-                <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
-                  <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
-                  <div>
-                    <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
-                    <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
-                  </div>
-                </div>
-                <div className="mt-10 justify-center flex space-x-2">
-                  <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}><button className="secondary">Go to Dashboard</button></a>
-                  <a target="_parent" href={gitpodHostUrl.asStart(this.props.workspaceId).toString() /** move over 'start' here to fetch fresh credentials in case this is an older tab */}><button>Open Workspace</button></a>
-                </div>
-            </div>;
-          } else {
-            statusMessage = <p className="text-base text-gray-400">Opening Workspace …</p>;
-          }
-        } else {
-          phase = StartPhase.IdeReady;
-          const openLink = this.state.desktopIde.link;
-          const openLinkLabel = this.state.desktopIde.label;
-          const clientID = this.state.desktopIde.clientID
-          const client = clientID ? this.state.ideOptions?.clients?.[clientID] : undefined;
-          const installationSteps = client?.installationSteps?.length && <div className="flex flex-col text-center m-auto text-sm w-72 text-gray-400">
-            {client.installationSteps.map(step => <div dangerouslySetInnerHTML={{__html: step.replaceAll('${OPEN_LINK_LABEL}', openLinkLabel)}} />)}
-          </div>
-          statusMessage = <div>
-            <p className="text-base text-gray-400">Opening Workspace …</p>
-            <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
-              <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
-              <div>
-                <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
-                <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
-              </div>
-            </div>
-            {installationSteps}
-            <div className="mt-10 justify-center flex space-x-2">
-              <ContextMenu menuEntries={[
-                {
-                  title: 'Open in Browser',
-                  onClick: () => window.parent.postMessage({ type: 'openBrowserIde' }, '*'),
-                },
-                {
-                  title: 'Stop Workspace',
-                  onClick: () => getGitpodService().server.stopWorkspace(this.props.workspaceId),
-                },
-                {
-                  title: 'Go to Dashboard',
-                  href: gitpodHostUrl.asDashboard().toString(),
-                  target: "_parent",
-                },
-              ]} >
-                <button className="secondary">More Actions...<Arrow up={false} /></button>
-              </ContextMenu>
-              <button onClick={() => {
-                let redirect = false;
-                try {
-                  const desktopLink = new URL(openLink);
-                  redirect = desktopLink.protocol != 'http:' && desktopLink.protocol != 'https:';
-                } catch {}
-                if (redirect) {
-                  window.location.href = openLink;
-                } else {
-                  window.open(openLink, '_blank', 'noopener');
+    private readonly toDispose = new DisposableCollection();
+    componentWillMount() {
+        if (this.props.runsInIFrame) {
+            window.parent.postMessage({ type: "$setSessionId", sessionId }, "*");
+            const setStateEventListener = (event: MessageEvent) => {
+                if (
+                    event.data.type === "setState" &&
+                    "state" in event.data &&
+                    typeof event.data["state"] === "object"
+                ) {
+                    if (event.data.state.ideFrontendFailureCause) {
+                        const error = { message: event.data.state.ideFrontendFailureCause };
+                        this.setState({ error });
+                    }
+                    if (event.data.state.desktopIdeLink) {
+                        const label = event.data.state.desktopIdeLabel || "Open Desktop IDE";
+                        const clientID = event.data.state.desktopIdeClientID;
+                        this.setState({ desktopIde: { link: event.data.state.desktopIdeLink, label, clientID } });
+                    }
                 }
-              }}>{openLinkLabel}</button>
-            </div>
-            <div className="text-sm text-gray-400 dark:text-gray-500 mt-5">These IDE options are based on <a className="gp-link" href={gitpodHostUrl.asPreferences().toString()} target="_parent">your user preferences</a>.</div>
-          </div>;
+            };
+            window.addEventListener("message", setStateEventListener, false);
+            this.toDispose.push({
+                dispose: () => window.removeEventListener("message", setStateEventListener),
+            });
         }
 
-        break;
-
-      // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
-      // When in this state, we expect it to become running or stopping anytime soon.
-      case "interrupted":
-        phase = StartPhase.Running;
-        statusMessage = <p className="text-base text-gray-400">Checking workspace …</p>;
-        break;
-
-      // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
-      case "stopping":
-        if (isHeadless) {
-          return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
+        try {
+            this.toDispose.push(getGitpodService().registerClient(this));
+        } catch (error) {
+            console.error(error);
+            this.setState({ error });
         }
-        phase = StartPhase.Stopping;
-        statusMessage = <div>
-          <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 bg-gray-100 dark:bg-gray-800">
-            <div className="rounded-full w-3 h-3 text-sm bg-gitpod-kumquat">&nbsp;</div>
-            <div>
-              <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
-              <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
-            </div>
-          </div>
-          <div className="mt-10 flex justify-center">
-            <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}><button className="secondary">Go to Dashboard</button></a>
-          </div>
-        </div>;
-        break;
 
-      // Stopped means the workspace ended regularly because it was shut down.
-      case "stopped":
-        phase = StartPhase.Stopped;
-        if (this.state.hasImageBuildLogs) {
-          const restartWithDefaultImage = (event: React.MouseEvent) => {
-            (event.target as HTMLButtonElement).disabled = true;
-            this.startWorkspace(true, true);
-          }
-          return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} onStartWithDefaultImage={restartWithDefaultImage} phase={phase} error={error} />;
+        if (this.props.dontAutostart) {
+            // we saw errors previously, or run in-frame
+            this.fetchWorkspaceInfo(undefined);
+        } else {
+            // dashboard case (w/o previous errors): start workspace as quickly as possible
+            this.startWorkspace();
         }
-        if (!isHeadless && this.state.workspaceInstance.status.conditions.timeout) {
-          title = 'Timed Out';
-        }
-        statusMessage = <div>
-          <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
-            <div className="rounded-full w-3 h-3 text-sm bg-gray-300">&nbsp;</div>
-            <div>
-              <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">{this.state.workspaceInstance.workspaceId}</p>
-              <a target="_parent" href={contextURL}><p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400" >{contextURL}</p></a>
-            </div>
-          </div>
-          <PendingChangesDropdown workspaceInstance={this.state.workspaceInstance} />
-          <div className="mt-10 justify-center flex space-x-2">
-            <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}><button className="secondary">Go to Dashboard</button></a>
-            <a target="_parent" href={gitpodHostUrl.asStart(this.state.workspaceInstance?.workspaceId).toString()}><button>Open Workspace</button></a>
-          </div>
-        </div>;
-        break;
+
+        // query IDE options so we can show them if necessary once the workspace is running
+        this.fetchIDEOptions();
     }
 
-    return <StartPage phase={phase} error={error} title={title}>
-      {statusMessage}
-    </StartPage>;
-  }
+    componentWillUnmount() {
+        this.toDispose.dispose();
+    }
+
+    componentDidUpdate(prevPros: StartWorkspaceProps, prevState: StartWorkspaceState) {
+        const newPhase = this.state?.workspaceInstance?.status.phase;
+        const oldPhase = prevState.workspaceInstance?.status.phase;
+        if (newPhase !== oldPhase) {
+            getGitpodService().server.trackEvent({
+                event: "status_rendered",
+                properties: {
+                    sessionId,
+                    instanceId: this.state.workspaceInstance?.id,
+                    workspaceId: this.props.workspaceId,
+                    type: this.state.workspace?.type,
+                    phase: newPhase,
+                },
+            });
+        }
+
+        if (!!this.state.error && this.state.error !== prevState.error) {
+            getGitpodService().server.trackEvent({
+                event: "error_rendered",
+                properties: {
+                    sessionId,
+                    instanceId: this.state.workspaceInstance?.id,
+                    workspaceId: this.state?.workspace?.id,
+                    type: this.state.workspace?.type,
+                    error: this.state.error,
+                },
+            });
+        }
+    }
+
+    async startWorkspace(restart = false, forceDefaultImage = false) {
+        const state = this.state;
+        if (state) {
+            if (!restart && state.startedInstanceId /* || state.errorMessage */) {
+                // We stick with a started instance until we're explicitly told not to
+                return;
+            }
+        }
+
+        const { workspaceId } = this.props;
+        try {
+            const result = await this.startWorkspaceRateLimited(workspaceId, { forceDefaultImage });
+            if (!result) {
+                throw new Error("No result!");
+            }
+            console.log("/start: started workspace instance: " + result.instanceID);
+            // redirect to workspaceURL if we are not yet running in an iframe
+            if (!this.props.runsInIFrame && result.workspaceURL) {
+                this.redirectTo(result.workspaceURL);
+                return;
+            }
+            // Start listening too instance updates - and explicitly query state once to guarantee we get at least one update
+            // (needed for already started workspaces, and not hanging in 'Starting ...' for too long)
+            this.fetchWorkspaceInfo(result.instanceID);
+        } catch (error) {
+            console.error(error);
+            if (typeof error === "string") {
+                // TODO: this needs a bit of refactoring, possibly server-side to always ensure a properly
+                // structured error message.
+                // eslint-disable-next-line no-ex-assign
+                error = { message: error };
+            }
+            if (error?.code === ErrorCodes.USER_BLOCKED) {
+                this.redirectTo(gitpodHostUrl.with({ pathname: "/blocked" }).toString());
+                return;
+            }
+            this.setState({ error });
+        }
+    }
+
+    /**
+     * TODO(gpl) Ideally this can be pushed into the GitpodService implementation. But to get started we hand-roll it here.
+     * @param workspaceId
+     * @param options
+     * @returns
+     */
+    protected async startWorkspaceRateLimited(
+        workspaceId: string,
+        options: GitpodServer.StartWorkspaceOptions,
+    ): Promise<StartWorkspaceResult> {
+        let retries = 0;
+        while (true) {
+            try {
+                return await getGitpodService().server.startWorkspace(workspaceId, options);
+            } catch (err) {
+                if (err?.code !== ErrorCodes.TOO_MANY_REQUESTS) {
+                    throw err;
+                }
+
+                if (retries >= 10) {
+                    throw err;
+                }
+                retries++;
+
+                const data = err?.data as RateLimiterError | undefined;
+                const timeoutSeconds = data?.retryAfter || 5;
+                console.log(
+                    `startWorkspace was rate-limited: waiting for ${timeoutSeconds}s before doing ${retries}nd retry...`,
+                );
+                await new Promise((resolve) => setTimeout(resolve, timeoutSeconds * 1000));
+            }
+        }
+    }
+
+    /**
+     * Fetches initial WorkspaceInfo from the server. If there is a WorkspaceInstance for workspaceId, we feed it
+     * into "onInstanceUpdate" and start accepting further updates.
+     *
+     * @param startedInstanceId The instanceId we want to listen on
+     */
+    async fetchWorkspaceInfo(startedInstanceId: string | undefined) {
+        // this ensures we're receiving updates for this instance
+        if (startedInstanceId) {
+            this.setState({ startedInstanceId });
+        }
+
+        const { workspaceId } = this.props;
+        try {
+            const info = await getGitpodService().server.getWorkspace(workspaceId);
+            if (info.latestInstance) {
+                const instance = info.latestInstance;
+                this.setState((s) => ({
+                    workspace: info.workspace,
+                    startedInstanceId: s.startedInstanceId || instance.id, // note: here's a potential mismatch between startedInstanceId and instance.id. TODO(gpl) How to handle this?
+                }));
+                this.onInstanceUpdate(instance);
+            }
+        } catch (error) {
+            console.error(error);
+            this.setState({ error });
+        }
+    }
+
+    /**
+     * Fetches the current IDEOptions config for this user
+     *
+     * TODO(gpl) Ideally this would be part of the WorkspaceInstance shape, really. And we'd display options based on
+     * what support it was started with.
+     */
+    protected async fetchIDEOptions() {
+        const ideOptions = await getGitpodService().server.getIDEOptions();
+        this.setState({ ideOptions });
+    }
+
+    notifyDidOpenConnection() {
+        this.fetchWorkspaceInfo(undefined);
+    }
+
+    async onInstanceUpdate(workspaceInstance: WorkspaceInstance) {
+        if (workspaceInstance.workspaceId !== this.props.workspaceId) {
+            return;
+        }
+
+        // Here we filter out updates to instances we haven't started to avoid issues with updates coming in out-of-order
+        // (e.g., multiple "stopped" events from the older instance, where we already started a fresh one after the first)
+        // Only exception is when we do the switch from the "old" to the "new" one.
+        const startedInstanceId = this.state?.startedInstanceId;
+        if (startedInstanceId !== workspaceInstance.id) {
+            // do we want to switch to "new" instance we just received an update for?
+            const switchToNewInstance =
+                this.state.workspaceInstance?.status.phase === "stopped" &&
+                workspaceInstance.status.phase !== "stopped";
+            if (!switchToNewInstance) {
+                return;
+            }
+            this.setState({
+                startedInstanceId: workspaceInstance.id,
+                workspaceInstance,
+            });
+
+            // now we're listening to a new instance, which might have been started with other IDEoptions
+            this.fetchIDEOptions();
+        }
+
+        await this.ensureWorkspaceAuth(workspaceInstance.id);
+
+        // Redirect to workspaceURL if we are not yet running in an iframe.
+        // It happens this late if we were waiting for a docker build.
+        if (!this.props.runsInIFrame && workspaceInstance.ideUrl && !this.props.dontAutostart) {
+            this.redirectTo(workspaceInstance.ideUrl);
+            return;
+        }
+
+        if (workspaceInstance.status.phase === "preparing") {
+            this.setState({ hasImageBuildLogs: true });
+        }
+
+        let error: StartWorkspaceError | undefined;
+        if (workspaceInstance.status.conditions.failed) {
+            error = { message: workspaceInstance.status.conditions.failed };
+        }
+
+        // Successfully stopped and headless: the prebuild is done, let's try to use it!
+        if (!error && workspaceInstance.status.phase === "stopped" && this.state.workspace?.type !== "regular") {
+            // here we want to point to the original context, w/o any modifiers "workspace" was started with (as this might have been a manually triggered prebuild!)
+            const contextURL = ContextURL.getNormalizedURL(this.state.workspace);
+            if (contextURL) {
+                this.redirectTo(gitpodHostUrl.withContext(contextURL.toString()).toString());
+            } else {
+                console.error(`unable to parse contextURL: ${contextURL}`);
+            }
+        }
+
+        this.setState({ workspaceInstance, error });
+    }
+
+    async ensureWorkspaceAuth(instanceID: string) {
+        if (!document.cookie.includes(`${instanceID}_owner_`)) {
+            const authURL = gitpodHostUrl.asWorkspaceAuth(instanceID);
+            const response = await fetch(authURL.toString());
+            if (response.redirected) {
+                this.redirectTo(response.url);
+                return;
+            }
+            if (!response.ok) {
+                // getting workspace auth didn't work as planned - redirect
+                this.redirectTo(authURL.asWorkspaceAuth(instanceID, true).toString());
+                return;
+            }
+        }
+    }
+
+    redirectTo(url: string) {
+        if (this.props.runsInIFrame) {
+            window.parent.postMessage({ type: "relocate", url }, "*");
+        } else {
+            window.location.href = url;
+        }
+    }
+
+    render() {
+        const { error } = this.state;
+        const isHeadless = this.state.workspace?.type !== "regular";
+        const isPrebuilt = WithPrebuild.is(this.state.workspace?.context);
+        let phase: StartPhase | undefined = StartPhase.Preparing;
+        let title = undefined;
+        let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
+        const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
+
+        switch (this.state?.workspaceInstance?.status.phase) {
+            // unknown indicates an issue within the system in that it cannot determine the actual phase of
+            // a workspace. This phase is usually accompanied by an error.
+            case "unknown":
+                break;
+
+            // Preparing means that we haven't actually started the workspace instance just yet, but rather
+            // are still preparing for launch. This means we're building the Docker image for the workspace.
+            case "preparing":
+                return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} />;
+
+            // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
+            // some space within the cluster. If for example the cluster needs to scale up to accomodate the
+            // workspace, the workspace will be in Pending state until that happened.
+            case "pending":
+                phase = StartPhase.Preparing;
+                statusMessage = <p className="text-base text-gray-400">Allocating resources …</p>;
+                break;
+
+            // Creating means the workspace is currently being created. That includes downloading the images required
+            // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
+            // network speed, image size and cache states.
+            case "creating":
+                phase = StartPhase.Creating;
+                statusMessage = <p className="text-base text-gray-400">Pulling container image …</p>;
+                break;
+
+            // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
+            // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
+            case "initializing":
+                phase = StartPhase.Starting;
+                statusMessage = (
+                    <p className="text-base text-gray-400">
+                        {isPrebuilt ? "Loading prebuild …" : "Initializing content …"}
+                    </p>
+                );
+                break;
+
+            // Running means the workspace is able to actively perform work, either by serving a user through Theia,
+            // or as a headless workspace.
+            case "running":
+                if (isHeadless) {
+                    return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
+                }
+                if (!this.state.desktopIde) {
+                    phase = StartPhase.Running;
+
+                    if (this.props.dontAutostart) {
+                        // hide the progress bar, as we're already running
+                        phase = undefined;
+                        title = "Running";
+
+                        // in case we dontAutostart the IDE we have to provide controls to do so
+                        statusMessage = (
+                            <div>
+                                <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
+                                    <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
+                                    <div>
+                                        <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
+                                            {this.state.workspaceInstance.workspaceId}
+                                        </p>
+                                        <a target="_parent" href={contextURL}>
+                                            <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                                                {contextURL}
+                                            </p>
+                                        </a>
+                                    </div>
+                                </div>
+                                <div className="mt-10 justify-center flex space-x-2">
+                                    <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}>
+                                        <button className="secondary">Go to Dashboard</button>
+                                    </a>
+                                    <a
+                                        target="_parent"
+                                        href={
+                                            gitpodHostUrl
+                                                .asStart(this.props.workspaceId)
+                                                .toString() /** move over 'start' here to fetch fresh credentials in case this is an older tab */
+                                        }
+                                    >
+                                        <button>Open Workspace</button>
+                                    </a>
+                                </div>
+                            </div>
+                        );
+                    } else {
+                        statusMessage = <p className="text-base text-gray-400">Opening Workspace …</p>;
+                    }
+                } else {
+                    phase = StartPhase.IdeReady;
+                    const openLink = this.state.desktopIde.link;
+                    const openLinkLabel = this.state.desktopIde.label;
+                    const clientID = this.state.desktopIde.clientID;
+                    const client = clientID ? this.state.ideOptions?.clients?.[clientID] : undefined;
+                    const installationSteps = client?.installationSteps?.length && (
+                        <div className="flex flex-col text-center m-auto text-sm w-72 text-gray-400">
+                            {client.installationSteps.map((step) => (
+                                <div
+                                    dangerouslySetInnerHTML={{
+                                        // TODO: this seems a good use case for definitely disable this linter rule
+                                        // Nonetheless, there might be some alternative way of doing the same thing
+                                        // without having to replace the placeholder like this.
+                                        // Worth exploring and refactoring.
+                                        // eslint-disable-next-line no-template-curly-in-string
+                                        __html: step.replaceAll("${OPEN_LINK_LABEL}", openLinkLabel),
+                                    }}
+                                />
+                            ))}
+                        </div>
+                    );
+                    statusMessage = (
+                        <div>
+                            <p className="text-base text-gray-400">Opening Workspace …</p>
+                            <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
+                                <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
+                                <div>
+                                    <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
+                                        {this.state.workspaceInstance.workspaceId}
+                                    </p>
+                                    <a target="_parent" href={contextURL}>
+                                        <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                                            {contextURL}
+                                        </p>
+                                    </a>
+                                </div>
+                            </div>
+                            {installationSteps}
+                            <div className="mt-10 justify-center flex space-x-2">
+                                <ContextMenu
+                                    menuEntries={[
+                                        {
+                                            title: "Open in Browser",
+                                            onClick: () => window.parent.postMessage({ type: "openBrowserIde" }, "*"),
+                                        },
+                                        {
+                                            title: "Stop Workspace",
+                                            onClick: () =>
+                                                getGitpodService().server.stopWorkspace(this.props.workspaceId),
+                                        },
+                                        {
+                                            title: "Go to Dashboard",
+                                            href: gitpodHostUrl.asDashboard().toString(),
+                                            target: "_parent",
+                                        },
+                                    ]}
+                                >
+                                    <button className="secondary">
+                                        More Actions...
+                                        <Arrow up={false} />
+                                    </button>
+                                </ContextMenu>
+                                <button
+                                    onClick={() => {
+                                        let redirect = false;
+                                        try {
+                                            const desktopLink = new URL(openLink);
+                                            redirect =
+                                                desktopLink.protocol !== "http:" && desktopLink.protocol !== "https:";
+                                        } catch {}
+                                        if (redirect) {
+                                            window.location.href = openLink;
+                                        } else {
+                                            window.open(openLink, "_blank", "noopener");
+                                        }
+                                    }}
+                                >
+                                    {openLinkLabel}
+                                </button>
+                            </div>
+                            <div className="text-sm text-gray-400 dark:text-gray-500 mt-5">
+                                These IDE options are based on{" "}
+                                <a className="gp-link" href={gitpodHostUrl.asPreferences().toString()} target="_parent">
+                                    your user preferences
+                                </a>
+                                .
+                            </div>
+                        </div>
+                    );
+                }
+
+                break;
+
+            // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
+            // When in this state, we expect it to become running or stopping anytime soon.
+            case "interrupted":
+                phase = StartPhase.Running;
+                statusMessage = <p className="text-base text-gray-400">Checking workspace …</p>;
+                break;
+
+            // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
+            case "stopping":
+                if (isHeadless) {
+                    return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
+                }
+                phase = StartPhase.Stopping;
+                statusMessage = (
+                    <div>
+                        <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 bg-gray-100 dark:bg-gray-800">
+                            <div className="rounded-full w-3 h-3 text-sm bg-gitpod-kumquat">&nbsp;</div>
+                            <div>
+                                <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
+                                    {this.state.workspaceInstance.workspaceId}
+                                </p>
+                                <a target="_parent" href={contextURL}>
+                                    <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                                        {contextURL}
+                                    </p>
+                                </a>
+                            </div>
+                        </div>
+                        <div className="mt-10 flex justify-center">
+                            <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}>
+                                <button className="secondary">Go to Dashboard</button>
+                            </a>
+                        </div>
+                    </div>
+                );
+                break;
+
+            // Stopped means the workspace ended regularly because it was shut down.
+            case "stopped":
+                phase = StartPhase.Stopped;
+                if (this.state.hasImageBuildLogs) {
+                    const restartWithDefaultImage = (event: React.MouseEvent) => {
+                        (event.target as HTMLButtonElement).disabled = true;
+                        this.startWorkspace(true, true);
+                    };
+                    return (
+                        <ImageBuildView
+                            workspaceId={this.state.workspaceInstance.workspaceId}
+                            onStartWithDefaultImage={restartWithDefaultImage}
+                            phase={phase}
+                            error={error}
+                        />
+                    );
+                }
+                if (!isHeadless && this.state.workspaceInstance.status.conditions.timeout) {
+                    title = "Timed Out";
+                }
+                statusMessage = (
+                    <div>
+                        <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
+                            <div className="rounded-full w-3 h-3 text-sm bg-gray-300">&nbsp;</div>
+                            <div>
+                                <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
+                                    {this.state.workspaceInstance.workspaceId}
+                                </p>
+                                <a target="_parent" href={contextURL}>
+                                    <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                                        {contextURL}
+                                    </p>
+                                </a>
+                            </div>
+                        </div>
+                        <PendingChangesDropdown workspaceInstance={this.state.workspaceInstance} />
+                        <div className="mt-10 justify-center flex space-x-2">
+                            <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}>
+                                <button className="secondary">Go to Dashboard</button>
+                            </a>
+                            <a
+                                target="_parent"
+                                href={gitpodHostUrl.asStart(this.state.workspaceInstance?.workspaceId).toString()}
+                            >
+                                <button>Open Workspace</button>
+                            </a>
+                        </div>
+                    </div>
+                );
+                break;
+        }
+
+        return (
+            <StartPage phase={phase} error={error} title={title}>
+                {statusMessage}
+            </StartPage>
+        );
+    }
 }
 
 interface ImageBuildViewProps {
-  workspaceId: string;
-  onStartWithDefaultImage?: (event: React.MouseEvent) => void;
-  phase?: StartPhase;
-  error?: StartWorkspaceError;
+    workspaceId: string;
+    onStartWithDefaultImage?: (event: React.MouseEvent) => void;
+    phase?: StartPhase;
+    error?: StartWorkspaceError;
 }
 
 function ImageBuildView(props: ImageBuildViewProps) {
-  const logsEmitter = new EventEmitter();
+    const logsEmitter = useMemo(() => new EventEmitter(), []);
 
-  useEffect(() => {
-    let registered = false;
-    const watchBuild = () => {
-      if (registered) {
-        return;
-      }
+    useEffect(() => {
+        let registered = false;
+        const watchBuild = () => {
+            if (registered) {
+                return;
+            }
 
-      getGitpodService().server.watchWorkspaceImageBuildLogs(props.workspaceId)
-        .then(() => registered = true)
-        .catch(err => {
-
-          if (err?.code === ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE) {
-            // wait, and then retry
-            setTimeout(watchBuild, 5000);
-          }
-        })
-    }
-    watchBuild();
-
-    const toDispose = getGitpodService().registerClient({
-      notifyDidOpenConnection: () => {
-        registered = false; // new connection, we're not registered anymore
+            getGitpodService()
+                .server.watchWorkspaceImageBuildLogs(props.workspaceId)
+                .then(() => (registered = true))
+                .catch((err) => {
+                    if (err?.code === ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE) {
+                        // wait, and then retry
+                        setTimeout(watchBuild, 5000);
+                    }
+                });
+        };
         watchBuild();
-      },
-      onWorkspaceImageBuildLogs: (info: WorkspaceImageBuild.StateInfo, content?: WorkspaceImageBuild.LogContent) => {
-        if (!content) {
-          return;
-        }
-        logsEmitter.emit('logs', content.text);
-      },
-    });
 
-    return function cleanup() {
-      toDispose.dispose();
-    };
-  }, []);
+        const toDispose = getGitpodService().registerClient({
+            notifyDidOpenConnection: () => {
+                registered = false; // new connection, we're not registered anymore
+                watchBuild();
+            },
+            onWorkspaceImageBuildLogs: (
+                info: WorkspaceImageBuild.StateInfo,
+                content?: WorkspaceImageBuild.LogContent,
+            ) => {
+                if (!content) {
+                    return;
+                }
+                logsEmitter.emit("logs", content.text);
+            },
+        });
 
-  return <StartPage title="Building Image" phase={props.phase}>
-    <Suspense fallback={<div />}>
-      <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
-    </Suspense>
-    {!!props.onStartWithDefaultImage && <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>Continue with Default Image</button>}
-  </StartPage>;
+        return function cleanup() {
+            toDispose.dispose();
+        };
+    }, [logsEmitter, props.workspaceId]);
+
+    return (
+        <StartPage title="Building Image" phase={props.phase}>
+            <Suspense fallback={<div />}>
+                <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
+            </Suspense>
+            {!!props.onStartWithDefaultImage && (
+                <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>
+                    Continue with Default Image
+                </button>
+            )}
+        </StartPage>
+    );
 }
 
 function HeadlessWorkspaceView(props: { instanceId: string }) {
-  const logsEmitter = new EventEmitter();
+    const logsEmitter = useMemo(() => new EventEmitter(), []);
 
-  useEffect(() => {
-    const disposables = watchHeadlessLogs(props.instanceId, (chunk) => logsEmitter.emit('logs', chunk), async () => { return false; });
-    return function cleanup() {
-      disposables.dispose();
-    };
-  }, []);
+    useEffect(() => {
+        const disposables = watchHeadlessLogs(
+            props.instanceId,
+            (chunk) => logsEmitter.emit("logs", chunk),
+            async () => {
+                return false;
+            },
+        );
+        return function cleanup() {
+            disposables.dispose();
+        };
+    }, [logsEmitter, props.instanceId]);
 
-  return <StartPage title="Prebuild in Progress">
-    <Suspense fallback={<div />}>
-      <WorkspaceLogs logsEmitter={logsEmitter} />
-    </Suspense>
-  </StartPage>;
+    return (
+        <StartPage title="Prebuild in Progress">
+            <Suspense fallback={<div />}>
+                <WorkspaceLogs logsEmitter={logsEmitter} />
+            </Suspense>
+        </StartPage>
+    );
 }

--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -9,18 +9,18 @@ import { useHistory } from "react-router-dom";
 import { getGitpodService } from "../service/service";
 import { TeamsContext } from "./teams-context";
 
-export default function() {
+export default function () {
     const { setTeams } = useContext(TeamsContext);
     const history = useHistory();
 
-    const [ joinError, setJoinError ] = useState<Error>();
-    const inviteId = new URL(window.location.href).searchParams.get('inviteId');
+    const [joinError, setJoinError] = useState<Error>();
+    const inviteId = new URL(window.location.href).searchParams.get("inviteId");
 
     useEffect(() => {
         (async () => {
             try {
                 if (!inviteId) {
-                    throw new Error('This invite URL is incorrect.');
+                    throw new Error("This invite URL is incorrect.");
                 }
 
                 let team;
@@ -46,9 +46,11 @@ export default function() {
                 setJoinError(error);
             }
         })();
-    }, []);
+    }, [history, inviteId, setTeams]);
 
-    useEffect(() => { document.title = 'Joining Team — Gitpod' }, []);
+    useEffect(() => {
+        document.title = "Joining Team — Gitpod";
+    }, []);
 
     return joinError ? <div className="mt-16 text-center text-gitpod-red">{String(joinError)}</div> : <></>;
 }

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -13,25 +13,24 @@ import DropDown from "../components/DropDown";
 import { ItemsList, Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
 import Modal from "../components/Modal";
 import Tooltip from "../components/Tooltip";
-import copy from '../images/copy.svg';
+import copy from "../images/copy.svg";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import { TeamsContext, getCurrentTeam } from "./teams-context";
 import { trackEvent } from "../Analytics";
 
-
-export default function() {
+export default function () {
     const { user } = useContext(UserContext);
     const { teams, setTeams } = useContext(TeamsContext);
     const history = useHistory();
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const [ members, setMembers ] = useState<TeamMemberInfo[]>([]);
-    const [ genericInvite, setGenericInvite ] = useState<TeamMembershipInvite>();
-    const [ showInviteModal, setShowInviteModal ] = useState<boolean>(false);
-    const [ searchText, setSearchText ] = useState<string>('');
-    const [ roleFilter, setRoleFilter ] = useState<TeamMemberRole | undefined>();
-    const [ leaveTeamEnabled, setLeaveTeamEnabled ] = useState<boolean>(false);
+    const [members, setMembers] = useState<TeamMemberInfo[]>([]);
+    const [genericInvite, setGenericInvite] = useState<TeamMembershipInvite>();
+    const [showInviteModal, setShowInviteModal] = useState<boolean>(false);
+    const [searchText, setSearchText] = useState<string>("");
+    const [roleFilter, setRoleFilter] = useState<TeamMemberRole | undefined>();
+    const [leaveTeamEnabled, setLeaveTeamEnabled] = useState<boolean>(false);
 
     useEffect(() => {
         if (!team) {
@@ -45,24 +44,24 @@ export default function() {
             setMembers(infos);
             setGenericInvite(invite);
         })();
-    }, [ team ]);
+    }, [team]);
 
     useEffect(() => {
-        const owners = members.filter(m => m.role === "owner");
-        const isOwner = owners.some(o => o.userId === user?.id);
+        const owners = members.filter((m) => m.role === "owner");
+        const isOwner = owners.some((o) => o.userId === user?.id);
         setLeaveTeamEnabled(!isOwner || owners.length > 1);
-    }, [ members ]);
+    }, [members, user?.id]);
 
-    const ownMemberInfo = members.find(m => m.userId === user?.id);
+    const ownMemberInfo = members.find((m) => m.userId === user?.id);
 
     const getInviteURL = (inviteId: string) => {
         const link = new URL(window.location.href);
-        link.pathname = '/teams/join';
-        link.search = '?inviteId=' + inviteId;
+        link.pathname = "/teams/join";
+        link.search = "?inviteId=" + inviteId;
         return link.href;
-    }
+    };
 
-    const [ copied, setCopied ] = useState<boolean>(false);
+    const [copied, setCopied] = useState<boolean>(false);
     const copyToClipboard = (text: string) => {
         const el = document.createElement("textarea");
         el.value = text;
@@ -84,143 +83,234 @@ export default function() {
             const newInvite = await getGitpodService().server.resetGenericInvite(team!.id);
             setGenericInvite(newInvite);
         }
-    }
+    };
 
     const setTeamMemberRole = async (userId: string, role: TeamMemberRole) => {
         await getGitpodService().server.setTeamMemberRole(team!.id, userId, role);
         setMembers(await getGitpodService().server.getTeamMembers(team!.id));
-    }
+    };
 
     const removeTeamMember = async (userId: string) => {
         await getGitpodService().server.removeTeamMember(team!.id, userId);
         const newTeams = await getGitpodService().server.getTeams();
-        if (newTeams.some(t => t.id === team!.id)) {
+        if (newTeams.some((t) => t.id === team!.id)) {
             // We're still a member of this team.
             const newMembers = await getGitpodService().server.getTeamMembers(team!.id);
             setMembers(newMembers);
         } else {
             // We're no longer a member of this team (note: we navigate away first in order to avoid a 404).
-            history.push('/');
+            history.push("/");
             setTeams(newTeams);
         }
-    }
+    };
 
-    const filteredMembers = members.filter(m => {
+    const filteredMembers = members.filter((m) => {
         if (!!roleFilter && m.role !== roleFilter) {
             return false;
         }
-        const memberSearchText = `${m.fullName||''}${m.primaryEmail||''}`.toLocaleLowerCase();
+        const memberSearchText = `${m.fullName || ""}${m.primaryEmail || ""}`.toLocaleLowerCase();
         if (!memberSearchText.includes(searchText.toLocaleLowerCase())) {
             return false;
         }
         return true;
     });
 
-    return <>
-        <Header title="Members" subtitle="Manage team members." />
-        <div className="app-container">
-            <div className="flex mt-8">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16"><path fill="#A8A29E" d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"/></svg>
-                    </div>
-                    <input type="search" placeholder="Search Members" onChange={e => setSearchText(e.target.value)} />
-                </div>
-                <div className="flex-1" />
-                <div className="py-3 pl-3">
-                    <DropDown prefix="Role: " contextMenuWidth="w-32" activeEntry={roleFilter === 'owner' ? 'Owner' : (roleFilter === 'member' ? 'Member' : 'All')} entries={[{
-                        title: 'All',
-                        onClick: () => setRoleFilter(undefined)
-                    }, {
-                        title: 'Owner',
-                        onClick: () => setRoleFilter('owner')
-                    }, {
-                        title: 'Member',
-                        onClick: () => setRoleFilter('member')
-                    }]} />
-                </div>
-                <button onClick={() => {
-                    trackEvent("invite_url_requested",{
-                        invite_url: getInviteURL(genericInvite!.id)
-                    });
-                    setShowInviteModal(true);
-                }
-                } className="ml-2">Invite Members</button>
-            </div>
-            <ItemsList className="mt-2">
-                <Item header={true} className="grid grid-cols-3">
-                    <ItemField className="my-auto">
-                        <span className="pl-14">Name</span>
-                    </ItemField>
-                    <ItemField className="flex items-center space-x-1 my-auto">
-                        <span>Joined</span>
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" className="h-4 w-4" viewBox="0 0 16 16"><path fill="#A8A29E" fill-rule="evenodd" d="M13.366 8.234a.8.8 0 010 1.132l-4.8 4.8a.8.8 0 01-1.132 0l-4.8-4.8a.8.8 0 111.132-1.132L7.2 11.67V2.4a.8.8 0 111.6 0v9.269l3.434-3.435a.8.8 0 011.132 0z" clip-rule="evenodd"/></svg>
-                    </ItemField>
-                    <ItemField className="flex items-center my-auto">
-                        <span className="flex-grow">Role</span>
-                    </ItemField>
-                </Item>
-                {filteredMembers.length === 0
-                    ? <p className="pt-16 text-center">No members found</p>
-                    : filteredMembers.map(m => <Item className="grid grid-cols-3" key={m.userId}>
-                        <ItemField className="flex items-center my-auto">
-                            <div className="w-14">{m.avatarUrl && <img className="rounded-full w-8 h-8" src={m.avatarUrl || ''} alt={m.fullName} />}</div>
-                            <div>
-                                <div className="text-base text-gray-900 dark:text-gray-50 font-medium">{m.fullName}</div>
-                                <p>{m.primaryEmail}</p>
-                            </div>
-                        </ItemField>
-                        <ItemField className="my-auto">
-                            <span className="text-gray-400">{moment(m.memberSince).fromNow()}</span>
-                        </ItemField>
-                        <ItemField className="flex items-center my-auto">
-                            <span className="text-gray-400 capitalize">{ownMemberInfo?.role !== 'owner'
-                                ? m.role
-                                : <DropDown contextMenuWidth="w-32" activeEntry={m.role} entries={[{
-                                    title: 'owner',
-                                    onClick: () => setTeamMemberRole(m.userId, 'owner')
-                                }, {
-                                    title: 'member',
-                                    onClick: () => setTeamMemberRole(m.userId, 'member')
-                                }]} />}</span>
-                            <span className="flex-grow" />
-                            <ItemFieldContextMenu menuEntries={m.userId === user?.id
-                                ? [{
-                                    title: leaveTeamEnabled ? 'Leave Team' : 'Remaining owner',
-                                    customFontStyle: leaveTeamEnabled ? 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300' : 'text-gray-400 dark:text-gray-200',
-                                    onClick: () => leaveTeamEnabled && removeTeamMember(m.userId)
-                                }]
-                                : (ownMemberInfo?.role === 'owner'
-                                    ? [{
-                                        title: 'Remove',
-                                        customFontStyle: 'text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300',
-                                        onClick: () => removeTeamMember(m.userId)
-                                    }]
-                                    : [])} />
-                        </ItemField>
-                    </Item>)}
-            </ItemsList>
-        </div>
-        {genericInvite && showInviteModal && <Modal visible={true} onClose={() => setShowInviteModal(false)}>
-            <h3 className="mb-4">Invite Members</h3>
-            <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
-                <label htmlFor="inviteUrl" className="font-medium">Invite URL</label>
-                <div className="w-full relative">
-                    <input name="inviteUrl" disabled={true} readOnly={true} type="text" value={getInviteURL(genericInvite.id)} className="rounded-md w-full truncate pr-8" />
-                    <div className="cursor-pointer" onClick={() => copyToClipboard(getInviteURL(genericInvite.id))}>
-                        <div className="absolute top-1/3 right-3">
-                            <Tooltip content={copied ? 'Copied!' : 'Copy Invite URL'}>
-                                <img src={copy} title="Copy Invite URL" />
-                            </Tooltip>
+    return (
+        <>
+            <Header title="Members" subtitle="Manage team members." />
+            <div className="app-container">
+                <div className="flex mt-8">
+                    <div className="flex">
+                        <div className="py-4">
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                height="16"
+                            >
+                                <path
+                                    fill="#A8A29E"
+                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                />
+                            </svg>
                         </div>
+                        <input
+                            type="search"
+                            placeholder="Search Members"
+                            onChange={(e) => setSearchText(e.target.value)}
+                        />
                     </div>
+                    <div className="flex-1" />
+                    <div className="py-3 pl-3">
+                        <DropDown
+                            prefix="Role: "
+                            contextMenuWidth="w-32"
+                            activeEntry={roleFilter === "owner" ? "Owner" : roleFilter === "member" ? "Member" : "All"}
+                            entries={[
+                                {
+                                    title: "All",
+                                    onClick: () => setRoleFilter(undefined),
+                                },
+                                {
+                                    title: "Owner",
+                                    onClick: () => setRoleFilter("owner"),
+                                },
+                                {
+                                    title: "Member",
+                                    onClick: () => setRoleFilter("member"),
+                                },
+                            ]}
+                        />
+                    </div>
+                    <button
+                        onClick={() => {
+                            trackEvent("invite_url_requested", {
+                                invite_url: getInviteURL(genericInvite!.id),
+                            });
+                            setShowInviteModal(true);
+                        }}
+                        className="ml-2"
+                    >
+                        Invite Members
+                    </button>
                 </div>
-                <p className="mt-1 text-gray-500 text-sm">Use this URL to join this team as a Member.</p>
+                <ItemsList className="mt-2">
+                    <Item header={true} className="grid grid-cols-3">
+                        <ItemField className="my-auto">
+                            <span className="pl-14">Name</span>
+                        </ItemField>
+                        <ItemField className="flex items-center space-x-1 my-auto">
+                            <span>Joined</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" className="h-4 w-4" viewBox="0 0 16 16">
+                                <path
+                                    fill="#A8A29E"
+                                    fill-rule="evenodd"
+                                    d="M13.366 8.234a.8.8 0 010 1.132l-4.8 4.8a.8.8 0 01-1.132 0l-4.8-4.8a.8.8 0 111.132-1.132L7.2 11.67V2.4a.8.8 0 111.6 0v9.269l3.434-3.435a.8.8 0 011.132 0z"
+                                    clip-rule="evenodd"
+                                />
+                            </svg>
+                        </ItemField>
+                        <ItemField className="flex items-center my-auto">
+                            <span className="flex-grow">Role</span>
+                        </ItemField>
+                    </Item>
+                    {filteredMembers.length === 0 ? (
+                        <p className="pt-16 text-center">No members found</p>
+                    ) : (
+                        filteredMembers.map((m) => (
+                            <Item className="grid grid-cols-3" key={m.userId}>
+                                <ItemField className="flex items-center my-auto">
+                                    <div className="w-14">
+                                        {m.avatarUrl && (
+                                            <img
+                                                className="rounded-full w-8 h-8"
+                                                src={m.avatarUrl || ""}
+                                                alt={m.fullName}
+                                            />
+                                        )}
+                                    </div>
+                                    <div>
+                                        <div className="text-base text-gray-900 dark:text-gray-50 font-medium">
+                                            {m.fullName}
+                                        </div>
+                                        <p>{m.primaryEmail}</p>
+                                    </div>
+                                </ItemField>
+                                <ItemField className="my-auto">
+                                    <span className="text-gray-400">{moment(m.memberSince).fromNow()}</span>
+                                </ItemField>
+                                <ItemField className="flex items-center my-auto">
+                                    <span className="text-gray-400 capitalize">
+                                        {ownMemberInfo?.role !== "owner" ? (
+                                            m.role
+                                        ) : (
+                                            <DropDown
+                                                contextMenuWidth="w-32"
+                                                activeEntry={m.role}
+                                                entries={[
+                                                    {
+                                                        title: "owner",
+                                                        onClick: () => setTeamMemberRole(m.userId, "owner"),
+                                                    },
+                                                    {
+                                                        title: "member",
+                                                        onClick: () => setTeamMemberRole(m.userId, "member"),
+                                                    },
+                                                ]}
+                                            />
+                                        )}
+                                    </span>
+                                    <span className="flex-grow" />
+                                    <ItemFieldContextMenu
+                                        menuEntries={
+                                            m.userId === user?.id
+                                                ? [
+                                                      {
+                                                          title: leaveTeamEnabled ? "Leave Team" : "Remaining owner",
+                                                          customFontStyle: leaveTeamEnabled
+                                                              ? "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
+                                                              : "text-gray-400 dark:text-gray-200",
+                                                          onClick: () => leaveTeamEnabled && removeTeamMember(m.userId),
+                                                      },
+                                                  ]
+                                                : ownMemberInfo?.role === "owner"
+                                                ? [
+                                                      {
+                                                          title: "Remove",
+                                                          customFontStyle:
+                                                              "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                                                          onClick: () => removeTeamMember(m.userId),
+                                                      },
+                                                  ]
+                                                : []
+                                        }
+                                    />
+                                </ItemField>
+                            </Item>
+                        ))
+                    )}
+                </ItemsList>
             </div>
-            <div className="flex justify-end mt-6 space-x-2">
-                <button className="secondary" onClick={() => resetInviteLink()}>Reset Invite Link</button>
-                <button className="secondary" onClick={() => setShowInviteModal(false)}>Close</button>
-            </div>
-        </Modal>}
-    </>;
+            {genericInvite && showInviteModal && (
+                <Modal visible={true} onClose={() => setShowInviteModal(false)}>
+                    <h3 className="mb-4">Invite Members</h3>
+                    <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
+                        <label htmlFor="inviteUrl" className="font-medium">
+                            Invite URL
+                        </label>
+                        <div className="w-full relative">
+                            <input
+                                name="inviteUrl"
+                                disabled={true}
+                                readOnly={true}
+                                type="text"
+                                value={getInviteURL(genericInvite.id)}
+                                className="rounded-md w-full truncate pr-8"
+                            />
+                            <div
+                                className="cursor-pointer"
+                                onClick={() => copyToClipboard(getInviteURL(genericInvite.id))}
+                            >
+                                <div className="absolute top-1/3 right-3">
+                                    <Tooltip content={copied ? "Copied!" : "Copy Invite URL"}>
+                                        <img src={copy} title="Copy Invite URL" alt="Copy Invite URL" />
+                                    </Tooltip>
+                                </div>
+                            </div>
+                        </div>
+                        <p className="mt-1 text-gray-500 text-sm">Use this URL to join this team as a Member.</p>
+                    </div>
+                    <div className="flex justify-end mt-6 space-x-2">
+                        <button className="secondary" onClick={() => resetInviteLink()}>
+                            Reset Invite Link
+                        </button>
+                        <button className="secondary" onClick={() => setShowInviteModal(false)}>
+                            Close
+                        </button>
+                    </div>
+                </Modal>
+            )}
+        </>
+    );
 }

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -17,7 +17,7 @@ import { getCurrentTeam, TeamsContext } from "./teams-context";
 export function getTeamSettingsMenu(team?: Team) {
     return [
         {
-            title: 'General',
+            title: "General",
             link: [`/t/${team?.slug}/settings`],
         },
     ];
@@ -25,7 +25,7 @@ export function getTeamSettingsMenu(team?: Team) {
 
 export default function TeamSettings() {
     const [modal, setModal] = useState(false);
-    const [teamSlug, setTeamSlug] = useState('');
+    const [teamSlug, setTeamSlug] = useState("");
     const [isUserOwner, setIsUserOwner] = useState(true);
     const { teams } = useContext(TeamsContext);
     const { user } = useContext(UserContext);
@@ -38,46 +38,70 @@ export default function TeamSettings() {
         (async () => {
             if (!team) return;
             const members = await getGitpodService().server.getTeamMembers(team.id);
-            const currentUserInTeam = members.find(member => member.userId === user?.id);
-            setIsUserOwner(currentUserInTeam?.role === 'owner');
+            const currentUserInTeam = members.find((member) => member.userId === user?.id);
+            setIsUserOwner(currentUserInTeam?.role === "owner");
         })();
-    }, []);
+    }, [team, user?.id]);
 
     if (!isUserOwner) {
-        return <Redirect to="/" />
-    };
+        return <Redirect to="/" />;
+    }
     const deleteTeam = async () => {
         if (!team || !user) {
-            return
+            return;
         }
         await getGitpodService().server.deleteTeam(team.id, user.id);
         document.location.href = gitpodHostUrl.asDashboard().toString();
     };
 
-    return <>
-        <PageWithSubMenu subMenu={getTeamSettingsMenu(team)} title="Settings" subtitle="Manage general team settings.">
-            <h3>Delete Team</h3>
-            <p className="text-base text-gray-500 pb-4 max-w-2xl">Deleting this team will also remove all associated data with this team, including projects and workspaces. Deleted teams cannot be restored!</p>
-            <button className="danger secondary" onClick={() => setModal(true)}>Delete Team</button>
-        </PageWithSubMenu>
+    return (
+        <>
+            <PageWithSubMenu
+                subMenu={getTeamSettingsMenu(team)}
+                title="Settings"
+                subtitle="Manage general team settings."
+            >
+                <h3>Delete Team</h3>
+                <p className="text-base text-gray-500 pb-4 max-w-2xl">
+                    Deleting this team will also remove all associated data with this team, including projects and
+                    workspaces. Deleted teams cannot be restored!
+                </p>
+                <button className="danger secondary" onClick={() => setModal(true)}>
+                    Delete Team
+                </button>
+            </PageWithSubMenu>
 
-        <ConfirmationModal
-            title="Delete Team"
-            buttonText="Delete Team"
-            buttonDisabled={teamSlug !== team!.slug}
-            visible={modal}
-            warningText="Warning: This action cannot be reversed."
-            onClose={close}
-            onConfirm={deleteTeam}
-        >
-            <p className="text-base text-gray-500">You are about to permanently delete <b>{team?.slug}</b> including all associated data with this team.</p>
-            <ol className="text-gray-500 text-m list-outside list-decimal">
-                <li className="ml-5">All <b>projects</b> added in this team will be deleted and cannot be restored afterwards.</li>
-                <li className="ml-5">All <b>workspaces</b> opened for projects within this team will be deleted for all team members and cannot be restored afterwards.</li>
-                <li className="ml-5">All <b>members</b> of this team will lose access to this team, associated projects and workspaces.</li>
-            </ol>
-            <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">Type <CodeText>{team?.slug}</CodeText> to confirm</p>
-            <input autoFocus className="w-full" type="text" onChange={e => setTeamSlug(e.target.value)}></input>
-        </ConfirmationModal>
-    </>
+            <ConfirmationModal
+                title="Delete Team"
+                buttonText="Delete Team"
+                buttonDisabled={teamSlug !== team!.slug}
+                visible={modal}
+                warningText="Warning: This action cannot be reversed."
+                onClose={close}
+                onConfirm={deleteTeam}
+            >
+                <p className="text-base text-gray-500">
+                    You are about to permanently delete <b>{team?.slug}</b> including all associated data with this
+                    team.
+                </p>
+                <ol className="text-gray-500 text-m list-outside list-decimal">
+                    <li className="ml-5">
+                        All <b>projects</b> added in this team will be deleted and cannot be restored afterwards.
+                    </li>
+                    <li className="ml-5">
+                        All <b>workspaces</b> opened for projects within this team will be deleted for all team members
+                        and cannot be restored afterwards.
+                    </li>
+                    <li className="ml-5">
+                        All <b>members</b> of this team will lose access to this team, associated projects and
+                        workspaces.
+                    </li>
+                </ol>
+                <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">
+                    Type <CodeText>{team?.slug}</CodeText> to confirm
+                </p>
+                <input autoFocus className="w-full" type="text" onChange={(e) => setTeamSlug(e.target.value)}></input>
+            </ConfirmationModal>
+        </>
+    );
 }

--- a/components/dashboard/src/theme-context.tsx
+++ b/components/dashboard/src/theme-context.tsx
@@ -4,37 +4,33 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useEffect, useState } from "react";
 
 export const ThemeContext = createContext<{
-    isDark?: boolean,
-    setIsDark: React.Dispatch<boolean>,
+    isDark?: boolean;
+    setIsDark: React.Dispatch<boolean>;
 }>({
     setIsDark: () => null,
 });
 
 export const ThemeContextProvider: React.FC = ({ children }) => {
-    const [ isDark, setIsDark ] = useState<boolean>(document.documentElement.classList.contains('dark'));
+    const [isDark, setIsDark] = useState<boolean>(document.documentElement.classList.contains("dark"));
     const actuallySetIsDark = (dark: boolean) => {
-      document.documentElement.classList.toggle('dark', dark);
-      setIsDark(dark);
-    }
+        document.documentElement.classList.toggle("dark", dark);
+        setIsDark(dark);
+    };
 
     useEffect(() => {
         const observer = new MutationObserver(() => {
-            if (document.documentElement.classList.contains('dark') !== isDark) {
+            if (document.documentElement.classList.contains("dark") !== isDark) {
                 setIsDark(!isDark);
             }
         });
         observer.observe(document.documentElement, { attributes: true });
         return function cleanUp() {
             observer.disconnect();
-        }
-    }, []);
+        };
+    }, [isDark]);
 
-    return (
-        <ThemeContext.Provider value={{ isDark, setIsDark: actuallySetIsDark }}>
-            {children}
-        </ThemeContext.Provider>
-    )
-}
+    return <ThemeContext.Provider value={{ isDark, setIsDark: actuallySetIsDark }}>{children}</ThemeContext.Provider>;
+};

--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -17,12 +17,18 @@ export function StartWorkspaceModal() {
     // Close the modal on navigation events.
     useEffect(() => {
         setIsStartWorkspaceModalVisible(false);
-    }, [location]);
+    }, [location, setIsStartWorkspaceModalVisible]);
 
-    return <Modal onClose={() => setIsStartWorkspaceModalVisible(false)} onEnter={() => false} visible={!!isStartWorkspaceModalVisible}>
-        <h3 className="pb-2">Open in Gitpod</h3>
-        <div className="border-t border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 pt-4">
-            <RepositoryFinder />
-        </div>
-    </Modal>;
+    return (
+        <Modal
+            onClose={() => setIsStartWorkspaceModalVisible(false)}
+            onEnter={() => false}
+            visible={!!isStartWorkspaceModalVisible}
+        >
+            <h3 className="pb-2">Open in Gitpod</h3>
+            <div className="border-t border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 pt-4">
+                <RepositoryFinder />
+            </div>
+        </Modal>
+    );
 }

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -1,60 +1,69 @@
 {
-   "folders": [
-      { "path": "." },
-      { "path": "components/blobserve" },
-      { "path": "components/common-go" },
-      { "path": "components/content-service" },
-      { "path": "components/docker-up" },
-      { "path": "components/ee/agent-smith" },
-      { "path": "components/gitpod-cli" },
-      { "path": "components/gitpod-protocol" },
-      { "path": "components/image-builder-bob" },
-      { "path": "components/image-builder-mk3" },
-      { "path": "components/licensor" },
-      { "path": "components/local-app" },
-      { "path": "components/registry-facade" },
-      { "path": "components/service-waiter" },
-      { "path": "components/supervisor" },
-      { "path": "components/workspacekit" },
-      { "path": "components/ws-daemon" },
-      { "path": "components/ws-manager" },
-      { "path": "components/ws-proxy" },
-      { "path": "test" },
-      { "path": "dev/blowtorch" },
-      { "path": "dev/changelog" },
-      { "path": "dev/gpctl" },
-      { "path": "dev/loadgen" },
-      { "path": "dev/poolkeeper" },
-      { "path": "dev/sweeper" },
-      { "path": "install/installer" }
-   ],
-   "settings": {
-      "typescript.tsdk": "gitpod/node_modules/typescript/lib",
-      "[json]": {
-         "editor.insertSpaces": true,
-         "editor.tabSize": 2
-      },
-      "[yaml]": {
-         "editor.insertSpaces": true,
-         "editor.tabSize": 2
-      },
-      "[go]": {
-         "editor.formatOnSave": true
-      },
-      "[tf]": {
-         "editor.insertSpaces": true,
-         "editor.tabSize": 2
-      },
-      "go.formatTool": "goimports",
-      "go.useLanguageServer": true,
-      "workspace.supportMultiRootWorkspace": true,
-      "launch": {},
-      "files.exclude": {
-         "**/.git": true
-      },
-      "go.lintTool": "golangci-lint",
-      "gopls": {
-         "allowModfileModifications": true
-      }
-   }
+    "folders": [
+        { "path": "." },
+        { "path": "components/blobserve" },
+        { "path": "components/common-go" },
+        { "path": "components/content-service" },
+        { "path": "components/docker-up" },
+        { "path": "components/ee/agent-smith" },
+        { "path": "components/gitpod-cli" },
+        { "path": "components/gitpod-protocol" },
+        { "path": "components/image-builder-bob" },
+        { "path": "components/image-builder-mk3" },
+        { "path": "components/licensor" },
+        { "path": "components/local-app" },
+        { "path": "components/registry-facade" },
+        { "path": "components/service-waiter" },
+        { "path": "components/supervisor" },
+        { "path": "components/workspacekit" },
+        { "path": "components/ws-daemon" },
+        { "path": "components/ws-manager" },
+        { "path": "components/ws-proxy" },
+        { "path": "test" },
+        { "path": "dev/blowtorch" },
+        { "path": "dev/changelog" },
+        { "path": "dev/gpctl" },
+        { "path": "dev/loadgen" },
+        { "path": "dev/poolkeeper" },
+        { "path": "dev/sweeper" },
+        { "path": "install/installer" }
+    ],
+    "settings": {
+        "typescript.tsdk": "gitpod/node_modules/typescript/lib",
+        "[javascript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode",
+            "editor.formatOnSave": true
+        },
+        "[typescript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode",
+            "editor.formatOnSave": true
+        },
+        "[json]": {
+            "editor.insertSpaces": true,
+            "editor.tabSize": 2
+        },
+        "[yaml]": {
+            "editor.insertSpaces": true,
+            "editor.tabSize": 2
+        },
+        "[go]": {
+            "editor.formatOnSave": true
+        },
+        "[tf]": {
+            "editor.insertSpaces": true,
+            "editor.tabSize": 2
+        },
+        "go.formatTool": "goimports",
+        "go.useLanguageServer": true,
+        "workspace.supportMultiRootWorkspace": true,
+        "launch": {},
+        "files.exclude": {
+            "**/.git": true
+        },
+        "go.lintTool": "golangci-lint",
+        "gopls": {
+            "allowModfileModifications": true
+        },
+        "prettier.configPath": ".prettierrc.json"
+    }
 }


### PR DESCRIPTION
## Description

The fixes are few and fairly easy so far, so I'm doing them all I guess.

Look at this beauty 💖
<img width="635" alt="image" src="https://user-images.githubusercontent.com/462705/158223650-ba782d89-5cfc-4ce9-a586-7fa4c36e385b.png">

- Installed ESLint (and Prettier) VSCode extension
- Following the lead of the suggested fixes and working from there for non-basic ones

There are some TODOs I marked, which need clarifications/go-ahead by a couple Gitpodders:
I commented in the "code review" interface directly mentioning @geropl and @AlexTugarev. 

There are a couple more TODOs that mark linter warnings I silenced, with code that would need a more complex refactor.
Do you want me to open issues for each of them?

@jankeromnes I was thinking we could also add a linting step to the CI (I'm assuming there's none, at least for the dashboard, at this time) so that the warnings "per se" don't become errors but the CI fails when there are linting warnings.
I'm not familiar with the system in use, but I can look into it if you want.
To complete this, we could then add the files that still need work to [that `.eslintignore` you were suggesting](https://github.com/gitpod-io/gitpod/issues/3841#issuecomment-895253942).
Although I'd rather fix the linting warnings as soon as the problems arise (and fix everything in the dashboard right in this PR to start with a clean slate), because I fear files included in the `.eslintignore` would just become forgotten sooner than later 🙈 .

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #3841 

## How to test
Use the dashboard 😬

Everything should still work, but warnings both in the terminal and in the browser devtools console should be gone for the files changed by this PR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed linting warnings in the dashboard app
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
