### PR TITLE
[dashboard]: Use prebuild record when determining prebuild actions

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -19,7 +19,6 @@ const WorkspaceLogs = React.lazy(() => import("./WorkspaceLogs"));
 
 export interface PrebuildLogsProps {
     workspaceId?: string;
-    onInstanceUpdate?: (instance: WorkspaceInstance) => void;
 }
 
 export default function PrebuildLogs(props: PrebuildLogsProps) {
@@ -81,9 +80,6 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
     }, [props.workspaceId]);
 
     useEffect(() => {
-        if (props.onInstanceUpdate && workspaceInstance) {
-            props.onInstanceUpdate(workspaceInstance);
-        }
         switch (workspaceInstance?.status.phase) {
             // Preparing means that we haven't actually started the workspace instance just yet, but rather
             // are still preparing for launch. This means we're building the Docker image for the workspace.

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -5,7 +5,7 @@
  */
 
 import moment from "moment";
-import { PrebuildWithStatus, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { PrebuildWithStatus } from "@gitpod/gitpod-protocol";
 import { useContext, useEffect, useState } from "react";
 import { useHistory, useLocation, useRouteMatch } from "react-router";
 import Header from "../components/Header";
@@ -30,7 +30,6 @@ export default function () {
     const prebuildId = match?.params?.prebuildId;
 
     const [prebuild, setPrebuild] = useState<PrebuildWithStatus | undefined>();
-    const [prebuildInstance, setPrebuildInstance] = useState<WorkspaceInstance | undefined>();
     const [isRerunningPrebuild, setIsRerunningPrebuild] = useState<boolean>(false);
     const [isCancellingPrebuild, setIsCancellingPrebuild] = useState<boolean>(false);
 
@@ -56,6 +55,16 @@ export default function () {
             });
             setPrebuild(prebuilds[0]);
         })();
+
+        return getGitpodService().registerClient({
+            onPrebuildUpdate(update: PrebuildWithStatus) {
+                if (update.info.id !== prebuildId) {
+                    return;
+                }
+
+                setPrebuild(update);
+            },
+        }).dispose;
     }, [prebuildId, projectSlug, team, teams]);
 
     const renderTitle = () => {
@@ -109,18 +118,6 @@ export default function () {
         );
     };
 
-    const onInstanceUpdate = async (instance: WorkspaceInstance) => {
-        setPrebuildInstance(instance);
-        if (!prebuild) {
-            return;
-        }
-        const prebuilds = await getGitpodService().server.findPrebuilds({
-            projectId: prebuild.info.projectId,
-            prebuildId,
-        });
-        setPrebuild(prebuilds[0]);
-    };
-
     const rerunPrebuild = async () => {
         if (!prebuild) {
             return;
@@ -161,15 +158,12 @@ export default function () {
             <div className="app-container mt-8">
                 <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
                     <div className="h-96 flex">
-                        <PrebuildLogs
-                            workspaceId={prebuild?.info?.buildWorkspaceId}
-                            onInstanceUpdate={onInstanceUpdate}
-                        />
+                        <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId} />
                     </div>
                     <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
                         {prebuild && <PrebuildStatus prebuild={prebuild} />}
                         <div className="flex-grow" />
-                        {prebuild?.status === "aborted" || prebuild?.status === "timeout" || !!prebuild?.error ? (
+                        {["aborted", "timeout", "failed"].includes(prebuild?.status || "") || !!prebuild?.error ? (
                             <button
                                 className="flex items-center space-x-2"
                                 disabled={isRerunningPrebuild}
@@ -178,16 +172,12 @@ export default function () {
                                 {isRerunningPrebuild && (
                                     <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
                                 )}
-                                <span>Rerun Prebuild ({prebuild.info.branch})</span>
+                                <span>Rerun Prebuild ({prebuild?.info.branch})</span>
                             </button>
-                        ) : prebuild?.status === "building" ? (
+                        ) : ["building", "queued"].includes(prebuild?.status || "") ? (
                             <button
                                 className="danger flex items-center space-x-2"
-                                disabled={
-                                    isCancellingPrebuild ||
-                                    (prebuildInstance?.status.phase !== "initializing" &&
-                                        prebuildInstance?.status.phase !== "running")
-                                }
+                                disabled={isCancellingPrebuild}
                                 onClick={cancelPrebuild}
                             >
                                 {isCancellingPrebuild && (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Actions shown on Prebuild Detail view are now based on the `prebuild` record, rather than a Workspace Instance.

<img width="1333" alt="Screenshot 2022-04-05 at 19 40 19" src="https://user-images.githubusercontent.com/1419286/161817194-b1f71985-e9a5-4e31-868b-42195dcdc3f9.png">
<img width="1329" alt="Screenshot 2022-04-05 at 19 40 07" src="https://user-images.githubusercontent.com/1419286/161817197-0459d5f3-0802-4f9b-b9c8-6c9edea3d58e.png">
<img width="1328" alt="Screenshot 2022-04-05 at 19 39 56" src="https://user-images.githubusercontent.com/1419286/161817201-ad42d408-5eb4-45f6-b137-a8fa0dc9365a.png">
<img width="1335" alt="Screenshot 2022-04-05 at 19 39 51" src="https://user-images.githubusercontent.com/1419286/161817204-547c9842-c313-475c-92da-7ec726eff8a9.png">

Visual remain unchanged, only logic for showing various buttons is updated.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to https://github.com/gitpod-io/gitpod/issues/8197

## How to test
<!-- Provide steps to test this PR -->
1. Setup a project with https://gitlab.com/gitpod-milan/gitpod-large-image
2. Trigger prebuilds for the following branches:
	* pass
	* timeout
	* fail-prebuild-fast
	* fail-prebuild (and cancel the prebuild)
3. Observe appropriate buttons shown on prebuild detail view

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Prebuild Detail view buttons are based on Prebuild status, instead of WorkspaceInstance
```

/hold