### PR TITLE
[dashboard] Remove prebuild status errors from prebuild logs

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -85,58 +85,12 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
             props.onInstanceUpdate(workspaceInstance);
         }
         switch (workspaceInstance?.status.phase) {
-            // unknown indicates an issue within the system in that it cannot determine the actual phase of
-            // a workspace. This phase is usually accompanied by an error.
-            case "unknown":
-                break;
-
             // Preparing means that we haven't actually started the workspace instance just yet, but rather
             // are still preparing for launch. This means we're building the Docker image for the workspace.
             case "preparing":
-                getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
-                break;
-
-            // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
-            // some space within the cluster. If for example the cluster needs to scale up to accomodate the
-            // workspace, the workspace will be in Pending state until that happened.
-            case "pending":
-                break;
-
-            // Creating means the workspace is currently being created. That includes downloading the images required
-            // to run the workspace over the network. The time spent in this phase varies widely and depends on the current
-            // network speed, image size and cache states.
-            case "creating":
-                break;
-
-            // Initializing is the phase in which the workspace is executing the appropriate workspace initializer (e.g. Git
-            // clone or backup download). After this phase one can expect the workspace to either be Running or Failed.
-            case "initializing":
-                break;
-
-            // Running means the workspace is able to actively perform work, either by serving a user through Theia,
-            // or as a headless workspace.
-            case "running":
-                break;
-
-            // Interrupted is an exceptional state where the container should be running but is temporarily unavailable.
-            // When in this state, we expect it to become running or stopping anytime soon.
-            case "interrupted":
-                break;
-
-            // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
-            case "stopping":
-                break;
-
-            // Stopped means the workspace ended regularly because it was shut down.
             case "stopped":
                 getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
                 break;
-        }
-        if (workspaceInstance?.status.conditions.headlessTaskFailed) {
-            setError(new Error(workspaceInstance.status.conditions.headlessTaskFailed));
-        }
-        if (workspaceInstance?.status.conditions.failed) {
-            setError(new Error(workspaceInstance.status.conditions.failed));
         }
     }, [props.workspaceId, workspaceInstance?.status.phase]);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes injection of prebuild/workspace instance status errors into the logs. The error/status is already shown below the logs view.

<img width="1330" alt="Screenshot 2022-03-31 at 11 22 17" src="https://user-images.githubusercontent.com/1419286/161029448-f674b285-47e0-4611-9e71-48cbccf112a4.png">
<img width="1336" alt="Screenshot 2022-03-31 at 11 19 27" src="https://user-images.githubusercontent.com/1419286/161029463-195e37c4-8f8e-4f5c-a1b7-644b1516c51f.png">

Doing this addresses the following problems:
* Simplifies state checking logic
* Removes a race-condition where sometimes (fairly frequently) the error is injected at the top of the logs but with enough log output, the error is not in the view.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Clone https://gitlab.com/gitpod-milan/gitpod-large-image
2. Setup the repo in step 1. as a project
3. Trigger pre-builds for the following example branches:
	* main
	* timeout
	* fail
4. Observe the error is not injected into the logs
5. Image build & logs continue to be streamed
6. Once built, logs should continue to be accessible

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Remove prebuild error message from prebuild log view
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc
/hold