### PR TITLE
Add WebApp to /components/common-go codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /.github/CODEOWNERS
 
 /components/blobserve @gitpod-io/engineering-workspace
-/components/common-go @gitpod-io/engineering-workspace
+/components/common-go @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp
 /components/content-service-api @csweichel @geropl
 /components/content-service @gitpod-io/engineering-workspace
 /components/dashboard @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As WebApp continues to do more work in Go (see https://github.com/gitpod-io/gitpod/issues/9229), requiring only workspace team approvals on changes to `common-go` (including dependencies) can put extra strain on the team. This change adds web-app as well so they can approve within their scope.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->
NONE

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE