### PR TITLE
[ws-daemon] Remove warning when cpu.stat does not exist

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -6,6 +6,8 @@ package cpulimit
 
 import (
 	"bufio"
+	"errors"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -123,6 +125,10 @@ func (basePath CgroupV1CFSController) readCpuUsage() (time.Duration, error) {
 func (basePath CgroupV1CFSController) NrThrottled() (uint64, error) {
 	f, err := os.Open(filepath.Join(string(basePath), "cpu.stat"))
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+
 		return 0, xerrors.Errorf("cannot read cpu.stat: %w", err)
 	}
 	defer f.Close()

--- a/components/ws-daemon/pkg/cpulimit/cfs_v2.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs_v2.go
@@ -6,6 +6,8 @@ package cpulimit
 
 import (
 	"bufio"
+	"errors"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -104,6 +106,10 @@ func (basePath CgroupV2CFSController) readParentQuota() time.Duration {
 func (basePath CgroupV2CFSController) getFlatKeyedValue(key string) (int64, error) {
 	stats, err := os.Open(filepath.Join(string(basePath), "cpu.stat"))
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+
 		return 0, xerrors.Errorf("cannot read cpu.stat: %w", err)
 	}
 	defer stats.Close()


### PR DESCRIPTION
## Description

The output of the warning pollutes the log.

## Release Notes
```release-note
[ws-daemon] Remove warning when cpu.stat does not exist
```
