### PR TITLE
[ws-manager-bridge] Skip stale prebuild events

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -68,7 +68,11 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
             if (prebuild.statusVersion <= status.statusVersion) {
                 // prebuild.statusVersion = 0 is the default value in the DB, these shouldn't be counted as stale in our metrics
                 if (prebuild.statusVersion > 0) {
+                    // We've gotten an event which is younger than one we've already processed. We shouldn't process the stale one.
+                    span.setTag("updatePrebuiltWorkspace.staleEvent", true);
                     this.prometheusExporter.recordStalePrebuildEvent();
+                    log.info(logCtx, "Stale prebuild event received, skipping.");
+                    return;
                 }
             }
             prebuild.statusVersion = status.statusVersion;


### PR DESCRIPTION
This reverts commit 67ad495fd40a16e78de0d5ed6460b29eb633fb86.

* Originally added in https://github.com/gitpod-io/gitpod/pull/9116
* Then reverted in https://github.com/gitpod-io/gitpod/pull/9153 because of issues caused by deserializiation of BIGINT types
* Deserialization issues fixed in https://github.com/gitpod-io/gitpod/pull/9152
* We can now re-add the change.

## Description
<!-- Describe your changes in detail -->

[Metrics](https://grafana.gitpod-staging.com/explore?orgId=1&left=%7B%22datasource%22:%22VictoriaMetrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:false,%22expr%22:%22sum(increase(gitpod_ws_manager_bridge_stale_prebuild_events_total))%22%7D%5D,%22range%22:%7B%22from%22:%221649397517026%22,%22to%22:%221649405079713%22%7D%7D) show that we receive stale prebuild events when handling WorkspaceStatus updates on `ws-manager-bridge`. This change skips events which are stale.


<img width="3276" alt="Screenshot 2022-04-08 at 10 05 03" src="https://user-images.githubusercontent.com/1419286/162392973-d2322867-5c5e-48e6-9fc1-38cf8823e1b0.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9107 

## How to test
<!-- Provide steps to test this PR -->
Requires a degree of luck, as it depends on event ordering on the message bus, but:

Start a prebuild
port-forward ws-manager-bridge on port 9500 and fetch metrics with curl localhost:9500/metrics
Check metrics contain gitpod_ws_manager_bridge_stale_prebuild_events_total with a positive count
Check ws-manager-bridge logs contain Stale prebuild event received, skipping.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager-bridge] Skip stale prebuild events.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE