### PR TITLE
Discard log output from slirp4netns

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -486,9 +486,6 @@ var ring1Cmd = &cobra.Command{
 		slirpCmd.SysProcAttr = &syscall.SysProcAttr{
 			Pdeathsig: syscall.SIGKILL,
 		}
-		slirpCmd.Stdin = os.Stdin
-		slirpCmd.Stdout = os.Stdout
-		slirpCmd.Stderr = os.Stderr
 
 		err = slirpCmd.Start()
 		if err != nil {


### PR DESCRIPTION
## Description
Discard log output from slirp4netns.

![slirp4netns_log_output](https://user-images.githubusercontent.com/24721048/158571829-726bad15-b45a-422b-bad9-f93870cde291.png)


## Related Issue(s)
Partially fixes #1337. The rest seems to come from supervisor.

## How to test
- Open workspace and check logs in GCP

## Release Notes
```release-note
NONE
```

