### PR TITLE
[ws-manager-bridge] Fix counting of stale prebuild events

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -59,7 +59,10 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
             span.setTag("updatePrebuiltWorkspace.workspaceInstance.statusVersion", status.statusVersion);
 
             if (prebuild.statusVersion <= status.statusVersion) {
-                this.prometheusExporter.recordStalePrebuildEvent()
+                // prebuild.statusVersion = 0 is the default value in the DB, these shouldn't be counted as stale in our metrics
+                if (prebuild.statusVersion > 0) {
+                    this.prometheusExporter.recordStalePrebuildEvent();
+                }
             }
             prebuild.statusVersion = status.statusVersion
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We'd count records with statusVersion = 0 stale, but this is the default value set in the DB. We want to exclude these from metrics to get an accurate count of what is actually stale.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
1. Start prebuild
2. No metric initially reported

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
