### PR TITLE
Redirect web page when instance changed

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -324,7 +324,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
         // Redirect to workspaceURL if we are not yet running in an iframe.
         // It happens this late if we were waiting for a docker build.
-        if (!this.props.runsInIFrame && workspaceInstance.ideUrl && !this.props.dontAutostart) {
+        if (
+            !this.props.runsInIFrame &&
+            workspaceInstance.ideUrl &&
+            (!this.props.dontAutostart || workspaceInstance.status.phase === "running")
+        ) {
             this.redirectTo(workspaceInstance.ideUrl);
             return;
         }
@@ -431,48 +435,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 }
                 if (!this.state.desktopIde) {
                     phase = StartPhase.Running;
-
-                    if (this.props.dontAutostart) {
-                        // hide the progress bar, as we're already running
-                        phase = undefined;
-                        title = "Running";
-
-                        // in case we dontAutostart the IDE we have to provide controls to do so
-                        statusMessage = (
-                            <div>
-                                <div className="flex space-x-3 items-center text-left rounded-xl m-auto px-4 h-16 w-72 mt-4 mb-2 bg-gray-100 dark:bg-gray-800">
-                                    <div className="rounded-full w-3 h-3 text-sm bg-green-500">&nbsp;</div>
-                                    <div>
-                                        <p className="text-gray-700 dark:text-gray-200 font-semibold w-56 truncate">
-                                            {this.state.workspaceInstance.workspaceId}
-                                        </p>
-                                        <a target="_parent" href={contextURL}>
-                                            <p className="w-56 truncate hover:text-blue-600 dark:hover:text-blue-400">
-                                                {contextURL}
-                                            </p>
-                                        </a>
-                                    </div>
-                                </div>
-                                <div className="mt-10 justify-center flex space-x-2">
-                                    <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}>
-                                        <button className="secondary">Go to Dashboard</button>
-                                    </a>
-                                    <a
-                                        target="_parent"
-                                        href={
-                                            gitpodHostUrl
-                                                .asStart(this.props.workspaceId)
-                                                .toString() /** move over 'start' here to fetch fresh credentials in case this is an older tab */
-                                        }
-                                    >
-                                        <button>Open Workspace</button>
-                                    </a>
-                                </div>
-                            </div>
-                        );
-                    } else {
-                        statusMessage = <p className="text-base text-gray-400">Opening Workspace …</p>;
-                    }
+                    statusMessage = <p className="text-base text-gray-400">Opening Workspace …</p>;
                 } else {
                     phase = StartPhase.IdeReady;
                     const openLink = this.state.desktopIde.link;

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -108,9 +108,19 @@ const toStop = new DisposableCollection();
     //#region current-frame
     let current: HTMLElement = loading.frame;
     let desktopRedirected = false;
+    let currentInstanceId = "";
     const nextFrame = () => {
         const instance = gitpodServiceClient.info.latestInstance;
         if (instance) {
+            // refresh web page when instanceId changed
+            if (currentInstanceId !== "") {
+                if (instance.id !== currentInstanceId && instance.ideUrl !== "") {
+                    currentInstanceId = instance.id;
+                    window.location.href = instance.ideUrl;
+                }
+            } else {
+                currentInstanceId = instance.id;
+            }
             if (instance.status.phase === 'running') {
                 if (!hideDesktopIde) {
                     if (isDesktopIde == undefined) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Display opening workspace when ide is not ready yet. Relates PR https://github.com/gitpod-io/gitpod/pull/8125

Refresh web page when instanceId changed to get ide config and ws works again

Need to verify
1. One frame running phase does not display (will display `Starting`, `Opening workspace...`
2. Stopped workspace URL contains `not_found` works after ws started
3. Stopped workspace works after ws started https://github.com/gitpod-io/gitpod/pull/9004#issuecomment-1084573937

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8990
Fixes #8226

## How to test
<!-- Provide steps to test this PR -->

1. Start same workspace in tab 1\2\3 (tab1 <-> verify1/3, tab2 <-> verify2
2. After they started, stop workspace in dashboard
3. Wait until tabs 1\2\3 Stopped
4. Refresh tab2
5. Go to tab3 click `Open Workspace`
6. See if tabs 1\2\3 work fine

We can do negative test like this PR https://github.com/gitpod-io/gitpod/pull/8125 in staging here https://hw-fix-8990-crash.staging.gitpod-dev.com/workspaces which will make Insiders VSCode crash https://github.com/gitpod-io/gitpod/commit/bb705e2d9d851b0c3cefb3c6f84f4a392722edba

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed one frame running phase when starting workspace
Fixed IDE options display incorrectly when restarting the workspace
Fixed stopped workspace does not work again if it started in another place
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
