### PR TITLE
[gitpod-db] Don't consider garbage-collected prebuilds as potential bases for incremental prebuilds

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -754,6 +754,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         query = query.orderBy("pws.creationTime", "DESC");
         query = query.innerJoinAndMapOne("pws.workspace", DBWorkspace, "ws", "pws.buildWorkspaceId = ws.id");
         query = query.andWhere("ws.deleted = false");
+        query = query.andWhere("ws.contentDeletedTime = ''");
 
         const res = await query.getMany();
         return res.map((r) => {

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -106,6 +106,8 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
             // Walk back the last prebuilds and check if they are valid ancestor.
             let ws;
             if (context.commitHistory && context.commitHistory.length > 0) {
+                // Note: This query returns only not-garbage-collected prebuilds in order to reduce cardinality
+                // (e.g., at the time of writing, the Gitpod repository has 16K+ prebuilds, but only ~300 not-garbage-collected)
                 const recentPrebuilds = await this.db
                     .trace({ span })
                     .findPrebuildsWithWorkpace(commitContext.repository.cloneUrl);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Don't consider garbage-collected prebuilds as potential bases for incremental prebuilds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes high cardinality on frequently-run SQL queries.

For example, for the [Gitpod](https://github.com/gitpod-io/gitpod) repository,
- The current query returns 16K+ entries
- The fixed query returns 335 entries

For the official [GitLab](https://gitlab.com/gitlab-org/gitlab) repository,
- The current query returns 81K+ entries
- The fixed query returns 6 entries (😳)

## How to test
<!-- Provide steps to test this PR -->

1. Run the query in a copy of the production database (e.g. eu-failover) for a few highly-active repositories

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gitpod-db] Don't consider garbage-collected prebuilds as potential bases for incremental prebuilds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
