### PR TITLE
[server] Fix checkoutLocation for imagebuilds

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -726,13 +726,13 @@ export class WorkspaceStarter {
                 ) {
                     // TODO(se): we cannot change this initializer structure now because it is part of how baserefs are computed in image-builder.
                     // Image builds should however just use the initialization if the workspace they are running for (i.e. the one from above).
-
+                    checkoutLocation = ".";
                     const { initializer, disposable } = await this.createCommitInitializer(
                         { span },
                         workspace,
                         {
                             ...imgsrc.dockerFileSource,
-                            checkoutLocation: ".",
+                            checkoutLocation,
                             title: "irrelevant",
                             ref: undefined,
                         },


### PR DESCRIPTION
## Description
This attemps to fix the problem by replicating [the original mechanism](https://github.com/gitpod-io/gitpod/pull/8582/files#diff-b1c591e18af598ccba93b570ce7c97dece0988c9109a6d3be82bbe0df1fbd619R532-R558) as close as possible.

The general problem here is obviously that we're lagging tests for `workspace-starter.ts`. :roll_eyes: 

Thx @iQQBot for identifying the problem with #8833 :pray: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8851

## How to test
 - https://gpl-8851-imgbuilds.staging.gitpod-dev.com/#https://github.com/geropl/roborally
 - notice how the builds starts properly (but fails later due to a bad dockerfile) :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix broken image builds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
