### PR TITLE
[installer] open-vsx: configure redis

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -99,8 +99,55 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Env: common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
 						),
-					}},
+					}, {
+						Name:  "redis",
+						Image: "redis:6.2",
+						Command: []string{
+							"redis-server",
+							"/config/redis.conf",
+						},
+						Env: []v1.EnvVar{{
+							Name:  "MASTER",
+							Value: "true",
+						}},
+						ImagePullPolicy: "IfNotPresent",
+						Ports: []v1.ContainerPort{{
+							ContainerPort: 6379,
+						}},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"cpu":    resource.MustParse("1m"),
+								"memory": resource.MustParse("512Mi"),
+							},
+						},
+						VolumeMounts: []v1.VolumeMount{{
+							Name:      "config",
+							MountPath: "/config",
+						}, {
+							Name:      "redis-data",
+							MountPath: "/data",
+						}},
+					},
+					},
 				},
+			},
+			VolumeClaimTemplates: []v1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      Component,
+					Namespace: ctx.Namespace,
+					Labels:    labels,
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"storage": resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
 			},
 		},
 	}}, nil


### PR DESCRIPTION
## Description
This adds redis backend for open-vsx and brings it in line with the prod config.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
openvsx/installer: configure redis
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
