### PR TITLE
[wip][dashboard] license tab in the admin dashboard

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -13,13 +13,14 @@ import { UserContext } from "./user-context";
 import { TeamsContext } from "./teams/teams-context";
 import { ThemeContext } from "./theme-context";
 import { AdminContext } from "./admin-context";
+import { LicenseContext } from "./license-context";
 import { getGitpodService } from "./service/service";
 import { shouldSeeWhatsNew, WhatsNew } from "./whatsnew/WhatsNew";
 import gitpodIcon from "./icons/gitpod.svg";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { useHistory } from "react-router-dom";
 import { trackButtonOrAnchor, trackPathChange, trackLocation } from "./Analytics";
-import { User } from "@gitpod/gitpod-protocol";
+import { LicenseInfo, User } from "@gitpod/gitpod-protocol";
 import * as GitpodCookie from "@gitpod/gitpod-protocol/lib/util/gitpod-cookie";
 import { Experiment } from "./experiments";
 import { workspacesPathMain } from "./workspaces/workspaces.routes";
@@ -77,6 +78,7 @@ const AdminSettings = React.lazy(() => import(/* webpackPrefetch: true */ "./adm
 const ProjectsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/ProjectsSearch"));
 const TeamsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/TeamsSearch"));
 const OAuthClientApproval = React.lazy(() => import(/* webpackPrefetch: true */ "./OauthClientApproval"));
+const License = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/License"));
 
 function Loading() {
     return <></>;
@@ -150,6 +152,7 @@ function App() {
     const { teams, setTeams } = useContext(TeamsContext);
     const { setAdminSettings } = useContext(AdminContext);
     const { setIsDark } = useContext(ThemeContext);
+    const { setLicense } = useContext(LicenseContext);
 
     const [loading, setLoading] = useState<boolean>(true);
     const [isWhatsNewShown, setWhatsNewShown] = useState(false);
@@ -186,6 +189,9 @@ function App() {
                 if (user?.rolesOrPermissions?.includes("admin")) {
                     const adminSettings = await getGitpodService().server.adminGetSettings();
                     setAdminSettings(adminSettings);
+
+                    var license: LicenseInfo = await getGitpodService().server.adminGetLicense();
+                    setLicense(license);
                 }
             } catch (error) {
                 console.error(error);
@@ -367,6 +373,7 @@ function App() {
                     <AdminRoute path="/admin/teams" component={TeamsSearch} />
                     <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
                     <AdminRoute path="/admin/projects" component={ProjectsSearch} />
+                    <AdminRoute path="/admin/license" component={License} />
                     <AdminRoute path="/admin/settings" component={AdminSettings} />
 
                     <Route path={["/", "/login"]} exact>

--- a/components/dashboard/src/admin/License.tsx
+++ b/components/dashboard/src/admin/License.tsx
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { adminMenu } from "./admin-menu";
+
+import { LicenseContext } from "../license-context";
+import { ReactElement, useContext } from "react";
+import { UserContext } from "../user-context";
+import { Redirect } from "react-router-dom";
+import { BlackBox, LightBox } from "../components/InfoBox";
+
+import { ReactComponent as Bang } from "../images/exclamation.svg";
+import { ReactComponent as Tick } from "../images/tick.svg";
+
+export default function License() {
+    // @ts-ignore
+    const { license, setLicense } = useContext(LicenseContext);
+    const { user } = useContext(UserContext);
+
+    if (!user || !user?.rolesOrPermissions?.includes("admin")) {
+        return <Redirect to="/" />;
+    }
+
+    const featureList = license?.enabledFeatures;
+    const features = license?.features;
+    const licenseType = license?.type ? capitalizeInitials(license?.type) : "";
+
+    const userLimit = license?.seats == 0 ? "Unlimited" : license?.seats;
+    // const communityLicense = license?.key == "default-license"
+
+    const [licenseLevel, paid, msg, tick] = getSubscriptionLevel(
+        license?.plan || "",
+        license?.userCount || 0,
+        license?.seats || 0,
+        false,
+    );
+
+    return (
+        <div>
+            <PageWithSubMenu subMenu={adminMenu} title="License" subtitle="License information of your account.">
+                {!license?.valid ? (
+                    <p className="text-base text-gray-500 pb-4 max-w-2xl">
+                        You do not have a valid license associated with this account. {license?.errorMsg}
+                    </p>
+                ) : (
+                    <div className="flex flex-row space-x-4">
+                        <div>
+                            <BlackBox>
+                                <p className="text-white dark:text-black font-bold pt-4 text-sm"> {licenseLevel}</p>
+                                <p className="font-semibold dark:text-gray-500">{paid}</p>
+                                <p className="font-semibold text-gray-400 pt-4 pb-2 text-sm">Available features:</p>
+                                <div className="pb-4">
+                                    {features &&
+                                        features.map((feat: string) => (
+                                            <div>
+                                                {featureList?.includes(feat) ? (
+                                                    <svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        className="h-4 w-4 inline-block pr-1"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        stroke="currentColor"
+                                                        strokeWidth={2}
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            d="M5 13l4 4L19 7"
+                                                        />
+                                                    </svg>
+                                                ) : (
+                                                    <svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        className="h-4 w-4 inline-block pr-1"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        stroke="currentColor"
+                                                        strokeWidth={2}
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            d="M6 18L18 6M6 6l12 12"
+                                                        />
+                                                    </svg>
+                                                )}
+                                                {capitalizeInitials(feat)}
+                                            </div>
+                                        ))}
+                                </div>
+                            </BlackBox>
+                        </div>
+                        <div>
+                            <LightBox>
+                                <div className="text-gray-600 dark:text-gray-200 font-semibold text-sm flex py-4">
+                                    <div>{msg}</div>
+                                    <div className="pr-4 pl-1 py-1">{getLicenseValidIcon(tick)}</div>
+                                </div>
+                                <p className="font-semibold dark:text-gray-500  pt-4 ">Registered Users</p>
+                                <h4 className="font-semibold inline-block">
+                                    <span className="dark:text-gray-300 pt-1 text-lg">{license.userCount || 0}</span>
+                                    <span className="dark:text-gray-500 text-gray-400 pt-1 text-lg">
+                                        {" "}
+                                        / {userLimit}{" "}
+                                    </span>
+                                </h4>
+                                <p className="font-semibold dark:text-gray-500 pt-2 ">License Type</p>
+                                <h4 className="font-semibold dark:text-gray-300 pt-1 text-lg">{licenseType}</h4>
+                            </LightBox>
+                        </div>
+                    </div>
+                )}
+            </PageWithSubMenu>
+        </div>
+    );
+}
+
+function capitalizeInitials(str: string): string {
+    return str
+        .split("-")
+        .map((item) => {
+            return item.charAt(0).toUpperCase() + item.slice(1);
+        })
+        .join(" ");
+}
+
+function getSubscriptionLevel(level: string, userCount: number, seats: number, fallbackAllowed: boolean): string[] {
+    switch (level) {
+        case "prod": {
+            return professionalPlan(userCount, seats);
+        }
+        case "community": {
+            return communityPlan(userCount, seats, fallbackAllowed);
+        }
+        case "trial": {
+            return ["Trial", "Free", "You have a trial license.", "grey-tick"];
+        }
+        default: {
+            return ["Unknown", "Free", "No active licenses.", "red-cross"];
+        }
+    }
+}
+
+function professionalPlan(userCount: number, seats: number): string[] {
+    const aboveLimit: boolean = userCount >= seats;
+    let msg: string, tick: string;
+    if (aboveLimit) {
+        msg = "You have reached the usage limit.";
+        tick = "red-cross";
+    } else {
+        msg = "You have an active professional license.";
+        tick = "green-tick";
+    }
+
+    return ["Professional", "Paid", msg, tick];
+}
+
+function communityPlan(userCount: number, seats: number, fallbackAllowed: boolean): string[] {
+    const aboveLimit: boolean = userCount >= seats;
+
+    let msg: string = "You are using the free community edition";
+    let tick: string = "grey-tick";
+    if (aboveLimit) {
+        if (fallbackAllowed) {
+            msg = "No active license. You are using the community edition.";
+        } else {
+            msg = "No active license. You have reached your usage limit.";
+            tick = "red-cross";
+        }
+    }
+
+    return ["Community", "Free", msg, tick];
+}
+
+function getLicenseValidIcon(iconname: string): ReactElement {
+    switch (iconname) {
+        case "green-tick":
+            return <Tick fill="green"></Tick>;
+        case "grey-tick":
+            return <Tick fill="gray"></Tick>;
+        case "red-cross":
+            return <Bang fill="red"></Bang>;
+        default:
+            return <Bang fill="gray"></Bang>;
+    }
+}

--- a/components/dashboard/src/admin/admin-menu.ts
+++ b/components/dashboard/src/admin/admin-menu.ts
@@ -22,6 +22,10 @@ export const adminMenu = [
         link: ["/admin/teams"],
     },
     {
+        title: "License",
+        link: ["/admin/license"],
+    },
+    {
         title: "Settings",
         link: ["/admin/settings"],
     },

--- a/components/dashboard/src/components/InfoBox.tsx
+++ b/components/dashboard/src/components/InfoBox.tsx
@@ -19,29 +19,3 @@ export default function InfoBox(p: { className?: string; children?: React.ReactN
         </div>
     );
 }
-
-export function BlackBox(p: { className?: string; children?: React.ReactNode }) {
-    return (
-        <div
-            className={
-                "flex rounded-xl bg-gray-800 dark:bg-white text-white dark:text-gray-400 font-semibold text-xs w-72 h-64 px-4" +
-                (p.className || "")
-            }
-        >
-            <span>{p.children}</span>
-        </div>
-    );
-}
-
-export function LightBox(p: { className?: string; children?: React.ReactNode }) {
-    return (
-        <div
-            className={
-                "flex rounded-xl bg-gray-200 dark:bg-gray-900 text-gray-600 dark:text-gray-600 text-xs w-72 h-64 px-4" +
-                (p.className || "")
-            }
-        >
-            <span>{p.children}</span>
-        </div>
-    );
-}

--- a/components/dashboard/src/components/InfoBox.tsx
+++ b/components/dashboard/src/components/InfoBox.tsx
@@ -19,3 +19,29 @@ export default function InfoBox(p: { className?: string; children?: React.ReactN
         </div>
     );
 }
+
+export function BlackBox(p: { className?: string; children?: React.ReactNode }) {
+    return (
+        <div
+            className={
+                "flex rounded-xl bg-gray-800 dark:bg-white text-white dark:text-gray-400 font-semibold text-xs w-72 h-64 px-4" +
+                (p.className || "")
+            }
+        >
+            <span>{p.children}</span>
+        </div>
+    );
+}
+
+export function LightBox(p: { className?: string; children?: React.ReactNode }) {
+    return (
+        <div
+            className={
+                "flex rounded-xl bg-gray-200 dark:bg-gray-900 text-gray-600 dark:text-gray-600 text-xs w-72 h-64 px-4" +
+                (p.className || "")
+            }
+        >
+            <span>{p.children}</span>
+        </div>
+    );
+}

--- a/components/dashboard/src/images/check.svg
+++ b/components/dashboard/src/images/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+</svg>

--- a/components/dashboard/src/images/tick.svg
+++ b/components/dashboard/src/images/tick.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+</svg>

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -10,6 +10,7 @@ import App from "./App";
 import { UserContextProvider } from "./user-context";
 import { AdminContextProvider } from "./admin-context";
 import { PaymentContextProvider } from "./payment-context";
+import { LicenseContextProvider } from "./license-context";
 import { TeamsContextProvider } from "./teams/teams-context";
 import { ProjectContextProvider } from "./projects/project-context";
 import { ThemeContextProvider } from "./theme-context";
@@ -23,17 +24,19 @@ ReactDOM.render(
         <UserContextProvider>
             <AdminContextProvider>
                 <PaymentContextProvider>
-                    <TeamsContextProvider>
-                        <ProjectContextProvider>
-                            <ThemeContextProvider>
-                                <StartWorkspaceModalContextProvider>
-                                    <BrowserRouter>
-                                        <App />
-                                    </BrowserRouter>
-                                </StartWorkspaceModalContextProvider>
-                            </ThemeContextProvider>
-                        </ProjectContextProvider>
-                    </TeamsContextProvider>
+                    <LicenseContextProvider>
+                        <TeamsContextProvider>
+                            <ProjectContextProvider>
+                                <ThemeContextProvider>
+                                    <StartWorkspaceModalContextProvider>
+                                        <BrowserRouter>
+                                            <App />
+                                        </BrowserRouter>
+                                    </StartWorkspaceModalContextProvider>
+                                </ThemeContextProvider>
+                            </ProjectContextProvider>
+                        </TeamsContextProvider>
+                    </LicenseContextProvider>
                 </PaymentContextProvider>
             </AdminContextProvider>
         </UserContextProvider>

--- a/components/dashboard/src/license-context.tsx
+++ b/components/dashboard/src/license-context.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import React, { createContext, useState } from "react";
+import { LicenseInfo } from "@gitpod/gitpod-protocol";
+
+const LicenseContext = createContext<{
+    license?: LicenseInfo;
+    setLicense: React.Dispatch<LicenseInfo>;
+}>({
+    setLicense: () => null,
+});
+
+const LicenseContextProvider: React.FC = ({ children }) => {
+    const [license, setLicense] = useState<LicenseInfo>();
+    return <LicenseContext.Provider value={{ license, setLicense }}>{children}</LicenseContext.Provider>;
+};
+
+export { LicenseContext, LicenseContextProvider };

--- a/components/gitpod-protocol/src/license-protocol.ts
+++ b/components/gitpod-protocol/src/license-protocol.ts
@@ -15,9 +15,15 @@ export type LicenseIssue = "seats-exhausted";
 export interface LicenseInfo {
     key: string;
     seats: number;
+    userCount?: number;
     valid: boolean;
     validUntil: string;
     plan?: string;
+    features?: string[];
+    enabledFeatures?: string[];
+    type?: string;
+    errorMsg?: string;
+    fallbackAllowed: boolean;
 }
 
 export interface GetLicenseInfoResult {
@@ -33,5 +39,6 @@ export enum LicenseFeature {
 export interface LicenseService {
     validateLicense(): Promise<LicenseValidationResult>;
     getLicenseInfo(): Promise<GetLicenseInfoResult>;
+    adminGetLicense(): Promise<LicenseInfo>;
     licenseIncludesFeature(feature: LicenseFeature): Promise<boolean>;
 }

--- a/components/licensor/ee/pkg/licensor/gitpod.go
+++ b/components/licensor/ee/pkg/licensor/gitpod.go
@@ -21,6 +21,7 @@ func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 		return &Evaluator{
 			lic:           defaultLicense,
 			allowFallback: true,
+			plan:          CommunityLicense,
 		}
 	}
 
@@ -63,6 +64,7 @@ func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 
 	return &Evaluator{
 		lic:           lic.LicensePayload,
-		allowFallback: false, // Gitpod licenses cannot fallback - assume these are always paid-for
+		allowFallback: false,               // Gitpod licenses cannot fallback - assume these are always paid-for
+		plan:          ProfessionalLicense, //  This essentially means "paid" license
 	}
 }

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -137,8 +137,6 @@ var fallbackLicense = LicensePayload{
 	ID:    "fallback-license",
 	Level: LevelTeam,
 	Seats: 0,
-	// we set default licese type as "Gitpod"
-	// Type: LicenseTypeGitpod,
 	// Domain, ValidUntil are free for all
 }
 
@@ -147,8 +145,6 @@ var defaultLicense = LicensePayload{
 	ID:    "default-license",
 	Level: LevelEnterprise,
 	Seats: 10,
-	// we set default licese type as "Gitpod"
-	// Type: LicenseTypeGitpod,
 	// Domain, ValidUntil are free for all
 }
 

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -24,12 +24,30 @@ const (
 	LicenseTypeReplicated LicenseType = "replicated"
 )
 
+// LicenseSubscriptionLevel is initialized to have a standard license plan
+// between replicated and gitpod licenses
+type LicenseSubscriptionLevel string
+
+const (
+	CommunityLicense    LicenseSubscriptionLevel = "community"
+	ProfessionalLicense LicenseSubscriptionLevel = "prod"
+)
+
+// LicenseData has type specific info about the license
+type LicenseData struct {
+	Type            LicenseType              `json:"type"`
+	Payload         LicensePayload           `json:"payload"`
+	Plan            LicenseSubscriptionLevel `json:"plan"`
+	FallbackAllowed bool                     `json:"fallbackAllowed"`
+}
+
 // LicensePayload is the actual license content
 type LicensePayload struct {
 	ID         string       `json:"id"`
 	Domain     string       `json:"domain"`
 	Level      LicenseLevel `json:"level"`
 	ValidUntil time.Time    `json:"validUntil"`
+	// Type       LicenseType  `json:"type"`
 
 	// Seats == 0 means there's no seat limit
 	Seats int `json:"seats"`
@@ -119,6 +137,8 @@ var fallbackLicense = LicensePayload{
 	ID:    "fallback-license",
 	Level: LevelTeam,
 	Seats: 0,
+	// we set default licese type as "Gitpod"
+	// Type: LicenseTypeGitpod,
 	// Domain, ValidUntil are free for all
 }
 
@@ -127,6 +147,8 @@ var defaultLicense = LicensePayload{
 	ID:    "default-license",
 	Level: LevelEnterprise,
 	Seats: 10,
+	// we set default licese type as "Gitpod"
+	// Type: LicenseTypeGitpod,
 	// Domain, ValidUntil are free for all
 }
 
@@ -153,6 +175,7 @@ type Evaluator struct {
 	invalid       string
 	allowFallback bool // Paid licenses cannot fallback and prevent additional signups
 	lic           LicensePayload
+	plan          LicenseSubscriptionLevel // Specifies if it is a community/free plan or paid plan
 }
 
 // Validate returns false if the license isn't valid and a message explaining why that is.
@@ -210,6 +233,21 @@ func (e *Evaluator) HasEnoughSeats(seats int) bool {
 // those kinds of decisions must be part of the Evaluator.
 func (e *Evaluator) Inspect() LicensePayload {
 	return e.lic
+}
+
+func (e *Evaluator) LicenseData() LicenseData {
+	data := LicenseData{
+		Type:            LicenseType(e.GetLicenseType()),
+		Payload:         e.Inspect(),
+		FallbackAllowed: e.allowFallback,
+		Plan:            e.plan,
+	}
+
+	return data
+}
+
+func (e *Evaluator) GetLicenseType() string {
+	return os.Getenv("GITPOD_LICENSE_TYPE")
 }
 
 // Sign signs a license so that it can be used with the evaluator

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -28,7 +28,7 @@ type licenseTest struct {
 	Validate              func(t *testing.T, eval *Evaluator)
 	Type                  LicenseType
 	NeverExpires          bool
-	ReplicatedLicenseType *ReplicatedLicenseType
+	ReplicatedLicenseType *LicenseSubscriptionLevel
 }
 
 // roundTripFunc .
@@ -77,7 +77,7 @@ func (test *licenseTest) Run(t *testing.T) {
 				}
 
 				payload, err := json.Marshal(replicatedLicensePayload{
-					LicenseType: func() ReplicatedLicenseType {
+					LicenseType: func() LicenseSubscriptionLevel {
 						if test.ReplicatedLicenseType == nil {
 							return ReplicatedLicenseTypePaid
 						}
@@ -220,7 +220,7 @@ func TestFeatures(t *testing.T) {
 		Features              []Feature
 		LicenseType           LicenseType
 		UserCount             int
-		ReplicatedLicenseType *ReplicatedLicenseType
+		ReplicatedLicenseType *LicenseSubscriptionLevel
 	}{
 		{"Gitpod (in seats): no license", true, LicenseLevel(0), []Feature{
 			FeatureAdminDashboard,

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -23,30 +23,30 @@ type replicatedFields struct {
 	Value interface{} `json:"value"` // This is of type "fieldType"
 }
 
-type ReplicatedLicenseType string
-
 // variable names are what Replicated calls them in the vendor portal
 const (
-	ReplicatedLicenseTypeCommunity   ReplicatedLicenseType = "community"
-	ReplicatedLicenseTypeDevelopment ReplicatedLicenseType = "dev"
-	ReplicatedLicenseTypePaid        ReplicatedLicenseType = "prod"
-	ReplicatedLicenseTypeTrial       ReplicatedLicenseType = "trial"
+	ReplicatedLicenseTypeCommunity   LicenseSubscriptionLevel = "community"
+	ReplicatedLicenseTypeDevelopment LicenseSubscriptionLevel = "dev"
+	ReplicatedLicenseTypePaid        LicenseSubscriptionLevel = "prod"
+	ReplicatedLicenseTypeTrial       LicenseSubscriptionLevel = "trial"
 )
 
 // replicatedLicensePayload exists to convert the JSON structure to a LicensePayload
 type replicatedLicensePayload struct {
-	LicenseID      string                `json:"license_id"`
-	InstallationID string                `json:"installation_id"`
-	Assignee       string                `json:"assignee"`
-	ReleaseChannel string                `json:"release_channel"`
-	LicenseType    ReplicatedLicenseType `json:"license_type"`
-	ExpirationTime *time.Time            `json:"expiration_time,omitempty"` // Not set if license never expires
-	Fields         []replicatedFields    `json:"fields"`
+	LicenseID      string                   `json:"license_id"`
+	InstallationID string                   `json:"installation_id"`
+	Assignee       string                   `json:"assignee"`
+	ReleaseChannel string                   `json:"release_channel"`
+	LicenseType    LicenseSubscriptionLevel `json:"license_type"`
+	ExpirationTime *time.Time               `json:"expiration_time,omitempty"` // Not set if license never expires
+	Fields         []replicatedFields       `json:"fields"`
 }
 
 type ReplicatedEvaluator struct {
-	invalid string
-	lic     LicensePayload
+	invalid       string
+	lic           LicensePayload
+	plan          LicenseSubscriptionLevel
+	allowFallback bool
 }
 
 func (e *ReplicatedEvaluator) Enabled(feature Feature) bool {
@@ -66,6 +66,17 @@ func (e *ReplicatedEvaluator) HasEnoughSeats(seats int) bool {
 	return e.lic.Seats == 0 || seats <= e.lic.Seats
 }
 
+func (e *ReplicatedEvaluator) LicenseData() LicenseData {
+	data := LicenseData{
+		Type:            LicenseTypeReplicated,
+		Payload:         e.Inspect(),
+		FallbackAllowed: e.allowFallback,
+		Plan:            e.plan,
+	}
+
+	return data
+}
+
 func (e *ReplicatedEvaluator) Inspect() LicensePayload {
 	return e.lic
 }
@@ -80,9 +91,11 @@ func (e *ReplicatedEvaluator) Validate() (msg string, valid bool) {
 
 // defaultReplicatedLicense this is the default license if call fails
 func defaultReplicatedLicense() *Evaluator {
+
 	return &Evaluator{
 		lic:           defaultLicense,
 		allowFallback: true,
+		plan:          ReplicatedLicenseTypeCommunity,
 	}
 }
 
@@ -131,6 +144,7 @@ func newReplicatedEvaluator(client *http.Client, domain string) (res *Evaluator)
 	return &Evaluator{
 		lic:           lic,
 		allowFallback: replicatedPayload.LicenseType == ReplicatedLicenseTypeCommunity, // Only community licenses are allowed to fallback
+		plan:          replicatedPayload.LicenseType,
 	}
 }
 

--- a/components/licensor/typescript/ee/genapi.go
+++ b/components/licensor/typescript/ee/genapi.go
@@ -74,6 +74,26 @@ func main() {
 		res = append(res, t)
 	}
 
+	ts, err = bel.Extract(licensor.LicenseData{}, bel.WithEnumerations(handler))
+	if err != nil {
+		panic(err)
+	}
+	for _, t := range ts {
+		if t.Name == "" {
+			continue
+		}
+
+		if t.Name == "LicenseData" {
+			for i, m := range t.Members {
+				if m.Name == "payload" {
+					t.Members[i].Type.Name = "LicensePayload"
+				}
+			}
+		}
+
+		res = append(res, t)
+	}
+
 	sort.Slice(res, func(i, j int) bool { return res[i].Name < res[j].Name })
 
 	f, err := os.Create("src/api.ts")

--- a/components/licensor/typescript/ee/main.go
+++ b/components/licensor/typescript/ee/main.go
@@ -53,14 +53,6 @@ func GetLicenseData(id int) (licData *C.char, ok bool) {
 
 }
 
-// GetLicenseType returns the license type of the current Gitpod Installation
-//export GetLicenseType
-func GetLicenseType(id int) *C.char {
-	e, _ := instances[id]
-	licenseType := e.GetLicenseType()
-	return C.CString(licenseType)
-}
-
 // Validate returns false if the license isn't valid and a message explaining why that is.
 //export Validate
 func Validate(id int) (msg *C.char, valid bool) {

--- a/components/licensor/typescript/ee/main.go
+++ b/components/licensor/typescript/ee/main.go
@@ -35,6 +35,32 @@ func Init(key *C.char, domain *C.char) (id int) {
 	return id
 }
 
+// GetLicenseData returns the info about license for the admin dashboard
+//export GetLicenseData
+func GetLicenseData(id int) (licData *C.char, ok bool) {
+	e, ok := instances[id]
+	if !ok {
+		return
+	}
+
+	b, err := json.Marshal(e.LicenseData())
+	if err != nil {
+		log.WithError(err).Warn("GetLicenseData(): cannot retrieve license data")
+		return nil, false
+	}
+
+	return C.CString(string(b)), true
+
+}
+
+// GetLicenseType returns the license type of the current Gitpod Installation
+//export GetLicenseType
+func GetLicenseType(id int) *C.char {
+	e, _ := instances[id]
+	licenseType := e.GetLicenseType()
+	return C.CString(licenseType)
+}
+
 // Validate returns false if the license isn't valid and a message explaining why that is.
 //export Validate
 func Validate(id int) (msg *C.char, valid bool) {

--- a/components/licensor/typescript/ee/src/api.ts
+++ b/components/licensor/typescript/ee/src/api.ts
@@ -12,6 +12,13 @@ export enum Feature {
     FeatureSnapshot = "snapshot",
     FeatureWorkspaceSharing = "workspace-sharing",
 }
+export interface LicenseData {
+    type: LicenseType
+    payload: LicensePayload
+    plan: string
+    fallbackAllowed: boolean
+}
+
 export enum LicenseLevel {
     LevelTeam = 0,
     LevelEnterprise = 1,
@@ -22,4 +29,9 @@ export interface LicensePayload {
     level: LicenseLevel
     validUntil: string
     seats: number
+}
+
+export enum LicenseType {
+    LicenseTypeGitpod = "gitpod",
+    LicenseTypeReplicated = "replicated",
 }

--- a/components/licensor/typescript/ee/src/index.ts
+++ b/components/licensor/typescript/ee/src/index.ts
@@ -5,8 +5,8 @@
  */
 
 import { injectable, inject, postConstruct } from 'inversify';
-import { init, Instance, dispose, isEnabled, hasEnoughSeats, inspect, validate } from "./nativemodule";
-import { Feature, LicensePayload } from './api';
+import { init, Instance, dispose, isEnabled, hasEnoughSeats, inspect, validate, getLicenseType, getLicenseData } from "./nativemodule";
+import { Feature, LicensePayload, LicenseData } from './api';
 
 export const LicenseKeySource = Symbol("LicenseKeySource");
 
@@ -59,6 +59,14 @@ export class LicenseEvaluator {
 
     public inspect(): LicensePayload {
         return JSON.parse(inspect(this.instanceID));
+    }
+
+    public getLicenseType(): string {
+        return getLicenseType(this.instanceID);
+    }
+
+    public getLicenseData(): LicenseData {
+        return JSON.parse(getLicenseData(this.instanceID));
     }
 
     public dispose() {

--- a/components/licensor/typescript/ee/src/index.ts
+++ b/components/licensor/typescript/ee/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { injectable, inject, postConstruct } from 'inversify';
-import { init, Instance, dispose, isEnabled, hasEnoughSeats, inspect, validate, getLicenseType, getLicenseData } from "./nativemodule";
+import { init, Instance, dispose, isEnabled, hasEnoughSeats, inspect, validate, getLicenseData } from "./nativemodule";
 import { Feature, LicensePayload, LicenseData } from './api';
 
 export const LicenseKeySource = Symbol("LicenseKeySource");
@@ -59,10 +59,6 @@ export class LicenseEvaluator {
 
     public inspect(): LicensePayload {
         return JSON.parse(inspect(this.instanceID));
-    }
-
-    public getLicenseType(): string {
-        return getLicenseType(this.instanceID);
     }
 
     public getLicenseData(): LicenseData {

--- a/components/licensor/typescript/ee/src/module.cc
+++ b/components/licensor/typescript/ee/src/module.cc
@@ -201,7 +201,6 @@ void GetLicenseDataM(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(String::NewFromUtf8(isolate, r.r0).ToLocalChecked());
 }
 
-
 void InspectM(const FunctionCallbackInfo<Value> &args) {
     Isolate *isolate = args.GetIsolate();
     Local<Context> context = isolate->GetCurrentContext();
@@ -246,23 +245,6 @@ void DisposeM(const FunctionCallbackInfo<Value> &args) {
     Dispose(id);
 }
 
-void GetLicenseTypeM(const FunctionCallbackInfo<Value> &args) {
-    Isolate *isolate = args.GetIsolate();
-    Local<Context> context = isolate->GetCurrentContext();
-
-    if (args.Length() < 1) {
-        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "wrong number of arguments").ToLocalChecked()));
-        return;
-    }
-
-    double rid = args[0]->NumberValue(context).FromMaybe(0);
-    int id = static_cast<int>(rid);
-
-    char* r = GetLicenseType(id);
-
-    args.GetReturnValue().Set(String::NewFromUtf8(isolate, r).ToLocalChecked());
-}
-
 // add method to exports
 void initModule(Local<Object> exports) {
     NODE_SET_METHOD(exports, "init", InitM);
@@ -271,7 +253,6 @@ void initModule(Local<Object> exports) {
     NODE_SET_METHOD(exports, "hasEnoughSeats", HasEnoughSeatsM);
     NODE_SET_METHOD(exports, "inspect", InspectM);
     NODE_SET_METHOD(exports, "dispose", DisposeM);
-    NODE_SET_METHOD(exports, "getLicenseType", GetLicenseTypeM);
     NODE_SET_METHOD(exports, "getLicenseData", GetLicenseDataM);
 }
 

--- a/components/licensor/typescript/ee/src/module.cc
+++ b/components/licensor/typescript/ee/src/module.cc
@@ -176,6 +176,32 @@ void HasEnoughSeatsM(const FunctionCallbackInfo<Value> &args) {
     args.GetReturnValue().Set(Boolean::New(isolate, r.r0));
 }
 
+void GetLicenseDataM(const FunctionCallbackInfo<Value> &args) {
+    Isolate *isolate = args.GetIsolate();
+    Local<Context> context = isolate->GetCurrentContext();
+
+    if (args.Length() < 1) {
+        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "wrong number of arguments").ToLocalChecked()));
+        return;
+    }
+    if (!args[0]->IsNumber() || args[0]->IsUndefined()) {
+        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "argument 0 must be a number").ToLocalChecked()));
+        return;
+    }
+
+    double rid = args[0]->NumberValue(context).FromMaybe(0);
+    int id = static_cast<int>(rid);
+
+    GetLicenseData_return r = GetLicenseData(id);
+    if (!r.r1) {
+        isolate->ThrowException(Exception::Error(String::NewFromUtf8(isolate, "invalid instance ID").ToLocalChecked()));
+        return;
+    }
+
+    args.GetReturnValue().Set(String::NewFromUtf8(isolate, r.r0).ToLocalChecked());
+}
+
+
 void InspectM(const FunctionCallbackInfo<Value> &args) {
     Isolate *isolate = args.GetIsolate();
     Local<Context> context = isolate->GetCurrentContext();
@@ -220,6 +246,23 @@ void DisposeM(const FunctionCallbackInfo<Value> &args) {
     Dispose(id);
 }
 
+void GetLicenseTypeM(const FunctionCallbackInfo<Value> &args) {
+    Isolate *isolate = args.GetIsolate();
+    Local<Context> context = isolate->GetCurrentContext();
+
+    if (args.Length() < 1) {
+        isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "wrong number of arguments").ToLocalChecked()));
+        return;
+    }
+
+    double rid = args[0]->NumberValue(context).FromMaybe(0);
+    int id = static_cast<int>(rid);
+
+    char* r = GetLicenseType(id);
+
+    args.GetReturnValue().Set(String::NewFromUtf8(isolate, r).ToLocalChecked());
+}
+
 // add method to exports
 void initModule(Local<Object> exports) {
     NODE_SET_METHOD(exports, "init", InitM);
@@ -228,6 +271,8 @@ void initModule(Local<Object> exports) {
     NODE_SET_METHOD(exports, "hasEnoughSeats", HasEnoughSeatsM);
     NODE_SET_METHOD(exports, "inspect", InspectM);
     NODE_SET_METHOD(exports, "dispose", DisposeM);
+    NODE_SET_METHOD(exports, "getLicenseType", GetLicenseTypeM);
+    NODE_SET_METHOD(exports, "getLicenseData", GetLicenseDataM);
 }
 
 // create module

--- a/components/licensor/typescript/ee/src/nativemodule.d.ts
+++ b/components/licensor/typescript/ee/src/nativemodule.d.ts
@@ -13,3 +13,5 @@ export function isEnabled(id: Instance, feature: Feature, seats: int): boolean;
 export function hasEnoughSeats(id: Instance, seats: int): boolean;
 export function inspect(id: Instance): string;
 export function dispose(id: Instance);
+export function getLicenseType(id: Instance): string;
+export function getLicenseData(id: Instance): string;

--- a/components/licensor/typescript/ee/src/nativemodule.d.ts
+++ b/components/licensor/typescript/ee/src/nativemodule.d.ts
@@ -13,5 +13,4 @@ export function isEnabled(id: Instance, feature: Feature, seats: int): boolean;
 export function hasEnoughSeats(id: Instance, seats: int): boolean;
 export function inspect(id: Instance): string;
 export function dispose(id: Instance);
-export function getLicenseType(id: Instance): string;
 export function getLicenseData(id: Instance): string;

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -11,7 +11,7 @@ import { Server } from "../../src/server";
 import { ServerEE } from "./server";
 import { UserController } from "../../src/user/user-controller";
 import { UserControllerEE } from "./user/user-controller";
-import { LicenseEvaluator, LicenseKeySource } from "@gitpod/licensor/lib";
+import { LicenseKeySource } from "@gitpod/licensor/lib";
 import { DBLicenseKeySource } from "./license-source";
 import { UserService } from "../../src/user/user-service";
 import { UserServiceEE } from "./user/user-service";
@@ -82,7 +82,6 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
 
     bind(UserCounter).toSelf().inSingletonScope();
 
-    bind(LicenseEvaluator).toSelf().inSingletonScope();
     bind(LicenseKeySource).to(DBLicenseKeySource).inSingletonScope();
 
     // GitpodServerImpl (stateful per user)

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -59,7 +59,7 @@ import {
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { v4 as uuidv4 } from "uuid";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { LicenseEvaluator, LicenseKeySource } from "@gitpod/licensor/lib";
+import { LicenseKeySource } from "@gitpod/licensor/lib";
 import { Feature } from "@gitpod/licensor/lib/api";
 import { LicenseValidationResult, LicenseFeature } from "@gitpod/gitpod-protocol/lib/license-protocol";
 import { PrebuildManager } from "../prebuilds/prebuild-manager";
@@ -102,7 +102,6 @@ import { UserCounter } from "../user/user-counter";
 
 @injectable()
 export class GitpodServerEEImpl extends GitpodServerImpl {
-    @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
     @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
     @inject(LicenseDB) protected readonly licenseDB: LicenseDB;
     @inject(LicenseKeySource) protected readonly licenseKeySource: LicenseKeySource;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -146,6 +146,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         adminGetProjectsBySearchTerm: { group: "default", points: 1 },
         adminGetProjectById: { group: "default", points: 1 },
         adminFindPrebuilds: { group: "default", points: 1 },
+        adminGetLicense: { group: "default", points: 1 },
         adminSetLicense: { group: "default", points: 1 },
         adminGetSettings: { group: "default", points: 1 },
         adminUpdateSettings: { group: "default", points: 1 },

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -97,6 +97,7 @@ import { LocalMessageBroker, LocalRabbitMQBackedMessageBroker } from "./messagin
 import { contentServiceBinder } from "@gitpod/content-service/lib/sugar";
 import { ReferrerPrefixParser } from "./workspace/referrer-prefix-context-parser";
 import { InstallationAdminTelemetryDataProvider } from "./installation-admin/telemetry-data-provider";
+import { LicenseEvaluator } from "@gitpod/licensor/lib";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -212,6 +213,8 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(TermsProvider).toSelf().inSingletonScope();
 
     bind(InstallationAdminTelemetryDataProvider).toSelf().inSingletonScope();
+
+    bind(LicenseEvaluator).toSelf().inSingletonScope();
 
     // binds all content services
     contentServiceBinder((ctx) => {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2612,7 +2612,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const userCount = await this.userDB.getUserCount(true);
 
         const features = Object.keys(Feature);
-        const enabledFeatures = await this.licenseFeatures(ctx, features);
+        const enabledFeatures = await this.licenseFeatures(ctx, features, userCount);
 
         return {
             key: licensePayload.id,
@@ -2629,9 +2629,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         };
     }
 
-    async licenseFeatures(ctx: TraceContext, features: string[]): Promise<string[]> {
+    async licenseFeatures(ctx: TraceContext, features: string[], userCount: number): Promise<string[]> {
         var enabledFeatures: string[] = [];
-        const userCount = await this.userDB.getUserCount(true);
         for (const feature of features) {
             const featureName: Feature = Feature[feature as keyof typeof Feature];
             if (this.licenseEvaluator.isEnabled(featureName, userCount)) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a `License` tab in the admin dashboard listing relevant information about the associated license

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8413

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
