### PR TITLE
[bitbucket-server] add to Git Integrations UI

### DIFF
--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -11,6 +11,7 @@ import AlertBox from "../components/AlertBox";
 import CheckBox from "../components/CheckBox";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { ContextMenuEntry } from "../components/ContextMenu";
+import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon, ItemsList } from "../components/ItemsList";
 import Modal from "../components/Modal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
@@ -443,7 +444,7 @@ function GitIntegrations() {
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
                     <h3>Git Integrations</h3>
-                    <h2>Manage Git integrations for GitLab or GitHub self-hosted instances.</h2>
+                    <h2>Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.</h2>
                 </div>
                 {providers.length !== 0 ? (
                     <div className="mt-3 flex mt-0">
@@ -710,6 +711,8 @@ export function GitIntegrationModal(
                 return "github.example.com";
             case "GitLab":
                 return "gitlab.example.com";
+            case "BitbucketServer":
+                return "bitbucket.example.com";
             default:
                 return "";
         }
@@ -737,7 +740,7 @@ export function GitIntegrationModal(
                 <div className="flex flex-col">
                     <span className="text-gray-500">
                         {props.headerText ||
-                            "Configure a Git integration with a GitLab or GitHub self-hosted instance."}
+                            "Configure an integration with a self-managed instance of GitLab, GitHub, or Bitbucket."}
                     </span>
                 </div>
 
@@ -756,8 +759,22 @@ export function GitIntegrationModal(
                             >
                                 <option value="GitHub">GitHub</option>
                                 <option value="GitLab">GitLab</option>
+                                <option value="BitbucketServer">Bitbucket Server</option>
                             </select>
                         </div>
+                    )}
+                    {mode === "new" && type === "BitbucketServer" && (
+                        <InfoBox className="my-4 mx-auto">
+                            OAuth 2.0 support in Bitbucket Server was added in version 7.20.{" "}
+                            <a
+                                target="_blank"
+                                href="https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-and-server-7-20-release-notes-1101934428.html"
+                                rel="noopener noreferrer"
+                                className="gp-link"
+                            >
+                                Learn more
+                            </a>
+                        </InfoBox>
                     )}
                     <div className="flex flex-col space-y-2">
                         <label htmlFor="hostName" className="font-medium">

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -12,6 +12,7 @@ import { Config } from "../config";
 import { v4 as uuidv4 } from "uuid";
 import { oauthUrls as githubUrls } from "../github/github-urls";
 import { oauthUrls as gitlabUrls } from "../gitlab/gitlab-urls";
+import { oauthUrls as bbsUrls } from "../bitbucket-server/bitbucket-server-urls";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
@@ -110,7 +111,18 @@ export class AuthProviderService {
     }
     protected initializeNewProvider(newEntry: AuthProviderEntry.NewEntry): AuthProviderEntry {
         const { host, type, clientId, clientSecret } = newEntry;
-        const urls = type === "GitHub" ? githubUrls(host) : type === "GitLab" ? gitlabUrls(host) : undefined;
+        let urls;
+        switch (type) {
+            case "GitHub":
+                urls = githubUrls(host);
+                break;
+            case "GitLab":
+                urls = gitlabUrls(host);
+                break;
+            case "BitbucketServer":
+                urls = bbsUrls(host);
+                break;
+        }
         if (!urls) {
             throw new Error("Unexpected service type.");
         }

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -221,7 +221,10 @@ export class Authenticator {
 
         // prepare session
         await AuthFlow.attach(req.session, { host, returnTo, overrideScopes: override });
-        let wantedScopes = scopes.split(",");
+        let wantedScopes = scopes
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
         if (wantedScopes.length === 0) {
             if (authProvider.info.requirements) {
                 wantedScopes = authProvider.info.requirements.default;

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -39,7 +39,7 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
             ...oauth,
             authorizationUrl: oauth.authorizationUrl || `https://${this.params.host}/rest/oauth2/latest/authorize`,
             tokenUrl: oauth.tokenUrl || `https://${this.params.host}/rest/oauth2/latest/token`,
-            settingsUrl: oauth.settingsUrl || `https://${this.params.host}/plugins/servlet/oauth/users/access-tokens/`,
+            settingsUrl: oauth.settingsUrl,
             scope: BitbucketServerOAuthScopes.ALL.join(scopeSeparator),
             scopeSeparator,
         };
@@ -75,14 +75,4 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
             throw error;
         }
     };
-
-    protected normalizeScopes(scopes: string[]) {
-        const set = new Set(scopes);
-        for (const item of set.values()) {
-            if (!BitbucketServerOAuthScopes.Requirements.DEFAULT.includes(item)) {
-                set.delete(item);
-            }
-        }
-        return Array.from(set).sort();
-    }
 }

--- a/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
@@ -10,14 +10,14 @@ export namespace BitbucketServerOAuthScopes {
     /** View projects and repositories that are publicly accessible, including pulling code and cloning repositories. */
     export const PUBLIC_REPOS = "PUBLIC_REPOS";
     /** View projects and repositories the user account can view, including pulling code, cloning, and forking repositories. Create and comment on pull requests. */
-    export const REPOSITORY_READ = "REPO_READ";
+    export const REPO_READ = "REPO_READ";
     /** Push over https, fork repo */
-    export const REPOSITORY_WRITE = "REPO_WRITE";
+    export const REPO_WRITE = "REPO_WRITE";
 
     export const REPO_ADMIN = "REPO_ADMIN";
     export const PROJECT_ADMIN = "PROJECT_ADMIN";
 
-    export const ALL = [PUBLIC_REPOS, REPOSITORY_READ, REPOSITORY_WRITE, REPO_ADMIN, PROJECT_ADMIN];
+    export const ALL = [PUBLIC_REPOS, REPO_READ, REPO_WRITE, REPO_ADMIN, PROJECT_ADMIN];
 
     export const Requirements = {
         /**

--- a/components/server/src/bitbucket-server/bitbucket-server-urls.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-urls.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+// cf. https://confluence.atlassian.com/bitbucketserver/bitbucket-oauth-2-0-provider-api-1108483661.html
+//
+export function oauthUrls(host: string) {
+    return {
+        authorizationUrl: `https://${host}/rest/oauth2/latest/authorize`,
+        tokenUrl: `https://${host}/rest/oauth2/latest/token`,
+        settingsUrl: ``,
+    };
+}


### PR DESCRIPTION
This PR adds the option to setup an integration for a self-managed Bitbucket Server in user's account.

A notice on the limited compatibility is included in the Git Integrations modal. 

<img width="560" alt="Screen Shot 2022-04-11 at 10 45 43" src="https://user-images.githubusercontent.com/914497/162699687-630734f8-6eb0-4d4f-9b3d-f39df7b5368f.png">


```release-note
Connect to self-managed Bitbucket Server in Git Integration modal.
```