### PR TITLE
Fix werft job wipe-devstaging

### DIFF
--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -38,10 +38,11 @@ pod:
 
       werft log phase prepare
       gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
-      gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev
 
       export NAMESPACE="{{ .Annotations.namespace }}"
       sudo chown -R gitpod:gitpod /workspace
+
+      KUBECONFIG=/workspace/gitpod/kubeconfigs/core-dev gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev
 
       cd .werft
       yarn install


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix werft job wipe-devstaging

From this PR https://github.com/gitpod-io/gitpod/pull/9016, We put kubeconfig for different clusters in different locations to avoid confusing them, but left out changing wipe-devstaging, which makes sweeper not work properly

for core-dev, the kubeconfig should be store in `/workspace/gitpod/kubeconfigs/core-dev` see https://github.com/gitpod-io/gitpod/pull/9016/files#diff-4203e5cbe14202020be028daecba59bca4c1693ce65d610a44d15f4fab68cacaR2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
open a workspace
run `werft run github -a namespace={YOUR_NAMESPACE} --remote-job-path .werft/wipe-devstaging.yaml github.com/gitpod-io/gitpod:pd/wipe-dev`
and check the werft result, the namespace of {YOUR_NAMESPACE} will be wipe

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
