### PR TITLE
[installer] Allow configuration of resource requests and limits

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -351,6 +351,21 @@ func Replicas(ctx *RenderContext, component string) *int32 {
 	return &replicas
 }
 
+func ResourceRequirements(ctx *RenderContext, component, containerName string, defaults corev1.ResourceRequirements) corev1.ResourceRequirements {
+	resources := defaults
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.Common != nil && cfg.Common.PodConfig[component] != nil {
+			if cfg.Common.PodConfig[component].Resources[containerName] != nil {
+				resources = *cfg.Common.PodConfig[component].Resources[containerName]
+			}
+		}
+		return nil
+	})
+
+	return resources
+}
+
 // ObjectHash marshals the objects to YAML and produces a sha256 hash of the output.
 // This function is useful for restarting pods when the config changes.
 // Takes an error as argument to make calling it more conventient. If that error is not nil,

--- a/install/installer/pkg/components/agent-smith/daemonset.go
+++ b/install/installer/pkg/components/agent-smith/daemonset.go
@@ -54,12 +54,12 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.AgentSmith.Version),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Args:            []string{"run", "--config", "/config/config.json"},
-						Resources: corev1.ResourceRequirements{
+						Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),
 								"memory": resource.MustParse("32Mi"),
 							},
-						},
+						}),
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "config",
 							MountPath: "/config",

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -100,12 +100,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Name:          ServicePortName,
 								ContainerPort: ContainerPort,
 							}},
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("32Mi"),
 								},
-							},
+							}),
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 								RunAsUser:  pointer.Int64(1000),

--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -48,12 +48,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				"--config",
 				"/config/config.json",
 			},
-			Resources: corev1.ResourceRequirements{
+			Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("100m"),
 					"memory": resource.MustParse("32Mi"),
 				},
-			},
+			}),
 			Ports: []corev1.ContainerPort{{
 				Name:          RPCServiceName,
 				ContainerPort: RPCPort,

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -49,12 +49,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Dashboard.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("32Mi"),
 								},
-							},
+							}),
 							Ports: []corev1.ContainerPort{{
 								ContainerPort: ContainerPort,
 								Name:          PortName,

--- a/install/installer/pkg/components/ide-proxy/deployment.go
+++ b/install/installer/pkg/components/ide-proxy/deployment.go
@@ -49,12 +49,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.IDEProxy.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("32Mi"),
 								},
-							},
+							}),
 							Ports: []corev1.ContainerPort{{
 								ContainerPort: ContainerPort,
 								Name:          PortName,

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -153,12 +153,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							common.DefaultEnv(&ctx.Config),
 							common.TracingEnv(ctx),
 						),
-						Resources: corev1.ResourceRequirements{
+						Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),
 								"memory": resource.MustParse("200Mi"),
 							},
-						},
+						}),
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: RPCPort,
 							Name:          RPCPortName,

--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -28,6 +28,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
+	const redisContainerName = "redis"
 	return []runtime.Object{&appsv1.StatefulSet{
 		TypeMeta: common.TypeMetaStatefulSet,
 		ObjectMeta: metav1.ObjectMeta{
@@ -79,12 +80,12 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 						},
 						ImagePullPolicy: v1.PullIfNotPresent,
-						Resources: v1.ResourceRequirements{
+						Resources: common.ResourceRequirements(ctx, Component, Component, v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu":    resource.MustParse("1m"),
 								"memory": resource.MustParse("150Mi"),
 							},
-						},
+						}),
 						Ports: []v1.ContainerPort{{
 							Name:          PortName,
 							ContainerPort: ContainerPort,
@@ -100,7 +101,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							common.DefaultEnv(&ctx.Config),
 						),
 					}, {
-						Name:  "redis",
+						Name:  redisContainerName,
 						Image: ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, common.DockerRegistryURL), "library/redis", "6.2"),
 						Command: []string{
 							"redis-server",
@@ -114,12 +115,12 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Ports: []v1.ContainerPort{{
 							ContainerPort: 6379,
 						}},
-						Resources: v1.ResourceRequirements{
+						Resources: common.ResourceRequirements(ctx, Component, redisContainerName, v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu":    resource.MustParse("1m"),
 								"memory": resource.MustParse("150Mi"),
 							},
-						},
+						}),
 						VolumeMounts: []v1.VolumeMount{{
 							Name:      "config",
 							MountPath: "/config",

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -46,12 +46,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.PublicAPIServer.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("32Mi"),
 								},
-							},
+							}),
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: HTTPContainerPort,

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -207,12 +207,12 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.RegistryFacade.Version),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Args:            []string{"run", "/mnt/config/config.json"},
-						Resources: corev1.ResourceRequirements{
+						Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),
 								"memory": resource.MustParse("32Mi"),
 							},
-						},
+						}),
 						Ports: []corev1.ContainerPort{{
 							Name:          ContainerPortName,
 							ContainerPort: ContainerPort,

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -14,6 +14,7 @@ import (
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
 	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -163,6 +164,28 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		env = append(env, *envv)
 	}
 
+	var podAntiAffinity *corev1.PodAntiAffinity
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.UsePodAffinity {
+			podAntiAffinity = &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      "component",
+								Operator: "In",
+								Values:   []string{Component},
+							}},
+						},
+						TopologyKey: cluster.AffinityLabelMeta,
+					},
+				}},
+			}
+		}
+		return nil
+	})
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
@@ -185,7 +208,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
+						Affinity: &corev1.Affinity{
+							NodeAffinity:    common.NodeAffinity(cluster.AffinityLabelMeta).NodeAffinity,
+							PodAntiAffinity: podAntiAffinity,
+						},
 						PriorityClassName:  common.SystemNodeCritical,
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -225,12 +225,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Server.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("200m"),
 									"memory": resource.MustParse("200Mi"),
 								},
-							},
+							}),
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 								RunAsUser:  pointer.Int64(31001),

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -213,10 +213,10 @@ fi
 						},
 					}},
 				),
-				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("1m"),
 					"memory": resource.MustParse("1Mi"),
-				}},
+				}}),
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:             "working-area",

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -111,12 +111,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManagerBridge.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("64Mi"),
 								},
-							},
+							}),
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 								RunAsUser:  pointer.Int64(31001),

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -37,12 +37,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Args:            []string{"run", "--config", "/config/config.json"},
 			Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManager.Version),
 			ImagePullPolicy: corev1.PullIfNotPresent,
-			Resources: corev1.ResourceRequirements{
+			Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("100m"),
 					"memory": resource.MustParse("32Mi"),
 				},
-			},
+			}),
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          RPCPortName,

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -117,12 +117,12 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Args:            []string{"run", "/config/config.json"},
 							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSProxy.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("32Mi"),
 								},
-							},
+							}),
 							Ports: []corev1.ContainerPort{{
 								Name:          HTTPProxyPortName,
 								ContainerPort: HTTPProxyPort,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -10,7 +10,10 @@
 // If you use any setting herein, you forfeit support from Gitpod.
 package experimental
 
-import "k8s.io/apimachinery/pkg/api/resource"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 // Config contains all experimental configuration.
 type Config struct {
@@ -25,7 +28,8 @@ type CommonConfig struct {
 }
 
 type PodConfig struct {
-	Replicas *int32 `json:"replicas,omitempty"`
+	Replicas  *int32                                  `json:"replicas,omitempty"`
+	Resources map[string]*corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type WorkspaceConfig struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -65,8 +65,9 @@ type WorkspaceConfig struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI *PublicAPIConfig `json:"publicApi,omitempty"`
-	Server    *ServerConfig    `json:"server,omitempty"`
+	PublicAPI      *PublicAPIConfig `json:"publicApi,omitempty"`
+	Server         *ServerConfig    `json:"server,omitempty"`
+	UsePodAffinity bool             `json:"usePodAffinity"`
 }
 
 type ServerConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR adds the ability to configure the resource requests and limits for all components via the `experimental` section in the installer config file.

## Related Issue(s)

Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  common:
    podConfig:
      server:
        resources:
          server:
            requests:
              cpu: 50m
              memory: 100Mi
            limits:
              cpu: 500m
              memory: 800Mi
      dashboard:
        resources:
          dashboard:
            requests:
              cpu: 60m
              memory: 100Mi
            limits:
              cpu: 100m
              memory: 500Mi

```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The rendered output will have the values from the config for the `server` and `dashboard` component resource requests and limits. All other components will use their default hard-coded resources as before.

## Release Notes

```release-note
Allow resource requests and limits for each component to be configurable through the installer
```

## Documentation

None.
