### PR TITLE
[server] Use image-builder from workspace cluster

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -99,6 +99,7 @@ import { ReferrerPrefixParser } from "./workspace/referrer-prefix-context-parser
 import { InstallationAdminTelemetryDataProvider } from "./installation-admin/telemetry-data-provider";
 import { IDEService } from "./ide-service";
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
+import { WorkspaceClusterImagebuilderClientProvider } from "./workspace/workspace-cluster-imagebuilder-client-provider";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -162,7 +163,8 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
         return { address: config.imageBuilderAddr };
     });
     bind(CachingImageBuilderClientProvider).toSelf().inSingletonScope();
-    bind(ImageBuilderClientProvider).toService(CachingImageBuilderClientProvider);
+    bind(WorkspaceClusterImagebuilderClientProvider).toSelf().inSingletonScope();
+    bind(ImageBuilderClientProvider).toService(WorkspaceClusterImagebuilderClientProvider);
     bind(ImageBuilderClientCallMetrics).toService(IClientCallMetrics);
 
     /* The binding order of the context parser does not configure preference/a working order. Each context parser must be able

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1562,7 +1562,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
             log.warn(logCtx, "imageBuild logs: fallback!");
             ctx.span?.setTag("workspace.imageBuild.logs.fallback", true);
-            await this.deprecatedDoWatchWorkspaceImageBuildLogs(ctx, logCtx, workspace);
+            await this.deprecatedDoWatchWorkspaceImageBuildLogs(ctx, logCtx, user, workspace);
             return;
         }
 
@@ -1611,6 +1611,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     protected async deprecatedDoWatchWorkspaceImageBuildLogs(
         ctx: TraceContext,
         logCtx: LogContext,
+        user: User,
         workspace: Workspace,
     ) {
         if (!workspace.imageNameResolved) {
@@ -1619,7 +1620,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
 
         try {
-            const imgbuilder = this.imageBuilderClientProvider.getDefault();
+            const imgbuilder = await this.imageBuilderClientProvider.getDefault(
+                user,
+                workspace,
+                {} as WorkspaceInstance,
+            );
             const req = new LogsRequest();
             req.setCensored(true);
             req.setBuildRef(workspace.imageNameResolved);

--- a/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
+++ b/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
+import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import {
+    ImageBuilderClient,
+    ImageBuilderClientCallMetrics,
+    ImageBuilderClientProvider,
+    PromisifiedImageBuilderClient,
+} from "@gitpod/image-builder/lib";
+import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+import {
+    WorkspaceManagerClientProviderCompositeSource,
+    WorkspaceManagerClientProviderSource,
+} from "@gitpod/ws-manager/lib/client-provider-source";
+import { ExtendedUser } from "@gitpod/ws-manager/lib/constraints";
+import { inject, injectable, optional } from "inversify";
+
+@injectable()
+export class WorkspaceClusterImagebuilderClientProvider implements ImageBuilderClientProvider {
+    @inject(WorkspaceManagerClientProviderCompositeSource)
+    protected readonly source: WorkspaceManagerClientProviderSource;
+    @inject(WorkspaceManagerClientProvider) protected readonly clientProvider: WorkspaceManagerClientProvider;
+    @inject(ImageBuilderClientCallMetrics) @optional() protected readonly clientCallMetrics: IClientCallMetrics;
+
+    // gRPC connections can be used concurrently, even across services.
+    // Thus it makes sense to cache them rather than create a new connection for each request.
+    protected readonly connectionCache = new Map<string, ImageBuilderClient>();
+
+    async getDefault(
+        user: ExtendedUser,
+        workspace: Workspace,
+        instance: WorkspaceInstance,
+    ): Promise<PromisifiedImageBuilderClient> {
+        const clusters = await this.clientProvider.getStartClusterSets(user, workspace, instance);
+        for await (let cluster of clusters) {
+            const info = await this.source.getWorkspaceCluster(cluster.installation);
+            if (!info) {
+                continue;
+            }
+
+            var client = this.connectionCache.get(info.name);
+            if (!client) {
+                client = this.clientProvider.createConnection(ImageBuilderClient, info, defaultGRPCOptions);
+                this.connectionCache.set(info.name, client);
+            }
+            return new PromisifiedImageBuilderClient(client, []);
+        }
+
+        throw new Error("no image-builder available");
+    }
+}

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -249,7 +249,11 @@ export class WorkspaceStarter {
                 auth.setTotal(allowAll);
                 req.setAuth(auth);
 
-                const client = this.imagebuilderClientProvider.getDefault();
+                const client = await this.imagebuilderClientProvider.getDefault(
+                    user,
+                    workspace,
+                    {} as WorkspaceInstance,
+                );
                 const res = await client.resolveBaseImage({ span }, req);
                 workspace.imageSource = <WorkspaceImageSourceReference>{
                     baseImageResolved: res.getRef(),
@@ -902,7 +906,7 @@ export class WorkspaceStarter {
     ): Promise<boolean> {
         const span = TraceContext.startSpan("needsImageBuild", ctx);
         try {
-            const client = this.imagebuilderClientProvider.getDefault();
+            const client = await this.imagebuilderClientProvider.getDefault(user, workspace, instance);
             const { src, auth, disposable } = await this.prepareBuildRequest(
                 { span },
                 workspace,
@@ -942,7 +946,7 @@ export class WorkspaceStarter {
 
         try {
             // Start build...
-            const client = this.imagebuilderClientProvider.getDefault();
+            const client = await this.imagebuilderClientProvider.getDefault(user, workspace, instance);
             const { src, auth, disposable } = await this.prepareBuildRequest(
                 { span },
                 workspace,

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -4,26 +4,33 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/content-service/lib/client-call-metrics";
+import {
+    createClientCallMetricsInterceptor,
+    IClientCallMetrics,
+} from "@gitpod/content-service/lib/client-call-metrics";
 import { Disposable, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
-import { defaultGRPCOptions } from '@gitpod/gitpod-protocol/lib/util/grpc';
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
-import { WorkspaceClusterWoTLS, WorkspaceManagerConnectionInfo } from '@gitpod/gitpod-protocol/lib/workspace-cluster';
+import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { WorkspaceClusterWoTLS, WorkspaceManagerConnectionInfo } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import * as grpc from "@grpc/grpc-js";
-import { inject, injectable, optional } from 'inversify';
-import { WorkspaceManagerClientProviderCompositeSource, WorkspaceManagerClientProviderSource } from "./client-provider-source";
+import { inject, injectable, optional } from "inversify";
+import {
+    WorkspaceManagerClientProviderCompositeSource,
+    WorkspaceManagerClientProviderSource,
+} from "./client-provider-source";
 import { ExtendedUser, workspaceClusterSetsAuthorized } from "./constraints";
-import { WorkspaceManagerClient } from './core_grpc_pb';
+import { WorkspaceManagerClient } from "./core_grpc_pb";
 import { linearBackoffStrategy, PromisifiedWorkspaceManagerClient } from "./promisified-client";
 
-export const IWorkspaceManagerClientCallMetrics = Symbol('IWorkspaceManagerClientCallMetrics')
+export const IWorkspaceManagerClientCallMetrics = Symbol("IWorkspaceManagerClientCallMetrics");
 
 @injectable()
 export class WorkspaceManagerClientProvider implements Disposable {
     @inject(WorkspaceManagerClientProviderCompositeSource)
     protected readonly source: WorkspaceManagerClientProviderSource;
 
-    @inject(IWorkspaceManagerClientCallMetrics) @optional()
+    @inject(IWorkspaceManagerClientCallMetrics)
+    @optional()
     protected readonly clientCallMetrics: IClientCallMetrics;
 
     // gRPC connections maintain their connectivity themselves, i.e. they reconnect when neccesary.
@@ -41,17 +48,23 @@ export class WorkspaceManagerClientProvider implements Disposable {
      * @param instance the instance we want to start
      * @returns a set of workspace clusters we can start the workspace in
      */
-    public async getStartClusterSets(user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): Promise<IWorkspaceClusterStartSet> {
+    public async getStartClusterSets(
+        user: ExtendedUser,
+        workspace: Workspace,
+        instance: WorkspaceInstance,
+    ): Promise<IWorkspaceClusterStartSet> {
         const allClusters = await this.source.getAllWorkspaceClusters();
-        const availableClusters = allClusters.filter(c => c.score > 0 && c.state === "available");
+        const availableClusters = allClusters.filter((c) => c.score > 0 && c.state === "available");
 
-        const sets = workspaceClusterSetsAuthorized.map(constraints => {
-            const r = constraints.constraint(availableClusters, user, workspace, instance);
-            if (!r) {
-                return;
-            }
-            return new ClusterSet(this, r);
-        }).filter(s => s !== undefined) as ClusterSet[];
+        const sets = workspaceClusterSetsAuthorized
+            .map((constraints) => {
+                const r = constraints.constraint(availableClusters, user, workspace, instance);
+                if (!r) {
+                    return;
+                }
+                return new ClusterSet(this, r);
+            })
+            .filter((s) => s !== undefined) as ClusterSet[];
 
         return {
             [Symbol.asyncIterator]: (): AsyncIterator<ClusterClientEntry> => {
@@ -59,7 +72,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
                     next: async (): Promise<IteratorResult<ClusterClientEntry>> => {
                         while (true) {
                             if (sets.length === 0) {
-                                return {done: true, value: undefined};
+                                return { done: true, value: undefined };
                             }
 
                             let res = await sets[0].next();
@@ -70,10 +83,10 @@ export class WorkspaceManagerClientProvider implements Disposable {
 
                             return res;
                         }
-                    }
-                }
-            }
-        }
+                    },
+                };
+            },
+        };
     }
 
     /**
@@ -92,7 +105,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
         let client = this.connectionCache.get(name);
         if (!client) {
             const info = await getConnectionInfo();
-            client = client = this.createConnection(WorkspaceManagerClient, info, grpcOptions);
+            client = this.createConnection(WorkspaceManagerClient, info, grpcOptions);
             this.connectionCache.set(name, client);
         } else if (client.getChannel().getConnectivityState(true) != grpc.connectivityState.READY) {
             client.close();
@@ -105,11 +118,16 @@ export class WorkspaceManagerClientProvider implements Disposable {
 
         let interceptor: grpc.Interceptor[] = [];
         if (this.clientCallMetrics) {
-            interceptor = [ createClientCallMetricsInterceptor(this.clientCallMetrics) ];
+            interceptor = [createClientCallMetricsInterceptor(this.clientCallMetrics)];
         }
 
         const stopSignal = { stop: false };
-        return new PromisifiedWorkspaceManagerClient(client, linearBackoffStrategy(30, 1000, stopSignal), interceptor, stopSignal);
+        return new PromisifiedWorkspaceManagerClient(
+            client,
+            linearBackoffStrategy(30, 1000, stopSignal),
+            interceptor,
+            stopSignal,
+        );
     }
 
     /**
@@ -119,10 +137,14 @@ export class WorkspaceManagerClientProvider implements Disposable {
         return this.source.getAllWorkspaceClusters();
     }
 
-    public createConnection<T extends grpc.Client>(creator: { new(address: string, credentials: grpc.ChannelCredentials, options?: grpc.ClientOptions): T }, info: WorkspaceManagerConnectionInfo, grpcOptions?: object): T {
+    public createConnection<T extends grpc.Client>(
+        creator: { new (address: string, credentials: grpc.ChannelCredentials, options?: grpc.ClientOptions): T },
+        info: WorkspaceManagerConnectionInfo,
+        grpcOptions?: object,
+    ): T {
         const options: Partial<grpc.ClientOptions> = {
             ...grpcOptions,
-            'grpc.ssl_target_name_override': "ws-manager",  // this makes sure we can call ws-manager with a URL different to "ws-manager"
+            "grpc.ssl_target_name_override": "ws-manager", // this makes sure we can call ws-manager with a URL different to "ws-manager"
         };
 
         let credentials: grpc.ChannelCredentials;
@@ -140,27 +162,33 @@ export class WorkspaceManagerClientProvider implements Disposable {
     }
 
     public dispose() {
-        Array.from(this.connectionCache.values()).map(c => c.close());
+        Array.from(this.connectionCache.values()).map((c) => c.close());
     }
 }
 
 export interface IWorkspaceClusterStartSet extends AsyncIterable<ClusterClientEntry> {}
 
-export interface ClusterClientEntry { manager: PromisifiedWorkspaceManagerClient, installation: string }
+export interface ClusterClientEntry {
+    manager: PromisifiedWorkspaceManagerClient;
+    installation: string;
+}
 
 /**
  * ClusterSet is an iterator
  */
 class ClusterSet implements AsyncIterator<ClusterClientEntry> {
     protected usedCluster: string[] = [];
-    constructor(protected readonly provider: WorkspaceManagerClientProvider, protected readonly cluster: WorkspaceClusterWoTLS[]) {}
+    constructor(
+        protected readonly provider: WorkspaceManagerClientProvider,
+        protected readonly cluster: WorkspaceClusterWoTLS[],
+    ) {}
 
     public async next(): Promise<IteratorResult<ClusterClientEntry>> {
-        const available = this.cluster.filter(c => !this.usedCluster.includes(c.name));
+        const available = this.cluster.filter((c) => !this.usedCluster.includes(c.name));
         const chosenCluster = chooseCluster(available);
         if (!chosenCluster) {
             // empty set
-            return {done: true, value: undefined };
+            return { done: true, value: undefined };
         }
         this.usedCluster.push(chosenCluster.name);
 
@@ -173,7 +201,7 @@ class ClusterSet implements AsyncIterator<ClusterClientEntry> {
             value: {
                 manager: client,
                 installation: chosenCluster.name,
-            }
+            },
         };
     }
 }
@@ -185,7 +213,7 @@ class ClusterSet implements AsyncIterator<ClusterClientEntry> {
  */
 function chooseCluster(availableCluster: WorkspaceClusterWoTLS[]): WorkspaceClusterWoTLS {
     const scoreFunc = (c: WorkspaceClusterWoTLS): number => {
-        let score = c.score;    // here is the point where we may want to implement non-static approaches
+        let score = c.score; // here is the point where we may want to implement non-static approaches
 
         // clamp to maxScore
         if (score > c.maxScore) {
@@ -194,14 +222,12 @@ function chooseCluster(availableCluster: WorkspaceClusterWoTLS[]): WorkspaceClus
         return score;
     };
 
-    const scoreSum = availableCluster
-        .map(scoreFunc)
-        .reduce((sum, cScore) => cScore + sum, 0);
-    const pNormalized = availableCluster.map(c => scoreFunc(c) / scoreSum);
+    const scoreSum = availableCluster.map(scoreFunc).reduce((sum, cScore) => cScore + sum, 0);
+    const pNormalized = availableCluster.map((c) => scoreFunc(c) / scoreSum);
     const p = Math.random();
     let pSummed = 0;
     for (let i = 0; i < availableCluster.length; i++) {
-        pSummed += pNormalized[i]
+        pSummed += pNormalized[i];
         if (p <= pSummed) {
             return availableCluster[i];
         }

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -34,7 +34,7 @@ import {
     UpdateResponse,
     AdmissionConstraint as GRPCAdmissionConstraint,
 } from "@gitpod/ws-manager-bridge-api/lib";
-import { GetWorkspacesRequest } from "@gitpod/ws-manager/lib";
+import { GetWorkspacesRequest, WorkspaceManagerClient } from "@gitpod/ws-manager/lib";
 import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import {
     WorkspaceManagerClientProviderCompositeSource,
@@ -151,7 +151,7 @@ export class ClusterService implements IClusterServiceServer {
 
                 // try to connect to validate the config. Throws an exception if it fails.
                 await new Promise<void>((resolve, reject) => {
-                    const c = this.clientProvider.createClient(newCluster);
+                    const c = this.clientProvider.createConnection(WorkspaceManagerClient, newCluster);
                     c.getWorkspaces(new GetWorkspacesRequest(), (err: any) => {
                         if (err) {
                             reject(


### PR DESCRIPTION
## Description
This PR makes server use the image builder from workspace cluster.

**Note: ** merge and deploy this only once #9335 is merged, deployed and running.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9248

## How to test
Start a workspace which requires an image-build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use image-builder from workspace cluster
```

 - [x] /werft run with-vm=true