### PR TITLE
[ws-manager-bridge] Add spans for prebuild state and error

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -99,6 +99,9 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
                     return;
                 }
 
+                span.setTag("updatePrebuildWorkspace.prebuild.state", prebuild.state)
+                span.setTag("updatePrebuildWorkspace.prebuild.error", prebuild.error)
+
                 if (writeToDB) {
                     await this.workspaceDB.trace({span}).storePrebuiltWorkspace(prebuild);
                 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Enrich traces with currently derived prebuild state and error

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
1. Start a prebuild
2. Traces have state

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
