### PR TITLE
Update OpenSSH to v9.0

### DIFF
--- a/components/supervisor/openssh/leeway.Dockerfile
+++ b/components/supervisor/openssh/leeway.Dockerfile
@@ -22,7 +22,7 @@
 # This Dockerfile was taken from https://github.com/ep76/docker-openssh-static and adapted.
 FROM alpine:3.15 AS builder
 
-ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_8_8_P1.tar.gz
+ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_0_P1.tar.gz
 
 WORKDIR /build
 
@@ -57,7 +57,7 @@ RUN ./configure \
 COPY supervisorenv.patch .
 ENV aports=https://raw.githubusercontent.com/alpinelinux/aports/master/main/openssh
 RUN curl -fsSL \
-    "${aports}/{fix-utmp,fix-verify-dns-segfault,sftp-interactive}.patch" \
+    "${aports}/{avoid-redefined-warnings-when-building-with-utmps,disable-forwarding-by-default,fix-utmp,fix-verify-dns-segfault,gss-serv.c,sftp-interactive}.patch" \
     | patch -p1
 RUN cat supervisorenv.patch | patch -p1
 RUN make install-nosysconf exec_prefix=/openssh


### PR DESCRIPTION
## Description

Update [OpenSSH to v9.0](https://www.openssh.com/txt/release-9.0) that includes several improvements in sftp and key exchange method 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update OpenSSH to v9.0
```
