### PR TITLE
[installer] Rename `common.Affinity` to `NodeAffinity`

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -317,7 +317,7 @@ func KubeRBACProxyContainer(ctx *RenderContext) *corev1.Container {
 	}
 }
 
-func Affinity(orLabels ...string) *corev1.Affinity {
+func NodeAffinity(orLabels ...string) *corev1.Affinity {
 	var terms []corev1.NodeSelectorTerm
 	for _, lbl := range orLabels {
 		terms = append(terms, corev1.NodeSelectorTerm{

--- a/install/installer/pkg/components/agent-smith/daemonset.go
+++ b/install/installer/pkg/components/agent-smith/daemonset.go
@@ -42,7 +42,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
+					Affinity:                      common.NodeAffinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					HostPID:                       true,
 					EnableServiceLinks:            pointer.Bool(false),

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -72,7 +72,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
+						Affinity:           common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),
 						Volumes: []corev1.Volume{{

--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -25,7 +25,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	podSpec := corev1.PodSpec{
-		Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+		Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 		ServiceAccountName:            Component,
 		EnableServiceLinks:            pointer.Bool(false),
 		DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -40,7 +40,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Labels:    labels,
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 						ServiceAccountName:            Component,
 						EnableServiceLinks:            pointer.Bool(false),
 						DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/database/init/job.go
+++ b/install/installer/pkg/components/database/init/job.go
@@ -33,7 +33,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: objectMeta,
 				Spec: corev1.PodSpec{
-					Affinity:           common.Affinity(cluster.AffinityLabelMeta),
+					Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: Component,
 					EnableServiceLinks: pointer.Bool(false),

--- a/install/installer/pkg/components/ide-proxy/deployment.go
+++ b/install/installer/pkg/components/ide-proxy/deployment.go
@@ -40,7 +40,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Labels:    labels,
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 						ServiceAccountName:            Component,
 						EnableServiceLinks:            pointer.Bool(false),
 						DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -131,7 +131,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Spec: corev1.PodSpec{
-					Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+					Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/migrations/job.go
+++ b/install/installer/pkg/components/migrations/job.go
@@ -29,7 +29,7 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: objectMeta,
 				Spec: corev1.PodSpec{
-					Affinity:           common.Affinity(cluster.AffinityLabelMeta),
+					Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: Component,
 					EnableServiceLinks: pointer.Bool(false),

--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -52,7 +52,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Spec: v1.PodSpec{
-					Affinity:                      common.Affinity(cluster.AffinityLabelIDE),
+					Affinity:                      common.NodeAffinity(cluster.AffinityLabelIDE),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -117,7 +117,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 						PriorityClassName:             common.SystemNodeCritical,
 						ServiceAccountName:            Component,
 						EnableServiceLinks:            pointer.Bool(false),

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -53,7 +53,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Labels:    labels,
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 						ServiceAccountName:            Component,
 						EnableServiceLinks:            pointer.Bool(false),
 						DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -139,7 +139,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 				Spec: corev1.PodSpec{
 					PriorityClassName:             common.SystemNodeCritical,
-					Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
+					Affinity:                      common.NodeAffinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -186,7 +186,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           common.Affinity(cluster.AffinityLabelMeta),
+						Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
 						PriorityClassName:  common.SystemNodeCritical,
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -313,7 +313,7 @@ fi
 		DNSPolicy:                     "ClusterFirst",
 		ServiceAccountName:            Component,
 		HostPID:                       true,
-		Affinity:                      common.Affinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
+		Affinity:                      common.NodeAffinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "node.kubernetes.io/disk-pressure",

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -84,7 +84,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                      common.Affinity(cluster.AffinityLabelMeta),
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
 						ServiceAccountName:            Component,
 						PriorityClassName:             common.SystemNodeCritical,
 						EnableServiceLinks:            pointer.Bool(false),

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -26,7 +26,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	podSpec := corev1.PodSpec{
 		PriorityClassName:  common.SystemNodeCritical,
-		Affinity:           common.Affinity(cluster.AffinityLabelWorkspaceServices),
+		Affinity:           common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
 		EnableServiceLinks: pointer.Bool(false),
 		ServiceAccountName: Component,
 		SecurityContext: &corev1.PodSecurityContext{

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -84,7 +84,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 					Spec: corev1.PodSpec{
 						PriorityClassName: common.SystemNodeCritical,
-						Affinity:          common.Affinity(cluster.AffinityLabelWorkspaceServices),
+						Affinity:          common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
 						TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 							corev1.TopologySpreadConstraint{
 								LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},

--- a/install/installer/pkg/helm/helm.go
+++ b/install/installer/pkg/helm/helm.go
@@ -112,7 +112,7 @@ func writeCharts(chart *charts.Chart) (string, error) {
 
 // AffinityYaml convert an affinity into a YAML byte array
 func AffinityYaml(orLabels ...string) ([]byte, error) {
-	affinities := common.Affinity(orLabels...)
+	affinities := common.NodeAffinity(orLabels...)
 
 	marshal, err := yaml.Marshal(affinities)
 	if err != nil {


### PR DESCRIPTION
## Description

Rename `common.Affinity` to `NodeAffinity`. As part of #9097 we will want to configure pod anti-affinity via the installer too, so rename this function to make those subsequent changes clearer.

## Related Issue(s)

Part of #9097.

## How to test

n/a - automated refactoring.

## Release Notes

```release-note
NONE
```

## Documentation

n/a
