### PR TITLE
[ws-daemon] Enable workspace IP forwarding

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -464,6 +464,13 @@ func main() {
 					return nil
 				},
 			},
+			{
+				Name:  "enable-ip-forward",
+				Usage: "enable IPv4 forwarding",
+				Action: func(c *cli.Context) error {
+					return os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1"), 0644)
+				},
+			},
 		},
 	}
 

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -344,6 +344,14 @@ func (wbs *InWorkspaceServiceServer) SetupPairVeths(ctx context.Context, req *ap
 		return nil, status.Errorf(codes.Internal, "cannot setup a peer veths")
 	}
 
+	err = nsinsider(wbs.Session.InstanceID, int(pid), func(c *exec.Cmd) {
+		c.Args = append(c.Args, "enable-ip-forward")
+	}, enterMountNS(true))
+	if err != nil {
+		log.WithError(err).WithFields(wbs.Session.OWI()).Error("SetupPairVeths: cannot enable IP forwarding")
+		return nil, status.Errorf(codes.Internal, "cannot enable IP forwarding")
+	}
+
 	return &api.SetupPairVethsResponse{}, nil
 }
 


### PR DESCRIPTION
## Description
To make the new nftables setup work.
It worked on core-dev because there IP forwarding is globally enabled.


## How to test
Run on an ephemeral cluster.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
