### PR TITLE
Properly update response in openvsx proxy

### DIFF
--- a/components/openvsx-proxy/pkg/openvsxproxy_test.go
+++ b/components/openvsx-proxy/pkg/openvsxproxy_test.go
@@ -6,6 +6,7 @@ package pkg
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,6 +35,38 @@ func TestReplaceHostInJSONResponse(t *testing.T) {
 		bodyBytes, _ := io.ReadAll(r.Body)
 		rw.Header().Set("Content-Type", "application/json")
 		rw.Write([]byte(fmt.Sprintf("Hello %s!", string(bodyBytes))))
+	}))
+	defer backend.Close()
+
+	frontend, _ := createFrontend(backend.URL)
+	defer frontend.Close()
+
+	frontendClient := frontend.Client()
+
+	requestBody := backend.URL
+	req, _ := http.NewRequest("POST", frontend.URL, bytes.NewBuffer([]byte(requestBody)))
+	req.Close = true
+	res, err := frontendClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedResponse := fmt.Sprintf("Hello %s!", frontend.URL)
+	if bodyBytes, _ := io.ReadAll(res.Body); string(bodyBytes) != expectedResponse {
+		t.Errorf("got body '%s'; expected '%s'", string(bodyBytes), expectedResponse)
+	}
+}
+
+func TestReplaceHostInCompressedJSONResponse(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.Header().Set("Content-Encoding", "gzip")
+
+		var b bytes.Buffer
+		w := gzip.NewWriter(&b)
+		w.Write([]byte(fmt.Sprintf("Hello %s!", string(bodyBytes))))
+		w.Close()
+		rw.Write(b.Bytes())
 	}))
 	defer backend.Close()
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates response when it's compressed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace
2. Run `NODE_DEBUG=http,https,tls /ide/node /ide/out/server-main.js --install-extension znck.vue --do-not-sync --log trace 2> debug.log` in terminal
3. Check in `debug.log` file that only requests to the openvsx proxy are made and extensions are installed sucessfully
4. Install extensions manually using UI, check extensions are installed sucessfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

