### PR TITLE
Convert to class to reduce argument passing

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -462,7 +462,7 @@ async function deployToDevWithHelm(werft: Werft, jobConfig: JobConfig, deploymen
     werft.log(`observability`, "Installing monitoring-satellite...")
     if (deploymentConfig.withObservability) {
         try {
-            await installMonitoring(werft, CORE_DEV_KUBECONFIG_PATH, namespace, nodeExporterPort, monitoringDomain, STACKDRIVER_SERVICEACCOUNT, false, jobConfig.observability.branch);
+            installMonitoring(werft, CORE_DEV_KUBECONFIG_PATH, namespace, nodeExporterPort, monitoringDomain, STACKDRIVER_SERVICEACCOUNT, false, jobConfig.observability.branch);
         } catch (err) {
             if (!jobConfig.mainBuild) {
                 werft.fail('observability', err);
@@ -771,7 +771,7 @@ async function installMetaCertificates(werft: Werft, branch: string, withVM: boo
     await installCertificate(werft, metaInstallCertParams, { ...metaEnv(), slice: slice });
 }
 
-async function installMonitoring(werft: Werft, kubeconfig: string, namespace: string, nodeExporterPort: number, domain: string, stackdriverServiceAccount: any, withVM: boolean, observabilityBranch: string) {
+function installMonitoring(werft: Werft, kubeconfig: string, namespace: string, nodeExporterPort: number, domain: string, stackdriverServiceAccount: any, withVM: boolean, observabilityBranch: string) {
     const installMonitoringSatellite = new MonitoringSatelliteInstaller({
         kubeconfigPath: kubeconfig,
         branch: observabilityBranch,

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -94,7 +94,7 @@ export class MonitoringSatelliteInstaller {
         this.ensureCorrectInstallationOrder();
     }
 
-    private async ensureCorrectInstallationOrder() {
+    private ensureCorrectInstallationOrder() {
         const { werft, kubeconfigPath } = this.options;
 
         werft.log(sliceName, "installing monitoring-satellite");
@@ -104,26 +104,25 @@ export class MonitoringSatelliteInstaller {
         this.checkReadiness();
     }
 
-    private async checkReadiness() {
+    private checkReadiness() {
         const { kubeconfigPath, satelliteNamespace } = this.options;
 
         // For some reason prometheus' statefulset always take quite some time to get created
         // Therefore we wait a couple of seconds
         exec(
             `sleep 30 && kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} statefulset prometheus-k8s`,
-            { slice: sliceName, async: true },
+            { slice: sliceName },
         );
         exec(`kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} deployment grafana`, {
             slice: sliceName,
-            async: true,
         });
         exec(
             `kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} deployment kube-state-metrics`,
-            { slice: sliceName, async: true },
+            { slice: sliceName },
         );
         exec(
             `kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} deployment otel-collector`,
-            { slice: sliceName, async: true },
+            { slice: sliceName },
         );
 
         // core-dev is just too unstable for node-exporter
@@ -131,12 +130,12 @@ export class MonitoringSatelliteInstaller {
         if (this.options.withVM) {
             exec(
                 `kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} daemonset node-exporter`,
-                { slice: sliceName, async: true },
+                { slice: sliceName },
             );
         }
     }
 
-    private async deployGitpodServiceMonitors() {
+    private deployGitpodServiceMonitors() {
         const { werft, kubeconfigPath } = this.options;
 
         werft.log(sliceName, "installing gitpod ServiceMonitor resources");

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -1,126 +1,162 @@
-import { exec } from '../util/shell';
-import { getGlobalWerftInstance } from '../util/werft';
-import * as shell from 'shelljs';
-import * as fs from 'fs';
+import { exec } from "../util/shell";
+import { getGlobalWerftInstance, Werft } from "../util/werft";
+import * as fs from "fs";
+
+type MonitoringSatelliteInstallerOptions = {
+    werft: Werft;
+    kubeconfigPath: string;
+    satelliteNamespace: string;
+    clusterName: string;
+    nodeExporterPort: number;
+    branch: string;
+    previewDomain: string;
+    stackdriverServiceAccount: any;
+    withVM: boolean;
+};
+
+const sliceName = "observability";
 
 /**
- * Monitoring satellite deployment bits
+ * Installs monitoring-satellite, while updating its dependencies to the latest commit in the branch it is running.
  */
- export class InstallMonitoringSatelliteParams {
-    kubeconfigPath: string
-    satelliteNamespace: string
-    clusterName: string
-    nodeExporterPort: number
-    branch: string
-    previewDomain: string
-    stackdriverServiceAccount: any
-    withVM: boolean
-}
+export class MonitoringSatelliteInstaller {
+    constructor(private readonly options: MonitoringSatelliteInstallerOptions) {}
 
-const sliceName = 'observability';
+    public install() {
+        const {
+            werft,
+            branch,
+            satelliteNamespace,
+            stackdriverServiceAccount,
+            withVM,
+            previewDomain,
+            nodeExporterPort,
+        } = this.options;
 
-/**
- * installMonitoringSatellite installs monitoring-satellite, while updating its dependencies to the latest commit in the branch it is running.
- */
-export async function installMonitoringSatellite(params: InstallMonitoringSatelliteParams) {
-    const werft = getGlobalWerftInstance()
+        werft.log(sliceName, `Cloning observability repository - Branch: ${branch}`);
+        exec(
+            `git clone --branch ${branch} https://roboquat:$(cat /mnt/secrets/monitoring-satellite-preview-token/token)@github.com/gitpod-io/observability.git`,
+            { silent: true },
+        );
+        let currentCommit = exec(`git rev-parse HEAD`, { silent: true }).stdout.trim();
+        let pwd = exec(`pwd`, { silent: true }).stdout.trim();
+        werft.log(
+            sliceName,
+            `Updating Gitpod's mixin in monitoring-satellite's jsonnetfile.json to latest commit SHA: ${currentCommit}`,
+        );
 
-    werft.log(sliceName, `Cloning observability repository - Branch: ${params.branch}`)
-    exec(`git clone --branch ${params.branch} https://roboquat:$(cat /mnt/secrets/monitoring-satellite-preview-token/token)@github.com/gitpod-io/observability.git`, {silent: true})
-    let currentCommit = exec(`git rev-parse HEAD`, {silent: true}).stdout.trim()
-    let pwd = exec(`pwd`, {silent: true}).stdout.trim()
-    werft.log(sliceName, `Updating Gitpod's mixin in monitoring-satellite's jsonnetfile.json to latest commit SHA: ${currentCommit}`);
+        let jsonnetFile = JSON.parse(fs.readFileSync(`${pwd}/observability/jsonnetfile.json`, "utf8"));
+        jsonnetFile.dependencies.forEach((dep) => {
+            if (dep.name == "gitpod") {
+                dep.version = currentCommit;
+            }
+        });
+        fs.writeFileSync(`${pwd}/observability/jsonnetfile.json`, JSON.stringify(jsonnetFile));
+        exec(`cd observability && jb update`, { slice: sliceName });
 
-    let jsonnetFile = JSON.parse(fs.readFileSync(`${pwd}/observability/jsonnetfile.json`, 'utf8'));
-    jsonnetFile.dependencies.forEach(dep => {
-        if(dep.name == 'gitpod') {
-            dep.version = currentCommit
-        }
-    });
-    fs.writeFileSync(`${pwd}/observability/jsonnetfile.json`, JSON.stringify(jsonnetFile));
-    exec(`cd observability && jb update`, {slice: sliceName})
-
-    let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
-    --ext-code config="{
-        namespace: '${params.satelliteNamespace}',
-        clusterName: '${params.satelliteNamespace}',
-        tracing: {
-            honeycombAPIKey: '${process.env.HONEYCOMB_API_KEY}',
-            honeycombDataset: 'preview-environments',
-        },
-        previewEnvironment: {
-            domain: '${params.previewDomain}',
-            nodeExporterPort: ${params.nodeExporterPort},
-        },
-        ${params.withVM ? '' : "nodeAffinity: { nodeSelector: { 'gitpod.io/workload_services': 'true' }, },"  }
-        stackdriver: {
-            defaultProject: '${params.stackdriverServiceAccount.project_id}',
-            clientEmail: '${params.stackdriverServiceAccount.client_email}',
-            privateKey: '${params.stackdriverServiceAccount.private_key}',
-        },
-        prometheus: {
-            resources: {
-                requests: { memory: '200Mi', cpu: '50m' },
+        let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
+        --ext-code config="{
+            namespace: '${satelliteNamespace}',
+            clusterName: '${satelliteNamespace}',
+            tracing: {
+                honeycombAPIKey: '${process.env.HONEYCOMB_API_KEY}',
+                honeycombDataset: 'preview-environments',
             },
-        },
-        kubescape: {},
-        pyrra: {},
-    }" \
-    monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
-    find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
+            previewEnvironment: {
+                domain: '${previewDomain}',
+                nodeExporterPort: ${nodeExporterPort},
+            },
+            ${withVM ? "" : "nodeAffinity: { nodeSelector: { 'gitpod.io/workload_services': 'true' }, },"}
+            stackdriver: {
+                defaultProject: '${stackdriverServiceAccount.project_id}',
+                clientEmail: '${stackdriverServiceAccount.client_email}',
+                privateKey: '${stackdriverServiceAccount.private_key}',
+            },
+            prometheus: {
+                resources: {
+                    requests: { memory: '200Mi', cpu: '50m' },
+                },
+            },
+            kubescape: {},
+            pyrra: {},
+        }" \
+        monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
+        find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`
 
-    werft.log(sliceName, 'rendering YAML files')
-    exec(jsonnetRenderCmd, {silent: true})
-    if(params.withVM) {
-        postProcessManifests()
+        werft.log(sliceName, "rendering YAML files");
+        exec(jsonnetRenderCmd, { silent: true });
+        if (withVM) {
+            this.postProcessManifests();
+        }
+
+        // The correct kubectl context should already be configured prior to this step
+        // Only checks node-exporter readiness for harvester
+        this.ensureCorrectInstallationOrder();
     }
 
-    // The correct kubectl context should already be configured prior to this step
-    // Only checks node-exporter readiness for harvester
-    ensureCorrectInstallationOrder(params.kubeconfigPath, params.satelliteNamespace, params.withVM)
-}
+    private async ensureCorrectInstallationOrder() {
+        const { werft, kubeconfigPath } = this.options;
 
-async function ensureCorrectInstallationOrder(kubeconfig: string, namespace: string, checkNodeExporterStatus: boolean){
-    const werft = getGlobalWerftInstance()
+        werft.log(sliceName, "installing monitoring-satellite");
+        exec(`cd observability && hack/deploy-satellite.sh --kubeconfig ${kubeconfigPath}`, { slice: sliceName });
 
-    werft.log(sliceName, 'installing monitoring-satellite')
-    exec(`cd observability && hack/deploy-satellite.sh --kubeconfig ${kubeconfig}`, {slice: sliceName})
-
-    deployGitpodServiceMonitors(kubeconfig)
-    checkReadiness(kubeconfig, namespace, checkNodeExporterStatus)
-}
-
-async function checkReadiness(kubeconfig: string, namespace: string, checkNodeExporterStatus: boolean) {
-    // For some reason prometheus' statefulset always take quite some time to get created
-    // Therefore we wait a couple of seconds
-    exec(`sleep 30 && kubectl --kubeconfig ${kubeconfig} rollout status -n ${namespace} statefulset prometheus-k8s`, {slice: sliceName, async: true})
-    exec(`kubectl --kubeconfig ${kubeconfig} rollout status -n ${namespace} deployment grafana`, {slice: sliceName, async: true})
-    exec(`kubectl --kubeconfig ${kubeconfig} rollout status -n ${namespace} deployment kube-state-metrics`, {slice: sliceName, async: true})
-    exec(`kubectl --kubeconfig ${kubeconfig} rollout status -n ${namespace} deployment otel-collector`, {slice: sliceName, async: true})
-
-    // core-dev is just too unstable for node-exporter
-    // we don't guarantee that it will run at all
-    if(checkNodeExporterStatus) {
-        exec(`kubectl --kubeconfig ${kubeconfig} rollout status -n ${namespace} daemonset node-exporter`, {slice: sliceName, async: true})
+        this.deployGitpodServiceMonitors();
+        this.checkReadiness();
     }
-}
 
-async function deployGitpodServiceMonitors(kubeconfig: string) {
-    const werft = getGlobalWerftInstance()
+    private async checkReadiness() {
+        const { kubeconfigPath, satelliteNamespace } = this.options;
 
-    werft.log(sliceName, 'installing gitpod ServiceMonitor resources')
-    exec(`kubectl --kubeconfig ${kubeconfig} apply -f observability/monitoring-satellite/manifests/gitpod/`, {silent: true})
-}
+        // For some reason prometheus' statefulset always take quite some time to get created
+        // Therefore we wait a couple of seconds
+        exec(
+            `sleep 30 && kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} statefulset prometheus-k8s`,
+            { slice: sliceName, async: true },
+        );
+        exec(`kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} deployment grafana`, {
+            slice: sliceName,
+            async: true,
+        });
+        exec(
+            `kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} deployment kube-state-metrics`,
+            { slice: sliceName, async: true },
+        );
+        exec(
+            `kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} deployment otel-collector`,
+            { slice: sliceName, async: true },
+        );
 
-function postProcessManifests() {
-    const werft = getGlobalWerftInstance()
+        // core-dev is just too unstable for node-exporter
+        // we don't guarantee that it will run at all
+        if (this.options.withVM) {
+            exec(
+                `kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} daemonset node-exporter`,
+                { slice: sliceName, async: true },
+            );
+        }
+    }
 
-    // We're hardcoding nodeports, so we can use them in .werft/vm/manifests.ts
-    // We'll be able to access Prometheus and Grafana's UI by port-forwarding the harvester proxy into the nodePort
-    werft.log(sliceName, 'Post-processing manifests so it works on Harvester')
-    exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.type 'NodePort'`)
-    exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.type 'NodePort'`)
+    private async deployGitpodServiceMonitors() {
+        const { werft, kubeconfigPath } = this.options;
 
-    exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`)
-    exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.ports[0].nodePort 32000`)
+        werft.log(sliceName, "installing gitpod ServiceMonitor resources");
+        exec(`kubectl --kubeconfig ${kubeconfigPath} apply -f observability/monitoring-satellite/manifests/gitpod/`, {
+            silent: true,
+        });
+    }
+
+    private postProcessManifests() {
+        const werft = getGlobalWerftInstance();
+
+        // We're hardcoding nodeports, so we can use them in .werft/vm/manifests.ts
+        // We'll be able to access Prometheus and Grafana's UI by port-forwarding the harvester proxy into the nodePort
+        werft.log(sliceName, "Post-processing manifests so it works on Harvester");
+        exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.type 'NodePort'`);
+        exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.type 'NodePort'`);
+
+        exec(
+            `yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`,
+        );
+        exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.ports[0].nodePort 32000`);
+    }
 }

--- a/.werft/util/werft.ts
+++ b/.werft/util/werft.ts
@@ -137,4 +137,13 @@ export class Werft {
 
         this.globalSpanAttributes = {...this.globalSpanAttributes, ...attributes}
     }
+
+    public getSpanForSlice(slice: string): Span {
+        const span = this.sliceSpans[slice]
+        if (!span) {
+            throw new Error(`No open span for ${slice}`)
+        }
+        return span
+
+    }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This promotes `installMonitoringSatellite` to be a class to reduce the need for passing the same arguments around to the functions.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9059

## How to test
<!-- Provide steps to test this PR -->

- [x] in core-dev with observability enabled `werft run github -f -a with-helm=true -a with-observability=true` - [job](https://werft.gitpod-dev.com/job/gitpod-build-mads-classify-monitoring-satellite.3) - was able to port-forward to Prometheus and Grafana.
- [x] with-vm ` werft run github -f -a with-vm=true` - [job](https://werft.gitpod-dev.com/job/gitpod-build-mads-classify-monitoring-satellite.4) - was able to port-forward to Prometheus and Grafana but had to use the following commands instead of our own script. I suspect there's a bug in our proxy. Will open a follow up issue.
  ```
  kubectl --context=k3s-preview-environment port-forward svc/prometheus-k8s "9090:9090"
  kubectl --context=k3s-preview-environment port-forward svc/grafana "3000:3000"
  ```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A