### PR TITLE
[installer] Disable `definitely-gp` by default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -300,7 +300,7 @@ components:
       minAgePrebuildDays: 7
       contentRetentionPeriodDays: 21
       contentChunkLimit: 1000
-    definitelyGpDisabled: "false"
+    definitelyGpDisabled: true
     enableLocalApp: false
     disableDynamicAuthProviderLogin: false
     maxEnvvarPerUserCount: 4048

--- a/install/installer/docs/air-gap.md
+++ b/install/installer/docs/air-gap.md
@@ -22,11 +22,10 @@ done
 
 ## Install Gitpod in Air-Gap Mode
 
-To install Gitpod in an air-gap network, you need to configure the repository of the images needed by Gitpod (see previous step) and disable the `definitely-gp` feature. Add this to your Gitpod config:
+To install Gitpod in an air-gap network, you need to configure the repository of the images needed by Gitpod (see previous step). Add this to your Gitpod config:
 
 ```yaml
 repository: your-registry.example.com
-disableDefinitelyGp: true
 ```
 
 That's it. Run the following commands as usual and Gitpod fetches the images from your registry and does not need internet access to operate:

--- a/install/installer/example-config.yaml
+++ b/install/installer/example-config.yaml
@@ -10,7 +10,7 @@ containerRegistry:
   inCluster: true
 database:
   inCluster: true
-disableDefinitelyGp: false
+disableDefinitelyGp: true
 domain: ""
 kind: Full
 metadata:

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -54,7 +54,7 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
 	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
 	cfg.OpenVSX.URL = "https://open-vsx.org"
-	cfg.DisableDefinitelyGP = false
+	cfg.DisableDefinitelyGP = true
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`definitely-gp` is being deprecated soon, and hence
it is important to be disabled by default. Once it
is fully deprecated, even this option has to be removed.

For now, The following changes have been made:

- Update the `definitelyGpDisabled` option to be true, Thus
  disabling it by default
- Update the airgap docs to remove a mention of this

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8740

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Disable `definitely-gp` by default
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
