### PR TITLE
[installer] set the ServiceType as LB for ws-proxy

### DIFF
--- a/install/installer/README.md
+++ b/install/installer/README.md
@@ -163,12 +163,21 @@ yq eval-all --inplace \
   gitpod.yaml
 ```
 
+Similarly, if you are doing a `Workspace` only install (specifying `Workspace`
+as the kind in config) you might want to change the service type of `ws-proxy` to `ClusterIP`
+instead of the default `LoadBalancer`. You can post-process the YAML to change that.
+
+```shell
+yq eval-all --inplace \
+  '(select(.kind == "Service" and .metadata.name == "ws-proxy") | .spec.type) |= "ClusterIP"' \
+  gitpod.yaml
+```
+
 ## Error validating `StatefulSet.status`
 
 ```shell
 error: error validating "gitpod.yaml": error validating data: ValidationError(StatefulSet.status): missing required field "availableReplicas" in io.k8s.api.apps.v1.StatefulSetStatus; if you choose to ignore these errors, turn validation off with --validate=false
 ```
-
 Depending upon your Kubernetes implementation, you may receive this error. This is
 due to a bug in the underlying StatefulSet dependency, which is used to generate the
 OpenVSX proxy (see [#8529](https://github.com/gitpod-io/gitpod/issues/8529)).


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, the type of the service created for `ws-proxy` is `ClusterIP` by default. When setting up in cloud in just the `Workspace` installation, this creates a requirement for having to post process the YAML to change the type to `LoadBalancer`. With this PR, the default value of `ws-proxy` service type is set as `LoadBalancer` when the installation is of the kind `Workspace`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7734

## How to test
<!-- Provide steps to test this PR -->
Set the value of `kind` in config file `Workspace`. Run the render command, `installer render --config gitpod.config.yaml > gitpod.yaml`. This will render `Service` definition of the app `ws-proxy` as type `LoadBalancer`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
