### PR TITLE
Use dynamic links for downloading the latest version of JetBrains Tools

### DIFF
--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -52,8 +52,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.intellijLatest
       buildArgs:
-        # "https://data.services.jetbrains.com/products?code=IIU&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000"
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/idea/ideaIU-221.5080.169.tar.gz"
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=IIU"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
@@ -99,8 +98,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.golandLatest
       buildArgs:
-        # "https://data.services.jetbrains.com/products?code=GO&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000"
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/go/goland-221.5080.169.tar.gz"
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=GO"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_goland.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
@@ -146,8 +144,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.pycharmLatest
       buildArgs:
-        # "https://data.services.jetbrains.com/products?code=PCP&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000"
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/python/pycharm-professional-221.5080.186.tar.gz"
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PCP"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_pycharm.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
@@ -193,8 +190,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.phpstormLatest
       buildArgs:
-        # "https://data.services.jetbrains.com/products?code=PS&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000"
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/webide/PhpStorm-221.5080.177.tar.gz"
+        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PS"
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_phpstorm.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
EAP versions of JetBrains Tools have an expiration date. So we need to keep constantly updating the build config for picking up the latest version (be it EAP, RC, or even the stable release if it was the last one published).

This PR makes the latest versions to be downloaded from dynamic links provided by JetBrains API, to ensure we never get the following error again:

```
2022-04-12 14:52:28,208 [      3]   INFO - #c.i.i.StartupUtil - ------------------------------------------------------ IDE STARTED ------------------------------------------------------
2022-04-12 14:52:28,291 [     86]   INFO - #c.i.i.StartupUtil - JNA library (64-bit) loaded in 14 ms
2022-04-12 14:52:28,306 [    101]   INFO - #c.i.i.p.PluginManager - Using broken plugins file from IDE distribution
2022-04-12 14:52:28,315 [    110]   INFO - #c.i.i.StartupUtil - IDE: IntelliJ IDEA (build #IU-221.4994.44, 11 Mar 2022 18:02)
2022-04-12 14:52:28,315 [    110]   INFO - #c.i.i.StartupUtil - OS: Linux (5.4.0-1059-gke, amd64)
2022-04-12 14:52:28,320 [    115]   INFO - #c.i.i.StartupUtil - JRE: 11.0.14.1+1-b2043.11 (JetBrains s.r.o.)
2022-04-12 14:52:28,320 [    115]   INFO - #c.i.i.StartupUtil - JVM: 11.0.14.1+1-b2043.11 (OpenJDK 64-Bit Server VM)
2022-04-12 14:52:28,325 [    120]   INFO - #c.i.i.StartupUtil - WM detected: null, desktop: -
2022-04-12 14:52:28,326 [    121]   INFO - #c.i.i.StartupUtil - args: [cwmHostNoLobby, /workspace/spring-petclinic]
2022-04-12 14:52:28,327 [    122]   INFO - #c.i.i.StartupUtil - library path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
2022-04-12 14:52:28,327 [    122]   INFO - #c.i.i.StartupUtil - boot library path: /ide-desktop/backend/jbr/lib
2022-04-12 14:52:28,367 [    162]   INFO - #c.i.i.StartupUtil - locale=en_US JNU=UTF-8 file.encoding=UTF-8
  idea.config.path=/workspace/.config/JetBrains/RemoteDev-IU/_workspace_spring-petclinic
  idea.system.path=/workspace/.cache/JetBrains/RemoteDev-IU/_workspace_spring-petclinic
  idea.plugins.path=/workspace/.config/JetBrains/RemoteDev-IU/_workspace_spring-petclinic/plugins
  idea.log.path=/workspace/.cache/JetBrains/RemoteDev-IU/_workspace_spring-petclinic/log
2022-04-12 14:52:28,384 [    179]   INFO - #c.i.i.StartupUtil - CPU cores: 1; ForkJoinPool.commonPool: java.util.concurrent.ForkJoinPool@5c58b26d[Running, parallelism = 1, size = 1, active = 1, running = 1, steals = 0, tasks = 0, submissions = 1]; factory: com.intellij.concurrency.IdeaForkJoinWorkerThreadFactory@7faded87
2022-04-12 14:52:28,405 [    200]   INFO - STDOUT - This IDE build has expired. Please download a new build from JetBrains official site
2022-04-12 14:52:28,406 [    201]   INFO - #c.i.i.StartupUtil - ------------------------------------------------------ IDE SHUTDOWN ------------------------------------------------------
```

Note the `This IDE build has expired. Please download a new build from JetBrains official site` message in the snippet above.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NONE

## How to test
<!-- Provide steps to test this PR -->
Open any JetBrains Tool with "Latest" checkbox checked and confirm it works.

Alternatively, you can access the download links on your browser and confirm they're all working:

- https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=IIU (IDEA)
- https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=GO (Goland)
- https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PCP (Pycharm)
- https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PS (PhpStorm)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE