### PR TITLE
[dev] Add yq v4.23.1 as `yq4` binary in dev image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -68,7 +68,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     env:

--- a/.werft/ide-run-integration-tests.yaml
+++ b/.werft/ide-run-integration-tests.yaml
@@ -25,7 +25,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:prs-ws-man-bridge-audit.10
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-clean-up-werft-build-nodes.yaml
+++ b/.werft/platform-clean-up-werft-build-nodes.yaml
@@ -16,7 +16,7 @@ pod:
         type: Directory
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -18,7 +18,7 @@ pod:
       secretName: gcp-sa-gitpod-release-deployer
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kyleb-kubecdl-qol.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/components/supervisor/pkg/config/gitpod-config_test.go
+++ b/components/supervisor/pkg/config/gitpod-config_test.go
@@ -28,7 +28,7 @@ func TestGitpodConfig(t *testing.T) {
 		{
 			Desc: "parsing",
 			Content: `
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -47,7 +47,7 @@ vscode:
     - hangxingliu.vscode-nginx-conf-hint@0.1.0:UATTe2sTFfCYWQ3jw4IRsw==
     - zxh404.vscode-proto3@0.4.2:ZnPmyF/Pb8AIWeCqc83gPw==`,
 			Expectation: &gitpod.GitpodConfig{
-				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-upgrade-dev-image.1",
+				Image:             "eu.gcr.io/gitpod-core-dev/dev/dev-environment:clu-yq4.1",
 				WorkspaceLocation: "gitpod/gitpod-ws.code-workspace",
 				CheckoutLocation:  "gitpod",
 				Ports: []*gitpod.PortsItems{

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -66,6 +66,8 @@ RUN cd /usr/bin && curl -fsSL https://github.com/csweichel/werft/releases/downlo
 # yq - jq for YAML files
 # Note: we rely on version 3.x.x in various places, 4.x breaks this!
 RUN cd /usr/bin && curl -fsSL https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 > yq && chmod +x yq
+# yq4 as separate binary
+RUN cd /usr/bin && curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linux_amd64 > yq4 && chmod +x yq4
 
 # release helper
 RUN cd /usr/bin && curl -fsSL https://github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | tar xz


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds `yq` in version 4.x to the dev image as `yq4` binary. That allows to use the more powerful `yq` version but is still backward compatible where `yq` in version 3.x is used.

## How to test
<!-- Provide steps to test this PR -->

Open a workspace: https://gitpod.io/#https://github.com/gitpod-io/gitpod/tree/clu/yq4

Check that `yq` in version 3.x and `yq4` in version 4.x is available:
```shell
$ yq --version
yq version 3.4.1
$ yq4 --version
yq (https://github.com/mikefarah/yq/) version 4.23.1
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```