### PR TITLE
WIP: Base server for go

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 
 /components/blobserve @gitpod-io/engineering-workspace
 /components/common-go @gitpod-io/engineering-workspace
+/components/common-go/baseserver @gitpod-io/engineering-webapp
 /components/content-service-api @csweichel @geropl
 /components/content-service @gitpod-io/engineering-workspace
 /components/dashboard @gitpod-io/engineering-webapp

--- a/components/common-go/baseserver/http.go
+++ b/components/common-go/baseserver/http.go
@@ -1,0 +1,11 @@
+package baseserver
+
+import "net/http"
+
+var healthyResponse = []byte(`healthy`)
+
+func ReadyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(healthyResponse)
+	})
+}

--- a/components/common-go/baseserver/http.go
+++ b/components/common-go/baseserver/http.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
 package baseserver
 
 import "net/http"

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -1,0 +1,73 @@
+package baseserver
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+type Option func(cfg *config) error
+
+func WithHTTPPort(port int) Option {
+	return func(cfg *config) error {
+		if port < 0 {
+			return fmt.Errorf("http port must be greater than 0, got: %d", port)
+		}
+
+		cfg.httpPort = port
+		return nil
+	}
+}
+
+func WithGRPCPort(port int) Option {
+	return func(cfg *config) error {
+		if port < 0 {
+			return fmt.Errorf("grpc port must be greater than 0, got: %d", port)
+		}
+
+		cfg.grpcPort = port
+		return nil
+	}
+}
+
+func WithTLS(certs Certs) Option {
+	return func(cfg *config) error {
+		caCertPath := strings.TrimSpace(certs.CACertPath)
+		serverCertPath := strings.TrimSpace(certs.ServerCertPath)
+		serverKeyPath := strings.TrimSpace(certs.ServerKeyPath)
+
+		if caCertPath == "" {
+			return fmt.Errorf("empty certificate authority path specified")
+		}
+		if serverCertPath == "" {
+			return fmt.Errorf("empty server certificate path specified")
+		}
+		if serverKeyPath == "" {
+			return fmt.Errorf("empty server key path specified")
+		}
+
+		cfg.certs = &certs
+		return nil
+	}
+}
+
+func WithLogger(logger *logrus.Entry) Option {
+	return func(cfg *config) error {
+		if logger == nil {
+			return fmt.Errorf("nil logger specified")
+		}
+
+		cfg.logger = logger
+		return nil
+	}
+}
+
+func evaluateOptions(cfg *config, opts ...Option) (*config, error) {
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, fmt.Errorf("failed to evaluate config: %w", err)
+		}
+	}
+
+	return cfg, nil
+}

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -8,6 +8,13 @@ import (
 
 type Option func(cfg *config) error
 
+func WithHostname(hostname string) Option {
+	return func(cfg *config) error {
+		cfg.hostname = hostname
+		return nil
+	}
+}
+
 func WithHTTPPort(port int) Option {
 	return func(cfg *config) error {
 		if port < 0 {

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -3,10 +3,22 @@ package baseserver
 import (
 	"fmt"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
 	"strings"
 )
 
 type Option func(cfg *config) error
+
+func WithContext(ctx context.Context) Option {
+	return func(cfg *config) error {
+		if ctx == nil {
+			return fmt.Errorf("nil context is an invalid option")
+		}
+
+		cfg.ctx = ctx
+		return nil
+	}
+}
 
 func WithHostname(hostname string) Option {
 	return func(cfg *config) error {

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
 package baseserver
 
 import (

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -1,0 +1,138 @@
+package baseserver
+
+import (
+	"context"
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"net"
+	"net/http"
+)
+
+type Opts struct {
+	GRPCPort int
+	HTTPPort int
+}
+
+func New(name string, opts Opts) *Server {
+	logger := log.New()
+	server := &Server{
+		logger: logger,
+	}
+	server.opts = opts
+
+	server.Name = name
+
+	server.HTTPMux = http.NewServeMux()
+	server.GRPC = grpc.NewServer()
+	server.HTTP = &http.Server{
+		Addr:    fmt.Sprintf(":%d", opts.HTTPPort),
+		Handler: server.HTTPMux,
+	}
+
+	return server
+}
+
+type Server struct {
+	logger *logrus.Entry
+
+	// Name is the name of this server, used for logging context
+	Name string
+
+	// HTTP is an HTTP Server
+	HTTP         *http.Server
+	HTTPMux      *http.ServeMux
+	httpListener net.Listener
+
+	// GRPC is a GRPC Server
+	GRPC         *grpc.Server
+	grpcListener net.Listener
+
+	opts Opts
+}
+
+func (s *Server) ListenAndServe() error {
+	var err error
+	// First, we start the GRPC server
+	s.grpcListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.opts.GRPCPort))
+	if err != nil {
+		return fmt.Errorf("failed to acquire port %d", s.opts.GRPCPort)
+	}
+
+	s.httpListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.opts.HTTPPort))
+	if err != nil {
+		return fmt.Errorf("failed to acquire port %d", s.opts.GRPCPort)
+	}
+
+	errors := make(chan error)
+
+	go func() {
+		s.Logger().
+			WithField("protocol", "grpc").
+			Infof("Serving gRPC on %s", s.grpcListener.Addr().String())
+		if serveErr := s.GRPC.Serve(s.grpcListener); serveErr != nil {
+			// TODO: Log
+			errors <- serveErr
+		}
+	}()
+
+	go func() {
+		s.Logger().
+			WithField("protocol", "http").
+			Infof("Serving HTTP on %s", s.httpListener.Addr().String())
+		if serveErr := s.HTTP.Serve(s.httpListener); serveErr != nil {
+			// TODO: Log
+			errors <- serveErr
+		}
+	}()
+
+	fmt.Println("Waiting for errors")
+	for serveErr := range errors {
+		fmt.Println("errors", serveErr)
+
+		// TODO: Shut down both servers
+
+		return fmt.Errorf("server failed: %w", serveErr)
+	}
+
+	return nil
+}
+
+func (s *Server) Close(ctx context.Context) error {
+	s.Logger().Info("Received graceful shutdown request.")
+
+	s.GRPC.GracefulStop()
+	s.Logger().Info("GRPC server terminated.")
+
+	// s.GRPC.GracefulStop() also closes the underlying net.Listener, we just release the reference.
+	s.grpcListener = nil
+
+	if err := s.HTTP.Shutdown(ctx); err != nil {
+		return fmt.Errorf("failed to close HTTP server: %w", err)
+	}
+
+	// s.HTTP.Shutdown() also closes the underlying net.Listener, we just release the reference.
+	s.httpListener = nil
+
+	return nil
+}
+
+func (s *Server) Logger() *logrus.Entry {
+	return s.logger
+}
+
+func (s *Server) HTTPAddress() string {
+	return s.httpListener.Addr().String()
+}
+
+func (s *Server) GRPCAddress() string {
+	return s.grpcListener.Addr().String()
+}
+
+type GRPCOptions struct {
+	Port           int
+	CACertPath     string
+	ServerCertPath string
+	ServerKeyPath  string
+}

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
 package baseserver
 
 import (

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -82,9 +82,6 @@ type Server struct {
 
 	// listening indicates the server is serving. When closed, the server is in the process of graceful termination.
 	listening chan struct{}
-
-	// closed signals the server has completed closing.
-	closed chan struct{}
 }
 
 func (s *Server) ListenAndServe() error {

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -10,7 +10,17 @@ import (
 )
 
 func TestServer_WithOptions(t *testing.T) {
-	s := baseserver.New("server_name",
+	c := make(chan string)
+	close(c)
+
+	val, isClosed := <-c
+	fmt.Println(val, isClosed)
+	val, isClosed = <-c
+	fmt.Println(val, isClosed)
+	val, isClosed = <-c
+	fmt.Println(val, isClosed)
+
+	_, err := baseserver.New("server_name",
 		baseserver.WithHTTPPort(9000),
 		baseserver.WithGRPCPort(9001),
 		baseserver.WithTLS(baseserver.Certs{
@@ -20,13 +30,17 @@ func TestServer_WithOptions(t *testing.T) {
 		}),
 		baseserver.WithLogger(log.New()),
 	)
+	if err != nil {
+		t.Errorf("failed to construct base server: %s", err)
+	}
+
 }
 
 func TestServer(t *testing.T) {
-	s := baseserver.New("test", baseserver.Opts{
-		GRPCPort: 9001,
-		HTTPPort: 9000,
-	})
+	s, err := baseserver.New("test_server")
+	if err != nil {
+		t.Errorf("failed to construct base server: %s", err)
+	}
 
 	go func() {
 		if err := s.ListenAndServe(); err != nil {
@@ -39,15 +53,13 @@ func TestServer(t *testing.T) {
 	if err := s.Close(context.Background()); err != nil {
 		t.Fatal("failed to shut down server")
 	}
-
-	fmt.Println("server terminated")
 }
 
 func TestServer2(t *testing.T) {
-	s := baseserver.New("test", baseserver.Opts{
-		GRPCPort: 9001,
-		HTTPPort: 9000,
-	})
+	s, err := baseserver.New("test_server")
+	if err != nil {
+		t.Errorf("failed to construct base server: %s", err)
+	}
 
 	go func() {
 		if err := s.ListenAndServe(); err != nil {
@@ -60,6 +72,4 @@ func TestServer2(t *testing.T) {
 	if err := s.Close(context.Background()); err != nil {
 		t.Fatal("failed to shut down server")
 	}
-
-	fmt.Println("server terminated")
 }

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -1,0 +1,51 @@
+package baseserver_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"testing"
+	"time"
+)
+
+func TestServer(t *testing.T) {
+	s := baseserver.New("test", baseserver.Opts{
+		GRPCPort: 9001,
+		HTTPPort: 9000,
+	})
+
+	go func() {
+		if err := s.ListenAndServe(); err != nil {
+			t.Fatal("Server failed to start")
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+
+	if err := s.Close(context.Background()); err != nil {
+		t.Fatal("failed to shut down server")
+	}
+
+	fmt.Println("server terminated")
+}
+
+func TestServer2(t *testing.T) {
+	s := baseserver.New("test", baseserver.Opts{
+		GRPCPort: 9001,
+		HTTPPort: 9000,
+	})
+
+	go func() {
+		if err := s.ListenAndServe(); err != nil {
+			t.Fatal("Server failed to start")
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+
+	if err := s.Close(context.Background()); err != nil {
+		t.Fatal("failed to shut down server")
+	}
+
+	fmt.Println("server terminated")
+}

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -4,9 +4,23 @@ import (
 	"context"
 	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"testing"
 	"time"
 )
+
+func TestServer_WithOptions(t *testing.T) {
+	s := baseserver.New("server_name",
+		baseserver.WithHTTPPort(9000),
+		baseserver.WithGRPCPort(9001),
+		baseserver.WithTLS(baseserver.Certs{
+			CACertPath:     "",
+			ServerCertPath: "",
+			ServerKeyPath:  "",
+		}),
+		baseserver.WithLogger(log.New()),
+	)
+}
 
 func TestServer(t *testing.T) {
 	s := baseserver.New("test", baseserver.Opts{

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -2,9 +2,11 @@ package baseserver_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/stretchr/testify/require"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -39,4 +41,21 @@ func TestServer_Options(t *testing.T) {
 		baseserver.WithLogger(log.New()),
 	)
 	require.NoError(t, err)
+}
+
+func TestServer_ServesMetrics(t *testing.T) {
+	srv, err := baseserver.New("server_test")
+	require.NoError(t, err)
+
+	go func(t *testing.T) {
+		require.NoError(t, srv.ListenAndServe())
+	}(t)
+
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	require.True(t, srv.WaitForServerToBeReachable(ctx), "server did not start")
+
+	metricsURL := fmt.Sprintf("%s/metrics", srv.HTTPAddress())
+	resp, err := http.Get(metricsURL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
 package baseserver_test
 
 import (

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
 package baseserver
 
 import (

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -1,0 +1,20 @@
+package baseserver
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// NewForTests constructs a *baseserver.Server which is automatically closed after the test finishes.
+func NewForTests(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+
+	srv, err := New("test_server", opts...)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, srv.Close())
+	})
+
+	return srv
+}

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -27,9 +27,12 @@ require (
 	k8s.io/apimachinery v0.23.4
 )
 
+require github.com/stretchr/testify v1.7.0
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -39,6 +42,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
@@ -47,6 +51,7 @@ require (
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/components/common-go/log/log.go
+++ b/components/common-go/log/log.go
@@ -47,6 +47,10 @@ type ServiceContext struct {
 // Log is the application wide console logger
 var Log = log.WithFields(log.Fields{})
 
+func New() *log.Entry {
+	return Log.Dup()
+}
+
 // setup default log level for components without initial invocation of log.Init.
 func init() {
 	logLevelFromEnv()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Introduces a library called `baseserver`. It is a combination of an HTTP and gRPC server designed to make it dead-easy to get sensible defaults and be able to use a server.

Using a common base server can give us the following benefits:
* Reduced learning curve for each server engineers interact with
* Drive good sensible defaults
* Provide security out of the box
* Provide authentication & authorization out of the box
* Metrics, logging, profiling all out of the box
* Engineers can focus on building services, not servers
* No reason to not write good client-to-server tests as unit tests when standing up a server is so easy

To fulfill the role outlined above, the following will be needed as well. These will be added incrementally as we need them.
- [ ] Prometheus metrics server
- [ ] gRPC Interceptors
- [ ] HTTP Interceptors
- [ ] Use k8s health handler
- [ ] pprof

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
* go test ./...

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc
/hold