### PR TITLE
[ide] Disable the exit dialog on JetBrains IDEs

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
@@ -1,0 +1,27 @@
+package io.gitpod.jetbrains.remote
+
+import com.jetbrains.rdserver.unattendedHost.customization.GatewayClientCustomizationProvider
+import com.jetbrains.rdserver.unattendedHost.customization.GatewayExitCustomizationProvider
+import javax.swing.Icon
+import io.gitpod.jetbrains.remote.icons.GitpodIcons
+
+class GitpodGatewayClientCustomizationProvider : GatewayClientCustomizationProvider {
+    override val icon: Icon = GitpodIcons.Logo
+    override val title: String = System.getenv("GITPOD_WORKSPACE_ID") ?: "Gitpod"
+
+    override val exitCustomization: GatewayExitCustomizationProvider = object: GatewayExitCustomizationProvider {
+        override val body: String = "1"
+        override val isEnabled: Boolean = true
+        override val primaryActionButtonText: String = "2"
+        override val rememberId: String = "3"
+        override val title: String = "4"
+
+        override fun primaryAction() {
+            TODO("Not yet implemented")
+        }
+
+        override fun primaryActionWillExit(): Boolean {
+            TODO("Not yet implemented")
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,7 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
+        <gateway.customization.name implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker" client="guest" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodProjectManager" preload="true"/>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #8037

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains IDEs won't show an exit dialog anymore. The exit dialog shows and option to close and stop the IDE, but it doesn't actually close it, as on Gitpod, the IDE can only be closed by the Supervisor.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-vm=true