### PR TITLE
[server] always use `.` for image builder checkoutLocation

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -718,8 +718,7 @@ export class WorkspaceStarter {
             if (WorkspaceImageSourceDocker.is(imgsrc)) {
                 let source: WorkspaceInitializer;
                 const disp = new DisposableCollection();
-                let checkoutLocation =
-                    (CommitContext.is(workspace.context) && workspace.context.checkoutLocation) || ".";
+                let checkoutLocation = ".";
                 if (
                     !AdditionalContentContext.hasDockerConfig(workspace.context, workspace.config) &&
                     imgsrc.dockerFileSource


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
all preview environment can't build image, this is because
https://github.com/gitpod-io/gitpod/blob/45f13cf8e9214db664adc23a418e53d92364fbb7/components/server/src/workspace/workspace-starter.ts#L721-L735
L721 using workspace.context.checkoutLocation and L735 is . 

In image build stage we don't care checkoutLocation, this PR always use `.` for checkoutLocation
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace which need image build, like `https://github.com/iQQBot/test.test` you will see image builder is work
2. and start another workspace check everything is like before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixes image builder not work
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
