### PR TITLE
[ws-daemon] Fix check logic for I/O limits

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
@@ -96,13 +96,13 @@ func (c *IOLimiterV1) Apply(ctx context.Context, basePath, cgroupPath string) er
 	}
 
 	writeLimit := func(limitPath string, content []string) error {
-		for _, l := range content {
-			_, err := os.Stat(limitPath)
-			if errors.Is(err, os.ErrNotExist) {
-				log.WithError(err).WithField("limitPath", limitPath).Debug("blkio file does not exist")
-				continue
-			}
+		_, err := os.Stat(limitPath)
+		if errors.Is(err, os.ErrNotExist) {
+			log.WithError(err).WithField("limitPath", limitPath).Debug("blkio file does not exist")
+			return nil
+		}
 
+		for _, l := range content {
 			err = os.WriteFile(limitPath, []byte(l), 0644)
 			if err != nil {
 				log.WithError(err).WithField("limitPath", limitPath).WithField("line", l).Warn("cannot write limit")


### PR DESCRIPTION
## Release Notes
```release-note
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->

```
