### PR TITLE
[kots]: allow deployment whilst installer job running

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -7,24 +7,27 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: installer
+  # Appending cursor allows us to replace with new versions
+  name: installer-{{repl Cursor }}
   labels:
     app: gitpod
     component: gitpod-installer
+    cursor: "{{repl Cursor }}"
 spec:
-  ttlSecondsAfterFinished: 60
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       labels:
         app: gitpod
         component: gitpod-installer
+        cursor: "{{repl Cursor }}"
     spec:
       serviceAccountName: installer
       restartPolicy: OnFailure
       containers:
         - name: installer
           # This will normally be the release tag
-          image: 'eu.gcr.io/gitpod-core-dev/build/installer:main.2968'
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:main.2968"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -49,6 +52,26 @@ spec:
           args:
             - |
               set -e
+
+              echo "Gitpod: Killing any in-progress installations"
+
+              kubectl delete jobs.batch -n {{repl Namespace }} -l component=gitpod-installer,cursor!={{repl Cursor }} --force --grace-period 0 || true
+              kubectl delete pod -n {{repl Namespace }} -l component=gitpod-installer,cursor!={{repl Cursor }} --force --grace-period 0 || true
+
+              if [ "$(helm status -n {{repl Namespace }} gitpod -o json | jq '.info.status == "deployed"')" = "false" ];
+              then
+                echo "Gitpod: Deployment in-progress - clearing"
+
+                VERSION="$(helm status -n {{repl Namespace }} gitpod -o json | jq '.version')"
+                if [ "${VERSION}" -le 1 ];
+                then
+                  echo "Gitpod: Uninstall application"
+                  helm uninstall -n {{repl Namespace }} gitpod --wait || true
+                else
+                  echo "Gitpod: Rolling back application"
+                  helm rollback -n {{repl Namespace }} gitpod --wait || true
+                fi
+              fi
 
               echo "Gitpod: Generate the base Installer config"
               /app/installer init > "${CONFIG_FILE}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
> In this PR, install means "install or upgrade" unless otherwise stated

Allow deployment whilst an existing Installer job running. This should allow for recovery in the following scenarios:

1. Deployment failed/stopped mid-install and user wants to redeploy same version
2. Deployment failed/stopped mid-install and user wants to deploy a different version
3. User decides to trigger a new deployment whilst an existing deployment is in progress

This appends the [cursor](https://docs.replicated.com/reference/template-functions-license-context#cursor) to the job name. This is necessary to allow us to change the `image` on the container, effectively replacing the existing job. The first part of this script then removes any already running jobs/pods, thus clearing up the state.

It then rolls back (or uninstalls if it's the first deployment) before starting the next `helm upgrade`. For a user, this should then allow them to unstick their issues.

Setting of the `ttlSecondsAfterFinished` to `0` means that the "redeploy" button works as soon as the job as finished

## How to test
<!-- Provide steps to test this PR -->
Get your Helm deployment into either a `pending-install` or `pending-upgrade` state. The script does this anyway for an upgrade, but to do this manually, suggest starting an install job then running:

```shell
kubectl delete jobs.batch -n gitpod -l component=gitpod-installer --force --grace-period 0
kubectl delete pod -n gitpod -l component=gitpod-installer --force --grace-period 0
```

> The reason it doesn't work for a redeployment is because Kubernetes sees the request to deploy a job called `installer-1234` and, as that's already deployed, it thinks "oooh, nothing to do". There seems to be no way of generating a random value at deploy-time with KOTS - have asked as a [question in our channel](https://gitpod.slack.com/archives/C02SWJ49JQ2/p1650571390051829)

Ensure by running `helm ls -aA`.

Now, run the following - all of these should result in a successful deployment, and will need you to get it to enter the same "pending" state as above:
1. Redeploy the existing deployment.
4. Publish a new version to KOTS and deploy that

For regression, we should also test:
1. A fresh installation (run `helm un -n gitpod gitpod`)
2. An upgrade that's not in a "pending" state
5. A redeployment that's not in a "pending" state

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: allow deployment whilst installer job running
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
