### PR TITLE
.werft/observabilityAdd configuration to deploy kubescape

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -63,6 +63,7 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
                 requests: { memory: '200Mi', cpu: '50m' },
             },
         },
+        kubescape: {},
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
As a follow-up to https://github.com/gitpod-io/observability/pull/100, we're adding Kubescape to our preview environments so one can search for vulnerabilities while developing.

## How to test
<!-- Provide steps to test this PR -->

- Spin up a preview environment (prefer to use the `with-vm=true` annotation)
- run `./dev/preview/portforward-monitoring-satellite-harvester.sh`
- look for the `Kubescape / Vulnerabilities` dashboard inside the Platform Team folder

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
