### PR TITLE
[idea] ignore compiled files in gitpod repo

### DIFF
--- a/.idea/gitpod.iml
+++ b/.idea/gitpod.iml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/components/dashboard/build" />
+      <excludeFolder url="file://$MODULE_DIR$/components/gitpod-db/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/gitpod-messagebus/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/gitpod-protocol/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/licensor/typescript/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/server/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/components/ee/payment-endpoint/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/supervisor-api/typescript-grpcweb/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/supervisor-api/typescript-rest/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/components/content-service-api/typescript/lib" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Marks compiled and distribution files as ignored in Jetbrains IDEs. This significantly speeds up indexing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Repository opens with Jetbrains and changes can be made, but `dist` level files are not indexed. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
