### PR TITLE
[server] add editor prefix to choose custom IDE

### DIFF
--- a/components/gitpod-protocol/src/context-url.ts
+++ b/components/gitpod-protocol/src/context-url.ts
@@ -20,6 +20,7 @@ export namespace ContextURL {
     export const IMAGEBUILD_PREFIX = "imagebuild";
     export const SNAPSHOT_PREFIX = "snapshot";
     export const REFERRER_PREFIX = "referrer:";
+    export const EDITOR_PREFIX = "editor:";
 
     /**
      * This function will (try to) return the HTTP(S) URL of the context the user originally created this workspace on.
@@ -94,7 +95,8 @@ export namespace ContextURL {
             firstSegment === INCREMENTAL_PREBUILD_PREFIX ||
             firstSegment === IMAGEBUILD_PREFIX ||
             firstSegment === SNAPSHOT_PREFIX ||
-            firstSegment.startsWith(REFERRER_PREFIX)
+            firstSegment.startsWith(REFERRER_PREFIX) ||
+            firstSegment.startsWith(EDITOR_PREFIX)
         ) {
             return segmentsToURL(1);
         }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -863,6 +863,17 @@ export namespace PrebuiltWorkspaceContext {
     }
 }
 
+export interface WithEditorContext extends WorkspaceContext {
+    ide: string;
+    useLatest?: boolean;
+}
+
+export namespace WithEditorContext {
+    export function is(context: any): context is WithEditorContext {
+        return context && "ide" in context;
+    }
+}
+
 export interface WithReferrerContext extends WorkspaceContext {
     referrer: string;
     referrerIde?: string;

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -96,6 +96,7 @@ import { DebugApp } from "./debug-app";
 import { LocalMessageBroker, LocalRabbitMQBackedMessageBroker } from "./messaging/local-message-broker";
 import { contentServiceBinder } from "@gitpod/content-service/lib/sugar";
 import { ReferrerPrefixParser } from "./workspace/referrer-prefix-context-parser";
+import { EditorPrefixParser } from "./workspace/editor-prefix-context-parser";
 import { InstallationAdminTelemetryDataProvider } from "./installation-admin/telemetry-data-provider";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -169,6 +170,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(SnapshotContextParser).toSelf().inSingletonScope();
     bind(IContextParser).to(SnapshotContextParser).inSingletonScope();
     bind(IPrefixContextParser).to(ReferrerPrefixParser).inSingletonScope();
+    bind(IPrefixContextParser).to(EditorPrefixParser).inSingletonScope();
     bind(IPrefixContextParser).to(EnvvarPrefixParser).inSingletonScope();
     bind(IPrefixContextParser).to(ImageBuildPrefixContextParser).inSingletonScope();
     bind(IPrefixContextParser).to(AdditionalContentPrefixContextParser).inSingletonScope();

--- a/components/server/src/workspace/editor-prefix-context-parser.ts
+++ b/components/server/src/workspace/editor-prefix-context-parser.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { IPrefixContextParser } from "./context-parser";
+import { User, WorkspaceContext, WithEditorContext } from "@gitpod/gitpod-protocol";
+import { injectable } from "inversify";
+
+@injectable()
+export class EditorPrefixParser implements IPrefixContextParser {
+    private readonly prefix = /^\/?editor:([^\/:]*?)(?::([^\/:]*?))?\//;
+
+    findPrefix(_: User, context: string): string | undefined {
+        return this.prefix.exec(context)?.[0] || undefined;
+    }
+
+    async handle(_: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext | WithEditorContext> {
+        const matches = this.prefix.exec(prefix);
+        const ide = matches?.[1];
+        const useLatest = matches?.[2] === "latest";
+        return ide ? { ...context, ide, useLatest } : context;
+    }
+}

--- a/components/server/src/workspace/workspace-starter.spec.ts
+++ b/components/server/src/workspace/workspace-starter.spec.ts
@@ -249,5 +249,19 @@ describe("workspace-starter", function () {
             const result = chooseIDE("unknown-custom", customOptions, useLatest, hasPerm);
             expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
         });
+
+        it("not exists ide with custom permission", function () {
+            const useLatest = true;
+            const hasPerm = true;
+            const result = chooseIDE("not-exists", ideOptions, useLatest, hasPerm);
+            expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
+        });
+
+        it("not exists ide with custom permission", function () {
+            const useLatest = true;
+            const hasPerm = false;
+            const result = chooseIDE("not-exists", ideOptions, useLatest, hasPerm);
+            expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
+        });
     });
 });

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -156,7 +156,7 @@ export const chooseIDE = (
     const data: { desktopIdeImage?: string; ideImage: string } = {
         ideImage: defaultIdeImage,
     };
-    const chooseOption = ideOptions.options[ideChoice];
+    const chooseOption = ideOptions.options[ideChoice] ?? defaultIDEOption;
     const isDesktopIde = chooseOption.type === "desktop";
     if (isDesktopIde) {
         data.desktopIdeImage = useLatest ? chooseOption?.latestImage ?? chooseOption?.image : chooseOption?.image;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Support choose custom IDE with prefix `/#editor:<ide>:<version?>/<repo>`

|Name|Desc|Required|values|Default|Example|
|:-:|:-:|:-:|:-:|:-:|:-:|
|ide| IDE id choose to open| true | see [here](https://github.com/gitpod-io/gitpod/blob/b2d07b8bf0d3364cd8b831e487a79fa7ab1fc638/chart/templates/server-ide-configmap.yaml#L45-L89) | code | `code` `goland` ... |
|version| IDE version | false| stable or latest | stable | latest |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9434

https://github.com/gitpod-io/template-sveltejs
## How to test
<!-- Provide steps to test this PR -->
Open with 

1. code stable => https://hw-9434-open-via-url.staging.gitpod-dev.com/#editor:code/https://github.com/gitpod-io/template-sveltejs
2. code desktop stable => https://hw-9434-open-via-url.staging.gitpod-dev.com/#editor:code-desktop/https://github.com/gitpod-io/template-sveltejs
3. goland stable => https://hw-9434-open-via-url.staging.gitpod-dev.com/#editor:goland/https://github.com/gitpod-io/template-sveltejs
4. goland latest => https://hw-9434-open-via-url.staging.gitpod-dev.com/#editor:goland:latest/https://github.com/gitpod-io/template-sveltejs
5. **unknown ide** will use default code => https://hw-9434-open-via-url.staging.gitpod-dev.com/#editor:not-exists:latest/https://github.com/gitpod-io/template-sveltejs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe