### PR TITLE
[kots]: add an installation status pod

### DIFF
--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -111,6 +111,7 @@ function publishKots(werft: Werft, jobConfig: JobConfig) {
 
     // Set the tag to the current version
     exec(`yq w -i ${REPLICATED_YAML_DIR}/gitpod-installer-job.yaml ${INSTALLER_JOB_IMAGE} ${image}:${jobConfig.version}`, { slice: phases.PUBLISH_KOTS });
+    exec(`yq w -i ${REPLICATED_YAML_DIR}/gitpod-installation-status.yaml ${INSTALLER_JOB_IMAGE} ${image}:${jobConfig.version}`, { slice: phases.PUBLISH_KOTS });
 
     // Generate the logo
     exec(`make logo -C ${REPLICATED_DIR}`, { slice: phases.PUBLISH_KOTS });

--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:3.15
 COPY --from=alpine/helm:3.8.0 /usr/bin/helm /usr/bin/helm
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
-RUN apk add --no-cache curl yq  \
+RUN apk add --no-cache curl jq yq  \
     && curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 ENTRYPOINT [ "/app/installer" ]

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: installation-status
+  labels:
+    app: gitpod
+    component: gitpod-installer-status
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: gitpod-installer-status
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gitpod
+        component: gitpod-installer-status
+    spec:
+      restartPolicy: Always
+      serviceAccountName: installer
+      containers:
+        - name: installation-status
+          # This will normally be the release tag
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:main.2968"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              set -e
+
+              while true
+              do
+                echo "Checking installation status"
+
+                if [ "$(helm status -n {{repl Namespace }} gitpod -o json | jq '.info.status == "deployed"')" != "true" ];
+                then
+                  echo "Gitpod: Installation not complete"
+                  exit 1
+                fi
+
+                echo "Sleeping for 10 seconds"
+                sleep 10
+              done
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "500m"

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -23,8 +23,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: installer
-          # This will normally be the release tag - using this tag as need the license evaluator
-          image: 'eu.gcr.io/gitpod-core-dev/build/installer:sje-airgapped.0'
+          # This will normally be the release tag
+          image: 'eu.gcr.io/gitpod-core-dev/build/installer:main.2968'
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -211,6 +211,9 @@ spec:
                 --wait \
                 gitpod \
                 "${GITPOD_OBJECTS}"
+
+              echo "Gitpod: Restarting installation status job"
+              kubectl delete pod -n {{repl Namespace }} -l component=gitpod-installer-status || true
 
               echo "Gitpod: Installer job finished - goodbye"
       volumes:

--- a/install/kots/manifests/kots-app.yaml
+++ b/install/kots/manifests/kots-app.yaml
@@ -17,6 +17,7 @@ spec:
     - deployment/dashboard
     - deployment/ide-proxy
     - deployment/image-builder-mk3
+    - deployment/installation-status
     - deployment/proxy
     - deployment/server
     - deployment/ws-manager


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Under normal circumstances, a KOTS application is able to manage the [status of a deployment](https://docs.replicated.com/vendor/admin-console-display-app-status) - presumably through checking an annotation exists on a pod. As we are using the Installer rather than Kustomize/Helm and we cannot add the required annotations, the status will simply check that the resource exists which means that upgrades will find the _old_ resource rather than the new, falsely reporting that the application is deployed.

This uses the Helm status to find out the status of the Helm installation and crashes if it is not "deployed". This gives a KOTS user feedback as to the status of the Gitpod installation job. Unfortunately, it's a little bit brute-force so it show "unavailable" rather than "upgrading", but we're limited by what KOTS provides us.

![image](https://user-images.githubusercontent.com/275848/164461112-38c4727d-ee39-4000-a05f-7a184d6148b7.png)

When the Helm deployment has been successfully completed, it deletes the pod. This is important as the Kubernetes job works on an exponential back-off time - if the installation takes a while, this can result in many minutes until it's marked as "deployed". This makes the feedback as fast as possible.

This is the first of various tasks to make KOTS a more reliable and enjoyable experience, especially when not following the Happy Path.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9195 

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS and check the status

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add an installation status pod
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
