### PR TITLE
[jb-gw]: disable new workspace button when url is blank

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
@@ -15,6 +15,7 @@ import com.intellij.ui.dsl.builder.TopGap
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.layout.ComponentPredicate
+import com.intellij.ui.layout.enteredTextSatisfies
 import com.intellij.util.EventDispatcher
 import com.jetbrains.rd.util.concurrentMapOf
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -72,20 +73,14 @@ class GitpodStartWorkspaceView(
                     this.text = "https://github.com/gitpod-io/spring-petclinic"
                 }
             button("New Workspace") {
-                // TODO(ak) disable button if blank
                 if (contextUrl.component.text.isNotBlank()) {
-                    val backend = backendsModel.selectedItem
-                    val selectedBackendId = if (backend != null) {
-                        backendToId[backend]
-                    } else null
-                    val backendParam = if (selectedBackendId != null) {
-                        ":$selectedBackendId"
-                    } else {
-                        ""
+                    backendsModel.selectedItem?.let {
+                        backendToId[it]?.let { backend ->
+                            BrowserUtil.browse("https://${settings.gitpodHost}#referrer:jetbrains-gateway:${backend}/${contextUrl.component.text}")
+                        }
                     }
-                    BrowserUtil.browse("https://${settings.gitpodHost}#referrer:jetbrains-gateway$backendParam/${contextUrl.component.text}")
                 }
-            }
+            }.enabledIf(contextUrl.component.enteredTextSatisfies { it.isNotBlank() })
             cell()
         }.topGap(TopGap.NONE)
             .rowComment(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Disable new workspace button if url is blank
- Use safe calls (`?.let`) for null checks

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Clean up TODOs inside codebase

## How to test
<!-- Provide steps to test this PR -->

Build & Install the plugin following
https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/README.md#L8


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The "New Workspace" button gets disabled if the repository URL is blank, on JetBrains Gateway.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
