### PR TITLE
Add "publish-to-kots" flag in werft

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -16,6 +16,7 @@ export interface JobConfig {
     publishRelease: boolean;
     publishToJBMarketplace: string
     publishToNpm: string
+    publishToKots: boolean;
     retag: string
     storage: string;
     version: string;
@@ -78,6 +79,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const withIntegrationTests = "with-integration-tests" in buildConfig && !mainBuild;
     const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
     const publishToJBMarketplace = "publish-to-jb-marketplace" in buildConfig || mainBuild;
+    const publishToKots = "publish-to-kots" in buildConfig || mainBuild;
     const analytics = buildConfig["analytics"];
     const localAppVersion = mainBuild || ("with-localapp-version" in buildConfig) ? version : "unknown";
     const retag = ("with-retag" in buildConfig) ? "" : "--dont-retag";
@@ -125,6 +127,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         publishRelease,
         publishToJBMarketplace,
         publishToNpm,
+        publishToKots,
         repository,
         retag,
         storage,

--- a/.werft/jobs/build/publish-kots.ts
+++ b/.werft/jobs/build/publish-kots.ts
@@ -11,6 +11,10 @@ const REPLICATED_YAML_DIR = './install/kots/manifests';
 const INSTALLER_JOB_IMAGE = 'spec.template.spec.containers[0].image';
 
 export async function publishKots(werft: Werft, config: JobConfig) {
+    if (!config.publishToKots) {
+        return;
+    }
+
     werft.phase(phases.PUBLISH_KOTS, 'Publish release to KOTS');
 
     const imageAndTag = exec(`yq r ${REPLICATED_YAML_DIR}/gitpod-installer-job.yaml ${INSTALLER_JOB_IMAGE}`);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add a `publish-to-kots=true` to Werft. This makes the publish to KOTS only happen when requested or on the `main` branch

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
