### PR TITLE
[build] Remove image check

### DIFF
--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -19,7 +19,6 @@ export async function prepare(werft: Werft, config: JobConfig) {
     werft.phase(phaseName);
     try {
         werft.log(prepareSlices.CONFIGURE_CORE_DEV, prepareSlices.CONFIGURE_CORE_DEV)
-        compareWerftAndGitpodImage()
         activateCoreDevServiceAccount()
         configureDocker()
         configureStaticClustersAccess()
@@ -31,16 +30,6 @@ export async function prepare(werft: Werft, config: JobConfig) {
         werft.fail(phaseName, err);
     }
     werft.done(phaseName);
-}
-
-// We want to assure that our Workspace behaves the exactly same way as
-// it behaves when running a werft job. Therefore, we want them to always be equal.
-function compareWerftAndGitpodImage() {
-    const werftImg = exec("cat .werft/build.yaml | grep dev-environment", { silent: true }).trim().split(": ")[1];
-    const devImg = exec("yq r .gitpod.yml image", { silent: true }).trim();
-    if (werftImg !== devImg) {
-        throw new Error(`Werft job image (${werftImg}) and Gitpod dev image (${devImg}) do not match`);
-    }
 }
 
 function activateCoreDevServiceAccount() {


### PR DESCRIPTION
## Description
This PR removes a check which ensures the PR was produced on the same image as the CI build is running on. With the "branch protection" enabled for our builds is check no longer makes sense.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
