### PR TITLE
[code] update stable to 1.65.2

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -358,7 +358,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-a5d259949a3fa8d3bbfbb4cb19fd2c3fb0cdf00b"
+      stableVersion: "commit-93edb90833d8d662f4c1a64b2ad8ced456e62862"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-a5d259949a3fa8d3bbfbb4cb19fd2c3fb0cdf00b" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-93edb90833d8d662f4c1a64b2ad8ced456e62862" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates stable VS Code Web to 1.65.2
VSCode Endgame: https://github.com/microsoft/vscode/issues/144838

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Select vscode stable in dashboard settings
- Start a workspace.
- Use about dialog to check that version is 1.65.2

Tested here https://github.com/gitpod-io/gitpod/pull/8737

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update code to 1.65.2
```
/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe