### PR TITLE
Install pre-commit hooks during prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -44,7 +44,7 @@ tasks:
     before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build
   - name: Go
-    before: pre-commit install
+    before: pre-commit install --install-hooks
     init: leeway exec --filter-type go -v -- go mod verify
     openMode: split-right
 vscode:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Speed-up first commit in a workspace by pre-installing hooks. Without this, they are first installed when a commit is issued (and corresponding git hook triggered).

Relevant docs: https://pre-commit.com/#pre-commit-install-hooks

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Create a branch based on this
2. Modify a file
3. Commit the file, should not block on installing the hooks

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
