### PR TITLE
Fix error handling

### DIFF
--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -257,6 +257,7 @@ export async function waitUntilAllPodsAreReady(namespace: string, shellOpts: Exe
             pods = getPods(namespace)
         } catch (err) {
             werft.log(shellOpts.slice, err)
+            continue
         }
         if (pods.length == 0) {
             werft.log(shellOpts.slice, `The namespace is empty or does not exist.`)


### PR DESCRIPTION
## Description
Fix 
```
[monitor server deployment] Error: "kubectl get pods -n default  -o=jsonpath='{range .items[*]}{@.metadata.name}:{@.metadata.ownerReferences[0].kind}:{@.status.phase};{end}'" failed with code 1; stdout: ; stderr: Unable to connect to the server: EOF

[url|RESULT] {"payload":"https://ui.honeycomb.io/gitpod/datasets/werft/trace?trace_id=844db1ef450e47dc45182d08412ac282\u0026trace_start_ts=1646925933\u0026trace_end_ts=1646927738","channels":["github-check-honeycomb-trace"],"description":"Honeycomb trace"}
Error TypeError: Cannot read properties of undefined (reading 'length')
    at /workspace/.werft/util/kubectl.ts:261:18
    at step (/workspace/.werft/util/kubectl.ts:44:23)
    at Object.next (/workspace/.werft/util/kubectl.ts:25:53)
    at fulfilled (/workspace/.werft/util/kubectl.ts:16:58)
```
source: https://werft.gitpod-dev.com/job/gitpod-build-lad-with-vm-4.0/raw

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
