### PR TITLE
Fix docker run --privileged

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -414,11 +414,6 @@ func installUidMap() error {
 }
 
 func installRunc() error {
-	_, exists := os.LookupEnv(DaemonArgs)
-	if !exists {
-		return nil
-	}
-
 	runc, _ := exec.LookPath("runc")
 	if runc != "" {
 		// if the required version or a more recent one is already


### PR DESCRIPTION
## Description
Allow use of the privileged flag with docker. Previously this would cause an error. The fix is to ensure that the latest version of runc is installed.

## Related Issue(s)
Fixes #2459 

## How to test
- docker run --privileged -it busybox sh
--> No error should be happening

## Release Notes
```release-note
Allow use of the --privileged flag with docker.
```
