### PR TITLE
[public-api] Ensure no objects are rendered by installer without experimental config

### DIFF
--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -4,10 +4,8 @@
 package public_api_server
 
 import (
-	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -18,21 +16,6 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	var experimentalCfg *experimental.Config
-
-	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		experimentalCfg = ucfg
-		return nil
-	})
-
-	if experimentalCfg == nil || experimentalCfg.WebApp == nil || experimentalCfg.WebApp.PublicAPI == nil {
-		// We don't want to render anything for this deployment
-		return nil, nil
-	}
-
-	publicAPIConfig := experimentalCfg.WebApp.PublicAPI
-	log.Debug("Detected experimental.WebApp.PublicApi configuration", publicAPIConfig)
-
 	labels := common.DefaultLabels(Component)
 	return []runtime.Object{
 		&appsv1.Deployment{

--- a/install/installer/pkg/components/public-api-server/objects.go
+++ b/install/installer/pkg/components/public-api-server/objects.go
@@ -3,10 +3,38 @@
 
 package public_api_server
 
-import "github.com/gitpod-io/gitpod/installer/pkg/common"
-
-var Objects = common.CompositeRenderFunc(
-	deployment,
-	rolebinding,
-	common.DefaultServiceAccount(Component),
+import (
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
+	cfg := getExperimentalPublicAPIConfig(ctx)
+	if cfg == nil {
+		return nil, nil
+	}
+
+	log.Debug("Detected experimental.WebApp.PublicApi configuration", cfg)
+	return common.CompositeRenderFunc(
+		deployment,
+		rolebinding,
+		common.DefaultServiceAccount(Component),
+	)(ctx)
+}
+
+func getExperimentalPublicAPIConfig(ctx *common.RenderContext) *experimental.PublicAPIConfig {
+	var experimentalCfg *experimental.Config
+
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		experimentalCfg = ucfg
+		return nil
+	})
+
+	if experimentalCfg == nil || experimentalCfg.WebApp == nil || experimentalCfg.WebApp.PublicAPI == nil {
+		return nil
+	}
+
+	return experimentalCfg.WebApp.PublicAPI
+}

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestObjects_NotRenderedDefault(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test-namespace")
+	require.NoError(t, err)
+
+	objects, err := Objects(ctx)
+	require.NoError(t, err)
+	require.Empty(t, objects, "no objects should be rendered with default config")
+}
+
+func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				PublicAPI: &experimental.PublicAPIConfig{Enabled: true},
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			PublicAPIServer: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	objects, err := Objects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ensures that all config related to `public-api` is only rendered when the experimental config is specified. Currently, only the `deployment` resource is conditionally rendered but the ServiceAccount and RoleBinding still get rendered.

<details>
  <summary>Before</summary>
  
  ```yaml
---
# v1/ServiceAccount public-api-server
apiVersion: v1
automountServiceAccountToken: true
kind: ServiceAccount
metadata:
  creationTimestamp: null
  labels:
    app: gitpod
    component: public-api-server
  name: public-api-server
  namespace: default
---
# rbac.authorization.k8s.io/v1/RoleBinding public-api-server
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  creationTimestamp: null
  labels:
    app: gitpod
    component: public-api-server
  name: public-api-server
  namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: default-ns-psp:restricted-root-user
subjects:
- kind: ServiceAccount
  name: public-api-server
---
  ```
</details>

With this change, this config above is not rendered.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
1. `cd install/installer`
2. Generate config with `go run main.go init > installer.yaml`
3. Edit the config and set domain anything non-empty
4. Fetch versions `docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:main.2872" cat versions.yaml > versions.yaml`
5. Extend the config from step 2. to add 
```yaml
experimental:
  webapp:
    publicApi:
      enabled: true
```
6. Run 
```bash
export LOG_LEVEL=debug
go run main.go render --config "./installer.yaml" --use-experimental-config --debug-version-file versions.yaml
```
7. Search the file for `public-api` and see no occurences


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/hold