### PR TITLE
[Analytics] Track when users save a change to the dotfile repo

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -10,168 +10,162 @@ import Cookies from "js-cookie";
 import { v4 } from "uuid";
 import { Experiment } from "./experiments";
 
-
-export type Event = "invite_url_requested" | "organisation_authorised";
+export type Event = "invite_url_requested" | "organisation_authorised" | "dotfile_repo_changed";
 type InternalEvent = Event | "path_changed" | "dashboard_clicked";
 
-export type EventProperties =
-    TrackOrgAuthorised
-  | TrackInviteUrlRequested
-;
-type InternalEventProperties = TrackUIExperiments & (
-    EventProperties
-  | TrackDashboardClick
-  | TrackPathChanged
-);
+export type EventProperties = TrackOrgAuthorised | TrackInviteUrlRequested | TrackDotfileRepo;
+type InternalEventProperties = TrackUIExperiments & (EventProperties | TrackDashboardClick | TrackPathChanged);
 
 export interface TrackOrgAuthorised {
-  installation_id: string,
-  setup_action: string | undefined,
+    installation_id: string;
+    setup_action: string | undefined;
 }
 
 export interface TrackInviteUrlRequested {
-  invite_url: string,
+    invite_url: string;
+}
+
+export interface TrackDotfileRepo {
+    previous?: string;
+    current: string;
 }
 
 interface TrackDashboardClick {
-  dnt?: boolean,
-  path: string,
-  button_type?: string,
-  label?: string,
-  destination?: string,
-};
+    dnt?: boolean;
+    path: string;
+    button_type?: string;
+    label?: string;
+    destination?: string;
+}
 
 interface TrackPathChanged {
-  prev: string,
-  path: string,
+    prev: string;
+    path: string;
 }
 
 interface TrackUIExperiments {
-  ui_experiments?: {},
+    ui_experiments?: {};
 }
 
 interface Traits {
-  unsubscribed_onboarding?: boolean,
-  unsubscribed_changelog?: boolean,
-  unsubscribed_devx?: boolean
+    unsubscribed_onboarding?: boolean;
+    unsubscribed_changelog?: boolean;
+    unsubscribed_devx?: boolean;
 }
 
 //call this to track all events outside of button and anchor clicks
 export const trackEvent = (event: Event, properties: EventProperties) => {
-  trackEventInternal(event, properties);
-}
+    trackEventInternal(event, properties);
+};
 
 const trackEventInternal = (event: InternalEvent, properties: InternalEventProperties) => {
-  properties.ui_experiments = Experiment.get();
+    properties.ui_experiments = Experiment.get();
 
-  getGitpodService().server.trackEvent({
-    anonymousId: getAnonymousId(),
-    event,
-    properties,
-  });
+    getGitpodService().server.trackEvent({
+        anonymousId: getAnonymousId(),
+        event,
+        properties,
+    });
 };
 
 export const trackButtonOrAnchor = (target: HTMLAnchorElement | HTMLButtonElement | HTMLDivElement) => {
-  //read manually passed analytics props from 'data-analytics' attribute of event target
-  let passedProps: TrackDashboardClick | undefined;
-  if (target.dataset.analytics) {
-    try {
-      passedProps = JSON.parse(target.dataset.analytics) as TrackDashboardClick;
-      if (passedProps.dnt) {
-        return;
-      }
-    } catch (error) {
-      log.debug(error);
+    //read manually passed analytics props from 'data-analytics' attribute of event target
+    let passedProps: TrackDashboardClick | undefined;
+    if (target.dataset.analytics) {
+        try {
+            passedProps = JSON.parse(target.dataset.analytics) as TrackDashboardClick;
+            if (passedProps.dnt) {
+                return;
+            }
+        } catch (error) {
+            log.debug(error);
+        }
     }
 
-  }
+    let trackingMsg: TrackDashboardClick = {
+        path: window.location.pathname,
+        label: target.textContent || undefined,
+    };
 
-  let trackingMsg: TrackDashboardClick = {
-    path: window.location.pathname,
-    label: target.textContent || undefined
-  };
-
-  if (target instanceof HTMLButtonElement || target instanceof HTMLDivElement) {
-    //parse button data
-    if (target.classList.contains("secondary")) {
-      trackingMsg.button_type = "secondary";
-    } else {
-      trackingMsg.button_type = "primary"; //primary button is the default if secondary is not specified
+    if (target instanceof HTMLButtonElement || target instanceof HTMLDivElement) {
+        //parse button data
+        if (target.classList.contains("secondary")) {
+            trackingMsg.button_type = "secondary";
+        } else {
+            trackingMsg.button_type = "primary"; //primary button is the default if secondary is not specified
+        }
+        //retrieve href if parent is an anchor element
+        if (target.parentElement instanceof HTMLAnchorElement) {
+            const anchor = target.parentElement as HTMLAnchorElement;
+            trackingMsg.destination = anchor.href;
+        }
     }
-    //retrieve href if parent is an anchor element
-    if (target.parentElement instanceof HTMLAnchorElement) {
-      const anchor = target.parentElement as HTMLAnchorElement;
-      trackingMsg.destination = anchor.href;
+
+    if (target instanceof HTMLAnchorElement) {
+        const anchor = target as HTMLAnchorElement;
+        trackingMsg.destination = anchor.href;
     }
-  }
 
-  if (target instanceof HTMLAnchorElement) {
-    const anchor = target as HTMLAnchorElement;
-    trackingMsg.destination = anchor.href;
-  }
+    const getAncestorProps = (curr: HTMLElement | null): TrackDashboardClick | undefined => {
+        if (!curr || curr instanceof Document) {
+            return;
+        }
+        const ancestorProps: TrackDashboardClick | undefined = getAncestorProps(curr.parentElement);
+        const currProps = JSON.parse(curr.dataset.analytics || "{}") as TrackDashboardClick;
+        return { ...ancestorProps, ...currProps };
+    };
 
-  const getAncestorProps = (curr: HTMLElement | null): TrackDashboardClick | undefined => {
-    if (!curr || curr instanceof Document) {
-      return;
-    }
-    const ancestorProps: TrackDashboardClick | undefined = getAncestorProps(curr.parentElement);
-    const currProps = JSON.parse(curr.dataset.analytics || "{}") as TrackDashboardClick;
-    return {...ancestorProps, ...currProps};
-  }
+    const ancestorProps = getAncestorProps(target);
 
-  const ancestorProps = getAncestorProps(target);
+    //props that were passed directly to the event target take precedence over those passed to ancestor elements, which take precedence over those implicitly determined.
+    trackingMsg = { ...trackingMsg, ...ancestorProps, ...passedProps };
 
-  //props that were passed directly to the event target take precedence over those passed to ancestor elements, which take precedence over those implicitly determined.
-  trackingMsg = {...trackingMsg, ...ancestorProps, ...passedProps};
-
-  trackEventInternal("dashboard_clicked", trackingMsg);
-}
+    trackEventInternal("dashboard_clicked", trackingMsg);
+};
 
 //call this when the path changes. Complete page call is unnecessary for SPA after initial call
 export const trackPathChange = (props: TrackPathChanged) => {
-  trackEventInternal("path_changed", props);
-}
-
+    trackEventInternal("path_changed", props);
+};
 
 type TrackLocationProperties = TrackUIExperiments & {
-  referrer: string,
-  path: string,
-  host: string,
-  url: string,
+    referrer: string;
+    path: string;
+    host: string;
+    url: string;
 };
 
 export const trackLocation = async (includePII: boolean) => {
-  const props: TrackLocationProperties = {
-    referrer: document.referrer,
-    path: window.location.pathname,
-    host: window.location.hostname,
-    url: window.location.href,
-    ui_experiments: Experiment.get(),
-  };
+    const props: TrackLocationProperties = {
+        referrer: document.referrer,
+        path: window.location.pathname,
+        host: window.location.hostname,
+        url: window.location.href,
+        ui_experiments: Experiment.get(),
+    };
 
-  getGitpodService().server.trackLocation({
-    //if the user is authenticated, let server determine the id. else, pass anonymousId explicitly.
-    includePII: includePII,
-    anonymousId: getAnonymousId(),
-    properties: props
-  });
-}
+    getGitpodService().server.trackLocation({
+        //if the user is authenticated, let server determine the id. else, pass anonymousId explicitly.
+        includePII: includePII,
+        anonymousId: getAnonymousId(),
+        properties: props,
+    });
+};
 
 export const identifyUser = async (traits: Traits) => {
-  getGitpodService().server.identifyUser({
-    anonymousId: getAnonymousId(),
-    traits: traits
-  });
-}
+    getGitpodService().server.identifyUser({
+        anonymousId: getAnonymousId(),
+        traits: traits,
+    });
+};
 
 const getAnonymousId = (): string => {
-  let anonymousId = Cookies.get('ajs_anonymous_id');
-  if (anonymousId) {
-    return anonymousId.replace(/^"(.+(?="$))"$/, '$1'); //strip enclosing double quotes before returning
-  }
-  else {
-    anonymousId = v4();
-    Cookies.set('ajs_anonymous_id', anonymousId, {domain: '.'+window.location.hostname, expires: 365});
-  };
-  return anonymousId;
-}
+    let anonymousId = Cookies.get("ajs_anonymous_id");
+    if (anonymousId) {
+        return anonymousId.replace(/^"(.+(?="$))"$/, "$1"); //strip enclosing double quotes before returning
+    } else {
+        anonymousId = v4();
+        Cookies.set("ajs_anonymous_id", anonymousId, { domain: "." + window.location.hostname, expires: 365 });
+    }
+    return anonymousId;
+};

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -15,19 +15,20 @@ import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
 import settingsMenu from "./settings-menu";
-import IDENone from '../icons/IDENone.svg';
-import IDENoneDark from '../icons/IDENoneDark.svg';
+import IDENone from "../icons/IDENone.svg";
+import IDENoneDark from "../icons/IDENoneDark.svg";
 import CheckBox from "../components/CheckBox";
+import { trackEvent } from "../Analytics";
 
-type Theme = 'light' | 'dark' | 'system';
+type Theme = "light" | "dark" | "system";
 
 const DesktopNoneId = "none";
 const DesktopNone: IDEOption = {
-    "image": "",
-    "logo": IDENone,
-    "orderKey": "-1",
-    "title": "None",
-    "type": "desktop"
+    image: "",
+    logo: IDENone,
+    orderKey: "-1",
+    title: "None",
+    type: "desktop",
 };
 
 export default function Preferences() {
@@ -44,36 +45,43 @@ export default function Preferences() {
         settings.defaultDesktopIde = desktopIde;
         settings.useLatestVersion = useLatestVersion;
         additionalData.ideSettings = settings;
-        getGitpodService().server.trackEvent({
-            event: "ide_configuration_changed",
-            properties: {
-                useDesktopIde,
-                defaultIde,
-                defaultDesktopIde: desktopIde,
-                useLatestVersion,
-            },
-        }).then().catch(console.error);
+        getGitpodService()
+            .server.trackEvent({
+                event: "ide_configuration_changed",
+                properties: {
+                    useDesktopIde,
+                    defaultIde,
+                    defaultDesktopIde: desktopIde,
+                    useLatestVersion,
+                },
+            })
+            .then()
+            .catch(console.error);
         await getGitpodService().server.updateLoggedInUser({ additionalData });
-    }
+    };
 
     const [defaultIde, setDefaultIde] = useState<string>(user?.additionalData?.ideSettings?.defaultIde || "");
     const actuallySetDefaultIde = async (value: string) => {
         await updateUserIDEInfo(defaultDesktopIde, value, useLatestVersion);
         setDefaultIde(value);
-    }
+    };
 
-    const [defaultDesktopIde, setDefaultDesktopIde] = useState<string>((user?.additionalData?.ideSettings?.useDesktopIde && user?.additionalData?.ideSettings?.defaultDesktopIde) || DesktopNoneId);
+    const [defaultDesktopIde, setDefaultDesktopIde] = useState<string>(
+        (user?.additionalData?.ideSettings?.useDesktopIde && user?.additionalData?.ideSettings?.defaultDesktopIde) ||
+            DesktopNoneId,
+    );
     const actuallySetDefaultDesktopIde = async (value: string) => {
         await updateUserIDEInfo(value, defaultIde, useLatestVersion);
         setDefaultDesktopIde(value);
-    }
+    };
 
-    const [useLatestVersion, setUseLatestVersion] = useState<boolean>(user?.additionalData?.ideSettings?.useLatestVersion ?? false);
+    const [useLatestVersion, setUseLatestVersion] = useState<boolean>(
+        user?.additionalData?.ideSettings?.useLatestVersion ?? false,
+    );
     const actuallySetUseLatestVersion = async (value: boolean) => {
         await updateUserIDEInfo(defaultDesktopIde, defaultIde, value);
         setUseLatestVersion(value);
-    }
-
+    };
 
     const [ideOptions, setIdeOptions] = useState<IDEOptions | undefined>(undefined);
     useEffect(() => {
@@ -81,7 +89,7 @@ export default function Preferences() {
             const ideopts = await getGitpodService().server.getIDEOptions();
             ideopts.options[DesktopNoneId] = DesktopNone;
             setIdeOptions(ideopts);
-            if (!(defaultIde)) {
+            if (!defaultIde) {
                 setDefaultIde(ideopts.defaultIde);
             }
             if (!defaultDesktopIde) {
@@ -90,17 +98,19 @@ export default function Preferences() {
         })();
     }, []);
 
-    const [theme, setTheme] = useState<Theme>(localStorage.theme || 'system');
+    const [theme, setTheme] = useState<Theme>(localStorage.theme || "system");
     const actuallySetTheme = (theme: Theme) => {
-        if (theme === 'dark' || theme === 'light') {
+        if (theme === "dark" || theme === "light") {
             localStorage.theme = theme;
         } else {
-            localStorage.removeItem('theme');
+            localStorage.removeItem("theme");
         }
-        const isDark = localStorage.theme === 'dark' || (localStorage.theme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        const isDark =
+            localStorage.theme === "dark" ||
+            (localStorage.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
         setIsDark(isDark);
         setTheme(theme);
-    }
+    };
 
     const browserIdeOptions = ideOptions && orderedIdeOptions(ideOptions, "browser");
     const desktopIdeOptions = ideOptions && orderedIdeOptions(ideOptions, "desktop");
@@ -108,94 +118,187 @@ export default function Preferences() {
     const [dotfileRepo, setDotfileRepo] = useState<string>(user?.additionalData?.dotfileRepo || "");
     const actuallySetDotfileRepo = async (value: string) => {
         const additionalData = user?.additionalData || {};
+        const prevDotfileRepo = additionalData.dotfileRepo;
         additionalData.dotfileRepo = value;
         await getGitpodService().server.updateLoggedInUser({ additionalData });
+        trackEvent("dotfile_repo_changed", {
+            previous: prevDotfileRepo,
+            current: value,
+        });
     };
 
-    return <div>
-        <PageWithSubMenu subMenu={settingsMenu} title='Preferences' subtitle='Configure user preferences.'>
-            {ideOptions && <>
-                {browserIdeOptions && <>
-                    <h3>Browser Editor</h3>
-                    <p className="text-base text-gray-500 dark:text-gray-400">Choose the default editor for opening workspaces in the browser.</p>
-                    <div className="my-4 gap-4 flex flex-wrap">
-                        {
-                            browserIdeOptions.map(([id, option]) => {
-                                const selected = defaultIde === id;
-                                const onSelect = () => actuallySetDefaultIde(id);
-                                return renderIdeOption(option, selected, onSelect);
-                            })
-                        }
-                    </div>
-                    {ideOptions.options[defaultIde]?.notes &&
-                        <InfoBox className="my-5 max-w-2xl"><ul>
-                            {ideOptions.options[defaultIde].notes?.map((x, idx) => <li className={idx > 0 ? "mt-2" : ""}>{x}</li>)}
-                        </ul></InfoBox>
-                    }
-                </>}
-                {desktopIdeOptions && <>
-                    <h3 className="mt-12 flex">
-                        Desktop Editor
-                      <PillLabel type="warn" className="font-semibold py-0.5 px-2 self-center">Beta</PillLabel>
-                    </h3>
-                    <p className="text-base text-gray-500 dark:text-gray-400">Optionally, choose the default desktop editor for opening workspaces.</p>
-                    <div className="my-4 gap-4 flex flex-wrap max-w-2xl">
-                        {
-                            desktopIdeOptions.map(([id, option]) => {
-                                const selected = defaultDesktopIde === id;
-                                const onSelect = () => actuallySetDefaultDesktopIde(id);
-                                if (id === DesktopNoneId) {
-                                    option.logo = isDark ? IDENoneDark : IDENone
-                                }
-                                return renderIdeOption(option, selected, onSelect);
-                            })
-                        }
-                    </div>
-                    {ideOptions.options[defaultDesktopIde]?.notes &&
-                        <InfoBox className="my-5 max-w-2xl"><ul>
-                            {ideOptions.options[defaultDesktopIde].notes?.map((x, idx) => <li className={idx > 0 ? "mt-2" : ""}>{x}</li>)}
-                        </ul></InfoBox>
-                    }
-                    <p className="text-left w-full text-gray-500">
-                        The <strong>JetBrains desktop IDEs</strong> are currently in beta. <a href="https://github.com/gitpod-io/gitpod/issues/6576" target="gitpod-feedback-issue" rel="noopener" className="gp-link">Send feedback</a> · <a href="https://www.gitpod.io/docs/integrations/jetbrains" target="_blank" rel="noopener noreferrer" className="gp-link">Documentation</a>
-                    </p>
-                </>}
-                <CheckBox title="Latest Release" desc="Include the latest Early Access Program (EAP) version for each JetBrains IDE." checked={useLatestVersion} onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}/>
-            </>}
-            <h3 className="mt-12">Theme</h3>
-            <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
-            <div className="mt-4 space-x-4 flex">
-                <SelectableCard className="w-36 h-32" title="Light" selected={theme === 'light'} onClick={() => actuallySetTheme('light')}>
-                    <div className="flex-grow flex justify-center items-end">
-                        <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" /><rect width="32" height="16" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="24" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" /></svg>
-                    </div>
-                </SelectableCard>
-                <SelectableCard className="w-36 h-32" title="Dark" selected={theme === 'dark'} onClick={() => actuallySetTheme('dark')}>
-                    <div className="flex-grow flex justify-center items-end">
-                        <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#737373" rx="8" /><rect width="32" height="16" fill="#737373" rx="8" /><rect width="32" height="16" y="24" fill="#737373" rx="8" /><rect width="32" height="16" y="48" fill="#737373" rx="8" /></svg>
-                    </div>
-                </SelectableCard>
-                <SelectableCard className="w-36 h-32" title="System" selected={theme === 'system'} onClick={() => actuallySetTheme('system')}>
-                    <div className="flex-grow flex justify-center items-end">
-                        <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64"><rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" /><path fill="#737373" d="M74.111 3.412A8 8 0 0180.665 0H100a8 8 0 018 8v24a8 8 0 01-8 8H48.5L74.111 3.412z" /><rect width="32" height="16" fill="#C4C4C4" rx="8" /><rect width="32" height="16" y="24" fill="#737373" rx="8" /><rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" /></svg>
-                    </div>
-                </SelectableCard>
-            </div>
+    return (
+        <div>
+            <PageWithSubMenu subMenu={settingsMenu} title="Preferences" subtitle="Configure user preferences.">
+                {ideOptions && (
+                    <>
+                        {browserIdeOptions && (
+                            <>
+                                <h3>Browser Editor</h3>
+                                <p className="text-base text-gray-500 dark:text-gray-400">
+                                    Choose the default editor for opening workspaces in the browser.
+                                </p>
+                                <div className="my-4 gap-4 flex flex-wrap">
+                                    {browserIdeOptions.map(([id, option]) => {
+                                        const selected = defaultIde === id;
+                                        const onSelect = () => actuallySetDefaultIde(id);
+                                        return renderIdeOption(option, selected, onSelect);
+                                    })}
+                                </div>
+                                {ideOptions.options[defaultIde]?.notes && (
+                                    <InfoBox className="my-5 max-w-2xl">
+                                        <ul>
+                                            {ideOptions.options[defaultIde].notes?.map((x, idx) => (
+                                                <li className={idx > 0 ? "mt-2" : ""}>{x}</li>
+                                            ))}
+                                        </ul>
+                                    </InfoBox>
+                                )}
+                            </>
+                        )}
+                        {desktopIdeOptions && (
+                            <>
+                                <h3 className="mt-12 flex">
+                                    Desktop Editor
+                                    <PillLabel type="warn" className="font-semibold py-0.5 px-2 self-center">
+                                        Beta
+                                    </PillLabel>
+                                </h3>
+                                <p className="text-base text-gray-500 dark:text-gray-400">
+                                    Optionally, choose the default desktop editor for opening workspaces.
+                                </p>
+                                <div className="my-4 gap-4 flex flex-wrap max-w-2xl">
+                                    {desktopIdeOptions.map(([id, option]) => {
+                                        const selected = defaultDesktopIde === id;
+                                        const onSelect = () => actuallySetDefaultDesktopIde(id);
+                                        if (id === DesktopNoneId) {
+                                            option.logo = isDark ? IDENoneDark : IDENone;
+                                        }
+                                        return renderIdeOption(option, selected, onSelect);
+                                    })}
+                                </div>
+                                {ideOptions.options[defaultDesktopIde]?.notes && (
+                                    <InfoBox className="my-5 max-w-2xl">
+                                        <ul>
+                                            {ideOptions.options[defaultDesktopIde].notes?.map((x, idx) => (
+                                                <li className={idx > 0 ? "mt-2" : ""}>{x}</li>
+                                            ))}
+                                        </ul>
+                                    </InfoBox>
+                                )}
+                                <p className="text-left w-full text-gray-500">
+                                    The <strong>JetBrains desktop IDEs</strong> are currently in beta.{" "}
+                                    <a
+                                        href="https://github.com/gitpod-io/gitpod/issues/6576"
+                                        target="gitpod-feedback-issue"
+                                        rel="noopener"
+                                        className="gp-link"
+                                    >
+                                        Send feedback
+                                    </a>{" "}
+                                    ·{" "}
+                                    <a
+                                        href="https://www.gitpod.io/docs/integrations/jetbrains"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="gp-link"
+                                    >
+                                        Documentation
+                                    </a>
+                                </p>
+                            </>
+                        )}
+                        <CheckBox
+                            title="Latest Release"
+                            desc="Include the latest Early Access Program (EAP) version for each JetBrains IDE."
+                            checked={useLatestVersion}
+                            onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}
+                        />
+                    </>
+                )}
+                <h3 className="mt-12">Theme</h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
+                <div className="mt-4 space-x-4 flex">
+                    <SelectableCard
+                        className="w-36 h-32"
+                        title="Light"
+                        selected={theme === "light"}
+                        onClick={() => actuallySetTheme("light")}
+                    >
+                        <div className="flex-grow flex justify-center items-end">
+                            <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64">
+                                <rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" y="24" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" />
+                            </svg>
+                        </div>
+                    </SelectableCard>
+                    <SelectableCard
+                        className="w-36 h-32"
+                        title="Dark"
+                        selected={theme === "dark"}
+                        onClick={() => actuallySetTheme("dark")}
+                    >
+                        <div className="flex-grow flex justify-center items-end">
+                            <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64">
+                                <rect width="68" height="40" x="40" fill="#737373" rx="8" />
+                                <rect width="32" height="16" fill="#737373" rx="8" />
+                                <rect width="32" height="16" y="24" fill="#737373" rx="8" />
+                                <rect width="32" height="16" y="48" fill="#737373" rx="8" />
+                            </svg>
+                        </div>
+                    </SelectableCard>
+                    <SelectableCard
+                        className="w-36 h-32"
+                        title="System"
+                        selected={theme === "system"}
+                        onClick={() => actuallySetTheme("system")}
+                    >
+                        <div className="flex-grow flex justify-center items-end">
+                            <svg className="h-16" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 108 64">
+                                <rect width="68" height="40" x="40" fill="#C4C4C4" rx="8" />
+                                <path
+                                    fill="#737373"
+                                    d="M74.111 3.412A8 8 0 0180.665 0H100a8 8 0 018 8v24a8 8 0 01-8 8H48.5L74.111 3.412z"
+                                />
+                                <rect width="32" height="16" fill="#C4C4C4" rx="8" />
+                                <rect width="32" height="16" y="24" fill="#737373" rx="8" />
+                                <rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" />
+                            </svg>
+                        </div>
+                    </SelectableCard>
+                </div>
 
-            <h3 className="mt-12">Dotfiles <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">Beta</PillLabel></h3>
-            <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
-            <div className="mt-4 max-w-md">
-                <h4>Repository URL</h4>
-                <input type="text" value={dotfileRepo} className="w-full" placeholder="e.g. https://github.com/username/dotfiles" onChange={(e) => setDotfileRepo(e.target.value)} />
-                <div className="mt-1">
-                    <p className="text-gray-500 dark:text-gray-400">Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for every new workspace.</p>
-                </div>
+                <h3 className="mt-12">
+                    Dotfiles{" "}
+                    <PillLabel type="warn" className="font-semibold mt-2 py-0.5 px-2 self-center">
+                        Beta
+                    </PillLabel>
+                </h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
                 <div className="mt-4 max-w-md">
-                    <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
+                    <h4>Repository URL</h4>
+                    <input
+                        type="text"
+                        value={dotfileRepo}
+                        className="w-full"
+                        placeholder="e.g. https://github.com/username/dotfiles"
+                        onChange={(e) => setDotfileRepo(e.target.value)}
+                    />
+                    <div className="mt-1">
+                        <p className="text-gray-500 dark:text-gray-400">
+                            Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for
+                            every new workspace.
+                        </p>
+                    </div>
+                    <div className="mt-4 max-w-md">
+                        <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
+                    </div>
                 </div>
-            </div>
-        </PageWithSubMenu>
-    </div>;
+            </PageWithSubMenu>
+        </div>
+    );
 }
 
 function orderedIdeOptions(ideOptions: IDEOptions, type: "browser" | "desktop") {
@@ -210,18 +313,27 @@ function orderedIdeOptions(ideOptions: IDEOptions, type: "browser" | "desktop") 
 }
 
 function renderIdeOption(option: IDEOption, selected: boolean, onSelect: () => void): JSX.Element {
-    const card = <SelectableCard className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
-        <div className="flex justify-center mt-3">
-            <img className="w-16 filter-grayscale self-center"
-                src={option.logo} alt="logo" />
-        </div>
-        {option.label ? <div className={`font-semibold text-sm ${selected ? 'text-green-500' : 'text-gray-500 dark:text-gray-400'} uppercase mt-2 px-3 py-1 self-center`}>{option.label}</div> : <></>}
-    </SelectableCard>;
+    const card = (
+        <SelectableCard className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
+            <div className="flex justify-center mt-3">
+                <img className="w-16 filter-grayscale self-center" src={option.logo} alt="logo" />
+            </div>
+            {option.label ? (
+                <div
+                    className={`font-semibold text-sm ${
+                        selected ? "text-green-500" : "text-gray-500 dark:text-gray-400"
+                    } uppercase mt-2 px-3 py-1 self-center`}
+                >
+                    {option.label}
+                </div>
+            ) : (
+                <></>
+            )}
+        </SelectableCard>
+    );
 
     if (option.tooltip) {
-        return <Tooltip content={option.tooltip} >
-            {card}
-        </Tooltip>;
+        return <Tooltip content={option.tooltip}>{card}</Tooltip>;
     }
     return card;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
tracks when a users save a change to their dotfile repo in `/preferences`.
apologies for all the drive-by formatting changes. the prettier pre-commit test would not pass unless i accepted their changes.
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

1. Go to `/preferences in the preview environment, enter some value for the Repository URL in the Dotfiles section, then save
2. Add another value and save again
3. Go to the [Debugger of Segment's Staging Untrusted Source](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and ensure there are two `track("dotfile_repo_changed")` calls there the first should contain the `current` prop with the intially set value for the dotfile repo, the second should include the second value set for the dotifle repo in `current` and the previously set value in `previous`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe