### PR TITLE
Update team deletion confirmation modal

### DIFF
--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -89,10 +89,6 @@ export default function TeamSettings() {
                         All <b>projects</b> added in this team will be deleted and cannot be restored afterwards.
                     </li>
                     <li className="ml-5">
-                        All <b>workspaces</b> opened for projects within this team will be deleted for all team members
-                        and cannot be restored afterwards.
-                    </li>
-                    <li className="ml-5">
                         All <b>members</b> of this team will lose access to this team, associated projects and
                         workspaces.
                     </li>


### PR DESCRIPTION
## Description

Update team deletion modal to reflect changes in the product.

## How to test
1. Create a team
2. Try to delete a team
3. Check the confirmation modal is accurate

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update team deletion confirmation modal
```