### PR TITLE
Added mirror for k3s

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -158,6 +158,13 @@ chpasswd:
     ubuntu:ubuntu
   expire: False
 write_files:
+  - path: /etc/rancher/k3s/registries.yaml
+    permissions: '0755'
+    content: |
+      mirrors:
+        docker.io:
+          endpoint:
+            - "https://mirror.gcr.io"
   - path: /etc/disable-services.sh
     permissions: '0755'
     content: |


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
According to the [documentation](https://rancher.com/docs/k3s/latest/en/installation/private-registry/#without-tls) adding the file is sufficient to configure the mirror. I would like to test that using a loadtests. I am also checking if we can see that in logs or verify that the request is going to the right endpoint.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8746 

## How to test
<!-- Provide steps to test this PR -->
Start a new workspace and run `werft run github -a with-vm=true`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
