### PR TITLE
Allow configuration of cross-cutting pod-level concerns to the installer

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -353,6 +353,19 @@ func RepoName(repo, name string) string {
 	return pref.String()
 }
 
+func Replicas(ctx *RenderContext, component string) *int32 {
+	replicas := int32(1)
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.PodConfig[component] != nil {
+			replicas = cfg.PodConfig[component].Replicas
+		}
+		return nil
+	})
+
+	return &replicas
+}
+
 func ImageName(repo, name, tag string) string {
 	ref := fmt.Sprintf("%s:%s", RepoName(repo, name), tag)
 	pref, err := reference.ParseNamed(ref)

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -173,8 +173,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -10,13 +10,23 @@
 // If you use any setting herein, you forfeit support from Gitpod.
 package experimental
 
-import "k8s.io/apimachinery/pkg/api/resource"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 // Config contains all experimental configuration.
 type Config struct {
-	Workspace *WorkspaceConfig `json:"workspace,omitempty"`
-	WebApp    *WebAppConfig    `json:"webapp,omitempty"`
-	IDE       *IDEConfig       `json:"ide,omitempty"`
+	Workspace *WorkspaceConfig      `json:"workspace,omitempty"`
+	WebApp    *WebAppConfig         `json:"webapp,omitempty"`
+	IDE       *IDEConfig            `json:"ide,omitempty"`
+	PodConfig map[string]*PodConfig `json:"podConfig,omitempty"`
+}
+
+type PodConfig struct {
+	Replicas  int32                       `json:"replicas"`
+	Affinity  corev1.Affinity             `json:"affinity"`
+	Resources corev1.ResourceRequirements `json:"resources"`
 }
 
 type WorkspaceConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we may need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR adds a way to configure cross-cutting pod-level concerns like number of replicas, pod affinity and resource requests/limits. The idea is to add a new top-level `experimental` config section called `podConfig`, under which components can configure these details. 

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/9097

## How to test

Add an experimental section to the bottom of an installer config file like this:

```yaml
experimental:
  podConfig:
    server:
      replicas: 3
```

and invoke this installer:

```
installer render --config /path/to/config --use-experimental-config
```

The `server` deployment should then have the specified number of replicas set:

```yaml
- apiVersion: apps/v1
  kind: Deployment
  metadata:
    creationTimestamp: null
    labels:
      app: gitpod
      component: server
    name: server
  spec:
    replicas: 3
    ...
```

If the `experimental` config section is removed, the number of replicas defaults back to 1.

## Release Notes

```release-note
Add ability to configure cross-cutting pod-level concerns like replicas to the installer.
```

## Documentation

No changes required as this is experimental configuration for deploying Gitpod SaaS, not intended to be used by self-hosted installations.