### PR TITLE
[dashboard] Show prebuild status based on prebuild workspace record

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -13,7 +13,7 @@ import PrebuildLogs from "../components/PrebuildLogs";
 import Spinner from "../icons/Spinner.svg";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
-import { PrebuildInstanceStatus } from "./Prebuilds";
+import { PrebuildStatus } from "./Prebuilds";
 import { shortCommitMessage } from "./render-utils";
 
 export default function () {
@@ -167,7 +167,7 @@ export default function () {
                         />
                     </div>
                     <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
-                        {prebuildInstance && <PrebuildInstanceStatus prebuildInstance={prebuildInstance} />}
+                        {prebuildInstance && <PrebuildStatus prebuild={prebuild!} />}
                         <div className="flex-grow" />
                         {prebuild?.status === "aborted" || prebuild?.status === "timeout" || !!prebuild?.error ? (
                             <button

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -167,7 +167,7 @@ export default function () {
                         />
                     </div>
                     <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
-                        {prebuildInstance && <PrebuildStatus prebuild={prebuild!} />}
+                        {prebuild && <PrebuildStatus prebuild={prebuild} />}
                         <div className="flex-grow" />
                         {prebuild?.status === "aborted" || prebuild?.status === "timeout" || !!prebuild?.error ? (
                             <button

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -329,12 +329,66 @@ export function prebuildStatusIcon(prebuild?: PrebuildWithStatus) {
     }
 }
 
+function PrebuildStatusDescription(props: { prebuild: PrebuildWithStatus }) {
+    switch (props.prebuild.status) {
+        case "queued":
+            return <span>Prebuild is queued and will be processed when there is execution capacity.</span>;
+        case "building":
+            return <span>Prebuild is currently in progress.</span>;
+        case "aborted":
+            return (
+                <span>
+                    Prebuild has been cancelled. Either a user cancelled it, or the prebuild rate limit has been
+                    exceeded. {props.prebuild.error}
+                </span>
+            );
+        case "failed":
+            return <span>Prebuild failed for system reasons. Please contact support. {props.prebuild.error}</span>;
+        case "timeout":
+            return (
+                <span>
+                    Prebuild timed out. Either the image, or the prebuild tasks took too long. {props.prebuild.error}
+                </span>
+            );
+        case "available":
+            if (props.prebuild?.error) {
+                return (
+                    <span>
+                        The tasks executed in the prebuild returned a non-zero exit code. {props.prebuild.error}
+                    </span>
+                );
+            }
+            return <span>Prebuild completed succesfully.</span>;
+        default:
+            return <span>Unknown prebuild status.</span>;
+    }
+}
+
 function formatDuration(milliseconds: number) {
     const hours = Math.floor(milliseconds / (1000 * 60 * 60));
     return (hours > 0 ? `${hours}:` : "") + moment(milliseconds).format("mm:ss");
 }
 
-export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInstance }) {
+export function PrebuildStatus(props: { prebuild: PrebuildWithStatus }) {
+    const prebuild = props.prebuild;
+
+    return (
+        <div className="flex flex-col space-y-1 justify-center text-sm font-semibold">
+            <div>
+                <div className="flex space-x-1 items-center">
+                    {prebuildStatusIcon(prebuild)}
+                    {prebuildStatusLabel(prebuild)}
+                </div>
+            </div>
+            <div className="flex space-x-1 items-center text-gray-400">
+                <PrebuildStatusDescription prebuild={prebuild} />
+            </div>
+        </div>
+    );
+}
+
+// Deprecated. Use PrebuildStatus instead.
+export function PrebuildInstanceStatus(props: { prebuildInstance?: WorkspaceInstance; prebuild?: PrebuildWithStatus }) {
     let status = <></>;
     let details = <></>;
     switch (props.prebuildInstance?.status.phase) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, the Prebuild detail view (with logs and status) uses the `WorkspaceInstance` status. This is inconsistent with respect to the Prebuild List view. This PR uses the `prebuild` status instead of status from the `WorkspaceInstance`.

This PR does not remove all instances of this inconcistent usage (another in [ConfigureProject.tsx](https://github.com/gitpod-io/gitpod/blob/main/components/dashboard/src/projects/ConfigureProject.tsx#L368)). It will be removed in a subsequent PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Related to #5611
* Relates to #7384
* Relates to #8197

## How to test
<!-- Provide steps to test this PR -->
1. [Preview env](https://mp-pb-status.staging.gitpod-dev.com/)
2. Add/clone https://gitlab.com/gitpod-milan/gitpod-large-image as a Project
3. Trigger builds for the following branches:
	* main
	* pass
	* timeout
	* fail-prebuild
4. Observe various statuses reported
5. Trigger a new prebuild and cancel it manually - observe cancelled status

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Dashboard reports prebuild status consistently between list view and detail view.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## How it looks
<img width="1354" alt="Screenshot 2022-03-15 at 19 41 18" src="https://user-images.githubusercontent.com/1419286/158448898-65b4616f-17fd-419b-8c0d-b045232714fa.png">
<img width="1372" alt="Screenshot 2022-03-15 at 19 41 11" src="https://user-images.githubusercontent.com/1419286/158448906-3956a49d-690e-447d-845d-7279ff15bb4b.png">
<img width="1329" alt="Screenshot 2022-03-15 at 19 41 02" src="https://user-images.githubusercontent.com/1419286/158448910-9577f648-8030-4cae-8e03-a468d30fcc95.png">
<img width="1343" alt="Screenshot 2022-03-15 at 19 42 51" src="https://user-images.githubusercontent.com/1419286/158449095-4abd696c-c4c2-4ad2-9f47-cbdb1b34eeb1.png">
<img width="1335" alt="Screenshot 2022-03-15 at 19 42 39" src="https://user-images.githubusercontent.com/1419286/158449097-68169607-2056-4205-91d1-ea8170937f4e.png">
<img width="1350" alt="Screenshot 2022-03-15 at 19 45 31" src="https://user-images.githubusercontent.com/1419286/158449505-1103e9f9-03e6-4caf-8617-e5834cc8da3f.png">

## Open questions
* Designs could be improved with respect to showing the underlying error. I think we can follow-up with a cleanup of the styling to communicate the underlying error message more cleanly

/hold

- [x] /werft with-clean-slate-deployment