### PR TITLE
Add new 'building' phase to workspaces

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -82,8 +82,10 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
     useEffect(() => {
         switch (workspaceInstance?.status.phase) {
             // Preparing means that we haven't actually started the workspace instance just yet, but rather
-            // are still preparing for launch. This means we're building the Docker image for the workspace.
+            // are still preparing for launch.
             case "preparing":
+            // Building means we're building the Docker image for the workspace so the workspace hasn't started yet.
+            case "building":
             case "stopped":
                 getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
                 break;

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -340,7 +340,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             return;
         }
 
-        if (workspaceInstance.status.phase === "preparing") {
+        if (workspaceInstance.status.phase === "building" || workspaceInstance.status.phase == "preparing") {
             this.setState({ hasImageBuildLogs: true });
         }
 
@@ -402,10 +402,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             // a workspace. This phase is usually accompanied by an error.
             case "unknown":
                 break;
-
             // Preparing means that we haven't actually started the workspace instance just yet, but rather
-            // are still preparing for launch. This means we're building the Docker image for the workspace.
+            // are still preparing for launch.
             case "preparing":
+            // Building means we're building the Docker image for the workspace.
+            case "building":
                 return <ImageBuildView workspaceId={this.state.workspaceInstance.workspaceId} />;
 
             // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -530,13 +530,14 @@ const hasWindow = typeof window !== "undefined";
 const phasesOrder: Record<WorkspaceInstancePhase, number> = {
     unknown: 0,
     preparing: 1,
-    pending: 2,
-    creating: 3,
-    initializing: 4,
-    running: 5,
-    interrupted: 6,
-    stopping: 7,
-    stopped: 8,
+    building: 2,
+    pending: 3,
+    creating: 4,
+    initializing: 5,
+    running: 6,
+    interrupted: 7,
+    stopping: 8,
+    stopped: 9,
 };
 export class WorkspaceInstanceUpdateListener {
     private readonly onDidChangeEmitter = new Emitter<void>();

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -98,8 +98,12 @@ export type WorkspaceInstancePhase =
     | "unknown"
 
     // Preparing means that we haven't actually started the workspace instance just yet, but rather
-    // are still preparing for launch. This means we're building the Docker image for the workspace.
+    // are still preparing for launch.
     | "preparing"
+
+    // Building means that we are building the Docker image for the workspace. A workspace will enter this phase only
+    // if an image build is required for that workspace.
+    | "building"
 
     // Pending means the workspace does not yet consume resources in the cluster, but rather is looking for
     // some space within the cluster. If for example the cluster needs to scale up to accomodate the

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -164,6 +164,10 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                         when (update.status.phase) {
                             "preparing" -> {
                                 phaseMessage.text = "Preparing"
+                                statusMessage.text = "Preparing workspace..."
+                            }
+                            "building" -> {
+                                phaseMessage.text = "Building"
                                 statusMessage.text = "Building workspace image..."
                             }
                             "pending" -> {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1541,8 +1541,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             await new Promise((resolve) => setTimeout(resolve, 2000));
 
             const wsi = await this.workspaceDb.trace(ctx).findInstanceById(instance.id);
-            if (!wsi || wsi.status.phase !== "preparing") {
-                log.debug(logCtx, `imagebuild logs: instance is not/no longer in 'preparing' state`, {
+            if (!wsi || (wsi.status.phase !== "preparing" && wsi.status.phase !== "building")) {
+                log.debug(logCtx, `imagebuild logs: instance is not/no longer in 'building' state`, {
                     phase: wsi?.status.phase,
                 });
                 return;

--- a/components/server/src/workspace/headless-log-service.ts
+++ b/components/server/src/workspace/headless-log-service.ts
@@ -416,6 +416,7 @@ export class HeadlessLogService {
 function isSupervisorAvailableSoon(wsi: WorkspaceInstance): boolean {
     switch (wsi.status.phase) {
         case "creating":
+        case "building":
         case "preparing":
         case "initializing":
         case "pending":

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -106,7 +106,7 @@ export class WorkspaceManagerBridge implements Disposable {
             // Still, listen to all updates, generate/derive new state and distribute it locally!
             startStatusUpdateHandler(false);
 
-            // emulate WorkspaceInstance updates for all Workspaces in the "preparing" phase in this cluster
+            // emulate WorkspaceInstance updates for all Workspaces in the  "preparing" or "building" phase in this cluster
             const updateEmulator = this.preparingUpdateEmulatorFactory() as PreparingUpdateEmulator;
             this.disposables.push(updateEmulator);
             updateEmulator.start(cluster.name);

--- a/components/ws-manager-bridge/src/preparing-update-emulator.ts
+++ b/components/ws-manager-bridge/src/preparing-update-emulator.ts
@@ -42,7 +42,13 @@ export class PreparingUpdateEmulator implements Disposable {
                 const span = TraceContext.startSpan("preparingUpdateEmulatorRun");
                 const ctx = { span };
                 try {
-                    const instances = await this.workspaceDb.findInstancesByPhaseAndRegion("preparing", region);
+                    const instances = (
+                        await Promise.all([
+                            this.workspaceDb.findInstancesByPhaseAndRegion("preparing", region),
+                            this.workspaceDb.findInstancesByPhaseAndRegion("building", region),
+                        ])
+                    ).flat();
+
                     span.setTag("preparingUpdateEmulatorRun.nrOfInstances", instances.length);
                     for (const instance of instances) {
                         const hash = hasher(instance);


### PR DESCRIPTION
## Description

Add a new `building` phase to the list of phases that a workspace passes through on its way to running. A workspace is in `building` iff its workspace docker image is being built.

## Related Issue(s)

Part of #9410

## How to test
Refactoring that should have no effect on behaviour:

* Visit the preview environment for this PR
* Add a new project and start a workspace from it.
* The workspace starts up as normal.

## Release Notes

```release-note
NONE
```

## Documentation

None

 - [x] /werft with-vm=true