### PR TITLE
Ignore VNC related ports on boot

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,6 +24,12 @@ ports:
     onOpen: ignore
   # Dev Theia
   - port: 13444
+  # noVNC
+  - port: 6080
+    onOpen: ignore
+  # VNC
+  - port: 5900
+    onOpen: ignore
 tasks:
   - name: Add Harvester kubeconfig
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,15 @@ ports:
     onOpen: ignore
   - port: 4000
     onOpen: ignore
+  # VNC
+  - port: 5900
+    onOpen: ignore
+  # noVNC
+  - port: 6080
+    onOpen: ignore
+  # Werft
+  - port: 7777
+    onOpen: ignore
   - port: 9229
     onOpen: ignore
   # Go proxy
@@ -19,17 +28,8 @@ ports:
     onOpen: ignore
   - port: 13001
     onOpen: ignore
-  # Werft
-  - port: 7777
-    onOpen: ignore
   # Dev Theia
   - port: 13444
-  # noVNC
-  - port: 6080
-    onOpen: ignore
-  # VNC
-  - port: 5900
-    onOpen: ignore
 tasks:
   - name: Add Harvester kubeconfig
     command: |


### PR DESCRIPTION
## Description
When you open a new workspace for gitpod-io/gitpod you'll get two little popups about open ports. Given that we always start these services I added them to the gitpod.yaml and marked them as "ignored" so we won't get popups for them anymore.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

If you opened a workspace before you would get the following:

![screenshot-on-main](https://user-images.githubusercontent.com/83561/160602994-56f5cb35-6aab-42dc-9acb-c77287dd479a.png)

On this branch you'll get: 

![screenshot-on-pr-branch](https://user-images.githubusercontent.com/83561/160603073-23823e14-2cfa-4420-b37f-1039e3cc1912.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A