### PR TITLE
[installer]: handle different line endings on apiVersion extraction

### DIFF
--- a/install/installer/pkg/config/loader.go
+++ b/install/installer/pkg/config/loader.go
@@ -106,7 +106,7 @@ func Load(overrideConfig string) (cfg interface{}, version string, err error) {
 	// `apiVersion: vx` line is removed from config since the version dependant
 	// Config structure doesn't have that field
 	// The line-ending is either comma (minified YAML) or newline (unminified)
-	apiVersionRegexp := regexp.MustCompile(`apiVersion: ` + apiVersion + `(,|\n)`)
+	apiVersionRegexp := regexp.MustCompile(`apiVersion: ` + apiVersion + `(,)?`)
 	overrideConfig = apiVersionRegexp.ReplaceAllString(overrideConfig, "")
 
 	// Override passed configuration onto the default


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I've just found that, even on Linux, you can get Windows line endings. This removes the `\n` from the `apiVersion` extraction and makes the comma optional

## How to test
<!-- Provide steps to test this PR -->
Generate config and render with Installer

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
