### PR TITLE
Pre-install Prettier and ESLint VSCode extensions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -62,6 +62,8 @@ vscode:
     - timonwong.shellcheck
     - vscjava.vscode-java-pack
     - fwcd.kotlin
+    - dbaeumer.vscode-eslint
+    - esbenp.prettier-vscode
 jetbrains:
   goland:
     prebuilds:

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -1,60 +1,69 @@
 {
-   "folders": [
-      { "path": "." },
-      { "path": "components/blobserve" },
-      { "path": "components/common-go" },
-      { "path": "components/content-service" },
-      { "path": "components/docker-up" },
-      { "path": "components/ee/agent-smith" },
-      { "path": "components/gitpod-cli" },
-      { "path": "components/gitpod-protocol" },
-      { "path": "components/image-builder-bob" },
-      { "path": "components/image-builder-mk3" },
-      { "path": "components/licensor" },
-      { "path": "components/local-app" },
-      { "path": "components/registry-facade" },
-      { "path": "components/service-waiter" },
-      { "path": "components/supervisor" },
-      { "path": "components/workspacekit" },
-      { "path": "components/ws-daemon" },
-      { "path": "components/ws-manager" },
-      { "path": "components/ws-proxy" },
-      { "path": "test" },
-      { "path": "dev/blowtorch" },
-      { "path": "dev/changelog" },
-      { "path": "dev/gpctl" },
-      { "path": "dev/loadgen" },
-      { "path": "dev/poolkeeper" },
-      { "path": "dev/sweeper" },
-      { "path": "install/installer" }
-   ],
-   "settings": {
-      "typescript.tsdk": "gitpod/node_modules/typescript/lib",
-      "[json]": {
-         "editor.insertSpaces": true,
-         "editor.tabSize": 2
-      },
-      "[yaml]": {
-         "editor.insertSpaces": true,
-         "editor.tabSize": 2
-      },
-      "[go]": {
-         "editor.formatOnSave": true
-      },
-      "[tf]": {
-         "editor.insertSpaces": true,
-         "editor.tabSize": 2
-      },
-      "go.formatTool": "goimports",
-      "go.useLanguageServer": true,
-      "workspace.supportMultiRootWorkspace": true,
-      "launch": {},
-      "files.exclude": {
-         "**/.git": true
-      },
-      "go.lintTool": "golangci-lint",
-      "gopls": {
-         "allowModfileModifications": true
-      }
-   }
+    "folders": [
+        { "path": "." },
+        { "path": "components/blobserve" },
+        { "path": "components/common-go" },
+        { "path": "components/content-service" },
+        { "path": "components/docker-up" },
+        { "path": "components/ee/agent-smith" },
+        { "path": "components/gitpod-cli" },
+        { "path": "components/gitpod-protocol" },
+        { "path": "components/image-builder-bob" },
+        { "path": "components/image-builder-mk3" },
+        { "path": "components/licensor" },
+        { "path": "components/local-app" },
+        { "path": "components/registry-facade" },
+        { "path": "components/service-waiter" },
+        { "path": "components/supervisor" },
+        { "path": "components/workspacekit" },
+        { "path": "components/ws-daemon" },
+        { "path": "components/ws-manager" },
+        { "path": "components/ws-proxy" },
+        { "path": "test" },
+        { "path": "dev/blowtorch" },
+        { "path": "dev/changelog" },
+        { "path": "dev/gpctl" },
+        { "path": "dev/loadgen" },
+        { "path": "dev/poolkeeper" },
+        { "path": "dev/sweeper" },
+        { "path": "install/installer" }
+    ],
+    "settings": {
+        "typescript.tsdk": "gitpod/node_modules/typescript/lib",
+        "[javascript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode",
+            "editor.formatOnSave": true
+        },
+        "[typescript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode",
+            "editor.formatOnSave": true
+        },
+        "[json]": {
+            "editor.insertSpaces": true,
+            "editor.tabSize": 2
+        },
+        "[yaml]": {
+            "editor.insertSpaces": true,
+            "editor.tabSize": 2
+        },
+        "[go]": {
+            "editor.formatOnSave": true
+        },
+        "[tf]": {
+            "editor.insertSpaces": true,
+            "editor.tabSize": 2
+        },
+        "go.formatTool": "goimports",
+        "go.useLanguageServer": true,
+        "workspace.supportMultiRootWorkspace": true,
+        "launch": {},
+        "files.exclude": {
+            "**/.git": true
+        },
+        "go.lintTool": "golangci-lint",
+        "gopls": {
+            "allowModfileModifications": true
+        },
+        "prettier.configPath": ".prettierrc.json"
+    }
 }


### PR DESCRIPTION
## Description

In an effort to further simplify #8995, this only adds pre-installed and pre-activated ESLint & Prettier extensions for VSCode with "format on save".

It's a cherry-pick from #8895 so it's expected to vanish from that PR once this gets merged.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Re #3841
This is a prerequisite to ensure the work on the linting issues can proceed with sane defaults. 

## How to test
<!-- Provide steps to test this PR -->

For Prettier: open a TS file, and see if the code you write gets formatted on save.
For ESLint: open a TS file, produce a linting error, and see if VSCode marks it with a squiggly yellow line.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- [devx]: Added ESLint and Prettier to the auto-installed VSCode extensions
- [devx]: Activated "format on save" for TypeScript and JavaScript
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
