### PR TITLE
[common-go] Add keyed gRPC rate limits

### DIFF
--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/components/common-go/go.sum
+++ b/components/common-go/go.sum
@@ -176,6 +176,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=

--- a/components/common-go/grpc/ratelimit.go
+++ b/components/common-go/grpc/ratelimit.go
@@ -6,60 +6,143 @@ package grpc
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/gitpod-io/gitpod/common-go/util"
+	lru "github.com/hashicorp/golang-lru"
 )
+
+type keyFunc func(req interface{}) (string, error)
 
 // RateLimit configures the reate limit for a function
 type RateLimit struct {
 	Block          bool          `json:"block"`
 	BucketSize     uint          `json:"bucketSize"`
 	RefillInterval util.Duration `json:"refillInterval"`
+
+	KeyCacheSize uint   `json:"keyCacheSize,omitempty"`
+	Key          string `json:"key,omitempty"`
+}
+
+func (r RateLimit) Limiter() *rate.Limiter {
+	return rate.NewLimiter(rate.Every(time.Duration(r.RefillInterval)), int(r.BucketSize))
 }
 
 // NewRatelimitingInterceptor creates a new rate limiting interceptor
 func NewRatelimitingInterceptor(f map[string]RateLimit) RatelimitingInterceptor {
-	funcs := make(map[string]ratelimitedFunction, len(f))
+	funcs := make(map[string]*ratelimitedFunction, len(f))
 	for name, fnc := range f {
-		funcs[name] = ratelimitedFunction{
-			Block: fnc.Block,
-			L:     rate.NewLimiter(rate.Every(time.Duration(fnc.RefillInterval)), int(fnc.BucketSize)),
+		var (
+			keyedLimit *lru.Cache
+			key        keyFunc
+		)
+		if fnc.Key != "" && fnc.KeyCacheSize > 0 {
+			keyedLimit, _ = lru.New(int(fnc.KeyCacheSize))
+			key = fieldAccessKey(fnc.Key)
+		}
+
+		funcs[name] = &ratelimitedFunction{
+			RateLimit:   fnc,
+			GlobalLimit: fnc.Limiter(),
+			Key:         key,
+			KeyedLimit:  keyedLimit,
 		}
 	}
 	return funcs
 }
 
+func fieldAccessKey(key string) keyFunc {
+	return func(req interface{}) (string, error) {
+		msg, ok := req.(proto.Message)
+		if !ok {
+			return "", status.Errorf(codes.Internal, "request was not a protobuf message")
+		}
+
+		val, ok := getFieldValue(msg.ProtoReflect(), strings.Split(key, "."))
+		if !ok {
+			return "", status.Errorf(codes.Internal, "Field %s does not exist in message. This is a rate limiting configuration error.", key)
+		}
+		return val, nil
+	}
+}
+
+func getFieldValue(msg protoreflect.Message, path []string) (val string, ok bool) {
+	if len(path) == 0 {
+		return "", false
+	}
+
+	field := msg.Descriptor().Fields().ByName(protoreflect.Name(path[0]))
+	if field == nil {
+		return "", false
+	}
+	if len(path) > 1 {
+		if field.Kind() != protoreflect.MessageKind {
+			// we should go deeper but the field is not a message
+			return "", false
+		}
+		child := msg.Get(field).Message()
+		return getFieldValue(child, path[1:])
+	}
+
+	if field.Kind() != protoreflect.StringKind {
+		// we only support string fields
+		return "", false
+	}
+
+	return msg.Get(field).String(), true
+}
+
 // RatelimitingInterceptor limits how often a gRPC function may be called. If the limit has been
 // exceeded, we'll return resource exhausted.
-type RatelimitingInterceptor map[string]ratelimitedFunction
+type RatelimitingInterceptor map[string]*ratelimitedFunction
 
 type ratelimitedFunction struct {
-	Block bool
-	L     *rate.Limiter
+	RateLimit RateLimit
+
+	GlobalLimit *rate.Limiter
+	Key         keyFunc
+	KeyedLimit  *lru.Cache
 }
 
 // UnaryInterceptor creates a unary interceptor that implements the rate limiting
 func (r RatelimitingInterceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 		f, ok := r[info.FullMethod]
-		if ok {
-			if f.Block {
-				err := f.L.Wait(ctx)
-				if err == context.Canceled {
-					return nil, err
-				}
-				if err != nil {
-					return nil, status.Error(codes.ResourceExhausted, err.Error())
-				}
-			} else if !f.L.Allow() {
-				return nil, status.Error(codes.ResourceExhausted, "too many requests")
+		if !ok {
+			return handler(ctx, req)
+		}
+
+		var limit *rate.Limiter
+		if f.Key == nil {
+			limit = f.GlobalLimit
+		} else {
+			key, err := f.Key(req)
+			if err != nil {
+				return nil, err
 			}
+
+			f.KeyedLimit.ContainsOrAdd(key, f.RateLimit.Limiter())
+			v, _ := f.KeyedLimit.Get(key)
+			limit = v.(*rate.Limiter)
+		}
+		if f.RateLimit.Block {
+			err := limit.Wait(ctx)
+			if err == context.Canceled {
+				return nil, err
+			}
+			if err != nil {
+				return nil, status.Error(codes.ResourceExhausted, err.Error())
+			}
+		} else if !limit.Allow() {
+			return nil, status.Error(codes.ResourceExhausted, "too many requests")
 		}
 
 		return handler(ctx, req)

--- a/components/common-go/grpc/ratelimit.go
+++ b/components/common-go/grpc/ratelimit.go
@@ -47,7 +47,7 @@ func NewRatelimitingInterceptor(f map[string]RateLimit) RatelimitingInterceptor 
 	cacheHitCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "grpc",
 		Subsystem: "server",
-		Name:      "rate_limiter_calls_total",
+		Name:      "rate_limiter_cache_hit_total",
 	}, []string{"grpc_method"})
 
 	funcs := make(map[string]*ratelimitedFunction, len(f))

--- a/components/common-go/grpc/ratelimit_test.go
+++ b/components/common-go/grpc/ratelimit_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package grpc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/apipb"
+	"google.golang.org/protobuf/types/known/sourcecontextpb"
+)
+
+func TestGetFieldValue(t *testing.T) {
+	type Expectation struct {
+		Found bool
+		Val   string
+	}
+	tests := []struct {
+		Name        string
+		Message     proto.Message
+		Path        string
+		Expectation Expectation
+	}{
+		{
+			Name:        "direct access",
+			Message:     &apipb.Api{Name: "bar"},
+			Path:        "name",
+			Expectation: Expectation{Found: true, Val: "bar"},
+		},
+		{
+			Name:        "empty field",
+			Message:     &apipb.Api{},
+			Path:        "name",
+			Expectation: Expectation{Found: true},
+		},
+		{
+			Name:        "non-existent field",
+			Message:     &apipb.Api{},
+			Path:        "does-not-exist",
+			Expectation: Expectation{Found: false},
+		},
+		{
+			Name: "nest struct",
+			Message: &apipb.Api{
+				SourceContext: &sourcecontextpb.SourceContext{
+					FileName: "bar",
+				},
+			},
+			Path:        "source_context.file_name",
+			Expectation: Expectation{Found: true, Val: "bar"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var act Expectation
+			act.Val, act.Found = getFieldValue(test.Message.ProtoReflect(), strings.Split(test.Path, "."))
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected getFieldValue (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkGetFieldValue(b *testing.B) {
+	msg := apipb.Api{
+		SourceContext: &sourcecontextpb.SourceContext{
+			FileName: "bar",
+		},
+	}
+	msgr := msg.ProtoReflect()
+	path := []string{"source_context", "file_name"}
+	// run the Fib function b.N times
+	for n := 0; n < b.N; n++ {
+		getFieldValue(msgr, path)
+	}
+}

--- a/components/content-service-api/go/go.mod
+++ b/components/content-service-api/go/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/components/content-service-api/go/go.sum
+++ b/components/content-service-api/go/go.sum
@@ -140,6 +140,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/components/content-service/go.mod
+++ b/components/content-service/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect

--- a/components/content-service/go.sum
+++ b/components/content-service/go.sum
@@ -446,6 +446,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/components/image-builder-api/go/go.mod
+++ b/components/image-builder-api/go/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/components/image-builder-api/go/go.sum
+++ b/components/image-builder-api/go/go.sum
@@ -142,6 +142,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/components/image-builder-mk3/go.mod
+++ b/components/image-builder-mk3/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/klauspost/compress v1.11.13 // indirect

--- a/components/image-builder-mk3/go.sum
+++ b/components/image-builder-mk3/go.sum
@@ -215,6 +215,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -477,6 +477,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/components/workspacekit/go.sum
+++ b/components/workspacekit/go.sum
@@ -192,6 +192,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/components/ws-manager-api/go/go.mod
+++ b/components/ws-manager-api/go/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/components/ws-manager-api/go/go.sum
+++ b/components/ws-manager-api/go/go.sum
@@ -172,6 +172,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -119,6 +119,7 @@ var runCmd = &cobra.Command{
 			log.WithField("ratelimits", cfg.RPCServer.RateLimits).Info("imposing rate limits on the gRPC interface")
 		}
 		ratelimits := common_grpc.NewRatelimitingInterceptor(cfg.RPCServer.RateLimits)
+		metrics.Registry.MustRegister(ratelimits)
 
 		grpcMetrics := grpc_prometheus.NewServerMetrics()
 		grpcMetrics.EnableHandlingTimeHistogram()

--- a/components/ws-manager/go.mod
+++ b/components/ws-manager/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/components/ws-manager/go.sum
+++ b/components/ws-manager/go.sum
@@ -482,6 +482,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -286,6 +286,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/dev/gpctl/go.sum
+++ b/dev/gpctl/go.sum
@@ -249,6 +249,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/test/go.mod
+++ b/test/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -491,6 +491,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=


### PR DESCRIPTION
## Description
This PR adds support for message-keyed gRPC rate limits to common-go.
Using this functionality, we can e.g. add per-user rate limits in ws-manager.

For example:
```JSON
{
    "rateLimits": {
        "/wsman.WorkspaceManager/StartWorkspace": {
            "bucketSize": 5,
            "refillInterval": "1s",
            "key": "metadata.owner",
            "keyCacheSize": 200
        }
    }
}
```

would impose a 5 workspaces per second rate limit per workspace owner.

## How to test
- See unit test
- Manually add the config to ws-manager and use loadgen

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] Support more fine-grained rate limits
```
