### PR TITLE
[jetbrains] experimental support of warm up in prebuilds

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -271,6 +271,22 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "prebuilds": {
+                            "type": "object",
+                            "description": "Enable warming up of IntelliJ in prebuilds.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "enum": [
+                                        "stable",
+                                        "latest",
+                                        "both"
+                                    ],
+                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
+                                }
+                            }
                         }
                     }
                 },
@@ -284,6 +300,22 @@
                             "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "prebuilds": {
+                            "type": "object",
+                            "description": "Enable warming up of GoLand in prebuilds.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "enum": [
+                                        "stable",
+                                        "latest",
+                                        "both"
+                                    ],
+                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
+                                }
                             }
                         }
                     }
@@ -299,6 +331,22 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "prebuilds": {
+                            "type": "object",
+                            "description": "Enable warming up of PyCharm in prebuilds.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "enum": [
+                                        "stable",
+                                        "latest",
+                                        "both"
+                                    ],
+                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
+                                }
+                            }
                         }
                     }
                 },
@@ -312,6 +360,22 @@
                             "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "prebuilds": {
+                            "type": "object",
+                            "description": "Enable warming up of PhpStorm in prebuilds.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "enum": [
+                                        "stable",
+                                        "latest",
+                                        "both"
+                                    ],
+                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
+                                }
                             }
                         }
                     }

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -169,6 +169,16 @@ type JetBrainsProduct struct {
 
 	// List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.
 	Plugins []string `yaml:"plugins,omitempty"`
+
+	// Enable warming up of JetBrains product in prebuilds
+	Prebuilds *JetBrainsPrebuilds `yaml:"prebuilds,omitempty"`
+}
+
+// Enable warming up of JetBrains product in prebuilds
+type JetBrainsPrebuilds struct {
+
+	// Whether only stable, latest or both versions should be warmed up.
+	Version string `yaml:"version,omitempty"`
 }
 
 func (strct *Github) MarshalJSON() ([]byte, error) {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -545,6 +545,19 @@ export interface VSCodeConfig {
     extensions?: string[];
 }
 
+export interface JetBrainsConfig {
+    intellij?: JetBrainsProductConfig;
+    goland?: JetBrainsProductConfig;
+    pycharm?: JetBrainsProductConfig;
+    phpstorm?: JetBrainsProductConfig;
+}
+export interface JetBrainsProductConfig {
+    prebuilds?: JetBrainsPrebuilds;
+}
+export interface JetBrainsPrebuilds {
+    version?: "stable" | "latest" | "both";
+}
+
 export interface RepositoryCloneInformation {
     url: string;
     checkoutLocation?: string;
@@ -561,6 +574,7 @@ export interface WorkspaceConfig {
     gitConfig?: { [config: string]: string };
     github?: GithubAppConfig;
     vscode?: VSCodeConfig;
+    jetbrains?: JetBrainsConfig;
 
     /** deprecated. Enabled by default **/
     experimentalNetwork?: boolean;

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -207,6 +207,7 @@ export interface WorkspaceInstanceRepoStatus {
 // ConfigurationIdeConfig ide config of WorkspaceInstanceConfiguration
 export interface ConfigurationIdeConfig {
     useLatest?: boolean;
+    desktopIdeAlias?: string;
 }
 
 // WorkspaceInstanceConfiguration contains all per-instance configuration

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -97,10 +97,12 @@ import { LocalMessageBroker, LocalRabbitMQBackedMessageBroker } from "./messagin
 import { contentServiceBinder } from "@gitpod/content-service/lib/sugar";
 import { ReferrerPrefixParser } from "./workspace/referrer-prefix-context-parser";
 import { InstallationAdminTelemetryDataProvider } from "./installation-admin/telemetry-data-provider";
+import { IDEService } from "./ide-service";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
     bind(IDEConfigService).toSelf().inSingletonScope();
+    bind(IDEService).toSelf().inSingletonScope();
 
     bind(UserService).toSelf().inSingletonScope();
     bind(UserDeletionService).toSelf().inSingletonScope();

--- a/components/server/src/ide-service.ts
+++ b/components/server/src/ide-service.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { JetBrainsConfig, TaskConfig, Workspace } from "@gitpod/gitpod-protocol";
+import { injectable } from "inversify";
+
+@injectable()
+export class IDEService {
+    resolveGitpodTasks(ws: Workspace): TaskConfig[] {
+        const tasks: TaskConfig[] = [];
+        if (ws.config.tasks) {
+            tasks.push(...ws.config.tasks);
+        }
+        // TODO(ak) it is a hack to get users going, we should rather layer JB products on prebuild workspaces and move logic to corresponding images
+        if (ws.type === "prebuild" && ws.config.jetbrains) {
+            let warmUp = "";
+            for (const key in ws.config.jetbrains) {
+                let productCode;
+                if (key === "intellij") {
+                    productCode = "IIU";
+                } else if (key === "goland") {
+                    productCode = "GO";
+                } else if (key === "pycharm") {
+                    productCode = "PCP";
+                } else if (key === "phpstorm") {
+                    productCode = "PS";
+                }
+                const prebuilds = productCode && ws.config.jetbrains[key as keyof JetBrainsConfig]?.prebuilds;
+                if (prebuilds) {
+                    warmUp +=
+                        prebuilds.version === "latest"
+                            ? ""
+                            : `
+echo 'warming up stable release of ${key}...'
+echo 'downloading stable ${key} backend...'
+mkdir /tmp/backend
+curl -sSLo /tmp/backend/backend.tar.gz "https://download.jetbrains.com/product?type=release&distribution=linux&code=${productCode}"
+tar -xf /tmp/backend/backend.tar.gz --strip-components=1 --directory /tmp/backend
+
+echo 'configuring JB system config and caches aligned with runtime...'
+printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend/bin/idea.properties"
+unset JAVA_TOOL_OPTIONS
+export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains
+export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
+
+echo 'running stable ${key} backend in warmup mode...'
+/tmp/backend/bin/remote-dev-server.sh warmup "$GITPOD_REPO_ROOT"
+
+echo 'removing stable ${key} backend...'
+rm -rf /tmp/backend
+`;
+                    warmUp +=
+                        prebuilds.version === "stable"
+                            ? ""
+                            : `
+echo 'warming up latest release of ${key}...'
+echo 'downloading latest ${key} backend...'
+mkdir /tmp/backend-latest
+curl -sSLo /tmp/backend-latest/backend-latest.tar.gz "https://download.jetbrains.com/product?type=release,eap,rc&distribution=linux&code=${productCode}"
+tar -xf /tmp/backend-latest/backend-latest.tar.gz --strip-components=1 --directory /tmp/backend-latest
+
+echo 'configuring JB system config and caches aligned with runtime...'
+printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend-latest/bin/idea.properties"
+unset JAVA_TOOL_OPTIONS
+export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains-latest
+export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains-latest
+
+echo 'running ${key} backend in warmup mode...'
+/tmp/backend-latest/bin/remote-dev-server.sh warmup "$GITPOD_REPO_ROOT"
+
+echo 'removing latest ${key} backend...'
+rm -rf /tmp/backend-latest
+`;
+                }
+            }
+            if (warmUp) {
+                tasks.push({
+                    init: warmUp.trim(),
+                });
+            }
+        }
+        return tasks;
+    }
+}

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -109,6 +109,7 @@ import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { ExtendedUser } from "@gitpod/ws-manager/lib/constraints";
 import { increaseFailedInstanceStartCounter, increaseSuccessfulInstanceStartCounter } from "../prometheus-metrics";
 import { ContextParser } from "./context-parser-service";
+import { IDEService } from "../ide-service";
 
 export interface StartWorkspaceOptions {
     rethrow?: boolean;
@@ -119,6 +120,7 @@ export interface StartWorkspaceOptions {
 const MAX_INSTANCE_START_RETRIES = 2;
 const INSTANCE_START_RETRY_INTERVAL_SECONDS = 2;
 
+// TODO(ak) move to IDE service
 export const migrationIDESettings = (user: User) => {
     if (!user?.additionalData?.ideSettings || user.additionalData.ideSettings.settingVersion === "2.0") {
         return;
@@ -145,6 +147,7 @@ export const migrationIDESettings = (user: User) => {
     return newIDESettings;
 };
 
+// TODO(ak) move to IDE service
 export const chooseIDE = (
     ideChoice: string,
     ideOptions: IDEOptions,
@@ -181,6 +184,7 @@ export class WorkspaceStarter {
     @inject(WorkspaceManagerClientProvider) protected readonly clientProvider: WorkspaceManagerClientProvider;
     @inject(Config) protected readonly config: Config;
     @inject(IDEConfigService) private readonly ideConfigService: IDEConfigService;
+    @inject(IDEService) private readonly ideService: IDEService;
     @inject(TracedWorkspaceDB) protected readonly workspaceDb: DBWithTracing<WorkspaceDB>;
     @inject(TracedUserDB) protected readonly userDB: DBWithTracing<UserDB>;
     @inject(TokenProvider) protected readonly tokenProvider: TokenProvider;
@@ -598,6 +602,7 @@ export class WorkspaceStarter {
         excludeFeatureFlags: NamedWorkspaceFeatureFlag[],
         ideConfig: IDEConfig,
     ): Promise<WorkspaceInstance> {
+        //#endregion IDE resolution TODO(ak) move to IDE service
         // TODO: Compatible with ide-config not deployed, need revert after ide-config deployed
         delete ideConfig.ideOptions.options["code-latest"];
         delete ideConfig.ideOptions.options["code-desktop-insiders"];
@@ -654,6 +659,7 @@ export class WorkspaceStarter {
                     });
             }
         }
+        //#endregion
 
         let featureFlags: NamedWorkspaceFeatureFlag[] = workspace.config._featureFlags || [];
         featureFlags = featureFlags.concat(this.config.workspaceDefaults.defaultFeatureFlags);
@@ -706,6 +712,7 @@ export class WorkspaceStarter {
         return instance;
     }
 
+    // TODO(ak) move to IDE service
     protected resolveReferrerIDE(
         workspace: Workspace,
         user: User,
@@ -1129,12 +1136,13 @@ export class WorkspaceStarter {
         envvars.push(contextEnv);
 
         log.debug("Workspace config", workspace.config);
-        if (!!workspace.config.tasks) {
-            // The task config is interpreted by Theia only, there's little point in transforming it into something
+        const tasks = this.ideService.resolveGitpodTasks(workspace);
+        if (tasks.length) {
+            // The task config is interpreted by supervisor only, there's little point in transforming it into something
             // wsman understands and back into the very same structure.
             const ev = new EnvironmentVariable();
             ev.setName("GITPOD_TASKS");
-            ev.setValue(JSON.stringify(workspace.config.tasks));
+            ev.setValue(JSON.stringify(tasks));
             envvars.push(ev);
         }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It introduces very experimental support of warming up JetBrains's products in prebuilds. It is based on a synthetic task inferred from .gitpod.yml configuration. [Here](https://github.com/akosyakov/spring-petclinic/blob/97613e245be3312160b2b073f6ab41c44cb4b084/.gitpod.yml#L18-L29) is an example:
```yaml
jetbrains:
  intellij:
    plugins:
      - com.haulmont.jpab
    prebuilds:
      version: stable
  goland:
    prebuilds:
      version: latest
  pycharm:
    prebuilds:
      version: both
```

A user can configure which products should be warmed up during prebuild and controls whether stable, latest or both version should be indexed. 

**Caveat:** This approach does not respect plugins and versions of JB products how they are treated by JB imaged produced by Gitpod. Ideally we should layer such images and move logic there.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/6740

## How to test
<!-- Provide steps to test this PR -->

### Proper way
- Enable IntelliJ in preferences https://ak-jb-prebuilds.preview.gitpod-dev.com/preferences
- Fork https://github.com/akosyakov/spring-petclinic
- Add a fork as a project into https://ak-jb-prebuilds.preview.gitpod-dev.com/projects
- Go to https://ak-jb-prebuilds.preview.gitpod-dev.com/projects/spring-petclinic
- Start a prebuild for **jb_warm_up** branch of fork
- Wait for a prebuild to finish successfully... it can take about 20-30mins. Prebuild UI shows only one task at time so be patient. You can though reload the page if one tasks finished but not entire prebuild after reload it will show output of next task...
- Start a new workspace for **jb_warm_up** branch of fork, it should use prebuild and IntelliJ should recognise the index 
- Check logs of indexing with `cat /workspace/.gitpod/prebuild-log-1` in terminal of a workspace.

### Lazy way
- Start a new workspace: https://ak-jb-prebuilds.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/akosyakov/spring-petclinic/tree/jb_warm_up
-  it should use prebuild and IntelliJ should recognise the index 
- Check logs of indexing with `cat /workspace/.gitpod/prebuild-log-1` in terminal of a workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added experimental support of warming up JetBrains's products in prebuilds via .gitpod.yml.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-vm