### PR TITLE
[werft] Add cleanup unuse loadbalancer for cleanup job

### DIFF
--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -16,6 +16,9 @@ pod:
   - name: gcp-sa-release
     secret:
       secretName: gcp-sa-gitpod-release-deployer
+  - name: harvester-kubeconfig
+    secret:
+      secretName: harvester-kubeconfig
   containers:
   - name: build
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-werft.0
@@ -28,6 +31,8 @@ pod:
     - name: gcp-sa-release
       mountPath: /mnt/secrets/gcp-sa-release
       readOnly: true
+    - name: harvester-kubeconfig
+      mountPath: /mnt/secrets/harvester-kubeconfig
     env:
     - name: WERFT_HOST
       value: "werft.werft.svc.cluster.local:7777"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR is follow #9391

It will cleanup unuse loadbalancers

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in this branch
2. start a werft build job use annotation `with-vm`
3. delete harvester namespace `preview-pd-clean-lbs`
4. until delete process is done, run `werft run github --remote-job-path .werft/platform-delete-preview-environments-cron.yaml github.com/gitpod-io/gitpod:pd/clean-lbs`
5. verify the loadbalancer `deployment` and `service` is deleted (in core-dev loadbalancers namespace)

or you can view this job https://werft.gitpod-dev.com/job/gitpod-platform-delete-preview-environments-cron-pd-cleana.3

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-vm=true