### PR TITLE
Automatically block users that are running blacklisted workloads

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -315,6 +315,7 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
     werft.done(installerSlices.DEPLOYMENT_WAITING);
 
     await addDNSRecord(werft, deploymentConfig.namespace, deploymentConfig.domain, !withVM, installer.options.kubeconfigPath)
+    addAgentSmithToken(werft, deploymentConfig.namespace, installer.options.kubeconfigPath)
 
     // TODO: Fix sweeper, it does not appear to be doing clean-up
     werft.log('sweeper', 'installing Sweeper');
@@ -718,4 +719,11 @@ function getCoreDevIngressIP(): string {
 
 function metaEnv(_parent?: ExecOptions): ExecOptions {
     return env("", _parent);
+}
+
+function addAgentSmithToken(werft: Werft, namespace: string, kubeconfigPath: string) {
+    process.env.KUBECONFIG = kubeconfigPath
+    setKubectlContextNamespace(namespace, {})
+    exec("leeway run components:add-gitpod-token")
+    delete process.env.KUBECONFIG
 }

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -33,6 +33,7 @@ export type InstallerOptions = {
     withVM: boolean
     workspaceFeatureFlags: string[]
     gitpodDaemonsetPorts: GitpodDaemonsetPorts
+    smithToken: string
 }
 
 export class Installer {
@@ -206,7 +207,7 @@ export class Installer {
         const nodepoolIndex = getNodePoolIndex(this.options.deploymentNamespace);
         const flags = this.options.withVM ? "WITH_VM=true " : ""
 
-        exec(`${flags}./.werft/jobs/build/installer/post-process.sh ${this.options.gitpodDaemonsetPorts.registryFacade} ${this.options.gitpodDaemonsetPorts.wsDaemon} ${nodepoolIndex} ${this.options.previewName}`, { slice: slice });
+        exec(`${flags}./.werft/jobs/build/installer/post-process.sh ${this.options.gitpodDaemonsetPorts.registryFacade} ${this.options.gitpodDaemonsetPorts.wsDaemon} ${nodepoolIndex} ${this.options.previewName} ${this.options.smithToken}`, { slice: slice });
     }
 
     install(slice: string): void {

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -13,8 +13,9 @@ REG_DAEMON_PORT=$1
 WS_DAEMON_PORT=$2
 NODE_POOL_INDEX=$3
 DEV_BRANCH=$4
-if [[ -z ${REG_DAEMON_PORT} ]] || [[ -z ${WS_DAEMON_PORT} ]] || [[ -z ${NODE_POOL_INDEX} ]] || [[ -z ${DEV_BRANCH} ]]; then
-   echo "One or more input params were invalid: ${REG_DAEMON_PORT} ${WS_DAEMON_PORT} ${NODE_POOL_INDEX} ${DEV_BRANCH}"
+SMITH_TOKEN=$5
+if [[ -z ${REG_DAEMON_PORT} ]] || [[ -z ${WS_DAEMON_PORT} ]] || [[ -z ${NODE_POOL_INDEX} ]] || [[ -z ${DEV_BRANCH} ]] || [[ -z ${SMITH_TOKEN} ]]; then
+   echo "One or more input params were invalid: ${REG_DAEMON_PORT} ${WS_DAEMON_PORT} ${NODE_POOL_INDEX} ${DEV_BRANCH} ${SMITH_TOKEN}"
    exit 1
 else
    echo "Running with the following params: ${REG_DAEMON_PORT} ${WS_DAEMON_PORT} ${NODE_POOL_INDEX} ${DEV_BRANCH}"
@@ -310,7 +311,7 @@ while [ "$documentIndex" -le "$DOCS" ]; do
 
       # replace gitpod token
       yq r /tmp/"$NAME"-"$KIND"-overrides.yaml 'data.[config.json]' \
-      | jq ".gitpodAPI.apiToken = \"365a017134b9579e9bff9b0c8bf5be6afb916211f2393493d06cd9320000c96\"" > /tmp/"$NAME"-"$KIND"-overrides.json
+      | jq ".gitpodAPI.apiToken = \"$SMITH_TOKEN\"" > /tmp/"$NAME"-"$KIND"-overrides.json
 
       # create override file
       touch /tmp/"$NAME"-"$KIND"-data-overrides.yaml

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -247,7 +247,7 @@ scripts:
       fi
       kill $PID || true
 
-  - name: add-gitpod-token
+  - name: add-smith-token
     deps:
       - components/service-waiter:app
     script: |
@@ -263,10 +263,10 @@ scripts:
         exit 1
       fi
 
-      query="insert into d_b_user(id,name,creationDate,rolesOrPermissions,additionalData) values('buildin-user-agent-smith-0000000', 'agent-smith', DATE_FORMAT(NOW(3), '%Y-%m-%dT%T.%fZ'),'[\"admin\"]','{\"emailNotificationSettings\": {\"allowsChangelogMail\": false, \"allowsOnboardingMail\": true}}') on duplicate key update id=id;"
+      query="insert into d_b_user(id,name,creationDate,rolesOrPermissions,additionalData) values('builtin-user-agent-smith-0000000', 'agent-smith', DATE_FORMAT(NOW(3), '%Y-%m-%dT%T.%fZ'),'[\"admin\"]','{\"emailNotificationSettings\": {\"allowsChangelogMail\": false, \"allowsOnboardingMail\": true}}') on duplicate key update id=id;"
       mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
 
-      query="insert into d_b_gitpod_token(tokenHash,name,type,userId,scopes,created,deleted) VALUES('7569b65274b76c74af40fc5141aa8a63b1334e8ffe520bc920a4518d4ca6577c','agent-smith',0,'buildin-user-agent-smith-0000000','function:adminBlockUser', '2021-03-16T10:28:57.608Z', false) on duplicate key update tokenHash=tokenHash;"
+      query="insert into d_b_gitpod_token(tokenHash,name,type,userId,scopes,created,deleted) VALUES('$TOKEN','agent-smith',0,'builtin-user-agent-smith-0000000','function:adminBlockUser', '2021-03-16T10:28:57.608Z', false) on duplicate key update tokenHash=tokenHash;"
       mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
 
       kill $PID || true

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -246,3 +246,27 @@ scripts:
         mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
       fi
       kill $PID || true
+
+  - name: add-gitpod-token
+    deps:
+      - components/service-waiter:app
+    script: |
+      echo "$"
+      export DB_USERNAME=$(kubectl get secrets mysql -o jsonpath="{.data.username}" | base64 -d)
+      export DB_PASSWORD=$(kubectl get secrets mysql -o jsonpath="{.data.password}" | base64 -d)
+      kubectl port-forward statefulset/mysql 3306 &
+      PID=$!
+      service-waiter database -t 20s
+      if [ $? -ne 0 ]; then
+        echo "could not connect to DB"
+        kill $PID || true
+        exit 1
+      fi
+
+      query="insert into d_b_user(id,name,creationDate,rolesOrPermissions,additionalData) values('buildin-user-agent-smith-0000000', 'agent-smith', DATE_FORMAT(NOW(3), '%Y-%m-%dT%T.%fZ'),'[\"admin\"]','{\"emailNotificationSettings\": {\"allowsChangelogMail\": false, \"allowsOnboardingMail\": true}}') on duplicate key update id=id;"
+      mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
+
+      query="insert into d_b_gitpod_token(tokenHash,name,type,userId,scopes,created,deleted) VALUES('7569b65274b76c74af40fc5141aa8a63b1334e8ffe520bc920a4518d4ca6577c','agent-smith',0,'buildin-user-agent-smith-0000000','function:adminBlockUser', '2021-03-16T10:28:57.608Z', false) on duplicate key update tokenHash=tokenHash;"
+      mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
+
+      kill $PID || true

--- a/components/ee/agent-smith/cmd/run.go
+++ b/components/ee/agent-smith/cmd/run.go
@@ -79,10 +79,10 @@ var runCmd = &cobra.Command{
 					err = nil
 
 					if i.Kind.Severity() == common.SeverityAudit {
-						err = notifySlack(cfg.SlackWebhooks.Audit, cfg.HostURL, violation, penalties)
+						err = notifySlack(cfg.SlackWebhooks.Audit, cfg.Config.GitpodAPI.HostURL, violation, penalties)
 						break
 					} else if i.Kind.Severity() != common.SeverityBarely {
-						err = notifySlack(cfg.SlackWebhooks.Warning, cfg.HostURL, violation, penalties)
+						err = notifySlack(cfg.SlackWebhooks.Warning, cfg.Config.GitpodAPI.HostURL, violation, penalties)
 						break
 					}
 				}

--- a/components/ee/agent-smith/config-schema.json
+++ b/components/ee/agent-smith/config-schema.json
@@ -58,12 +58,6 @@
         },
         "systemMemoryLimitMib": {
           "type": "integer"
-        },
-        "hostURL": {
-          "type": "string"
-        },
-        "gitpodAPIToken": {
-          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/components/ee/agent-smith/pkg/agent/actions.go
+++ b/components/ee/agent-smith/pkg/agent/actions.go
@@ -41,6 +41,12 @@ func (agent *Smith) blockUser(ownerID string) error {
 		return xerrors.Errorf("not connected to Gitpod API")
 	}
 
+	if len(ownerID) == 0 {
+		return xerrors.Errorf("cannot block user as user id is empty")
+	}
+
+	log.Infof("Blocking user %s", ownerID)
+
 	req := protocol.AdminBlockUserRequest{
 		UserID:    ownerID,
 		IsBlocked: true,

--- a/components/ee/agent-smith/pkg/config/config.go
+++ b/components/ee/agent-smith/pkg/config/config.go
@@ -56,9 +56,6 @@ type ServiceConfig struct {
 	// We have had memory leak issues with agent smith in the past due to experimental gRPC use.
 	// This upper limit causes agent smith to stop itself should it go above this limit.
 	MaxSysMemMib uint64 `json:"systemMemoryLimitMib,omitempty"`
-
-	HostURL        string `json:"hostURL,omitempty"`
-	GitpodAPIToken string `json:"gitpodAPIToken,omitempty"`
 }
 
 type Enforcement struct {

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -28,7 +28,13 @@ import {
 import { inject, injectable, postConstruct } from "inversify";
 import { EntityManager, Repository } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
-import { BUILTIN_WORKSPACE_PROBE_USER_ID, MaybeUser, PartialUserUpdate, UserDB } from "../user-db";
+import {
+    BUILTIN_WORKSPACE_PROBE_USER_ID,
+    BUILTIN_WORKSPACE_USER_AGENT_SMITH,
+    MaybeUser,
+    PartialUserUpdate,
+    UserDB,
+} from "../user-db";
 import { DBGitpodToken } from "./entity/db-gitpod-token";
 import { DBIdentity } from "./entity/db-identity";
 import { DBTokenEntry } from "./entity/db-token-entry";
@@ -356,7 +362,7 @@ export class TypeORMUserDBImpl implements UserDB {
             WHERE markedDeleted != true`;
         if (excludeBuiltinUsers) {
             query = `${query}
-                AND id <> '${BUILTIN_WORKSPACE_PROBE_USER_ID}'`;
+                AND id NOT IN ('${BUILTIN_WORKSPACE_PROBE_USER_ID}', '${BUILTIN_WORKSPACE_USER_AGENT_SMITH}')`;
         }
         const res = await userRepo.query(query);
         const count = res[0].cnt;

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -143,6 +143,8 @@ export type PartialUserUpdate = Partial<Omit<User, "identities">> & Pick<User, "
 
 export const BUILTIN_WORKSPACE_PROBE_USER_ID = "builtin-user-workspace-probe-0000000";
 
+export const BUILTIN_WORKSPACE_USER_AGENT_SMITH = "buildin-user-agent-smith-0000000";
+
 export interface OwnerAndRepo {
     owner: string;
     repo: string;

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -143,7 +143,7 @@ export type PartialUserUpdate = Partial<Omit<User, "identities">> & Pick<User, "
 
 export const BUILTIN_WORKSPACE_PROBE_USER_ID = "builtin-user-workspace-probe-0000000";
 
-export const BUILTIN_WORKSPACE_USER_AGENT_SMITH = "buildin-user-agent-smith-0000000";
+export const BUILTIN_WORKSPACE_USER_AGENT_SMITH = "builtin-user-agent-smith-0000000";
 
 export interface OwnerAndRepo {
     owner: string;

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -614,6 +614,7 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 	result := []corev1.EnvVar{}
 	result = append(result, corev1.EnvVar{Name: "GITPOD_REPO_ROOT", Value: getWorkspaceRelativePath(repoRoot)})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_CLI_APITOKEN", Value: startContext.CLIAPIKey})
+	result = append(result, corev1.EnvVar{Name: "GITPOD_OWNER_ID", Value: startContext.Request.Metadata.Owner})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_ID", Value: startContext.Request.Metadata.MetaId})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_INSTANCE_ID", Value: startContext.Request.Id})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_THEIA_PORT", Value: strconv.Itoa(int(startContext.IDEPort))})

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
@@ -88,6 +88,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -77,6 +77,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -71,6 +71,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -88,6 +88,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -88,6 +88,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -77,6 +77,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -88,6 +88,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -76,6 +76,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -88,6 +88,10 @@
                             "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
                         },
                         {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
                             "name": "GITPOD_WORKSPACE_ID",
                             "value": "foobar"
                         },

--- a/install/installer/pkg/components/agent-smith/configmap.go
+++ b/install/installer/pkg/components/agent-smith/configmap.go
@@ -24,7 +24,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	ascfg := config.ServiceConfig{
 		PProfAddr:      fmt.Sprintf("localhost:%d", PProfPort),
 		PrometheusAddr: fmt.Sprintf("localhost:%d", PrometheusPort),
-		HostURL:        fmt.Sprintf("https://%s", ctx.Config.Domain),
 		Config: config.Config{
 			Blocklists: &config.Blocklists{
 				Very: &config.PerLevelBlocklist{
@@ -49,6 +48,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 			Kubernetes: config.Kubernetes{Enabled: true},
+			GitpodAPI: config.GitpodAPI{
+				HostURL: fmt.Sprintf("https://%s", ctx.Config.Domain),
+			},
 		},
 	}
 


### PR DESCRIPTION
## Description
Users that are running workloads listed in the **very** category will be blocked by agent-smith. This PR also adds support for testing blocking users in preview environments by adding a token and a user for agent-smith (only in preview environments). Before testing had to be done against gitpod.io.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [#483](https://github.com/gitpod-io/ops/issues/483)
https://github.com/gitpod-io/ops/pull/1863
https://github.com/gitpod-io/ops/pull/1862

## How to test
- Open workspace
- Run watch date (I have added watch to the list of banned executables in this preview environment)
-> Your workspace should be stopped after a few seconds and your account should have been blocked (in the preview environment, your gitpod.io account should not be affected)

## Notes for reviewers 
- Web App has been added as reviewer because I had to exclude one additional user (the new agent-smith user) from user count, otherwise the first actual user in the preview environment will not have the admin role.

## Release Notes
```release-note
Automatically block users that are running blacklisted workloads
```