### PR TITLE
[code] Build stable image for 1.66.2 with proxy fix

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 4342b6bfa3e8cd7c206b57b21c4b0b7755222c3f
+  codeCommit: e1404ed79129ff1dc0cc888f3162a9bd627dc41f
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.1.tar.gz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update code to 1.66.2 with proxy fix https://github.com/gitpod-io/openvscode-server/commit/e1404ed79129ff1dc0cc888f3162a9bd627dc41f

## How to test
<!-- Provide steps to test this PR -->
1. Select insiders
1. Open workspace
2. Check commit is `e1404ed79129ff1dc0cc888f3162a9bd627dc41f`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
