### PR TITLE
[webapp] move admin redirects to `App.tsx`

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -119,6 +119,28 @@ function isWebsiteSlug(pathName: string) {
     return slugs.some((slug) => pathName.startsWith("/" + slug + "/") || pathName === "/" + slug);
 }
 
+// A wrapper for <Route> that redirects to the workspaces screen if the user isn't a admin.
+// This wrapper only accepts the component property
+function AdminRoute({ component }: any) {
+    const { user } = useContext(UserContext);
+    return (
+        <Route
+            render={({ location }: any) =>
+                user?.rolesOrPermissions?.includes("admin") ? (
+                    <Route component={component}></Route>
+                ) : (
+                    <Redirect
+                        to={{
+                            pathname: "/workspaces",
+                            state: { from: location },
+                        }}
+                    />
+                )
+            }
+        />
+    );
+}
+
 export function getURLHash() {
     return window.location.hash.replace(/^[#/]+/, "");
 }
@@ -281,6 +303,7 @@ function App() {
     if (!user) {
         return <Login />;
     }
+
     if (window.location.pathname.startsWith("/blocked")) {
         return (
             <div className="mt-48 text-center">
@@ -340,11 +363,11 @@ function App() {
                     <Route path={projectsPathInstallGitHubApp} exact component={InstallGitHubApp} />
                     <Route path="/from-referrer" exact component={FromReferrer} />
 
-                    <Route path="/admin/users" component={UserSearch} />
-                    <Route path="/admin/teams" component={TeamsSearch} />
-                    <Route path="/admin/workspaces" component={WorkspacesSearch} />
-                    <Route path="/admin/projects" component={ProjectsSearch} />
-                    <Route path="/admin/settings" component={AdminSettings} />
+                    <AdminRoute path="/admin/users" component={UserSearch} />
+                    <AdminRoute path="/admin/teams" component={TeamsSearch} />
+                    <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
+                    <AdminRoute path="/admin/projects" component={ProjectsSearch} />
+                    <AdminRoute path="/admin/settings" component={AdminSettings} />
 
                     <Route path={["/", "/login"]} exact>
                         <Redirect to={workspacesPathMain} />

--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -6,12 +6,11 @@
 
 import moment from "moment";
 import { useLocation } from "react-router";
-import { Link, Redirect } from "react-router-dom";
-import { useContext, useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
 
 import { adminMenu } from "./admin-menu";
 import ProjectDetail from "./ProjectDetail";
-import { UserContext } from "../user-context";
 import { getGitpodService } from "../service/service";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { AdminGetListResult, Project } from "@gitpod/gitpod-protocol";
@@ -26,7 +25,6 @@ export default function ProjectsSearchPage() {
 
 export function ProjectsSearch() {
     const location = useLocation();
-    const { user } = useContext(UserContext);
     const [searchTerm, setSearchTerm] = useState("");
     const [searching, setSearching] = useState(false);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<Project>>({ total: 0, rows: [] });
@@ -68,10 +66,6 @@ export function ProjectsSearch() {
             }
         })();
     }, [currentProject]);
-
-    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
-        return <Redirect to="/" />;
-    }
 
     if (currentProject) {
         return <ProjectDetail project={currentProject} owner={currentProjectOwner} />;

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -13,13 +13,10 @@ import { getGitpodService } from "../service/service";
 import { adminMenu } from "./admin-menu";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
-import { Redirect } from "react-router-dom";
-import { UserContext } from "../user-context";
 
 export default function Settings() {
     const { adminSettings, setAdminSettings } = useContext(AdminContext);
     const [telemetryData, setTelemetryData] = useState<TelemetryData>();
-    const { user } = useContext(UserContext);
 
     useEffect(() => {
         if (isGitpodIo()) {
@@ -33,10 +30,6 @@ export default function Settings() {
             setAdminSettings(setting);
         })();
     }, []);
-
-    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
-        return <Redirect to="/" />;
-    }
 
     const actuallySetTelemetryPrefs = async (value: InstallationAdminSettings) => {
         await getGitpodService().server.adminUpdateSettings(value);

--- a/components/dashboard/src/admin/TeamsSearch.tsx
+++ b/components/dashboard/src/admin/TeamsSearch.tsx
@@ -5,13 +5,12 @@
  */
 
 import moment from "moment";
-import { useState, useContext, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import TeamDetail from "./TeamDetail";
 import { adminMenu } from "./admin-menu";
 import { useLocation } from "react-router";
-import { Link, Redirect } from "react-router-dom";
-import { UserContext } from "../user-context";
+import { Link } from "react-router-dom";
 import { getGitpodService } from "../service/service";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { AdminGetListResult, Team } from "@gitpod/gitpod-protocol";
@@ -27,7 +26,6 @@ export default function TeamsSearchPage() {
 
 export function TeamsSearch() {
     const location = useLocation();
-    const { user } = useContext(UserContext);
     const [searching, setSearching] = useState(false);
     const [searchTerm, setSearchTerm] = useState("");
     const [currentTeam, setCurrentTeam] = useState<Team | undefined>(undefined);
@@ -49,10 +47,6 @@ export function TeamsSearch() {
             setCurrentTeam(undefined);
         }
     }, [location]);
-
-    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
-        return <Redirect to="/" />;
-    }
 
     if (currentTeam) {
         return <TeamDetail team={currentTeam} />;

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -7,18 +7,16 @@
 import { AdminGetListResult, User } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import moment from "moment";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
-import { Link, Redirect } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import { UserContext } from "../user-context";
 import { adminMenu } from "./admin-menu";
 import UserDetail from "./UserDetail";
 
 export default function UserSearch() {
     const location = useLocation();
-    const { user } = useContext(UserContext);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<User>>({ rows: [], total: 0 });
     const [searchTerm, setSearchTerm] = useState("");
     const [searching, setSearching] = useState(false);
@@ -40,10 +38,6 @@ export default function UserSearch() {
             setCurrentUserState(undefined);
         }
     }, [location]);
-
-    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
-        return <Redirect to="/" />;
-    }
 
     if (currentUser) {
         return <UserDetail user={currentUser} />;

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -16,12 +16,11 @@ import {
     matchesNewWorkspaceIdExactly,
 } from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
 import moment from "moment";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
-import { Link, Redirect } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import { UserContext } from "../user-context";
 import { getProject, WorkspaceStatusIndicator } from "../workspaces/WorkspaceEntry";
 import { adminMenu } from "./admin-menu";
 import WorkspaceDetail from "./WorkspaceDetail";
@@ -41,7 +40,6 @@ export default function WorkspaceSearchPage() {
 
 export function WorkspaceSearch(props: Props) {
     const location = useLocation();
-    const { user } = useContext(UserContext);
     const [searchResult, setSearchResult] = useState<AdminGetListResult<WorkspaceAndInstance>>({ rows: [], total: 0 });
     const [queryTerm, setQueryTerm] = useState("");
     const [searching, setSearching] = useState(false);
@@ -69,10 +67,6 @@ export function WorkspaceSearch(props: Props) {
             search();
         }
     }, [props.user]);
-
-    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
-        return <Redirect to="/" />;
-    }
 
     if (currentWorkspace) {
         return <WorkspaceDetail workspace={currentWorkspace} />;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, Each page in `admin` has its own redirect to check if
the user has admin access. This is error-prone as some pages
can miss these tags causing unexpected privelleges for non-admin
users.

This is fixed by moving these redirects into admin, where the URL router
is added. We create a new wrapper called `AdminRoute` which has to
be used for all the `/admin` routes.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8303

## How to test
<!-- Provide steps to test this PR -->

- Login to https://tar-admin-gate.staging.gitpod-dev.com/workspaces
- Try to access `/admin` pages as a non-admin user.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
