### PR TITLE
[public-api-server] Add k8s deployment into installer

### DIFF
--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package public_api_server
+
+const (
+	Component     = "public-api-server"
+	ContainerPort = 9000
+	PortName      = "http"
+)

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -5,9 +5,16 @@ package public_api_server
 
 import (
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -26,5 +33,68 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	publicAPIConfig := experimentalCfg.WebApp.PublicAPI
 	log.Debug("Detected experimental.WebApp.PublicApi configuration", publicAPIConfig)
 
-	return nil, nil
+	labels := common.DefaultLabels(Component)
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: common.TypeMetaDeployment,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+				Replicas: pointer.Int32(1),
+				Strategy: common.DeploymentStrategy,
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      Component,
+						Namespace: ctx.Namespace,
+						Labels:    labels,
+					},
+					Spec: corev1.PodSpec{
+						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+						ServiceAccountName:            Component,
+						EnableServiceLinks:            pointer.Bool(false),
+						DNSPolicy:                     "ClusterFirst",
+						RestartPolicy:                 "Always",
+						TerminationGracePeriodSeconds: pointer.Int64(30),
+						Containers: []corev1.Container{{
+							Name:            Component,
+							Image:           common.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.PublicAPIServer.Version),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("100m"),
+									"memory": resource.MustParse("32Mi"),
+								},
+							},
+							Ports: []corev1.ContainerPort{{
+								ContainerPort: ContainerPort,
+								Name:          PortName,
+							}},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.Bool(false),
+							},
+							Env: common.MergeEnv(
+								common.DefaultEnv(&ctx.Config),
+							),
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/",
+										Port:   intstr.IntOrString{IntVal: ContainerPort},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								FailureThreshold: 3,
+								SuccessThreshold: 1,
+								TimeoutSeconds:   1,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}, nil
 }

--- a/install/installer/pkg/components/public-api-server/objects.go
+++ b/install/installer/pkg/components/public-api-server/objects.go
@@ -7,4 +7,6 @@ import "github.com/gitpod-io/gitpod/installer/pkg/common"
 
 var Objects = common.CompositeRenderFunc(
 	deployment,
+	rolebinding,
+	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/public-api-server/rolebinding.go
+++ b/install/installer/pkg/components/public-api-server/rolebinding.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{&rbacv1.RoleBinding{
+		TypeMeta: common.TypeMetaRoleBinding,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      Component,
+			Namespace: ctx.Namespace,
+			Labels:    common.DefaultLabels(Component),
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind: "ServiceAccount",
+			Name: Component,
+		}},
+	}}, nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Generates a deployment config for k8s, including rolebinding and service account:

<details>
<summary>With experimental config</summary>

```yaml
experimental:
  webapp:
    publicApi:
      enabled: true
```
generates
```yaml
# apps/v1/Deployment public-api-server
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: gitpod
    component: public-api-server
  name: public-api-server
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: gitpod
      component: public-api-server
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: gitpod
        component: public-api-server
      name: public-api-server
      namespace: default
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: gitpod.io/workload_meta
                operator: Exists
      containers:
      - env:
        - name: GITPOD_DOMAIN
          value: dev.gitpod.io
        - name: GITPOD_INSTALLATION_LONGNAME
          value: dev.gitpod.io
        - name: GITPOD_INSTALLATION_SHORTNAME
          value: dev.gitpod.io
        - name: GITPOD_REGION
          value: local
        - name: HOST_URL
          value: https://dev.gitpod.io
        - name: KUBE_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: KUBE_DOMAIN
          value: svc.cluster.local
        - name: LOG_LEVEL
          value: info
        image: eu.gcr.io/gitpod-core-dev/build/public-api-server:commit-01b3dc2371dea9f079043566c6f296d19d30c1c0
        imagePullPolicy: IfNotPresent
        name: public-api-server
        ports:
        - containerPort: 9000
          name: http
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /
            port: 9000
            scheme: HTTP
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          requests:
            cpu: 100m
            memory: 32Mi
        securityContext:
          privileged: false
      dnsPolicy: ClusterFirst
      enableServiceLinks: false
      restartPolicy: Always
      serviceAccountName: public-api-server
      terminationGracePeriodSeconds: 30
status: {}
```
</details>

Without experimental config, no `public-api-server` is rendered

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Depends on https://github.com/gitpod-io/gitpod/pull/9252
Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
```
 go run main.go render --config "./installer.conf.yaml" --use-experimental-config --debug-version-file versions.yaml > rendered.yaml
```
Inspect rendered.yaml it contains the config.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/uncc
/hold