### PR TITLE
[observability] Update agent smith graph

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/components/agent-smith.json
+++ b/operations/observability/mixins/workspace/dashboards/components/agent-smith.json
@@ -431,9 +431,9 @@
             "uid": "P4169E866C3094E38"
           },
           "exemplar": true,
-          "expr": "sum(rate(gitpod_agent_smith_egress_violations_total{cluster=~\"$cluster\"}[5m])) by (cluster)",
+          "expr": "count by (severity,cluster) (gitpod_agent_smith_egress_violations_total)",
           "interval": "",
-          "legendFormat": "{{cluster}} - {{penalty}}",
+          "legendFormat": "{{cluster}} - {{severity}}",
           "queryType": "randomWalk",
           "refId": "A"
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update agent-smith `Egress Violation` graph to display the count of violations per severity per cluster.
This gives a better intuitive way to understand what is going on in the cluster compared to the previous `rate` query.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes NA

## How to test
<!-- Provide steps to test this PR -->

I updated the graph in the agent-smith dashboard and could see correct render. You can test using the same query and legend.
<img width="2182" alt="image" src="https://user-images.githubusercontent.com/32481722/159655137-a59b73c2-dd96-46ee-8c86-9907d265e21b.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
