### PR TITLE
[ws-man-bridge] Fix Workspace Instance status update dashboard to work across web-app clusters

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/ws-manager-bridge.json
+++ b/operations/observability/mixins/meta/dashboards/components/ws-manager-bridge.json
@@ -110,7 +110,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(gitpod_ws_manager_bridge_status_updates_total{cluster=\"$cluster\"}[1m]) * 60",
+          "expr": "rate(gitpod_ws_manager_bridge_status_updates_total{cluster=~\"$cluster\"}[1m]) * 60",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Before:
<img width="1651" alt="Screenshot 2022-04-25 at 9 18 55" src="https://user-images.githubusercontent.com/1419286/165039612-4b8bf608-de65-4bd6-bc2f-c322663475b9.png">


After:
<img width="1650" alt="Screenshot 2022-04-25 at 9 19 22" src="https://user-images.githubusercontent.com/1419286/165039473-ed44973b-79d3-4561-80a1-67b5b016efb7.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
Try the same query in [production dashboard](https://grafana.gitpod.io/d/ws-manager-bridge/gitpod-component-ws-manager-bridge?orgId=1&from=now-2d&to=now&var-cluster=All&var-node=All&var-pod=All&var-datasource=VictoriaMetrics) by editing it, but not saving.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE