### PR TITLE
[ws-manager] Set network bandwidth limits

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -315,6 +315,9 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 		// prevent cluster-autoscaler from removing a node
 		// https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
 		"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+		// TODO(aledbf): use workspace classes to allow custom values
+		"kubernetes.io/ingress-bandwidth": "200M",
+		"kubernetes.io/egress-bandwidth":  "200M",
 	}
 	if req.Spec.Timeout != "" {
 		_, err := time.ParseDuration(req.Spec.Timeout)

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -29,6 +29,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -30,6 +30,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -29,6 +29,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "test-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -28,6 +28,8 @@
                 "gitpod/servicePrefix": "foobarservice",
                 "gitpod/traceid": "",
                 "gitpod/url": "foobar-foobarservice-gitpod.io",
+                "kubernetes.io/egress-bandwidth": "200M",
+                "kubernetes.io/ingress-bandwidth": "200M",
                 "prometheus.io/path": "/metrics",
                 "prometheus.io/port": "23000",
                 "prometheus.io/scrape": "true",


### PR DESCRIPTION
## Description

Set bandwidth limits to avoid one or more workspaces the utilization of 100% of the network bandwidth, affecting other workspaces UX.

Without limits, the bandwidth in SaaS is
```
   Speedtest by Ookla

     Server: CenturyLink - Portland, OR (id = 10162)
        ISP: Google Cloud
    Latency:     9.59 ms   (0.55 ms jitter)
   Download:  2107.16 Mbps (data used: 2.9 GB )                               
     Upload:  2300.90 Mbps (data used: 2.2 GB )                               
Packet Loss:     0.0%
Result URL: https://www.speedtest.net/result/c/bcb71ec2-256f-4a6b-b939-387923b5d536
```

## How to test
- Install speedtest cli 
```
curl -s https://install.speedtest.net/app/cli/install.deb.sh | sudo bash
sudo install-packages speedtest
```
- run `speedtest`
```
   Speedtest by Ookla

     Server: 1Ago - Sint-Niklaas (id = 45320)
        ISP: Google Cloud
    Latency:     6.99 ms   (0.08 ms jitter)
   Download:   491.37 Mbps (data used: 868.8 MB )                               
     Upload:   305.43 Mbps (data used: 859.3 MB )                               
Packet Loss:     0.0%
 Result URL: https://www.speedtest.net/result/c/2ad578b6-dab2-4dc8-ba17-fd772e2980a8
```

The limit is progressive, meaning we get the 100% of the bandwidth at the start, and then we start getting throttled


## Release Notes
```release-note
[ws-manager] Set network bandwidth limits
```


Edit: maybe we can just set this in the workspace template, but that only allows one value