### PR TITLE
feat(gitpod-cli): add tasks cmd

### DIFF
--- a/components/gitpod-cli/cmd/tasks.go
+++ b/components/gitpod-cli/cmd/tasks.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/gitpod-io/gitpod/gitpod-cli/cmd/tasks"
+	"github.com/spf13/cobra"
+)
+
+// tasksCmd represents the tasks command
+var tasksCmd = &cobra.Command{
+	Use:   "tasks",
+	Short: "Interact with workspace tasks",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Help()
+		}
+	},
+}
+
+var attachTaskCmdOpts struct {
+	Interactive bool
+	ForceResize bool
+}
+
+// listTasksCmd represents the tasks list command
+var listTasksCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists the workspace tasks and their state",
+	Run:   tasks.ListTasksCmd,
+}
+
+// attachTaskCmd represents the attach task command
+var attachTaskCmd = &cobra.Command{
+	Use:   "attach <id>",
+	Short: "Attach to a workspace task",
+	Args:  cobra.MaximumNArgs(1),
+	Run:   tasks.AttachTasksCmd,
+}
+
+func init() {
+	rootCmd.AddCommand(tasksCmd)
+
+	tasksCmd.AddCommand(listTasksCmd)
+	tasksCmd.AddCommand(attachTaskCmd)
+
+	attachTaskCmd.Flags().BoolVarP(&attachTaskCmdOpts.Interactive, "interactive", "i", true, "assume control over the terminal")
+	attachTaskCmd.Flags().BoolVarP(&attachTaskCmdOpts.ForceResize, "force-resize", "r", true, "force this terminal's size irregardless of other clients")
+}

--- a/components/gitpod-cli/cmd/tasks/tasks-attach.go
+++ b/components/gitpod-cli/cmd/tasks/tasks-attach.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func AttachTasksCmd(cmd *cobra.Command, args []string) {
+	var terminalAlias string
+
+	conn := supervisor.Dial()
+
+	if len(args) > 0 {
+		terminalAlias = args[0]
+	} else {
+		statusClient := api.NewStatusServiceClient(conn)
+		stateToFilter := api.TaskState(api.TaskState_value["running"])
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		tasks := supervisor.GetTasksListByState(ctx, statusClient, stateToFilter)
+
+		if len(tasks) == 0 {
+			fmt.Println("There are no running tasks")
+			return
+		}
+
+		var taskNames []string
+		var taskIndex int
+
+		if len(tasks) == 1 {
+			taskIndex = 0
+		} else {
+
+			for _, task := range tasks {
+				taskNames = append(taskNames, task.Presentation.Name)
+			}
+
+			prompt := promptui.Select{
+				Label: "What task do you want attach to?",
+				Items: taskNames,
+				Templates: &promptui.SelectTemplates{
+					Selected: "Attaching to task: {{ . }}",
+				},
+			}
+
+			selectedIndex, selectedValue, err := prompt.Run()
+
+			if selectedValue == "" {
+				return
+			}
+
+			if err != nil {
+				panic(err)
+			}
+
+			taskIndex = selectedIndex
+		}
+
+		terminalAlias = tasks[taskIndex].Terminal
+	}
+
+	terminalClient := api.NewTerminalServiceClient(conn)
+
+	terminal, err := terminalClient.Get(context.Background(), &api.GetTerminalRequest{Alias: terminalAlias})
+	if err != nil {
+		if e, ok := status.FromError(err); ok {
+			switch e.Code() {
+			case codes.NotFound:
+				fmt.Println("Terminal is inactive:", terminalAlias)
+			default:
+				fmt.Println(e.Code(), e.Message())
+			}
+			return
+		} else {
+			panic(err)
+		}
+	}
+	ppid := int64(os.Getppid())
+
+	if ppid == terminal.Pid {
+		fmt.Println("You are already in terminal:", terminalAlias)
+		return
+	}
+
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	forceResize, _ := cmd.Flags().GetBool("force-resize")
+
+	supervisor.AttachToTerminal(context.Background(), terminalClient, terminalAlias, supervisor.AttachToTerminalOpts{
+		ForceResize: forceResize,
+		Interactive: interactive,
+	})
+}

--- a/components/gitpod-cli/cmd/tasks/tasks-list.go
+++ b/components/gitpod-cli/cmd/tasks/tasks-list.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/spf13/cobra"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func ListTasksCmd(cmd *cobra.Command, args []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn := supervisor.Dial()
+	client := api.NewStatusServiceClient(conn)
+
+	tasks := supervisor.GetTasksList(ctx, client)
+
+	if len(tasks) == 0 {
+		fmt.Println("No tasks detected")
+		return
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Terminal ID", "Name", "State"})
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+
+	mapStatusToColor := map[api.TaskState]int{
+		0: tablewriter.FgHiGreenColor,
+		1: tablewriter.FgHiGreenColor,
+		2: tablewriter.FgHiBlackColor,
+	}
+
+	for _, task := range tasks {
+		table.Rich([]string{task.Terminal, task.Presentation.Name, task.State.String()}, []tablewriter.Colors{{}, {}, {mapStatusToColor[task.State]}})
+	}
+
+	table.Render()
+}

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -23,8 +23,11 @@ require (
 )
 
 require (
+	github.com/creack/pty v1.1.17
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/procfs v0.7.3
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )
 
 require (
@@ -43,6 +46,7 @@ require (
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 // indirect

--- a/components/gitpod-cli/go.sum
+++ b/components/gitpod-cli/go.sum
@@ -68,6 +68,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -223,6 +225,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -239,6 +243,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nicksnyder/go-i18n v1.10.1 h1:isfg77E/aCD7+0lD/D00ebR2MV5vgeQ276WYyDaCRQc=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -437,6 +443,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/components/gitpod-cli/pkg/supervisor/status-tasks.go
+++ b/components/gitpod-cli/pkg/supervisor/status-tasks.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package supervisor
+
+import (
+	"context"
+	"io"
+
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	log "github.com/sirupsen/logrus"
+)
+
+func GetTasksList(ctx context.Context, client api.StatusServiceClient) []*api.TaskStatus {
+	listen, err := client.TasksStatus(ctx, &api.TasksStatusRequest{Observe: false})
+	if err != nil {
+		log.WithError(err).Error("Cannot list tasks")
+	}
+
+	taskschan := make(chan []*api.TaskStatus)
+
+	go func() {
+		for {
+			resp, err := listen.Recv()
+			if err != nil && err != io.EOF {
+				panic(err)
+			}
+
+			chunk := resp.GetTasks()
+
+			if chunk == nil {
+				close(taskschan)
+				break
+			} else {
+				taskschan <- chunk
+			}
+		}
+	}()
+
+	return <-taskschan
+}
+
+func GetTasksListByState(ctx context.Context, client api.StatusServiceClient, filterState api.TaskState) []*api.TaskStatus {
+	tasks := GetTasksList(ctx, client)
+
+	var filteredTasks []*api.TaskStatus
+
+	for _, task := range tasks {
+		if task.State == filterState {
+			filteredTasks = append(filteredTasks, task)
+		}
+	}
+
+	return filteredTasks
+}

--- a/components/gitpod-cli/pkg/supervisor/supervisor.go
+++ b/components/gitpod-cli/pkg/supervisor/supervisor.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package supervisor
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+func Dial() *grpc.ClientConn {
+	supervisorAddr := os.Getenv("SUPERVISOR_ADDR")
+	if supervisorAddr == "" {
+		supervisorAddr = "localhost:22999"
+	}
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	if err != nil {
+		log.WithError(err).Fatal("cannot connect to supervisor")
+	}
+
+	return supervisorConn
+}

--- a/components/gitpod-cli/pkg/supervisor/terminal-attach.go
+++ b/components/gitpod-cli/pkg/supervisor/terminal-attach.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package supervisor
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/creack/pty"
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/term"
+)
+
+type AttachToTerminalOpts struct {
+	Interactive bool
+	ForceResize bool
+	Token       string
+}
+
+func AttachToTerminal(ctx context.Context, client api.TerminalServiceClient, alias string, opts AttachToTerminalOpts) {
+	// Copy to stdout/stderr
+	listen, err := client.Listen(ctx, &api.ListenTerminalRequest{
+		Alias: alias,
+	})
+	if err != nil {
+		log.WithError(err).Fatal("cannot attach to terminal")
+	}
+	var exitCode int
+	errchan := make(chan error, 5)
+	go func() {
+		for {
+			resp, err := listen.Recv()
+			if err != nil {
+				errchan <- err
+			}
+			os.Stdout.Write(resp.GetData())
+			terminalExitCode := resp.GetExitCode()
+			if terminalExitCode > 0 {
+				exitCode = int(terminalExitCode)
+			}
+		}
+	}()
+
+	// Set stdin in raw mode.
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort.
+
+	if opts.Interactive {
+		// Handle pty size.
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGWINCH)
+		go func() {
+			for range ch {
+				size, err := pty.GetsizeFull(os.Stdin)
+				if err != nil {
+					log.WithError(err).Error("cannot determine stdin's terminal size")
+					continue
+				}
+
+				req := &api.SetTerminalSizeRequest{
+					Alias: alias,
+					Size: &api.TerminalSize{
+						Cols:     uint32(size.Cols),
+						Rows:     uint32(size.Rows),
+						WidthPx:  uint32(size.X),
+						HeightPx: uint32(size.Y),
+					},
+				}
+
+				var expectResize bool
+				if opts.ForceResize {
+					req.Priority = &api.SetTerminalSizeRequest_Force{Force: true}
+					expectResize = true
+				} else if opts.Token != "" {
+					req.Priority = &api.SetTerminalSizeRequest_Token{Token: opts.Token}
+					expectResize = true
+				}
+
+				_, err = client.SetSize(ctx, req)
+				if err != nil && expectResize {
+					log.WithError(err).Error("cannot set terminal size")
+					continue
+				}
+			}
+		}()
+		ch <- syscall.SIGWINCH // Initial resize.
+
+		// Copy stdin to the pty and the pty to stdout.
+		go func() {
+			buf := make([]byte, 32*1024)
+			for {
+				n, err := os.Stdin.Read(buf)
+				if n > 0 {
+					_, serr := client.Write(ctx, &api.WriteTerminalRequest{Alias: alias, Stdin: buf[:n]})
+					if serr != nil {
+						errchan <- err
+						return
+					}
+				}
+				if err != nil {
+					errchan <- err
+					return
+				}
+			}
+		}()
+	}
+
+	// wait indefinitely
+	stopch := make(chan os.Signal, 1)
+	signal.Notify(stopch, syscall.SIGTERM|syscall.SIGINT)
+	select {
+	case err := <-errchan:
+		if err != io.EOF {
+			log.WithError(err).Error("error")
+		} else {
+			os.Exit(exitCode)
+		}
+	case <-stopch:
+	}
+}


### PR DESCRIPTION
## Description
Adds a command with 2 sub-commands to gitpod-cli.

- gp tasks list
- gp tasks attach

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/7016

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
