### PR TITLE
Add script to preload images onto nodes

### DIFF
--- a/dev/preview/distribute-images.sh
+++ b/dev/preview/distribute-images.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[[ "$(kubectx -c)" == "harvester" ]] || ( echo "Set kubectx to 'harvester'."; exit 1)
+
+while getopts i:s: flag
+do
+    case "${flag}" in
+        i) IMAGEID="${OPTARG}";;
+        s) STORAGECLASS="${OPTARG}";;
+        *) ;;
+    esac
+done
+
+NODES=$(kubectl get nodes -o=jsonpath='{.items[*].metadata.name}')
+NAMESPACE="distribute-${IMAGEID}"
+
+kubectl get ns "${NAMESPACE}" && kubectl delete ns "${NAMESPACE}"
+kubectl create ns "${NAMESPACE}"
+
+for NODE in $NODES
+do
+    VMNAME="${IMAGEID}-on-${NODE}"
+    PVC="pvc-${STORAGECLASS}-${NODE}"
+    kubectl apply -f - << YAML
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  namespace: ${NAMESPACE}
+  annotations:
+    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"${PVC}","annotations":{"harvesterhci.io/imageId":"default/${IMAGEID}"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"200Gi"}},"volumeMode":"Block","storageClassName":"${STORAGECLASS}"}}]'
+    network.harvesterhci.io/ips: "[]"
+  labels:
+    harvesterhci.io/creator: harvester
+    harvesterhci.io/os: ubuntu
+  name: ${VMNAME}
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        harvesterhci.io/sshNames: "[]"
+      labels:
+        harvesterhci.io/vmName: ${VMNAME}
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ${NODE}
+      domain:
+        machine:
+          type: q35
+        cpu:
+          cores: 2
+          sockets: 1
+          threads: 1
+        devices:
+          interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+          disks:
+            - name: system
+              bootOrder: 1
+              disk:
+                bus: scsi
+        resources:
+          limits:
+            memory: 4Gi
+            cpu: 2
+      evictionStrategy: LiveMigrate
+      networks:
+        - pod: {}
+          name: default
+      volumes:
+        - name: system
+          persistentVolumeClaim:
+            claimName: ${PVC}
+YAML
+done

--- a/dev/preview/distribute-images.sh
+++ b/dev/preview/distribute-images.sh
@@ -13,6 +13,8 @@ do
     esac
 done
 
+// We don't delete the namespace "distribute-${IMAGEID} because we want to avoid
+// images from being garbage collected
 NODES=$(kubectl get nodes -o=jsonpath='{.items[*].metadata.name}')
 NAMESPACE="distribute-${IMAGEID}"
 


### PR DESCRIPTION
## Description
This PR adds a script that preloads the VM image onto all harvester nodes by creating a VM on every node.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # https://github.com/gitpod-io/gitpod/issues/8634

## How to test
Run `./dev/preview/distribute-images.sh -i image-xcx77 -s longhorn-image-xcx77-onereplica`
See VMs getting created. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
