### PR TITLE
[server] fix ide option not exists bug

### DIFF
--- a/components/server/src/workspace/workspace-starter.spec.ts
+++ b/components/server/src/workspace/workspace-starter.spec.ts
@@ -249,5 +249,19 @@ describe("workspace-starter", function () {
             const result = chooseIDE("unknown-custom", customOptions, useLatest, hasPerm);
             expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
         });
+
+        it("not exists ide with custom permission", function () {
+            const useLatest = true;
+            const hasPerm = true;
+            const result = chooseIDE("not-exists", ideOptions, useLatest, hasPerm);
+            expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
+        });
+
+        it("not exists ide with custom permission", function () {
+            const useLatest = true;
+            const hasPerm = false;
+            const result = chooseIDE("not-exists", ideOptions, useLatest, hasPerm);
+            expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
+        });
     });
 });

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -159,7 +159,7 @@ export const chooseIDE = (
     const data: { desktopIdeImage?: string; ideImage: string } = {
         ideImage: defaultIdeImage,
     };
-    const chooseOption = ideOptions.options[ideChoice];
+    const chooseOption = ideOptions.options[ideChoice] ?? defaultIDEOption;
     const isDesktopIde = chooseOption.type === "desktop";
     if (isDesktopIde) {
         data.desktopIdeImage = useLatest ? chooseOption?.latestImage ?? chooseOption?.image : chooseOption?.image;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix function `chooseIDE` func not cover not exists IDE id

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Open Gitpod with this PR, exec 
```
cd components/server && yarn test
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft no-preview
