### PR TITLE
[observability] Add alert when workspaces don't start

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -73,6 +73,23 @@
               gitpod_workspace_regular_not_active_percentage > 0.15 AND sum(gitpod_ws_manager_workspace_activity_total) > 100
             |||,
           },
+          {
+            alert: 'GitpodWorkspacesNotStarting',
+            labels: {
+              severity: 'critical',
+            },
+            'for': '10m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNotStarting.md',
+              summary: 'workspaces are not starting',
+              description: 'inactive regular workspaces exists but workspaces are not being started',
+            },
+            expr: |||
+              avg_over_time(gitpod_workspace_regular_not_active_percentage[1m]) > 0
+              AND
+              rate(gitpod_ws_manager_workspace_startup_seconds_sum{type="REGULAR"}[1m]) == 0
+            |||,
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

For the given formula the alerts can fire very often for xl clusters. To disable it I have created a custom pagerduty eventrule to suppress alerts being fired from the xl clusters. Refer to this [internal thread](https://gitpod.slack.com/archives/C0201TXMV54/p1650443926088999)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8448

## How to test
<!-- Provide steps to test this PR -->
The alert generation itself does not need to be tested as this is a standard addition to alerts. However , you can review this as part of review:

### If alerts are suppressed for xl clusters
**NOTE**: Please make sure you inform the oncall about your tests, or override yourself to be the oncall before running the test

* Start a workspace and fetch kubeconfig of a cluster from which you want to generate the alert.
* port forward alertmanager service in the terminal 

```
kubectl port-forward svc/alertmanager-main 9093:9093
```

* From a different terminal run these one by one and check pager duty.


1. Create an alert with right name but cluster is not xl -> You should see an incident in pagerduty

```console
curl -d '[{"labels": {"Alertname": "GitpodWorkspacesNotStarting", "severity": "critical", "cluster": "us41", "container": "ws-daemon", "instance": "10.20.169.66:8443"}}]' http://localhost:9093/api/v1/alerts
```

2. Create an alert with right name and cluster set to xl -> You should NOT see an incident in pagerduty

```console
curl -d '[{"labels": {"Alertname": "GitpodWorkspacesNotStarting", "severity": "critical", "cluster": "us41xl", "container": "ws-daemon", "instance": "10.20.169.66:8443"}}]' http://localhost:9093/api/v1/alerts
```

3. Create an alert with wrong name but cluster is xl -> You should see an incident in pagerduty

```console
curl -d '[{"labels": {"Alertname": "G1itpodWorkspacesNotStarting", "severity": "critical", "cluster": "us41xl", "container": "ws-daemon", "instance": "10.20.169.66:8443"}}]' http://localhost:9093/api/v1/alerts
```


### Additional References
You can use this formula to plot graph (you would need to set cluster variable in dashboard settings, refer to the success criteria dashboard for the formula)

```
count(avg_over_time(gitpod_workspace_regular_not_active_percentage{cluster=~"$cluster"}[10m])) * count(rate(gitpod_ws_manager_workspace_startup_seconds_sum{type="REGULAR",cluster=~"$cluster"}[10m]) == 0)
```

<details>
    <summary>You can alternatively just import this dashboard in Grafana.</summary>
https://gist.github.com/princerachit/c28960e5afb4a316e0cfc35d3d674987
</details>

#### Past Data
Here is a list of various cluster screenshots. Each point in the cluster indicates that this alert would have been fired

<details>
    <summary>us38</summary>
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/32481722/165066417-ca6df9ea-c986-4f2f-bd26-0af5ca90ab3f.png">
</details>


<details>
    <summary>eu38</summary>

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/32481722/165066548-bd85ee54-d539-486f-b47e-c0e3bb56ed5c.png">
</details>


<details>
    <summary>us40</summary>
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/32481722/165066696-36d0a87f-313e-416f-88f9-f38c5fd48b4a.png">
</details>

<details>
    <summary>eu40</summary>
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/32481722/165066770-b4d501c2-b022-4bc0-b367-e38524f30fbe.png">
</details>

<details>
    <summary>us39</summary>

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/32481722/165066868-ec7b1b6b-84fb-4f53-b6bb-05f28d78e487.png">
</details>

<details>
    <summary>eu39</summary>

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/32481722/165066996-ae165064-affb-4650-9399-5d4c3b3e5ac7.png">
</details>

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
