### PR TITLE
Revert "[registry-facade] remove supervisor from static layer"

### DIFF
--- a/install/installer/pkg/components/registry-facade/configmap.go
+++ b/install/installer/pkg/components/registry-facade/configmap.go
@@ -71,6 +71,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			RequireAuth: false,
 			StaticLayer: []regfac.StaticLayerCfg{
 				{
+					Ref:  common.ImageName(ctx.Config.Repository, SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
+					Type: "image",
+				},
+				{
 					Ref:  common.ImageName(ctx.Config.Repository, WorkspacekitImage, ctx.VersionManifest.Components.Workspace.Workspacekit.Version),
 					Type: "image",
 				},


### PR DESCRIPTION
Reverts gitpod-io/gitpod#9315

@csweichel @iQQBot 
imagebuild pod now fails with:
`"cmd":"/.supervisor/supervisor","error":"no such file or directory","level":"error","message":"cannot exec","ring":2`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```