### PR TITLE
Fix concurrent workspace limit

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -82,9 +82,6 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
 
     useEffect(() => {
         switch (workspaceInstance?.status.phase) {
-            // Preparing means that we haven't actually started the workspace instance just yet, but rather
-            // are still preparing for launch.
-            case "preparing":
             // Building means we're building the Docker image for the workspace so the workspace hasn't started yet.
             case "building":
             case "stopped":

--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -147,7 +147,7 @@ export class EligibilityService {
 
         const hasHitParallelWorkspaceLimit = async (): Promise<HitParallelWorkspaceLimit | undefined> => {
             const max = await this.getMaxParallelWorkspaces(user);
-            const instances = (await runningInstances).filter((i) => i.status.phase !== "unknown");
+            const instances = (await runningInstances).filter((i) => i.status.phase !== "preparing");
             const current = instances.length; // >= parallelWorkspaceAllowance;
             if (current >= max) {
                 return {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -14,7 +14,7 @@ type GitpodServerMethodType =
     | keyof Omit<GitpodServer, "dispose" | "setClient">
     | typeof accessCodeSyncStorage
     | typeof accessHeadlessLogs;
-type GroupKey = "default" | "startWorkspace";
+type GroupKey = "default" | "startWorkspace" | "createWorkspace";
 type GroupsConfig = {
     [key: string]: {
         points: number;
@@ -42,6 +42,10 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
             points: 1, // 1 workspace start per user per 10s
             durationsSec: 10,
         },
+        createWorkspace: {
+            points: 3, // 3 workspace creates per user per 10s
+            durationsSec: 10,
+        },
     };
     const defaultFunctions: FunctionsConfig = {
         getLoggedInUser: { group: "default", points: 1 },
@@ -66,7 +70,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         getWorkspace: { group: "default", points: 1 },
         isWorkspaceOwner: { group: "default", points: 1 },
         getOwnerToken: { group: "default", points: 1 },
-        createWorkspace: { group: "default", points: 1 },
+        createWorkspace: { group: "createWorkspace", points: 1 },
         startWorkspace: { group: "startWorkspace", points: 1 },
         stopWorkspace: { group: "default", points: 1 },
         deleteWorkspace: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1547,7 +1547,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             await new Promise((resolve) => setTimeout(resolve, 2000));
 
             const wsi = await this.workspaceDb.trace(ctx).findInstanceById(instance.id);
-            if (!wsi || (wsi.status.phase !== "preparing" && wsi.status.phase !== "building")) {
+            if (!wsi || wsi.status.phase !== "building") {
                 log.debug(logCtx, `imagebuild logs: instance is not/no longer in 'building' state`, {
                     phase: wsi?.status.phase,
                 });

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -718,7 +718,7 @@ export class WorkspaceStarter {
             workspaceImage: "", // Initially empty, filled during starting process
             status: {
                 conditions: {},
-                phase: "unknown",
+                phase: "preparing",
             },
             configuration,
         };

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -997,7 +997,7 @@ export class WorkspaceStarter {
             // Update workspace instance to tell the world we're building an image
             const workspaceImage = result.ref;
             const status: WorkspaceInstanceStatus = result.actuallyNeedsBuild
-                ? { ...instance.status, phase: "preparing" }
+                ? { ...instance.status, phase: "building" }
                 : instance.status;
             instance = await this.workspaceDb
                 .trace({ span })
@@ -1050,7 +1050,7 @@ export class WorkspaceStarter {
             }
 
             instance = await this.workspaceDb.trace({ span }).updateInstancePartial(instance.id, {
-                status: { ...instance.status, phase: "preparing", conditions: { failed: message }, message },
+                status: { ...instance.status, phase: "building", conditions: { failed: message }, message },
             });
             await this.messageBus.notifyOnInstanceUpdate(workspace.ownerId, instance);
 

--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -33,6 +33,7 @@ export interface Configuration {
     timeouts: {
         metaInstanceCheckIntervalSeconds: number;
         preparingPhaseSeconds: number;
+        buildingPhaseSeconds: number;
         stoppingPhaseSeconds: number;
         unknownPhaseSeconds: number;
     };

--- a/components/ws-manager-bridge/src/meta-instance-controller.ts
+++ b/components/ws-manager-bridge/src/meta-instance-controller.ts
@@ -41,6 +41,7 @@ export class MetaInstanceController implements Disposable {
                     const creationTime = new Date(instance.latestInstance.creationTime).getTime();
                     const stoppingTime = new Date(instance.latestInstance.stoppingTime ?? now).getTime(); // stoppingTime only set if entered stopping state
                     const timedOutInPreparing = now >= creationTime + this.config.timeouts.preparingPhaseSeconds * 1000;
+                    const timedOutInBuilding = now >= creationTime + this.config.timeouts.buildingPhaseSeconds * 1000;
                     const timedOutInStopping = now >= stoppingTime + this.config.timeouts.stoppingPhaseSeconds * 1000;
                     const timedOutInUnknown = now >= creationTime + this.config.timeouts.unknownPhaseSeconds * 1000;
                     const currentPhase = instance.latestInstance.status.phase;
@@ -56,6 +57,7 @@ export class MetaInstanceController implements Disposable {
 
                     if (
                         (currentPhase === "preparing" && timedOutInPreparing) ||
+                        (currentPhase === "building" && timedOutInBuilding) ||
                         (currentPhase === "stopping" && timedOutInStopping) ||
                         (currentPhase === "unknown" && timedOutInUnknown)
                     ) {

--- a/install/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/install/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -27,6 +27,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Timeouts: Timeouts{
 			MetaInstanceCheckIntervalSeconds: 60,
 			PreparingPhaseSeconds:            3600,
+			BuildingPhaseSeconds:             3600,
 			StoppingPhaseSeconds:             3600,
 			UnknownPhaseSeconds:              600,
 		},

--- a/install/installer/pkg/components/ws-manager-bridge/types.go
+++ b/install/installer/pkg/components/ws-manager-bridge/types.go
@@ -26,6 +26,7 @@ type Timeouts struct {
 	MetaInstanceCheckIntervalSeconds int32 `json:"metaInstanceCheckIntervalSeconds"`
 	PreparingPhaseSeconds            int32 `json:"preparingPhaseSeconds"`
 	StoppingPhaseSeconds             int32 `json:"stoppingPhaseSeconds"`
+	BuildingPhaseSeconds             int32 `json:"buildingPhaseSeconds"`
 	UnknownPhaseSeconds              int32 `json:"unknownPhaseSeconds"`
 }
 


### PR DESCRIPTION
## Description

Change the initial phase of a workspace from `unknown` to `preparing` to avoid filtering them out when calculating a user's concurrent workspace limit.

Builds on #9453 to allow us to distinguish between workspaces waiting for an image build and workspaces that may not need one.

## Related Issue(s)

Fixes #9410

## How to test

Smoke test various IDEs:

- [x] In-browser vscode
- [x] Desktop vscode
- [x] Goland (via Jetbrains Gateway)
- [x] local companion app

## Release Notes

```release-note
Correctly enforce the parallel workspace limit
```

## Documentation

None

 - [x] /werft with-vm=true