### PR TITLE
Change settings sidebar colors

### DIFF
--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -31,7 +31,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                             if (e.link.some((l) => l === location.pathname)) {
                                 classes += " bg-gray-300 text-gray-800 dark:bg-gray-800 dark:text-gray-50";
                             } else {
-                                classes += " hover:bg-gray-100 dark:hover:bg-gray-800";
+                                classes += " hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-500";
                             }
                             return (
                                 <Link to={e.link[0]} key={e.title}>


### PR DESCRIPTION
## Description

Following the changes in https://github.com/gitpod-io/gitpod/pull/9002, this will change settings sidebar colors. 🖍️ 

## How to test
1. Go to **[`/account`](https://hw-fix-8028.staging.gitpod-dev.com/account)**.
2. Check that the active menu is color accessible when using the dark theme. 🌔 