### PR TITLE
Fix kubecdl to work with workspace-clusters

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -68,7 +68,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-clean-up-werft-build-nodes.yaml
+++ b/.werft/platform-clean-up-werft-build-nodes.yaml
@@ -16,7 +16,7 @@ pod:
         type: Directory
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -18,7 +18,7 @@ pod:
       secretName: gcp-sa-gitpod-release-deployer
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-update-dep.2
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -230,4 +230,5 @@ RUN curl https://raw.githubusercontent.com/replicatedhq/replicated/v0.38.0/insta
     curl https://kots.io/install/1.65.0 | bash
 
 # Copy our own tools
+ENV NEW_KUBECDL=1
 COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl /usr/bin/

--- a/dev/kubecdl/.vscode/launch.json
+++ b/dev/kubecdl/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+        {
+            "name": "kubecdl",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileWorkspaceFolder}",
+            "args": [
+                "-p",
+                "workspace-clusters",
+                "us38"
+            ]
+        },
+	]
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The version of `kubecdl` on the path is old in our `dev-environment` image, and does not work with `workspace-clusters` anymore. If you authenticate with `gcloud` and try using `kubecdl`, you'll get `invalid character 'W' looking for beginning of value"`. This will make it tough for someone who is on-call :telephone_receiver: or a little sleepy :woozy_face: .

This change updates our `dev-environment` to use the latest `kubecdl`, and adds a debug configuration cause, why not? :hugs: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
n/a

## How to test
<!-- Provide steps to test this PR -->
```bash
gitpod /workspace/gitpod (kyleb/kubecdl-qol) $ gcloud auth list
           Credentialed Accounts
ACTIVE             ACCOUNT
*                  kyle@gitpod.io

gitpod /workspace/gitpod (kyleb/kubecdl-qol) $ kubectx
dev
harvester
gitpod /workspace/gitpod (kyleb/kubecdl-qol) $ kubecdl -p workspace-clusters us38
gitpod /workspace/gitpod (kyleb/kubecdl-qol) $ kubectx -c
us38
gitpod /workspace/gitpod (kyleb/kubecdl-qol) $ which kubecdl
/usr/bin/kubecdl
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
