### PR TITLE
[installer] Add docs for workspace SSH access

### DIFF
--- a/install/installer/docs/workspace-ssh-access.md
+++ b/install/installer/docs/workspace-ssh-access.md
@@ -1,0 +1,26 @@
+# Installing Gitpod with SSH access to workspaces with the Gitpod Installer
+**_Needed by some desktop IDEs to connect to a workspace._**
+
+> **IMPORTANT:** When you use k3s, this will open port 22 on your Kubernetes nodes for accessing the workspaces. This will prevent login to the cluster via SSH. If you wish to maintain SSH access to your cluster, please configure another SSH port on your nodes.
+
+To enable the SSH gateway you need to generate a host key, need to add it as secret to your Kubernetes cluster, and need to configure the Gitpod Installer to use this secret.
+
+You can use `ssh-keygen` to generate a host key like this:
+
+```
+ssh-keygen -t rsa -q -N "" -f host.key
+```
+
+Add it to your Kubernetes cluster like this:
+```
+kubectl create secret generic ssh-gateway-host-key --from-file=host.key
+```
+
+Add the following to your Gitpod config `gitpod.config.yaml`:
+```yaml
+sshGatewayHostKey:
+  kind: secret
+  name: ssh-gateway-host-key
+```
+
+That's it. Install Gitpod as usual, consider adding firewall rules that allow the connection on port 22 to your workspace nodes, and you can use desktop IDEs that need SSH access to connect to your workspace.


### PR DESCRIPTION
## Description
This pull request adds docs on how to configure the Gitpod installer to enable the SSH gateway.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8493

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Meta

/werft no-preview