### PR TITLE
Fix the shell error

### DIFF
--- a/scripts/setup-google-adc.sh
+++ b/scripts/setup-google-adc.sh
@@ -13,7 +13,7 @@ GCLOUD_ADC_PATH="/home/gitpod/.config/gcloud/application_default_credentials.jso
 if [ ! -f "$GCLOUD_ADC_PATH" ]; then
     if [ -z "$GCP_ADC_FILE" ]; then
         echo "GCP_ADC_FILE not set, doing nothing."
-        return;
+        exit 0
     fi
     echo "$GCP_ADC_FILE" > "$GCLOUD_ADC_PATH"
     #echo "Set GOOGLE_APPLICATION_CREDENTIALS value based on contents from GCP_ADC_FILE"


### PR DESCRIPTION
## Description
Fix the shell outputs
```
return: can only `return' from a function or sourced script
```

## Related Issue(s)
N/A

## How to test
1. Manually move the `/home/gitpod/.config/gcloud/application_default_credentials.json` to `/home/gitpod/.config/gcloud/application_default_credentials.json.bak`
2. Unset the environment variable `GCP_ADC_FILE`
   ```shell
   unset GCP_ADC_FILE
   ```
4. Run the script ./scripts/setup-google-adc.sh

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
