### PR TITLE
Add new VS Code domain to config maps

### DIFF
--- a/chart/templates/blobserve-configmap.yaml
+++ b/chart/templates/blobserve-configmap.yaml
@@ -29,6 +29,9 @@ data:
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" },
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.main.js" },
                         { "search": "vscode-webview.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js" }
+                        { "search": "vscode-cdn.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" },
+                        { "search": "vscode-cdn.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.main.js" },
+                        { "search": "vscode-cdn.net", "replacement": "{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js" }
                         {{- if not .Values.components.openVsxProxy.disabled }}
                         , { "search": "https://open-vsx.org", "replacement": "https://open-vsx.{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.api.js" }
                         , { "search": "https://open-vsx.org", "replacement": "https://open-vsx.{{ .Values.hostname }}", "path": "/ide/out/vs/workbench/workbench.web.main.js" }

--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -51,6 +51,18 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Replacement: ctx.Config.Domain,
 						Path:        "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
 					}, {
+						Search:      "vscode-cdn.net",
+						Replacement: ctx.Config.Domain,
+						Path:        "/ide/out/vs/workbench/workbench.web.api.js",
+					}, {
+						Search:      "vscode-cdn.net",
+						Replacement: ctx.Config.Domain,
+						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
+					}, {
+						Search:      "vscode-cdn.net",
+						Replacement: ctx.Config.Domain,
+						Path:        "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
+					}, {
 						Search:      "open-vsx.org",
 						Replacement: openVSXProxyUrl,
 						Path:        "/ide/out/vs/workbench/workbench.web.api.js",


### PR DESCRIPTION
## Description
This change is needed for VS Code versions after `1.66.0`, because they no longer use `vscode-webview.net` as the host domain for their webviews. Instead, they started using `vscode-cdn.net`. 

## Related Issue(s)
~This is needed for https://github.com/gitpod-io/gitpod/issues/9020~
This is not needed for VS Code 1.66 immediately, but it will be needed in the next release for stable and for insiders right after the release of 1.66.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

