### PR TITLE
Stop running prebuilds for inactive projects (10+ weeks)

### DIFF
--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -4,7 +4,7 @@
  * See License.enterprise.txt in the project root folder.
  */
 
-import { PartialProject, Project, ProjectEnvVar, ProjectEnvVarWithValue } from "@gitpod/gitpod-protocol";
+import { PartialProject, Project, ProjectEnvVar, ProjectEnvVarWithValue, ProjectUsage } from "@gitpod/gitpod-protocol";
 
 export const ProjectDB = Symbol("ProjectDB");
 export interface ProjectDB {
@@ -30,4 +30,6 @@ export interface ProjectDB {
     getProjectEnvironmentVariableValues(envVars: ProjectEnvVar[]): Promise<ProjectEnvVarWithValue[]>;
     findCachedProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
     storeCachedProjectOverview(projectId: string, overview: Project.Overview): Promise<void>;
+    getProjectUsage(projectId: string): Promise<ProjectUsage | undefined>;
+    updateProjectUsage(projectId: string, usage: Partial<ProjectUsage>): Promise<void>;
 }

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -256,6 +256,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             deletionColumn: "deleted",
             timeColumn: "_lastModified",
         },
+        {
+            name: "d_b_project_usage",
+            primaryKeys: ["projectId"],
+            deletionColumn: "deleted",
+            timeColumn: "_lastModified",
+        },
         /**
          * BEWARE
          *

--- a/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
+++ b/components/gitpod-db/src/typeorm/deleted-entry-gc.ts
@@ -61,6 +61,7 @@ const tables: TableWithDeletion[] = [
     { deletionColumn: "deleted", name: "d_b_oss_allow_list" },
     { deletionColumn: "deleted", name: "d_b_project_env_var" },
     { deletionColumn: "deleted", name: "d_b_project_info" },
+    { deletionColumn: "deleted", name: "d_b_project_usage" },
 ];
 
 interface TableWithDeletion {

--- a/components/gitpod-db/src/typeorm/entity/db-project-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project-usage.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { Entity, Column, PrimaryColumn } from "typeorm";
+
+import { TypeORM } from "../../typeorm/typeorm";
+
+@Entity()
+// on DB but not Typeorm: @Index("ind_dbsync", ["_lastModified"])   // DBSync
+export class DBProjectUsage {
+    @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+    projectId: string;
+
+    @Column("varchar")
+    lastWebhookReceived: string;
+
+    @Column("varchar")
+    lastWorkspaceStart: string;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
+}

--- a/components/gitpod-db/src/typeorm/migration/1649667202321-ProjectUsage.ts
+++ b/components/gitpod-db/src/typeorm/migration/1649667202321-ProjectUsage.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ProjectUsage1649667202321 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TABLE IF NOT EXISTS `d_b_project_usage` (`projectId` char(36) NOT NULL, `lastWebhookReceived` varchar(255) NOT NULL DEFAULT '', `lastWorkspaceStart` varchar(255) NOT NULL DEFAULT '', `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`projectId`), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -69,6 +69,11 @@ export namespace Project {
 
 export type PartialProject = DeepPartial<Project> & Pick<Project, "id">;
 
+export interface ProjectUsage {
+    lastWebhookReceived: string;
+    lastWorkspaceStart: string;
+}
+
 export interface PrebuildWithStatus {
     info: PrebuildInfo;
     status: PrebuiltWorkspaceState;

--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -240,8 +240,14 @@ export class GithubApp {
             const installationId = ctx.payload.installation?.id;
             const cloneURL = ctx.payload.repository.clone_url;
             let { user, project } = await this.findOwnerAndProject(installationId, cloneURL);
-            const logCtx: LogContext = { userId: user.id };
+            if (project) {
+                /* tslint:disable-next-line */
+                /** no await */ this.projectDB.updateProjectUsage(project.id, {
+                    lastWebhookReceived: new Date().toISOString(),
+                });
+            }
 
+            const logCtx: LogContext = { userId: user.id };
             if (!!user.blocked) {
                 log.info(logCtx, `Blocked user tried to start prebuild`, { repo: ctx.payload.repository });
                 return;
@@ -347,6 +353,12 @@ export class GithubApp {
             const pr = ctx.payload.pull_request;
             const contextURL = pr.html_url;
             let { user, project } = await this.findOwnerAndProject(installationId, cloneURL);
+            if (project) {
+                /* tslint:disable-next-line */
+                /** no await */ this.projectDB.updateProjectUsage(project.id, {
+                    lastWebhookReceived: new Date().toISOString(),
+                });
+            }
 
             const context = (await this.contextParser.handle({ span }, user, contextURL)) as CommitContext;
             const config = await this.prebuildManager.fetchConfig({ span }, user, context);

--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -116,6 +116,15 @@ export class GitHubEnterpriseApp {
     ): Promise<StartPrebuildResult | undefined> {
         const span = TraceContext.startSpan("GitHubEnterpriseApp.handlePushHook", ctx);
         try {
+            const cloneURL = payload.repository.clone_url;
+            const projectAndOwner = await this.findProjectAndOwner(cloneURL, user);
+            if (projectAndOwner.project) {
+                /* tslint:disable-next-line */
+                /** no await */ this.projectDB.updateProjectUsage(projectAndOwner.project.id, {
+                    lastWebhookReceived: new Date().toISOString(),
+                });
+            }
+
             const contextURL = this.createContextUrl(payload);
             span.setTag("contextURL", contextURL);
             const context = (await this.contextParser.handle({ span }, user, contextURL)) as CommitContext;
@@ -127,15 +136,13 @@ export class GitHubEnterpriseApp {
 
             log.debug("GitHub Enterprise push event: Starting prebuild.", { contextURL });
 
-            const cloneURL = payload.repository.clone_url;
-            const projectAndOwner = await this.findProjectAndOwner(cloneURL, user);
             const commitInfo = await this.getCommitInfo(user, payload.repository.url, payload.after);
             const ws = await this.prebuildManager.startPrebuild(
                 { span },
                 {
                     context,
                     user: projectAndOwner.user,
-                    project: projectAndOwner?.project,
+                    project: projectAndOwner.project,
                     commitInfo,
                 },
             );

--- a/components/server/ee/src/prebuilds/gitlab-app.ts
+++ b/components/server/ee/src/prebuilds/gitlab-app.ts
@@ -108,6 +108,13 @@ export class GitLabApp {
             span.setTag("contextURL", contextURL);
             const context = (await this.contextParser.handle({ span }, user, contextURL)) as CommitContext;
             const projectAndOwner = await this.findProjectAndOwner(context.repository.cloneUrl, user);
+            if (projectAndOwner.project) {
+                /* tslint:disable-next-line */
+                /** no await */ this.projectDB.updateProjectUsage(projectAndOwner.project.id, {
+                    lastWebhookReceived: new Date().toISOString(),
+                });
+            }
+
             const config = await this.prebuildManager.fetchConfig({ span }, user, context);
             if (!this.prebuildManager.shouldPrebuild(config)) {
                 log.debug({ userId: user.id }, "GitLab push hook: There is no prebuild config.", {
@@ -123,8 +130,8 @@ export class GitLabApp {
             const ws = await this.prebuildManager.startPrebuild(
                 { span },
                 {
-                    user: projectAndOwner?.user || user,
-                    project: projectAndOwner?.project,
+                    user: projectAndOwner.user || user,
+                    project: projectAndOwner.project,
                     context,
                     commitInfo,
                 },

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -159,31 +159,9 @@ export class PrebuildManager {
                 prebuildContext,
                 context.normalizedContextURL!,
             );
-            const prebuildPromise = this.workspaceDB.trace({ span }).findPrebuildByWorkspaceID(workspace.id)!;
-
-            span.setTag("starting", true);
-            const projectEnvVars = await projectEnvVarsPromise;
-            await this.workspaceStarter.startWorkspace({ span }, workspace, user, [], projectEnvVars, {
-                excludeFeatureFlags: ["full_workspace_backup"],
-            });
-            const prebuild = await prebuildPromise;
+            const prebuild = await this.workspaceDB.trace({ span }).findPrebuildByWorkspaceID(workspace.id)!;
             if (!prebuild) {
                 throw new Error(`Failed to create a prebuild for: ${context.normalizedContextURL}`);
-            }
-
-            if (await this.shouldRateLimitPrebuild(span, cloneURL)) {
-                prebuild.state = "aborted";
-                prebuild.error =
-                    "Prebuild is rate limited. Please contact Gitpod if you believe this happened in error.";
-
-                await this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild);
-                span.setTag("starting", false);
-                span.setTag("ratelimited", true);
-                return {
-                    wsid: workspace.id,
-                    prebuildId: prebuild.id,
-                    done: false,
-                };
             }
 
             if (project) {
@@ -205,6 +183,26 @@ export class PrebuildManager {
                 }
                 await this.storePrebuildInfo({ span }, project, prebuild, workspace, user, aCommitInfo);
             }
+
+            if (await this.shouldRateLimitPrebuild(span, cloneURL)) {
+                prebuild.state = "aborted";
+                prebuild.error =
+                    "Prebuild is rate limited. Please contact Gitpod if you believe this happened in error.";
+                await this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild);
+                span.setTag("ratelimited", true);
+            } else if (project && (await this.shouldSkipInactiveProject(project))) {
+                prebuild.state = "aborted";
+                prebuild.error =
+                    "Project is inactive. Please start a new workspace for this project to re-enable prebuilds.";
+                await this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild);
+            } else {
+                span.setTag("starting", true);
+                const projectEnvVars = await projectEnvVarsPromise;
+                await this.workspaceStarter.startWorkspace({ span }, workspace, user, [], projectEnvVars, {
+                    excludeFeatureFlags: ["full_workspace_backup"],
+                });
+            }
+
             return { prebuildId: prebuild.id, wsid: workspace.id, done: false };
         } catch (err) {
             TraceContext.setError({ span }, err);
@@ -346,5 +344,16 @@ export class PrebuildManager {
 
         // Last resort default
         return PREBUILD_LIMITER_DEFAULT_LIMIT;
+    }
+
+    private async shouldSkipInactiveProject(project: Project): Promise<boolean> {
+        const usage = await this.projectService.getProjectUsage(project.id);
+        if (!usage?.lastWorkspaceStart) {
+            return false;
+        }
+        const now = Date.now();
+        const lastUse = new Date(usage.lastWorkspaceStart).getTime();
+        const inactiveProjectTime = 1000 * 60 * 60 * 24 * 7 * 10; // 10 weeks
+        return now - lastUse > inactiveProjectTime;
     }
 }

--- a/components/server/src/gitlab/api.ts
+++ b/components/server/src/gitlab/api.ts
@@ -75,7 +75,7 @@ export class GitLabApi {
             log.error(`GitLab request error`, error);
             throw error;
         } finally {
-            log.info(`GitLab request took ${new Date().getTime() - before} ms`);
+            log.debug(`GitLab request took ${new Date().getTime() - before} ms`);
         }
     }
 

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -19,7 +19,7 @@ import {
 import { HostContextProvider } from "../auth/host-context-provider";
 import { RepoURL } from "../repohost";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { PartialProject } from "@gitpod/gitpod-protocol/src/teams-projects-protocol";
+import { PartialProject, ProjectUsage } from "@gitpod/gitpod-protocol/src/teams-projects-protocol";
 
 @injectable()
 export class ProjectsService {
@@ -247,5 +247,9 @@ export class ProjectsService {
 
     async deleteProjectEnvironmentVariable(variableId: string): Promise<void> {
         return this.projectDB.deleteProjectEnvironmentVariable(variableId);
+    }
+
+    async getProjectUsage(projectId: string): Promise<ProjectUsage | undefined> {
+        return this.projectDB.getProjectUsage(projectId);
     }
 }

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -580,7 +580,7 @@ export class UserController {
         await this.userService.updateUserEnvVarsOnLogin(user, envVars);
         await this.userService.acceptCurrentTerms(user);
 
-        /* no await */ trackSignup(user, req, this.analytics).catch((err) =>
+        /** no await */ trackSignup(user, req, this.analytics).catch((err) =>
             log.warn({ userId: user.id }, "trackSignup", err),
         );
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -206,6 +206,13 @@ export class WorkspaceStarter {
         const span = TraceContext.startSpan("WorkspaceStarter.startWorkspace", ctx);
         span.setTag("workspaceId", workspace.id);
 
+        if (workspace.projectId && workspace.type === "regular") {
+            /* tslint:disable-next-line */
+            /** no await */ this.projectDB.updateProjectUsage(workspace.projectId, {
+                lastWorkspaceStart: new Date().toISOString(),
+            });
+        }
+
         options = options || {};
         try {
             // Some workspaces do not have an image source.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Stop running prebuilds for projects that did not start a workspace in the last 10+ weeks.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8911
Drive-by fixes prebuild rate limits again

## How to test
<!-- Provide steps to test this PR -->

1. Add a Project
2. Verify that Prebuilds are triggered successfully and workspaces can be started
3. Verify that `lastWorkspaceStart` and `lastWebhookReceived` are properly set in `d_b_project_usage`
4. Manually set `lastWorkspaceStart` to a date more than 10 weeks ago in `d_b_project_usage`
5. Trigger new Prebuilds -- verify that they now get auto-cancelled on start due to Project inactivity

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Stop running prebuilds for projects that did not start a workspace in the last 10+ weeks
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
