### PR TITLE
[image-bob-builder] Add support for stargz

### DIFF
--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM moby/buildkit:v0.9.3
+FROM moby/buildkit:v0.10.0
 
 USER root
 RUN apk --no-cache add sudo bash \

--- a/components/image-builder-bob/pkg/builder/builder.go
+++ b/components/image-builder-bob/pkg/builder/builder.go
@@ -138,7 +138,7 @@ func buildImage(ctx context.Context, contextDir, dockerfile, authLayer, target s
 		// "--debug",
 		"build",
 		"--progress=plain",
-		"--output=type=image,name=" + target + ",push=true,oci-mediatypes=true",
+		"--output=type=image,name=" + target + ",push=true,oci-mediatypes=true,compression=estargz,force-compression=true",
 		//"--export-cache=type=inline",
 		"--local=context=" + contextdir,
 		//"--export-cache=type=registry,ref=" + target + "-cache",


### PR DESCRIPTION
## Description

Add additional build attributes to generate stargz images during builds.

## How to test
- Check builds keep working
- Using `oci-tool` from an image, it should contain new OCI manifest for the stargz layer.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[image-bob-builder] Add support for stargz
```
