### PR TITLE
[bitbucket-server] reuse icon from bitbucket

### DIFF
--- a/components/dashboard/src/provider-utils.tsx
+++ b/components/dashboard/src/provider-utils.tsx
@@ -17,6 +17,8 @@ function iconForAuthProvider(type: string) {
             return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={gitlab} />;
         case "Bitbucket":
             return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={bitbucket} />;
+        case "BitbucketServer":
+            return <img className="fill-current filter-grayscale w-5 h-5 ml-3 mr-3 my-auto" src={bitbucket} />;
         default:
             return <></>;
     }


### PR DESCRIPTION
A quick fix for the login page.

fixes https://github.com/gitpod-io/gitpod/issues/8603

```release-note
NONE
```