### PR TITLE
[ws-manager] fix workspace status flipping pending to deleted 

### DIFF
--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -77,6 +77,9 @@ const (
 
 	// stoppedByRequestAnnotation is set on a pod when it was requested to stop using a StopWorkspace call
 	stoppedByRequestAnnotation = "gitpod.io/stoppedByRequest"
+
+	// attemptingToCreatePodAnnotation is set when ws-manager is trying to create pod and is removed when pod is successfully scheduled on the node
+	attemptingToCreatePodAnnotation = "gitpod.io/attemptingToCreate"
 )
 
 // markWorkspaceAsReady adds annotations to a workspace pod

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -306,6 +306,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 		kubernetes.WorkspaceImageSpecAnnotation: imageSpec,
 		kubernetes.OwnerTokenAnnotation:         startContext.OwnerToken,
 		wsk8s.TraceIDAnnotation:                 startContext.TraceID,
+		attemptingToCreatePodAnnotation:         "true",
 		// TODO(cw): post Kubernetes 1.19 use GA form for settings those profiles
 		"container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
 		// We're using a custom seccomp profile for user namespaces to allow clone, mount and chroot.

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -290,6 +290,13 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 		return nil, xerrors.Errorf("cannot create workspace pod: %w", err)
 	}
 
+	// remove annotation to signal that workspace pod was indeed created and scheduled on the node
+	err = m.markWorkspace(ctx, req.Id, deleteMark(attemptingToCreatePodAnnotation))
+	if err != nil {
+		clog.WithError(err).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Error("failed to remove annotation after creating workspace pod. this will break things")
+		return nil, xerrors.Errorf("couldn't remove annotation after creating workspace pod: %w", err)
+	}
+
 	span.LogKV("event", "pod started successfully")
 
 	// all workspaces get a service now

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -326,6 +326,13 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 		}
 	}
 
+	// if ws-manager is still attempting to create workspace pod, keep status in pending
+	// pod might get deleted several times if we cannot schedule it on the node
+	if _, atc := pod.Annotations[attemptingToCreatePodAnnotation]; atc {
+		result.Phase = api.WorkspacePhase_PENDING
+		return nil
+	}
+
 	if isPodBeingDeleted(pod) {
 		result.Phase = api.WorkspacePhase_STOPPING
 

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_everyone",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod.io/cpuLimit": "900m",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -19,6 +19,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/fullWorkspaceBackup": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/customTimeout": "35m20s",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "test",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -18,6 +18,7 @@
             "annotations": {
                 "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
                 "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
                 "gitpod/admission": "admit_owner_only",
                 "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
                 "gitpod/id": "foobar",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes an issue where workspace status can get flipped from PENDING to TERMINATED back and forth if workspace pod is stuck in pending state (can happen if we are scaling up). When this happens, ws-manager will delete the pod after 5s and try again. Deletion of the pod would trigger workspace status update to get flipped into TERMINATED state causing webapp to delete workspace token from db. 
This PR fixes this issue.

@geropl there is a small UX issue when pod is stuck in pending: it doesn't seem like there is any way to signal to stop the workspace. It will be stuck in pending with no way to stop it unless ws-manager will be able to schedule it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8703 

## How to test
<!-- Provide steps to test this PR -->
Spin up workspace preview env
Start workspace and observe it starts normally
Stop workspace
Cordon the node
Start workspace again
Observe that ws-manager keeps re-creating the pod every 5s as it is stuck in pending state but dashboard will remain now on Preparing workspace phase. Also observe that ws-manager-bridge is now only getting status updates that indicate phase is pending.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] fix a bug when opening workspace you would be signed out from git and not able to do git commands
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
