### PR TITLE
[baseserver] Helper for starting server in tests

### DIFF
--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -11,19 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
-	"time"
 )
 
 func TestServer_StartStop(t *testing.T) {
 	// We don't use the helper NewForTests, because we want to control stopping ourselves.
 	srv, err := baseserver.New("server_test", baseserver.WithHTTPPort(8765), baseserver.WithGRPCPort(8766))
 	require.NoError(t, err)
+	baseserver.StartServerForTests(t, srv)
 
-	go func() {
-		require.NoError(t, srv.ListenAndServe())
-	}()
-
-	baseserver.WaitForServerToBeReachable(t, srv, 3*time.Second)
 	require.Equal(t, "http://localhost:8765", srv.HTTPAddress())
 	require.Equal(t, "localhost:8766", srv.GRPCAddress())
 	require.NoError(t, srv.Close())
@@ -31,12 +26,7 @@ func TestServer_StartStop(t *testing.T) {
 
 func TestServer_ServesReady(t *testing.T) {
 	srv := baseserver.NewForTests(t)
-
-	go func(t *testing.T) {
-		require.NoError(t, srv.ListenAndServe())
-	}(t)
-
-	baseserver.WaitForServerToBeReachable(t, srv, 3*time.Second)
+	baseserver.StartServerForTests(t, srv)
 
 	readyURL := fmt.Sprintf("%s/ready", srv.HTTPAddress())
 	resp, err := http.Get(readyURL)
@@ -47,11 +37,7 @@ func TestServer_ServesReady(t *testing.T) {
 func TestServer_ServesMetricsEndpointWithDefaultConfig(t *testing.T) {
 	srv := baseserver.NewForTests(t)
 
-	go func(t *testing.T) {
-		require.NoError(t, srv.ListenAndServe())
-	}(t)
-
-	baseserver.WaitForServerToBeReachable(t, srv, 3*time.Second)
+	baseserver.StartServerForTests(t, srv)
 
 	readyUR := fmt.Sprintf("%s/metrics", srv.HTTPAddress())
 	resp, err := http.Get(readyUR)
@@ -65,11 +51,7 @@ func TestServer_ServesMetricsEndpointWithCustomMetricsConfig(t *testing.T) {
 		baseserver.WithMetricsRegistry(registry),
 	)
 
-	go func(t *testing.T) {
-		require.NoError(t, srv.ListenAndServe())
-	}(t)
-
-	baseserver.WaitForServerToBeReachable(t, srv, 3*time.Second)
+	baseserver.StartServerForTests(t, srv)
 
 	readyUR := fmt.Sprintf("%s/metrics", srv.HTTPAddress())
 	resp, err := http.Get(readyUR)

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -34,7 +34,20 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 	return srv
 }
 
-func WaitForServerToBeReachable(t *testing.T, srv *Server, timeout time.Duration) {
+// StartServerForTests starts the server for test purposes.
+// This is a helper which also ensures the server is reachable before returning.
+func StartServerForTests(t *testing.T, srv *Server) {
+	t.Helper()
+
+	go func() {
+		err := srv.ListenAndServe()
+		require.NoError(t, err)
+	}()
+
+	waitForServerToBeReachable(t, srv, 3*time.Second)
+}
+
+func waitForServerToBeReachable(t *testing.T, srv *Server, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/components/public-api-server/integration_test.go
+++ b/components/public-api-server/integration_test.go
@@ -14,19 +14,14 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"testing"
-	"time"
 )
 
 func TestPublicAPIServer(t *testing.T) {
 	ctx := context.Background()
 	srv := baseserver.NewForTests(t)
+
 	require.NoError(t, register(srv))
-
-	go func() {
-		require.NoError(t, srv.ListenAndServe())
-	}()
-
-	baseserver.WaitForServerToBeReachable(t, srv, 1*time.Second)
+	baseserver.StartServerForTests(t, srv)
 
 	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactor repeated pattern of `start` and `waitToBeReachable` in tests into a helper


## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE