### PR TITLE
[installer]: Allow replica counts to be specified for all components

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -337,6 +337,20 @@ func NodeAffinity(orLabels ...string) *corev1.Affinity {
 	}
 }
 
+func Replicas(ctx *RenderContext, component string) *int32 {
+	replicas := int32(1)
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.Common != nil && cfg.Common.PodConfig[component] != nil {
+			if cfg.Common.PodConfig[component].Replicas != nil {
+				replicas = *cfg.Common.PodConfig[component].Replicas
+			}
+		}
+		return nil
+	})
+	return &replicas
+}
+
 // ObjectHash marshals the objects to YAML and produces a sha256 hash of the output.
 // This function is useful for restarting pods when the config changes.
 // Takes an error as argument to make calling it more conventient. If that error is not nil,

--- a/install/installer/pkg/common/render_test.go
+++ b/install/installer/pkg/common/render_test.go
@@ -36,18 +36,22 @@ func TestCompositeRenderFunc_NilObjectsNilError(t *testing.T) {
 func TestReplicas(t *testing.T) {
 	testCases := []struct {
 		Component        string
+		Name             string
 		ExpectedReplicas int32
 	}{
 		{
 			Component:        server.Component,
+			Name:             "server takes replica count from common config",
 			ExpectedReplicas: 123,
 		},
 		{
 			Component:        dashboard.Component,
+			Name:             "dashboard takes replica count from common config",
 			ExpectedReplicas: 456,
 		},
 		{
 			Component:        content_service.Component,
+			Name:             "content_service takes default replica count",
 			ExpectedReplicas: 1,
 		},
 	}
@@ -64,12 +68,14 @@ func TestReplicas(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, testCase := range testCases {
-		actualReplicas := common.Replicas(ctx, testCase.Component)
+		t.Run(testCase.Name, func(t *testing.T) {
+			actualReplicas := common.Replicas(ctx, testCase.Component)
 
-		if *actualReplicas != testCase.ExpectedReplicas {
-			t.Errorf("expected %d replicas for %q component, but got %d",
-				testCase.ExpectedReplicas, testCase.Component, *actualReplicas)
-		}
+			if *actualReplicas != testCase.ExpectedReplicas {
+				t.Errorf("expected %d replicas for %q component, but got %d",
+					testCase.ExpectedReplicas, testCase.Component, *actualReplicas)
+			}
+		})
 	}
 }
 

--- a/install/installer/pkg/common/render_test.go
+++ b/install/installer/pkg/common/render_test.go
@@ -6,6 +6,9 @@ package common
 import (
 	"testing"
 
+	"github.com/gitpod-io/gitpod/installer/pkg/components/content_service"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/dashboard"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
@@ -35,15 +38,15 @@ func TestReplicas(t *testing.T) {
 		ExpectedReplicas int32
 	}{
 		{
-			Component:        "server",
+			Component:        server.Component,
 			ExpectedReplicas: 123,
 		},
 		{
-			Component:        "dashboard",
+			Component:        dashboard.Component,
 			ExpectedReplicas: 456,
 		},
 		{
-			Component:        "content-service",
+			Component:        content_service.Component,
 			ExpectedReplicas: 1,
 		},
 	}

--- a/install/installer/pkg/common/render_test.go
+++ b/install/installer/pkg/common/render_test.go
@@ -1,12 +1,13 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-package common
+package common_test
 
 import (
 	"testing"
 
-	"github.com/gitpod-io/gitpod/installer/pkg/components/content_service"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	content_service "github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/dashboard"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
@@ -19,12 +20,12 @@ import (
 )
 
 func TestCompositeRenderFunc_NilObjectsNilError(t *testing.T) {
-	f := CompositeRenderFunc(
-		func(cfg *RenderContext) ([]runtime.Object, error) {
+	f := common.CompositeRenderFunc(
+		func(cfg *common.RenderContext) ([]runtime.Object, error) {
 			return nil, nil
 		})
 
-	ctx, err := NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
+	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
 	require.NoError(t, err)
 
 	objects, err := f(ctx)
@@ -50,7 +51,7 @@ func TestReplicas(t *testing.T) {
 			ExpectedReplicas: 1,
 		},
 	}
-	ctx, err := NewRenderContext(config.Config{
+	ctx, err := common.NewRenderContext(config.Config{
 		Experimental: &experimental.Config{
 			Common: &experimental.CommonConfig{
 				PodConfig: map[string]*experimental.PodConfig{
@@ -63,7 +64,7 @@ func TestReplicas(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, testCase := range testCases {
-		actualReplicas := Replicas(ctx, testCase.Component)
+		actualReplicas := common.Replicas(ctx, testCase.Component)
 
 		if *actualReplicas != testCase.ExpectedReplicas {
 			t.Errorf("expected %d replicas for %q component, but got %d",
@@ -170,7 +171,7 @@ func TestRepoName(t *testing.T) {
 					}
 				}()
 
-				ctx, err := NewRenderContext(config.Config{
+				ctx, err := common.NewRenderContext(config.Config{
 					DropImageRepo: test.DropImageRepo,
 					Repository:    test.CfgRepo,
 				}, versions.Manifest{}, "test_namespace")

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -60,7 +60,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -96,7 +96,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: v1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -30,8 +30,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/database/cloudsql/deployment.go
+++ b/install/installer/pkg/components/database/cloudsql/deployment.go
@@ -35,8 +35,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      Component,

--- a/install/installer/pkg/components/ide-proxy/deployment.go
+++ b/install/installer/pkg/components/ide-proxy/deployment.go
@@ -30,8 +30,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -118,7 +118,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
-			Replicas: pointer.Int32(1),
+			Replicas: common.Replicas(ctx, Component),
 			Strategy: common.DeploymentStrategy,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -41,7 +41,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			ServiceName: Component,
 			// todo(sje): receive config value
-			Replicas: pointer.Int32(1),
+			Replicas: common.Replicas(ctx, Component),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      Component,

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -105,7 +105,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -27,7 +27,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -173,8 +173,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -72,7 +72,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -133,7 +133,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -70,8 +70,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				// todo(sje): receive config value
-				Replicas: pointer.Int32(1),
+				Replicas: common.Replicas(ctx, Component),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -17,6 +17,15 @@ type Config struct {
 	Workspace *WorkspaceConfig `json:"workspace,omitempty"`
 	WebApp    *WebAppConfig    `json:"webapp,omitempty"`
 	IDE       *IDEConfig       `json:"ide,omitempty"`
+	Common    *CommonConfig    `json:"common,omitempty"`
+}
+
+type CommonConfig struct {
+	PodConfig map[string]*PodConfig `json:"podConfig,omitempty"`
+}
+
+type PodConfig struct {
+	Replicas *int32 `json:"replicas,omitempty"`
 }
 
 type WorkspaceConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR adds the ability to configure the number of replicas for each component, rather than using to a hard-coded value of `1`.

## Related Issue(s)

Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  common:
    podConfig:
      server:
        replicas: 123
      content-service:
        replicas: 456
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
installer render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The rendered output will have the values from the config for the `server` and `content-service` components and the old default of `1` for all other components.

## Release Notes

```release-note
Allow replica counts for each component to be configurable through the installer
```

## Documentation

None.
