### PR TITLE
Implement Cookie Consent Banner and Form (#8836)

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -25,7 +25,7 @@
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.22",
-    "@types/js-cookie": "^2.2.7",
+    "@types/js-cookie": "^3.0.1",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.3",

--- a/components/dashboard/src/CookieBanner.tsx
+++ b/components/dashboard/src/CookieBanner.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { setCookie } from "./consent-cookie";
+
+function CookieBanner(props: {
+    onOpenCookieSettings: () => void;
+    onAcceptAllCookies: () => void;
+    onRejectAllCookies: () => void;
+}) {
+    const onAccept = () => {
+        setCookie(true, true);
+        props.onAcceptAllCookies();
+    };
+
+    const onReject = () => {
+        setCookie(false, false);
+        props.onRejectAllCookies();
+    };
+
+    return (
+        <div className="flex justify-between items-center mx-auto h-12 px-4 py-2 text-center text-xs text-gray-600 bg-gray-200 w-full bottom-0 left-0 fixed">
+            <p className="text-gray-600">
+                The website uses cookies to enhance the user experience. Read our{" "}
+                <a
+                    className="gp-link hover:text-gray-600"
+                    target="gitpod-privacy"
+                    href="https://www.gitpod.io/privacy/"
+                >
+                    privacy policy{" "}
+                </a>
+                for more info.
+            </p>
+            <div className="flex gap-1">
+                <button
+                    className="py-3 bg-sand-dark underline text-xs text-gray-400 hover:text-gray-600"
+                    onClick={() => props.onOpenCookieSettings()}
+                >
+                    Modify settings
+                </button>
+                <button className="bg-gray-100 rounded-lg hover:bg-white text-xs text-gray-600" onClick={onAccept}>
+                    Accept Cookies
+                </button>
+                <button className="bg-gray-100 rounded-lg hover:bg-white text-xs text-gray-600" onClick={onReject}>
+                    Reject All
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default CookieBanner;

--- a/components/dashboard/src/CookieSettingsModal.tsx
+++ b/components/dashboard/src/CookieSettingsModal.tsx
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useState } from "react";
+import CheckBox from "./components/CheckBox";
+import Modal from "./components/Modal";
+import { cookieConsentDefaultValue, getConsentCookies, setCookie } from "./consent-cookie";
+
+function CookieSettingsModal(props: {
+    showCookieSettings: boolean;
+    cookiePreferences: { necessary: boolean; analytical: boolean; targeting: boolean };
+    onClose: () => void;
+    onSave: () => void;
+}) {
+    const [cookiePreferences, setCookiePreferences] = useState(cookieConsentDefaultValue);
+
+    const handleAnalyticalCheckboxChange = () => {
+        setCookiePreferences({
+            ...cookiePreferences,
+            analytical: !cookiePreferences.analytical,
+        });
+    };
+
+    const handleTargetingCheckboxChange = () => {
+        setCookiePreferences({
+            ...cookiePreferences,
+            targeting: !cookiePreferences.targeting,
+        });
+    };
+
+    const onSave = () => {
+        setCookie(cookiePreferences.analytical, cookiePreferences.targeting);
+        setCookiePreferences({
+            ...cookieConsentDefaultValue,
+            analytical: cookiePreferences.analytical,
+            targeting: cookiePreferences.targeting,
+        });
+
+        props.onSave();
+    };
+
+    const onClose = () => {
+        const value = getConsentCookies();
+        if (value) {
+            setCookiePreferences(JSON.parse(value));
+        }
+
+        props.onClose();
+    };
+
+    return (
+        <Modal visible={props.showCookieSettings} onClose={onClose}>
+            <h3 className="mb-4">Cookie settings</h3>
+            <div className="flex flex-col -mx-6 px-6 py-4 border-t border-b border-gray-200 dark:border-gray-800">
+                <div className="flex gap-2">
+                    <div className="-mt-4">
+                        <CheckBox title="" desc={undefined} checked={true} disabled={true} name="necessary" />
+                    </div>
+                    <h4>Strictly necessary cookies</h4>
+                </div>
+                <p className="mb-4">
+                    These are cookies that are required for the operation of our website and under our terms with you.
+                    They include, for example, cookies that enable you to log into secure areas of our website or make
+                    use of our teams and subscription services.
+                </p>
+                <div className="flex gap-2">
+                    <div className="-mt-4">
+                        <CheckBox
+                            title=""
+                            desc={undefined}
+                            checked={cookiePreferences.analytical}
+                            name="analytical"
+                            onChange={handleAnalyticalCheckboxChange}
+                        />
+                    </div>
+                    <h4>Analytical & performance cookies</h4>
+                </div>
+                <p className="mb-4">
+                    These allow us to recognise and count the number of visitors and to see how visitors move around our
+                    website when they are using it. This helps us improve the way our website works, for example, by
+                    ensuring that users are finding what they are looking for easily.
+                </p>
+                <div className="flex gap-2">
+                    <div className="-mt-4">
+                        <CheckBox
+                            title=""
+                            desc={undefined}
+                            checked={cookiePreferences.targeting}
+                            name="targeting"
+                            onChange={handleTargetingCheckboxChange}
+                        />
+                    </div>
+                    <h4>Targeting & advertising cookies</h4>
+                </div>
+                <p className="mb-4">
+                    These cookies record your visit to our website, the pages you have visited and the links you have
+                    followed. We will use this information subject to your choices and preferences to make our website
+                    and the advertising displayed on it more relevant to your interests. We may also share this
+                    information with third parties for this purpose.
+                </p>
+            </div>
+            <div className="flex justify-end mt-6">
+                <button className="secondary" onClick={onClose}>
+                    Cancel
+                </button>
+                <button className="ml-2" onClick={onSave}>
+                    Save
+                </button>
+            </div>
+        </Modal>
+    );
+}
+
+export default CookieSettingsModal;

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -248,15 +248,6 @@ export function Login() {
                             >
                                 terms of service
                             </a>{" "}
-                            and{" "}
-                            <a
-                                className="gp-link hover:text-gray-600"
-                                target="gitpod-privacy"
-                                href="https://www.gitpod.io/privacy/"
-                            >
-                                privacy policy
-                            </a>
-                            .
                         </span>
                     </div>
                 </div>

--- a/components/dashboard/src/consent-cookie.test.ts
+++ b/components/dashboard/src/consent-cookie.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { cookieSettingOptions, getConsentCookies, setCookie } from "./consent-cookie";
+
+jest.useFakeTimers("modern").setSystemTime(new Date("2022-01-01"));
+
+test("cookieSettingOptions", () => {
+    expect(cookieSettingOptions("testing.dev.com")).toStrictEqual({
+        domain: ".testing.dev.com",
+        expires: 365,
+        path: "/",
+        sameSite: "lax",
+        secure: false,
+    });
+});
+
+test("setCookie", () => {
+    expect(setCookie(true, false)).toBe(
+        "localhost-consent={%22necessary%22:true%2C%22analytical%22:true%2C%22targeting%22:false}; path=/; domain=.localhost; expires=Sun, 01 Jan 2023 00:00:00 GMT; sameSite=lax",
+    );
+});
+
+test("getConsentCookies as set in the setCookie test", () => {
+    expect(getConsentCookies()).toBe('{"necessary":true,"analytical":true,"targeting":false}');
+});

--- a/components/dashboard/src/consent-cookie.ts
+++ b/components/dashboard/src/consent-cookie.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import Cookies, { CookieAttributes } from "js-cookie";
+
+export const COOKIE_NAME = `${window.location.hostname}-consent`;
+
+export let cookieConsentDefaultValue = {
+    necessary: true,
+    analytical: false,
+    targeting: false,
+};
+
+export function cookieSettingOptions(domain: string): CookieAttributes {
+    return {
+        domain: `.${domain}`,
+        expires: 365,
+        path: "/",
+        secure: false,
+        sameSite: "lax",
+    };
+}
+
+export function setNonNecessaryValues(analyticalValue: boolean, targetingValue: boolean) {
+    return {
+        ...cookieConsentDefaultValue,
+        analytical: analyticalValue,
+        targeting: targetingValue,
+    };
+}
+
+export function serialize(value: any) {
+    const stringified = JSON.stringify(value);
+    const quotesRemoved = stringified.replace("%22", '"');
+    return quotesRemoved;
+}
+
+export function setCookie(analyticalValue: boolean, targetingValue: boolean) {
+    return Cookies.set(
+        COOKIE_NAME,
+        serialize(setNonNecessaryValues(analyticalValue, targetingValue)),
+        cookieSettingOptions(window.location.hostname),
+    );
+}
+
+export function getConsentCookies() {
+    return Cookies.get(COOKIE_NAME);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,10 +2859,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/js-cookie@^2.2.7":
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
-  integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
+"@types/js-cookie@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.1.tgz#04aa743e2e0a85a22ee9aa61f6591a8bc19b5d68"
+  integrity sha512-7wg/8gfHltklehP+oyJnZrz9XBuX5ZPP4zB6UsI84utdlkRYLnOm2HfpLXazTwZA+fpGn0ir8tGNgVnMEleBGQ==
 
 "@types/js-yaml@^3.10.1":
   version "3.12.7"


### PR DESCRIPTION
## Description
1. Shows a cookie consent banner
2. Allows seeing and modifying cookie settings. The modifications don't affect the Dashboard because we only use strictly necessary cookies. Non-necessary cookies affect the website, which will be implemented by @nisarhassan12. 

Set cookies[[1](https://www.notion.so/gitpod/a8f22878433e4c00a98dc5affe08f42d)][[2](https://www.notion.so/gitpod/Cookie-consent-banner-9dfcb9a50b3444c99c2d4cc1947a8f68#88e4c5e5e60149b0bee20bda2de1cfe7)]:
```
"gitpod-io-consent": {
    necessary: true,
    analytical: false,
    targeting: false
}
```

| BANNER | SETTINGS |
| - | - |
| <img width="869" alt="Screenshot 2022-04-13 at 15 03 38" src="https://user-images.githubusercontent.com/8015191/163186277-9f14bd23-6968-42d4-86d3-0057a9924737.png"> | <img width="553" alt="Screenshot 2022-04-20 at 16 25 20" src="https://user-images.githubusercontent.com/8015191/164254873-a8d36d7d-085c-48b0-ac51-4bbe627b05e6.png"> |


Follow-up task with @nisarhassan12:
- [ ] Create an identical file that contains the format of the cookie settings, to be kept in-sync by both website and app.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #8836 
Another implementation will be done on the website.

## How to test
Visit https://laushinka-96c11f76fa.staging.gitpod-dev.com/workspaces.
1. Check your cookies either by going to Application in the dev tools or by running `document.cookie` in the console.
2. If `gp-analytical` and `gp-targeting` are not set, the banner should show.
3. Modify settings or click the buttons and run `document.cookie` to see that they are set properly.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow users to accept or reject cookies, compliant with GDPR.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
