### PR TITLE
[server] Improve GitHub Enterprise avatars handling

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -280,7 +280,7 @@ export default function (props: { project?: Project; isAdminDashboard?: boolean 
                                         <p>
                                             {p.info.changeAuthorAvatar && (
                                                 <img
-                                                    className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2"
+                                                    className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2 overflow-hidden"
                                                     src={p.info.changeAuthorAvatar || ""}
                                                     alt={p.info.changeAuthor}
                                                 />

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -261,7 +261,7 @@ export default function () {
 
                                     const avatar = branch.changeAuthorAvatar && (
                                         <img
-                                            className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2"
+                                            className="rounded-full w-4 h-4 inline-block align-text-bottom mr-2 overflow-hidden"
                                             src={branch.changeAuthorAvatar || ""}
                                             alt={branch.changeAuthor}
                                         />

--- a/components/server/ee/src/prebuilds/github-service.ts
+++ b/components/server/ee/src/prebuilds/github-service.ts
@@ -32,8 +32,10 @@ export class GitHubService extends RepositoryService {
             return <ProviderRepository>{
                 name: r.name,
                 cloneUrl: r.clone_url,
-                account: r.owner?.login,
-                accountAvatarUrl: r.owner?.avatar_url,
+                account: r.owner.login,
+                accountAvatarUrl: r.owner.gravatar_id
+                    ? `https://www.gravatar.com/avatar/${r.owner.gravatar_id}?size=128`
+                    : r.owner.avatar_url,
                 updatedAt: r.updated_at,
             };
         });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

GitHub Enterprise doesn't seem to allow cross-origin requests for user avatars, leading to a broken Gitpod UI.

Also, I initially wanted to fetch the avatars, and encode them as data URIs, however GitHub Enterprise also doesn't seem to have an API to download avatars (only browser authentication via cookies seems to work).

Thankfully, GitHub Enterprise does provide a Gravatar ID that we can use. This Pull Request does just that whenever possible, and also improves the display of avatars that cannot be found or loaded.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8755
Partially improves https://github.com/gitpod-io/gitpod/issues/8815

## How to test
<!-- Provide steps to test this PR -->

1. Connect with GitHub Enterprise
2. Open the org selector in `/new`
3. The avatars should work for all accounts/orgs that use Gravatar
4. Add a project and start a prebuild for a repo where the owner does **not** use Gravatar
5. In the Project Branches & Prebuilds pages, the broken avatar will show the alt text, but it should be truncated such that the rest of the details are still legible

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Improve GitHub Enterprise avatars handling
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
