### PR TITLE
allow to specify vm name when connecting to harvester VM

### DIFF
--- a/dev/preview/ssh-proxy-command.sh
+++ b/dev/preview/ssh-proxy-command.sh
@@ -5,11 +5,12 @@ source ./dev/preview/util/preview-name-from-branch.sh
 VM_NAME="$(preview-name-from-branch)"
 NAMESPACE="preview-${VM_NAME}"
 
-while getopts n:p: flag
+while getopts n:p:v: flag
 do
     case "${flag}" in
         n) NAMESPACE="${OPTARG}";;
         p) PORT="${OPTARG}";;
+        v) VM_NAME="${OPTARG}";;
         *) ;;
     esac
 done

--- a/dev/preview/ssh-vm.sh
+++ b/dev/preview/ssh-vm.sh
@@ -17,13 +17,14 @@ THIS_DIR="$(dirname "$0")"
 USER="ubuntu"
 COMMAND=""
 
-while getopts c:n:p:u: flag
+while getopts c:n:p:u:v: flag
 do
     case "${flag}" in
         c) COMMAND="${OPTARG}";;
         n) NAMESPACE="${OPTARG}";;
         p) PORT="${OPTARG}";;
         u) USER="${OPTARG}";;
+        v) VM_NAME="${OPTARG}";;
         *) ;;
     esac
 done
@@ -54,7 +55,8 @@ set-up-ssh
 ssh "$USER"@127.0.0.1 \
     -o UserKnownHostsFile=/dev/null \
     -o StrictHostKeyChecking=no \
-    -o "ProxyCommand=$THIS_DIR/ssh-proxy-command.sh -p $PORT -n $NAMESPACE" \
+    -o LogLevel=ERROR \
+    -o "ProxyCommand=$THIS_DIR/ssh-proxy-command.sh -p $PORT -n $NAMESPACE -v $VM_NAME" \
     -i "$HOME/.ssh/vm_id_rsa" \
     -p "$PORT" \
     "$COMMAND"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is related to work done in trying to setup workspace clusters on Harvester.
This allows to specify VM when attempting to SSH into Harvester VM.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
