### PR TITLE
Fix E2E tests TestBaseImageBuild and TestParallelBaseImageBuild 

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -78,7 +78,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
     const domain = withVM ? `${destname}.preview.gitpod-dev.com` : `${destname}.staging.gitpod-dev.com`;
     const monitoringDomain = `${destname}.preview.gitpod-dev.com`;
     const url = `https://${domain}`;
-    const imagePullAuth = exec(`printf "%s" "_json_key:$(kubectl get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
+    const imagePullAuth = exec(`printf "%s" "_json_key:$(kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} get secret ${IMAGE_PULL_SECRET_NAME} --namespace=keys -o yaml \
         | yq r - data['.dockerconfigjson'] \
         | base64 -d)" | base64 -w 0`, { silent: true }).stdout.trim();
 

--- a/components/ws-daemon/pkg/dispatch/dispatch.go
+++ b/components/ws-daemon/pkg/dispatch/dispatch.go
@@ -212,7 +212,7 @@ func (d *Dispatch) handlePodUpdate(oldPod, newPod *corev1.Pod) {
 			d.mu.Lock()
 			s := d.ctxs[workspaceInstanceID]
 			if s == nil {
-				log.WithFields(owi).Error("pod disappaered from dispatch state before container was ready")
+				log.WithFields(owi).Error("pod disappeared from dispatch state before container was ready")
 				d.mu.Unlock()
 				return
 			}

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This directory containts Gitpod's integration tests, including the framework that makes them possible.
+This directory contains Gitpod's integration tests, including the framework that makes them possible.
 
 Integration tests work by instrumenting Gitpod's components to modify and verify its state.
 Such tests are for example:
@@ -61,13 +61,13 @@ There are 4 different types of tests:
 To run the tests:
 1. Clone this repo (`git clone git@github.com:gitpod-io/gitpod.git`), and `cd` to `./gitpod/test`
 2. Run the tests like so
-  ```console
-  go test -v ./... \
-  -kubeconfig=<path_to_kube_config_file> \
-  -namespace=<namespace_where_gitpod_is_installed> \
-  -username=<gitpod_user_with_oauth_setup> \
-  -enterprise=<true|false> \
-  -gitlab=<true|false>
-  ```
+   ```console
+   go test -v ./... \
+     -kubeconfig=<path_to_kube_config_file> \
+     -namespace=<namespace_where_gitpod_is_installed> \
+     -username=<gitpod_user_with_oauth_setup> \
+     -enterprise=<true|false> \
+     -gitlab=<true|false>
+   ```
 3. Tests `TestUploadDownloadBlob` and `TestUploadDownloadBlobViaServer` will fail when testing locally, as they are trying to connect to cluster local resources directly. To test them use docker image instead that runs within the cluster.
 4. If you want to run specific test, add `-run <test>` before `-kubeconfig` parameter.

--- a/test/pkg/integration/common/port_forward.go
+++ b/test/pkg/integration/common/port_forward.go
@@ -17,7 +17,7 @@ import (
 
 // ForwardPort establishes a TCP port forwarding to a Kubernetes pod
 // Uses kubectl instead of Go to use a local process that can reproduce the same behavior outside the tests
-// Since we are using kubectl directly we need to pass kubeconfig explicetly
+// Since we are using kubectl directly we need to pass kubeconfig explicitly
 func ForwardPort(ctx context.Context, kubeconfig string, namespace, pod, port string) (readychan chan struct{}, errchan chan error) {
 	errchan = make(chan error, 1)
 	readychan = make(chan struct{}, 1)

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -182,7 +182,7 @@ func LaunchWorkspaceDirectly(ctx context.Context, api *ComponentAPI, opts ...Lau
 
 	wsm, err := api.WorkspaceManager()
 	if err != nil {
-		return nil, xerrors.Errorf("cannot start workspace: %q", err)
+		return nil, xerrors.Errorf("cannot start workspace manager: %q", err)
 	}
 
 	sresp, err := wsm.StartWorkspace(sctx, req)
@@ -192,7 +192,7 @@ func LaunchWorkspaceDirectly(ctx context.Context, api *ComponentAPI, opts ...Lau
 
 	lastStatus, err := WaitForWorkspaceStart(ctx, instanceID.String(), api, options.WaitForOpts...)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot start workspace: %q", err)
+		return nil, xerrors.Errorf("cannot wait for workspace start: %q", err)
 	}
 
 	// it.t.Logf("workspace is running: instanceID=%s", instanceID.String())

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -186,7 +186,6 @@ func LaunchWorkspaceDirectly(ctx context.Context, api *ComponentAPI, opts ...Lau
 	}
 
 	sresp, err := wsm.StartWorkspace(sctx, req)
-	scancel()
 	if err != nil {
 		return nil, xerrors.Errorf("cannot start workspace: %q", err)
 	}

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -70,7 +70,7 @@ func TestMountProc(t *testing.T) {
 
 			var wg sync.WaitGroup
 			wg.Add(parallel)
-			for i := 0; i < 5; i++ {
+			for i := 0; i < parallel; i++ {
 				go func() {
 					defer wg.Done()
 					loadMountProc(t, rsa)


### PR DESCRIPTION
## Description
Fix E2E tests TestBaseImageBuild and TestParallelBaseImageBuild.

## Related Issue(s)
Partially address #8800

## How to test
```shell
go test -v ./... \
    -kubeconfig=/home/gitpod/.kube/config
    -namespace=<namespace> \
    -run TestBaseImageBuild

go test -v ./... \
    -kubeconfig=/home/gitpod/.kube/config
    -namespace=<namespace> \
    -run TestParallelBaseImageBuild
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No