### PR TITLE
[public-api-server] Enable in preview environments

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -61,6 +61,7 @@ export class Installer {
             this.configureObservability(slice)
             this.configureAuthProviders(slice)
             this.configureSSHGateway(slice)
+            this.configurePublicAPIServer(slice)
 
             if (this.options.analytics) {
                 this.includeAnalytics(slice)
@@ -141,6 +142,10 @@ export class Installer {
                 | kubectl --kubeconfig ${this.options.kubeconfigPath} apply -f -`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} sshGatewayHostKey.kind "secret"`)
         exec(`yq w -i ${this.options.installerConfigPath} sshGatewayHostKey.name "host-key"`)
+    }
+
+    private configurePublicAPIServer(slice: string) {
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.publicApi.enabled true`, { slice: slice })
     }
 
     private includeAnalytics(slice: string): void {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Deploy public-api-server as part of preview deployments

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
1. Open the branch
2. Ensure you're on the right (branch) kube namespace
3. List deployments and observe
```bash
➜ k get deployment
NAME                READY   UP-TO-DATE   AVAILABLE   AGE
...
public-api-server   2/2     2            2           20h
...

➜ k get po
NAME                                 READY   STATUS    RESTARTS   AGE
...
public-api-server-6c59d7f9-kbqgh     1/1     Running   0          16h
public-api-server-6c59d7f9-pbkgc     1/1     Running   0          16h
...
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/hold