### PR TITLE
Improve sidebar menu colors

### DIFF
--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -29,7 +29,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                         {p.subMenu.map((e) => {
                             let classes = "flex block py-2 px-4 rounded-md";
                             if (e.link.some((l) => l === location.pathname)) {
-                                classes += " bg-gray-800 text-gray-50";
+                                classes += " bg-gray-300 text-gray-800 dark:bg-gray-800 text-gray-50";
                             } else {
                                 classes += " hover:bg-gray-100 dark:hover:bg-gray-800";
                             }


### PR DESCRIPTION
## Description

This will update the sidebar menu colors to match the specs in https://github.com/gitpod-io/gitpod/issues/7932.

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/7932

## How to test
1. Go to a page in user settings like `/preferences`
2. Notice the color difference of the sidebar menu.

## Screenshots 

| BEFORE | AFTER |
|-|-|
| <img width="843" alt="sidebar-before" src="https://user-images.githubusercontent.com/120486/160620636-4d2c7dde-c6dc-4560-a7ed-904a19b04e4d.png"> | <img width="843" alt="sidebar-after" src="https://user-images.githubusercontent.com/120486/160620640-fffeb346-2d01-46c9-8201-d38788fe88e3.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve sidebar menu colors
```