### PR TITLE
Make server githubApp.certSecretName configurable

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -59,7 +59,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			githubApp.LogLevel = cfg.WebApp.Server.GithubApp.LogLevel
 			githubApp.MarketplaceName = cfg.WebApp.Server.GithubApp.MarketplaceName
 			githubApp.WebhookSecret = cfg.WebApp.Server.GithubApp.WebhookSecret
-			githubApp.CertSecretname = cfg.WebApp.Server.GithubApp.CertSecretName
+			githubApp.CertSecretName = cfg.WebApp.Server.GithubApp.CertSecretName
 		}
 		return nil
 	})

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -59,6 +59,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			githubApp.LogLevel = cfg.WebApp.Server.GithubApp.LogLevel
 			githubApp.MarketplaceName = cfg.WebApp.Server.GithubApp.MarketplaceName
 			githubApp.WebhookSecret = cfg.WebApp.Server.GithubApp.WebhookSecret
+			githubApp.CertSecretname = cfg.WebApp.Server.GithubApp.CertSecretName
 		}
 		return nil
 	})

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -107,7 +107,7 @@ type GitHubApp struct {
 	CertPath        string `json:"certPath"`
 	MarketplaceName string `json:"marketplaceName"`
 	LogLevel        string `json:"logLevel"`
-	CertSecretname  string `json:"certSecretName"`
+	CertSecretName  string `json:"certSecretName"`
 }
 
 type Session struct {

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -107,6 +107,7 @@ type GitHubApp struct {
 	CertPath        string `json:"certPath"`
 	MarketplaceName string `json:"marketplaceName"`
 	LogLevel        string `json:"logLevel"`
+	CertSecretname  string `json:"certSecretName"`
 }
 
 type Session struct {


### PR DESCRIPTION
## Description

Allow the server config value `githubApp.certSecretName` to be configured via the installer config.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow up to #9297.

Part of the https://github.com/gitpod-io/gitpod/issues/9097 epic.

## How to test
Add an experimental section to the bottom of an installer config file like this:

```yaml
experimental:
  webapp:
    server:
      githubApp:
        appId: 123
        authProviderId: 'someAuthProviderId'
        baseUrl: 'someBaseUrl'
        certPath: 'someCertpath'
        enabled: true
        logLevel: 'someLogLevel'
        marketplaceName: 'someMarketPlacename'
        webhookSecret: 'somewebhookSecret'
        certSecretName: 'someCertSecretName'

```

and invoke this installer:

```
installer render --config /path/to/config --use-experimental-config
```

In the rendered installer output the `certSecretName` will be set in the `server-config` Configmap (`config.json` key).

## Release Notes

```
NONE
```

## Documentation

No changes needed.