### PR TITLE
[public-api] Caddy serves gRPC port instead of http

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -16,6 +16,12 @@
 	order gitpod.workspace_download     before redir
 	order gitpod.headless_log_download	before rewrite
 	order gitpod.sec_websocket_key      before header
+
+	servers {
+        protocol {
+            allow_h2c
+        }
+    }
 }
 
 (compression) {
@@ -135,6 +141,17 @@
 		disable_openmetrics
 	}
 }
+
+# public-api
+api.{$GITPOD_DOMAIN} {
+    log {
+        level DEBUG
+        output stdout
+    }
+
+    reverse_proxy h2c://public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9001
+}
+
 
 # always redirect to HTTPS
 http:// {
@@ -260,11 +277,6 @@ https://{$GITPOD_DOMAIN} {
 	handle_errors {
 		redir https://{$GITPOD_DOMAIN}/sorry/#Error%20{http.reverse_proxy.status_text} 302
 	}
-}
-
-# public-api
-https://api.{$GITPOD_DOMAIN} {
-    reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9000
 }
 
 # workspaces


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For now, we've been serving HTTP to easily show the server runs. But we actually need to serve the gRPC port for the API.

gRPC requires that we know the cert of the server, such that we can establish a TLS connection.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
**The easy way:**
1. Open workspace from https://github.com/gitpod-io/gitpod/pull/9588
2. `cd components/public-api-server/cmd`
3. `go run main.go workspace get --address apimp-papi-caddy-grpc.preview.gitpod-dev.com:443`
4. Observe it connects and returns Unimplemented - this is the expected response!

**The hard way**:
* There is no client implemented at this stage yet. 
* Fetch the public certificate we use for `*.<domain>` in preview envs with 
```bash
kubectl get secret proxy-config-certificates -o yaml | yq '.data.["tls.crt"]' | base64 -d > tls.crt
```
* Extend the `components/public-api-server/integration_test.go` with, update `pemServerCA` path to where you wrote the `tls.crt`
```go
func loadTLSCredentials() (credentials.TransportCredentials, error) {
	// Load certificate of the CA who signed server's certificate
	// TO TEST: update this path to where you downloaded the cert
	pemServerCA, err := ioutil.ReadFile("/workspace/gitpod/tls.crt")
	if err != nil {
		return nil, err
	}

	certPool := x509.NewCertPool()
	if !certPool.AppendCertsFromPEM(pemServerCA) {
		return nil, fmt.Errorf("failed to add server CA's certificate")
	}

	// Create the credentials and return it
	config := &tls.Config{
		RootCAs: certPool,
		CipherSuites: []uint16{
			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
		},
		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
		MinVersion:       tls.VersionTLS12,
		MaxVersion:       tls.VersionTLS12,
		NextProtos:       []string{"h2"},
	}

	return credentials.NewTLS(config), nil
}

func TestPublicAPIServer_v1(t *testing.T) {
	ctx := context.Background()
	tlsCredentials, err := loadTLSCredentials()
	require.NoError(t, err)

	addr := "api.mp-papi-caddy-grpc.preview.gitpod-dev.com:443"
	var opts []grpc.DialOption

	opts = append(opts, grpc.WithTransportCredentials(tlsCredentials))

	conn, err := grpc.Dial(addr, opts...)
	require.NoError(t, err)

	workspaceClient := v1.NewWorkspacesServiceClient(conn)

	_, err = workspaceClient.GetWorkspace(ctx, &v1.GetWorkspaceRequest{})
	requireErrorStatusCode(t, codes.Unimplemented, err)
}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE


/werft with-vm