### PR TITLE
[public-api-server] Setup component in installer with experimental conf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 /install/installer/pkg/components/openvsx-proxy @gitpod-io/engineering-ide
 /install/installer/pkg/components/proxy @gitpod-io/engineering-webapp
 /install/installer/pkg/components/registry-facade @gitpod-io/engineering-workspace
+/install/installer/pkg/components/public-api-server @gitpod-io/engineering-webapp
 /install/installer/pkg/components/server @gitpod-io/engineering-webapp
 /install/installer/pkg/components/server/ide @gitpod-io/engineering-ide
 /install/installer/pkg/components/workspace @gitpod-io/engineering-workspace

--- a/install/installer/pkg/components/components-webapp/components.go
+++ b/install/installer/pkg/components/components-webapp/components.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/components/minio"
 	openvsxproxy "github.com/gitpod-io/gitpod/installer/pkg/components/openvsx-proxy"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
+	public_api_server "github.com/gitpod-io/gitpod/installer/pkg/components/public-api-server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/rabbitmq"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
@@ -33,6 +34,7 @@ var Objects = common.CompositeRenderFunc(
 	rabbitmq.Objects,
 	server.Objects,
 	wsmanagerbridge.Objects,
+	public_api_server.Objects,
 )
 
 var Helm = common.CompositeHelmFunc(

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
+	var experimentalCfg *experimental.Config
+
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		experimentalCfg = ucfg
+		return nil
+	})
+
+	if experimentalCfg == nil || experimentalCfg.WebApp == nil || experimentalCfg.WebApp.PublicAPI == nil {
+		// We don't want to render anything for this deployment
+		return nil, nil
+	}
+
+	publicAPIConfig := experimentalCfg.WebApp.PublicAPI
+	log.Debug("Detected experimental.WebApp.PublicApi configuration", publicAPIConfig)
+
+	return nil, nil
+}

--- a/install/installer/pkg/components/public-api-server/objects.go
+++ b/install/installer/pkg/components/public-api-server/objects.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package public_api_server
+
+import "github.com/gitpod-io/gitpod/installer/pkg/common"
+
+var Objects = common.CompositeRenderFunc(
+	deployment,
+)

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -46,6 +46,11 @@ type WorkspaceConfig struct {
 }
 
 type WebAppConfig struct {
+	PublicAPI *PublicAPIConfig `json:"publicApi,omitempty"`
+}
+
+type PublicAPIConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 type IDEConfig struct {

--- a/install/installer/pkg/config/versions/versions.go
+++ b/install/installer/pkg/config/versions/versions.go
@@ -33,6 +33,7 @@ type Components struct {
 	OpenVSXProxy          Versioned `json:"openVSXProxy"`
 	PaymentEndpoint       Versioned `json:"paymentEndpoint"`
 	Proxy                 Versioned `json:"proxy"`
+	PublicAPIServer       Versioned `json:"public-api-server"`
 	RegistryFacade        Versioned `json:"registryFacade"`
 	Server                Versioned `json:"server"`
 	ServiceWaiter         Versioned `json:"serviceWaiter"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Extend installer config with public-api-server, configured through experimental config. Not deployed as part of a regular self-hosted release at this point, as it's under heavy development.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Depends on https://github.com/gitpod-io/gitpod/pull/9254
Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->

**Sample experimental config**
```yaml
experimental:
  webapp:
    publicApi:
      enabled: true
```
The values of the publicApi config will change in subsequent PRs, here it's mostly to demonstrate it working end-to-end.

**To obtain versions.yaml**
```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:main.2872" cat versions.yaml > versions.yaml
```

Then run 
```
export LOG_LEVEL=debug
go run main.go render --config "./installer.yaml" --use-experimental-config --debug-version-file versions.yaml

DEBU[0000] Detected experimental.WebApp.PublicApi configuration {..}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold