### PR TITLE
[public-api] Route api.<domain> to public api service & deployment

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -262,6 +262,11 @@ https://{$GITPOD_DOMAIN} {
 	}
 }
 
+# public-api
+https://api.{$GITPOD_DOMAIN} {
+    reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9000
+}
+
 # workspaces
 https://*.*.{$GITPOD_DOMAIN} {
 	import enable_log

--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -22,6 +22,10 @@ func main() {
 		logger.WithError(err).Fatal("Failed to initialize public api server.")
 	}
 
+	if err := register(srv); err != nil {
+		logger.WithError(err).Fatal("Failed to register services.")
+	}
+
 	if listenErr := srv.ListenAndServe(); listenErr != nil {
 		logger.WithError(listenErr).Fatal("Failed to serve public api server")
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/9362
* Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
Navigate to preview build. Prepend `api.` to the URL and you should see `hello world`

https://api.mp-papi-caddy.staging.gitpod-dev.com

In prod, we haven't configured the DNS record to point to our loadbalancer so it won't work, yet. This is fine, we can iterate in preview for now.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE


/hold