### PR TITLE
Use the right `registry-facade` port in preview environments

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -206,7 +206,7 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
     let registryNodePortMeta = findLastHostPort(namespace, 'registry-facade', deploymentKubeconfig, metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }))
     let nodeExporterPort = findLastHostPort(namespace, 'node-exporter', deploymentKubeconfig, metaEnv({ slice: installerSlices.FIND_FREE_HOST_PORTS, silent: true }))
 
-    if (isNaN(wsdaemonPortMeta) || isNaN(wsdaemonPortMeta) || (isNaN(nodeExporterPort) && !withVM && withObservability)) {
+    if (isNaN(wsdaemonPortMeta) || isNaN(registryNodePortMeta) || (isNaN(nodeExporterPort) && !withVM && withObservability)) {
         werft.log(installerSlices.FIND_FREE_HOST_PORTS, "Can't reuse, check for some free ports.");
         [wsdaemonPortMeta, registryNodePortMeta, nodeExporterPort] = await findFreeHostPorts([
             { start: 10000, end: 11000 },

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -50,7 +50,7 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       echo "setting $NAME to $REG_DAEMON_PORT"
       yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.containers.[0].ports.[0].hostPort "$REG_DAEMON_PORT"
       echo "setting $NAME's update-containerd-certificates env port to $REG_DAEMON_PORT"
-      yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.initContainers.[1].env.[1].value "$REG_DAEMON_PORT"
+      yq w -i k8s.yaml -d "$documentIndex" --tag "!!str" "spec.template.spec.initContainers.[1].env.(name==REGISTRY_FACADE_PORT).value" "$REG_DAEMON_PORT"
    fi
    if [[ "$SIZE" -ne "0" ]] && [[ "$NAME" == "ws-daemon" ]] && [[ "$KIND" == "DaemonSet" ]] ; then
       echo "setting $NAME to $WS_DAEMON_PORT"

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -49,6 +49,8 @@ while [ "$documentIndex" -le "$DOCS" ]; do
    if [[ "$SIZE" -ne "0" ]] && [[ "$NAME" == "registry-facade" ]] && [[ "$KIND" == "DaemonSet" ]] ; then
       echo "setting $NAME to $REG_DAEMON_PORT"
       yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.containers.[0].ports.[0].hostPort "$REG_DAEMON_PORT"
+      echo "setting $NAME's update-containerd-certificates env port to $REG_DAEMON_PORT"
+      yq w -i k8s.yaml -d "$documentIndex" spec.template.spec.initContainers.[1].env.[1].value "$REG_DAEMON_PORT"
    fi
    if [[ "$SIZE" -ne "0" ]] && [[ "$NAME" == "ws-daemon" ]] && [[ "$KIND" == "DaemonSet" ]] ; then
       echo "setting $NAME to $WS_DAEMON_PORT"

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -187,10 +187,14 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 									},
 								},
 								corev1.EnvVar{
+									Name:  "REGISTRY_FACADE_PORT",
+									Value: fmt.Sprintf("%v", ServicePort),
+								},
+								corev1.EnvVar{
 									// Install gitpod ca.crt in containerd to allow pulls from the host
 									// https://github.com/containerd/containerd/blob/main/docs/hosts.md
 									Name:  "SETUP_SCRIPT",
-									Value: fmt.Sprintf(`TARGETS="docker containerd";for TARGET in $TARGETS;do mkdir -p /mnt/dst/etc/$TARGET/certs.d/reg.%s:%v && echo "$GITPOD_CA_CERT" > /mnt/dst/etc/$TARGET/certs.d/reg.%s:%v/ca.crt && echo "OK";done`, ctx.Config.Domain, ServicePort, ctx.Config.Domain, ServicePort),
+									Value: fmt.Sprintf(`TARGETS="docker containerd";for TARGET in $TARGETS;do mkdir -p /mnt/dst/etc/$TARGET/certs.d/reg.%s:$REGISTRY_FACADE_PORT && echo "$GITPOD_CA_CERT" > /mnt/dst/etc/$TARGET/certs.d/reg.%s:$REGISTRY_FACADE_PORT/ca.crt && echo "OK";done`, ctx.Config.Domain, ctx.Config.Domain),
 								},
 							)
 							c.VolumeMounts = append(c.VolumeMounts,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

After #9518 , `StartWorkspace` seems to fail on preview environments, as we randomize ports in the preview environment but we specifically use the port number in the `update-containerd-certificates` init Contianer to specify the cert for that `URL:PORT`.

This PR fixes that by passing the same into the `update-containerd-ceritificates` during post processing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow up to #9518 

## How to test
<!-- Provide steps to test this PR -->

Preview environments should be able to start and run workspaces.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
