### PR TITLE
[ws-daemon] Support config reload for IO limits

### DIFF
--- a/components/ws-daemon/cmd/root.go
+++ b/components/ws-daemon/cmd/root.go
@@ -5,8 +5,6 @@
 package cmd
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -14,7 +12,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
-	"github.com/gitpod-io/gitpod/ws-daemon/pkg/config"
 )
 
 var (
@@ -47,23 +44,6 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-func getConfig() *config.Config {
-	ctnt, err := os.ReadFile(configFile)
-	if err != nil {
-		log.WithError(err).Fatal("cannot read configuration. Maybe missing --config?")
-	}
-
-	var cfg config.Config
-	dec := json.NewDecoder(bytes.NewReader(ctnt))
-	dec.DisallowUnknownFields()
-	err = dec.Decode(&cfg)
-	if err != nil {
-		log.WithError(err).Fatal("cannot decode configuration. Maybe missing --config?")
-	}
-
-	return &cfg
 }
 
 func init() {

--- a/components/ws-daemon/pkg/config/config.go
+++ b/components/ws-daemon/pkg/config/config.go
@@ -5,15 +5,98 @@
 package config
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"time"
 
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/daemon"
 )
+
+func Read(fn string) (*Config, error) {
+	ctnt, err := os.ReadFile(fn)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot read config file: %w", err)
+	}
+
+	var cfg Config
+	dec := json.NewDecoder(bytes.NewReader(ctnt))
+	dec.DisallowUnknownFields()
+	err = dec.Decode(&cfg)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot parse config file: %w")
+	}
+
+	return &cfg, nil
+}
+
+// watchConfig watches the configuration file and if changed reloads the static layer
+func Watch(fn string, cb func(context.Context, *daemon.Config) error) {
+	hashConfig := func() (hash string, err error) {
+		f, err := os.Open(fn)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+
+		h := sha256.New()
+		_, err = io.Copy(h, f)
+		if err != nil {
+			return "", err
+		}
+
+		return hex.EncodeToString(h.Sum(nil)), nil
+	}
+	reloadConfig := func() error {
+		cfg, err := Read(fn)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		return cb(ctx, &cfg.Daemon)
+	}
+
+	var (
+		tick    = time.NewTicker(30 * time.Second)
+		oldHash string
+	)
+	defer tick.Stop()
+	for range tick.C {
+		currentHash, err := hashConfig()
+		if err != nil {
+			log.WithError(err).Warn("cannot check if config has changed")
+		}
+
+		if oldHash == "" {
+			oldHash = currentHash
+		}
+		if currentHash == oldHash {
+			continue
+		}
+		oldHash = currentHash
+
+		err = reloadConfig()
+		if err == nil {
+			log.Info("configuration was updated - reloaded static layer config")
+		} else {
+			log.WithError(err).Error("cannot reload config - config hot reloading did not work")
+		}
+	}
+}
 
 type Config struct {
 	Daemon             daemon.Config `json:"daemon"`


### PR DESCRIPTION
## Description
This PR adds support for hot config reloading of the IO bandwidth limiting in ws-daemon.

## How to test
- change the config
- check if the v1 IO limits change

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
