### PR TITLE
Clarify WS Conditions - failed vs headlessTaskFailed

### DIFF
--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -55,7 +55,7 @@ export interface WorkspaceInstance {
     /**
      * Contains information about the image build, if there was any
      */
-     imageBuildInfo?: ImageBuildInfo;
+    imageBuildInfo?: ImageBuildInfo;
 }
 
 // WorkspaceInstanceStatus describes the current state of a workspace instance
@@ -95,49 +95,50 @@ export interface WorkspaceInstanceStatus {
 export type WorkspaceInstancePhase =
     // unknown indicates an issue within the system in that it cannot determine the actual phase of
     // a workspace. This phase is usually accompanied by an error.
-    "unknown" |
+    | "unknown"
 
     // Preparing means that we haven't actually started the workspace instance just yet, but rather
     // are still preparing for launch. This means we're building the Docker image for the workspace.
-    "preparing" |
+    | "preparing"
 
     // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
     // some space within the cluster. If for example the cluster needs to scale up to accomodate the
     // workspace, the workspace will be in Pending state until that happened.
-    "pending" |
+    | "pending"
 
     // Creating means the workspace is currently being created. Thati includes downloading the images required
     // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
     // network speed, image size and cache states.
-    "creating" |
+    | "creating"
 
     // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
     // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
-    "initializing" |
+    | "initializing"
 
     // Running means the workspace is able to actively perform work, either by serving a user through Theia,
     // or as a headless workspace.
-    "running" |
+    | "running"
 
     // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
     // When in this state, we expect it to become running or stopping anytime soon.
-    "interrupted" |
+    | "interrupted"
 
     // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
-    "stopping" |
+    | "stopping"
 
     // Stopped means the workspace ended regularly because it was shut down.
-    "stopped";
+    | "stopped";
 
 export interface WorkspaceInstanceConditions {
     // Failed contains the reason the workspace failed to operate. If this field is empty, the workspace has not failed.
-    failed?: string
+    // failed contains technical details for the failure of the workspace.
+    failed?: string;
 
     // timeout contains the reason the workspace has timed out. If this field is empty, the workspace has not timed out.
-    timeout?: string
+    timeout?: string;
 
     // PullingImages marks if the workspace is currently pulling its images. This condition can only be set during PhaseCreating
-    pullingImages?: boolean
+    pullingImages?: boolean;
 
     // deployed marks that a workspace instance was sent/deployed at a workspace manager
     deployed?: boolean;
@@ -148,7 +149,10 @@ export interface WorkspaceInstanceConditions {
     // ISO8601 timestamp when the first user activity was registered in the frontend. Only set if the workspace is running.
     firstUserActivity?: string;
 
-    // headless_task_failed indicates that a headless workspace task failed
+    // headlessTaskFailed indicates that a headless workspace task failed
+    // headlessTaskFailed is only set if:
+    //  * this workspace is headless
+    //  * the task being run returned a non 0 exit status code
     headlessTaskFailed?: string;
 
     // stopped_by_request is true if the workspace was stopped using a StopWorkspace call
@@ -156,10 +160,10 @@ export interface WorkspaceInstanceConditions {
 }
 
 // AdmissionLevel describes who can access a workspace instance and its ports.
-export type AdmissionLevel = 'owner_only' | 'everyone';
+export type AdmissionLevel = "owner_only" | "everyone";
 
 // PortVisibility describes how a port can be accessed
-export type PortVisibility = 'public' | 'private';
+export type PortVisibility = "public" | "private";
 
 // WorkspaceInstancePort describes a port exposed on a workspace instance
 export interface WorkspaceInstancePort {
@@ -185,19 +189,19 @@ export interface WorkspaceInstanceRepoStatus {
     uncommitedFiles?: string[];
 
     // the total number of uncommited files
-    totalUncommitedFiles?: number
+    totalUncommitedFiles?: number;
 
     // untrackedFiles is the list of untracked files in the workspace, possibly truncated
     untrackedFiles?: string[];
 
     // the total number of untracked files
-    totalUntrackedFiles?: number
+    totalUntrackedFiles?: number;
 
     // unpushedCommits is the list of unpushed changes in the workspace, possibly truncated
     unpushedCommits?: string[];
 
     // the total number of unpushed changes
-    totalUnpushedCommits?: number
+    totalUnpushedCommits?: number;
 }
 
 // WorkspaceInstanceConfiguration contains all per-instance configuration
@@ -213,7 +217,7 @@ export interface WorkspaceInstanceConfiguration {
     ideImage: string;
 
     // desktopIdeImage is the ref of the desktop IDE image this instance uses.
-    desktopIdeImage?: string
+    desktopIdeImage?: string;
 
     // supervisorImage is the ref of the supervisor image this instance uses.
     supervisorImage?: string;
@@ -223,13 +227,13 @@ export interface WorkspaceInstanceConfiguration {
  * Holds information about the image build (if there was one) for this WorkspaceInstance
  */
 export interface ImageBuildInfo {
-    log?: ImageBuildLogInfo,
+    log?: ImageBuildLogInfo;
 }
 
 /**
  * Holds information about how to access logs for this an image build
  */
 export interface ImageBuildLogInfo {
-    url: string,
-    headers: { [key: string]: string },
+    url: string;
+    headers: { [key: string]: string };
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Extends code-level documentation of `WorkspaceInstanceConditions`, in particular around `failed` and `healdessTaskFailed`
* Applies prettier style (can extract into a pre-PR if needed).



## How to test
<!-- Provide steps to test this PR -->
No logic change.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```