### PR TITLE
Remove truncation and overflow team invitation URL

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -206,7 +206,7 @@ export default function() {
             <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
                 <label htmlFor="inviteUrl" className="font-medium">Invite URL</label>
                 <div className="w-full relative">
-                    <input name="inviteUrl" disabled={true} readOnly={true} type="text" value={getInviteURL(genericInvite.id)} className="rounded-md w-full truncate pr-8" />
+                    <input name="inviteUrl" disabled={true} readOnly={true} type="text" value={getInviteURL(genericInvite.id)} className="rounded-md overflow-x-scroll w-full pr-8" />
                     <div className="cursor-pointer" onClick={() => copyToClipboard(getInviteURL(genericInvite.id))}>
                         <div className="absolute top-1/3 right-3">
                             <Tooltip content={copied ? 'Copied!' : 'Copy Invite URL'}>


### PR DESCRIPTION
## Description

Picking up a community contribution from https://github.com/gitpod-io/gitpod/pull/8044. Thanks, @Harshil-Jani! 🍊 

## Related Issue(s)

Fix https://github.com/gitpod-io/gitpod/issues/7991

## How to test
1. Create a team
2. Invite members
3. Scroll horizontally on the disabled text input containing the invitaiton URL

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove truncation and overflow team invitation URL
```
