### PR TITLE
[kots] Add a pre-flight check for `cert-manager`

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -95,3 +95,11 @@ spec:
               message: The cluster must contain at least 4 cores
           - pass:
               message: There are at least 2 cores in the cluster
+    - customResourceDefinition:
+        checkName: Cert-manager is installed
+        customResourceDefinitionName: certificates.cert-manager.io
+        outcomes:
+          - fail:
+              message: Custom resource definition `certificates.cert-manager.io` was not found in the cluster. Please [install `cert-manager`](https://cert-manager.io/docs/installation/) to proceed.
+          - pass:
+              message: Cert-manager is installed and available.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With https://github.com/gitpod-io/gitpod/pull/8785, We expect users
to install their own `cert-manager` install. This PR adds a new
pre-flight check to verify the existence of the `cert-manager`.

As there is no general way to check for the existence of `cert-manager`,
We check for the `certificates.cert-manager.io` CRD instead.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8823 

## How to test
<!-- Provide steps to test this PR -->
Install it by running
```
k kots install gitpod-pov/dev-tar
```

and you should see

![image](https://user-images.githubusercontent.com/7892868/158665300-3eea440b-499e-4e8e-b590-272fe58c0e08.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] Add a pre-flight check for `cert-manager`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
