### PR TITLE
Use new branch for integration test

### DIFF
--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -20,6 +20,11 @@ pod:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: ROBOQUAT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-roboquat-automatic-changelog
+          key: token
     volumeMounts:
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa
@@ -33,34 +38,46 @@ pod:
     - |
       set -euo pipefail
 
+      BRANCH="inte-test/"$(date +%Y%m%d%H%M%S)
+
       function cleanup ()
       {
-        werft log phase "cleanup preview environment" "cleanup preview environment"
-        BUILD_ID=$(werft run github -a namespace=staging-gitpod-test-main --remote-job-path .werft/wipe-devstaging.yaml github.com/gitpod-io/gitpod:main)
-
-        echo "start cleanup preview environment, job name: ${BUILD_ID}" | werft log slice "cleanup"
-        werft log result -d "cleanup job" url "https://werft.gitpod-dev.com/job/${BUILD_ID}"
-
-        werft job logs ${BUILD_ID} | werft log slice "cleanup"
+        git push origin :$BRANCH
       }
+
+      source ./dev/preview/util/preview-name-from-branch.sh
 
       echo "preparing config." | werft log slice prepare
       sudo chown -R gitpod:gitpod /workspace
       gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
       export GOOGLE_APPLICATION_CREDENTIALS="/home/gitpod/.config/gcloud/legacy_credentials/cd-gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json"
+
+      git config --global user.name roboquat
+      git config --global user.email roboquat@gitpod.io
+      git remote set-url origin https://oauth2:$ROBOQUAT_TOKEN@github.com/gitpod-io/gitpod.git
+
       echo "copied config..." | werft log slice prepare
       go install github.com/csweichel/oci-tool@latest 2>&1 | werft log slice prepare
       werft log slice prepare --done
 
       werft log phase "build preview environment" "build preview environment"
-      # this is because we don't want to increate gitpod-build-main number, we can choose a name
-      cp .werft/build.yaml .werft/test.yaml
-      # version is actual namespace that werft is build, --job-file should be same with above
-      VERSION=$(werft run github -j .werft/test.yaml -a version=gitpod-test-main github.com/gitpod-io/gitpod:main)
-      echo "start build preview environment, job name: ${VERSION}, this will take long time" | werft log slice "build test environment"
-      werft log result -d "build job" url "https://werft.gitpod-dev.com/job/${VERSION}"
+      echo integration test >> README.md
+      git checkout -B $BRANCH
+      git add README.md
+      git commit -m "integration test"
+      git push --set-upstream origin $BRANCH
+      trap cleanup SIGINT SIGTERM EXIT
 
-      if ! werft job logs ${VERSION} | werft log slice "build test environment";
+      BUILD_ID=$(werft job list repo.ref==refs/heads/${BRANCH} -o yaml | yq r - "result[0].name")
+      until [ "$BUILD_ID" != "" ]
+      do
+          sleep 1
+          BUILD_ID=$(werft job list repo.ref==refs/heads/${BRANCH} -o yaml | yq r - "result[0].name")
+      done
+      echo "start build preview environment, job name: ${BUILD_ID}, this will take long time" | werft log slice "build test environment"
+      werft log result -d "build job" url "https://werft.gitpod-dev.com/job/${BUILD_ID}"
+
+      if ! werft job logs ${BUILD_ID} | werft log slice "build test environment";
       then
           echo "build failed" | werft log slice "build test environment"
           exit 1
@@ -68,19 +85,16 @@ pod:
       echo "build success" | werft log slice "build test environment"
       werft log slice "build test environment" --done
 
-      # clean preview environment when the script exits
-      trap cleanup SIGINT SIGTERM EXIT
-
       werft log phase "integration test" "integration test"
       # we need get integration-test version like: jp-run-integration-test.61
 
-      oci-tool fetch file eu.gcr.io/gitpod-core-dev/build/versions:gitpod-test-main versions.yaml
+      oci-tool fetch file eu.gcr.io/gitpod-core-dev/build/versions:${BUILD_ID:13} versions.yaml
       INTEGRATION_VERSION=$(cat versions.yaml | yq r - 'components.integrationTest.version')
 
       echo "using integration-test image: ${INTEGRATION_VERSION}" | werft log slice "test"
 
-
-      TEST_BUILD_ID=$(werft run github -a version=${INTEGRATION_VERSION} -a namespace=staging-gitpod-test-main --remote-job-path .werft/ide-run-integration-tests.yaml -a testPattern=vscode.test github.com/gitpod-io/gitpod:main)
+      NAMESPACE="$(preview-name-from-branch)"
+      TEST_BUILD_ID=$(werft run github -a version=${INTEGRATION_VERSION} -a namespace=staging-${NAMESPACE} --remote-job-path .werft/ide-run-integration-tests.yaml -a testPattern=vscode.test)
 
       echo "running integration, job name: ${TEST_BUILD_ID}" | werft log slice "test"
       werft log result -d "integration test job" url "https://werft.gitpod-dev.com/job/${TEST_BUILD_ID}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Every integration test use new branch, to prevent cleanup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
open workspace for this PR, run 
```bash
werft run github --remote-job-path .werft/ide-integration-tests-startup.yaml github.com/gitpod-io/gitpod:pd/fix-vscode-test
```
you will got a success integration

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
