### PR TITLE
[dashboard] support connect via SSH

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -27,6 +27,7 @@ import PendingChangesDropdown from "../components/PendingChangesDropdown";
 import { watchHeadlessLogs } from "../components/PrebuildLogs";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
+import ConnectToSSHModal from "../workspaces/ConnectToSSHModal";
 const sessionId = v4();
 
 const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
@@ -91,6 +92,8 @@ export interface StartWorkspaceState {
         clientID?: string;
     };
     ideOptions?: IDEOptions;
+    isSSHModalVisible?: boolean;
+    ownerToken?: string;
 }
 
 export default class StartWorkspace extends React.Component<StartWorkspaceProps, StartWorkspaceState> {
@@ -520,6 +523,15 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                                 getGitpodService().server.stopWorkspace(this.props.workspaceId),
                                         },
                                         {
+                                            title: "Connect via SSH",
+                                            onClick: async () => {
+                                                const ownerToken = await getGitpodService().server.getOwnerToken(
+                                                    this.props.workspaceId,
+                                                );
+                                                this.setState({ isSSHModalVisible: true, ownerToken });
+                                            },
+                                        },
+                                        {
                                             title: "Go to Dashboard",
                                             href: gitpodHostUrl.asDashboard().toString(),
                                             target: "_parent",
@@ -556,6 +568,14 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                 </a>
                                 .
                             </div>
+                            {this.state.isSSHModalVisible === true && this.state.ownerToken && (
+                                <ConnectToSSHModal
+                                    workspaceId={this.props.workspaceId}
+                                    ownerToken={this.state.ownerToken}
+                                    ideUrl={this.state.workspaceInstance?.ideUrl.replaceAll("https://", "")}
+                                    onClose={() => this.setState({ isSSHModalVisible: false, ownerToken: "" })}
+                                />
+                            )}
                         </div>
                     );
                 }

--- a/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
+++ b/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useState } from "react";
+import Modal from "../components/Modal";
+import Tooltip from "../components/Tooltip";
+import copy from "../images/copy.svg";
+import AlertBox from "../components/AlertBox";
+import InfoBox from "../components/InfoBox";
+
+function InputWithCopy(props: { value: string; tip?: string; className?: string }) {
+    const [copied, setCopied] = useState<boolean>(false);
+    const copyToClipboard = (text: string) => {
+        const el = document.createElement("textarea");
+        el.value = text;
+        document.body.appendChild(el);
+        el.select();
+        try {
+            document.execCommand("copy");
+        } finally {
+            document.body.removeChild(el);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+    const tip = props.tip ?? "Click to copy";
+    return (
+        <div className={`w-full relative ${props.className ?? ""}`}>
+            <input
+                disabled={true}
+                readOnly={true}
+                autoFocus
+                className="w-full pr-8 overscroll-none"
+                type="text"
+                defaultValue={props.value}
+            />
+            <div className="cursor-pointer" onClick={() => copyToClipboard(props.value)}>
+                <div className="absolute top-1/3 right-3">
+                    <Tooltip content={copied ? "Copied" : tip}>
+                        <img src={copy} alt="copy icon" title={tip} />
+                    </Tooltip>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+interface SSHProps {
+    workspaceId: string;
+    ownerToken: string;
+    ideUrl: string;
+}
+
+function SSHView(props: SSHProps) {
+    const sshCommand = `ssh ${props.workspaceId}#${props.ownerToken}@${props.ideUrl}`;
+    return (
+        <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-6">
+            <div className="mt-1 mb-4">
+                <AlertBox>
+                    <p className="text-red-500 whitespace-normal text-base">
+                        <b>Anyone</b> on the internet with this command can access the running workspace. The command
+                        includes a generated access token that resets on every workspace restart.
+                    </p>
+                </AlertBox>
+                <InfoBox className="mt-4">
+                    <p className="text-gray-500 whitespace-normal text-base">
+                        Before connecting via SSH, make sure you have an existing SSH private key on your machine. You
+                        can create one using&nbsp;
+                        <a
+                            href="https://en.wikipedia.org/wiki/Ssh-keygen"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="gp-link"
+                        >
+                            ssh-keygen
+                        </a>
+                        .
+                    </p>
+                </InfoBox>
+                <p className="mt-4 text-gray-500 whitespace-normal text-base">
+                    The following shell command can be used to SSH into this workspace.
+                </p>
+            </div>
+            <InputWithCopy value={sshCommand} tip="Copy SSH Command" />
+        </div>
+    );
+}
+
+export default function ConnectToSSHModal(props: {
+    workspaceId: string;
+    ownerToken: string;
+    ideUrl: string;
+    onClose: () => void;
+}) {
+    return (
+        <Modal visible={true} onClose={props.onClose}>
+            <h3 className="mb-4">Connect via SSH</h3>
+            <SSHView workspaceId={props.workspaceId} ownerToken={props.ownerToken} ideUrl={props.ideUrl} />
+            <div className="flex justify-end mt-6">
+                <button className={"ml-2 secondary"} onClick={() => props.onClose()}>
+                    Close
+                </button>
+            </div>
+        </Modal>
+    );
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that we have the new SSH gateway and the simpler authentication flow, it is possible that a user can copy/paste an SSH command onto their local machine to facilitate quicker/easier access to a Gitpod workspace. 

This PR introduces a way to direct connect ssh to workspace 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7713

## How to test
<!-- Provide steps to test this PR -->
start a workspace in preview environment, you can see Connect via SSH in workspace list and workspace start page(desktop IDE)

![image](https://user-images.githubusercontent.com/8299500/160644433-52a58f27-b504-4698-be98-72116981951c.png)

![image](https://user-images.githubusercontent.com/8299500/160644400-f0b25bde-0fe4-4bde-b3dd-218eb85c6ca1.png)

![image](https://user-images.githubusercontent.com/8299500/161242392-bda9d333-bd84-492c-b041-f0cd1495b27c.png)

![image](https://user-images.githubusercontent.com/8299500/161242646-a303cdfa-7b03-43ab-b1d1-1495f7a2cdea.png)



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
support direct connect workspace via ssh command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
