### PR TITLE
[baseserver] Add /ready and /live endpoints, with config

### DIFF
--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -7,6 +7,7 @@ package baseserver
 import (
 	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"time"
@@ -27,15 +28,18 @@ type config struct {
 
 	// metricsRegistry configures the metrics registry to use for exporting metrics. When not set, the default prometheus registry is used.
 	metricsRegistry *prometheus.Registry
+
+	healthHandler healthcheck.Handler
 }
 
 func defaultConfig() *config {
 	return &config{
-		logger:       log.New(),
-		hostname:     "localhost",
-		httpPort:     9000,
-		grpcPort:     9001,
-		closeTimeout: 5 * time.Second,
+		logger:        log.New(),
+		hostname:      "localhost",
+		httpPort:      9000,
+		grpcPort:      9001,
+		closeTimeout:  5 * time.Second,
+		healthHandler: healthcheck.NewHandler(),
 	}
 }
 
@@ -95,6 +99,17 @@ func WithMetricsRegistry(r *prometheus.Registry) Option {
 		}
 
 		cfg.metricsRegistry = r
+		return nil
+	}
+}
+
+func WithHealthHandler(handler healthcheck.Handler) Option {
+	return func(cfg *config) error {
+		if handler == nil {
+			return fmt.Errorf("nil healthcheck handler provided")
+		}
+
+		cfg.healthHandler = handler
 		return nil
 	}
 }

--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -6,6 +6,7 @@ package baseserver
 
 import (
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -19,6 +20,7 @@ func TestOptions(t *testing.T) {
 	timeout := 10 * time.Second
 	hostname := "another_hostname"
 	registry := prometheus.NewRegistry()
+	health := healthcheck.NewHandler()
 
 	var opts = []Option{
 		WithHostname(hostname),
@@ -27,6 +29,7 @@ func TestOptions(t *testing.T) {
 		WithLogger(logger),
 		WithCloseTimeout(timeout),
 		WithMetricsRegistry(registry),
+		WithHealthHandler(health),
 	}
 	cfg, err := evaluateOptions(defaultConfig(), opts...)
 	require.NoError(t, err)
@@ -38,6 +41,7 @@ func TestOptions(t *testing.T) {
 		httpPort:        httpPort,
 		closeTimeout:    timeout,
 		metricsRegistry: registry,
+		healthHandler:   health,
 	}, cfg)
 }
 

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -212,10 +212,8 @@ func (s *Server) initializeHTTP() error {
 
 func (s *Server) newHTTPMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	// TODO(milan): Use a ready/health package already used in ws-manager
-	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`ready`))
-	})
+	mux.HandleFunc("/ready", s.cfg.healthHandler.ReadyEndpoint)
+	mux.HandleFunc("/live", s.cfg.healthHandler.LiveEndpoint)
 
 	// Metrics endpoint
 	metricsHandler := promhttp.Handler()

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -24,14 +24,23 @@ func TestServer_StartStop(t *testing.T) {
 	require.NoError(t, srv.Close())
 }
 
-func TestServer_ServesReady(t *testing.T) {
-	srv := baseserver.NewForTests(t)
-	baseserver.StartServerForTests(t, srv)
+func TestServer_ServesHealthEndpoints(t *testing.T) {
+	for _, scenario := range []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "ready endpoint", endpoint: "/ready"},
+		{name: "live endpoint", endpoint: "/live"},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			srv := baseserver.NewForTests(t)
+			baseserver.StartServerForTests(t, srv)
 
-	readyURL := fmt.Sprintf("%s/ready", srv.HTTPAddress())
-	resp, err := http.Get(readyURL)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+			resp, err := http.Get(srv.HTTPAddress() + scenario.endpoint)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
 }
 
 func TestServer_ServesMetricsEndpointWithDefaultConfig(t *testing.T) {

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -9,10 +9,12 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
@@ -26,8 +28,6 @@ require (
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
 )
-
-require github.com/stretchr/testify v1.7.0
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -49,6 +49,7 @@ require (
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
+	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/components/common-go/go.sum
+++ b/components/common-go/go.sum
@@ -174,6 +174,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -597,6 +599,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -5,6 +5,8 @@ go 1.17
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/public-api v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.7.0
+	google.golang.org/grpc v1.45.0
 )
 
 require (
@@ -12,6 +14,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
@@ -19,12 +22,10 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
-	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -135,6 +135,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -475,6 +477,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Extends baseserver to out-of-the-box serve `/ready` and `/live` endpoints which are used by k8s to establish readiness and liveliness checks.

The change here also allows to provide a `healthcheck.Handler` to further extend the data returned from these endpoints.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229
* Depends on https://github.com/gitpod-io/gitpod/pull/9313

## How to test
<!-- Provide steps to test this PR -->
`cd components/common-go && go test ./...`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/uncc
/hold