### PR TITLE
Remove truncation and overflow team invitation URL

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -286,7 +286,7 @@ export default function () {
                                 readOnly={true}
                                 type="text"
                                 value={getInviteURL(genericInvite.id)}
-                                className="rounded-md w-full truncate pr-8"
+                                className="rounded-md w-full truncate overflow-x-scroll pr-8"
                             />
                             <div
                                 className="cursor-pointer"


### PR DESCRIPTION
## Description

Picking up a community contribution from https://github.com/gitpod-io/gitpod/pull/8044. Thanks, @Harshil-Jani! 🍊 

## Related Issue(s)

Fix https://github.com/gitpod-io/gitpod/issues/7991

## How to test
1. Create a team
2. Invite members
3. Scroll horizontally on the disabled text input containing the invitaiton URL

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove truncation and overflow team invitation URL
```
