### PR TITLE
[bitbucket-server] handle pull-request context url

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -265,7 +265,7 @@ export class BitbucketServerApi {
         );
     }
 
-    setWebhook(
+    async setWebhook(
         user: User,
         params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string },
         webhook: BitbucketServer.WebhookParams,
@@ -301,6 +301,17 @@ export class BitbucketServerApi {
         }
         return this.runQuery<BitbucketServer.Paginated<BitbucketServer.Repository>>(user, `/repos${q}`);
     }
+
+    async getPullRequest(
+        user: User,
+        params: { repoKind: "projects" | "users"; owner: string; repositorySlug: string; nr: number },
+    ): Promise<BitbucketServer.PullRequest> {
+        const result = await this.runQuery<BitbucketServer.PullRequest>(
+            user,
+            `/${params.repoKind}/${params.owner}/repos/${params.repositorySlug}/pull-requests/${params.nr}`,
+        );
+        return result;
+    }
 }
 
 export namespace BitbucketServer {
@@ -329,6 +340,7 @@ export namespace BitbucketServer {
         id: number;
         name: string;
         public: boolean;
+        type: "PERSONAL" | "NORMAL";
     }
 
     export interface Branch {
@@ -373,6 +385,45 @@ export namespace BitbucketServer {
         commiter: BitbucketServer.User;
         committerTimestamp: number;
         message: string;
+    }
+
+    export interface PullRequest {
+        id: number;
+        version: number;
+        title: string;
+        description: string;
+        state: "OPEN" | string;
+        open: boolean;
+        closed: boolean;
+        createdDate: number;
+        updatedDate: number;
+        fromRef: Ref;
+        toRef: Ref;
+        locked: boolean;
+        author: {
+            user: User;
+            role: "AUTHOR" | string;
+            approved: boolean;
+            status: "UNAPPROVED" | string;
+        };
+        // reviewers: [];
+        // participants: [];
+        links: {
+            self: [
+                {
+                    //"https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/pull-requests/1"
+                    href: string;
+                },
+            ];
+        };
+    }
+
+    export interface Ref {
+        id: string; // "refs/heads/foo"
+        displayId: string; //"foo"
+        latestCommit: string;
+        type: "BRANCH" | string;
+        repository: Repository;
     }
 
     export interface Paginated<T> {

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -88,7 +88,7 @@ class TestBitbucketServerContextParser {
         expect(result).to.deep.include({
             ref: "master",
             refType: "branch",
-            revision: "535924584468074ec5dcbe935f4e68fbc3f0cb2d",
+            revision: "9eea1cca9bb98f0caf7ae77c740d5d24548ff33c",
             path: "",
             isFile: false,
             repository: {
@@ -115,7 +115,7 @@ class TestBitbucketServerContextParser {
         expect(result).to.deep.include({
             ref: "master",
             refType: "branch",
-            revision: "535924584468074ec5dcbe935f4e68fbc3f0cb2d",
+            revision: "9eea1cca9bb98f0caf7ae77c740d5d24548ff33c",
             path: "",
             isFile: false,
             repository: {
@@ -142,7 +142,7 @@ class TestBitbucketServerContextParser {
         expect(result).to.deep.include({
             ref: "main",
             refType: "branch",
-            revision: "a15d7d15adee54d0afdbe88148c8e587e8fb609d",
+            revision: "d4bdb1459f9fc90756154bdda5eb23c39457a89c",
             path: "",
             isFile: false,
             repository: {
@@ -156,6 +156,152 @@ class TestBitbucketServerContextParser {
                 repoKind: "users",
             },
             title: "alextugarev/tada - main",
+        });
+    }
+
+    @test async test_commit_context_01() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/users/jan/repos/yolo/commits/ec15264e536e9684034ea8e08f3afc3fd485b613",
+        );
+
+        expect(result).to.deep.include({
+            refType: "revision",
+            revision: "ec15264e536e9684034ea8e08f3afc3fd485b613",
+            path: "",
+            isFile: false,
+            repository: {
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/~jan/yolo.git",
+                defaultBranch: "master",
+                host: "bitbucket.gitpod-self-hosted.com",
+                name: "YOLO",
+                owner: "jan",
+                private: true,
+                repoKind: "users",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/users/jan/repos/yolo",
+            },
+            title: "jan/yolo - ec15264e536e9684034ea8e08f3afc3fd485b613",
+        });
+    }
+
+    @test async test_PR_context_01() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/pull-requests/1/commits",
+        );
+
+        expect(result).to.deep.include({
+            title: "Let's do it",
+            nr: 1,
+            ref: "foo",
+            refType: "branch",
+            revision: "1384b6842d73b8705feaf45f3e8aa41f00529042",
+            repository: {
+                host: "bitbucket.gitpod-self-hosted.com",
+                owner: "FOO",
+                name: "repo123",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                defaultBranch: "master",
+                private: true,
+                repoKind: "projects",
+            },
+            base: {
+                ref: "master",
+                refType: "branch",
+                repository: {
+                    host: "bitbucket.gitpod-self-hosted.com",
+                    owner: "FOO",
+                    name: "repo123",
+                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                    defaultBranch: "master",
+                    private: true,
+                    repoKind: "projects",
+                },
+            },
+        });
+    }
+
+    @test async test_PR_context_02() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/pull-requests/2/overview",
+        );
+
+        expect(result).to.deep.include({
+            title: "Let's do it again",
+            nr: 2,
+            ref: "foo",
+            refType: "branch",
+            revision: "1384b6842d73b8705feaf45f3e8aa41f00529042",
+            repository: {
+                host: "bitbucket.gitpod-self-hosted.com",
+                owner: "LAL",
+                name: "repo123",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/lal/repo123.git",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/LAL/repos/repo123",
+                defaultBranch: "master",
+                private: true,
+                repoKind: "projects",
+            },
+            base: {
+                ref: "master",
+                refType: "branch",
+                repository: {
+                    host: "bitbucket.gitpod-self-hosted.com",
+                    owner: "FOO",
+                    name: "repo123",
+                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                    defaultBranch: "master",
+                    private: true,
+                    repoKind: "projects",
+                },
+            },
+        });
+    }
+
+    @test async test_PR_context_03() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-self-hosted.com/projects/LAL/repos/repo123/pull-requests/1/overview",
+        );
+
+        expect(result).to.deep.include({
+            title: "U turn",
+            nr: 1,
+            ref: "foo",
+            refType: "branch",
+            revision: "1384b6842d73b8705feaf45f3e8aa41f00529042",
+            repository: {
+                host: "bitbucket.gitpod-self-hosted.com",
+                owner: "FOO",
+                name: "repo123",
+                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                defaultBranch: "master",
+                private: true,
+                repoKind: "projects",
+            },
+            base: {
+                ref: "master",
+                refType: "branch",
+                repository: {
+                    host: "bitbucket.gitpod-self-hosted.com",
+                    owner: "LAL",
+                    name: "repo123",
+                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/lal/repo123.git",
+                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/LAL/repos/repo123",
+                    defaultBranch: "master",
+                    private: true,
+                    repoKind: "projects",
+                },
+            },
         });
     }
 }


### PR DESCRIPTION
This PR adds support for Pull Request context URLs.

Part of #8499

### How to test

* Prepend a PR of a BBS with this preview environment location, e.g. `https://at-bbs.staging.gitpod-dev.com/#https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/pull-requests/1/overview`
  <img width="954" alt="Screen Shot 2022-04-25 at 13 32 55" src="https://user-images.githubusercontent.com/914497/165080973-441a67cd-ba67-4d22-8e7a-213abb99a184.png">



### Release Notes

```release-notes
[Bitbucket-Server] handle Pull Request context URLs
```

- [x] /werft with-clean-slate-deployment