### PR TITLE
Fix validation of user env vars

### DIFF
--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -198,8 +198,8 @@ export default function EnvVars() {
         if (name.trim() === "") {
             return "Name must not be empty.";
         }
-        if (!/^[a-zA-Z0-9_]*$/.test(name)) {
-            return "Name must match /[a-zA-Z_]+[a-zA-Z0-9_]*/.";
+        if (!/^[a-zA-Z_]+[a-zA-Z0-9_]*$/.test(name)) {
+            return "Name must match /^[a-zA-Z_]+[a-zA-Z0-9_]*$/.";
         }
         if (variable.value.trim() === "") {
             return "Value must not be empty.";

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -5,6 +5,9 @@
  */
 
 export namespace ErrorCodes {
+    // 400 Unauthorized
+    export const BAD_REQUEST = 400;
+
     // 401 Unauthorized
     export const NOT_AUTHENTICATED = 401;
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -191,6 +191,39 @@ export interface UserEnvVar extends UserEnvVarValue {
 }
 
 export namespace UserEnvVar {
+    /**
+     * @param variable
+     * @returns Either a string containing an error message or undefined.
+     */
+    export function validate(variable: UserEnvVarValue): string | undefined {
+        const name = variable.name;
+        const pattern = variable.repositoryPattern;
+        if (name.trim() === "") {
+            return "Name must not be empty.";
+        }
+        if (!/^[a-zA-Z_]+[a-zA-Z0-9_]*$/.test(name)) {
+            return "Name must match /^[a-zA-Z_]+[a-zA-Z0-9_]*$/.";
+        }
+        if (variable.value.trim() === "") {
+            return "Value must not be empty.";
+        }
+        if (pattern.trim() === "") {
+            return "Scope must not be empty.";
+        }
+        const split = pattern.split("/");
+        if (split.length < 2) {
+            return "A scope must use the form 'organization/repo'.";
+        }
+        for (const name of split) {
+            if (name !== "*") {
+                if (!/^[a-zA-Z0-9_\-.\*]+$/.test(name)) {
+                    return "Invalid scope segment. Only ASCII characters, numbers, -, _, . or * are allowed.";
+                }
+            }
+        }
+        return undefined;
+    }
+
     // DEPRECATED: Use ProjectEnvVar instead of repositoryPattern - https://github.com/gitpod-com/gitpod/issues/5322
     export function normalizeRepoPattern(pattern: string) {
         return pattern.toLocaleLowerCase();

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1840,6 +1840,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const user = this.checkAndBlockUser("setEnvVar");
         const userId = user.id;
 
+        // validate input
+        const validationError = UserEnvVar.validate(variable);
+        if (validationError) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, validationError);
+        }
+
         variable.repositoryPattern = UserEnvVar.normalizeRepoPattern(variable.repositoryPattern);
         const existingVars = (await this.userDB.getEnvVars(user.id)).filter((v) => !v.deleted);
 


### PR DESCRIPTION
## Description
This PR does 3 things:
 - fixes env var validation in the dashboard by enforcing are not starting with a number
 - extracts the validation into `protocol`
 - uses the same validation in `server` on `setEnvVar`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8950

## How to test
- head to https://gpl-8950-envs.preview.gitpod-dev.com/variables
- try to create a variable named `22`: should fail :x: 
- try to create a variable named `_22`: should pass :green_circle: 
- try to create a variable named `a22`: should pass :green_circle: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix and improve validation of user environment variables
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
