### PR TITLE
[content-service] Deprecate KUBE_STAGE/Stage, and replace it with bucketPrefix

### DIFF
--- a/.werft/jobs/build/helm/values.dev.yaml
+++ b/.werft/jobs/build/helm/values.dev.yaml
@@ -38,7 +38,6 @@ components:
   server:
     replicas: 1
     makeNewUsersAdmin: true # for development
-    theiaPluginsBucketNameOverride: gitpod-core-dev-plugins
     enableLocalApp: true
     oauthServer:
       enabled: true

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -92,10 +92,6 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       touch /tmp/"$NAME"overrides.yaml
       yq r k8s.yaml -d "$documentIndex" data | yq prefix - data > /tmp/"$NAME"overrides.yaml
 
-      THEIA_BUCKET_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml components.server.theiaPluginsBucketNameOverride)
-      THEIA_BUCKET_NAME_EXPR="s/\"theiaPluginsBucketNameOverride\": \"\"/\"theiaPluginsBucketNameOverride\": \"$THEIA_BUCKET_NAME\"/"
-      sed -i "$THEIA_BUCKET_NAME_EXPR" /tmp/"$NAME"overrides.yaml
-
       DEV_BRANCH_EXPR="s/\"devBranch\": \"\"/\"devBranch\": \"$DEV_BRANCH\"/"
       sed -i "$DEV_BRANCH_EXPR" /tmp/"$NAME"overrides.yaml
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -178,8 +178,8 @@ env:
   value: "https://{{ $gp.hostname }}"
 - name: GITPOD_REGION
   value: {{ $gp.installation.region | quote }}
-- name: GITPOD_INSTALLATION_LONGNAME
-  value: {{ template "gitpod.installation.longname" . }}
+- name: GITPOD_INSTALLATION_SHORTNAME
+  value: {{ template "gitpod.installation.shortname" . }}
 - name: LOG_LEVEL
   value: {{ template "gitpod.loglevel" . }}
 {{- end -}}

--- a/chart/templates/server-configmap.yaml
+++ b/chart/templates/server-configmap.yaml
@@ -19,7 +19,6 @@ data:
         "version": "{{ .Values.version }}",
         "hostUrl": "https://{{ .Values.hostname }}",
         "installationShortname": "{{ template "gitpod.installation.shortname" $this }}",
-        "stage": "{{ .Values.installation.stage }}",
 {{- if .Values.devBranch }}
         "devBranch": "{{ .Values.devBranch }}",
 {{- end }}

--- a/chart/templates/server-configmap.yaml
+++ b/chart/templates/server-configmap.yaml
@@ -44,9 +44,6 @@ data:
         "incrementalPrebuilds": {{ $comp.incrementalPrebuilds | toJson }},
         "blockNewUsers": {{ $comp.blockNewUsers | toJson }},
         "makeNewUsersAdmin": {{ $comp.makeNewUsersAdmin }},
-{{- if $comp.theiaPluginsBucketNameOverride }}
-        "theiaPluginsBucketNameOverride": "{{ $comp.theiaPluginsBucketNameOverride }}",
-{{- end }}
         "defaultBaseImageRegistryWhitelist": {{ $comp.defaultBaseImageRegistryWhitelist | toJson }},
         "runDbDeleter": {{ $comp.runDbDeleter }},
         "oauthServer": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -306,7 +306,6 @@ components:
     maxEnvvarPerUserCount: 4048
     maxConcurrentPrebuildsPerRef: 10
     makeNewUsersAdmin: false
-    theiaPluginsBucketNameOverride: null
     oauthServer:
       enabled: false
     rateLimiter:

--- a/components/content-service-api/go/config/config.go
+++ b/components/content-service-api/go/config/config.go
@@ -17,9 +17,6 @@ import (
 
 // StorageConfig configures the remote storage we use
 type StorageConfig struct {
-	// Stage represents the deployment environment in which we're operating
-	Stage Stage `json:"stage"`
-
 	// Kind determines the type of storage we ought to use
 	Kind RemoteStorageType `json:"kind"`
 
@@ -99,6 +96,8 @@ type GCPConfig struct {
 	ParallelUpload  int    `json:"parallelUpload"`
 
 	MaximumBackupCount int `json:"maximumBackupCount"`
+	// BucketPrefix is an optional prefix that's prepended to all bucket names
+	BucketPrefix string `json:"bucketPrefix,omitempty"`
 }
 
 // MinIOConfig MinIOconfigures the MinIO remote storage backend

--- a/components/content-service/pkg/service/headless-log-service_test.go
+++ b/components/content-service/pkg/service/headless-log-service_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestListLogs(t *testing.T) {
 	cfg := config.StorageConfig{
-		Stage: config.StageProduction,
 		Kind:  config.GCloudStorage, // dummy, mocked away
 		BackupTrail: struct {
 			Enabled   bool "json:\"enabled\""

--- a/components/content-service/pkg/storage/gcloud_test.go
+++ b/components/content-service/pkg/storage/gcloud_test.go
@@ -11,7 +11,6 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/gitpod-io/gitpod/content-service/api/config"
 	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
 )
 
@@ -19,7 +18,6 @@ func TestObjectAccessToNonExistentObj(t *testing.T) {
 	storage := objDoesNotExistGCloudStorage{
 		Delegate: &DirectGCPStorage{
 			WorkspaceName: "foobar",
-			Stage:         config.StageDevStaging,
 		},
 	}
 	var mappings []archive.IDMapping

--- a/components/content-service/pkg/storage/storage.go
+++ b/components/content-service/pkg/storage/storage.go
@@ -239,14 +239,9 @@ const (
 
 // NewDirectAccess provides direct access to a storage system
 func NewDirectAccess(c *config.StorageConfig) (DirectAccess, error) {
-	stage := c.GetStage()
-	if stage == "" {
-		return nil, xerrors.Errorf("missing storage stage")
-	}
-
 	switch c.Kind {
 	case config.GCloudStorage:
-		return newDirectGCPAccess(c.GCloudConfig, stage)
+		return newDirectGCPAccess(c.GCloudConfig)
 	case config.MinIOStorage:
 		return newDirectMinIOAccess(c.MinIOConfig)
 	default:
@@ -256,14 +251,9 @@ func NewDirectAccess(c *config.StorageConfig) (DirectAccess, error) {
 
 // NewPresignedAccess provides presigned URLs to access a storage system
 func NewPresignedAccess(c *config.StorageConfig) (PresignedAccess, error) {
-	stage := c.GetStage()
-	if stage == "" {
-		return nil, xerrors.Errorf("missing storage stage")
-	}
-
 	switch c.Kind {
 	case config.GCloudStorage:
-		return newPresignedGCPAccess(c.GCloudConfig, stage)
+		return newPresignedGCPAccess(c.GCloudConfig)
 	case config.MinIOStorage:
 		return newPresignedMinIOAccess(c.MinIOConfig)
 	default:

--- a/components/gitpod-protocol/src/env.ts
+++ b/components/gitpod-protocol/src/env.ts
@@ -6,28 +6,9 @@
 
 import { injectable } from "inversify";
 
-const legacyStagenameTranslation: { [key: string]: KubeStage } = {
-    production: "production",
-    staging: "prodcopy",
-    devstaging: "dev",
-    dev: "dev",
-};
-
-export function translateLegacyStagename(kubeStage: string): KubeStage {
-    const stage = legacyStagenameTranslation[kubeStage];
-    if (!stage) {
-        throw new Error(`Invalid KUBE_STAGE: ${kubeStage}`);
-    }
-
-    return stage;
-}
-
 @injectable()
 export abstract class AbstractComponentEnv {
-    readonly kubeStage: KubeStage = getEnvVarParsed("KUBE_STAGE", translateLegacyStagename);
 }
-
-export type KubeStage = "production" | "prodcopy" | "staging" | "dev";
 
 export function getEnvVar(name: string, defaultValue?: string): string {
     const value = process.env[name] || defaultValue;

--- a/components/gitpod-protocol/src/env.ts
+++ b/components/gitpod-protocol/src/env.ts
@@ -25,8 +25,6 @@ export function translateLegacyStagename(kubeStage: string): KubeStage {
 @injectable()
 export abstract class AbstractComponentEnv {
     readonly kubeStage: KubeStage = getEnvVarParsed("KUBE_STAGE", translateLegacyStagename);
-
-    readonly installationLongname: string = getEnvVar("GITPOD_INSTALLATION_LONGNAME");
 }
 
 export type KubeStage = "production" | "prodcopy" | "staging" | "dev";

--- a/components/gitpod-protocol/src/util/logging.ts
+++ b/components/gitpod-protocol/src/util/logging.ts
@@ -315,7 +315,6 @@ function makeLogItem(
         component,
         severity,
         time: new Date().toISOString(),
-        environment: process.env.KUBE_STAGE,
         context,
         message,
         error,

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -92,7 +92,7 @@
 }
 
 (debug_headers) {
-	header X-Gitpod-Region {$GITPOD_INSTALLATION_LONGNAME}
+	header X-Gitpod-Region {$GITPOD_REGION}.{$GITPOD_INSTALLATION_SHORTNAME}
 }
 
 (workspace_transport) {

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -15,11 +15,10 @@ import { ChargebeeProviderOptions, readOptionsFromFile } from "@gitpod/gitpod-pa
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { log, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { filePathTelepresenceAware, KubeStage, translateLegacyStagename } from "@gitpod/gitpod-protocol/lib/env";
+import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 
 export const Config = Symbol("Config");
 export type Config = Omit<ConfigSerialized, "hostUrl" | "chargebeeProviderOptionsFile"> & {
-    stage: KubeStage;
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
     chargebeeProviderOptions?: ChargebeeProviderOptions;
@@ -50,7 +49,6 @@ export interface ConfigSerialized {
     version: string;
     hostUrl: string;
     installationShortname: string;
-    stage: string;
     devBranch?: string;
     insecureNoDomain: boolean;
     logLevel: LogrusLogLevel;
@@ -112,9 +110,6 @@ export interface ConfigSerialized {
     };
 
     makeNewUsersAdmin: boolean;
-
-    /** this value - if present - overrides the default naming scheme for the GCloud bucket that Theia Plugins are stored in */
-    theiaPluginsBucketNameOverride?: string;
 
     /** defaultBaseImageRegistryWhitelist is the list of registryies users get acces to by default */
     defaultBaseImageRegistryWhitelist: string[];
@@ -209,7 +204,6 @@ export namespace ConfigFile {
         }
         return {
             ...config,
-            stage: translateLegacyStagename(config.stage),
             hostUrl,
             authProviderConfigs,
             builtinAuthProvidersConfigured,

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -154,14 +154,6 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
             // CORS allows subdomains to access gitpod.io)
             const verifyCSRF = (origin: string) => {
                 let allowedRequest = isAllowedWebsocketDomain(origin, this.config.hostUrl.url.hostname);
-                if (this.config.stage === "prodcopy" || this.config.stage === "staging") {
-                    // On staging and devstaging, we want to allow Theia to be able to connect to the server from this magic port
-                    // This enables debugging Theia from inside Gitpod
-                    const url = new URL(origin);
-                    if (url.hostname.startsWith("13444-")) {
-                        allowedRequest = true;
-                    }
-                }
                 if (!allowedRequest && this.config.insecureNoDomain) {
                     log.warn("Websocket connection CSRF guard disabled");
                     allowedRequest = true;

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -50,7 +50,6 @@ func DefaultEnv(cfg *config.Config) []corev1.EnvVar {
 
 	return []corev1.EnvVar{
 		{Name: "GITPOD_DOMAIN", Value: cfg.Domain},
-		{Name: "GITPOD_INSTALLATION_LONGNAME", Value: cfg.Domain},  // todo(sje): figure out these values
 		{Name: "GITPOD_INSTALLATION_SHORTNAME", Value: cfg.Domain}, // todo(sje): figure out these values
 		{Name: "GITPOD_REGION", Value: cfg.Metadata.Region},
 		{Name: "HOST_URL", Value: "https://" + cfg.Domain},

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -69,7 +69,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Version:               ctx.VersionManifest.Version,
 		HostURL:               fmt.Sprintf("https://%s", ctx.Config.Domain),
 		InstallationShortname: ctx.Config.Metadata.InstallationShortname,
-		Stage:                 "production", // todo(sje): is this needed?
 		LicenseFile:           license,
 		WorkspaceHeartbeat: WorkspaceHeartbeat{
 			IntervalSeconds: 60,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -16,7 +16,6 @@ type ConfigSerialized struct {
 	Version                           string   `json:"version"`
 	HostURL                           string   `json:"hostUrl"`
 	InstallationShortname             string   `json:"installationShortname"`
-	Stage                             string   `json:"stage"`
 	DevBranch                         string   `json:"devBranch"`
 	InsecureNoDomain                  bool     `json:"insecureNoDomain"`
 	License                           string   `json:"license"`

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -27,7 +27,6 @@ type ConfigSerialized struct {
 	MaxEnvvarPerUserCount             int32    `json:"maxEnvvarPerUserCount"`
 	MaxConcurrentPrebuildsPerRef      int32    `json:"maxConcurrentPrebuildsPerRef"`
 	MakeNewUsersAdmin                 bool     `json:"makeNewUsersAdmin"`
-	TheiaPluginsBucketNameOverride    string   `json:"theiaPluginsBucketNameOverride"`
 	DefaultBaseImageRegistryWhitelist []string `json:"defaultBaseImageRegistryWhitelist"`
 	RunDbDeleter                      bool     `json:"runDbDeleter"`
 	ContentServiceAddr                string   `json:"contentServiceAddr"`

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -153,6 +153,8 @@ type ObjectStorageS3 struct {
 type ObjectStorageCloudStorage struct {
 	ServiceAccount ObjectRef `json:"serviceAccount" validate:"required"`
 	Project        string    `json:"project" validate:"required"`
+	// BucketPrefix is an optional prefix that's prepended to all bucket names
+	BucketPrefix   string    `json:"bucketPrefix,omitempty"`
 }
 
 type ObjectStorageAzure struct {


### PR DESCRIPTION
## Description
Based on: https://github.com/gitpod-io/gitpod/pull/9333
ToDo:
 - test
 - think about and discuss Self-Hosted implications
 - make adjacent ops changes (use it for prod/staging)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
