### PR TITLE
.werft/build: Refactor installer steps into dedicated class

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -10,7 +10,7 @@ import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
 import { Werft } from "../../util/werft";
 import { JobConfig } from "./job-config";
 import * as VM from '../../vm/vm'
-import { Analytics, newInstaller } from "./installer/installer";
+import { Analytics, Installer } from "./installer/installer";
 
 // used by both deploys (helm and Installer)
 const PROXY_SECRET_NAME = "proxy-config-certificates";
@@ -282,7 +282,7 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
         analytics.token = deploymentConfig.analytics!.substring("segment|".length)
     }
 
-    const installer = newInstaller("config.yaml", version, PROXY_SECRET_NAME, deploymentConfig.domain, deploymentConfig.destname, IMAGE_PULL_SECRET_NAME, namespace, analytics, deploymentConfig.installEELicense, withVM, workspaceFeatureFlags, gitpodDaemonsetPorts)
+    const installer = new Installer(werft, "config.yaml", version, PROXY_SECRET_NAME, deploymentConfig.domain, deploymentConfig.destname, IMAGE_PULL_SECRET_NAME, namespace, analytics, deploymentConfig.installEELicense, withVM, workspaceFeatureFlags, gitpodDaemonsetPorts)
     try {
         installer.init(installerSlices.INSTALLER_INIT)
         installer.addPreviewConfiguration(installerSlices.PREVIEW_CONFIG)

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -1,0 +1,237 @@
+import { exec } from "../../../util/shell";
+import { getGlobalWerftInstance } from "../../../util/werft";
+import { getNodePoolIndex } from "../deploy-to-preview-environment";
+
+const blockNewUserConfigPath = './blockNewUsers';
+const workspaceSizeConfigPath = './workspaceSizing';
+const PROJECT_NAME = "gitpod-core-dev";
+const CONTAINER_REGISTRY_URL = `eu.gcr.io/${PROJECT_NAME}/build/`;
+const CONTAINERD_RUNTIME_DIR = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io";
+
+export interface Installer {
+    configPath: string,
+    version: string,
+    proxySecretName: string
+    domain: string
+    previewName: string
+    imagePullSecretName: string
+    deploymentNamespace: string
+    analytics: Analytics,
+    withEELicense: boolean,
+    withVM: boolean,
+    workspaceFeatureFlags: string[],
+    gitpodDaemonsetPorts: GitpodDaemonsetPorts
+
+    init(slice: string): void
+    addPreviewConfiguration(slice: string): void
+    validateConfiguration(slice: string)
+    render(slice: string): void
+    postProcessing(slice: string): void
+    install(slice: string): void
+}
+
+export interface Analytics {
+    type: string,
+    token: string
+}
+
+export interface GitpodDaemonsetPorts {
+    registryFacade: number,
+    wsDaemon: number,
+}
+
+export function newInstaller(configPath: string, version: string, proxySecretName: string, domain: string, previewName: string, imagePullSecretName: string, deploymentNamespace: string, analytics: Analytics, withEELicense: boolean, withVM: boolean, workspaceFeatureFlags: string[], gitpodDaemonsetPorts: GitpodDaemonsetPorts): Installer {
+
+    const init = function init(slice) {
+        const werft = getGlobalWerftInstance()
+        werft.log(slice, "Downloading installer and initializing config file");
+        exec(`docker run --entrypoint sh --rm eu.gcr.io/gitpod-core-dev/build/installer:${this.version} -c "cat /app/installer" > /tmp/installer`, { slice: slice });
+        exec(`chmod +x /tmp/installer`, { slice: slice });
+        exec(`/tmp/installer init > ${this.configPath}`, { slice: slice });
+        werft.done(slice);
+    }
+
+    const addPreviewConfiguration = function addPreviewConfiguration(slice) {
+        const werft = getGlobalWerftInstance()
+        werft.log(slice, "Adding extra configuration");
+        try {
+            getDevCustomValues(slice, this.configPath)
+            configureContainerRegistry(slice, this.configPath, this.proxySecretName, this.imagePullSecretName)
+            configureDomain(slice, this.configPath, this.domain)
+            configureWorkspaces(slice, this.configPath)
+            configureObservability(slice, this.configPath)
+            configureAuthProviders(slice, this.configPath, this.deploymentNamespace)
+            configureSSHGateway(slice, this.configPath, this.deploymentNamespace)
+
+            if (this.analytics) {
+                includeAnalytics(slice, this.configPath, this.analytics.token)
+            } else {
+                dontIncludeAnalytics(slice, this.configPath)
+            }
+        } catch (err) {
+            throw new Error(err)
+        }
+        werft.done(slice)
+    }
+
+    const validateConfiguration = function validateConfiguration(slice) {
+        const werft = getGlobalWerftInstance()
+        werft.log(slice, "Validating configuration");
+        exec(`/tmp/installer validate config -c ${this.configPath}`, { slice: slice });
+        exec(`/tmp/installer validate cluster -c ${this.configPath} || true`, { slice: slice });
+        werft.done(slice)
+    }
+
+    const render = function render(slice) {
+        const werft = getGlobalWerftInstance()
+        werft.log(slice, "Rendering YAML manifests");
+        exec(`/tmp/installer render --namespace ${this.deploymentNamespace} --config ${this.configPath} > k8s.yaml`, { slice: slice });
+        werft.done(slice)
+    }
+
+    const postProcessing = function postProcessing(slice) {
+        const werft = getGlobalWerftInstance()
+        werft.log(slice, "Post processing YAML manfests");
+        const nodepoolIndex = getNodePoolIndex(this.deploymentNamespace);
+
+        configureLicense(slice, this.withEELicense, this.withVM)
+        configureWorkspaceFeatureFlags(slice, this.workspaceFeatureFlags)
+        process(slice, this.withVM, this.gitpodDaemonsetPorts, nodepoolIndex, this.previewName)
+
+        werft.done(slice)
+    }
+
+    const install = function install(slice) {
+        const werft = getGlobalWerftInstance()
+        werft.log(slice, "Installing Gitpod");
+        exec(`kubectl delete -n ${this.deploymentNamespace} job migrations || true`, { silent: true });
+        // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
+        exec(`kubectl apply -f k8s.yaml`, { silent: true });
+
+        exec(`werft log result -d "dev installation" -c github-check-preview-env url https://${domain}/workspaces`);
+        werft.done(slice)
+    }
+
+    const installer = {
+        configPath,
+        version,
+        proxySecretName,
+        domain,
+        previewName,
+        imagePullSecretName,
+        deploymentNamespace,
+        analytics,
+        withEELicense,
+        withVM,
+        workspaceFeatureFlags,
+        gitpodDaemonsetPorts,
+        init,
+        addPreviewConfiguration,
+        validateConfiguration,
+        render,
+        postProcessing,
+        install,
+    }
+
+    return installer
+}
+
+function getDevCustomValues(slice: string, configPath: string): void {
+    exec(`yq r ./.werft/jobs/build/helm/values.dev.yaml components.server.blockNewUsers | yq prefix - 'blockNewUsers' > ${blockNewUserConfigPath}`, { slice: slice });
+    exec(`yq r ./.werft/jobs/build/helm/values.variant.cpuLimits.yaml workspaceSizing.dynamic.cpu.buckets | yq prefix - 'workspace.resources.dynamicLimits.cpu' > ${workspaceSizeConfigPath}`, { slice: slice });
+
+    exec(`yq m -i --overwrite ${configPath} ${blockNewUserConfigPath}`, { slice: slice });
+    exec(`yq m -i ${configPath} ${workspaceSizeConfigPath}`, { slice: slice });
+}
+
+function configureContainerRegistry(slice: string, configPath: string, proxySecretName: string, imagePullSecretName: string): void {
+    exec(`yq w -i ${configPath} certificate.name ${proxySecretName}`, { slice: slice });
+    exec(`yq w -i ${configPath} containerRegistry.inCluster false`, { slice: slice });
+    exec(`yq w -i ${configPath} containerRegistry.external.url ${CONTAINER_REGISTRY_URL}`, { slice: slice });
+    exec(`yq w -i ${configPath} containerRegistry.external.certificate.kind secret`, { slice: slice });
+    exec(`yq w -i ${configPath} containerRegistry.external.certificate.name ${imagePullSecretName}`, { slice: slice });
+}
+
+function configureDomain(slice: string, configPath: string, domain: string) {
+    exec(`yq w -i ${configPath} domain ${domain}`, { slice: slice });
+}
+
+function configureWorkspaces(slice: string, configPath: string) {
+    exec(`yq w -i ${configPath} workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: slice });
+    exec(`yq w -i ${configPath} workspace.resources.requests.cpu "100m"`, { slice: slice });
+}
+
+function configureObservability(slice: string, configPath: string) {
+    const tracingEndpoint = exec(`yq r ./.werft/jobs/build/helm/values.tracing.yaml tracing.endpoint`, { slice: slice }).stdout.trim();
+    exec(`yq w -i ${configPath} observability.tracing.endpoint ${tracingEndpoint}`, { slice: slice });
+}
+
+// auth-provider-secret.yml is a file generated by this job by reading a secret from core-dev cluster
+// 'preview-envs-authproviders' for previews running in core-dev and
+// 'preview-envs-authproviders-harvester' for previews running in Harvester VMs.
+// To understand how it is generated, search for 'auth-provider-secret.yml' in the code.
+function configureAuthProviders(slice: string, configPath: string, namespace: string) {
+    exec(`for row in $(cat auth-provider-secret.yml \
+        | base64 -d -w 0 \
+        | yq r - authProviders -j \
+        | jq -r 'to_entries | .[] | @base64'); do
+            key=$(echo $row | base64 -d | jq -r '.key')
+            providerId=$(echo $row | base64 -d | jq -r '.value.id | ascii_downcase')
+            data=$(echo $row | base64 -d | yq r - value --prettyPrint)
+
+            yq w -i ${configPath} authProviders[$key].kind "secret"
+            yq w -i ${configPath} authProviders[$key].name "$providerId"
+
+            kubectl create secret generic "$providerId" \
+                --namespace "${namespace}" \
+                --from-literal=provider="$data" \
+                --dry-run=client -o yaml | \
+                kubectl replace --force -f -
+        done`, { slice: slice })
+}
+
+function configureSSHGateway(slice: string, configPath: string, namespace: string) {
+    exec(`cat /workspace/host-key.yaml \
+            | yq w - metadata.namespace ${namespace} \
+            | yq d - metadata.uid \
+            | yq d - metadata.resourceVersion \
+            | yq d - metadata.creationTimestamp \
+            | kubectl apply -f -`, { slice: slice })
+    exec(`yq w -i ${configPath} sshGatewayHostKey.kind "secret"`)
+    exec(`yq w -i ${configPath} sshGatewayHostKey.name "host-key"`)
+}
+
+function includeAnalytics(slice: string, configPath: string, token: string): void {
+    exec(`yq w -i ${configPath} analytics.writer segment`, { slice: slice });
+    exec(`yq w -i ${configPath} analytics.segmentKey ${token}`, { slice: slice });
+}
+
+function dontIncludeAnalytics(slice: string, configPath: string): void {
+    exec(`yq w -i ${configPath} analytics.writer ""`, { slice: slice });
+}
+
+function configureLicense(slice: string, withEELicense: boolean, withVM: boolean): void {
+    if (withEELicense) {
+        // Previews in core-dev and harvester use different domain, which requires different licenses.
+        exec(`cp /mnt/secrets/gpsh-${withVM ? 'harvester' : 'coredev'}/license /tmp/license`, { slice: slice });
+        // post-process.sh looks for /tmp/license, and if it exists, adds it to the configmap
+    } else {
+        exec(`touch /tmp/license`, { slice: slice });
+    }
+}
+
+function configureWorkspaceFeatureFlags(slice: string, workspaceFeatureFlags: string[]): void {
+    exec(`touch /tmp/defaultFeatureFlags`, { slice: slice });
+    if (workspaceFeatureFlags && workspaceFeatureFlags.length > 0) {
+        workspaceFeatureFlags.forEach(featureFlag => {
+            exec(`echo \'"${featureFlag}"\' >> /tmp/defaultFeatureFlags`, { slice: slice });
+        })
+        // post-process.sh looks for /tmp/defaultFeatureFlags
+        // each "flag" string gets added to the configmap
+    }
+}
+
+function process(slice: string, withVM: boolean, daemonsetPorts: GitpodDaemonsetPorts, nodepoolIndex: number, previewName: string): void {
+    const flags = withVM ? "WITH_VM=true " : ""
+    exec(`${flags}./.werft/jobs/build/installer/post-process.sh ${daemonsetPorts.registryFacade} ${daemonsetPorts.wsDaemon} ${nodepoolIndex} ${previewName}`, { slice: slice });
+}

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -2,8 +2,8 @@ import { exec } from "../../../util/shell";
 import { Werft } from "../../../util/werft";
 import { getNodePoolIndex } from "../deploy-to-preview-environment";
 
-const blockNewUserConfigPath = './blockNewUsers';
-const workspaceSizeConfigPath = './workspaceSizing';
+const BLOCK_NEW_USER_CONFIG_PATH = './blockNewUsers';
+const WORKSPACE_SIZE_CONFIG_PATH = './workspaceSizing';
 const PROJECT_NAME = "gitpod-core-dev";
 const CONTAINER_REGISTRY_URL = `eu.gcr.io/${PROJECT_NAME}/build/`;
 const CONTAINERD_RUNTIME_DIR = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io";
@@ -80,11 +80,11 @@ export class Installer {
     }
 
     private getDevCustomValues(slice: string): void {
-        exec(`yq r ./.werft/jobs/build/helm/values.dev.yaml components.server.blockNewUsers | yq prefix - 'blockNewUsers' > ${blockNewUserConfigPath}`, { slice: slice });
-        exec(`yq r ./.werft/jobs/build/helm/values.variant.cpuLimits.yaml workspaceSizing.dynamic.cpu.buckets | yq prefix - 'workspace.resources.dynamicLimits.cpu' > ${workspaceSizeConfigPath}`, { slice: slice });
+        exec(`yq r ./.werft/jobs/build/helm/values.dev.yaml components.server.blockNewUsers | yq prefix - 'blockNewUsers' > ${BLOCK_NEW_USER_CONFIG_PATH}`, { slice: slice });
+        exec(`yq r ./.werft/jobs/build/helm/values.variant.cpuLimits.yaml workspaceSizing.dynamic.cpu.buckets | yq prefix - 'workspace.resources.dynamicLimits.cpu' > ${WORKSPACE_SIZE_CONFIG_PATH}`, { slice: slice });
 
-        exec(`yq m -i --overwrite ${this.configPath} ${blockNewUserConfigPath}`, { slice: slice });
-        exec(`yq m -i ${this.configPath} ${workspaceSizeConfigPath}`, { slice: slice });
+        exec(`yq m -i --overwrite ${this.configPath} ${BLOCK_NEW_USER_CONFIG_PATH}`, { slice: slice });
+        exec(`yq m -i ${this.configPath} ${WORKSPACE_SIZE_CONFIG_PATH}`, { slice: slice });
     }
 
     private configureContainerRegistry(slice: string): void {

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -1,5 +1,5 @@
 import { exec } from "../../../util/shell";
-import { getGlobalWerftInstance } from "../../../util/werft";
+import { Werft } from "../../../util/werft";
 import { getNodePoolIndex } from "../deploy-to-preview-environment";
 
 const blockNewUserConfigPath = './blockNewUsers';
@@ -8,170 +8,113 @@ const PROJECT_NAME = "gitpod-core-dev";
 const CONTAINER_REGISTRY_URL = `eu.gcr.io/${PROJECT_NAME}/build/`;
 const CONTAINERD_RUNTIME_DIR = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io";
 
-export interface Installer {
-    configPath: string,
-    version: string,
+export type Analytics = {
+    type: string,
+    token: string
+}
+
+export type GitpodDaemonsetPorts = {
+    registryFacade: number,
+    wsDaemon: number,
+}
+
+export class Installer {
+    werft: Werft
+    configPath: string
+    version: string
     proxySecretName: string
     domain: string
     previewName: string
     imagePullSecretName: string
     deploymentNamespace: string
-    analytics: Analytics,
-    withEELicense: boolean,
-    withVM: boolean,
-    workspaceFeatureFlags: string[],
+    analytics: Analytics
+    withEELicense: boolean
+    withVM: boolean
+    workspaceFeatureFlags: string[]
     gitpodDaemonsetPorts: GitpodDaemonsetPorts
 
-    init(slice: string): void
-    addPreviewConfiguration(slice: string): void
-    validateConfiguration(slice: string)
-    render(slice: string): void
-    postProcessing(slice: string): void
-    install(slice: string): void
-}
+    constructor(werft: Werft, configPath: string, version: string, proxySecretName: string, domain: string, previewName: string, imagePullSecretName: string, deploymentNamespace: string, analytics: Analytics, withEELicense: boolean, withVM: boolean, workspaceFeatureFlags: string[], gitpodDaemonsetPorts: GitpodDaemonsetPorts) {
+        this.werft = werft
+        this.configPath = configPath
+        this.version = version
+        this.proxySecretName = proxySecretName
+        this.domain = domain
+        this.previewName = previewName
+        this.imagePullSecretName = imagePullSecretName
+        this.deploymentNamespace = deploymentNamespace
+        this.analytics = analytics
+        this.withEELicense = withEELicense
+        this.withVM = withVM
+        this.workspaceFeatureFlags = workspaceFeatureFlags
+        this.gitpodDaemonsetPorts = gitpodDaemonsetPorts
+    }
 
-export interface Analytics {
-    type: string,
-    token: string
-}
-
-export interface GitpodDaemonsetPorts {
-    registryFacade: number,
-    wsDaemon: number,
-}
-
-export function newInstaller(configPath: string, version: string, proxySecretName: string, domain: string, previewName: string, imagePullSecretName: string, deploymentNamespace: string, analytics: Analytics, withEELicense: boolean, withVM: boolean, workspaceFeatureFlags: string[], gitpodDaemonsetPorts: GitpodDaemonsetPorts): Installer {
-
-    const init = function init(slice) {
-        const werft = getGlobalWerftInstance()
-        werft.log(slice, "Downloading installer and initializing config file");
+    init(slice: string): void {
+        this.werft.log(slice, "Downloading installer and initializing config file");
         exec(`docker run --entrypoint sh --rm eu.gcr.io/gitpod-core-dev/build/installer:${this.version} -c "cat /app/installer" > /tmp/installer`, { slice: slice });
         exec(`chmod +x /tmp/installer`, { slice: slice });
         exec(`/tmp/installer init > ${this.configPath}`, { slice: slice });
-        werft.done(slice);
+        this.werft.done(slice);
     }
 
-    const addPreviewConfiguration = function addPreviewConfiguration(slice) {
-        const werft = getGlobalWerftInstance()
-        werft.log(slice, "Adding extra configuration");
+    addPreviewConfiguration(slice: string): void {
+        this.werft.log(slice, "Adding extra configuration");
         try {
-            getDevCustomValues(slice, this.configPath)
-            configureContainerRegistry(slice, this.configPath, this.proxySecretName, this.imagePullSecretName)
-            configureDomain(slice, this.configPath, this.domain)
-            configureWorkspaces(slice, this.configPath)
-            configureObservability(slice, this.configPath)
-            configureAuthProviders(slice, this.configPath, this.deploymentNamespace)
-            configureSSHGateway(slice, this.configPath, this.deploymentNamespace)
+            this.getDevCustomValues(slice)
+            this.configureContainerRegistry(slice)
+            this.configureDomain(slice)
+            this.configureWorkspaces(slice)
+            this.configureObservability(slice)
+            this.configureAuthProviders(slice)
+            this.configureSSHGateway(slice)
 
             if (this.analytics) {
-                includeAnalytics(slice, this.configPath, this.analytics.token)
+                this.includeAnalytics(slice)
             } else {
-                dontIncludeAnalytics(slice, this.configPath)
+                this.dontIncludeAnalytics(slice)
             }
         } catch (err) {
             throw new Error(err)
         }
-        werft.done(slice)
+        this.werft.done(slice)
     }
 
-    const validateConfiguration = function validateConfiguration(slice) {
-        const werft = getGlobalWerftInstance()
-        werft.log(slice, "Validating configuration");
-        exec(`/tmp/installer validate config -c ${this.configPath}`, { slice: slice });
-        exec(`/tmp/installer validate cluster -c ${this.configPath} || true`, { slice: slice });
-        werft.done(slice)
+    private getDevCustomValues(slice: string): void {
+        exec(`yq r ./.werft/jobs/build/helm/values.dev.yaml components.server.blockNewUsers | yq prefix - 'blockNewUsers' > ${blockNewUserConfigPath}`, { slice: slice });
+        exec(`yq r ./.werft/jobs/build/helm/values.variant.cpuLimits.yaml workspaceSizing.dynamic.cpu.buckets | yq prefix - 'workspace.resources.dynamicLimits.cpu' > ${workspaceSizeConfigPath}`, { slice: slice });
+
+        exec(`yq m -i --overwrite ${this.configPath} ${blockNewUserConfigPath}`, { slice: slice });
+        exec(`yq m -i ${this.configPath} ${workspaceSizeConfigPath}`, { slice: slice });
     }
 
-    const render = function render(slice) {
-        const werft = getGlobalWerftInstance()
-        werft.log(slice, "Rendering YAML manifests");
-        exec(`/tmp/installer render --namespace ${this.deploymentNamespace} --config ${this.configPath} > k8s.yaml`, { slice: slice });
-        werft.done(slice)
+    private configureContainerRegistry(slice: string): void {
+        exec(`yq w -i ${this.configPath} certificate.name ${this.proxySecretName}`, { slice: slice });
+        exec(`yq w -i ${this.configPath} containerRegistry.inCluster false`, { slice: slice });
+        exec(`yq w -i ${this.configPath} containerRegistry.external.url ${CONTAINER_REGISTRY_URL}`, { slice: slice });
+        exec(`yq w -i ${this.configPath} containerRegistry.external.certificate.kind secret`, { slice: slice });
+        exec(`yq w -i ${this.configPath} containerRegistry.external.certificate.name ${this.imagePullSecretName}`, { slice: slice });
     }
 
-    const postProcessing = function postProcessing(slice) {
-        const werft = getGlobalWerftInstance()
-        werft.log(slice, "Post processing YAML manfests");
-        const nodepoolIndex = getNodePoolIndex(this.deploymentNamespace);
-
-        configureLicense(slice, this.withEELicense, this.withVM)
-        configureWorkspaceFeatureFlags(slice, this.workspaceFeatureFlags)
-        process(slice, this.withVM, this.gitpodDaemonsetPorts, nodepoolIndex, this.previewName)
-
-        werft.done(slice)
+    private configureDomain(slice: string) {
+        exec(`yq w -i ${this.configPath} domain ${this.domain}`, { slice: slice });
     }
 
-    const install = function install(slice) {
-        const werft = getGlobalWerftInstance()
-        werft.log(slice, "Installing Gitpod");
-        exec(`kubectl delete -n ${this.deploymentNamespace} job migrations || true`, { silent: true });
-        // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
-        exec(`kubectl apply -f k8s.yaml`, { silent: true });
-
-        exec(`werft log result -d "dev installation" -c github-check-preview-env url https://${domain}/workspaces`);
-        werft.done(slice)
+    private configureWorkspaces(slice: string) {
+        exec(`yq w -i ${this.configPath} workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: slice });
+        exec(`yq w -i ${this.configPath} workspace.resources.requests.cpu "100m"`, { slice: slice });
     }
 
-    const installer = {
-        configPath,
-        version,
-        proxySecretName,
-        domain,
-        previewName,
-        imagePullSecretName,
-        deploymentNamespace,
-        analytics,
-        withEELicense,
-        withVM,
-        workspaceFeatureFlags,
-        gitpodDaemonsetPorts,
-        init,
-        addPreviewConfiguration,
-        validateConfiguration,
-        render,
-        postProcessing,
-        install,
+    private configureObservability(slice: string) {
+        const tracingEndpoint = exec(`yq r ./.werft/jobs/build/helm/values.tracing.yaml tracing.endpoint`, { slice: slice }).stdout.trim();
+        exec(`yq w -i ${this.configPath} observability.tracing.endpoint ${tracingEndpoint}`, { slice: slice });
     }
 
-    return installer
-}
-
-function getDevCustomValues(slice: string, configPath: string): void {
-    exec(`yq r ./.werft/jobs/build/helm/values.dev.yaml components.server.blockNewUsers | yq prefix - 'blockNewUsers' > ${blockNewUserConfigPath}`, { slice: slice });
-    exec(`yq r ./.werft/jobs/build/helm/values.variant.cpuLimits.yaml workspaceSizing.dynamic.cpu.buckets | yq prefix - 'workspace.resources.dynamicLimits.cpu' > ${workspaceSizeConfigPath}`, { slice: slice });
-
-    exec(`yq m -i --overwrite ${configPath} ${blockNewUserConfigPath}`, { slice: slice });
-    exec(`yq m -i ${configPath} ${workspaceSizeConfigPath}`, { slice: slice });
-}
-
-function configureContainerRegistry(slice: string, configPath: string, proxySecretName: string, imagePullSecretName: string): void {
-    exec(`yq w -i ${configPath} certificate.name ${proxySecretName}`, { slice: slice });
-    exec(`yq w -i ${configPath} containerRegistry.inCluster false`, { slice: slice });
-    exec(`yq w -i ${configPath} containerRegistry.external.url ${CONTAINER_REGISTRY_URL}`, { slice: slice });
-    exec(`yq w -i ${configPath} containerRegistry.external.certificate.kind secret`, { slice: slice });
-    exec(`yq w -i ${configPath} containerRegistry.external.certificate.name ${imagePullSecretName}`, { slice: slice });
-}
-
-function configureDomain(slice: string, configPath: string, domain: string) {
-    exec(`yq w -i ${configPath} domain ${domain}`, { slice: slice });
-}
-
-function configureWorkspaces(slice: string, configPath: string) {
-    exec(`yq w -i ${configPath} workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: slice });
-    exec(`yq w -i ${configPath} workspace.resources.requests.cpu "100m"`, { slice: slice });
-}
-
-function configureObservability(slice: string, configPath: string) {
-    const tracingEndpoint = exec(`yq r ./.werft/jobs/build/helm/values.tracing.yaml tracing.endpoint`, { slice: slice }).stdout.trim();
-    exec(`yq w -i ${configPath} observability.tracing.endpoint ${tracingEndpoint}`, { slice: slice });
-}
-
-// auth-provider-secret.yml is a file generated by this job by reading a secret from core-dev cluster
-// 'preview-envs-authproviders' for previews running in core-dev and
-// 'preview-envs-authproviders-harvester' for previews running in Harvester VMs.
-// To understand how it is generated, search for 'auth-provider-secret.yml' in the code.
-function configureAuthProviders(slice: string, configPath: string, namespace: string) {
-    exec(`for row in $(cat auth-provider-secret.yml \
+    // auth-provider-secret.yml is a file generated by this job by reading a secret from core-dev cluster
+    // 'preview-envs-authproviders' for previews running in core-dev and
+    // 'preview-envs-authproviders-harvester' for previews running in Harvester VMs.
+    // To understand how it is generated, search for 'auth-provider-secret.yml' in the code.
+    private configureAuthProviders(slice: string) {
+        exec(`for row in $(cat auth-provider-secret.yml \
         | base64 -d -w 0 \
         | yq r - authProviders -j \
         | jq -r 'to_entries | .[] | @base64'); do
@@ -179,59 +122,97 @@ function configureAuthProviders(slice: string, configPath: string, namespace: st
             providerId=$(echo $row | base64 -d | jq -r '.value.id | ascii_downcase')
             data=$(echo $row | base64 -d | yq r - value --prettyPrint)
 
-            yq w -i ${configPath} authProviders[$key].kind "secret"
-            yq w -i ${configPath} authProviders[$key].name "$providerId"
+            yq w -i ${this.configPath} authProviders[$key].kind "secret"
+            yq w -i ${this.configPath} authProviders[$key].name "$providerId"
 
             kubectl create secret generic "$providerId" \
-                --namespace "${namespace}" \
+                --namespace "${this.deploymentNamespace}" \
                 --from-literal=provider="$data" \
                 --dry-run=client -o yaml | \
                 kubectl replace --force -f -
         done`, { slice: slice })
-}
-
-function configureSSHGateway(slice: string, configPath: string, namespace: string) {
-    exec(`cat /workspace/host-key.yaml \
-            | yq w - metadata.namespace ${namespace} \
-            | yq d - metadata.uid \
-            | yq d - metadata.resourceVersion \
-            | yq d - metadata.creationTimestamp \
-            | kubectl apply -f -`, { slice: slice })
-    exec(`yq w -i ${configPath} sshGatewayHostKey.kind "secret"`)
-    exec(`yq w -i ${configPath} sshGatewayHostKey.name "host-key"`)
-}
-
-function includeAnalytics(slice: string, configPath: string, token: string): void {
-    exec(`yq w -i ${configPath} analytics.writer segment`, { slice: slice });
-    exec(`yq w -i ${configPath} analytics.segmentKey ${token}`, { slice: slice });
-}
-
-function dontIncludeAnalytics(slice: string, configPath: string): void {
-    exec(`yq w -i ${configPath} analytics.writer ""`, { slice: slice });
-}
-
-function configureLicense(slice: string, withEELicense: boolean, withVM: boolean): void {
-    if (withEELicense) {
-        // Previews in core-dev and harvester use different domain, which requires different licenses.
-        exec(`cp /mnt/secrets/gpsh-${withVM ? 'harvester' : 'coredev'}/license /tmp/license`, { slice: slice });
-        // post-process.sh looks for /tmp/license, and if it exists, adds it to the configmap
-    } else {
-        exec(`touch /tmp/license`, { slice: slice });
     }
-}
 
-function configureWorkspaceFeatureFlags(slice: string, workspaceFeatureFlags: string[]): void {
-    exec(`touch /tmp/defaultFeatureFlags`, { slice: slice });
-    if (workspaceFeatureFlags && workspaceFeatureFlags.length > 0) {
-        workspaceFeatureFlags.forEach(featureFlag => {
-            exec(`echo \'"${featureFlag}"\' >> /tmp/defaultFeatureFlags`, { slice: slice });
-        })
-        // post-process.sh looks for /tmp/defaultFeatureFlags
-        // each "flag" string gets added to the configmap
+    private configureSSHGateway(slice: string) {
+        exec(`cat /workspace/host-key.yaml \
+                | yq w - metadata.namespace ${this.deploymentNamespace} \
+                | yq d - metadata.uid \
+                | yq d - metadata.resourceVersion \
+                | yq d - metadata.creationTimestamp \
+                | kubectl apply -f -`, { slice: slice })
+        exec(`yq w -i ${this.configPath} sshGatewayHostKey.kind "secret"`)
+        exec(`yq w -i ${this.configPath} sshGatewayHostKey.name "host-key"`)
     }
-}
 
-function process(slice: string, withVM: boolean, daemonsetPorts: GitpodDaemonsetPorts, nodepoolIndex: number, previewName: string): void {
-    const flags = withVM ? "WITH_VM=true " : ""
-    exec(`${flags}./.werft/jobs/build/installer/post-process.sh ${daemonsetPorts.registryFacade} ${daemonsetPorts.wsDaemon} ${nodepoolIndex} ${previewName}`, { slice: slice });
+    private includeAnalytics(slice: string): void {
+        exec(`yq w -i ${this.configPath} analytics.writer segment`, { slice: slice });
+        exec(`yq w -i ${this.configPath} analytics.segmentKey ${this.analytics.token}`, { slice: slice });
+    }
+
+    private dontIncludeAnalytics(slice: string): void {
+        exec(`yq w -i ${this.configPath} analytics.writer ""`, { slice: slice });
+    }
+
+    validateConfiguration(slice: string): void {
+        this.werft.log(slice, "Validating configuration");
+        exec(`/tmp/installer validate config -c ${this.configPath}`, { slice: slice });
+        exec(`/tmp/installer validate cluster -c ${this.configPath} || true`, { slice: slice });
+        this.werft.done(slice)
+    }
+
+    render(slice: string): void {
+        this.werft.log(slice, "Rendering YAML manifests");
+        exec(`/tmp/installer render --namespace ${this.deploymentNamespace} --config ${this.configPath} > k8s.yaml`, { slice: slice });
+        this.werft.done(slice)
+    }
+
+    postProcessing(slice: string): void {
+        this.werft.log(slice, "Post processing YAML manfests");
+
+        this.configureLicense(slice)
+        this.configureWorkspaceFeatureFlags(slice)
+        this.process(slice)
+
+        this.werft.done(slice)
+    }
+
+    private configureLicense(slice: string): void {
+        if (this.withEELicense) {
+            // Previews in core-dev and harvester use different domain, which requires different licenses.
+            exec(`cp /mnt/secrets/gpsh-${this.withVM ? 'harvester' : 'coredev'}/license /tmp/license`, { slice: slice });
+            // post-process.sh looks for /tmp/license, and if it exists, adds it to the configmap
+        } else {
+            exec(`touch /tmp/license`, { slice: slice });
+        }
+    }
+
+
+    private configureWorkspaceFeatureFlags(slice: string): void {
+        exec(`touch /tmp/defaultFeatureFlags`, { slice: slice });
+        if (this.workspaceFeatureFlags && this.workspaceFeatureFlags.length > 0) {
+            this.workspaceFeatureFlags.forEach(featureFlag => {
+                exec(`echo \'"${featureFlag}"\' >> /tmp/defaultFeatureFlags`, { slice: slice });
+            })
+            // post-process.sh looks for /tmp/defaultFeatureFlags
+            // each "flag" string gets added to the configmap
+        }
+    }
+
+    private process(slice: string): void {
+        const nodepoolIndex = getNodePoolIndex(this.deploymentNamespace);
+        const flags = this.withVM ? "WITH_VM=true " : ""
+
+        exec(`${flags}./.werft/jobs/build/installer/post-process.sh ${this.gitpodDaemonsetPorts.registryFacade} ${this.gitpodDaemonsetPorts.wsDaemon} ${nodepoolIndex} ${this.previewName}`, { slice: slice });
+    }
+
+    install(slice: string): void {
+        this.werft.log(slice, "Installing Gitpod");
+        exec(`kubectl delete -n ${this.deploymentNamespace} job migrations || true`, { silent: true });
+        // errors could result in outputing a secret to the werft log when kubernetes patches existing objects...
+        exec(`kubectl apply -f k8s.yaml`, { silent: true });
+
+        exec(`werft log result -d "dev installation" -c github-check-preview-env url https://${this.domain}/workspaces`);
+        this.werft.done(slice)
+    }
+
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR tries to reduce amount of code under `.werft/jobs/build/deploy-to-preview-environments.ts` by moving all code related to installer to a dedicated `Installer` interface.

That way, we can make the deploy phase as simple as:
```typescript
werft.phase(deploy)
const installer = newInstaller(params...)
try {
        installer.init(installerSlices.INSTALLER_INIT)
        installer.addPreviewConfiguration(installerSlices.PREVIEW_CONFIG)
        installer.validateConfiguration(installerSlices.VALIDATE_CONFIG)
        installer.render(installerSlices.INSTALLER_RENDER)
        installer.postProcessing(installerSlices.INSTALLER_POST_PROCESSING)
        installer.install(installerSlices.APPLY_INSTALL_MANIFESTS)
    } catch (err) {
        if (!jobConfig.mainBuild) {
            werft.fail(phases.DEPLOY, err)
        }
        exec('exit 0')
    }
werft.done(deploy)
```

I'm opening it as a draft just to collect early feedback on the approach. @gitpod-io/platform do you agree with the approach here?

## How to test
<!-- Provide steps to test this PR -->

- [x] Start a preview on core-dev and make sure workspaces start
- [x] Start a preview on Harvester and make sure workspaces start

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
