### PR TITLE
[agent-smith] use tap0 to account egress traffic

### DIFF
--- a/components/ee/agent-smith/pkg/agent/egress.go
+++ b/components/ee/agent-smith/pkg/agent/egress.go
@@ -20,5 +20,5 @@ func getEgressTraffic(pid int) (int64, error) {
 		return -1, err
 	}
 
-	return int64(nd.Total().TxBytes), nil
+	return int64(nd["tap0"].TxBytes), nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use only tap0 interface to account for egress traffic in agent-smith. We (will in future) penalize worspaces and users based on the egress traffic. With existing implementation we were accounting for all the interfaces to calculate egress, however, this should not be a case as local running servers, local docker registries etc will cause the workspace to be penalized when no actual violation has occurred.

We should use only `tap0` interface to calculate egress traffic.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/ops/issues/1384#issuecomment-1078900091

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace using this branch
2. Start a local http server/ docker registry e.g. `python3 -m http.server`
3. Upload/Download a huge file e.g. `wget 0.0.0.0:8000/testfile`
4. You should not see logs in agent smith about infringing workspace.
5. 
Tip: You can create testfile using `fallocate testfile -l 5G`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
