### PR TITLE
[installer] reduce openvsx-proxy request memory

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -82,7 +82,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu":    resource.MustParse("1m"),
-								"memory": resource.MustParse("2.25Gi"),
+								"memory": resource.MustParse("150Mi"),
 							},
 						},
 						Ports: []v1.ContainerPort{{
@@ -117,7 +117,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu":    resource.MustParse("1m"),
-								"memory": resource.MustParse("512Mi"),
+								"memory": resource.MustParse("150Mi"),
 							},
 						},
 						VolumeMounts: []v1.VolumeMount{{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
this PR reduce the Resource requirement for `openvsx-proxy` and `redis` 2.25G looks like too big

As you can see, in a production environment, the memory of `openvsx` is basically stable at 150MB, so a request of 150MB is reasonable.

![image](https://user-images.githubusercontent.com/20944364/164409775-bfe3dd52-7dbb-49a9-9db5-c3bdfedada7f.png)

same with redis
![image](https://user-images.githubusercontent.com/20944364/164410121-20acdd55-f1dc-4222-b0a4-f8cffc9fa718.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
no need

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
