### PR TITLE
Refresh web page when instanceId changed

### DIFF
--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -108,9 +108,20 @@ const toStop = new DisposableCollection();
     //#region current-frame
     let current: HTMLElement = loading.frame;
     let desktopRedirected = false;
+    let currentInstanceId = "";
     const nextFrame = () => {
         const instance = gitpodServiceClient.info.latestInstance;
         if (instance) {
+            // refresh web page when instanceId changed
+            if (currentInstanceId !== "") {
+                if (instance.id !== currentInstanceId && instance.ideUrl !== "") {
+                    currentInstanceId = instance.id;
+                    window.location.href = instance.ideUrl;
+                    return;
+                }
+            } else {
+                currentInstanceId = instance.id;
+            }
             if (instance.status.phase === 'running') {
                 if (!hideDesktopIde) {
                     if (isDesktopIde == undefined) {
@@ -148,7 +159,7 @@ const toStop = new DisposableCollection();
     }
     const updateCurrentFrame = () => {
         const newCurrent = nextFrame();
-        if (current === newCurrent) {
+        if (newCurrent == null || current === newCurrent) {
             return;
         }
         current.style.visibility = 'hidden';


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/gitpod/issues/8226#issuecomment-1080807298 Option3 with refresh page

Refresh web page when instanceId changed to get ide config again

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8226

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace A (ie. browser IDE only) in tab 1
2. Go to Dashboard in tab2 to stop A, go to Preferences to choose one desktop IDE, and re-open A
3. Note tab1 to see if display "Open in xxx"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix IDE options display incorrectly when restarting the workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
