### PR TITLE
workspacekit: Remove slirp4netns codes where it affects the supervisor.

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -310,14 +310,6 @@ var ring1Cmd = &cobra.Command{
 			)
 		}
 
-		f, err := ioutil.TempDir("", "wskit-slirp4netns")
-		if err != nil {
-			log.WithError(err).Error("cannot create slirp4netns socket tempdir")
-			return
-		}
-
-		mnts = append(mnts, mnte{Target: "/.supervisor/slirp4netns.sock", Source: f, Flags: unix.MS_BIND | unix.MS_REC})
-
 		for _, m := range mnts {
 			dst := filepath.Join(ring2Root, m.Target)
 			_ = os.MkdirAll(dst, 0644)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR is a follow-up PR to #9213
no4 of https://github.com/gitpod-io/gitpod/issues/8106#issuecomment-1094418016

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/8106

## How to test
<!-- Provide steps to test this PR -->

on gitpod
https://to-veths-again4.staging.gitpod-dev.com/workspaces
```console
$ docker run hello-world
$ python -m http.server 5000 # and ensure to be able to access 5000 port from outward
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
workspacekit: Remove slirp4netns codes where it affects the supervisor.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No