### PR TITLE
[dashboard] Make sure we have the auth cookie set before redirecting to the workspace URL

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -199,8 +199,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 throw new Error("No result!");
             }
             console.log("/start: started workspace instance: " + result.instanceID);
+
             // redirect to workspaceURL if we are not yet running in an iframe
             if (!this.props.runsInIFrame && result.workspaceURL) {
+                // before redirect, make sure we actually have the auth cookie set!
+                await this.ensureWorkspaceAuth(result.instanceID);
                 this.redirectTo(result.workspaceURL);
                 return;
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9145 

## How to test
 - [starting a workspace](https://gpl-9145-ensureauth.preview.gitpod-dev.com/#https://github.com/gitpod-io/template-rust-cli) should work as usual :green_circle: 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix a dashboard bug where you might end up on a workspace without having access to it
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
