### PR TITLE
[code] Build stable image for 1.66.2

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: e7430877d63066eb812360b3ec2b82f1fae9d558
+  codeCommit: 4342b6bfa3e8cd7c206b57b21c4b0b7755222c3f
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2021.3.4.tar.gz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update code to 1.66.2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/9020

Upstream changes are just fixes for [vscode dektop on windows](https://github.com/microsoft/vscode/milestone/186?closed=1), so no need to do full smoke test
Relevant changes in our fork is https://github.com/gitpod-io/openvscode-server/commit/4342b6bfa3e8cd7c206b57b21c4b0b7755222c3f

## How to test
<!-- Provide steps to test this PR -->

- Switch to VS Code Insiders in settings.
- Start a workspace.
- Check that you can install extensions sucessfully both manually and automatically extensions from `gitpod.yml`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

