### PR TITLE
[installer]: allow for minified config YAML

### DIFF
--- a/install/installer/pkg/config/loader.go
+++ b/install/installer/pkg/config/loader.go
@@ -105,7 +105,8 @@ func Load(overrideConfig string) (cfg interface{}, version string, err error) {
 
 	// `apiVersion: vx` line is removed from config since the version dependant
 	// Config structure doesn't have that field
-	apiVersionRegexp := regexp.MustCompile(`apiVersion: .+\n`)
+	// The line-ending is either comma (minified YAML) or newline (unminified)
+	apiVersionRegexp := regexp.MustCompile(`apiVersion: ` + apiVersion + `(,|\n)`)
 	overrideConfig = apiVersionRegexp.ReplaceAllString(overrideConfig, "")
 
 	// Override passed configuration onto the default

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag - using this tag as need the license evaluator
-          image: 'eu.gcr.io/gitpod-core-dev/build/installer:sje-kots-helm.7'
+          image: 'eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-mini-config.0'
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -171,6 +171,7 @@ spec:
               appVersion: "$(/app/installer version | yq e '.version' -)"
               EOF
 
+              echo "Gitpod: render Kubernetes manifests"
               /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} > "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
               # Workaround for #8532 and #8529


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The regex for the `apiVersion` errored if the YAML was minified, which is what we're using in KOTS installation job.

## How to test
<!-- Provide steps to test this PR -->
Run `gitpod-installer render` with both the config in `example-config.yaml` and a minified version (below)

```yaml
{apiVersion: v1, authProviders: [], blockNewUsers: {enabled: false, passlist: []}, certificate: {kind: secret, name: https-certificates}, containerRegistry: {inCluster: true}, database: {inCluster: true}, disableDefinitelyGp: false, domain: "gitpod.io", kind: Full, metadata: {region: local}, objectStorage: {inCluster: true}, observability: {logLevel: info}, openVSX: {url: 'https://open-vsx.org'}, repository: eu.gcr.io/gitpod-core-dev/build, workspace: {resources: {requests: {cpu: "1", memory: 2Gi}}, runtime: {containerdRuntimeDir: /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io, containerdSocket: /run/k3s/containerd/containerd.sock, fsShiftMethod: fuse}}, license: {kind: secret, name: gitpod-license}}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: allow for minified config YAML
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
