### PR TITLE
Fix dead link for the source of docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@ The most up-to-date documentation can be found at https://www.gitpod.io/docs.
 
 ## Source
 
-The docs content is hosted in the [gitpod-io/website](https://github.com/gitpod-io/website) repository, specifically in Markdown files located at https://github.com/gitpod-io/website/tree/main/src/routes/docs.
+The docs content is hosted in the [gitpod-io/website](https://github.com/gitpod-io/website) repository, specifically in Markdown files located at https://github.com/gitpod-io/website/tree/main/gitpod/docs.


### PR DESCRIPTION
## Description

Fix dead link for the source of docs at https://github.com/gitpod-io/gitpod/blob/1e0db9e9de42805c9923a8ebf99d8bb427f08b3d/docs/README.md#source

## Related Issue(s)
n/a

## How to test
Test if the link at https://github.com/gitpod-io/gitpod/tree/main/docs#source should work.

## Release Notes
```release-note
NONE
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No
  * https://github.com/gitpod-io/website/pull/1398 already updated it.

cf. https://github.com/gitpod-io/website/pull/1398

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
