### PR TITLE
[code] Update stable to 1.66.2 with proxy fix

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -357,7 +357,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-c89358b24c9577d1fd986d57387f3847f7dfb06f"
+      stableVersion: "commit-e4d4c1cc703e3adc62e4cfe935f37d5d2eeb6df3"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-c89358b24c9577d1fd986d57387f3847f7dfb06f" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-e4d4c1cc703e3adc62e4cfe935f37d5d2eeb6df3" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates stable VS Code Web to 1.66.2 with proxy fix https://github.com/gitpod-io/openvscode-server/commit/e1404ed79129ff1dc0cc888f3162a9bd627dc41f

## How to test
<!-- Provide steps to test this PR -->
- Select stable
- Open workspace
- Check commit is `e1404ed79129ff1dc0cc888f3162a9bd627dc41f`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
