### PR TITLE
[registry-facade] remove supervisor from static layer

### DIFF
--- a/install/installer/pkg/components/registry-facade/configmap.go
+++ b/install/installer/pkg/components/registry-facade/configmap.go
@@ -71,10 +71,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			RequireAuth: false,
 			StaticLayer: []regfac.StaticLayerCfg{
 				{
-					Ref:  common.ImageName(ctx.Config.Repository, SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
-					Type: "image",
-				},
-				{
 					Ref:  common.ImageName(ctx.Config.Repository, WorkspacekitImage, ctx.VersionManifest.Components.Workspace.Workspacekit.Version),
 					Type: "image",
 				},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[registry-facade] remove supervisor from static layer
in https://github.com/gitpod-io/gitpod/pull/6628 we move supervisor to special `ImageSpec`, so this static layer is not use anymore, to avoid confusion and secondary overlays, this PR removes the supervisor from the static layer

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Start a workspace, check everything should be work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
