### PR TITLE
[jb] allow to specify plugins per a product

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -255,9 +255,65 @@
             "properties": {
                 "plugins": {
                     "type": "array",
-                    "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
+                    "description": "List of plugins which should be installed for all JetBrains product for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
                     "items": {
                         "type": "string"
+                    }
+                },
+                "intellij": {
+                    "type": "object",
+                    "description": "Configure IntelliJ integration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "plugins": {
+                            "type": "array",
+                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "goland": {
+                    "type": "object",
+                    "description": "Configure GoLand integration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "plugins": {
+                            "type": "array",
+                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "pycharm": {
+                    "type": "object",
+                    "description": "Configure PyCharm integration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "plugins": {
+                            "type": "array",
+                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpstorm": {
+                    "type": "object",
+                    "description": "Configure PhpStorm integration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "plugins": {
+                            "type": "array",
+                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -150,6 +150,25 @@ type JetBrains struct {
 
 	// List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.
 	Plugins []string `yaml:"plugins,omitempty"`
+
+	// Configure IntelliJ integration
+	IntelliJ *JetBrainsProduct `yaml:"intellij,omitempty"`
+
+	// Configure GoLand integration
+	GoLand *JetBrainsProduct `yaml:"goland,omitempty"`
+
+	// Configure PyCharm integration
+	PyCharm *JetBrainsProduct `yaml:"pycharm,omitempty"`
+
+	// Configure PhpStorm integration
+	PhpStorm *JetBrainsProduct `yaml:"phpstorm,omitempty"`
+}
+
+// Configure JetBrains product
+type JetBrainsProduct struct {
+
+	// List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.
+	Plugins []string `yaml:"plugins,omitempty"`
 }
 
 func (strct *Github) MarshalJSON() ([]byte, error) {

--- a/components/ide/jetbrains/image/status/go.mod
+++ b/components/ide/jetbrains/image/status/go.mod
@@ -2,7 +2,10 @@ module github.com/gitpod-io/gitpod/jetbrains/status
 
 go 1.17
 
-require github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
+require (
+	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
+	github.com/google/go-cmp v0.5.6
+)
 
 require (
 	github.com/golang/mock v1.6.0 // indirect

--- a/components/ide/jetbrains/image/status/go.sum
+++ b/components/ide/jetbrains/image/status/go.sum
@@ -144,8 +144,8 @@ github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37/go.mod h1:Zaf
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -420,6 +420,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/components/ide/jetbrains/image/status/main_test.go
+++ b/components/ide/jetbrains/image/status/main_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"testing"
+
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetProductConfig(t *testing.T) {
+	expectation := &protocol.JetBrainsProduct{}
+	actual := getProductConfig(&protocol.GitpodConfig{
+		JetBrains: &protocol.JetBrains{
+			IntelliJ: expectation,
+		},
+	}, "intellij")
+
+	if diff := cmp.Diff(expectation, actual); diff != "" {
+		t.Errorf("unexpected output (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

JB plugins are often are product specific. Although it makes sense to configure some plugins which should be installed for all products it is better to allow installation of plugins per a concrete product like [here](https://github.com/akosyakov/spring-petclinic/blob/a58f7788a4a1417cf2b0006bbb0bd5aea4f2632c/.gitpod.yml#L19).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace: https://akosyakov-1f3b5e8079.staging.gitpod-dev.com#referrer:jetbrains-gateway:intellij/https://github.com/akosyakov/spring-petclinic
- Check that JPA plugin is installed on host

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow to configure JB plugins on repo level per a product, i.e. specific for IntelliJ or GoLand. 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
