### PR TITLE
Use timingSafeEqual for signature comparision

### DIFF
--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -5,7 +5,8 @@
  */
 
 import * as express from "express";
-import { createHmac } from "crypto";
+import { createHmac, timingSafeEqual } from "crypto";
+import { Buffer } from 'buffer'
 import { postConstruct, injectable, inject } from "inversify";
 import { ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { PrebuildManager } from "../prebuilds/prebuild-manager";
@@ -97,7 +98,7 @@ export class GitHubEnterpriseApp {
                     createHmac("sha256", user.id + "|" + tokenEntry.token.value)
                         .update(body)
                         .digest("hex");
-                return sig === signature;
+                return timingSafeEqual(Buffer.from(sig), Buffer.from(signature ?? ''));
             });
             if (!signingToken) {
                 throw new Error(`User ${user.id} has no token matching the payload signature.`);

--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -6,7 +6,7 @@
 
 import * as express from "express";
 import { createHmac, timingSafeEqual } from "crypto";
-import { Buffer } from 'buffer'
+import { Buffer } from "buffer";
 import { postConstruct, injectable, inject } from "inversify";
 import { ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { PrebuildManager } from "../prebuilds/prebuild-manager";
@@ -98,7 +98,7 @@ export class GitHubEnterpriseApp {
                     createHmac("sha256", user.id + "|" + tokenEntry.token.value)
                         .update(body)
                         .digest("hex");
-                return timingSafeEqual(Buffer.from(sig), Buffer.from(signature ?? ''));
+                return timingSafeEqual(Buffer.from(sig), Buffer.from(signature ?? ""));
             });
             if (!signingToken) {
                 throw new Error(`User ${user.id} has no token matching the payload signature.`);


### PR DESCRIPTION
## Description

Address [this comment](https://github.com/gitpod-io/gitpod/pull/8574#discussion_r822892187) in a previous review of the work to support GHE.

## Related Issue(s)


## How to test

Use the steps in the **How to test** section of #8574 to add a GHE integration and ensure that prebuilds are triggered as expected.

## Release Notes

```release-note
NONE
```
