### PR TITLE
[installer] Fix registry facade env variables for IPFS and redis

### DIFF
--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -202,6 +202,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 									},
 								},
 							},
+							envvars,
 						),
 						VolumeMounts: append(
 							[]corev1.VolumeMount{


### PR DESCRIPTION
## Description

Enabling experimental config and IPFS doesn't create the env variable for IPFS host

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Fix registry facade env variables for IPFS and redis
```
