### PR TITLE
[ws-daemon] Improve cgroup plugin activation count

### DIFF
--- a/components/ws-daemon/pkg/cgroup/cgroup.go
+++ b/components/ws-daemon/pkg/cgroup/cgroup.go
@@ -92,7 +92,7 @@ func (host *PluginHost) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspa
 		go func(plg Plugin) {
 			err := plg.Apply(ctx, host.CGroupBasePath, cgroupPath)
 			if err == context.Canceled || err == context.DeadlineExceeded {
-				return
+				err = nil
 			}
 			if err != nil {
 				log.WithError(err).WithFields(ws.OWI()).WithField("plugin", plg.Name()).Error("cgroup plugin failure")


### PR DESCRIPTION
## Description
Improves the counting of cgroup plugin activation, specifically the IO limiter.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
