### PR TITLE
[docker-up] Add docker-compose binary

### DIFF
--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -40,6 +40,9 @@ packages:
         - ["rm", "-r", "components-docker-up--bin-docker-up"]
         - ["mv", "components-docker-up--bin-runc-facade/docker-up", "runc-facade"]
         - ["rm", "-r", "components-docker-up--bin-runc-facade"]
+        # Override docker-compose with custom version https://github.com/aledbf/compose/pull/1
+        - ["curl", "-sSL", "https://github.com/aledbf/compose/releases/download/v2.4.1.1-gitpod/docker-compose-linux-x86_64", "-o", "docker-compose"]
+        - ["chmod", "+x", "docker-compose"]
   - name: docker
     type: docker
     deps:

--- a/components/docker-up/leeway.Dockerfile
+++ b/components/docker-up/leeway.Dockerfile
@@ -5,6 +5,8 @@
 FROM scratch
 
 LABEL skip-n.registry-facade.gitpod.io="1"
-WORKDIR /usr/bin
 
+WORKDIR /usr/bin
 COPY components-docker-up--app/* ./
+
+COPY components-docker-up--app/docker-compose /usr/local/bin/docker-compose


### PR DESCRIPTION
## Description

Use registry-facade to use a custom `docker-compose` binary that set a custom MTU value, aligning the value with the default one from `ceth0`

## How to test
- Use any project that uses docker-compose, like https://github.com/gitpod-io/template-docker-compose/tree/aledbf/main
- After the workspace starts, check the MTU value of the network interfaces, it should be equal to `ceth0`.
- Run 
```
docker run -it debian:11 bash -c \
  "apt update && apt install -y curl && while true;do 
    curl -s -o /dev/null -w '%{http_code}\n' https://www.drupal.org/;sleep 1;
  done"
```
(without the change it hangs after some requests)

- Running `docker-compose --version` should return `Docker Compose version v2.4.1.1-gitpod`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[docker-up] Add docker-compose binary
```

xref: https://github.com/aledbf/compose/pull/1