### PR TITLE
[server] Stop signup for blocklisted email domains

### DIFF
--- a/components/gitpod-db/src/email-domain-filter-db.ts
+++ b/components/gitpod-db/src/email-domain-filter-db.ts
@@ -10,5 +10,9 @@ export const EmailDomainFilterDB = Symbol("EmailDomainFilterDB");
 export interface EmailDomainFilterDB {
     storeFilterEntry(entry: EmailDomainFilterEntry): Promise<void>;
 
+    /**
+     * @param emailDomain
+     * @returns false iff this emailDomain is meant to be blocked, aka "filtered out from the list"
+     */
     filter(emailDomain: string): Promise<boolean>;
 }

--- a/components/server/ee/src/auth/email-domain-service.ts
+++ b/components/server/ee/src/auth/email-domain-service.ts
@@ -25,7 +25,7 @@ export class EMailDomainServiceImpl implements EMailDomainService {
 
     async isBlocked(email: string): Promise<boolean> {
         const { domain } = this.parseMail(email);
-        return !this.domainFilterDb.filter(domain);
+        return !(await this.domainFilterDb.filter(domain));
     }
 
     async hasEducationalInstitutionSuffix(email: string): Promise<boolean> {

--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -34,6 +34,7 @@ export async function trackSignup(user: User, request: Request, analytics: IAnal
         properties: {
             auth_provider: user.identities[0].authProviderId,
             qualified: !!request.cookies["gitpod-marketing-website-visited"],
+            blocked: user.blocked,
         },
     });
 }

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -575,7 +575,9 @@ export class UserController {
             await this.userService.updateUserIdentity(user, additionalIdentity, additionalToken);
         }
 
-        // const { isBlocked } = tosFlowInfo; // todo@alex: this setting is in conflict with the env var
+        if (user.blocked) {
+            log.warn({ user: user.id }, "user blocked on signup");
+        }
 
         await this.userService.updateUserEnvVarsOnLogin(user, envVars);
         await this.userService.acceptCurrentTerms(user);
@@ -592,6 +594,7 @@ export class UserController {
         newUser.name = authUser.authName;
         newUser.fullName = authUser.name || undefined;
         newUser.avatarUrl = authUser.avatarUrl;
+        newUser.blocked = tosFlowInfo.isBlocked;
     }
 
     protected getSorryUrl(message: string) {

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -594,7 +594,7 @@ export class UserController {
         newUser.name = authUser.authName;
         newUser.fullName = authUser.name || undefined;
         newUser.avatarUrl = authUser.avatarUrl;
-        newUser.blocked = tosFlowInfo.isBlocked;
+        newUser.blocked = newUser.blocked || tosFlowInfo.isBlocked;
     }
 
     protected getSorryUrl(message: string) {

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -5,7 +5,17 @@
  */
 
 import { injectable, inject } from "inversify";
-import { User, Identity, WorkspaceTimeoutDuration, UserEnvVarValue, Token, WORKSPACE_TIMEOUT_DEFAULT_SHORT, WORKSPACE_TIMEOUT_DEFAULT_LONG, WORKSPACE_TIMEOUT_EXTENDED, WORKSPACE_TIMEOUT_EXTENDED_ALT } from "@gitpod/gitpod-protocol";
+import {
+    User,
+    Identity,
+    WorkspaceTimeoutDuration,
+    UserEnvVarValue,
+    Token,
+    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
+    WORKSPACE_TIMEOUT_DEFAULT_LONG,
+    WORKSPACE_TIMEOUT_EXTENDED,
+    WORKSPACE_TIMEOUT_EXTENDED_ALT,
+} from "@gitpod/gitpod-protocol";
 import { TermsAcceptanceDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
@@ -142,7 +152,8 @@ export class UserService {
                 this.config.blockNewUsers.passlist.some((e) => mail.endsWith(`@${e}`));
             const canPass = newUser.identities.some((i) => !!i.primaryEmail && emailDomainInPasslist(i.primaryEmail));
 
-            newUser.blocked = !canPass;
+            // blocked = if user already blocked OR is not allowed to pass
+            newUser.blocked = newUser.blocked || !canPass;
         }
         if (!newUser.blocked && (isFirstUser || this.config.makeNewUsersAdmin)) {
             newUser.rolesOrPermissions = ["admin"];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6285 

## How to test
 - try to log-in to https://gpl-6285-edomains.staging.gitpod-dev.com/workspaces with gitpod.io user
 - see that you are being blocked:
![image](https://user-images.githubusercontent.com/32448529/163869580-3b98566c-5cc2-4025-8d66-ae03f2af39fd.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
re-enables blocklisting of email domains
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
