### PR TITLE
[gitpod-db] add index on `workspaceDB.Type` Column

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace.ts
@@ -68,6 +68,7 @@ export class DBWorkspace implements Workspace {
     })
     shareable?: boolean;
 
+    @Index("ind_type")
     @Column({
         default: "regular",
     })

--- a/components/gitpod-db/src/typeorm/migration/1647290507971-IndexWorkspaceType.ts
+++ b/components/gitpod-db/src/typeorm/migration/1647290507971-IndexWorkspaceType.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import {MigrationInterface, QueryRunner} from "typeorm";
+import { indexExists } from "./helper/helper";
+
+export class IndexWorkspaceType1647290507971 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const TABLE_NAME = "d_b_workspace";
+        const TYPE_INDEX_NAME = "ind_type";
+        if (!(await indexExists(queryRunner, TABLE_NAME, TYPE_INDEX_NAME))) {
+            await queryRunner.query(`CREATE INDEX ${TYPE_INDEX_NAME} ON ${TABLE_NAME} (type)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

For Telemetry queries to be less intensive on the CPU, We need to
build Indexes to make the querying faster. This PR creates
a index on the `type` column for the `workspaceDB` as
we filter on `type=='regular'`

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8638 

## How to test
<!-- Provide steps to test this PR -->

After creating the index on prod, The query seems to be faster 
```
mysql> select count(*) from d_b_workspace_instance join d_b_workspace on d_b_workspace_instance.workspaceId = d_b_workspace.id where d_b_workspace.type = 'regular';
+----------+
| count(*) |
+----------+
|  5665695 |
+----------+
1 row in set (11.80 sec)
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gitpod-db] add index on `workspaceDB.Type` Column
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
