### PR TITLE
[cgroupv2] Enable fuse device

### DIFF
--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cilium/ebpf v0.7.0 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect
 	github.com/containerd/fifo v1.0.0 // indirect
 	github.com/containerd/ttrpc v1.1.0 // indirect

--- a/components/ws-daemon/go.sum
+++ b/components/ws-daemon/go.sum
@@ -155,6 +155,7 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -352,6 +353,7 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=

--- a/components/ws-daemon/pkg/daemon/cgroup_customizer.go
+++ b/components/ws-daemon/pkg/daemon/cgroup_customizer.go
@@ -6,10 +6,17 @@ package daemon
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/containerd/cgroups"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/dispatch"
+	"github.com/opencontainers/runc/libcontainer/cgroups/ebpf"
+	"github.com/opencontainers/runc/libcontainer/cgroups/ebpf/devicefilter"
+	"github.com/opencontainers/runc/libcontainer/devices"
+	"github.com/opencontainers/runc/libcontainer/specconv"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 )
 
@@ -18,24 +25,31 @@ var (
 	fuseDeviceMinor int64 = 229
 )
 
-type CgroupCustomizer struct {
+func NewCGroupCustomizer(basePath string, unified bool) dispatch.Listener {
+	if unified {
+		return &CgroupCustomizerV2{
+			cgroupBasePath: basePath,
+		}
+	} else {
+		return &CgroupCustomizerV1{
+			cgroupBasePath: basePath,
+		}
+	}
+}
+
+type CgroupCustomizerV1 struct {
 	cgroupBasePath string
 }
 
-func (c *CgroupCustomizer) WithCgroupBasePath(basePath string) {
+func (c *CgroupCustomizerV1) WithCgroupBasePath(basePath string) {
 	c.cgroupBasePath = basePath
 }
 
 // WorkspaceAdded will customize the cgroups for every workspace that is started
-func (c *CgroupCustomizer) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspace) error {
-	disp := dispatch.GetFromContext(ctx)
-	if disp == nil {
-		return xerrors.Errorf("no dispatch available")
-	}
-
-	cgroupPath, err := disp.Runtime.ContainerCGroupPath(context.Background(), ws.ContainerID)
+func (c *CgroupCustomizerV1) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspace) error {
+	cgroupPath, err := retrieveCGroupPath(ctx, ws.ContainerID)
 	if err != nil {
-		return xerrors.Errorf("cannot start governer: %w", err)
+		return err
 	}
 
 	control, err := cgroups.Load(c.customV1, cgroups.StaticPath(cgroupPath))
@@ -64,8 +78,72 @@ func (c *CgroupCustomizer) WorkspaceAdded(ctx context.Context, ws *dispatch.Work
 	return nil
 }
 
-func (c *CgroupCustomizer) customV1() ([]cgroups.Subsystem, error) {
+func (c *CgroupCustomizerV1) customV1() ([]cgroups.Subsystem, error) {
 	return []cgroups.Subsystem{
 		cgroups.NewDevices(c.cgroupBasePath),
 	}, nil
+}
+
+type CgroupCustomizerV2 struct {
+	cgroupBasePath string
+}
+
+func (c *CgroupCustomizerV2) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspace) error {
+	cgroupPath, err := retrieveCGroupPath(ctx, ws.ContainerID)
+	if err != nil {
+		return err
+	}
+
+	fullCgroupPath := filepath.Join(c.cgroupBasePath, cgroupPath)
+	cgroupFD, err := unix.Open(fullCgroupPath, unix.O_DIRECTORY|unix.O_RDONLY, 0o600)
+	if err != nil {
+		return xerrors.Errorf("cannot get directory fd for %s", fullCgroupPath)
+	}
+	defer unix.Close(cgroupFD)
+
+	insts, license, err := devicefilter.DeviceFilter(composeDeviceRules())
+	if err != nil {
+		return xerrors.Errorf("failed to generate device filter: %w", err)
+	}
+
+	_, err = ebpf.LoadAttachCgroupDeviceFilter(insts, license, cgroupFD)
+	return err
+}
+
+func retrieveCGroupPath(ctx context.Context, id container.ID) (string, error) {
+	disp := dispatch.GetFromContext(ctx)
+	if disp == nil {
+		return "", xerrors.Errorf("no dispatch available")
+	}
+
+	cgroupPath, err := disp.Runtime.ContainerCGroupPath(context.Background(), id)
+	if err != nil {
+		return "", xerrors.Errorf("cannot retrieve cgroup path: %w", err)
+	}
+
+	return cgroupPath, nil
+}
+
+func composeDeviceRules() []*devices.Rule {
+	denyAll := devices.Rule{
+		Type:        'a',
+		Permissions: "rwm",
+		Allow:       false,
+	}
+
+	allowFuse := devices.Rule{
+		Type:        'c',
+		Major:       fuseDeviceMajor,
+		Minor:       fuseDeviceMinor,
+		Permissions: "rwm",
+		Allow:       true,
+	}
+
+	deviceRules := make([]*devices.Rule, 0)
+	deviceRules = append(deviceRules, &denyAll, &allowFuse)
+	for _, device := range specconv.AllowedDevices {
+		deviceRules = append(deviceRules, &device.Rule)
+	}
+
+	return deviceRules
 }

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect
+	github.com/cilium/ebpf v0.7.0 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containerd/containerd v1.6.0 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect

--- a/install/installer/go.sum
+++ b/install/installer/go.sum
@@ -223,6 +223,7 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -474,6 +475,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNy
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
## Description
Enable fuse device on nodes that are using cgroup v2. 

## Related Issue(s)
Fixes #8417

## How to test
- Open workspace on a cgroup v2 system
- Compile this program (gcc -o fuse_test fuse_test.c)
```
#define _GNU_SOURCE
#include <unistd.h>

#include <sys/syscall.h>
#include <linux/fs.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <fcntl.h>
#include <stdio.h>


int main() {
  const char* src_path = "/dev/fuse";
  unsigned int flags = O_RDWR;
  printf("RET: %ld", syscall(SYS_openat, AT_FDCWD, src_path, flags));
}
```
- fuse_test should return 3

## Notes for reviewers
My initial implementation was using a runc facade like we discussed in #8471, but I switched to instead replacing the ebpf program that runc generates with our own.
- No need to touch the host (copying the runtime facade, modifying the config of containerd or of other runtimes if we want to support them in the future)
- No need to specify a runtime class when creating the workspace
- Implementation uses the same approach as the cgroup v1 implementation
- Less code

## Release Notes
```release-note
Enable the use of fuse device on cgroup v2 systems
```