### PR TITLE
feat(gp-cli): tasks restart

### DIFF
--- a/components/gitpod-cli/cmd/tasks.go
+++ b/components/gitpod-cli/cmd/tasks.go
@@ -40,11 +40,20 @@ var attachTaskCmd = &cobra.Command{
 	Run:   tasks.AttachTasksCmd,
 }
 
+// restartTaskCmd represents the restart task command
+var restartTaskCmd = &cobra.Command{
+	Use:   "restart <name>",
+	Short: "Restart a task",
+	Args:  cobra.MaximumNArgs(1),
+	Run:   tasks.RestartTaskCmd,
+}
+
 func init() {
 	rootCmd.AddCommand(tasksCmd)
 
 	tasksCmd.AddCommand(listTasksCmd)
 	tasksCmd.AddCommand(attachTaskCmd)
+	tasksCmd.AddCommand(restartTaskCmd)
 
 	attachTaskCmd.Flags().BoolVarP(&attachTaskCmdOpts.Interactive, "interactive", "i", true, "assume control over the terminal")
 	attachTaskCmd.Flags().BoolVarP(&attachTaskCmdOpts.ForceResize, "force-resize", "r", true, "force this terminal's size irregardless of other clients")

--- a/components/gitpod-cli/cmd/tasks/tasks-restart.go
+++ b/components/gitpod-cli/cmd/tasks/tasks-restart.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+
+	"encoding/json"
+)
+
+type Task struct {
+	Name    string `json:"name"`
+	Before  string `json:"before"`
+	Init    string `json:"init"`
+	Command string `json:"command"`
+}
+
+func RestartTaskCmd(cmd *cobra.Command, args []string) {
+	// TODO: handle restart <name>
+
+	rawJsonTasks := os.Getenv("GITPOD_TASKS")
+
+	// TODO: read tasks from .gitpod.yml to also allowing quickly testing changes in .gitpod.yml
+
+	tasks := []Task{}
+	err := json.Unmarshal([]byte(rawJsonTasks), &tasks)
+
+	if err != nil {
+		panic(err)
+	}
+
+	var taskNames []string
+
+	for _, task := range tasks {
+		taskNames = append(taskNames, task.Name)
+	}
+
+	prompt := promptui.Select{
+		Label: "What task do you want to restart?",
+		Items: taskNames,
+		Templates: &promptui.SelectTemplates{
+			Selected: "Restarting task: {{ . }}",
+		},
+	}
+
+	selectedIndex, selectedValue, err := prompt.Run()
+
+	if err != nil {
+		panic(err)
+	}
+
+	var terminalAlias string
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn := supervisor.Dial()
+
+	statusClient := api.NewStatusServiceClient(conn)
+
+	// TODO: detect if the terminal has been closed and open a new one
+	for _, task := range supervisor.GetTasksList(ctx, statusClient) {
+		if task.Presentation.Name == selectedValue {
+			terminalAlias = task.Terminal
+		}
+	}
+
+	terminalClient := api.NewTerminalServiceClient(conn)
+
+	restartCmd := fmt.Sprintf("%s%s%s%s%s", tasks[selectedIndex].Before, "\n", tasks[selectedIndex].Init, "\n", tasks[selectedIndex].Command)
+
+	_, err = terminalClient.Write(ctx, &api.WriteTerminalRequest{Alias: terminalAlias, Stdin: []byte(restartCmd)})
+
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Description
This is an attempt of providing gp-cli with a task restart functionality.

Restarting a task can be challenging and this PR is intentionally "lightweight" to get early feedback on the approach.

What I am doing here is leveraging the `/terminal/alias/write` endpoint of supervisor api. Once I know which task needs to be restart, I "re-write" those commands in the task terminal. It seems to work, but I've only briefly tested and I am concerned of side-effects of re-using the existing terminal (e.g. terminal session related things).

Ideally, we would shutdown the terminal, create a new one, set a title for it and write those commands. However, I didn't see an API endpoint for supervisor to create a new terminal. I've definitely seen capability in the supervisor-cli (`supervisor terminal new`) so perhaps it's easy to expose such endpoint.

## Related Issue(s)
Fixes #8691

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
