### PR TITLE
[protocol] fix generate id for bad repo names

### DIFF
--- a/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.spec.ts
@@ -14,7 +14,7 @@ const expect = chai.expect;
 @suite
 class TestGenerateWorkspaceId {
     @test public async testGenerateWorkspaceId() {
-        for (let i = 0; i < 100; i++) {
+        for (let i = 0; i < 10; i++) {
             const id = await generateWorkspaceID();
             expect(new GitpodHostUrl().withWorkspacePrefix(id, "eu").workspaceId).to.equal(id);
         }
@@ -32,13 +32,20 @@ class TestGenerateWorkspaceId {
             ["foo", "bar", "foo-bar-"],
             ["f", "bar", ".{2,16}-bar-"],
             ["gitpod-io", "gitpod", "gitpodio-gitpod-"],
+            ["breatheco-de", "python-flask-api-tutorial", "breathecode-pythonflask-"],
+            ["short", "muchlongerthaneleven", "short-muchlongerthanel-"],
+            ["muchlongerthaneleven", "short", "muchlongerthanel-short-"],
             [
                 'this is rather long and has some "§$"% special chars',
                 "also here pretty long and needs abbreviation",
-                "thisisratherlon-alsohere-",
+                "thisisrathe-alsoherepre-",
             ],
-            ["breatheco-de", "python-flask-api-tutorial", "breathecode-pythonflaska-"],
             ["UPPER", "CaSe", "upper-case-"],
+            [
+                "superlongfirstsegment",
+                "---------",
+                "superlong" /* we don't mantch for the whole first segment, because it has different length depending on the animal that is used to replace the -------*/,
+            ],
         ];
         for (const d of data) {
             const id = await generateWorkspaceID(d[0], d[1]);

--- a/components/gitpod-protocol/src/util/generate-workspace-id.ts
+++ b/components/gitpod-protocol/src/util/generate-workspace-id.ts
@@ -3,15 +3,19 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License-AGPL.txt in the project root for license information.
  */
+
 import randomNumber = require("random-number-csprng");
 
 export async function generateWorkspaceID(firstSegment?: string, secondSegment?: string): Promise<string> {
     const firstSeg = clean(firstSegment) || (await random(colors));
-    const secSeg = clean(secondSegment, Math.min(15, 23 - firstSeg.length)) || (await random(animals));
-    return firstSeg + "-" + secSeg + "-" + (await random(characters, 11));
+    const secSeg = clean(secondSegment) || (await random(animals));
+    function fit(makeFit: string, otherSeg: string) {
+        return makeFit.substring(0, Math.max(segLength, 2 * segLength - otherSeg.length));
+    }
+    return fit(firstSeg, secSeg) + "-" + fit(secSeg, firstSeg) + "-" + (await random(characters, segLength));
 }
 
-function clean(segment: string | undefined, maxChars: number = 15) {
+function clean(segment: string | undefined, maxChars: number = 16) {
     if (!segment) {
         return undefined;
     }
@@ -34,6 +38,8 @@ async function random(array: string[], length: number = 1): Promise<string> {
     }
     return result;
 }
+
+const segLength = 11;
 
 const characters = "abcdefghijklmnopqrstuvwxyz0123456789".split("");
 


### PR DESCRIPTION
Fixes possibly too long workspace id generation when the repo name doesn't contain any latin characters.

fixes #9399

```release-note
NONE
```