### PR TITLE
[kots]: escape golang template variables for Helm resources

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -167,7 +167,7 @@ spec:
               apiVersion: v2
               name: gitpod-kots
               description: Always ready-to-code
-              Version: "1.0.0"
+              version: "1.0.0"
               appVersion: "$(/app/installer version | yq e '.version' -)"
               EOF
 
@@ -179,6 +179,9 @@ spec:
               yq eval-all --inplace \
                 'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
                 "${GITPOD_OBJECTS}/templates/gitpod.yaml"
+
+              echo "Gitpod: Escape any Golang template values"
+              sed -i -r 's/(.*\{\{.*)/{{`\1`}}/' "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
               # The long timeout is to ensure the TLS cert is created (if required)
               echo "Gitpod: Apply the Kubernetes objects"


### PR DESCRIPTION
> This is quite annoying it got missed as (I thought) I had tested this deployment fully. Huge thanks to @geropl for helping me debug this one 🙏🏻 

## Description
<!-- Describe your changes in detail -->
Helm parses Golang template variables when rendering the Kubernetes objects. For the ws-manager config (and potentially others), this breaks as this includes Golang template variables which is interpolated at runtime.

Helm allows for escaping of Golang template variables if wrapped in ``{{`x`}}``. The sed command searches for any line containing `{{` and escapes the whole line - because we use backticks and it's (currently) only in a JSON configmap, this escapes everything adequately.

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS and run a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: escape golang template variables for Helm resources
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
