### PR TITLE
Ensure IO limits are written after first workspace is stopped

### DIFF
--- a/components/ws-daemon/pkg/cgroup/cgroup.go
+++ b/components/ws-daemon/pkg/cgroup/cgroup.go
@@ -81,7 +81,7 @@ func (host *PluginHost) WorkspaceAdded(ctx context.Context, ws *dispatch.Workspa
 
 	cgroupPath, err := disp.Runtime.ContainerCGroupPath(context.Background(), ws.ContainerID)
 	if err != nil {
-		return xerrors.Errorf("cannot start governer: %w", err)
+		return xerrors.Errorf("cannot get cgroup path for container %s: %w", ws.ContainerID, err)
 	}
 
 	for _, plg := range host.Plugins {

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -57,12 +57,7 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 		&cgroup.CacheReclaim{},
 		&cgroup.FuseDeviceEnablerV1{},
 		&cgroup.FuseDeviceEnablerV2{},
-		&cgroup.IOLimiterV2{
-			WriteBytesPerSecond: config.IOLimit.WriteBWPerSecond.Value(),
-			ReadBytesPerSecond:  config.IOLimit.ReadBWPerSecond.Value(),
-			WriteIOPs:           config.IOLimit.WriteIOPS,
-			ReadIOPs:            config.IOLimit.ReadIOPS,
-		},
+		cgroup.NewIOLimiterV2(config.IOLimit.WriteBWPerSecond.Value(), config.IOLimit.ReadBWPerSecond.Value(), config.IOLimit.WriteIOPS, config.IOLimit.ReadIOPS),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
IO limits stopped being written after the first workspace was stopped because the plugin is a singleton and we set IO limits to unlimited when the workspace is stopped.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/9341

## How to test
- Use workspace-preview or ephemeral cluster
- Open workspace -> observe IO limits are written
- Close workspace
- Open another workspace on the same node
- IO limits should be applied for the new workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed a bug where IO limits were not applied to the workspace
```
