### PR TITLE
[ws-manager-bridge] Fix statusVersion comparison

### DIFF
--- a/components/ws-manager-bridge/ee/src/bridge.ts
+++ b/components/ws-manager-bridge/ee/src/bridge.ts
@@ -65,15 +65,13 @@ export class WorkspaceManagerBridgeEE extends WorkspaceManagerBridge {
             span.setTag("updatePrebuiltWorkspace.workspaceInstance.statusVersion", status.statusVersion);
             log.info("Found prebuild record in database.", prebuild);
 
-            if (prebuild.statusVersion <= status.statusVersion) {
-                // prebuild.statusVersion = 0 is the default value in the DB, these shouldn't be counted as stale in our metrics
-                if (prebuild.statusVersion > 0) {
-                    // We've gotten an event which is younger than one we've already processed. We shouldn't process the stale one.
-                    span.setTag("updatePrebuiltWorkspace.staleEvent", true);
-                    this.prometheusExporter.recordStalePrebuildEvent();
-                    log.info(logCtx, "Stale prebuild event received, skipping.");
-                    return;
-                }
+            // prebuild.statusVersion = 0 is the default value in the DB, these shouldn't be counted as stale in our metrics
+            if (prebuild.statusVersion > 0 && prebuild.statusVersion >= status.statusVersion) {
+                // We've gotten an event which is younger than one we've already processed. We shouldn't process the stale one.
+                span.setTag("updatePrebuiltWorkspace.staleEvent", true);
+                this.prometheusExporter.recordStalePrebuildEvent();
+                log.info(logCtx, "Stale prebuild event received, skipping.");
+                return;
             }
             prebuild.statusVersion = status.statusVersion;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The comparison logic was the wrong way. We'd check the statusVersion stored in the DB <= new update and exit early if it was. That's the incorrect behaviour as status.statusVersion is monotonically **increasing**

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Create a prebuild
2. Observe it transitions to Done (previously it would hang on Preparing)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager-bridge] Fix statusVersion comparison.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE
