### PR TITLE
[jb-gw]: add workspace branch & creation timespan column for workspace panel

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/Repository.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/Repository.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.gitpodprotocol.api.entities;
+
+public class Repository {
+
+    private String branch;
+    private int totalUncommitedFiles;
+    private int totalUnpushedCommits;
+    private int totalUntrackedFiles;
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    public int getTotalUncommitedFiles() {
+        return totalUncommitedFiles;
+    }
+
+    public void setTotalUncommitedFiles(int totalUncommitedFiles) {
+        this.totalUncommitedFiles = totalUncommitedFiles;
+    }
+
+    public int getTotalUnpushedCommits() {
+        return totalUnpushedCommits;
+    }
+
+    public void setTotalUnpushedCommits(int totalUnpushedCommits) {
+        this.totalUnpushedCommits = totalUnpushedCommits;
+    }
+
+    public int getTotalUntrackedFiles() {
+        return totalUntrackedFiles;
+    }
+
+    public void setTotalUntrackedFiles(int totalUntrackedFiles) {
+        this.totalUntrackedFiles = totalUntrackedFiles;
+    }
+}

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceContext.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceContext.java
@@ -6,6 +6,7 @@ package io.gitpod.gitpodprotocol.api.entities;
 
 public class WorkspaceContext {
     private String normalizedContextURL;
+    private String ref;
 
     public String getNormalizedContextURL() {
         return normalizedContextURL;
@@ -13,5 +14,13 @@ public class WorkspaceContext {
 
     public void setNormalizedContextURL(String normalizedContextURL) {
         this.normalizedContextURL = normalizedContextURL;
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public void setRef(String ref) {
+        this.ref = ref;
     }
 }

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceInstanceStatus.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceInstanceStatus.java
@@ -8,6 +8,7 @@ public class WorkspaceInstanceStatus {
     private String phase;
     private String ownerToken;
     private WorkspaceInstanceConditions conditions;
+    private Repository repo;
 
     public String getPhase() {
         return phase;
@@ -31,5 +32,13 @@ public class WorkspaceInstanceStatus {
 
     public void setConditions(WorkspaceInstanceConditions conditions) {
         this.conditions = conditions;
+    }
+
+    public Repository getRepo() {
+        return repo;
+    }
+
+    public void setRepo(Repository repo) {
+        this.repo = repo;
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR relates to Gitpod's [JetBrains Gateway plugin](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway), which enables IntelliJ IDEs users to create or start a Gitpod workspace using desktop IDE client. The plugin is a great starting point for developers familiarized with local IntelliJ IDEs to try Gitpod remote development with [JB Gateway](https://www.jetbrains.com/remote-development/gateway/). 

However the workspace panel of JB-GW plugin lacks information such as workspace branch & creation time:
![image](https://user-images.githubusercontent.com/3115235/159717255-9d376270-9ead-4808-956e-371f82785237.png)

Compared with Gitpod's WebUI:
![image](https://user-images.githubusercontent.com/3115235/159713744-10fe4672-1f77-4c0f-80dd-36e075a677c9.png)

This PR adds workspace branch & creation timespan column:
![image](https://user-images.githubusercontent.com/3115235/159713575-cc2f8761-c5a0-4224-80d9-d65739eb956e.png)


## How to test
<!-- Provide steps to test this PR -->

Build & Install the plugin following
https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/README.md#L8

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add workspace branch & creation timespan column for Gitpod Jetbrains Gateway plugin workspace panel
```