### PR TITLE
[db] Add statusVersion to prebuilds to track status version

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
@@ -69,10 +69,10 @@ export class DBPrebuiltWorkspace implements PrebuiltWorkspace {
     })
     error?: string;
 
-    // stateVersion defines the last observed stateVersion from a WorkspaceStatus. See ws-manager-api/core.proto.
-    // stateVersion must only be set by controller/observer.
+    // statusVersion defines the last observed stateVersion from a WorkspaceStatus. See ws-manager-api/core.proto.
+    // statusVersion must only be set by controller/observer.
     @Column({
         default: 0,
     })
-    stateVersion: number;
+    statusVersion: number;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
@@ -68,4 +68,11 @@ export class DBPrebuiltWorkspace implements PrebuiltWorkspace {
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     error?: string;
+
+    // stateVersion defines the last observed stateVersion from a WorkspaceStatus. See ws-manager-api/core.proto.
+    // stateVersion must only be set by controller/observer.
+    @Column({
+        default: 0,
+    })
+    stateVersion: number;
 }

--- a/components/gitpod-db/src/typeorm/migration/1649107789640-PrebuildStatusVersionColumn.ts
+++ b/components/gitpod-db/src/typeorm/migration/1649107789640-PrebuildStatusVersionColumn.ts
@@ -7,6 +7,9 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 import { columnExists } from "./helper/helper";
 
+const TABLE_NAME = "d_b_prebuilt_workspace";
+const COLUMN_NAME = "statusVersion";
+
 export class PrebuildStatusVersionColumn1649107789640 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {

--- a/components/gitpod-db/src/typeorm/migration/1649107789640-PrebuildStatusVersionColumn.ts
+++ b/components/gitpod-db/src/typeorm/migration/1649107789640-PrebuildStatusVersionColumn.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+export class PrebuildStatusVersionColumn1649107789640 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN \`${COLUMN_NAME}\` BIGINT(20) NOT NULL DEFAULT '0'`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -247,6 +247,7 @@ class WorkspaceDBSpec {
             cloneURL: "",
             commit: "",
             state: "available",
+            statusVersion: 0,
         });
         if (usageDaysAgo !== undefined) {
             const now = new Date();
@@ -509,6 +510,7 @@ class WorkspaceDBSpec {
                 cloneURL: cloneURL,
                 commit: "",
                 state: "queued",
+                statusVersion: 0,
             }),
             // now and aborted
             this.storePrebuiltWorkspace({
@@ -518,6 +520,7 @@ class WorkspaceDBSpec {
                 cloneURL: cloneURL,
                 commit: "",
                 state: "aborted",
+                statusVersion: 0,
             }),
             // completed over a minute ago
             this.storePrebuiltWorkspace({
@@ -527,6 +530,7 @@ class WorkspaceDBSpec {
                 cloneURL: cloneURL,
                 commit: "",
                 state: "available",
+                statusVersion: 0,
             }),
         ]);
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -634,6 +634,7 @@ export interface PrebuiltWorkspace {
     buildWorkspaceId: string;
     creationTime: string;
     state: PrebuiltWorkspaceState;
+    stateVersion: number;
     error?: string;
     snapshot?: string;
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -634,7 +634,7 @@ export interface PrebuiltWorkspace {
     buildWorkspaceId: string;
     creationTime: string;
     state: PrebuiltWorkspaceState;
-    stateVersion: number;
+    statusVersion: number;
     error?: string;
     snapshot?: string;
 }

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -172,6 +172,7 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                 creationTime: new Date().toISOString(),
                 projectId: ws.projectId,
                 branch,
+                statusVersion: 0,
             });
 
             log.debug(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* https://github.com/gitpod-io/gitpod/issues/8596
* https://github.com/gitpod-io/gitpod/issues/9107

## How to test
<!-- Provide steps to test this PR -->
1. Preview works
2. New prebuilds can start
3. Column statusVersion appears in the DB

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
/uncc