### PR TITLE
make vm support ssh gateway

### DIFF
--- a/.werft/util/gcloud.ts
+++ b/.werft/util/gcloud.ts
@@ -39,7 +39,10 @@ function getExternalIp(name: string, region = "europe-west1") {
 export async function createDNSRecord(domain: string, dnsZone: string, IP: string, slice: string): Promise<void> {
     const werft = getGlobalWerftInstance()
 
-    const dnsClient = new DNS({ projectId: 'gitpod-dev', keyFilename: GCLOUD_SERVICE_ACCOUNT_PATH })
+    const dnsClient = new DNS({
+        projectId: dnsZone === "gitpod-dev.com" ? "gitpod-dev" : "gitpod-core-dev",
+        keyFilename: GCLOUD_SERVICE_ACCOUNT_PATH,
+    });
     const zone = dnsClient.zone(dnsZone)
 
     if (!(await matchesExistingRecord(zone, domain, IP))) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR make harvester VM preview environment support  SSH Gateway

How to archive this?
1. we setup [RouterOS](https://mikrotik.com/software) both in GCP and harvester side
2. setup wireguard between GCP and harvester routeros
3. setup VPC route for `harvester cluster service IP range` to RouterOS GCP side
4. setup route in RouterOS to route this range IP to harvester side RouterOS
5. for every preview environment in harvester, create a `pod` for forwarding traffic and create a `loadbalancer` type `service` for get `public IP address`

This PR only do step 5, Everything else is already done in core-dev and harvester
see internal notion page 

[How to setup routeros in GCP side](https://www.notion.so/gitpod/How-to-setup-routeros-in-GCP-side-949aa866383646758acba76dbd2c2d54)
[How to setup routeros in harvester side](https://www.notion.so/gitpod/How-to-setup-routeros-in-harvester-side-465defa5e6fd4c039c9aef303178bca4)


TODO: 
- [ ] clean loadbalancer after VM delete

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
run werft job in this PR
start a workspace, check ssh gateway is work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-vm=true