### PR TITLE
Add job attributes to all spans

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -49,9 +49,9 @@ export interface Observability {
 }
 
 export function jobConfig(werft: Werft, context: any): JobConfig {
-    const slideId = 'Parsing job configuration'
+    const sliceId = 'Parsing job configuration'
     werft.phase('Job configuration')
-    werft.log(slideId, "Parsing the job configuration")
+    werft.log(sliceId , "Parsing the job configuration")
     const version = parseVersion(context)
     const repo = `${context.Repository.host}/${context.Repository.owner}/${context.Repository.repo}`;
     const mainBuild = repo === "github.com/gitpod-io/gitpod" && context.Repository.ref.includes("refs/heads/main");
@@ -144,9 +144,9 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         return [`werft.job.config.${key}`, value]
     }))
     globalAttributes['werft.job.config.branch'] = context.Repository.ref
-    werft.addGlobalAttributes(globalAttributes)
+    werft.addAttributes(globalAttributes)
 
-    werft.done(slideId)
+    werft.done(sliceId)
 
     return jobConfig
 }

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -49,6 +49,9 @@ export interface Observability {
 }
 
 export function jobConfig(werft: Werft, context: any): JobConfig {
+    const slideId = 'Parsing job configuration'
+    werft.phase('Job configuration')
+    werft.log(slideId, "Parsing the job configuration")
     const version = parseVersion(context)
     const repo = `${context.Repository.host}/${context.Repository.owner}/${context.Repository.repo}`;
     const mainBuild = repo === "github.com/gitpod-io/gitpod" && context.Repository.ref.includes("refs/heads/main");
@@ -136,11 +139,15 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     }
 
     werft.log("job config", JSON.stringify(jobConfig));
-    werft.rootSpan.setAttributes(Object.fromEntries(Object.entries(jobConfig).map((kv) => {
+    const globalAttributes = Object.fromEntries(Object.entries(jobConfig).map((kv) => {
         const [key, value] = kv
         return [`werft.job.config.${key}`, value]
-    })))
-    werft.rootSpan.setAttribute('werft.job.config.branch', context.Repository.ref)
+    }))
+    globalAttributes['werft.job.config.branch'] = context.Repository.ref
+    werft.addGlobalAttributes(globalAttributes)
+
+    werft.done(slideId)
+
     return jobConfig
 }
 

--- a/.werft/util/werft.ts
+++ b/.werft/util/werft.ts
@@ -123,7 +123,7 @@ export class Werft {
      * This allows you to set attributes on all open and future Werft spans.
      * Any spans in phases that have already been closed won't get the attributes.
      */
-    public addGlobalAttributes(attributes: SpanAttributes): void {
+    public addAttributes(attributes: SpanAttributes): void {
 
         // Add the attributes to the root span.
         this.rootSpan.setAttributes(attributes)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds Werft job configuration span attributes - the ones in the namespace `werft.job.config.` - to all spans instead of just the root span. This is helpful as we often want to know how a job config influences a specific slice or phase, e.g. how does `werft.job.config.withVM` impact the deploy phase (for duration, error rates, etc.).

A note on the implementation. As far as I could see, the only way to add "global attributes" using the OpenTelemetry SDK for Node would be to provide a custom [SpanProcessor](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk_trace_base.SpanProcessor.html) which would add the attributes as it "processes" the spans - we would then add that along-side the one we use already. However, the SpanProcessor interface doesn't allow you to modify spans onEnd (it takes a ReadableSpan) only in onStart. That means we wouldn't get the attributes on all spans, only the ones that are started after we have parsed the job configuration (this means we wouldn't get it on the root span unless we also added logic to add it there).

So instead I went with adding the attributes to all the spans in our Werft class. This will still only allow us to add the attributes to spans in the currently open phase and all future phases/slices. As parsing the job configuration is the first phase, this effectively means we get it on the spans for all Werft spans.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8790

## How to test
<!-- Provide steps to test this PR -->

Here's [the trace](https://ui.honeycomb.io/gitpod/datasets/werft/trace/2tL6meww9YA?span=a02c8bdca5f4afc1) for [gitpod-build-mads-hartmann-propagate-job-attributes-8790.5](https://werft.gitpod-dev.com/job/gitpod-build-mads-hartmann-propagate-job-attributes-8790.5). The screenshot below shows that the werft attributes are not added to other spans than just the root span.

<img width="1355" alt="Screenshot 2022-03-17 at 20 26 48" src="https://user-images.githubusercontent.com/83561/158880688-bea92d2d-c321-4172-bb64-d4b873f759b9.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A