### PR TITLE
[server] Throw an error when trying to fetch a file from GitHub using an unknown revision

### DIFF
--- a/components/server/src/github/file-provider.ts
+++ b/components/server/src/github/file-provider.ts
@@ -52,7 +52,7 @@ export class GithubFileProvider implements FileProvider {
 
     public async getFileContent(commit: Commit, user: User, path: string) {
         if (!commit.revision) {
-            return undefined;
+            throw new Error(`Cannot fetch file content of ${path} (unknown revision: ${commit.revision})`);
         }
 
         try {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When we fetch the file content of a GitHub repository's `.gitpod.yml` file, but we don't know which `revision` (i.e. commit hash) to fetch, we currently act like there is no `.gitpod.yml` in the repo and continue without throwing any error:

https://github.com/gitpod-io/gitpod/blob/2f0b9462b0451f0974434fa36bd757420ef04e34/components/server/src/github/file-provider.ts#L53-L56

I believe this might potentially lead to us accidentally consider there is no `.gitpod.yml` in a repo, and overwrite it with something else when starting a workspace, even if there was actually a `.gitpod.yml`: https://github.com/gitpod-io/gitpod/issues/8445

Thus, I believe it might be better to throw an error when trying to fetch a GitHub file for an unknown revision.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Proof-of-concept related to https://github.com/gitpod-io/gitpod/issues/8445

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Throw an error when trying to fetch a file from GitHub using an unknown revision
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Anything else?

I believe `commit.revision` might accidentally be set to `undefined` or `""` (or `null` / other "falsy" value) in one of these places in the GitHub context parser:


https://github.com/gitpod-io/gitpod/blob/f6feb961ed1f4b5987ca0af71bc7929b33e73d26/components/server/src/github/github-context-parser.ts#L156

https://github.com/gitpod-io/gitpod/blob/f6feb961ed1f4b5987ca0af71bc7929b33e73d26/components/server/src/github/github-context-parser.ts#L235

https://github.com/gitpod-io/gitpod/blob/f6feb961ed1f4b5987ca0af71bc7929b33e73d26/components/server/src/github/github-context-parser.ts#L240

https://github.com/gitpod-io/gitpod/blob/f6feb961ed1f4b5987ca0af71bc7929b33e73d26/components/server/src/github/github-context-parser.ts#L421

https://github.com/gitpod-io/gitpod/blob/f6feb961ed1f4b5987ca0af71bc7929b33e73d26/components/server/src/github/github-context-parser.ts#L505

(For example, if there are edge cases we didn't foresee, or if the GitHub API misbehaves, or if they slightly change their response format...)