### PR TITLE
[idea] Ignore .idea/misc.xml which contains opened editor config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ components/ws-proxy/ws-proxy
 
 # Logs
 components/server/*.log
+
+# Jetbrains workspace files
+.idea/misc.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK" />
-</project>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When the IDE has panes open, it checks in cursor information into `.idea/misc.xml` with contents like 
```
 <component name="UnattendedHostPersistenceState">
    <option name="openedFilesInfos">
      <list>
        <OpenedFileInfo>
          <option name="caretOffset" value="0" />
          <option name="fileUrl" value="file://$PROJECT_DIR$/components/content-service/pkg/initializer/prebuild.go" />
        </OpenedFileInfo>
      </list>
    </option>
  </component>
```
This information is only meaningful to the local opened instance of the IDE and shouldn't be checked in. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Edit a file, run `git status` and see no changes are detected by git.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
