### PR TITLE
[dashboard] add notice for stable back and change latest desc

### DIFF
--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -110,7 +110,7 @@ export function StartPage(props: StartPageProps) {
                 {props.children}
                 {props.showLatestIdeWarning && (
                     <Alert type="warning" className="mt-4 w-96">
-                        You are using the latest release (unstable) for the editor.{" "}
+                        This workspace is configured with the latest release (unstable) for the editor.{" "}
                         <a className="gp-link" target="_blank" href={gitpodHostUrl.asPreferences().toString()}>
                             Change Preferences
                         </a>

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -28,6 +28,7 @@ import { watchHeadlessLogs } from "../components/PrebuildLogs";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
 import ConnectToSSHModal from "../workspaces/ConnectToSSHModal";
+import Alert from "../components/Alert";
 const sessionId = v4();
 
 const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
@@ -391,6 +392,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         let title = undefined;
         let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
         const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
+        const useLatest = !!this.state.workspaceInstance?.configuration?.ideConfig?.useLatest;
 
         switch (this.state?.workspaceInstance?.status.phase) {
             // unknown indicates an issue within the system in that it cannot determine the actual phase of
@@ -524,6 +526,19 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                     {openLinkLabel}
                                 </button>
                             </div>
+                            {!useLatest && (
+                                <Alert type="info" className="mt-4 w-96">
+                                    You can change the default editor for opening workspaces in{" "}
+                                    <a
+                                        className="gp-link"
+                                        target="_blank"
+                                        href={gitpodHostUrl.asPreferences().toString()}
+                                    >
+                                        user preferences
+                                    </a>
+                                    .
+                                </Alert>
+                            )}
                             {this.state.isSSHModalVisible === true && this.state.ownerToken && (
                                 <ConnectToSSHModal
                                     workspaceId={this.props.workspaceId}
@@ -626,7 +641,6 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 );
                 break;
         }
-        const useLatest = !!this.state.workspaceInstance?.configuration?.ideConfig?.useLatest;
         return (
             <StartPage phase={phase} error={error} title={title} showLatestIdeWarning={useLatest}>
                 {statusMessage}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add notice for stable back and change latest desc

|IDE Version|Dark|Light|
|:-:|:-:|:-:|
|stable|<img width="511" alt="image" src="https://user-images.githubusercontent.com/20944364/163177193-b0e5878e-f572-4e76-8c3d-6a80d7cfeade.png">|<img width="508" alt="image" src="https://user-images.githubusercontent.com/20944364/163177244-4ae7054d-fdd4-4935-a416-8790f378ae47.png">|
|latest| <img width="548" alt="image" src="https://user-images.githubusercontent.com/20944364/163177352-408bffc7-8422-468b-834b-0e1ca5ddcb23.png"> |<img width="560" alt="image" src="https://user-images.githubusercontent.com/20944364/163177317-7ab69013-49bd-401b-9d71-9a8797134027.png">|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace with stable IDE, to see if have warning for change Preferences
2. Open a workspace with latest IDE, to see if warning changed to `This workspace is configured with the latest release (unstable) for the editor`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
