### PR TITLE
[server] disallow deauthorization if account is blocked

### DIFF
--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -151,7 +151,7 @@ export class Authenticator {
 
     async deauthorize(req: express.Request, res: express.Response, next: express.NextFunction) {
         const user = req.user;
-        if (!req.isAuthenticated() || !User.is(user)) {
+        if (!req.isAuthenticated() || !User.is(user) || user.blocked) {
             log.info({ sessionId: req.sessionID }, `User is not authenticated.`);
             res.redirect(this.getSorryUrl(`Not authenticated. Please login.`));
             return;
@@ -191,7 +191,7 @@ export class Authenticator {
             return;
         }
         const user = req.user;
-        if (!req.isAuthenticated() || !User.is(user)) {
+        if (!req.isAuthenticated() || !User.is(user) || user.blocked) {
             log.info({ sessionId: req.sessionID }, `User is not authenticated.`, { "authorize-flow": true });
             res.redirect(this.getSorryUrl(`Not authenticated. Please login.`));
             return;

--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -151,7 +151,7 @@ export class Authenticator {
 
     async deauthorize(req: express.Request, res: express.Response, next: express.NextFunction) {
         const user = req.user;
-        if (!req.isAuthenticated() || !User.is(user) || user.blocked) {
+        if (!req.isAuthenticated() || !User.is(user)) {
             log.info({ sessionId: req.sessionID }, `User is not authenticated.`);
             res.redirect(this.getSorryUrl(`Not authenticated. Please login.`));
             return;
@@ -191,7 +191,7 @@ export class Authenticator {
             return;
         }
         const user = req.user;
-        if (!req.isAuthenticated() || !User.is(user) || user.blocked) {
+        if (!req.isAuthenticated() || !User.is(user)) {
             log.info({ sessionId: req.sessionID }, `User is not authenticated.`, { "authorize-flow": true });
             res.redirect(this.getSorryUrl(`Not authenticated. Please login.`));
             return;

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -140,12 +140,20 @@ export class UserController {
                 res.sendStatus(401);
                 return;
             }
+            if (req.user.blocked) {
+                res.sendStatus(403);
+                return;
+            }
             this.ensureSafeReturnToParam(req);
             this.authenticator.authorize(req, res, next).catch((err) => log.error("authenticator.authorize", err));
         });
         router.get("/deauthorize", (req: express.Request, res: express.Response, next: express.NextFunction) => {
             if (!User.is(req.user)) {
                 res.sendStatus(401);
+                return;
+            }
+            if (req.user.blocked) {
+                res.sendStatus(403);
                 return;
             }
             this.ensureSafeReturnToParam(req);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -525,7 +525,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     public async deleteAccount(ctx: TraceContext): Promise<void> {
-        const user = this.checkUser("deleteAccount");
+        const user = this.checkAndBlockUser("deleteAccount");
         await this.guardAccess({ kind: "user", subject: user! }, "delete");
 
         await this.userDeletionService.deleteUser(user.id);
@@ -574,7 +574,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { workspaceId });
         traceWI(ctx, { workspaceId });
 
-        this.checkUser("getOwnerToken");
+        this.checkAndBlockUser("getOwnerToken");
 
         const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);
         if (!workspace) {
@@ -905,7 +905,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { workspaceId });
         traceWI(ctx, { workspaceId });
 
-        this.checkUser("getWorkspaceUsers", undefined, { workspaceId });
+        this.checkAndBlockUser("getWorkspaceUsers", undefined, { workspaceId });
 
         const workspace = await this.internalGetWorkspace(workspaceId, this.workspaceDb.trace(ctx));
         await this.guardAccess({ kind: "workspace", subject: workspace }, "get");
@@ -1220,7 +1220,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<void> {}
 
     public async getFeaturedRepositories(ctx: TraceContext): Promise<WhitelistedRepository[]> {
-        const user = this.checkUser("getFeaturedRepositories");
+        const user = this.checkAndBlockUser("getFeaturedRepositories");
         const repositories = await this.workspaceDb.trace(ctx).getFeaturedRepositories();
         if (repositories.length === 0) return [];
 
@@ -1255,7 +1255,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     public async getSuggestedContextURLs(ctx: TraceContext): Promise<string[]> {
-        const user = this.checkUser("getSuggestedContextURLs");
+        const user = this.checkAndBlockUser("getSuggestedContextURLs");
         const suggestions: Array<{ url: string; lastUse?: string }> = [];
         const logCtx: LogContext = { userId: user.id };
 
@@ -1386,7 +1386,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { workspaceId });
         traceWI(ctx, { workspaceId });
 
-        this.checkUser("getOpenPorts");
+        this.checkAndBlockUser("getOpenPorts");
 
         const instance = await this.workspaceDb.trace(ctx).findRunningInstance(workspaceId);
         const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);


### PR DESCRIPTION
## Description
Note: This is already deployed in prod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
