### PR TITLE
[Dashboard] Increase IDE awareness during onboarding

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -4,22 +4,17 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
-import { useContext, useEffect, useState } from "react";
-import InfoBox from "../components/InfoBox";
+import { useContext, useState } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
 import SelectableCard from "../components/SelectableCard";
-import SelectableCardSolid from "../components/SelectableCardSolid";
-import Tooltip from "../components/Tooltip";
 import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
 import getSettingsMenu from "./settings-menu";
 import { trackEvent } from "../Analytics";
 import { PaymentContext } from "../payment-context";
-import CheckBox from "../components/CheckBox";
-import { IDESettings } from "@gitpod/gitpod-protocol";
+import SelectIDE from "./SelectIDE";
 
 type Theme = "light" | "dark" | "system";
 
@@ -27,79 +22,6 @@ export default function Preferences() {
     const { user } = useContext(UserContext);
     const { showPaymentUI } = useContext(PaymentContext);
     const { setIsDark } = useContext(ThemeContext);
-
-    const migrationIDESettings = () => {
-        if (!user?.additionalData?.ideSettings || user.additionalData.ideSettings.settingVersion === "2.0") {
-            return;
-        }
-        const newIDESettings: IDESettings = {
-            settingVersion: "2.0",
-        };
-        const ideSettings = user.additionalData.ideSettings;
-        if (ideSettings.useDesktopIde) {
-            if (ideSettings.defaultDesktopIde === "code-desktop") {
-                newIDESettings.defaultIde = "code-desktop";
-            } else if (ideSettings.defaultDesktopIde === "code-desktop-insiders") {
-                newIDESettings.defaultIde = "code-desktop";
-                newIDESettings.useLatestVersion = true;
-            } else {
-                newIDESettings.defaultIde = ideSettings.defaultDesktopIde;
-                newIDESettings.useLatestVersion = ideSettings.useLatestVersion;
-            }
-        } else {
-            const useLatest = ideSettings.defaultIde === "code-latest";
-            newIDESettings.defaultIde = "code";
-            newIDESettings.useLatestVersion = useLatest;
-        }
-        user.additionalData.ideSettings = newIDESettings;
-    };
-    migrationIDESettings();
-
-    const updateUserIDEInfo = async (selectedIde: string, useLatestVersion: boolean) => {
-        const additionalData = user?.additionalData ?? {};
-        const settings = additionalData.ideSettings ?? {};
-        settings.settingVersion = "2.0";
-        settings.defaultIde = selectedIde;
-        settings.useLatestVersion = useLatestVersion;
-        additionalData.ideSettings = settings;
-        getGitpodService()
-            .server.trackEvent({
-                event: "ide_configuration_changed",
-                properties: settings,
-            })
-            .then()
-            .catch(console.error);
-        await getGitpodService().server.updateLoggedInUser({ additionalData });
-    };
-
-    const [defaultIde, setDefaultIde] = useState<string>(user?.additionalData?.ideSettings?.defaultIde || "");
-    const actuallySetDefaultIde = async (value: string) => {
-        await updateUserIDEInfo(value, useLatestVersion);
-        setDefaultIde(value);
-    };
-
-    const [useLatestVersion, setUseLatestVersion] = useState<boolean>(
-        user?.additionalData?.ideSettings?.useLatestVersion ?? false,
-    );
-    const actuallySetUseLatestVersion = async (value: boolean) => {
-        await updateUserIDEInfo(defaultIde, value);
-        setUseLatestVersion(value);
-    };
-
-    const [ideOptions, setIdeOptions] = useState<IDEOptions | undefined>(undefined);
-    useEffect(() => {
-        (async () => {
-            const ideopts = await getGitpodService().server.getIDEOptions();
-            // TODO: Compatible with ide-config not deployed, need revert after ide-config deployed
-            delete ideopts.options["code-latest"];
-            delete ideopts.options["code-desktop-insiders"];
-
-            setIdeOptions(ideopts);
-            if (!defaultIde || ideopts.options[defaultIde] == null) {
-                setDefaultIde(ideopts.defaultIde);
-            }
-        })();
-    }, []);
 
     const [theme, setTheme] = useState<Theme>(localStorage.theme || "system");
     const actuallySetTheme = (theme: Theme) => {
@@ -114,8 +36,6 @@ export default function Preferences() {
         setIsDark(isDark);
         setTheme(theme);
     };
-
-    const allIdeOptions = ideOptions && orderedIdeOptions(ideOptions);
 
     const [dotfileRepo, setDotfileRepo] = useState<string>(user?.additionalData?.dotfileRepo || "");
     const actuallySetDotfileRepo = async (value: string) => {
@@ -136,80 +56,9 @@ export default function Preferences() {
                 title="Preferences"
                 subtitle="Configure user preferences."
             >
-                {ideOptions && (
-                    <>
-                        {allIdeOptions && (
-                            <>
-                                <h3>Editor</h3>
-                                <p className="text-base text-gray-500 dark:text-gray-400">
-                                    Choose the editor for opening workspaces.
-                                </p>
-                                <div className="my-4 gap-4 flex flex-wrap max-w-2xl">
-                                    {allIdeOptions.map(([id, option]) => {
-                                        const selected = defaultIde === id;
-                                        const onSelect = () => actuallySetDefaultIde(id);
-                                        return renderIdeOption(option, selected, onSelect);
-                                    })}
-                                </div>
-                                {ideOptions.options[defaultIde]?.notes && (
-                                    <InfoBox className="my-5 max-w-2xl">
-                                        <ul>
-                                            {ideOptions.options[defaultIde].notes?.map((x, idx) => (
-                                                <li className={idx > 0 ? "mt-2" : ""}>{x}</li>
-                                            ))}
-                                        </ul>
-                                    </InfoBox>
-                                )}
-                                <p className="text-left w-full text-gray-500">
-                                    The <strong>JetBrains desktop IDEs</strong> are currently in beta.{" "}
-                                    <a
-                                        href="https://github.com/gitpod-io/gitpod/issues/6576"
-                                        target="gitpod-feedback-issue"
-                                        rel="noopener"
-                                        className="gp-link"
-                                    >
-                                        Send feedback
-                                    </a>{" "}
-                                    ·{" "}
-                                    <a
-                                        href="https://www.gitpod.io/docs/integrations/jetbrains"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="gp-link"
-                                    >
-                                        Documentation
-                                    </a>
-                                </p>
-                            </>
-                        )}
-                        <CheckBox
-                            title="Latest Release (Unstable)"
-                            desc={
-                                <span>
-                                    Use the latest version for each editor.{" "}
-                                    <a
-                                        className="gp-link"
-                                        target="_blank"
-                                        href="https://code.visualstudio.com/blogs/2016/02/01/introducing_insiders_build"
-                                    >
-                                        Insiders
-                                    </a>{" "}
-                                    for VS Code,{" "}
-                                    <a
-                                        className="gp-link"
-                                        target="_blank"
-                                        href="https://www.jetbrains.com/resources/eap/"
-                                    >
-                                        EAP
-                                    </a>{" "}
-                                    for JetBrains IDEs.
-                                </span>
-                            }
-                            checked={useLatestVersion}
-                            onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}
-                        />
-                    </>
-                )}
+                <h3>Editor</h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">Choose the editor for opening workspaces.</p>
+                <SelectIDE />
                 <h3 className="mt-12">Theme</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
                 <div className="mt-4 space-x-4 flex">
@@ -293,42 +142,4 @@ export default function Preferences() {
             </PageWithSubMenu>
         </div>
     );
-}
-
-function orderedIdeOptions(ideOptions: IDEOptions) {
-    // TODO: Maybe convert orderKey to number before sort?
-    return Object.entries(ideOptions.options)
-        .filter(([_, x]) => !x.hidden)
-        .sort((a, b) => {
-            const keyA = a[1].orderKey || a[0];
-            const keyB = b[1].orderKey || b[0];
-            return keyA.localeCompare(keyB);
-        });
-}
-
-function renderIdeOption(option: IDEOption, selected: boolean, onSelect: () => void): JSX.Element {
-    const label = option.type === "desktop" ? "" : option.type;
-    const card = (
-        <SelectableCardSolid className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
-            <div className="flex justify-center mt-3">
-                <img className="w-16 filter-grayscale self-center" src={option.logo} alt="logo" />
-            </div>
-            {label ? (
-                <div
-                    className={`font-semibold text-sm ${
-                        selected ? "text-gray-100 dark:text-gray-600" : "text-gray-600 dark:text-gray-500"
-                    } uppercase mt-2 px-3 py-1 self-center`}
-                >
-                    {label}
-                </div>
-            ) : (
-                <></>
-            )}
-        </SelectableCardSolid>
-    );
-
-    if (option.tooltip) {
-        return <Tooltip content={option.tooltip}>{card}</Tooltip>;
-    }
-    return card;
 }

--- a/components/dashboard/src/settings/SelectIDE.tsx
+++ b/components/dashboard/src/settings/SelectIDE.tsx
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
+import { useContext, useEffect, useState } from "react";
+import InfoBox from "../components/InfoBox";
+import SelectableCardSolid from "../components/SelectableCardSolid";
+import Tooltip from "../components/Tooltip";
+import { getGitpodService } from "../service/service";
+import { UserContext } from "../user-context";
+import CheckBox from "../components/CheckBox";
+import { User } from "@gitpod/gitpod-protocol";
+
+interface SelectIDEProps {
+    updateUserContext?: boolean;
+}
+
+export const updateUserIDEInfo = async (user: User, selectedIde: string, useLatestVersion: boolean) => {
+    const additionalData = user?.additionalData ?? {};
+    const settings = additionalData.ideSettings ?? {};
+    settings.settingVersion = "2.0";
+    settings.defaultIde = selectedIde;
+    settings.useLatestVersion = useLatestVersion;
+    additionalData.ideSettings = settings;
+    getGitpodService()
+        .server.trackEvent({
+            event: "ide_configuration_changed",
+            properties: settings,
+        })
+        .then()
+        .catch(console.error);
+    return getGitpodService().server.updateLoggedInUser({ additionalData });
+};
+
+export default function SelectIDE(props: SelectIDEProps) {
+    const { user, setUser } = useContext(UserContext);
+
+    // Only exec once when we access this component
+    useEffect(() => {
+        user && User.migrationIDESettings(user);
+    }, []);
+
+    const actualUpdateUserIDEInfo = async (user: User, selectedIde: string, useLatestVersion: boolean) => {
+        const newUserData = await updateUserIDEInfo(user, selectedIde, useLatestVersion);
+        props.updateUserContext && setUser({ ...newUserData });
+    };
+
+    const [defaultIde, setDefaultIde] = useState<string>(user?.additionalData?.ideSettings?.defaultIde || "code");
+    const actuallySetDefaultIde = async (value: string) => {
+        await actualUpdateUserIDEInfo(user!, value, useLatestVersion);
+        setDefaultIde(value);
+    };
+
+    const [useLatestVersion, setUseLatestVersion] = useState<boolean>(
+        user?.additionalData?.ideSettings?.useLatestVersion ?? false,
+    );
+    const actuallySetUseLatestVersion = async (value: boolean) => {
+        await actualUpdateUserIDEInfo(user!, defaultIde, value);
+        setUseLatestVersion(value);
+    };
+
+    const [ideOptions, setIdeOptions] = useState<IDEOptions | undefined>(undefined);
+    useEffect(() => {
+        (async () => {
+            const ideopts = await getGitpodService().server.getIDEOptions();
+            // TODO: Compatible with ide-config not deployed, need revert after ide-config deployed
+            delete ideopts.options["code-latest"];
+            delete ideopts.options["code-desktop-insiders"];
+
+            setIdeOptions(ideopts);
+        })();
+    }, []);
+
+    const allIdeOptions = ideOptions && orderedIdeOptions(ideOptions);
+
+    return (
+        <>
+            {ideOptions && (
+                <>
+                    {allIdeOptions && (
+                        <>
+                            <div className={`my-4 gap-3 flex flex-wrap max-w-2xl`}>
+                                {allIdeOptions.map(([id, option]) => {
+                                    const selected = defaultIde === id;
+                                    const onSelect = () => actuallySetDefaultIde(id);
+                                    return renderIdeOption(option, selected, onSelect);
+                                })}
+                            </div>
+                            {ideOptions.options[defaultIde]?.notes && (
+                                <InfoBox className="my-5 max-w-2xl">
+                                    <ul>
+                                        {ideOptions.options[defaultIde].notes?.map((x, idx) => (
+                                            <li className={idx > 0 ? "mt-2" : ""}>{x}</li>
+                                        ))}
+                                    </ul>
+                                </InfoBox>
+                            )}
+
+                            <p className="text-left w-full text-gray-500">
+                                The <strong>JetBrains desktop IDEs</strong> are currently in beta.{" "}
+                                <a
+                                    href="https://github.com/gitpod-io/gitpod/issues/6576"
+                                    target="gitpod-feedback-issue"
+                                    rel="noopener"
+                                    className="gp-link"
+                                >
+                                    Send feedback
+                                </a>{" "}
+                                ·{" "}
+                                <a
+                                    href="https://www.gitpod.io/docs/integrations/jetbrains"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="gp-link"
+                                >
+                                    Documentation
+                                </a>
+                            </p>
+                        </>
+                    )}
+                    <CheckBox
+                        title="Latest Release (Unstable)"
+                        desc={
+                            <span>
+                                Use the latest version for each editor.{" "}
+                                <a
+                                    className="gp-link"
+                                    target="_blank"
+                                    href="https://code.visualstudio.com/blogs/2016/02/01/introducing_insiders_build"
+                                    rel="noreferrer"
+                                >
+                                    Insiders
+                                </a>{" "}
+                                for VS Code,{" "}
+                                <a
+                                    className="gp-link"
+                                    target="_blank"
+                                    href="https://www.jetbrains.com/resources/eap/"
+                                    rel="noreferrer"
+                                >
+                                    EAP
+                                </a>{" "}
+                                for JetBrains IDEs.
+                            </span>
+                        }
+                        checked={useLatestVersion}
+                        onChange={(e) => actuallySetUseLatestVersion(e.target.checked)}
+                    />
+                </>
+            )}
+        </>
+    );
+}
+
+function orderedIdeOptions(ideOptions: IDEOptions) {
+    // TODO: Maybe convert orderKey to number before sort?
+    return Object.entries(ideOptions.options)
+        .filter(([_, x]) => !x.hidden)
+        .sort((a, b) => {
+            const keyA = a[1].orderKey || a[0];
+            const keyB = b[1].orderKey || b[0];
+            return keyA.localeCompare(keyB);
+        });
+}
+
+function renderIdeOption(option: IDEOption, selected: boolean, onSelect: () => void): JSX.Element {
+    const label = option.type === "desktop" ? "" : option.type;
+    const card = (
+        <SelectableCardSolid className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
+            <div className="flex justify-center mt-3">
+                <img className="w-16 filter-grayscale self-center" src={option.logo} alt="logo" />
+            </div>
+            {label ? (
+                <div
+                    className={`font-semibold text-sm ${
+                        selected ? "text-gray-100 dark:text-gray-600" : "text-gray-600 dark:text-gray-500"
+                    } uppercase mt-2 px-3 py-1 self-center`}
+                >
+                    {label}
+                </div>
+            ) : (
+                <></>
+            )}
+        </SelectableCardSolid>
+    );
+
+    if (option.tooltip) {
+        return <Tooltip content={option.tooltip}>{card}</Tooltip>;
+    }
+    return card;
+}

--- a/components/dashboard/src/settings/SelectIDEModal.tsx
+++ b/components/dashboard/src/settings/SelectIDEModal.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useState, useContext } from "react";
+import { Link } from "react-router-dom";
+import { User } from "@gitpod/gitpod-protocol";
+import SelectIDE, { updateUserIDEInfo } from "./SelectIDE";
+import Modal from "../components/Modal";
+import { UserContext } from "../user-context";
+
+export default function () {
+    const { user, setUser } = useContext(UserContext);
+    const [visible, setVisible] = useState(true);
+
+    const actualUpdateUserIDEInfo = async (user: User, selectedIde: string, useLatestVersion: boolean) => {
+        const newUserData = await updateUserIDEInfo(user, selectedIde, useLatestVersion);
+        setUser({ ...newUserData });
+    };
+
+    const handleContinue = async () => {
+        setVisible(false);
+        if (!user || User.hasPreferredIde(user)) {
+            return;
+        }
+        // TODO: We need to get defaultIde in ideOptions..
+        const defaultIde = "code";
+        await actualUpdateUserIDEInfo(user, defaultIde, false);
+    };
+
+    return (
+        <Modal visible={visible} onClose={handleContinue} closeable={true} className="_max-w-xl">
+            <h3 className="pb-2">Select Editor</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
+                <p className="text-gray-500 text-base pb-3">
+                    Choose the editor for opening workspaces. You can always change later the editor in{" "}
+                    <Link
+                        to={"/preferences"}
+                        className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
+                    >
+                        user preferences
+                    </Link>
+                    .
+                </p>
+                <SelectIDE updateUserContext={false} />
+            </div>
+            <div className="flex justify-end mt-6">
+                <button onClick={handleContinue} className="ml-2">
+                    Continue
+                </button>
+            </div>
+        </Modal>
+    );
+}

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -13,8 +13,11 @@ import { WorkspaceEntry } from "./WorkspaceEntry";
 import { getGitpodService } from "../service/service";
 import { ItemsList } from "../components/ItemsList";
 import { TeamsContext } from "../teams/teams-context";
+import { UserContext } from "../user-context";
+import { User } from "@gitpod/gitpod-protocol";
 import { useLocation } from "react-router";
 import { StartWorkspaceModalContext, StartWorkspaceModalKeyBinding } from "./start-workspace-modal-context";
+import SelectIDEModal from "../settings/SelectIDEModal";
 
 export interface WorkspacesProps {}
 
@@ -27,6 +30,7 @@ export interface WorkspacesState {
 export default function () {
     const location = useLocation();
 
+    const { user } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
     const [activeWorkspaces, setActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [inactiveWorkspaces, setInactiveWorkspaces] = useState<WorkspaceInfo[]>([]);
@@ -40,9 +44,13 @@ export default function () {
         })();
     }, [teams, location]);
 
+    const isOnboardingUser = user && User.isOnboardingUser(user);
+
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
+
+            {isOnboardingUser && <SelectIDEModal />}
 
             {workspaceModel?.initialized &&
                 (activeWorkspaces.length > 0 || inactiveWorkspaces.length > 0 || workspaceModel.searchTerm ? (

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -101,7 +101,7 @@ export class TypeORMUserDBImpl implements UserDB {
             creationDate: new Date().toISOString(),
             identities: [],
             additionalData: {
-                ideSettings: { defaultIde: "code" },
+                ideSettings: {},
                 emailNotificationSettings: {
                     allowsChangelogMail: true,
                     allowsDevXMail: true,

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -95,6 +95,47 @@ export namespace User {
         }
         return undefined;
     }
+
+    export function hasPreferredIde(user: User) {
+        return (
+            typeof user?.additionalData?.ideSettings?.defaultIde !== "undefined" ||
+            typeof user?.additionalData?.ideSettings?.useLatestVersion !== "undefined"
+        );
+    }
+
+    export function isOnboardingUser(user: User) {
+        return !hasPreferredIde(user);
+    }
+
+    export function migrationIDESettings(user: User) {
+        if (
+            !user?.additionalData?.ideSettings ||
+            Object.keys(user.additionalData.ideSettings).length === 0 ||
+            user.additionalData.ideSettings.settingVersion === "2.0"
+        ) {
+            return;
+        }
+        const newIDESettings: IDESettings = {
+            settingVersion: "2.0",
+        };
+        const ideSettings = user.additionalData.ideSettings;
+        if (ideSettings.useDesktopIde) {
+            if (ideSettings.defaultDesktopIde === "code-desktop") {
+                newIDESettings.defaultIde = "code-desktop";
+            } else if (ideSettings.defaultDesktopIde === "code-desktop-insiders") {
+                newIDESettings.defaultIde = "code-desktop";
+                newIDESettings.useLatestVersion = true;
+            } else {
+                newIDESettings.defaultIde = ideSettings.defaultDesktopIde;
+                newIDESettings.useLatestVersion = ideSettings.useLatestVersion;
+            }
+        } else {
+            const useLatest = ideSettings.defaultIde === "code-latest";
+            newIDESettings.defaultIde = "code";
+            newIDESettings.useLatestVersion = useLatest;
+        }
+        user.additionalData.ideSettings = newIDESettings;
+    }
 }
 
 export interface AdditionalUserData {


### PR DESCRIPTION
## Description
An experiment to try to increase the awareness of other IDEs besides VS Code.

**Every selection from user will change User setting immediately**

The approach used: 

- Extract the "IDE selection" into a standalone component `<SelectIDE>`
- Introduced a new component `<SelectIDEModal>`
- ~~Extracted the util `updateUserIDEInfo` from `<SelectIDE>` to its own file~~
- Re-use the `<SelectIDE>` in both the settings page and in SelectIDEModal
- `<SelectIDEModal>` will appear in the workspaces page, if the user [isOnboardingUser](https://github.com/gitpod-io/gitpod/pull/9432/files#diff-957d9dd15b947e3969539ebd0dabcb8b40ce8b5564e5820cd9bb27d88be1dbc7R106)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9433
Relates to #6707

## How to test

The first thing to test is that workspaces started without this new preference, will default to VS Code browser. If you want to only test the onboarding flow, skip all `[optional]` steps below.

1. Sign-up in [this preview environment](https://af-ide-disbb5b4bbe7a.staging.gitpod-dev.com/workspaces)
2. `[optional]` Before selecting an IDE, try creating a workspace appending the repo to the preview env URL. This will make sure that users who skip this selection, can still launch workspaces with `code` as default IDE.
3. `[optional]`Once the workspace starts, verify that VS Code Browser is the default IDE
4. `[optional]`Stop the workspace `gp stop` and go back to the dashboard and delete your workspace
5. `[optional]`Go back to the workspaces page
6. Choose your preferred IDE (e.g IntelliJ)
7. Start a workspace and verify that IntelliJ opens or options to download the JetBrains Gateway are presented

### Test Cases

1. Choose nothing, refresh page will see modal again
2. Choose nothing and click `continue` or `X`, DB go with `code latest:false`
3. Check `use latest` and click continue or `X`, DB go with `code latest:true`
4. Choose any IDE, DB will change

#### FYI: Check and reset your ide option
```mysql
# check
SELECT id, name, additionalData->'$.ideSettings.defaultIde', additionalData->'$.ideSettings.useLatestVersion' FROM d_b_user WHERE id = '<your_user_id>';

# reset
UPDATE d_b_user SET additionalData='{"ideSettings":{},"emailNotificationSettings":{"allowsChangelogMail":true,"allowsDevXMail":true,"allowsOnboardingMail":true}}' WHERE id = '<your_user_id>';
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Prompt first-time users to choose their default IDE 
```

<!--
## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


## Screenshots

|Light|Dark|
|:-:|:-:|
|<img width="1715" alt="Screenshot 2022-04-27 at 15 34 49" src="https://user-images.githubusercontent.com/2318450/165531065-1ec7d721-cf22-43b6-976b-5c22c10bd6a8.png">|<img width="1710" alt="Screenshot 2022-04-27 at 15 35 32" src="https://user-images.githubusercontent.com/2318450/165531051-734338e4-8e51-4bb6-a342-3c167a779446.png">|
