### PR TITLE
Fix and re-enable automated prebuilds for GitHub Enterprise

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -500,13 +500,14 @@ function GitProviders(props: {
         setErrorMessage(undefined);
 
         const token = await getGitpodService().server.getToken({ host: ap.host });
-        if (token) {
+        const isGitHubEnterprise = ap.authProviderType === "GitHub" && ap.host !== "github.com";
+        if (token && !(isGitHubEnterprise && !token.scopes.includes("public_repo"))) {
             props.onHostSelected(ap.host);
             return;
         }
         await openAuthorizeWindow({
             host: ap.host,
-            scopes: ap.requirements?.default,
+            scopes: isGitHubEnterprise ? ["public_repo"] : ap.requirements?.default,
             onSuccess: async () => {
                 props.onHostSelected(ap.host, true);
             },

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -148,7 +148,7 @@ export class ProjectsService {
         const parsedUrl = RepoURL.parseRepoUrl(project.cloneUrl);
         const hostContext = parsedUrl?.host ? this.hostContextProvider.get(parsedUrl?.host) : undefined;
         const type = hostContext && hostContext.authProvider.info.authProviderType;
-        if (type === "GitLab" || type === "Bitbucket") {
+        if (type === "GitLab" || type === "Bitbucket" || (type === "GitHub" && parsedUrl?.host !== "github.com")) {
             const repositoryService = hostContext?.services?.repositoryService;
             if (repositoryService) {
                 // Note: For GitLab, we expect .canInstallAutomatedPrebuilds() to always return true, because earlier


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Okay, here is my theory on why project creation sometimes failed with `404` errors. The short version is: We never ensured that the user's GHE token is actually allowed to install a webhook.

1. User logs connects with GitHub Enterprise. Gitpod receives a token with minimum scopes (i.e. [user:email](https://github.com/gitpod-io/gitpod/blob/5e3897debdc361aea07575c4bf6b0529483d5d63/components/server/src/github/scopes.ts#L22))
2. User goes to `/new` to create a new Project, and sees all their repositories as available, because [gh.repos.listForAuthenticatedUser](https://github.com/gitpod-io/gitpod/blob/5e3897debdc361aea07575c4bf6b0529483d5d63/components/server/ee/src/prebuilds/github-service.ts#L29-L41) works without special scopes
3. User selects a repository, Project gets created, then [onDidCreateProject](https://github.com/gitpod-io/gitpod/blob/b10bdc67d96ed0f8c559cc654b969c3bd68c9631/components/server/src/projects/projects-service.ts#L129-L150) looks if it can/should install a webhook
  a. [canInstallAutomatedPrebuilds](https://github.com/gitpod-io/gitpod/blob/5e3897debdc361aea07575c4bf6b0529483d5d63/components/server/ee/src/prebuilds/github-service.ts#L43-L63) returns `true`, because the user has indeed `ADMIN` permission on the repo (and GraphQL tells you that without special scopes)
  b. However, [installAutomatedPrebuilds](https://github.com/gitpod-io/gitpod/blob/5e3897debdc361aea07575c4bf6b0529483d5d63/components/server/ee/src/prebuilds/github-service.ts#L65-L80) then fails, presumably with a `404` error (to not leak the existence of a repo you shouldn't be able to access?), because you do need at least `public_repo` or `repo` scope to actually install a webhook

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8719

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
