### PR TITLE
[analytics] Fix default notification settings in analytics call

### DIFF
--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -61,9 +61,9 @@ function fullIdentify(user: User, request: Request, analytics: IAnalyticsWriter)
             email: User.getPrimaryEmail(user),
             full_name: user.fullName,
             created_at: user.creationDate,
-            unsubscribed_onboarding: !user.additionalData?.emailNotificationSettings?.allowsOnboardingMail,
-            unsubscribed_changelog: !user.additionalData?.emailNotificationSettings?.allowsChangelogMail,
-            unsubscribed_devx: !user.additionalData?.emailNotificationSettings?.allowsDevXMail,
+            unsubscribed_onboarding: user.additionalData?.emailNotificationSettings?.allowsOnboardingMail === false,
+            unsubscribed_changelog: user.additionalData?.emailNotificationSettings?.allowsChangelogMail === false,
+            unsubscribed_devx: user.additionalData?.emailNotificationSettings?.allowsDevXMail === false,
         },
     });
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix default notification settings in the `fullIdentify` analytics tracking call.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes default notification settings

## How to test
<!-- Provide steps to test this PR -->

1. Sign up
2. Verify that Segment receives the correct default values for notification settings
3. Simulate an older user account by logging into the DB, and removing `emailNotificationSettings` from your user's `additionalData`
4. Log out and back in
5. Verify that Segment still receives the correct default values

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe