### PR TITLE
[licensor] fix fallback for `defaultlicense`

### DIFF
--- a/components/licensor/ee/pkg/licensor/gitpod.go
+++ b/components/licensor/ee/pkg/licensor/gitpod.go
@@ -19,7 +19,8 @@ func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 	if len(key) == 0 {
 		// fallback to the default license
 		return &Evaluator{
-			lic: defaultLicense,
+			lic:           defaultLicense,
+			allowFallback: true,
 		}
 	}
 

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -238,7 +238,7 @@ func TestFeatures(t *testing.T) {
 			FeaturePrebuild,
 		}, LicenseTypeGitpod, seats, nil},
 
-		{"Gitpod (over seats): no license", true, LicenseLevel(0), []Feature{}, LicenseTypeGitpod, 11, nil},
+		{"Gitpod (over seats): no license", true, LicenseLevel(0), []Feature{FeatureAdminDashboard}, LicenseTypeGitpod, 11, nil},
 		{"Gitpod (over seats): invalid license level", false, LicenseLevel(666), []Feature{}, LicenseTypeGitpod, seats + 1, nil},
 		{"Gitpod (over seats): enterprise license", false, LevelEnterprise, []Feature{}, LicenseTypeGitpod, seats + 1, nil},
 

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -81,7 +81,8 @@ func (e *ReplicatedEvaluator) Validate() (msg string, valid bool) {
 // defaultReplicatedLicense this is the default license if call fails
 func defaultReplicatedLicense() *Evaluator {
 	return &Evaluator{
-		lic: defaultLicense,
+		lic:           defaultLicense,
+		allowFallback: true,
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes the bug that stops the fallback (usage with limited features when number of users exceed 10) when no licence is installed, or in the case of replicated when licence domain does not match with the one issued (community licence). 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NA

## How to test
<!-- Provide steps to test this PR -->
Currently, if one setup Gitpod via the `installer` or `replicated` using the community licence, if you increase the number of users before 10, admin dashboard will fail to be available. With this fix, once can try setting up replicated and admin dashboard will continue to be accessible after 10 users, whereas features like prebuild, snapshot etc. will not be available.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
