### PR TITLE
[docker-up] Configure docker0 MTU

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -130,6 +130,8 @@ func runWithinNetns() (err error) {
 	}
 
 	args = append(args, fmt.Sprintf("--mtu=%v", netIface.Attrs().MTU))
+	// configure docker0 MTU (used as control plane, not related to containers)
+	args = append(args, fmt.Sprintf("--network-control-plane-mtu=%v", netIface.Attrs().MTU))
 
 	if listenFDs > 0 {
 		os.Setenv("LISTEN_PID", strconv.Itoa(os.Getpid()))


### PR DESCRIPTION
## Description

Configure the docker network control plane MTU (docker0)

## How to test
- Start a workspace
- Run `docker run alpine`
- Run `ip a s` and check the MTU of the `docker0` interface is the same than `ceth0`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[docker-up] Configure docker0 MTU
```
