### PR TITLE
Switch KOTS publish to use envvars

### DIFF
--- a/.werft/jobs/build/publish-kots.ts
+++ b/.werft/jobs/build/publish-kots.ts
@@ -22,16 +22,11 @@ export async function publishKots(werft: Werft, config: JobConfig) {
     // Update the additionalImages in the kots-app.yaml
     exec(`/tmp/installer mirror kots --file ${REPLICATED_YAML_DIR}/kots-app.yaml`);
 
-    const app = exec(`kubectl get secret ${REPLICATED_SECRET} --namespace werft -o jsonpath='{.data.app}' | base64 -d`);
-    const token = exec(`kubectl get secret ${REPLICATED_SECRET} --namespace werft -o jsonpath='{.data.token}' | base64 -d`);
-
     const replicatedChannel = config.mainBuild ? 'Unstable' : config.repository.branch;
 
     exec(`replicated release create \
         --lint \
         --ensure-channel \
-        --app ${app} \
-        --token ${token} \
         --yaml-dir ${REPLICATED_YAML_DIR} \
         --version ${config.version} \
         --release-notes "# ${config.version}\n\nSee [Werft job](https://werft.gitpod-dev.com/job/gitpod-build-${config.version}/logs) for notes" \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The KOTS publish job was causing random failures in `main` and other branches. This was due to the `kubectl get secrets replicated -n werft` command not always having the credentials to get the secret.

As suggested by @corneliusludmann in [the original PR](https://github.com/gitpod-io/gitpod/pull/8867#pullrequestreview-922437218), we this secret is already loaded to the Werft job so this bit is actually redundant.

As we have named the envvars in the manner that the Replicated CLI expects them, there's no need to assign the values here.

## How to test
<!-- Provide steps to test this PR -->
Run a werft job

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
