### PR TITLE
[dashboard] replace dev configuration with env vars

### DIFF
--- a/components/dashboard/README.md
+++ b/components/dashboard/README.md
@@ -6,14 +6,14 @@ The `App.tsx` is the entry point for the SPA and it uses React-Router to registe
 
 ```ts
 <Switch>
-  <Route path="/" exact component={Workspaces} />
-  <Route path="/profile" exact component={Profile} />
-  <Route path="/notifications" exact component={Notifications} />
-  <Route path="/subscriptions" exact component={Subscriptions} />
-  <Route path="/env-vars" exact component={EnvVars} />
-  <Route path="/git-integration" exact component={GitIntegration} />
-  <Route path="/feature-preview" exact component={FeaturePreview} />
-  <Route path="/default-ide" exact component={DefaultIDE} />
+    <Route path="/" exact component={Workspaces} />
+    <Route path="/profile" exact component={Profile} />
+    <Route path="/notifications" exact component={Notifications} />
+    <Route path="/subscriptions" exact component={Subscriptions} />
+    <Route path="/env-vars" exact component={EnvVars} />
+    <Route path="/git-integration" exact component={GitIntegration} />
+    <Route path="/feature-preview" exact component={FeaturePreview} />
+    <Route path="/default-ide" exact component={DefaultIDE} />
 </Switch>
 ```
 
@@ -36,32 +36,37 @@ After creating a new component, run the following to update the license header:
 
 ## How to develop in gitpod.io
 
-✍️ Edit `craco.config.js`:
+All the commands in this section are meant to be executed from the `components/dashboard` directory.
 
-- Add a `devServer` section:
+### 1. Environment variables
 
-```js
-     devServer: {
-         proxy: {
-             '/api': {
-                 target: 'https://' + GITPOD_HOST,
-                 ws: true,
-                 headers: {
-                     host: GITPOD_HOST,
-                     origin: 'https://' + GITPOD_HOST,
-                     cookie: '__REPLACE_YOUR_COOKIE__'
-                 },
-             }
-         }
-     }
+Set the following 2 [environment variables](https://www.gitpod.io/docs/environment-variables) either [via your account settings](https://gitpod.io/variables) or [via the command line](https://www.gitpod.io/docs/environment-variables#using-the-command-line-gp-env).
+
+You are not expected to update the values of these variables for a long time after you first set them.
+
+> **🚨 Heads up!** Be careful when using the command line, as the `gp` CLI will restrict the scope of the variables to the current project, meaning if you are not already working from your own personal fork you'll end up having variables you can't access when you do.
+
+You can always go to your account settings and edit the scope for each variable to something like `*/gitpod`.
+
+```bash
+# Use "gitpod.io" for the SaaS version of Gitpod, or specify the host of your self-hosted gitpod
+GP_DEV_HOST=gitpod.io
+
+# Notice the cookie name (_gitpod_io_) may be different if self-hosted.
+# Read below for how to get the actual value to use instead of "AUTHENTICATION_COOKIE_VALUE"
+GP_DEV_COOKIE="_gitpod_io_=AUTHENTICATION_COOKIE_VALUE"
 ```
 
-- Replace `GITPOD_HOST` with _SaaS Gitpod host_ (e.g. `gitpod.io`) or _self-hosted Gitpod host_ (e.g. the base URL of your target self-hosted Gitpod)
-- Replace `__REPLACE_YOUR_COOKIE__` with the stringified value of your auth cookie taken from your browser's dev tools while visiting your target Gitpod host (e.g. `_gitpod_io_=s%3Axxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.XXXXXXXXXXXXXXX` for `gitpod.io`).
-  ![Where to get the auth cookie name and value from](how-to-get-cookie.png)
-- You can view the dashboard at https://`PORT_NUMBER`-`GITPOD_WORKSPACE_URL`.
+Replace `AUTHENTICATION_COOKIE_VALUE` with the value of your auth cookie taken from your browser's dev tools while visiting your target Gitpod host (e.g. `s%3Axxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.XXXXXXXXXXXXXXX`).
+
+| ℹ️ How to get the cookie name and value                                    |
+| -------------------------------------------------------------------------- |
+| ![Where to get the auth cookie name and value from](how-to-get-cookie.png) |
+
+### 2. Start the dashboard app
 
 🚀 After following the above steps, run `yarn run start` to start developing.
+You can view the dashboard at https://`PORT_NUMBER`-`GITPOD_WORKSPACE_URL` (`PORT_NUMBER` is usually `3000`).
 
 ## Tests
 

--- a/components/dashboard/craco.config.js
+++ b/components/dashboard/craco.config.js
@@ -3,11 +3,27 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License-AGPL.txt in the project root for license information.
  */
+const { when } = require("@craco/craco");
 
 module.exports = {
-  style: {
-    postcss: {
-      plugins: [require("tailwindcss"), require("autoprefixer")],
+    style: {
+        postcss: {
+            plugins: [require("tailwindcss"), require("autoprefixer")],
+        },
     },
-  },
+    ...when(process.env.GP_DEV_HOST && process.env.GP_DEV_COOKIE, () => ({
+        devServer: {
+            proxy: {
+                "/api": {
+                    target: "https://" + process.env.GP_DEV_HOST,
+                    ws: true,
+                    headers: {
+                        host: process.env.GP_DEV_HOST,
+                        origin: "https://" + process.env.GP_DEV_HOST,
+                        cookie: process.env.GP_DEV_COOKIE,
+                    },
+                },
+            },
+        },
+    })),
 };


### PR DESCRIPTION
## Description

Set 2 variables once instead of editing `craco.config.js` every time you want to contribute to the dashboard app.

## How to test

- Follow the new instructions in `components/dashboard/README.md`
- Check if the dashboard loads properly
- 🚨 **IMPORTANT!** Do a production build and check that one as well: I never used CRACO's `whenDev` before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] It's now even easier to contribute: set a couple variables once, contribute for as long as you like.
```
