### PR TITLE
Only flush traces once

### DIFF
--- a/.werft/observability/tracing.ts
+++ b/.werft/observability/tracing.ts
@@ -37,10 +37,17 @@ export async function initialize() {
         process.exit(1)
     }
 
+    let didFlushTraces = false
     process.on('beforeExit', (code) => {
-        console.log(`About to exit with code ${code}. Shutting down tracing.`)
-        sdk.shutdown()
-            .then(() => console.log('Tracing terminated'))
-            .catch((error) => console.log('Error terminating tracing', error))
+        const sliceID = 'tracing shutdown'
+        if (!didFlushTraces) {
+            console.log(`[${sliceID}] About to exit with code ${code}. Shutting down tracing.`)
+            didFlushTraces = true
+            sdk.shutdown()
+                .then(() => console.log(`[${sliceID}] Tracing terminated`))
+                .catch((error) => console.log(`[${sliceID}] Error terminating tracing`, error))
+        } else {
+            console.log(`[${sliceID}] About to exit with code ${code}. Traces already flushed, no further action needed.`)
+        }
     })
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This ensure that we only try to flush traces once. We are triggering the flushing in the beforeExit handler which is invoked when Node doesn't have any more code to execute (or Promises in its queue). However, sdk.shutdown generates a new Promise which means that once that's done executing the beforeExit handler is invoked again. This seems to be okay (e.g. we have previous seen:

```
About to exit with code 0. Shutting down tracing.
Tracing terminated
About to exit with code 0. Shutting down tracing.
Tracing terminated
```

So presumably the second shutdown happens before the exitHandler is done executing and thus doesn't introduce an infinite loop. Even so, only trying to invoke sdk.shutdown once seems the better open, hence this PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No previous issue.

## How to test
<!-- Provide steps to test this PR -->

Just trigger a job and look at the output. We now see

```
About to exit with code 0. Shutting down tracing.
Tracing terminated
About to exit with code 0. Traces already flushed, no further action needed.
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A