### PR TITLE
[public-api] Add unimplemented workspace service

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -141,7 +141,7 @@ func (s *Server) HTTPAddress() string {
 	}
 	protocol := "http"
 	addr := s.httpListener.Addr().(*net.TCPAddr)
-	return fmt.Sprintf("%s://%s:%d", protocol, addr.IP, addr.Port)
+	return fmt.Sprintf("%s://%s:%d", protocol, s.cfg.hostname, addr.Port)
 }
 
 // GRPCAddress returns address of the gRPC Server
@@ -151,11 +151,15 @@ func (s *Server) GRPCAddress() string {
 		return ""
 	}
 	addr := s.grpcListener.Addr().(*net.TCPAddr)
-	return fmt.Sprintf("%s:%d", addr.IP, addr.Port)
+	return fmt.Sprintf("%s:%d", s.cfg.hostname, addr.Port)
 }
 
 func (s *Server) HTTPMux() *http.ServeMux {
 	return s.httpMux
+}
+
+func (s *Server) GRPC() *grpc.Server {
+	return s.grpc
 }
 
 func (s *Server) close(ctx context.Context) error {

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -24,8 +24,8 @@ func TestServer_StartStop(t *testing.T) {
 	}()
 
 	baseserver.WaitForServerToBeReachable(t, srv, 3*time.Second)
-	require.Equal(t, "http://:::8765", srv.HTTPAddress())
-	require.Equal(t, ":::8766", srv.GRPCAddress())
+	require.Equal(t, "http://localhost:8765", srv.HTTPAddress())
+	require.Equal(t, "localhost:8766", srv.GRPCAddress())
 	require.NoError(t, srv.Close())
 }
 

--- a/components/public-api-server/BUILD.yaml
+++ b/components/public-api-server/BUILD.yaml
@@ -7,6 +7,7 @@ packages:
       - "go.sum"
     deps:
       - components/common-go:lib
+      - components/public-api/go:lib
     env:
       - CGO_ENABLED=0
       - GOOS=linux

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -2,7 +2,10 @@ module github.com/gitpod-io/gitpod/public-api-server
 
 go 1.17
 
-require github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+require (
+	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/public-api v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -27,6 +30,8 @@ require (
 )
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace github.com/gitpod-io/gitpod/public-api => ../public-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.23.4 // leeway indirect from components/common-go:lib
 

--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/public-api/v1"
 	"net/http"
 )
 
@@ -21,11 +22,17 @@ func main() {
 		logger.WithError(err).Fatal("Failed to initialize public api server.")
 	}
 
-	srv.HTTPMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`hello world\n`))
-	})
-
 	if listenErr := srv.ListenAndServe(); listenErr != nil {
 		logger.WithError(listenErr).Fatal("Failed to serve public api server")
 	}
+}
+
+func register(srv *baseserver.Server) error {
+	srv.HTTPMux().HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`hello world`))
+	})
+
+	v1.RegisterWorkspacesServiceServer(srv.GRPC(), v1.UnimplementedWorkspacesServiceServer{})
+
+	return nil
 }

--- a/components/public-api/go/v1/examples_test.go
+++ b/components/public-api/go/v1/examples_test.go
@@ -91,11 +91,11 @@ func ExampleStartWorkspace_WithImageBuildLogs() {
 	for {
 		status, _ := updates.Recv()
 		switch status.InstanceStatus.Phase {
-		case v1.WorkspaceInstancePhase_WORKSPACE_INSTANCE_PHASE_IMAGEBUILD:
+		case v1.WorkspaceInstanceStatus_PHASE_IMAGEBUILD:
 			go listenToImageBuildLogs(ctx, wsi.InstanceId)
-		case v1.WorkspaceInstancePhase_WORKSPACE_INSTANCE_PHASE_RUNNING,
-			v1.WorkspaceInstancePhase_WORKSPACE_INSTANCE_PHASE_STOPPING,
-			v1.WorkspaceInstancePhase_WORKSPACE_INSTANCE_PHASE_STOPPED:
+		case v1.WorkspaceInstanceStatus_PHASE_RUNNING,
+			v1.WorkspaceInstanceStatus_PHASE_STOPPING,
+			v1.WorkspaceInstanceStatus_PHASE_STOPPED:
 			return
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds an unimplemented WorkspaceService to existing grpc server. Adds integration test for the unimplemented behavour.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
Uni tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/hold