### PR TITLE
[kots]: allow configuration of Open VSX URL

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -71,6 +71,12 @@ spec:
               yq e -i '.license.kind = "secret"' "${CONFIG_FILE}"
               yq e -i '.license.name = "gitpod-license"' "${CONFIG_FILE}"
 
+              if [ '{{repl ConfigOptionNotEquals "openVsxUrl" "" }}' = "true" ];
+              then
+                echo "Gitpod: Setting Open VSX Registry URL"
+                yq e -i ".openVSX.url = \"{{repl ConfigOption "openVsxUrl" }}\"" "${CONFIG_FILE}"
+              fi
+
               if [ '{{repl and (ConfigOptionEquals "db_incluster" "0") (ConfigOptionEquals "db_cloudsql_enabled" "1") }}' = "true" ];
               then
                 echo "Gitpod: configuring CloudSQLProxy"

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -16,6 +16,10 @@ spec:
           help_text: This will be the URL that you use to access your Gitpod instance. This should be in the format "gitpod.domain.com".
           type: text
           required: true
+        - name: openVsxUrl
+          title: What is your Open VSX Registry URL?
+          help_text: This will be the URL that you use to access [Open VSX](https://open-vsx.org). This should be a fully qualified domain name, including `https://`. Will default to `https://open-vsx.org` if not set.
+          type: text
 
     - name: container_registry
       title: Container registry


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
During this morning's support call with @akosyakov, I realised we didn't have the ability to change the Open VSX URL in KOTS

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: allow configuration of Open VSX URL
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
