### PR TITLE
[nsinsider] Make veth0 match container MTU

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -284,11 +284,16 @@ func main() {
 					}
 					targetPid := c.Int("target-pid")
 
+					eth0, err := netlink.LinkByName(containerIf)
+					if err != nil {
+						return xerrors.Errorf("cannot get container network device %s: %w", containerIf, err)
+					}
+
 					veth := &netlink.Veth{
 						LinkAttrs: netlink.LinkAttrs{
 							Name:  vethIf,
 							Flags: net.FlagUp,
-							MTU:   1500,
+							MTU:   eth0.Attrs().MTU,
 						},
 						PeerName:      cethIf,
 						PeerNamespace: netlink.NsPid(targetPid),


### PR DESCRIPTION
## Description
This PR makes the MTU of the veth0 pair and the container network device match.
If those two differ, we're seeing considerable performance problems in the workspace.

## How to test
- Start a workspace
- See if there are networking issues

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-daemon] Match veth0/eth0 MTU to improve network performance
```
