### PR TITLE
[Analytics] Include Invite ID with Team created Call

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1974,6 +1974,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         // Note: this operation is per-user only, hence needs no resource guard
         const user = this.checkAndBlockUser("createTeam");
         const team = await this.teamDB.createTeam(user.id, name);
+        const invite = await this.getGenericInvite(ctx, team.id);
         ctx.span?.setTag("teamId", team.id);
         this.analytics.track({
             userId: user.id,
@@ -1983,6 +1984,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 name: team.name,
                 slug: team.slug,
                 created_at: team.creationTime,
+                invite_id: invite.id,
             },
         });
         return team;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Generates and includes an invitation ID with each team created Segment call. This is done in order to have an ID available in downstream tools after a team was created so that it can be sent to users outside of the product.
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

1. Open a preview environment, sign up and create a team
2. Go to the [debugger of Staging Untrusted
](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and ensure that the `team_created` call includes an `invite_id`
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe