### PR TITLE
[ws-daemon] Fix CPU limit annotation

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -98,9 +98,11 @@ type DispatchListener struct {
 }
 
 type workspace struct {
-	CFS       CFSController
-	OWI       logrus.Fields
-	HardLimit ResourceLimiter
+	CFS        CgroupCFSController
+	OWI        logrus.Fields
+	BaseLimit  Bandwidth
+	BurstLimit Bandwidth
+	HardLimit  ResourceLimiter
 
 	lastThrottled uint64
 }
@@ -135,6 +137,8 @@ func (d *DispatchListener) source(context.Context) ([]Workspace, error) {
 			ID:          id,
 			NrThrottled: throttled,
 			Usage:       usage,
+			BaseLimit:   w.BaseLimit,
+			BurstLimit:  w.BurstLimit,
 		})
 	}
 	return res, nil
@@ -215,7 +219,8 @@ func (d *DispatchListener) WorkspaceUpdated(ctx context.Context, ws *dispatch.Wo
 		if err != nil {
 			return xerrors.Errorf("cannot enforce fixed CPU limit: %w", err)
 		}
-		wsinfo.HardLimit = FixedLimiter(BandwidthFromQuantity(limit))
+		wsinfo.BaseLimit = BandwidthFromQuantity(limit)
+		wsinfo.BurstLimit = BandwidthFromQuantity(limit)
 	}
 
 	return nil

--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -98,7 +98,7 @@ type DispatchListener struct {
 }
 
 type workspace struct {
-	CFS        CgroupCFSController
+	CFS        CFSController
 	OWI        logrus.Fields
 	BaseLimit  Bandwidth
 	BurstLimit Bandwidth

--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -221,6 +221,9 @@ func (d *DispatchListener) WorkspaceUpdated(ctx context.Context, ws *dispatch.Wo
 		}
 		wsinfo.BaseLimit = BandwidthFromQuantity(limit)
 		wsinfo.BurstLimit = BandwidthFromQuantity(limit)
+	} else {
+		wsinfo.BaseLimit = Bandwidth(0)
+		wsinfo.BurstLimit = Bandwidth(0)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix CPU limit annotation.
I actually annotated it manually and it worked.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9407

## How to test
<!-- Provide steps to test this PR -->

Annotate as follows and confirm that `cpu.max` of cgroup is set. 
Note: you have to enable CPU limit configuration in ws-daemon.

```console
$ kubectl annotate --overwrite pods $ws-pod gitpod.io/cpuLimit=50000m
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-daemon] Fix CPU limit annotation
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
