### PR TITLE
[supervisor] remove supervisor_readiness for headless workspaces

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -231,7 +231,9 @@ func Run(options ...RunOption) {
 	if cfg.DesktopIDE != nil {
 		desktopIdeReady = &ideReadyState{cond: sync.NewCond(&sync.Mutex{})}
 	}
-	go trackReadiness(ctx, gitpodService, cfg, cstate, ideReady, desktopIdeReady)
+	if !cfg.isHeadless() {
+		go trackReadiness(ctx, gitpodService, cfg, cstate, ideReady, desktopIdeReady)
+	}
 	tokenService.provider[KindGit] = []tokenProvider{NewGitTokenProvider(gitpodService, cfg.WorkspaceConfig, notificationService)}
 
 	go gitpodConfigService.Watch(ctx)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove `supervisor_readiness` tracking for headless workspaces

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9043

## How to test
<!-- Provide steps to test this PR -->
* Create a project to make a prebuild
* Check if [segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) have no log about `supervisor_readiness`

------

* Create a workspace
* Check if it sends `content` `ide` `ide-desktop` (check your Preference) tracking to [segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe

