### PR TITLE
[installer] Add custom CA secret support

### DIFF
--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -340,6 +340,13 @@ fi
 		return nil, err
 	}
 
+	if vol, mnt, _, ok := common.CustomCACertVolume(ctx); ok {
+		podSpec.Volumes = append(podSpec.Volumes, *vol)
+		pod := podSpec.Containers[0]
+		pod.VolumeMounts = append(pod.VolumeMounts, *mnt)
+		podSpec.Containers[0] = pod
+	}
+
 	return []runtime.Object{&appsv1.DaemonSet{
 		TypeMeta: common.TypeMetaDaemonset,
 		ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -90,6 +90,8 @@ type Config struct {
 
 	DisableDefinitelyGP bool `json:"disableDefinitelyGp"`
 
+	CustomCACert *ObjectRef `json:"customCACert,omitempty"`
+
 	Experimental *experimental.Config `json:"experimental,omitempty"`
 }
 

--- a/install/installer/pkg/config/v1/validation.go
+++ b/install/installer/pkg/config/v1/validation.go
@@ -211,6 +211,10 @@ func (v version) ClusterValidation(rcfg interface{}) cluster.ValidationChecks {
 		})))
 	}
 
+	if cfg.CustomCACert != nil {
+		res = append(res, cluster.CheckSecret(cfg.CustomCACert.Name, cluster.CheckSecretRequiredData("ca.crt")))
+	}
+
 	res = append(res, experimental.ClusterValidation(cfg.Experimental)...)
 
 	return res


### PR DESCRIPTION
## Description
Adds custom CA cert support to the installer. When specified, the CA certs are mounted into `server`, `image-builder` and `ws-daemon`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9077

## How to test
(proper test is to install Gitpod on a cluster trying to talk to a Docker registry and SCM which use custom certs).

```bash
# produce new config
installer init > cfg.yaml

# set required values
yq write -i config.yaml domain foobar.com
yq write -i config.yaml customCACert.kind secret
yq write -i config.yaml customCACert.name custom-ca-cert

# validate cluster (should fail)
installer validate cluster --config config.yaml # reports missing secret

# produce secret and validate (should succeed)
openssl genrsa -out ca.crt 2048
kubectl create secret generic custom-ca-certs --from-file=ca.crt=ca.crt
installer validate cluster --config config.yaml

# render
installer render --config config.yaml > objs.yaml

# make sure we got the certs rendered in
grep -B 5 objs.yaml custom-ca-certs
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add custom CA cert support to Gitpod services
```
