### PR TITLE
[agent-smith] Enable egress monitoring

### DIFF
--- a/components/ee/agent-smith/pkg/agent/metrics.go
+++ b/components/ee/agent-smith/pkg/agent/metrics.go
@@ -17,6 +17,7 @@ type metrics struct {
 	classificationBackpressureInCount  prometheus.GaugeFunc
 	classificationBackpressureOutCount prometheus.GaugeFunc
 	classificationBackpressureInDrop   prometheus.Counter
+	egressViolations                   *prometheus.CounterVec
 
 	mu sync.RWMutex
 	cl []prometheus.Collector
@@ -41,6 +42,14 @@ func newAgentMetrics() *metrics {
 			Help:      "The total amount of failed attempts that agent-smith is trying to apply a penalty.",
 		}, []string{"penalty", "reason"},
 	)
+	m.egressViolations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "gitpod",
+			Subsystem: "agent_smith",
+			Name:      "egress_violations_total",
+			Help:      "The total amount of egress violations that agent-smith discovered.",
+		}, []string{"severity"},
+	)
 	m.classificationBackpressureInDrop = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "gitpod",
 		Subsystem: "agent_smith",
@@ -51,6 +60,7 @@ func newAgentMetrics() *metrics {
 		m.penaltyAttempts,
 		m.penaltyFailures,
 		m.classificationBackpressureInDrop,
+		m.egressViolations,
 	}
 	return m
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1383

## How to test
<!-- Provide steps to test this PR -->
* Enable debug logs for your deployment in core-dev using `gpctl debug logs agent-smith`
* (optional) modify agent-smith config map and update the reduce the thresholds of egress in the cm. This will allow you to see right logs even when you push small files. The default config has 3G of threshold, so you need to push around 3G from your workspace
* Start a workspace A
* Start another workspace B
* Generate egress in your workspace A. You can copy a file to gcs bucket or push a docker image.
* Wait for 2 minutes (that is the ticker time)
* Stop workspace A and B
* Check the logs. You should see something similar to below:

**Logs**
* Adding a workspace to a map
```json
{"level":"debug","message":"adding workspace with pid 3495247 and workspaceId princerachit-atheoscommu-mowawkn4gso to workspaces","serviceContext":{"service":"agent-smith","version":"commit-17abe734cb4252becd7a3447bb0a2b5b4ff21de9"},"severity":"DEBUG","time":"2022-03-11T11:39:37Z"}
```
* Infringing workspace
```json
{"instanceId":"82c305b5-4c8a-4637-aeb9-4bcbd2f71df1","level":"info","message":"found egress infringing workspace","serviceContext":{"service":"agent-smith","version":"commit-c5295379290c4f83bb2fe5fb271c6ea8fba8104b"},"severity":"INFO","time":"2022-03-15T05:30:35Z","userId":"","workspaceId":"princerachit-atheoscommu-wqfinhsmx5f"}
```
* Logs from callback function reporting egress total bytes
```json
{"level":"debug","message":"total egress bytes 486787600","serviceContext":{"service":"agent-smith","version":"commit-17abe734cb4252becd7a3447bb0a2b5b4ff21de9"},"severity":"DEBUG","time":"2022-03-11T11:48:37Z"}
```
* Deletion of workspace from map post it is stopped
```json
{"level":"debug","message":"deleting workspace with pid 3495247 and workspaceId princerachit-atheoscommu-mowawkn4gso from workspaces","serviceContext":{"service":"agent-smith","version":"commit-17abe734cb4252becd7a3447bb0a2b5b4ff21de9"},"severity":"DEBUG","time":"2022-03-11T11:46:37Z"}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Enable egress metrics for agent-smith
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
