### PR TITLE
[baseserver] Serve pprof on /debug/pprof

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -7,6 +7,7 @@ package baseserver
 import (
 	"context"
 	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -213,7 +214,10 @@ func (s *Server) initializeHTTP() error {
 func (s *Server) newHTTPMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ready", s.cfg.healthHandler.ReadyEndpoint)
+	s.Logger().WithField("protocol", "http").Debug("Serving readiness handler on /ready")
+
 	mux.HandleFunc("/live", s.cfg.healthHandler.LiveEndpoint)
+	s.Logger().WithField("protocol", "http").Debug("Serving liveliness handler on /live")
 
 	// Metrics endpoint
 	metricsHandler := promhttp.Handler()
@@ -223,6 +227,10 @@ func (s *Server) newHTTPMux() *http.ServeMux {
 		)
 	}
 	mux.Handle("/metrics", metricsHandler)
+	s.Logger().WithField("protocol", "http").Debug("Serving metrics on /metrics")
+
+	mux.Handle(pprof.Path, pprof.Handler())
+	s.Logger().WithField("protocol", "http").Debug("Serving profiler on /debug/pprof")
 
 	return mux
 }

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -7,6 +7,7 @@ package baseserver_test
 import (
 	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/gitpod-io/gitpod/common-go/pprof"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"net/http"
@@ -66,4 +67,13 @@ func TestServer_ServesMetricsEndpointWithCustomMetricsConfig(t *testing.T) {
 	resp, err := http.Get(readyUR)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestServer_ServesPprof(t *testing.T) {
+	srv := baseserver.NewForTests(t)
+	baseserver.StartServerForTests(t, srv)
+
+	resp, err := http.Get(srv.HTTPAddress() + pprof.Path)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "must serve pprof on %s", pprof.Path)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds pprof https://pkg.go.dev/net/http/pprof

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE