### PR TITLE
[helm] Fix ws-daemon readiness probe

### DIFF
--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -4,10 +4,8 @@
 {{- define "ws-daemon.config" }}
 {{ $comp := .comp -}}
 {{ with .root }}
+readinessProbeAddr: ":9999"
 daemon:
-  readiness:
-    enabled: true
-    addr: ":9999"
   runtime:
     namespace: {{ .Release.Namespace | quote }}
     containerRuntime:

--- a/chart/templates/ws-daemon-daemonset.yaml
+++ b/chart/templates/ws-daemon-daemonset.yaml
@@ -285,7 +285,7 @@ spec:
         readinessProbe:
           httpGet:
             port: 9999
-            path: "/"
+            path: "/ready"
           initialDelaySeconds: 5
           periodSeconds: 10
         lifecycle:
@@ -304,7 +304,7 @@ spec:
         livenessProbe:
           httpGet:
             port: 9999
-            path: "/"
+            path: "/ready"
           initialDelaySeconds: 5
           periodSeconds: 10
           failureThreshold: 10


### PR DESCRIPTION
## Description
Fixes the helm charts to work with the recent ws-daemon readiness probe changes.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
