### PR TITLE
[kots]: add a kernel version check to the preflights

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -6,6 +6,16 @@ kind: Preflight
 metadata:
   name: gitpod
 spec:
+  collectors:
+    - run:
+        collectorName: "kernel"
+        image: alpine/semver
+        name: kernel
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - semver --coerce --range '>=5.4.0' $(uname -r) || echo invalid
   analyzers:
     - clusterVersion:
         outcomes:
@@ -19,7 +29,17 @@ spec:
               uri: https://kubernetes.io
           - pass:
               message: Your cluster meets the recommended and required versions of Kubernetes.
-    # @todo(sje): figure out a way of checking the Kernel version is >= 5.4.0-0
+    - textAnalyze:
+        checkName: Kernel version is 5.4.0 or above
+        fileName: kernel/kernel.log
+        regex: invalid
+        outcomes:
+          - pass:
+              when: "false"
+              message: Kernel version valid
+          - fail:
+              when: "true"
+              message: Kernel must be 5.4.0 or above
     - containerRuntime:
         outcomes:
           - pass:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add a preflight check to ensure that the kernel version is 5.4.0 or above. It includes preflight checks, so that `5.4.0-gke` would return as valid. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8862

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS.

To check the functionality, run some of the followings:

```shell
docker run --rm alpine/semver semver --coerce --range '>=5.4.0' 5.13.0-1019-gcp // valid
docker run --rm alpine/semver semver --coerce --range '>=5.4.0' 5.4.0-1009-gcp // valid
docker run --rm alpine/semver semver --coerce --range '>=5.4.0' 5.3.9-1009-gcp // errors - would return "invalid"
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add a kernel version check to the preflights
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
