### PR TITLE
[ws-daemon] Git configure safe.directory

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -169,6 +169,14 @@ func (c *Client) GitWithOutput(ctx context.Context, subcommand string, args ...s
 		env = append(env, fmt.Sprintf("GIT_AUTH_PASSWORD=%s", pwd))
 	}
 
+	homeDir, err := os.MkdirTemp("", "git")
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create temporal directory")
+	}
+	defer os.RemoveAll(homeDir)
+
+	env = append(env, fmt.Sprintf("HOME=%v", homeDir))
+
 	fullArgs = append(fullArgs, subcommand)
 	fullArgs = append(fullArgs, args...)
 

--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -169,13 +169,7 @@ func (c *Client) GitWithOutput(ctx context.Context, subcommand string, args ...s
 		env = append(env, fmt.Sprintf("GIT_AUTH_PASSWORD=%s", pwd))
 	}
 
-	homeDir, err := os.MkdirTemp("", "git")
-	if err != nil {
-		return nil, xerrors.Errorf("cannot create temporal directory")
-	}
-	defer os.RemoveAll(homeDir)
-
-	env = append(env, fmt.Sprintf("HOME=%v", homeDir))
+	env = append(env, "HOME=/home/gitpod")
 
 	fullArgs = append(fullArgs, subcommand)
 	fullArgs = append(fullArgs, args...)

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -273,6 +273,13 @@ func (s *Workspace) UpdateGitStatus(ctx context.Context) (res *csapi.GitStatus, 
 	}
 
 	c := git.Client{Location: loc}
+
+	err = c.Git(ctx, "config", "--global", "--add", "safe.directory", loc)
+	if err != nil {
+		log.WithError(err).WithFields(s.OWI()).Warn("cannot persist latest Git status")
+		err = nil
+	}
+
 	stat, err := c.Status(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

The last git version, v2.34.2 introduced a breaking change, requiring the configuration [safe.directory](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory). 
Without this setting, `git status` returns an error:
```
git status --porcelain=v2 --branch -uall failed (exit status 128): fatal: unsafe repository ('XXXXXX' is owned by someone else)
To add an exception for this directory, call:

git config --global --add safe.directory XXXXXX
```

## Release Notes
```release-note
NONE
```