### PR TITLE
Add `maximumBackupCount` and `blobQuota` configuration surface to the installer

### DIFF
--- a/install/installer/pkg/common/storage.go
+++ b/install/installer/pkg/common/storage.go
@@ -93,6 +93,9 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 	}
 	// 5 GiB
 	res.BlobQuota = 5 * 1024 * 1024 * 1024
+	if context.Config.ObjectStorage.BlobQuota != nil {
+		res.BlobQuota = *context.Config.ObjectStorage.BlobQuota
+	}
 
 	_ = context.WithExperimental(func(ucfg *experimental.Config) error {
 		if ucfg.Workspace != nil {

--- a/install/installer/pkg/common/storage.go
+++ b/install/installer/pkg/common/storage.go
@@ -34,6 +34,11 @@ func useMinio(context *RenderContext) bool {
 func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 	var res *storageconfig.StorageConfig
 	if context.Config.ObjectStorage.CloudStorage != nil {
+		maximumBackupCount := 3
+		if context.Config.ObjectStorage.MaximumBackupCount != nil {
+			maximumBackupCount = *context.Config.ObjectStorage.MaximumBackupCount
+		}
+
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.GCloudStorage,
 			GCloudConfig: storageconfig.GCPConfig{
@@ -41,7 +46,7 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 				Project:            context.Config.ObjectStorage.CloudStorage.Project,
 				CredentialsFile:    filepath.Join(storageMount, "service-account.json"),
 				ParallelUpload:     6,
-				MaximumBackupCount: 3,
+				MaximumBackupCount: maximumBackupCount,
 			},
 		}
 	}

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -132,10 +132,11 @@ type DatabaseCloudSQL struct {
 }
 
 type ObjectStorage struct {
-	InCluster    *bool                      `json:"inCluster,omitempty"`
-	S3           *ObjectStorageS3           `json:"s3,omitempty"`
-	CloudStorage *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
-	Azure        *ObjectStorageAzure        `json:"azure,omitempty"`
+	InCluster          *bool                      `json:"inCluster,omitempty"`
+	S3                 *ObjectStorageS3           `json:"s3,omitempty"`
+	CloudStorage       *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
+	Azure              *ObjectStorageAzure        `json:"azure,omitempty"`
+	MaximumBackupCount *int                       `json:"maximumBackupCount,omitempty"`
 }
 
 type ObjectStorageS3 struct {

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -137,6 +137,7 @@ type ObjectStorage struct {
 	CloudStorage       *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
 	Azure              *ObjectStorageAzure        `json:"azure,omitempty"`
 	MaximumBackupCount *int                       `json:"maximumBackupCount,omitempty"`
+	BlobQuota          *int64                     `json:"blobQuota,omitempty"`
 }
 
 type ObjectStorageS3 struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we may need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR adds configuration for two such values, `maximumBackupCount` and `blobQuota`, which are currently hard-coded in the installer but need to be configurable for SaaS.

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/9097.

## How to test

Build the installer and run it with

```
render --config /path/to/config
```

Where the config file contains a `objectStorage` configuration section including the new values, like:

```yaml
objectStorage:
  inCluster: false
  maximumBackupCount: 10
  blobQuota: 2
  cloudStorage:
    project: gitpod-staging
    serviceAccount:
      kind: secret
      name: ws-sync-gcloud
```

The rendered output for the `content-service` configMap should then contain the new values under the `config.json` key:

```yaml
- apiVersion: v1
  data:
    config.json: |-
      {
       "pprof": {
        "address": ":6060"
       },
       "prometheus": {
        "address": ":9500"
       },
       "service": {
        "address": ":8080",
        "tls": {
         "ca": "",
         "crt": "",
         "key": ""
        }
       },
       "storage": {
        "backupTrail": {
         "enabled": true,
         "maxLength": 3
        },
        "blobQuota": 2,
        "gcloud": {
         "credentialsFile": "/mnt/secrets/storage/service-account.json",
         "maximumBackupCount": 10,
         "parallelUpload": 6,
         "projectId": "gitpod-staging",
         "region": "europe-west1"
        },
        "kind": "gcloud",
        "minio": {
         "accessKey": "",
         "accessKeyFile": "",
         "endpoint": "",
         "region": "",
         "secretKey": "",
         "secretKeyFile": ""
        },
        "stage": ""
       }
      }
  kind: ConfigMap
  metadata:
    creationTimestamp: null
    labels:
      app: gitpod
      component: content-service
    name: content-service
```

## Release Notes

```release-note
Make `maximumBackupCount` and `blobQuota` configurable via the installer config file.
```

## Documentation

No changes required as these values should be left at the pre-existing defaults to self-hosted installations.
