### PR TITLE
[ide] Disable the exit dialog on JetBrains IDEs 

### DIFF
--- a/components/ide/jetbrains/image/leeway.Dockerfile
+++ b/components/ide/jetbrains/image/leeway.Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache --upgrade curl gzip tar unzip
 RUN curl -sSLo backend.tar.gz "$JETBRAINS_BACKEND_URL" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
 COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin/build/distributions/gitpod-remote-0.0.1.zip /workdir
 RUN unzip gitpod-remote-0.0.1.zip -d plugins/ && rm gitpod-remote-0.0.1.zip
+RUN printf '\n-Dgtw.disable.exit.dialog=true\n' >> $(find /workdir/bin/ -name "*64.vmoptions")
 # enable shared indexes by default
 RUN printf '\nshared.indexes.download.auto.consent=true' >> "/workdir/bin/idea.properties"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This disables the following exit dialog on JetBrains IDEs, as, in Gitpod, the IDE state is totally controlled by the Supervisor. So when user clicks "X" to close the Thin Client window, this dialog will not be displayed anymore.

<img width="533" alt="image" src="https://user-images.githubusercontent.com/418083/165118823-3d823aa6-dcbc-4ebb-9c93-5980940a69b0.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #8037

## How to test
<!-- Provide steps to test this PR -->
1. Open a new workspace on any JetBrains IDE. Here are some suggestions (you just need to check one of them):
    - [IntelliJ workspace on Preview Environment](https://vn-jetbrai6d7d7cb500.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/spring-petclinic)
    - [Goland workspace on Preview Environment](https://vn-jetbrai6d7d7cb500.preview.gitpod-dev.com/#referrer:jetbrains-gateway:goland/https://github.com/gitpod-io/template-golang-cli)
    - [Pycharm workspace on Preview Environment](https://vn-jetbrai6d7d7cb500.preview.gitpod-dev.com/#referrer:jetbrains-gateway:pycharm/https://github.com/gitpod-io/template-python-flask)
    - [PhpStorm workspace on Preview Environment](https://vn-jetbrai6d7d7cb500.preview.gitpod-dev.com/#referrer:jetbrains-gateway:phpstorm/https://github.com/gitpod-io/template-php-laravel-mysql)
2.  After the JetBrains Client is open, on the Terminal, run `cat $(find /ide-desktop/backend/bin/ -name "*64.vmoptions")` and confirm if the file contains the line `-Dgtw.disable.exit.dialog=true` (this line is appended to the file during the image build, so it should be around the end of the file).
    <img width="862" alt="image" src="https://user-images.githubusercontent.com/418083/165176281-c342daa1-a2bf-4c64-85b6-dbcd55b5b449.png">
3. Close the IDE by clicking "X" or by the menu option "Quit JetBrains Client").
4. Confirm that the IDE gets closed without displaying the exit dialog.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains IDEs won't show an exit dialog anymore, as the text on it was not necessary when running on Gitpod.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-vm=true