### PR TITLE
[installer] Allow composed render funcs to output no object

### DIFF
--- a/install/installer/pkg/common/render.go
+++ b/install/installer/pkg/common/render.go
@@ -31,6 +31,10 @@ func CompositeRenderFunc(f ...RenderFunc) RenderFunc {
 			if err != nil {
 				return nil, err
 			}
+			if len(obj) == 0 {
+				// the RenderFunc chose not to render anything, possibly based on config it received
+				continue
+			}
 			res = append(res, obj...)
 		}
 		return res, nil

--- a/install/installer/pkg/common/render_test.go
+++ b/install/installer/pkg/common/render_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package common
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+)
+
+func TestCompositeRenderFunc_NilObjectsNilError(t *testing.T) {
+	f := CompositeRenderFunc(
+		func(cfg *RenderContext) ([]runtime.Object, error) {
+			return nil, nil
+		})
+
+	ctx, err := NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	objects, err := f(ctx)
+	require.NoError(t, err)
+	require.Len(t, objects, 0)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I want to be able to read the experimenetal config and not output anything if some of my experimental values are not set.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

For an example, see https://github.com/gitpod-io/gitpod/pull/9252/files#diff-095fe8cd21505dabc69fc747fd072f2ee5c6b6faaeb969eace21e53a1bd84c45R10

## How to test
<!-- Provide steps to test this PR -->
`go test`


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE
