### PR TITLE
Iterate through pages

### DIFF
--- a/components/server/ee/src/bitbucket/bitbucket-app-support.ts
+++ b/components/server/ee/src/bitbucket/bitbucket-app-support.ts
@@ -4,10 +4,11 @@
  * See License.enterprise.txt in the project root folder.
  */
 
+// @ts-nocheck
 import { AuthProviderInfo, ProviderRepository, User } from "@gitpod/gitpod-protocol";
 import { inject, injectable } from "inversify";
 import { TokenProvider } from "../../../src/user/token-provider";
-import { Bitbucket } from "bitbucket";
+import { Bitbucket, Schema } from "bitbucket";
 import { URL } from "url";
 
 @injectable()
@@ -41,44 +42,55 @@ export class BitbucketAppSupport {
         const workspaces =
             (await api.workspaces.getWorkspaces({ pagelen: 100 })).data.values?.map((w) => w.slug!) || [];
 
-        const reposPromise = Promise.all(
-            workspaces.map((workspace) =>
-                api.repositories
+        const fetchAllRepos = async (workspace: string) => {
+            const result: Schema.Repository[] = [];
+            let page = 1;
+            let hasMorePages = true;
+            const pagelen = 100;
+
+            while (hasMorePages) {
+                const response = await api.repositories
                     .list({
                         workspace,
-                        pagelen: 100,
+                        pagelen,
+                        page,
                         role: "admin", // installation of webhooks is allowed for admins only
                     })
                     .catch((e) => {
                         console.error(e);
-                    }),
-            ),
-        );
-
-        const reposInWorkspace = await reposPromise;
-        for (const repos of reposInWorkspace) {
-            if (repos) {
-                for (const repo of repos.data.values || []) {
-                    let cloneUrl = repo.links!.clone!.find((x: any) => x.name === "https")!.href!;
-                    if (cloneUrl) {
-                        const url = new URL(cloneUrl);
-                        url.username = "";
-                        cloneUrl = url.toString();
-                    }
-                    const fullName = repo.full_name!;
-                    const updatedAt = repo.updated_on!;
-                    const accountAvatarUrl = repo.links!.avatar?.href!;
-                    const account = fullName.split("/")[0];
-
-                    (account === usersBitbucketAccount ? ownersRepos : result).push({
-                        name: repo.name!,
-                        account,
-                        cloneUrl,
-                        updatedAt,
-                        accountAvatarUrl,
                     });
+                if (response) {
+                    result.push(...response.data.values);
+                    hasMorePages = response.data.size! > pagelen * page;
+                    page++;
+                } else {
+                    hasMorePages = false;
                 }
             }
+            return result;
+        };
+
+        const repos = (await Promise.all(workspaces.map((workspace) => fetchAllRepos(workspace)))).flat();
+
+        for (let repo of repos) {
+            let cloneUrl = repo.links!.clone.find((x: any) => x.name === "https").href;
+            if (cloneUrl) {
+                const url = new URL(cloneUrl);
+                url.username = "";
+                cloneUrl = url.toString();
+            }
+            const fullName = repo.full_name!;
+            const updatedAt = repo.updated_on!;
+            const accountAvatarUrl = repo.links!.avatar?.href!;
+            const account = fullName.split("/")[0];
+
+            (account === usersBitbucketAccount ? ownersRepos : result).push({
+                name: repo.name!,
+                account,
+                cloneUrl,
+                updatedAt,
+                accountAvatarUrl,
+            });
         }
 
         // put owner's repos first. the frontend will pick first account to continue with


### PR DESCRIPTION
## Description
This change allows iterating through all the pages of Bitbucket API's response.

## Related Issue(s)
Fixes #8650

## How to test
1. Have some BitBucket repositories.
2. Go to https://laushinka-0486385fa8.staging.gitpod-dev.com/new
3. See all repositories

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allows fetching more than 100 BitBucket repositories.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
