### PR TITLE
[public-api] Extend k8s definitions with a service

### DIFF
--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -5,7 +5,13 @@
 package public_api_server
 
 const (
-	Component     = "public-api-server"
-	ContainerPort = 9000
-	PortName      = "http"
+	Component = "public-api-server"
+
+	HTTPPortName      = "http"
+	HTTPContainerPort = 9000
+	HTTPServicePort   = 9000
+
+	GRPCPortName      = "grpc"
+	GRPCContainerPort = 9001
+	GRPCServicePort   = 9001
 )

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -52,10 +52,16 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 									"memory": resource.MustParse("32Mi"),
 								},
 							},
-							Ports: []corev1.ContainerPort{{
-								ContainerPort: ContainerPort,
-								Name:          PortName,
-							}},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: HTTPContainerPort,
+									Name:          HTTPPortName,
+								},
+								{
+									ContainerPort: GRPCContainerPort,
+									Name:          GRPCPortName,
+								},
+							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 							},
@@ -66,7 +72,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path:   "/",
-										Port:   intstr.IntOrString{IntVal: ContainerPort},
+										Port:   intstr.IntOrString{IntVal: HTTPContainerPort},
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},

--- a/install/installer/pkg/components/public-api-server/objects.go
+++ b/install/installer/pkg/components/public-api-server/objects.go
@@ -21,6 +21,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		deployment,
 		rolebinding,
 		common.DefaultServiceAccount(Component),
+		service,
 	)(ctx)
 }
 

--- a/install/installer/pkg/components/public-api-server/service.go
+++ b/install/installer/pkg/components/public-api-server/service.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.GenerateService(Component, map[string]common.ServicePort{
+		HTTPPortName: {
+			ContainerPort: HTTPContainerPort,
+			ServicePort:   HTTPServicePort,
+		},
+		GRPCPortName: {
+			ContainerPort: GRPCContainerPort,
+			ServicePort:   GRPCServicePort,
+		},
+	})(ctx)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add a k8s service for existing `public-api` deployment. This will allow the service to be exposed in the Caddy proxy config such that we can route traffic to the deployment (accessible, but still unused), only in preview builds for now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229
* Depends on https://github.com/gitpod-io/gitpod/pull/9324/files

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace from this branch
2. List k8s services with `kubectl get service` and observe `public-api-service`
3. Hit the service:
```bash
kubectl exec mysql-0 -it -- /bin/bash

$ curl http://public-api-server:9000
hello world\n

```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/hold