### PR TITLE
[ws-daemon] Remove tar file size limit

### DIFF
--- a/components/content-service/pkg/archive/tar.go
+++ b/components/content-service/pkg/archive/tar.go
@@ -25,20 +25,12 @@ import (
 
 // TarConfig configures tarbal creation/extraction
 type TarConfig struct {
-	MaxSizeBytes int64
-	UIDMaps      []IDMapping
-	GIDMaps      []IDMapping
+	UIDMaps []IDMapping
+	GIDMaps []IDMapping
 }
 
 // BuildTarbalOption configures the tarbal creation
 type TarOption func(o *TarConfig)
-
-// TarbalMaxSize limits the size of a tarbal
-func TarbalMaxSize(n int64) TarOption {
-	return func(o *TarConfig) {
-		o.MaxSizeBytes = n
-	}
-}
 
 // IDMapping maps user or group IDs
 type IDMapping struct {

--- a/components/ws-daemon/pkg/content/archive.go
+++ b/components/ws-daemon/pkg/content/archive.go
@@ -82,14 +82,7 @@ func BuildTarbal(ctx context.Context, src string, dst string, fullWorkspaceBacku
 
 	defer fout.Close()
 
-	targetOut := newLimitWriter(fout, cfg.MaxSizeBytes)
-	defer func(e *error) {
-		if targetOut.DidMaxOut() {
-			*e = ErrMaxSizeExceeded
-		}
-	}(&err)
-
-	_, err = io.Copy(targetOut, tarout)
+	_, err = io.Copy(fout, tarout)
 	if err != nil {
 		return cleanCorruptedTarballAndReturnError(dst, xerrors.Errorf("cannot write tar file: %w", err))
 	}

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -443,7 +443,7 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 		defer tmpf.Close()
 
 		var opts []archive.TarOption
-		opts = append(opts, archive.TarbalMaxSize(int64(s.config.WorkspaceSizeLimit)))
+		opts = append(opts)
 		if !sess.FullWorkspaceBackup {
 			mappings := []archive.IDMapping{
 				{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},


### PR DESCRIPTION
## Description
This PR removes the backup tarbal size limit in favour of the XFS project quota. This removes one reason why users might not get a backup.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9037

## How to test
Fill the `/workspace` volume to the last byte, stop the workspace and start it again. You should get a backup.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Removed leftover workspace size limit which could prevent backups from being created.
```
