### PR TITLE
Add experimental config values for the Server component

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -40,6 +40,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	sessionSecret := "Important!Really-Change-This-Key!"
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Session.Secret != "" {
+			sessionSecret = cfg.WebApp.Session.Secret
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -60,7 +68,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		Session: Session{
 			MaxAgeMs: 259200000,
-			Secret:   "Important!Really-Change-This-Key!", // todo(sje): how best to do this?
+			Secret:   sessionSecret,
 		},
 		DefinitelyGpDisabled: ctx.Config.DisableDefinitelyGP,
 		WorkspaceGarbageCollection: WorkspaceGarbageCollection{

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -20,6 +20,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.OAuthServer.JWTSecret != "" {
+			jwtSecret = cfg.WebApp.OAuthServer.JWTSecret
+		}
+		return nil
+	})
 
 	license := ""
 	if ctx.Config.License != nil {

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -48,6 +48,21 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	githubApp := GitHubApp{}
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.GithubApp != nil {
+			githubApp.AppId = cfg.WebApp.GithubApp.AppId
+			githubApp.AuthProviderId = cfg.WebApp.GithubApp.AuthProviderId
+			githubApp.BaseUrl = cfg.WebApp.GithubApp.BaseUrl
+			githubApp.CertPath = cfg.WebApp.GithubApp.CertPath
+			githubApp.Enabled = cfg.WebApp.GithubApp.Enabled
+			githubApp.LogLevel = cfg.WebApp.GithubApp.LogLevel
+			githubApp.MarketplaceName = cfg.WebApp.GithubApp.MarketplaceName
+			githubApp.WebhookSecret = cfg.WebApp.GithubApp.WebhookSecret
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -71,6 +86,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Secret:   sessionSecret,
 		},
 		DefinitelyGpDisabled: ctx.Config.DisableDefinitelyGP,
+		GitHubApp:            githubApp,
 		WorkspaceGarbageCollection: WorkspaceGarbageCollection{
 			ChunkLimit:                 1000,
 			ContentChunkLimit:          1000,

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -21,8 +21,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.OAuthServer.JWTSecret != "" {
-			jwtSecret = cfg.WebApp.OAuthServer.JWTSecret
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.OAuthServer.JWTSecret != "" {
+			jwtSecret = cfg.WebApp.Server.OAuthServer.JWTSecret
 		}
 		return nil
 	})
@@ -34,31 +34,31 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	workspaceImage := common.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, ""), workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion)
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.WorkspaceDefaults.WorkspaceImage != "" {
-			workspaceImage = cfg.WebApp.WorkspaceDefaults.WorkspaceImage
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.WorkspaceDefaults.WorkspaceImage != "" {
+			workspaceImage = cfg.WebApp.Server.WorkspaceDefaults.WorkspaceImage
 		}
 		return nil
 	})
 
 	sessionSecret := "Important!Really-Change-This-Key!"
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.Session.Secret != "" {
-			sessionSecret = cfg.WebApp.Session.Secret
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.Session.Secret != "" {
+			sessionSecret = cfg.WebApp.Server.Session.Secret
 		}
 		return nil
 	})
 
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.GithubApp != nil {
-			githubApp.AppId = cfg.WebApp.GithubApp.AppId
-			githubApp.AuthProviderId = cfg.WebApp.GithubApp.AuthProviderId
-			githubApp.BaseUrl = cfg.WebApp.GithubApp.BaseUrl
-			githubApp.CertPath = cfg.WebApp.GithubApp.CertPath
-			githubApp.Enabled = cfg.WebApp.GithubApp.Enabled
-			githubApp.LogLevel = cfg.WebApp.GithubApp.LogLevel
-			githubApp.MarketplaceName = cfg.WebApp.GithubApp.MarketplaceName
-			githubApp.WebhookSecret = cfg.WebApp.GithubApp.WebhookSecret
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
+			githubApp.AppId = cfg.WebApp.Server.GithubApp.AppId
+			githubApp.AuthProviderId = cfg.WebApp.Server.GithubApp.AuthProviderId
+			githubApp.BaseUrl = cfg.WebApp.Server.GithubApp.BaseUrl
+			githubApp.CertPath = cfg.WebApp.Server.GithubApp.CertPath
+			githubApp.Enabled = cfg.WebApp.Server.GithubApp.Enabled
+			githubApp.LogLevel = cfg.WebApp.Server.GithubApp.LogLevel
+			githubApp.MarketplaceName = cfg.WebApp.Server.GithubApp.MarketplaceName
+			githubApp.WebhookSecret = cfg.WebApp.Server.GithubApp.WebhookSecret
 		}
 		return nil
 	})

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -59,6 +59,9 @@ type WebAppConfig struct {
 	OAuthServer struct {
 		JWTSecret string `json:"jwtSecret"`
 	} `json:"oauthServer"`
+	Session struct {
+		Secret string `json:"secret"`
+	} `json:"session"`
 }
 
 type PublicAPIConfig struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -56,6 +56,9 @@ type WebAppConfig struct {
 	WorkspaceDefaults struct {
 		WorkspaceImage string `json:"workspaceImage"`
 	} `json:"workspaceDefaults"`
+	OAuthServer struct {
+		JWTSecret string `json:"jwtSecret"`
+	} `json:"oauthServer"`
 }
 
 type PublicAPIConfig struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -52,7 +52,11 @@ type WorkspaceConfig struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI         *PublicAPIConfig `json:"publicApi,omitempty"`
+	PublicAPI *PublicAPIConfig `json:"publicApi,omitempty"`
+	Server    *ServerConfig    `json:"server,omitempty"`
+}
+
+type ServerConfig struct {
 	WorkspaceDefaults struct {
 		WorkspaceImage string `json:"workspaceImage"`
 	} `json:"workspaceDefaults"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -52,7 +52,10 @@ type WorkspaceConfig struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI *PublicAPIConfig `json:"publicApi,omitempty"`
+	PublicAPI         *PublicAPIConfig `json:"publicApi,omitempty"`
+	WorkspaceDefaults struct {
+		WorkspaceImage string `json:"workspaceImage"`
+	} `json:"workspaceDefaults"`
 }
 
 type PublicAPIConfig struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -62,6 +62,17 @@ type WebAppConfig struct {
 	Session struct {
 		Secret string `json:"secret"`
 	} `json:"session"`
+	GithubApp *struct {
+		AppId           int32  `json:"appId"`
+		AuthProviderId  string `json:"authProviderId"`
+		BaseUrl         string `json:"baseUrl"`
+		CertPath        string `json:"certPath"`
+		Enabled         bool   `json:"enabled"`
+		LogLevel        string `json:"logLevel"`
+		MarketplaceName string `json:"marketplaceName"`
+		WebhookSecret   string `json:"webhookSecret"`
+		CertSecretName  string `json:"certSecretName"`
+	} `json:"githubApp"`
 }
 
 type PublicAPIConfig struct {


### PR DESCRIPTION

## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we may need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR adds configuration for a few values which are currently hard-coded in the installer but need to be configurable for SaaS:

* `workspaceDefaults.workspaceImage`
*  `oauthServer.jwtSecret`
* `session.secret`
* `githubApp`

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/9097

## How to test

Add an experimental section to the bottom of an installer config file like this:

```yaml
experimental:
  webapp:
    workspaceDefaults:
      workspaceImage: "someWorkspaceImage"
    oauthServer:
      jwtSecret: "someJwtSecret"
    session:
      secret: "someSessionSecret"
    githubApp:
      appId: 123
      authProviderId: 'someAuthProviderId'
      baseUrl: 'someBaseUrl'
      certPath: 'someCertpath'
      enabled: true
      logLevel: 'someLogLevel'
      marketplaceName: 'someMarketPlacename'
      webhookSecret: 'somewebhookSecret'
      certSecretName: 'certSecretName'

```

and invoke this installer:

```
installer render --config /path/to/config --use-experimental-config
```

The `server-config` configMap should then contain the values set in the installer config:
<details>
<summary>config.json</summary>

```yaml
      {
        "version": "main.2686",
        "hostUrl": "https://gitpod-staging.com",
        "installationShortname": "eu01",
        "stage": "production",
        "devBranch": "",
        "insecureNoDomain": false,
        "license": "",
        "licenseFile": "",
        "definitelyGpDisabled": false,
        "enableLocalApp": true,
        "builtinAuthProvidersConfigured": true,
        "disableDynamicAuthProviderLogin": false,
        "maxEnvvarPerUserCount": 4048,
        "maxConcurrentPrebuildsPerRef": 10,
        "makeNewUsersAdmin": false,
        "theiaPluginsBucketNameOverride": "",
        "defaultBaseImageRegistryWhitelist": [],
        "runDbDeleter": true,
        "contentServiceAddr": "content-service:8080",
        "imageBuilderAddr": "image-builder-mk3:8080",
        "vsxRegistryUrl": "https://open-vsx.gitpod-staging.com",
        "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
        "enablePayment": false,
        "workspaceHeartbeat": {
          "intervalSeconds": 60,
          "timeoutSeconds": 300
        },
        "workspaceDefaults": {
          "workspaceImage": "someWorkspaceImage",
          "previewFeatureFlags": [],
          "defaultFeatureFlags": []
        },
        "session": {
          "maxAgeMs": 259200000,
          "secret": "someSessionSecret"
        },
        "githubApp": {
          "enabled": true,
          "appId": 123,
          "baseUrl": "someBaseUrl",
          "webhookSecret": "somewebhookSecret",
          "authProviderId": "someAuthProviderId",
          "certPath": "someCertpath",
          "marketplaceName": "someMarketPlacename",
          "logLevel": "someLogLevel"
        },
        "workspaceGarbageCollection": {
          "disabled": false,
          "startDate": 0,
          "chunkLimit": 1000,
          "minAgeDays": 14,
          "minAgePrebuildDays": 7,
          "contentRetentionPeriodDays": 21,
          "contentChunkLimit": 1000
        },
        "authProviderConfigFiles": [
          "/gitpod/auth-providers/public-gitlab/provider",
          "/gitpod/auth-providers/public-github/provider",
          "/gitpod/auth-providers/public-bitbucket/provider"
        ],
        "incrementalPrebuilds": {
          "repositoryPasslist": [],
          "commitHistory": 100
        },
        "blockNewUsers": {
          "enabled": true,
          "passlist": []
        },
        "oauthServer": {
          "enabled": true,
          "jwtSecret": "someJwtSecret"
        },
        "rateLimiter": {
          "groups": {
            "inWorkspaceUserAction": {
              "points": 10,
              "durationsSec": 2
            }
          },
          "functions": {
            "closePort": {
              "group": "inWorkspaceUserAction",
              "points": 0
            },
            "controlAdmission": {
              "group": "inWorkspaceUserAction",
              "points": 0
            },
            "openPort": {
              "group": "inWorkspaceUserAction",
              "points": 0
            },
            "shareSnapshot": {
              "group": "inWorkspaceUserAction",
              "points": 0
            }
          }
        },
        "codeSync": {
          "revLimit": 0,
          "contentLimit": 0,
          "resources": null
        },
        "prebuildLimiter": {
          "*": 50
        }
      }
```
</details>

If the `experimental` section is removed, the configMap falls back to the defaults.

## Release Notes

```release-note
Add experimental server config to the installer
```

## Documentation

No changes required as this is experimental configuration for deploying Gitpod SaaS, not intended to be used by self-hosted installations.