### PR TITLE
Allow workspace timeouts to be extended when a user has workspaces in multiple regions

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -312,11 +312,12 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             (i) => i.workspaceId !== workspaceId && i.status.timeout !== defaultTimeout && i.status.phase === "running",
         );
         await Promise.all(
-            instancesWithReset.map((i) => {
+            instancesWithReset.map(async (i) => {
                 const req = new SetTimeoutRequest();
                 req.setId(i.id);
                 req.setDuration(this.userService.workspaceTimeoutToDuration(defaultTimeout));
 
+                const client = await this.workspaceManagerClientProvider.get(i.region);
                 return client.setTimeout(ctx, req);
             }),
         );


### PR DESCRIPTION
## Description

Fix https://github.com/gitpod-io/gitpod/issues/9174 by correctly taking account of a workspace's region when extending workspace timeouts.

## Related Issue(s)
Fixes #9174

## How to test

TBD

## Release Notes

```release-note
Allow workspace timeouts to be extended when a user has workspaces in different regions.
```

## Documentation

None

/hold