### PR TITLE
[prebuilds] ignore inverse PRs

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -350,6 +350,11 @@ export class GithubApp {
         try {
             const installationId = ctx.payload.installation?.id;
             const cloneURL = ctx.payload.repository.clone_url;
+            // we are only interested in PRs that want to contribute to our repo
+            if (ctx.payload.pull_request?.base?.repo?.clone_url !== cloneURL) {
+                log.info("Ignoring inverse PR", ctx.payload.pull_request);
+                return;
+            }
             const pr = ctx.payload.pull_request;
             const contextURL = pr.html_url;
             let { user, project } = await this.findOwnerAndProject(installationId, cloneURL);


### PR DESCRIPTION
## Description
This change ignores inverse PRs, such as they are created by [pull bots](https://github.com/wei/pull).

## Related Issue(s)

Fixes https://github.com/gitpod-io/security/issues/26

## How to test
- Install webhook or GH App on a repo. 
- Create a fork
- Push to the main repo
- Create a PR in the fork that wants to update the fork

In prod a prebuild would be created and overwrite the original prebuild from the main repo. With this change no such prebuild should be created anymore.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

- [x] /werft with-vm