### PR TITLE
[bitbucket-server] support for projects and prebuilds

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -307,7 +307,7 @@ export interface ProviderRepository {
     account: string;
     accountAvatarUrl: string;
     cloneUrl: string;
-    updatedAt: string;
+    updatedAt?: string;
     installationId?: number;
     installationUpdatedAt?: string;
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1015,6 +1015,8 @@ export interface Repository {
     owner: string;
     name: string;
     cloneUrl: string;
+    /* Optional kind to differentiate between repositories of orgs/groups/projects and personal repos. */
+    repoKind?: string;
     description?: string;
     avatarUrl?: string;
     webUrl?: string;

--- a/components/server/ee/src/auth/host-container-mapping.ts
+++ b/components/server/ee/src/auth/host-container-mapping.ts
@@ -9,6 +9,7 @@ import { HostContainerMapping } from "../../../src/auth/host-container-mapping";
 import { gitlabContainerModuleEE } from "../gitlab/container-module";
 import { bitbucketContainerModuleEE } from "../bitbucket/container-module";
 import { gitHubContainerModuleEE } from "../github/container-module";
+import { bitbucketServerContainerModuleEE } from "../bitbucket-server/container-module";
 
 @injectable()
 export class HostContainerMappingEE extends HostContainerMapping {
@@ -20,9 +21,8 @@ export class HostContainerMappingEE extends HostContainerMapping {
                 return (modules || []).concat([gitlabContainerModuleEE]);
             case "Bitbucket":
                 return (modules || []).concat([bitbucketContainerModuleEE]);
-            // case "BitbucketServer":
-            // FIXME
-            // return (modules || []).concat([bitbucketContainerModuleEE]);
+            case "BitbucketServer":
+                return (modules || []).concat([bitbucketServerContainerModuleEE]);
             case "GitHub":
                 return (modules || []).concat([gitHubContainerModuleEE]);
             default:

--- a/components/server/ee/src/bitbucket-server/container-module.ts
+++ b/components/server/ee/src/bitbucket-server/container-module.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { ContainerModule } from "inversify";
+import { RepositoryService } from "../../../src/repohost/repo-service";
+import { BitbucketServerService } from "../prebuilds/bitbucket-server-service";
+
+export const bitbucketServerContainerModuleEE = new ContainerModule((_bind, _unbind, _isBound, rebind) => {
+    rebind(RepositoryService).to(BitbucketServerService).inSingletonScope();
+});

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -58,6 +58,7 @@ import { Config } from "../../src/config";
 import { SnapshotService } from "./workspace/snapshot-service";
 import { BitbucketAppSupport } from "./bitbucket/bitbucket-app-support";
 import { UserCounter } from "./user/user-counter";
+import { BitbucketServerApp } from "./prebuilds/bitbucket-server-app";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -77,6 +78,7 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(BitbucketApp).toSelf().inSingletonScope();
     bind(BitbucketAppSupport).toSelf().inSingletonScope();
     bind(GitHubEnterpriseApp).toSelf().inSingletonScope();
+    bind(BitbucketServerApp).toSelf().inSingletonScope();
 
     bind(UserCounter).toSelf().inSingletonScope();
 

--- a/components/server/ee/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-app.ts
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import * as express from "express";
+import { postConstruct, injectable, inject } from "inversify";
+import { ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { PrebuildManager } from "../prebuilds/prebuild-manager";
+import { TokenService } from "../../../src/user/token-service";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { CommitContext, CommitInfo, Project, StartPrebuildResult, User } from "@gitpod/gitpod-protocol";
+import { RepoURL } from "../../../src/repohost";
+import { HostContextProvider } from "../../../src/auth/host-context-provider";
+import { ContextParser } from "../../../src/workspace/context-parser-service";
+
+@injectable()
+export class BitbucketServerApp {
+    @inject(UserDB) protected readonly userDB: UserDB;
+    @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
+    @inject(TokenService) protected readonly tokenService: TokenService;
+    @inject(ProjectDB) protected readonly projectDB: ProjectDB;
+    @inject(TeamDB) protected readonly teamDB: TeamDB;
+    @inject(ContextParser) protected readonly contextParser: ContextParser;
+    @inject(HostContextProvider) protected readonly hostCtxProvider: HostContextProvider;
+
+    protected _router = express.Router();
+    public static path = "/apps/bitbucketserver/";
+
+    @postConstruct()
+    protected init() {
+        this._router.post("/", async (req, res) => {
+            try {
+                const payload = req.body;
+                if (PushEventPayload.is(req.body)) {
+                    const span = TraceContext.startSpan("BitbucketApp.handleEvent", {});
+                    let queryToken = req.query["token"] as string;
+                    if (typeof queryToken === "string") {
+                        queryToken = decodeURIComponent(queryToken);
+                    }
+                    const user = await this.findUser({ span }, queryToken);
+                    if (!user) {
+                        // If the webhook installer is no longer found in Gitpod's DB
+                        // we should send a UNAUTHORIZED signal.
+                        res.statusCode = 401;
+                        res.send();
+                        return;
+                    }
+                    await this.handlePushHook({ span }, user, payload);
+                } else {
+                    console.warn(`Ignoring unsupported BBS event.`, { headers: req.headers });
+                }
+            } catch (err) {
+                console.error(`Couldn't handle request.`, err, { headers: req.headers, reqBody: req.body });
+            } finally {
+                // we always respond with OK, when we received a valid event.
+                res.sendStatus(200);
+            }
+        });
+    }
+
+    protected async findUser(ctx: TraceContext, secretToken: string): Promise<User> {
+        const span = TraceContext.startSpan("BitbucketApp.findUser", ctx);
+        try {
+            span.setTag("secret-token", secretToken);
+            const [userid, tokenValue] = secretToken.split("|");
+            const user = await this.userDB.findUserById(userid);
+            if (!user) {
+                throw new Error("No user found for " + secretToken + " found.");
+            } else if (!!user.blocked) {
+                throw new Error(`Blocked user ${user.id} tried to start prebuild.`);
+            }
+            const identity = user.identities.find((i) => i.authProviderId === TokenService.GITPOD_AUTH_PROVIDER_ID);
+            if (!identity) {
+                throw new Error(`User ${user.id} has no identity for '${TokenService.GITPOD_AUTH_PROVIDER_ID}'.`);
+            }
+            const tokens = await this.userDB.findTokensForIdentity(identity);
+            const token = tokens.find((t) => t.token.value === tokenValue);
+            if (!token) {
+                throw new Error(`User ${user.id} has no token with given value.`);
+            }
+            return user;
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async handlePushHook(
+        ctx: TraceContext,
+        user: User,
+        event: PushEventPayload,
+    ): Promise<StartPrebuildResult | undefined> {
+        const span = TraceContext.startSpan("Bitbucket.handlePushHook", ctx);
+        try {
+            const contextUrl = this.createContextUrl(event);
+            span.setTag("contextUrl", contextUrl);
+            const context = await this.contextParser.handle({ span }, user, contextUrl);
+            if (!CommitContext.is(context)) {
+                throw new Error("CommitContext exprected.");
+            }
+            const cloneUrl = context.repository.cloneUrl;
+            const commit = context.revision;
+            const projectAndOwner = await this.findProjectAndOwner(cloneUrl, user);
+            const config = await this.prebuildManager.fetchConfig({ span }, user, context);
+            if (!this.prebuildManager.shouldPrebuild(config)) {
+                console.log("Bitbucket push event: No config. No prebuild.");
+                return undefined;
+            }
+
+            console.debug("Bitbucket Server push event: Starting prebuild.", { contextUrl });
+
+            const commitInfo = await this.getCommitInfo(user, cloneUrl, commit);
+
+            const ws = await this.prebuildManager.startPrebuild(
+                { span },
+                {
+                    user: projectAndOwner.user,
+                    project: projectAndOwner?.project,
+                    context,
+                    commitInfo,
+                },
+            );
+            return ws;
+        } finally {
+            span.finish();
+        }
+    }
+
+    private async getCommitInfo(user: User, repoURL: string, commitSHA: string) {
+        const parsedRepo = RepoURL.parseRepoUrl(repoURL)!;
+        const hostCtx = this.hostCtxProvider.get(parsedRepo.host);
+        let commitInfo: CommitInfo | undefined;
+        if (hostCtx?.services?.repositoryProvider) {
+            commitInfo = await hostCtx?.services?.repositoryProvider.getCommitInfo(
+                user,
+                parsedRepo.owner,
+                parsedRepo.repo,
+                commitSHA,
+            );
+        }
+        return commitInfo;
+    }
+
+    /**
+     * Finds the relevant user account and project to the provided webhook event information.
+     *
+     * First of all it tries to find the project for the given `cloneURL`, then it tries to
+     * find the installer, which is also supposed to be a team member. As a fallback, it
+     * looks for a team member which also has a bitbucket.org connection.
+     *
+     * @param cloneURL of the webhook event
+     * @param webhookInstaller the user account known from the webhook installation
+     * @returns a promise which resolves to a user account and an optional project.
+     */
+    protected async findProjectAndOwner(
+        cloneURL: string,
+        webhookInstaller: User,
+    ): Promise<{ user: User; project?: Project }> {
+        const project = await this.projectDB.findProjectByCloneUrl(cloneURL);
+        if (project) {
+            if (project.userId) {
+                const user = await this.userDB.findUserById(project.userId);
+                if (user) {
+                    return { user, project };
+                }
+            } else if (project.teamId) {
+                const teamMembers = await this.teamDB.findMembersByTeam(project.teamId || "");
+                if (teamMembers.some((t) => t.userId === webhookInstaller.id)) {
+                    return { user: webhookInstaller, project };
+                }
+                for (const teamMember of teamMembers) {
+                    const user = await this.userDB.findUserById(teamMember.userId);
+                    if (user && user.identities.some((i) => i.authProviderId === "Public-Bitbucket")) {
+                        return { user, project };
+                    }
+                }
+            }
+        }
+        return { user: webhookInstaller };
+    }
+
+    protected createContextUrl(event: PushEventPayload): string {
+        const projectBrowseUrl = event.repository.links.self[0].href;
+        const branchName = event.changes[0].ref.displayId;
+        const contextUrl = `${projectBrowseUrl}?at=${encodeURIComponent(branchName)}`;
+        return contextUrl;
+    }
+
+    get router(): express.Router {
+        return this._router;
+    }
+}
+
+interface PushEventPayload {
+    eventKey: "repo:refs_changed" | string;
+    date: string;
+    actor: {
+        name: string;
+        emailAddress: string;
+        id: number;
+        displayName: string;
+        slug: string;
+        type: "NORMAL" | string;
+    };
+    repository: {
+        slug: string;
+        id: number;
+        name: string;
+        project: {
+            key: string;
+            id: number;
+            name: string;
+            public: boolean;
+            type: "NORMAL" | "PERSONAL";
+        };
+        links: {
+            clone: {
+                href: string;
+                name: string;
+            }[];
+            self: {
+                href: string;
+            }[];
+        };
+        public: boolean;
+    };
+    changes: {
+        ref: {
+            id: string;
+            displayId: string;
+            type: "BRANCH" | string;
+        };
+        refId: string;
+        fromHash: string;
+        toHash: string;
+        type: "UPDATE" | string;
+    }[];
+}
+namespace PushEventPayload {
+    export function is(payload: any): payload is PushEventPayload {
+        return typeof payload === "object" && "eventKey" in payload && payload["eventKey"] === "repo:refs_changed";
+    }
+}

--- a/components/server/ee/src/prebuilds/bitbucket-server-service.spec.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-service.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User } from "@gitpod/gitpod-protocol";
+import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
+import { Container, ContainerModule } from "inversify";
+import { retries, suite, test, timeout } from "mocha-typescript";
+import { AuthProviderParams } from "../../../src/auth/auth-provider";
+import { HostContextProvider } from "../../../src/auth/host-context-provider";
+import { BitbucketServerApi } from "../../../src/bitbucket-server/bitbucket-server-api";
+import { BitbucketServerContextParser } from "../../../src/bitbucket-server/bitbucket-server-context-parser";
+import { BitbucketServerTokenHelper } from "../../../src/bitbucket-server/bitbucket-server-token-handler";
+import { TokenProvider } from "../../../src/user/token-provider";
+import { BitbucketServerService } from "./bitbucket-server-service";
+import { expect } from "chai";
+import { Config } from "../../../src/config";
+import { TokenService } from "../../../src/user/token-service";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+
+@suite(timeout(10000), retries(1), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER"))
+class TestBitbucketServerService {
+    protected service: BitbucketServerService;
+    protected user: User;
+
+    static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
+        id: "MyBitbucketServer",
+        type: "BitbucketServer",
+        verified: true,
+        description: "",
+        icon: "",
+        host: "bitbucket.gitpod-self-hosted.com",
+        oauth: {
+            callBackUrl: "",
+            clientId: "not-used",
+            clientSecret: "",
+            tokenUrl: "",
+            scope: "",
+            authorizationUrl: "",
+        },
+    };
+
+    public before() {
+        const container = new Container();
+        container.load(
+            new ContainerModule((bind, unbind, isBound, rebind) => {
+                bind(BitbucketServerService).toSelf().inSingletonScope();
+                bind(BitbucketServerContextParser).toSelf().inSingletonScope();
+                bind(AuthProviderParams).toConstantValue(TestBitbucketServerService.AUTH_HOST_CONFIG);
+                bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                bind(TokenService).toConstantValue({
+                    createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
+                } as any);
+                bind(Config).toConstantValue({
+                    hostUrl: new GitpodHostUrl(),
+                });
+                bind(TokenProvider).toConstantValue(<TokenProvider>{
+                    getTokenForHost: async () => {
+                        return {
+                            value: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"] || "undefined",
+                            scopes: [],
+                        };
+                    },
+                    getFreshPortAuthenticationToken: undefined as any,
+                });
+                bind(BitbucketServerApi).toSelf().inSingletonScope();
+                bind(HostContextProvider).toConstantValue({
+                    get: (hostname: string) => {
+                        authProvider: {
+                            ("BBS");
+                        }
+                    },
+                });
+            }),
+        );
+        this.service = container.get(BitbucketServerService);
+        this.user = {
+            creationDate: "",
+            id: "user1",
+            identities: [
+                {
+                    authId: "user1",
+                    authName: "AlexTugarev",
+                    authProviderId: "MyBitbucketServer",
+                },
+            ],
+        };
+    }
+
+    @test async test_canInstallAutomatedPrebuilds_unauthorized() {
+        const result = await this.service.canInstallAutomatedPrebuilds(
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/users/jldec/repos/test-repo",
+        );
+        expect(result).to.be.false;
+    }
+
+    @test async test_canInstallAutomatedPrebuilds_in_project_ok() {
+        const result = await this.service.canInstallAutomatedPrebuilds(
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/projects/jldec/repos/jldec-repo-march-30",
+        );
+        expect(result).to.be.true;
+    }
+
+    @test async test_canInstallAutomatedPrebuilds_ok() {
+        const result = await this.service.canInstallAutomatedPrebuilds(
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+        );
+        expect(result).to.be.true;
+    }
+
+    @test async test_canInstallAutomatedPrebuilds_users_project_ok() {
+        const result = await this.service.canInstallAutomatedPrebuilds(
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/scm/~alextugarev/yolo.git",
+        );
+        expect(result).to.be.true;
+    }
+
+    @test async test_installAutomatedPrebuilds_ok() {
+        try {
+            await this.service.installAutomatedPrebuilds(
+                this.user,
+                "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+            );
+        } catch (error) {
+            expect.fail(error);
+        }
+    }
+
+    @test async test_installAutomatedPrebuilds_unauthorized() {
+        try {
+            await this.service.installAutomatedPrebuilds(
+                this.user,
+                "https://bitbucket.gitpod-self-hosted.com/users/jldec/repos/test-repo",
+            );
+            expect.fail("should have failed");
+        } catch (error) {}
+    }
+
+    @test async test_installAutomatedPrebuilds_in_project_ok() {
+        try {
+            await this.service.installAutomatedPrebuilds(
+                this.user,
+                "https://bitbucket.gitpod-self-hosted.com/projects/jldec/repos/jldec-repo-march-30",
+            );
+        } catch (error) {
+            expect.fail(error);
+        }
+    }
+}
+
+module.exports = new TestBitbucketServerService();

--- a/components/server/ee/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-service.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { RepositoryService } from "../../../src/repohost/repo-service";
+import { ProviderRepository, User } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { BitbucketServerApi } from "../../../src/bitbucket-server/bitbucket-server-api";
+import { AuthProviderParams } from "../../../src/auth/auth-provider";
+import { BitbucketServerContextParser } from "../../../src/bitbucket-server/bitbucket-server-context-parser";
+import { Config } from "../../../src/config";
+import { TokenService } from "../../../src/user/token-service";
+import { BitbucketServerApp } from "./bitbucket-server-app";
+
+@injectable()
+export class BitbucketServerService extends RepositoryService {
+    static PREBUILD_TOKEN_SCOPE = "prebuilds";
+
+    @inject(BitbucketServerApi) protected api: BitbucketServerApi;
+    @inject(Config) protected readonly config: Config;
+    @inject(AuthProviderParams) protected authProviderConfig: AuthProviderParams;
+    @inject(TokenService) protected tokenService: TokenService;
+    @inject(BitbucketServerContextParser) protected contextParser: BitbucketServerContextParser;
+
+    async getRepositoriesForAutomatedPrebuilds(user: User): Promise<ProviderRepository[]> {
+        const repos = await this.api.getRepos(user, { limit: 100, permission: "REPO_ADMIN" });
+        return (repos.values || []).map((r) => {
+            const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href!;
+            // const webUrl = r.links?.self[0]?.href?.replace("/browse", "");
+            const accountAvatarUrl = this.api.getAvatarUrl(r.project.key);
+            return <ProviderRepository>{
+                name: r.name,
+                cloneUrl,
+                account: r.project.key,
+                accountAvatarUrl,
+                // updatedAt: TODO(at): this isn't provided directly
+            };
+        });
+    }
+
+    async canInstallAutomatedPrebuilds(user: User, cloneUrl: string): Promise<boolean> {
+        const { host, repoKind, owner, repoName } = await this.contextParser.parseURL(user, cloneUrl);
+        if (host !== this.authProviderConfig.host) {
+            return false;
+        }
+
+        const identity = user.identities.find((i) => i.authProviderId === this.authProviderConfig.id);
+        if (!identity) {
+            console.error(
+                `Unexpected call of canInstallAutomatedPrebuilds. Not authorized with ${this.authProviderConfig.host}.`,
+            );
+            return false;
+        }
+
+        try {
+            await this.api.getWebhooks(user, { repoKind, repositorySlug: repoName, owner });
+            // reading webhooks to check if admin scope is provided
+        } catch (error) {
+            return false;
+        }
+
+        if (repoKind === "users") {
+            const ownProfile = await this.api.getUserProfile(user, identity.authName);
+            if (owner === ownProfile.slug) {
+                return true;
+            }
+        }
+
+        let permission = await this.api.getPermission(user, { username: identity.authName, repoKind, owner, repoName });
+        if (!permission && repoKind === "projects") {
+            permission = await this.api.getPermission(user, { username: identity.authName, repoKind, owner });
+        }
+
+        if (this.hasPermissionToCreateWebhooks(permission)) {
+            return true;
+        }
+
+        console.debug(
+            `User is not allowed to install webhooks.\n${JSON.stringify(identity)}\n${JSON.stringify(permission)}`,
+        );
+        return false;
+    }
+
+    protected hasPermissionToCreateWebhooks(permission: string | undefined) {
+        return permission && ["REPO_ADMIN", "PROJECT_ADMIN"].indexOf(permission) !== -1;
+    }
+
+    async installAutomatedPrebuilds(user: User, cloneUrl: string): Promise<void> {
+        const { owner, repoName, repoKind } = await this.contextParser.parseURL(user, cloneUrl);
+
+        const existing = await this.api.getWebhooks(user, {
+            repoKind,
+            repositorySlug: repoName,
+            owner,
+        });
+        const hookUrl = this.getHookUrl();
+        if (existing.values && existing.values.some((hook) => hook.url && hook.url.indexOf(hookUrl) !== -1)) {
+            console.log(`BBS webhook already installed on ${cloneUrl}`);
+            return;
+        }
+        const tokenEntry = await this.tokenService.createGitpodToken(
+            user,
+            BitbucketServerService.PREBUILD_TOKEN_SCOPE,
+            cloneUrl,
+        );
+        try {
+            await this.api.setWebhook(
+                user,
+                { repoKind, repositorySlug: repoName, owner },
+                {
+                    name: `Gitpod Prebuilds for ${this.config.hostUrl}.`,
+                    active: true,
+                    configuration: {
+                        secret: "foobar123-secret",
+                    },
+                    url: hookUrl + `?token=${encodeURIComponent(user.id + "|" + tokenEntry.token.value)}`,
+                    events: ["repo:refs_changed"],
+                },
+            );
+            console.log("Installed Bitbucket Server Webhook for " + cloneUrl);
+        } catch (error) {
+            console.error(`Couldn't install Bitbucket Server Webhook for ${cloneUrl}`, error);
+        }
+    }
+
+    protected getHookUrl() {
+        return this.config.hostUrl
+            .with({
+                pathname: BitbucketServerApp.path,
+            })
+            .toString();
+    }
+}

--- a/components/server/ee/src/prebuilds/bitbucket-service.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-service.ts
@@ -25,13 +25,12 @@ export class BitbucketService extends RepositoryService {
     @inject(BitbucketContextParser) protected bitbucketContextParser: BitbucketContextParser;
 
     async canInstallAutomatedPrebuilds(user: User, cloneUrl: string): Promise<boolean> {
-        const { host } = await this.bitbucketContextParser.parseURL(user, cloneUrl);
+        const { host, owner, repoName } = await this.bitbucketContextParser.parseURL(user, cloneUrl);
         if (host !== this.authProviderConfig.host) {
             return false;
         }
 
         // only admins may install webhooks on repositories
-        const { owner, repoName } = await this.bitbucketContextParser.parseURL(user, cloneUrl);
         const api = await this.api.create(user);
         const response = await api.user.listPermissionsForRepos({
             q: `repository.full_name="${owner}/${repoName}"`,

--- a/components/server/ee/src/server.ts
+++ b/components/server/ee/src/server.ts
@@ -14,11 +14,13 @@ import { BitbucketApp } from "./prebuilds/bitbucket-app";
 import { GithubApp } from "./prebuilds/github-app";
 import { SnapshotService } from "./workspace/snapshot-service";
 import { GitHubEnterpriseApp } from "./prebuilds/github-enterprise-app";
+import { BitbucketServerApp } from "./prebuilds/bitbucket-server-app";
 
 export class ServerEE<C extends GitpodClient, S extends GitpodServer> extends Server<C, S> {
     @inject(GithubApp) protected readonly githubApp: GithubApp;
     @inject(GitLabApp) protected readonly gitLabApp: GitLabApp;
     @inject(BitbucketApp) protected readonly bitbucketApp: BitbucketApp;
+    @inject(BitbucketServerApp) protected readonly bitbucketServerApp: BitbucketServerApp;
     @inject(SnapshotService) protected readonly snapshotService: SnapshotService;
     @inject(GitHubEnterpriseApp) protected readonly gitHubEnterpriseApp: GitHubEnterpriseApp;
 
@@ -48,5 +50,8 @@ export class ServerEE<C extends GitpodClient, S extends GitpodServer> extends Se
 
         log.info("Registered GitHub EnterpriseApp app at " + GitHubEnterpriseApp.path);
         app.use(GitHubEnterpriseApp.path, this.gitHubEnterpriseApp.router);
+
+        log.info("Registered Bitbucket Server app at " + BitbucketServerApp.path);
+        app.use(BitbucketServerApp.path, this.bitbucketServerApp.router);
     }
 }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1785,6 +1785,13 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             }
         } else if (providerHost === "bitbucket.org" && provider) {
             repositories.push(...(await this.bitbucketAppSupport.getProviderRepositoriesForUser({ user, provider })));
+        } else if (provider?.authProviderType === "BitbucketServer") {
+            const hostContext = this.hostContextProvider.get(providerHost);
+            if (hostContext?.services) {
+                repositories.push(
+                    ...(await hostContext.services.repositoryService.getRepositoriesForAutomatedPrebuilds(user)),
+                );
+            }
         } else if (provider?.authProviderType === "GitLab") {
             repositories.push(...(await this.gitLabAppSupport.getProviderRepositoriesForUser({ user, provider })));
         } else {

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -27,7 +27,6 @@
     "/dist"
   ],
   "dependencies": {
-    "@atlassian/bitbucket-server": "^0.0.6",
     "@gitbeaker/node": "^25.6.0",
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-db": "0.1.5",

--- a/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User } from "@gitpod/gitpod-protocol";
+import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
+import { Container, ContainerModule } from "inversify";
+import { retries, suite, test, timeout } from "mocha-typescript";
+import { expect } from "chai";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { BitbucketServerContextParser } from "./bitbucket-server-context-parser";
+import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
+import { TokenService } from "../user/token-service";
+import { Config } from "../config";
+import { TokenProvider } from "../user/token-provider";
+import { BitbucketServerApi } from "./bitbucket-server-api";
+import { HostContextProvider } from "../auth/host-context-provider";
+
+@suite(timeout(10000), retries(0), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER"))
+class TestBitbucketServerApi {
+    protected api: BitbucketServerApi;
+    protected user: User;
+
+    static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
+        id: "MyBitbucketServer",
+        type: "BitbucketServer",
+        verified: true,
+        host: "bitbucket.gitpod-self-hosted.com",
+        oauth: {} as any,
+    };
+
+    public before() {
+        const container = new Container();
+        container.load(
+            new ContainerModule((bind, unbind, isBound, rebind) => {
+                bind(BitbucketServerApi).toSelf().inSingletonScope();
+                bind(BitbucketServerContextParser).toSelf().inSingletonScope();
+                bind(AuthProviderParams).toConstantValue(TestBitbucketServerApi.AUTH_HOST_CONFIG);
+                bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                bind(TokenService).toConstantValue({
+                    createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
+                } as any);
+                bind(Config).toConstantValue({
+                    hostUrl: new GitpodHostUrl(),
+                });
+                bind(TokenProvider).toConstantValue(<TokenProvider>{
+                    getTokenForHost: async () => {
+                        return {
+                            value: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"] || "undefined",
+                            scopes: [],
+                        };
+                    },
+                    getFreshPortAuthenticationToken: undefined as any,
+                });
+                bind(HostContextProvider).toConstantValue({
+                    get: (hostname: string) => {
+                        authProvider: {
+                            ("BBS");
+                        }
+                    },
+                });
+            }),
+        );
+        this.api = container.get(BitbucketServerApi);
+        this.user = {
+            creationDate: "",
+            id: "user1",
+            identities: [
+                {
+                    authId: "user1",
+                    authName: "AlexTugarev",
+                    authProviderId: "MyBitbucketServer",
+                },
+            ],
+        };
+    }
+
+    @test async test_currentUsername_ok() {
+        const result = await this.api.currentUsername(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!);
+        expect(result).to.equal("AlexTugarev");
+    }
+
+    @test async test_getUserProfile_ok() {
+        const result = await this.api.getUserProfile(process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"]!, "AlexTugarev");
+        expect(result).to.deep.include({
+            id: 105, // Identity.authId
+            name: "AlexTugarev", // Identity.authName
+            slug: "alextugarev", // used in URLs
+            displayName: "Alex Tugarev",
+        });
+    }
+}
+
+module.exports = new TestBitbucketServerApi();

--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -15,70 +15,309 @@ export class BitbucketServerApi {
     @inject(AuthProviderParams) protected readonly config: AuthProviderParams;
     @inject(BitbucketServerTokenHelper) protected readonly tokenHelper: BitbucketServerTokenHelper;
 
-    public async runQuery<T>(user: User, urlPath: string): Promise<T> {
+    public async runQuery<T>(
+        userOrToken: User | string,
+        urlPath: string,
+        method: string = "GET",
+        body?: string,
+    ): Promise<T> {
+        const token =
+            typeof userOrToken === "string"
+                ? userOrToken
+                : (await this.tokenHelper.getTokenWithScopes(userOrToken, [])).value;
+        const fullUrl = `${this.baseUrl}${urlPath}`;
+        let result: string = "OK";
+        try {
+            const response = await fetch(fullUrl, {
+                timeout: 10000,
+                method,
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
+                },
+                body,
+            });
+
+            if (!response.ok) {
+                let json: object | undefined;
+                try {
+                    json = await response.json();
+                } catch {
+                    // ignoring non-json responses and handling in general case bellow
+                }
+                if (BitbucketServer.ErrorResponse.is(json)) {
+                    throw Object.assign(new Error(`${response.status} / ${json.errors[0]?.message}`), {
+                        json,
+                    });
+                }
+                throw Object.assign(new Error(`${response.status} / ${response.statusText}`), { response });
+            }
+            return (await response.json()) as T;
+        } catch (error) {
+            result = "error " + error?.message;
+            throw error;
+        } finally {
+            console.debug(`BitbucketServer GET ${fullUrl} - ${result}`);
+        }
+    }
+
+    public async fetchContent(user: User, urlPath: string): Promise<string> {
         const token = (await this.tokenHelper.getTokenWithScopes(user, [])).value;
         const fullUrl = `${this.baseUrl}${urlPath}`;
-        const response = await fetch(fullUrl, {
-            timeout: 10000,
-            method: "GET",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-            },
-        });
-        if (!response.ok) {
-            throw Error(response.statusText);
+        let result: string = "OK";
+        try {
+            const response = await fetch(fullUrl, {
+                timeout: 10000,
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            });
+
+            if (!response.ok) {
+                throw Error(`${response.status} / ${response.statusText}`);
+            }
+            return await response.text();
+        } catch (error) {
+            result = "error " + error?.message;
+            throw error;
+        } finally {
+            console.debug(`BBS GET ${fullUrl} - ${result}`);
         }
-        const result = await response.json();
-        return result as T;
+    }
+
+    public async currentUsername(accessToken: string): Promise<string> {
+        const fullUrl = `https://${this.config.host}/plugins/servlet/applinks/whoami`;
+        let result: string = "OK";
+        try {
+            const response = await fetch(fullUrl, {
+                timeout: 10000,
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            });
+            if (!response.ok) {
+                throw new Error(`${response.status} / ${response.statusText}`);
+            }
+            return response.text();
+        } catch (error) {
+            result = error?.message;
+            console.error(`BBS GET ${fullUrl} - ${result}`);
+            throw error;
+        }
+    }
+
+    getAvatarUrl(username: string) {
+        return `https://${this.config.host}/users/${username}/avatar.png`;
+    }
+
+    async getUserProfile(userOrToken: User | string, username: string): Promise<BitbucketServer.User> {
+        return this.runQuery<BitbucketServer.User>(userOrToken, `/users/${username}`);
+    }
+
+    async getProject(userOrToken: User | string, projectSlug: string): Promise<BitbucketServer.Project> {
+        return this.runQuery<BitbucketServer.Project>(userOrToken, `/projects/${projectSlug}`);
+    }
+
+    async getPermission(
+        user: User,
+        params: { username: string; repoKind: BitbucketServer.RepoKind; owner: string; repoName?: string },
+    ): Promise<string | undefined> {
+        const { username, repoKind, owner, repoName } = params;
+        if (repoName) {
+            const repoPermissions = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.PermissionEntry>>(
+                user,
+                `/${repoKind}/${owner}/repos/${repoName}/permissions/users`,
+            );
+            const repoPermission = repoPermissions.values?.find((p) => p.user.name === username)?.permission;
+            if (repoPermission) {
+                return repoPermission;
+            }
+        }
+        if (repoKind === "projects") {
+            const projectPermissions = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.PermissionEntry>>(
+                user,
+                `/${repoKind}/${owner}/permissions/users`,
+            );
+            const projectPermission = projectPermissions.values?.find((p) => p.user.name === username)?.permission;
+            return projectPermission;
+        }
     }
 
     protected get baseUrl(): string {
         return `https://${this.config.host}/rest/api/1.0`;
     }
 
-    getRepository(
+    async getRepository(
         user: User,
-        params: { kind: "projects" | "users"; userOrProject: string; repositorySlug: string },
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
     ): Promise<BitbucketServer.Repository> {
         return this.runQuery<BitbucketServer.Repository>(
             user,
-            `/${params.kind}/${params.userOrProject}/repos/${params.repositorySlug}`,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}`,
         );
     }
 
-    getCommits(
+    async getCommits(
         user: User,
-        params: { kind: "projects" | "users"; userOrProject: string; repositorySlug: string; q?: { limit: number } },
+        params: {
+            repoKind: "projects" | "users" | string;
+            owner: string;
+            repositorySlug: string;
+            query?: { limit?: number; path?: string; shaOrRevision?: string };
+        },
     ): Promise<BitbucketServer.Paginated<BitbucketServer.Commit>> {
+        let q = "";
+        if (params.query) {
+            const segments = [];
+            if (params.query.limit) {
+                segments.push(`limit=${params.query.limit}`);
+            }
+            if (params.query.path) {
+                segments.push(`path=${params.query.path}`);
+            }
+            if (params.query.shaOrRevision) {
+                segments.push(`until=${params.query.shaOrRevision}`);
+            }
+            if (segments.length > 0) {
+                q = `?${segments.join("&")}`;
+            }
+        }
         return this.runQuery<BitbucketServer.Paginated<BitbucketServer.Commit>>(
             user,
-            `/${params.kind}/${params.userOrProject}/repos/${params.repositorySlug}/commits`,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/commits${q}`,
         );
     }
 
-    getDefaultBranch(
+    async getDefaultBranch(
         user: User,
-        params: { kind: "projects" | "users"; userOrProject: string; repositorySlug: string },
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
     ): Promise<BitbucketServer.Branch> {
-        //https://bitbucket.gitpod-self-hosted.com/rest/api/1.0/users/jldec/repos/test-repo/default-branch
         return this.runQuery<BitbucketServer.Branch>(
             user,
-            `/${params.kind}/${params.userOrProject}/repos/${params.repositorySlug}/default-branch`,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/default-branch`,
         );
+    }
+
+    getHtmlUrlForBranch(params: {
+        repoKind: "projects" | "users";
+        owner: string;
+        repositorySlug: string;
+        branchName: string;
+    }): string {
+        return `https://${this.config.host}/${params.repoKind}/${params.owner}/repos/${
+            params.repositorySlug
+        }/browse?at=${encodeURIComponent(`refs/heads/${params.branchName}`)}`;
+    }
+
+    async getBranch(
+        user: User,
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string; branchName: string },
+    ): Promise<BitbucketServer.BranchWithMeta> {
+        const result = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.BranchWithMeta>>(
+            user,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/branches?details=true&filterText=${params.branchName}&boostMatches=true`,
+        );
+        const first = result.values && result.values[0];
+        if (first && first.displayId === params.branchName) {
+            first.latestCommitMetadata =
+                first.metadata["com.atlassian.bitbucket.server.bitbucket-branch:latest-commit-metadata"];
+            first.htmlUrl = this.getHtmlUrlForBranch({
+                repoKind: params.repoKind,
+                owner: params.owner,
+                repositorySlug: params.repositorySlug,
+                branchName: first.displayId,
+            });
+            return first;
+        }
+        throw new Error(`Could not find branch "${params.branchName}."`);
+    }
+
+    async getBranches(
+        user: User,
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
+    ): Promise<BitbucketServer.BranchWithMeta[]> {
+        const result = await this.runQuery<BitbucketServer.Paginated<BitbucketServer.BranchWithMeta>>(
+            user,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/branches?details=true&orderBy=MODIFICATION&limit=1000`,
+        );
+        const branches = result.values || [];
+        for (const branch of branches) {
+            branch.latestCommitMetadata =
+                branch.metadata["com.atlassian.bitbucket.server.bitbucket-branch:latest-commit-metadata"];
+            branch.htmlUrl = this.getHtmlUrlForBranch({
+                repoKind: params.repoKind,
+                owner: params.owner,
+                repositorySlug: params.repositorySlug,
+                branchName: branch.displayId,
+            });
+        }
+        return branches;
+    }
+
+    async getWebhooks(
+        user: User,
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
+    ): Promise<BitbucketServer.Paginated<BitbucketServer.Webhook>> {
+        return this.runQuery<BitbucketServer.Paginated<BitbucketServer.Webhook>>(
+            user,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/webhooks`,
+        );
+    }
+
+    setWebhook(
+        user: User,
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
+        webhook: BitbucketServer.WebhookParams,
+    ) {
+        const body = JSON.stringify(webhook);
+        return this.runQuery<any>(
+            user,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/webhooks`,
+            "POST",
+            body,
+        );
+    }
+
+    async getRepos(
+        user: User,
+        query: {
+            permission?: "REPO_READ" | "REPO_WRITE" | "REPO_ADMIN";
+            limit: number;
+        },
+    ) {
+        let q = "";
+        if (query) {
+            const segments = [];
+            if (query.permission) {
+                segments.push(`permission=${query.permission}`);
+            }
+            if (query.limit) {
+                segments.push(`limit=${query.limit}`);
+            }
+            if (segments.length > 0) {
+                q = `?${segments.join("&")}`;
+            }
+        }
+        return this.runQuery<BitbucketServer.Paginated<BitbucketServer.Repository>>(user, `/repos${q}`);
     }
 }
 
 export namespace BitbucketServer {
+    export type RepoKind = "users" | "projects";
     export interface Repository {
         id: number;
         slug: string;
         name: string;
+        description?: string;
         public: boolean;
         links: {
             clone: {
                 href: string;
                 name: string;
+            }[];
+            self: {
+                href: string;
             }[];
         };
         project: Project;
@@ -100,6 +339,14 @@ export namespace BitbucketServer {
         isDefault: boolean;
     }
 
+    export interface BranchWithMeta extends Branch {
+        latestCommitMetadata: Commit;
+        htmlUrl: string;
+        metadata: {
+            "com.atlassian.bitbucket.server.bitbucket-branch:latest-commit-metadata": Commit;
+        };
+    }
+
     export interface User {
         name: string;
         emailAddress: string;
@@ -115,12 +362,17 @@ export namespace BitbucketServer {
                 },
             ];
         };
+        avatarUrl?: string;
     }
 
     export interface Commit {
         id: string;
         displayId: string;
         author: BitbucketServer.User;
+        authorTimestamp: number;
+        commiter: BitbucketServer.User;
+        committerTimestamp: number;
+        message: string;
     }
 
     export interface Paginated<T> {
@@ -130,5 +382,46 @@ export namespace BitbucketServer {
         start?: number;
         values?: T[];
         [k: string]: any;
+    }
+
+    export interface Webhook {
+        id: number;
+        name: "test-webhook";
+        createdDate: number;
+        updatedDate: number;
+        events: any;
+        configuration: any;
+        url: string;
+        active: boolean;
+    }
+
+    export interface PermissionEntry {
+        user: User;
+        permission: string;
+    }
+
+    export interface WebhookParams {
+        name: string;
+        events: string[];
+        // "events": [
+        //     "repo:refs_changed",
+        //     "repo:modified"
+        // ],
+        configuration: {
+            secret: string;
+        };
+        url: string;
+        active: boolean;
+    }
+
+    export interface ErrorResponse {
+        errors: {
+            message: string;
+        }[];
+    }
+    export namespace ErrorResponse {
+        export function is(o: any): o is ErrorResponse {
+            return typeof o === "object" && "errors" in o;
+        }
     }
 }

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User } from "@gitpod/gitpod-protocol";
+import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
+import { Container, ContainerModule } from "inversify";
+import { suite, test, timeout } from "mocha-typescript";
+import { expect } from "chai";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { BitbucketServerFileProvider } from "./bitbucket-server-file-provider";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { BitbucketServerContextParser } from "./bitbucket-server-context-parser";
+import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
+import { TokenService } from "../user/token-service";
+import { Config } from "../config";
+import { TokenProvider } from "../user/token-provider";
+import { BitbucketServerApi } from "./bitbucket-server-api";
+import { HostContextProvider } from "../auth/host-context-provider";
+
+@suite(timeout(10000), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER"))
+class TestBitbucketServerContextParser {
+    protected parser: BitbucketServerContextParser;
+    protected user: User;
+
+    static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
+        id: "MyBitbucketServer",
+        type: "BitbucketServer",
+        host: "bitbucket.gitpod-self-hosted.com",
+    };
+
+    public before() {
+        const container = new Container();
+        container.load(
+            new ContainerModule((bind, unbind, isBound, rebind) => {
+                bind(BitbucketServerFileProvider).toSelf().inSingletonScope();
+                bind(BitbucketServerContextParser).toSelf().inSingletonScope();
+                bind(AuthProviderParams).toConstantValue(TestBitbucketServerContextParser.AUTH_HOST_CONFIG);
+                bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                bind(TokenService).toConstantValue({
+                    createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
+                } as any);
+                bind(Config).toConstantValue({
+                    hostUrl: new GitpodHostUrl(),
+                });
+                bind(TokenProvider).toConstantValue(<TokenProvider>{
+                    getTokenForHost: async () => {
+                        return {
+                            value: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"] || "undefined",
+                            scopes: [],
+                        };
+                    },
+                    getFreshPortAuthenticationToken: undefined as any,
+                });
+                bind(BitbucketServerApi).toSelf().inSingletonScope();
+                bind(HostContextProvider).toConstantValue({
+                    get: (hostname: string) => {
+                        authProvider: {
+                            ("BBS");
+                        }
+                    },
+                });
+            }),
+        );
+        this.parser = container.get(BitbucketServerContextParser);
+        this.user = {
+            creationDate: "",
+            id: "user1",
+            identities: [
+                {
+                    authId: "user1",
+                    authName: "AlexTugarev",
+                    authProviderId: "MyBitbucketServer",
+                },
+            ],
+        };
+    }
+
+    @test async test_tree_context_01() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+        );
+
+        expect(result).to.deep.include({
+            ref: "master",
+            refType: "branch",
+            revision: "535924584468074ec5dcbe935f4e68fbc3f0cb2d",
+            path: "",
+            isFile: false,
+            repository: {
+                host: "bitbucket.gitpod-self-hosted.com",
+                owner: "FOO",
+                name: "repo123",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                defaultBranch: "master",
+                private: true,
+                repoKind: "projects",
+            },
+            title: "FOO/repo123 - master",
+        });
+    }
+
+    @test async test_tree_context_02() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+        );
+
+        expect(result).to.deep.include({
+            ref: "master",
+            refType: "branch",
+            revision: "535924584468074ec5dcbe935f4e68fbc3f0cb2d",
+            path: "",
+            isFile: false,
+            repository: {
+                host: "bitbucket.gitpod-self-hosted.com",
+                owner: "FOO",
+                name: "repo123",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                defaultBranch: "master",
+                private: true,
+                repoKind: "projects",
+            },
+            title: "foo/repo123 - master",
+        });
+    }
+
+    @test async test_tree_context_03() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/scm/~alextugarev/tada.git",
+        );
+
+        expect(result).to.deep.include({
+            ref: "main",
+            refType: "branch",
+            revision: "a15d7d15adee54d0afdbe88148c8e587e8fb609d",
+            path: "",
+            isFile: false,
+            repository: {
+                host: "bitbucket.gitpod-self-hosted.com",
+                owner: "alextugarev",
+                name: "tada",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/~alextugarev/tada.git",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/users/alextugarev/repos/tada",
+                defaultBranch: "main",
+                private: true,
+                repoKind: "users",
+            },
+            title: "alextugarev/tada - main",
+        });
+    }
+}
+
+module.exports = new TestBitbucketServerContextParser();

--- a/components/server/src/bitbucket-server/bitbucket-server-file-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-file-provider.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Repository, User } from "@gitpod/gitpod-protocol";
+import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
+import { Container, ContainerModule } from "inversify";
+import { retries, suite, test, timeout } from "mocha-typescript";
+import { expect } from "chai";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { BitbucketServerFileProvider } from "./bitbucket-server-file-provider";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { BitbucketServerContextParser } from "./bitbucket-server-context-parser";
+import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
+import { TokenService } from "../user/token-service";
+import { Config } from "../config";
+import { TokenProvider } from "../user/token-provider";
+import { BitbucketServerApi } from "./bitbucket-server-api";
+import { HostContextProvider } from "../auth/host-context-provider";
+
+@suite(timeout(10000), retries(1), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER"))
+class TestBitbucketServerFileProvider {
+    protected service: BitbucketServerFileProvider;
+    protected user: User;
+
+    static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
+        id: "MyBitbucketServer",
+        type: "BitbucketServer",
+        verified: true,
+        description: "",
+        icon: "",
+        host: "bitbucket.gitpod-self-hosted.com",
+        oauth: {
+            callBackUrl: "",
+            clientId: "not-used",
+            clientSecret: "",
+            tokenUrl: "",
+            scope: "",
+            authorizationUrl: "",
+        },
+    };
+
+    public before() {
+        const container = new Container();
+        container.load(
+            new ContainerModule((bind, unbind, isBound, rebind) => {
+                bind(BitbucketServerFileProvider).toSelf().inSingletonScope();
+                bind(BitbucketServerContextParser).toSelf().inSingletonScope();
+                bind(AuthProviderParams).toConstantValue(TestBitbucketServerFileProvider.AUTH_HOST_CONFIG);
+                bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                bind(TokenService).toConstantValue({
+                    createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
+                } as any);
+                bind(Config).toConstantValue({
+                    hostUrl: new GitpodHostUrl(),
+                });
+                bind(TokenProvider).toConstantValue(<TokenProvider>{
+                    getTokenForHost: async () => {
+                        return {
+                            value: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"] || "undefined",
+                            scopes: [],
+                        };
+                    },
+                    getFreshPortAuthenticationToken: undefined as any,
+                });
+                bind(BitbucketServerApi).toSelf().inSingletonScope();
+                bind(HostContextProvider).toConstantValue({
+                    get: (hostname: string) => {
+                        authProvider: {
+                            ("BBS");
+                        }
+                    },
+                });
+            }),
+        );
+        this.service = container.get(BitbucketServerFileProvider);
+        this.user = {
+            creationDate: "",
+            id: "user1",
+            identities: [
+                {
+                    authId: "user1",
+                    authName: "AlexTugarev",
+                    authProviderId: "MyBitbucketServer",
+                },
+            ],
+        };
+    }
+
+    @test async test_getGitpodFileContent_ok() {
+        const result = await this.service.getGitpodFileContent(
+            {
+                revision: "master",
+                repository: <Repository>{
+                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                    name: "repo123",
+                    repoKind: "projects",
+                    owner: "FOO",
+                },
+            } as any,
+            this.user,
+        );
+        expect(result).not.to.be.empty;
+        expect(result).to.contain("tasks:");
+    }
+
+    @test async test_getLastChangeRevision_ok() {
+        const result = await this.service.getLastChangeRevision(
+            {
+                owner: "FOO",
+                name: "repo123",
+                repoKind: "projects",
+                revision: "foo",
+                host: "bitbucket.gitpod-self-hosted.com",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+            } as Repository,
+            "foo",
+            this.user,
+            "folder/sub/test.txt",
+        );
+        expect(result).to.equal("1384b6842d73b8705feaf45f3e8aa41f00529042");
+    }
+}
+
+module.exports = new TestBitbucketServerFileProvider();

--- a/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
@@ -14,7 +14,10 @@ export namespace BitbucketServerOAuthScopes {
     /** Push over https, fork repo */
     export const REPOSITORY_WRITE = "REPO_WRITE";
 
-    export const ALL = [PUBLIC_REPOS, REPOSITORY_READ, REPOSITORY_WRITE];
+    export const REPO_ADMIN = "REPO_ADMIN";
+    export const PROJECT_ADMIN = "PROJECT_ADMIN";
+
+    export const ALL = [PUBLIC_REPOS, REPOSITORY_READ, REPOSITORY_WRITE, REPO_ADMIN, PROJECT_ADMIN];
 
     export const Requirements = {
         /**

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User } from "@gitpod/gitpod-protocol";
+import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
+import { Container, ContainerModule } from "inversify";
+import { retries, suite, test, timeout } from "mocha-typescript";
+import { expect } from "chai";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { BitbucketServerContextParser } from "./bitbucket-server-context-parser";
+import { BitbucketServerTokenHelper } from "./bitbucket-server-token-handler";
+import { TokenService } from "../user/token-service";
+import { Config } from "../config";
+import { TokenProvider } from "../user/token-provider";
+import { BitbucketServerApi } from "./bitbucket-server-api";
+import { HostContextProvider } from "../auth/host-context-provider";
+import { BitbucketServerRepositoryProvider } from "./bitbucket-server-repository-provider";
+
+@suite(timeout(10000), retries(0), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER"))
+class TestBitbucketServerRepositoryProvider {
+    protected service: BitbucketServerRepositoryProvider;
+    protected user: User;
+
+    static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
+        id: "MyBitbucketServer",
+        type: "BitbucketServer",
+        verified: true,
+        description: "",
+        icon: "",
+        host: "bitbucket.gitpod-self-hosted.com",
+        oauth: {
+            callBackUrl: "",
+            clientId: "not-used",
+            clientSecret: "",
+            tokenUrl: "",
+            scope: "",
+            authorizationUrl: "",
+        },
+    };
+
+    public before() {
+        const container = new Container();
+        container.load(
+            new ContainerModule((bind, unbind, isBound, rebind) => {
+                bind(BitbucketServerRepositoryProvider).toSelf().inSingletonScope();
+                bind(BitbucketServerContextParser).toSelf().inSingletonScope();
+                bind(AuthProviderParams).toConstantValue(TestBitbucketServerRepositoryProvider.AUTH_HOST_CONFIG);
+                bind(BitbucketServerTokenHelper).toSelf().inSingletonScope();
+                bind(TokenService).toConstantValue({
+                    createGitpodToken: async () => ({ token: { value: "foobar123-token" } }),
+                } as any);
+                bind(Config).toConstantValue({
+                    hostUrl: new GitpodHostUrl(),
+                });
+                bind(TokenProvider).toConstantValue(<TokenProvider>{
+                    getTokenForHost: async () => {
+                        return {
+                            value: process.env["GITPOD_TEST_TOKEN_BITBUCKET_SERVER"] || "undefined",
+                            scopes: [],
+                        };
+                    },
+                    getFreshPortAuthenticationToken: undefined as any,
+                });
+                bind(BitbucketServerApi).toSelf().inSingletonScope();
+                bind(HostContextProvider).toConstantValue({});
+            }),
+        );
+        this.service = container.get(BitbucketServerRepositoryProvider);
+        this.user = {
+            creationDate: "",
+            id: "user1",
+            identities: [
+                {
+                    authId: "user1",
+                    authName: "AlexTugarev",
+                    authProviderId: "MyBitbucketServer",
+                },
+            ],
+        };
+    }
+
+    @test async test_getRepo_ok() {
+        const result = await this.service.getRepo(this.user, "JLDEC", "jldec-repo-march-30");
+        expect(result).to.deep.include({
+            webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/JLDEC/repos/jldec-repo-march-30",
+            cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/jldec/jldec-repo-march-30.git",
+        });
+    }
+
+    @test async test_getBranch_ok() {
+        const result = await this.service.getBranch(this.user, "JLDEC", "jldec-repo-march-30", "main");
+        expect(result).to.deep.include({
+            name: "main",
+        });
+    }
+
+    @test async test_getBranches_ok() {
+        const result = await this.service.getBranches(this.user, "JLDEC", "jldec-repo-march-30");
+        expect(result.length).to.be.gte(1);
+        expect(result[0]).to.deep.include({
+            name: "main",
+        });
+    }
+
+    @test async test_getBranches_ok_2() {
+        try {
+            await this.service.getBranches(this.user, "mil", "gitpod-large-image");
+            expect.fail("this should not happen while 'mil/gitpod-large-image' has NO default branch configured.");
+        } catch (error) {
+            expect(error.message).to.include(
+                "refs/heads/master is set as the default branch, but this branch does not exist",
+            );
+        }
+    }
+
+    @test async test_getCommitInfo_ok() {
+        const result = await this.service.getCommitInfo(this.user, "JLDEC", "jldec-repo-march-30", "test");
+        expect(result).to.deep.include({
+            author: "Alex Tugarev",
+        });
+    }
+}
+
+module.exports = new TestBitbucketServerRepositoryProvider();

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -150,7 +150,12 @@ export class ProjectsService {
         const hostContext = parsedUrl?.host ? this.hostContextProvider.get(parsedUrl?.host) : undefined;
         const authProvider = hostContext && hostContext.authProvider.info;
         const type = authProvider && authProvider.authProviderType;
-        if (type === "GitLab" || type === "Bitbucket" || AuthProviderInfo.isGitHubEnterprise(authProvider)) {
+        if (
+            type === "GitLab" ||
+            type === "Bitbucket" ||
+            type === "BitbucketServer" ||
+            AuthProviderInfo.isGitHubEnterprise(authProvider)
+        ) {
             const repositoryService = hostContext?.services?.repositoryService;
             if (repositoryService) {
                 // Note: For GitLab, we expect .canInstallAutomatedPrebuilds() to always return true, because earlier

--- a/components/server/src/repohost/repo-url.ts
+++ b/components/server/src/repohost/repo-url.ts
@@ -18,7 +18,10 @@ export namespace RepoURL {
         }
         if (segments.length > 2) {
             const endSegment = segments[segments.length - 1];
-            const ownerSegments = segments.slice(0, segments.length - 1);
+            let ownerSegments = segments.slice(0, segments.length - 1);
+            if (ownerSegments[0] === "scm") {
+                ownerSegments = ownerSegments.slice(1);
+            }
             const owner = ownerSegments.join("/");
             const repo = endSegment.endsWith(".git") ? endSegment.slice(0, -4) : endSegment;
             return { host, owner, repo };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,6 @@
 # yarn lockfile v1
 
 
-"@atlassian/bitbucket-server@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@atlassian/bitbucket-server/-/bitbucket-server-0.0.6.tgz#7a0678264083c851e50a66216e66021efe1638cf"
-  integrity sha512-92EpKlSPw0ZZXiS4Qt+1DKuDxSIntL2j8Q0CWc8o/nUNOJAW/D9szIgcef5VPTbVslHeb2C3gBSMNnETdykdmQ==
-  dependencies:
-    before-after-hook "^1.1.0"
-    btoa-lite "^1.0.0"
-    debug "^3.1.0"
-    is-plain-object "^2.0.4"
-    node-fetch "^2.1.2"
-    url-template "^2.0.8"
-
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -4599,11 +4587,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-before-after-hook@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
-  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
 before-after-hook@^2.1.0, before-after-hook@^2.2.0:
   version "2.2.2"
@@ -12139,7 +12122,7 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.1.2, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.5, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.5, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
## Description
This enables prebuilds for Bitbucket Server integrations.

<img width="1443" alt="Screenshot 2022-03-19 at 06 00 10" src="https://user-images.githubusercontent.com/914497/159108098-89889b99-0c15-41a0-9826-f926b9df0f6d.png">

## Breaking Changes
* Admin scopes are required to make the webhook creation work. Full set of scopes to enable for the OAuth App: `PUBLIC_REPOS, REPO_READ, REPO_WRITE, REPO_ADMIN, PROJECT_ADMIN`
* Due to a change in `Identity.authName` mapping, users need to re-login to get that updated, otherwise repository services wont be able to read permissions properly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8455

## How to test
- [ ] Make sure to create a new account in the preview environment
- [ ] Make sure to create an account in https://bitbucket.gitpod-self-hosted.com (hint: log in as "roboquat" with the credentials in 1password, then create a new user account for yourself)
- [ ] Try to add repos with admin permission as projects. Test with personal repos as well as repos in repos.
  - [ ] Verify that webhooks are created on the BBS.
- [ ] Open workspaces for those repos and make changes.
  - [ ] Verify that prebuilds are triggered.
  - [ ] Verify that prebuilds ran on the proper branch for example.


### TODO
- [ ] manage and use webhook secret to verify events

### Known issues or out of scope
* No support for Issue and PR contexts
* No UI for setting up a BBS integration (this has to be done via config at the moment)

## Release Notes
```release-note
Adding support for Projects and Prebuilds for Bitbucket Server. 
```

