### PR TITLE
Blocking users by matching email domains suffixes

### DIFF
--- a/components/gitpod-db/src/email-domain-filter-db.ts
+++ b/components/gitpod-db/src/email-domain-filter-db.ts
@@ -12,7 +12,7 @@ export interface EmailDomainFilterDB {
 
     /**
      * @param emailDomain
-     * @returns false iff this emailDomain is meant to be blocked, aka "filtered out from the list"
+     * @returns true iff this emailDomain is meant to be blocked
      */
-    filter(emailDomain: string): Promise<boolean>;
+    isBlocked(emailDomain: string): Promise<boolean>;
 }

--- a/components/gitpod-db/src/typeorm/email-domain-filter-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/email-domain-filter-db-impl.ts
@@ -33,7 +33,8 @@ export class EmailDomainFilterDBImpl implements EmailDomainFilterDB {
         const repo = await this.getRepo();
         const result = await repo
             .createQueryBuilder("entry")
-            .where(`entry.domain = :domain`, { domain: domain })
+            .where(`:domain LIKE entry.domain`, { domain: domain })
+            .andWhere(`entry.domain != '%'`) // this ensures we do not accidentally block _all_ new users
             .andWhere(`entry.negative = '1'`)
             .getOne();
         return !!result;

--- a/components/gitpod-db/src/typeorm/email-domain-filter-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/email-domain-filter-db-impl.ts
@@ -29,13 +29,13 @@ export class EmailDomainFilterDBImpl implements EmailDomainFilterDB {
         await repo.save(entry);
     }
 
-    async filter(domain: string): Promise<boolean> {
+    async isBlocked(domain: string): Promise<boolean> {
         const repo = await this.getRepo();
         const result = await repo
             .createQueryBuilder("entry")
             .where(`entry.domain = :domain`, { domain: domain })
             .andWhere(`entry.negative = '1'`)
             .getOne();
-        return !result;
+        return !!result;
     }
 }

--- a/components/server/ee/src/auth/email-domain-service.ts
+++ b/components/server/ee/src/auth/email-domain-service.ts
@@ -25,7 +25,7 @@ export class EMailDomainServiceImpl implements EMailDomainService {
 
     async isBlocked(email: string): Promise<boolean> {
         const { domain } = this.parseMail(email);
-        return !(await this.domainFilterDb.filter(domain));
+        return this.domainFilterDb.isBlocked(domain);
     }
 
     async hasEducationalInstitutionSuffix(email: string): Promise<boolean> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9408 .

## How to test
- run tests and see they are green
- try to signup [here](https://gpl-9408-edomains.staging.gitpod-dev.com/workspaces) with an primary email that ends on `itpod.io`
- try to open a workspace and see that you are blocked :x: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
block abusers based on email domain suffixes
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
