### PR TITLE
fix #8738: Interpreting https://self as a hostname, not a keyword. If…

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -30,7 +30,7 @@
 		# disable clients from sniffing the media type
 		X-Content-Type-Options     nosniff
 		# Define valid parents that may embed a page
-		Content-Security-Policy    "frame-ancestors self https://*.{$GITPOD_DOMAIN} https://{$GITPOD_DOMAIN}"
+		Content-Security-Policy    "frame-ancestors 'self' https://*.{$GITPOD_DOMAIN} https://{$GITPOD_DOMAIN}"
 		# keep referrer data off of HTTP connections
 		Referrer-Policy            no-referrer-when-downgrade
 		# Enable cross-site filter (XSS) and tell browser to block detected attacks


### PR DESCRIPTION
… you intended this to be a keyword, use ‘self’

## Description
Replaces self with 'self'

## Related Issue(s)
Fixes #8738

## How to test
<!-- Provide steps to test this PR -->

## Release Notes

```release-note
NONE
```


