### PR TITLE
Revert "[ws-manager-bridge] Skip stale prebuild events"

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -65,11 +65,7 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
             if (prebuild.statusVersion <= status.statusVersion) {
                 // prebuild.statusVersion = 0 is the default value in the DB, these shouldn't be counted as stale in our metrics
                 if (prebuild.statusVersion > 0) {
-                    // We've gotten an event which is younger than one we've already processed. We shouldn't process the stale one.
-                    span.setTag("updatePrebuiltWorkspace.staleEvent", true);
                     this.prometheusExporter.recordStalePrebuildEvent();
-                    log.info(logCtx, "Stale prebuild event received, skipping.");
-                    return;
                 }
             }
             prebuild.statusVersion = status.statusVersion;


### PR DESCRIPTION
This reverts commit eb72c2f54f01f81e504ffecbc805d5cb795821ec.

## Description
<!-- Describe your changes in detail -->
Causes prebuildUpdates to not be correctly propagated to clients

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
