### PR TITLE
Fix default vscode settings sync value

### DIFF
--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -185,7 +185,8 @@ export class CodeSyncService {
                     value = await this.getTheiaCodeSyncResource(req.user.id);
                     version = 5;
                 } else if (resourceKey === SyncResource.Settings) {
-                    const settings = await this.userStorageResourcesDB.get(req.user.id, userSettingsUri);
+                    let settings = await this.userStorageResourcesDB.get(req.user.id, userSettingsUri);
+                    settings = settings === "" ? "{}" : settings;
                     value = JSON.stringify(<ISettingsSyncContent>{ settings });
                     version = 2;
                 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix default vscode settings sync value

## How to test
<!-- Provide steps to test this PR -->
1. ~~Bundle gitpod-desktop vsix from https://github.com/gitpod-io/openvscode-server/pull/337~~ Dowload this vsix file [gitpod-desktop-0.0.30.zip](https://github.com/gitpod-io/gitpod/files/8482016/gitpod-desktop-0.0.30.zip)
2. Install vsix in vscode desktop
3. Press <kbd>F1</kbd> and execute `Gitpod: Turn on Settings Sync` command
4. Close all windows
6. Reopen vscode and enable settings sync: Press `f1` and execute  `Settings Sync: Turn On...` command (make sure you have some local settings already modified)
7. When it prompts to resolve conflicts, choose manual
8. Observe diff editor for settings.json shows remote value as `{}` (empty object) instead of `{settings:""}`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
