### PR TITLE
Use placeholder text for Provider Host input

### DIFF
--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -448,7 +448,7 @@ export function GitIntegrationModal(props: ({
     const [providerEntry, setProviderEntry] = useState<AuthProviderEntry | undefined>(undefined);
 
     const [type, setType] = useState<string>("GitLab");
-    const [host, setHost] = useState<string>("gitlab.example.com");
+    const [host, setHost] = useState<string>("");
     const [redirectURL, setRedirectURL] = useState<string>(callbackUrl("gitlab.example.com"));
     const [clientId, setClientId] = useState<string>("");
     const [clientSecret, setClientSecret] = useState<string>("");
@@ -472,15 +472,6 @@ export function GitIntegrationModal(props: ({
         setErrorMessage(undefined);
         validate();
     }, [clientId, clientSecret, type])
-
-    useEffect(() => {
-        if (props.mode === "new") {
-            // If the host value has been modified e.g. not gitlab.example.com, assume it has been set by user and end operation
-            if (!host.includes(".example.com")) return;
-            const exampleHostname = `${type.toLowerCase()}.example.com`;
-            updateHostValue(exampleHostname);
-        }
-    }, [type]);
 
     const onClose = () => props.onClose && props.onClose();
     const onUpdate = () => props.onUpdate && props.onUpdate();
@@ -623,6 +614,14 @@ export function GitIntegrationModal(props: ({
         </span>);
     }
 
+    const getPlaceholderForIntegrationType = (type: string) => {
+      switch (type) {
+        case "GitHub": return "github.example.com";
+        case "GitLab": return "gitlab.example.com";
+        default: return "";
+      }
+    }
+
     const copyRedirectUrl = () => {
         const el = document.createElement("textarea");
         el.value = redirectURL;
@@ -658,7 +657,7 @@ export function GitIntegrationModal(props: ({
                 )}
                 <div className="flex flex-col space-y-2">
                     <label htmlFor="hostName" className="font-medium">Provider Host Name</label>
-                    <input name="hostName" disabled={mode === "edit"} type="text" value={host} className="w-full"
+                    <input name="hostName" disabled={mode === "edit"} type="text" placeholder={getPlaceholderForIntegrationType(type)} value={host} className="w-full"
                         onChange={(e) => updateHostValue(e.target.value)} />
                 </div>
                 <div className="flex flex-col space-y-2">


### PR DESCRIPTION
## Description

Change the default value in the **Provider Host** field on the new integration modal from a value that the user must delete before entering a valid host, to a [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder) that disappears when the input field has focus.

Before:

https://user-images.githubusercontent.com/8225907/157693897-9cd571e7-2fcf-45c3-9e81-53d401cf1e21.mov


After:

https://user-images.githubusercontent.com/8225907/157693909-694a5167-0418-43e4-8d41-de020864e08f.mov

## Related Issue(s)

## How to test

Open the modal at **Settings** -> **Integrations** -> **Add integration** and check that the value in the **Provider Host** field is now a placeholder not a value that must be deleted.

## Release Notes

```release-note
NONE
```

## Documentation

No changes needed.
