### PR TITLE
[ws-proxy] fix ACME challenge handler

### DIFF
--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -49,6 +49,9 @@ func HostBasedRouter(header, wsHostSuffix string, wsHostSuffixRegex string) Work
 			allClusterWsHostSuffixRegex = wsHostSuffix
 		}
 
+		// make sure acme router is the first handler setup to make sure it has a chance to catch acme challenge
+		setupAcmeRouter(r)
+
 		var (
 			getHostHeader = func(req *http.Request) string {
 				host := req.Header.Get(header)
@@ -63,8 +66,6 @@ func HostBasedRouter(header, wsHostSuffix string, wsHostSuffixRegex string) Work
 			portRouter      = r.MatcherFunc(matchWorkspaceHostHeader(wsHostSuffix, getHostHeader, true)).Subrouter()
 			ideRouter       = r.MatcherFunc(matchWorkspaceHostHeader(allClusterWsHostSuffixRegex, getHostHeader, false)).Subrouter()
 		)
-
-		setupAcmeRouter(r)
 
 		r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			hostname := getHostHeader(req)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes ACME challenge catcher not always working.
Making sure that ACME handler is the first one added, as handlers are processed in the order they are added.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1831

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-proxy] Do not allow ACME challenge to be processed by workspaces to ensure no one can register TLS for gitpod.io through letsencrypt
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
