### PR TITLE
[kots]: configure werft build command

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -11,6 +11,7 @@ import { deployToPreviewEnvironment } from './jobs/build/deploy-to-preview-envir
 import { triggerIntegrationTests } from './jobs/build/trigger-integration-tests';
 import { jobConfig } from './jobs/build/job-config';
 import { typecheckWerftJobs } from './jobs/build/typecheck-werft-jobs';
+import { publishKotsUnstable } from './jobs/build/publish-kots-unstable'
 
 // Will be set once tracing has been initialized
 let werft: Werft
@@ -59,4 +60,5 @@ async function run(context: any) {
 
     await deployToPreviewEnvironment(werft, config)
     await triggerIntegrationTests(werft, config, context.Owner)
+    await publishKotsUnstable(werft, config)
 }

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -183,6 +183,16 @@ pod:
           key: segmentIOToken
     - name: JAVA_HOME
       value: /home/gitpod/.sdkman/candidates/java/current
+    - name: REPLICATED_APP
+      valueFrom:
+        secretKeyRef:
+          name: replicated
+          key: app
+    - name: REPLICATED_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: replicated
+          key: token
     command:
       - bash
       - -c

--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -34,7 +34,7 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
     if (withContrib || publishRelease) {
         exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} -Dversion=${version} -DimageRepoBase=${imageRepo} contrib:all`);
     }
-    exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} ${retag} --coverage-output-path=${coverageOutput} -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo} -DlocalAppVersion=${localAppVersion} -DSEGMENT_IO_TOKEN=${process.env.SEGMENT_IO_TOKEN} -DnpmPublishTrigger=${publishToNpm ? Date.now() : 'false'} -DjbMarketplacePublishTrigger=${publishToJBMarketplace ? Date.now() : 'false'}`);
+    exec(`leeway build --docker-build-options network=host --werft=true -c remote ${dontTest ? '--dont-test' : ''} ${retag} --coverage-output-path=${coverageOutput} -Dversion=${version} -DremoveSources=false -DimageRepoBase=${imageRepo} -DlocalAppVersion=${localAppVersion} -DSEGMENT_IO_TOKEN=${process.env.SEGMENT_IO_TOKEN} -DREPLICATED_API_TOKEN=${process.env.REPLICATED_API_TOKEN} -DREPLICATED_APP=${process.env.REPLICATED_APP} -DnpmPublishTrigger=${publishToNpm ? Date.now() : 'false'} -DjbMarketplacePublishTrigger=${publishToJBMarketplace ? Date.now() : 'false'}`);
     if (publishRelease) {
         try {
             werft.phase("publish", "checking version semver compliance...");

--- a/.werft/jobs/build/publish-kots-unstable.ts
+++ b/.werft/jobs/build/publish-kots-unstable.ts
@@ -1,0 +1,39 @@
+import { exec } from '../../util/shell';
+import { Werft } from "../../util/werft";
+import { JobConfig } from "./job-config";
+
+const phases = {
+    PUBLISH_KOTS_UNSTABLE: 'publish kots unstable',
+};
+
+const REPLICATED_SECRET = 'replicated';
+const REPLICATED_CHANNEL = 'Unstable';
+const REPLICATED_YAML_DIR = './install/kots/manifests';
+const INSTALLER_JOB_IMAGE = 'spec.template.spec.containers[0].image';
+
+export async function publishKotsUnstable(werft: Werft, config: JobConfig) {
+    if (config.mainBuild) {
+        werft.phase(phases.PUBLISH_KOTS_UNSTABLE, 'Publish unstable release to KOTS');
+
+        const imageAndTag = exec(`yq r ${REPLICATED_YAML_DIR}/gitpod-installer-job.yaml ${INSTALLER_JOB_IMAGE}`);
+        const [image] = imageAndTag.split(':');
+
+        // Set the tag to the current version
+        exec(`yq w -i ${REPLICATED_YAML_DIR}/gitpod-installer-job.yaml ${INSTALLER_JOB_IMAGE} ${image}:${config.version}`);
+
+        const app = exec(`kubectl get secret ${REPLICATED_SECRET} --namespace werft -o jsonpath='{.data.app}' | base64 -d`);
+        const token = exec(`kubectl get secret ${REPLICATED_SECRET} --namespace werft -o jsonpath='{.data.token}' | base64 -d`);
+
+        exec(`replicated release create \
+            --lint \
+            --ensure-channel \
+            --app ${app} \
+            --token ${token} \
+            --yaml-dir ${REPLICATED_YAML_DIR} \
+            --version ${config.version} \
+            --release-notes "# ${config.version}\n\nSee [Werft job](https://werft.gitpod-dev.com/job/gitpod-build-${config.version}/logs) for notes" \
+            --promote ${REPLICATED_CHANNEL}`);
+
+        werft.done(phases.PUBLISH_KOTS_UNSTABLE);
+    }
+}

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -13,6 +13,7 @@ packages:
       - :publish-api
       - dev:all-app
       - install/installer:docker
+      - install/kots:lint
       - components/gitpod-protocol:all
       - operations/observability/mixins:lint
   - name: docker-versions

--- a/install/kots/BUILD.yaml
+++ b/install/kots/BUILD.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+packages:
+  - name: lint
+    type: generic
+    srcs:
+      - "**/*"
+    argdeps:
+      - REPLICATED_API_TOKEN
+      - REPLICATED_APP
+    config:
+      commands:
+        - ["make", "lint"]

--- a/install/kots/manifests/gitpod-certificate-secret.yaml
+++ b/install/kots/manifests/gitpod-certificate-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-certificate.yaml
+++ b/install/kots/manifests/gitpod-certificate.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/install/kots/manifests/gitpod-cloudsql-secret.yaml
+++ b/install/kots/manifests/gitpod-cloudsql-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-clusterrolebinding.yaml
+++ b/install/kots/manifests/gitpod-clusterrolebinding.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kots/manifests/gitpod-config-patch.yaml
+++ b/install/kots/manifests/gitpod-config-patch.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/install/kots/manifests/gitpod-database-secret.yaml
+++ b/install/kots/manifests/gitpod-database-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-installation.yaml
+++ b/install/kots/manifests/gitpod-installation.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 # This exists as debug information for the support bundle
 apiVersion: v1
 kind: ConfigMap

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 # The installer job is where the magic happens. It generates
 # the config, installs Gitpod and then deletes itself when
 # it's finished

--- a/install/kots/manifests/gitpod-license.yaml
+++ b/install/kots/manifests/gitpod-license.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-registry-s3-backend.yaml
+++ b/install/kots/manifests/gitpod-registry-s3-backend.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-registry-secret.yaml
+++ b/install/kots/manifests/gitpod-registry-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-serviceaccount.yaml
+++ b/install/kots/manifests/gitpod-serviceaccount.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kots/manifests/gitpod-storage-azure-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-azure-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-storage-gcp-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-gcp-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/gitpod-storage-s3-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-s3-secret.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kots/manifests/kots-app.yaml
+++ b/install/kots/manifests/kots-app.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: kots.io/v1beta1
 kind: Application
 metadata:

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: kots.io/v1beta1
 kind: Config
 metadata:

--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:

--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
 apiVersion: troubleshoot.replicated.com/v1beta1
 kind: SupportBundle
 metadata:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Automate the KOTS process.

1. Runs `make lint` on the manifests during the build phase. Although this is far from perfect, it's a good indication if there are any problems in the manifests. As per the guidelines, warnings and below return successful. The `replicated lint` command requires the `REPLICATED_APP` and `REPLICATED_API_TOKEN` envvars being set. This is a bug in the system
2. Whenever a `main` build is successful, updates the `gitpod-installer-job.yaml` image tag and pushes to `gitpod/unstable` channel in Replicated.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8866 

## How to test
<!-- Provide steps to test this PR -->
See [release 20](https://werft.gitpod-dev.com/job/gitpod-build-sje-kots-release.20/logs) as a demo of the `replicated release create` command working on any branch and then [release 21](https://werft.gitpod-dev.com/job/gitpod-build-sje-kots-release.21/logs) of it being wrapped in the `if mainBranch` conditional

And here's proof that the release to Replicated works

![image](https://user-images.githubusercontent.com/275848/158983271-9d982636-4b9c-4978-9f5e-cdc0a4bb4e79.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: configure werft build command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
