### PR TITLE
[ws-daemon] Only limit storage device classes

### DIFF
--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-daemon/api"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
@@ -51,6 +52,7 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 		return nil, err
 	}
 
+	log.Warn("Creating plugin host")
 	cgroupPlugins, err := cgroup.NewPluginHost(config.CPULimit.CGroupBasePath,
 		&cgroup.CacheReclaim{},
 		&cgroup.FuseDeviceEnablerV1{},
@@ -70,6 +72,7 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 		return nil, xerrors.Errorf("cannot register cgroup plugin metrics: %w", err)
 	}
 
+	log.Warn("Adding cgroup plugins")
 	listener := []dispatch.Listener{
 		cpulimit.NewDispatchListener(&config.CPULimit, reg),
 		markUnmountFallback,


### PR DESCRIPTION
## Description

Some `io.stat` file can return more classes. We need to apply limits only to storage.

```
# cat /sys/fs/cgroup/kubepods/besteffort/pod7d34503e-d63c-427c-bcd9-5f339039d55e/612035c1d87101e7c51997fab8184d966c6b9da851196c622a305246d1397459/io.stat 
8:0 rbytes=19054592 wbytes=0 rios=1240 wios=0 dbytes=0 dios=0
259:2 rbytes=77824 wbytes=3719168 rios=8 wios=809 dbytes=0 dios=0
259:3 rbytes=167936 wbytes=6172672 rios=17 wios=1362 dbytes=0 dios=0
9:43 rbytes=245760 wbytes=9891840 rios=25 wios=2311 dbytes=0 dios=0
``` 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
[ws-daemon] Only limit storage device classes
```
