### PR TITLE
Fix io limiting with cgroup v2

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v2.go
@@ -58,7 +58,7 @@ func (c *IOLimiterV2) Apply(ctx context.Context, basePath, cgroupPath string) er
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
-		ioMaxFile := filepath.Join(basePath, cgroupPath)
+		ioMaxFile := filepath.Join(basePath, cgroupPath, "workspace", "user")
 
 		for {
 			select {


### PR DESCRIPTION
## Description
Fix io limiting with cgroup v2. 

## Related Issue(s)
n.a.

## How to test
<!-- Provide steps to test this PR -->
https://www.loom.com/share/3fc4a931fe3c4541b673650f86d56430

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Ensure io limiting of workspaces works with cgroup v2
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
