### PR TITLE
Remove console statements introduced in #7715

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -170,11 +170,9 @@ export async function refreshSearchData(query: string, user: User | undefined): 
 
 // Fetch all possible search results and cache them into local storage
 async function actuallyRefreshSearchData(query: string, user: User | undefined): Promise<boolean> {
-    console.log("refreshing search data");
     const oldData = loadSearchData();
     const newData = await getGitpodService().server.getSuggestedContextURLs();
     if (JSON.stringify(oldData) !== JSON.stringify(newData)) {
-        console.log("new data:", newData);
         saveSearchData(newData);
         return true;
     }
@@ -190,6 +188,5 @@ async function findResults(query: string, onResults: (results: string[]) => void
             searchData.push(query);
         }
     } catch {}
-    // console.log('searching', query, 'in', searchData);
     onResults(searchData.filter((result) => result.toLowerCase().includes(query.toLowerCase())));
 }


### PR DESCRIPTION
## Description
I discovered that in parts of the dashboard my console is full of a very long array of my repo recommendations, so this PR fixes that by removing all `console.log()`s introduced in #7715.

## How to test
Should have no effect on anything at all :)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

I hope these really are not needed, I assumed they would only be needed in debugging.

cc @jankeromnes
