### PR TITLE
Extend compatibility of JetBrains Gateway plugin to the EAP version

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -6,13 +6,13 @@ pluginName=gitpod-gateway
 pluginVersion=0.0.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=213
-pluginUntilBuild=213.*
+pluginSinceBuild=221
+pluginUntilBuild=221.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2021.3.1
+pluginVerifierIdeVersions=2022.1
 platformType=GW
-platformVersion=213.6777.25-CUSTOM-SNAPSHOT
+platformVersion=221.5080.16-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
@@ -24,4 +24,3 @@ gitpodProtocolProjectPath=../../../gitpod-protocol/java
 # See https://stackoverflow.com/a/47607857/961588
 systemProp.org.gradle.internal.http.socketTimeout=100000
 systemProp.org.gradle.internal.http.connectionTimeout=100000
-

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnector.kt
@@ -12,7 +12,8 @@ import io.gitpod.jetbrains.icons.GitpodIcons
 import java.awt.Component
 import javax.swing.Icon
 import javax.swing.JComponent
-
+import com.intellij.ui.components.ActionLink
+import com.intellij.ide.BrowserUtil
 
 class GitpodConnector : GatewayConnector {
     override val icon: Icon
@@ -30,8 +31,12 @@ class GitpodConnector : GatewayConnector {
         return "Connect to Gitpod workspaces"
     }
 
-    override fun getDocumentationLink(): String {
-        return "https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway"
+    override fun getDocumentationLink(): ActionLink {
+        val documentationLink = ActionLink("Documentation") {
+            BrowserUtil.browse("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
+        }
+        documentationLink.setExternalLinkIcon()
+        return documentationLink
     }
 
     override fun getRecentConnections(setContentCallback: (Component) -> Unit): GatewayRecentConnections? {


### PR DESCRIPTION
## Description

Extend compatibility of JetBrains Gateway plugin to the EAP version.

![image](https://user-images.githubusercontent.com/418083/160436929-11c903d3-0edf-4389-971a-c8f3d0c5424e.png)


## Related Issue(s)

Fixes #8247

## How to test
<!-- Provide steps to test this PR -->
- Run `./gradlew runIde` as instructed [here](https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/README.md#L8) to build and run the Gateway EAP with this plugin.
- Explore all buttons and screens related to Gitpod in the Gateway app.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains Gateway EAP version is now supported.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE
