### PR TITLE
Extend build to typecheck Typescript files in .werft

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -10,6 +10,7 @@ import { prepare } from './jobs/build/prepare';
 import { deployToPreviewEnvironment } from './jobs/build/deploy-to-preview-environment';
 import { triggerIntegrationTests } from './jobs/build/trigger-integration-tests';
 import { jobConfig } from './jobs/build/job-config';
+import { typecheckWerftJobs } from './jobs/build/typecheck-werft-jobs';
 
 // Will be set once tracing has been initialized
 let werft: Werft
@@ -47,6 +48,7 @@ async function run(context: any) {
 
     await validateChanges(werft, config)
     await prepare(werft, config)
+    await typecheckWerftJobs(werft)
     await buildAndPublish(werft, config)
 
     if (config.noPreview) {

--- a/.werft/jobs/build/typecheck-werft-jobs.ts
+++ b/.werft/jobs/build/typecheck-werft-jobs.ts
@@ -1,0 +1,17 @@
+import { Werft } from "../../util/werft";
+import { exec } from "../../util/shell";
+
+/**
+ * This validates all the .ts files inside of the .werft folder and fails the
+ * build if there are compile errors.
+ */
+export async function typecheckWerftJobs(werft: Werft) {
+    werft.phase("Typecheck Typescript Werft files", "Typechecking Werft Typescript files");
+    const slice = "tsc";
+    try {
+        exec("cd .werft && tsc --noEmit", { slice });
+    } catch (e) {
+        werft.fail(slice, e);
+    }
+    werft.done(slice);
+}

--- a/.werft/jobs/build/typecheck-werft-jobs.ts
+++ b/.werft/jobs/build/typecheck-werft-jobs.ts
@@ -7,9 +7,10 @@ import { exec } from "../../util/shell";
  */
 export async function typecheckWerftJobs(werft: Werft) {
     werft.phase("Typecheck Typescript Werft files", "Typechecking Werft Typescript files");
-    const slice = "tsc";
+    const slice = "tsc --noEmit";
     try {
         exec("cd .werft && tsc --noEmit", { slice });
+        werft.log(slice, 'No compilation errors.')
     } catch (e) {
         werft.fail(slice, e);
     }

--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -1,9 +1,9 @@
-import { Werft } from '../util/werft';
-import * as Tracing from '../observability/tracing';
+import { Werft } from './util/werft';
+import * as Tracing from './observability/tracing';
 import { SpanStatusCode } from '@opentelemetry/api';
-import { wipePreviewEnvironmentAndNamespace, helmInstallName, listAllPreviewNamespaces } from '../util/kubectl';
-import { exec } from '../util/shell';
-import { previewNameFromBranchName } from '../util/preview';
+import { wipePreviewEnvironmentAndNamespace, helmInstallName, listAllPreviewNamespaces } from './util/kubectl';
+import { exec } from './util/shell';
+import { previewNameFromBranchName } from './util/preview';
 
 // Will be set once tracing has been initialized
 let werft: Werft


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently we don't validate any of the Typescript files we have in .werft as part of our build. We indirectly test build.ts of course as we run it for our build, but if you're modifying any of the other jobs it's possible to get a green build even when you have type errors (as I have done in the past, oops!)

This runs `tsc --noEmit` as part of our build and also fixes the TS error I had introduced previously.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
(Indirectly) Part of https://github.com/gitpod-io/ops/issues/1255 as that's where I introduced the TS errors.

## How to test
<!-- Provide steps to test this PR -->

- See job that failed when I had introduced the typechecking, but not yet fixed the errors ([link](https://werft.gitpod-dev.com/job/gitpod-build-mads-extend-build-to-tsc-werft-jobs.1))
- See job that succeeded after having fixed the TS errors ([link](https://werft.gitpod-dev.com/job/gitpod-build-mads-extend-build-to-tsc-werft-jobs.4))
- Job that I triggered manually using `werft run github -j platform-delete-preview-environments-cron.yaml -s platform-delete-preview-environments-cron.ts` ([link](https://werft.gitpod-dev.com/job/gitpod-custom-mads-extend-build-to-tsc-werft-jobs.0))

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A