### PR TITLE
[code] Update stable to 1.66.2

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -358,7 +358,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-54b4098031a1a3a600c1fd73d070c4aab27e1cd8"
+      stableVersion: "commit-c89358b24c9577d1fd986d57387f3847f7dfb06f"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-54b4098031a1a3a600c1fd73d070c4aab27e1cd8" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-c89358b24c9577d1fd986d57387f3847f7dfb06f" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates stable VS Code Web to 1.66.2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/9020

## How to test
<!-- Provide steps to test this PR -->
- Select vscode stable in dashboard settings
- Start a workspace.
- Use about dialog to check that version is 1.66.2

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update code to 1.66.2
```
