### PR TITLE
[kots]: remove wait-for-jobs

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -191,7 +191,6 @@ spec:
                 --reset-values \
                 --timeout 1h \
                 --wait \
-                --wait-for-jobs \
                 gitpod \
                 "${GITPOD_OBJECTS}"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove `wait-for-jobs` flag in Helm.

As we're deleting jobs on completion, the Helm command can error
wrongly if the job is deleted before Helm detects it's completed.

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: remove wait-for-jobs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
