### PR TITLE
[server] For GitLab projects without an owner avatar, fall back to the namespace avatar, or generate the default GitLab avatar

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -237,7 +237,11 @@ export default function NewProject() {
 
     const accounts = new Map<string, { avatarUrl: string }>();
     reposInAccounts.forEach((r) => {
-        if (!accounts.has(r.account)) accounts.set(r.account, { avatarUrl: r.accountAvatarUrl });
+        if (!accounts.has(r.account)) {
+            accounts.set(r.account, { avatarUrl: r.accountAvatarUrl });
+        } else if (!accounts.get(r.account)?.avatarUrl && r.accountAvatarUrl) {
+            accounts.get(r.account)!.avatarUrl = r.accountAvatarUrl;
+        }
     });
 
     const getDropDownEntries = (accounts: Map<string, { avatarUrl: string }>) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

For GitLab projects belonging to a group, it seems that there is no `owner.avatar_url` to be found here:

https://github.com/gitpod-io/gitpod/blob/fc68e4780eae27c5a3e7c0907f457ebb393a0371/components/server/ee/src/gitlab/gitlab-app-support.ts#L46

Example group project from GitLab's API:

```ts
{
  "id": 23116976,
  "description": "",
  "name": "sample-project",
  "name_with_namespace": "reproduction-group / sample-project",
  /* ... (no "owner") ... */
  "namespace": {
    "id": 10408914,
    "name": "reproduction-group",
    /* ... */
    "avatar_url": "/uploads/-/system/group/avatar/10408914/gitpod-ua.png",
    "web_url": "https://gitlab.com/groups/reproduction-group"
  },
  /* ... */
}
```

As you can see, there is no `"owner"`, but there is an avatar URL on the `"namespace"` (although it's relative).

When there is no owner avatar URL, this Pull Request falls back to the namespace avatar URL if available.

EDIT: When no avatar is available, it generates a SVG avatar that looks like GitLab's own default group avatar.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5330

## How to test
<!-- Provide steps to test this PR -->

1. Connect with GitLab
2. Be part of a group which has an avatar (e.g. https://gitlab.com/reproduction-group)
3. Go to `/new` -- the GitLab group should have the set avatar visible

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] For GitLab projects without an owner avatar, fall back to the namespace avatar, or generate the default GitLab avatar
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
