### PR TITLE
[Analytics] Enrich 'workspace_started' call with projectId and type

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -357,7 +357,9 @@ export class WorkspaceStarter {
                 properties: {
                     workspaceId: workspace.id,
                     instanceId: instance.id,
+                    projectId: workspace.projectId,
                     contextURL: workspace.contextURL,
+                    type: workspace.type,
                     usesPrebuild: spec.getInitializer()?.hasPrebuild(),
                 },
             });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Augments the `workspace_started` event call with `projectId`, `type`, `context`, and `config`.
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

1. Open a preview environment, sign up and start a workspace
2. Go to the [debugger of Staging Untrusted
](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and ensure the `workspace_started` event is delivered, including the new properties `projectId`, `type`, `context`, and `config`
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe