### PR TITLE
[ws-daemon] fix typo in cpulimiter

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/cpulimit.go
+++ b/components/ws-daemon/pkg/cpulimit/cpulimit.go
@@ -188,7 +188,7 @@ func (d *Distributor) Tick(dt time.Duration) (DistributorDebug, error) {
 		var burst bool
 		if totalBandwidth < d.TotalBandwidth && ws.Throttled() {
 			limiter := d.BurstLimiter
-			if w := wsidx[id]; w.BaseLimit > 0 {
+			if w := wsidx[id]; w.BurstLimit > 0 {
 				limiter = FixedLimiter(w.BurstLimit)
 			}
 			limit = limiter.Limit(ws.Usage())


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes a potential typo in https://github.com/gitpod-io/gitpod/pull/8459

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
