### PR TITLE
Fix issues with `self-signed` certificates

### DIFF
--- a/install/installer/pkg/common/ca.go
+++ b/install/installer/pkg/common/ca.go
@@ -10,17 +10,8 @@ import (
 
 const (
 	cacerts      = "cacerts"
-	etcSSLCerts  = "/etc/ssl/certs"
 	caVolumeName = "gitpod-ca-certificate"
 )
-
-func InternalCAVolumeMount() *corev1.VolumeMount {
-	return &corev1.VolumeMount{
-		Name:      cacerts,
-		ReadOnly:  true,
-		MountPath: etcSSLCerts,
-	}
-}
 
 func InternalCAVolume() *corev1.Volume {
 	return &corev1.Volume{

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -103,7 +103,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MountPath: PullSecretFile,
 			SubPath:   ".dockerconfigjson",
 		},
-		*common.InternalCAVolumeMount(),
 	}
 	if vol, mnt, _, ok := common.CustomCACertVolume(ctx); ok {
 		volumes = append(volumes, *vol)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR includes temporary fixes to get `Certificate` option working with `self-signed` certificates.

Currently, Whenever the `Certificate` config option is set to a specific secret, we seem to assume **by default**
 that they are publicly signed. This currently has the following issues when they are `self-signed` :
- Due to the usage of `Certificate` in internal facing services like `registry-facade`, Internal clients fail to communicate as the self-signed CA is not in their trust store.  (Fix: Update `registry-facade` to use `builtin-registry-facade-cert`, generated by `cert-manager`)
- Due to the fact that internal `registry` communication also flows through the `proxy`, This communication fails as the `proxy` cert is self-signed as its not available in the trust store. (Fix: Update the `registry-facade` daemonset to also incldue `crt` of `Certificate` in its trust store).

This PR also fixes an issue with `image-builder-mk3` when the `customCACert` option is set, by removing `InternalVolumeCAMount` as it makes the `etc/ssl/certs` empty and readOnly (which prevents from ounting the customCACert cert into `etc/ssl/certs`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9074 

## How to test
<!-- Provide steps to test this PR -->
Generate a CA, and self-signed SSL by following https://gist.github.com/Pothulapati/a7c68e073cdbf8573f12b64320711ce5 (or any other online tutorial for that matter)

```bash
# Create the relevant secrets before installing Gitpod
# myCa.pem is what you want to propogate across components to access things external to Gitpod
kubectl create secret generic ca-certificate --from-file=ca.crt=./certs/myCa.pem
# these are the ones created for the domain
kubectl create secret tls https-cert --cert=./certs/ssl.crt --key=./certs/ssl.key

# Set the relevant config options in config file
yq e -i ".certificate.name = \"https-cert\"" "${CONFIG_FILE}"
yq e -i ".certificate.kind = \"secret\"" "${CONFIG_FILE}"
yq e -i ".customCACert.kind = \"secret\"" "${CONFIG_FILE}"
yq e -i ".customCACert.name = \"ca-certificate\"" "${CONFIG_FILE}"

# Install GItpod
gitpod-installer \
        render \
        --config="${CONFIG_FILE}" > gitpod.yaml

# See https://github.com/gitpod-io/gitpod/tree/main/install/installer#error-validating-statefulsetstatus
yq eval-all --inplace \
        'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
        gitpod.yaml

kubectl apply -f gitpod.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix multiple issues with `self-signed` certs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
