### PR TITLE
[kots]: change the CPU and memory checks to be min not sum

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -103,24 +103,24 @@ spec:
           - pass:
               message: Cert-manager is installed and available.
     - nodeResources:
-        checkName: Total CPU Cores in the cluster
+        checkName: CPU Cores per node
         outcomes:
           - fail:
-              when: "sum(cpuCapacity) < 2"
+              when: "min(cpuCapacity) < 2"
               message: The cluster must contain at least 2 cores
           - warn:
-              when: "sum(cpuCapacity) < 4"
+              when: "min(cpuCapacity) < 4"
               message: The cluster must contain at least 4 cores
           - pass:
               message: There are at least 4 cores in the cluster
     - nodeResources:
-        checkName: Total memory in the cluster
+        checkName: Memory per node
         outcomes:
           - fail:
-              when: "sum(memoryCapacity) < 8G"
+              when: "min(memoryCapacity) < 8G"
               message: The cluster must have least 8GB of memory
           - warn:
-              when: "sum(memoryCapacity) < 16G"
+              when: "min(memoryCapacity) < 16G"
               message: The cluster must have least 16GB of memory
           - pass:
               message: There is at least 16GB of memory in the cluster


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Whilst helping someone in the community, noticed that the [memory/CPU recommendations](https://www.gitpod.io/docs/self-hosted/latest/requirements#minimum-compute-resources) and "per node" rather than "per cluster".

This updates the preflight checks to reflect that.

## How to test
<!-- Provide steps to test this PR -->
[Install](https://troubleshoot.sh/docs/#installation) the `preflight` plugin and run `kubectl preflight kots-preflight.yaml`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: change the CPU and memory checks to be min not sum
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
