### PR TITLE
[protoc] Automatically remove trailing spaces in generated TypeScript and Java files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,6 @@ repos:
       #  args: [--allow-multiple-documents]
       # - id: end-of-file-fixer
       - id: trailing-whitespace
-        exclude: .*/src/main/java/io/gitpod/supervisor/api/.*
-
       - id: check-symlinks
       - id: mixed-line-ending
       - id: check-case-conflict

--- a/components/supervisor-api/generate.sh
+++ b/components/supervisor-api/generate.sh
@@ -52,6 +52,8 @@ local_java_protoc() {
         --grpc-java_out=java/src/main/java \
         --java_out=java/src/main/java \
         ./*.proto
+    # remove trailing spaces
+    find components/supervisor-api/java/src/main/java/io/gitpod/supervisor/api -maxdepth 1 -name "*.java" -exec sed -i -e "s/[[:space:]]*$//" {} \;
     # revert Java reserved keywords
     sed -i 's/private_visibility = 0;/private = 0;/g' status.proto
     sed -i 's/public_visibility = 1;/public = 1;/g' status.proto

--- a/scripts/protoc-generator.sh
+++ b/scripts/protoc-generator.sh
@@ -69,8 +69,8 @@ typescript_protoc() {
         -I /usr/lib/protoc/include -I"$ROOT_DIR" -I.. -I"../$PROTO_DIR" \
         "../$PROTO_DIR"/*.proto
 
-    # shellcheck disable=SC2011
-    # ls -1 "$MODULE_DIR"/typescript/src/*_pb.d.ts | xargs sed -i -e "s/[[:space:]]*$//" || exit
+    # remove trailing spaces
+    find "$MODULE_DIR"/typescript/src -maxdepth 1 -name "*_pb.d.ts" -exec sed -i -e "s/[[:space:]]*$//" {} \;
 
     popd > /dev/null || exit
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**Problem**: `protoc` adds many trailing spaces in generated files https://github.com/gitpod-io/gitpod/pull/9205/files 👎

**Solution**: We can post-process `protoc` generation with a one-line trailing space remover 👍

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

1. Run `leeway run components:generate-code-from-protobuf` and verify that all is good

For convenience, here is what happens when you run the above: ~~https://github.com/gitpod-io/gitpod/commit/4bbd766dd67e9140000a14baa4cd93748dd16062~~ https://github.com/gitpod-io/gitpod/commit/e73a89474dd576881612ccef8282a5ba712d25e1

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
