### PR TITLE
[workspacekit] Increase rin0 ws-daemon socket timeout

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -68,7 +68,7 @@ var ring0Cmd = &cobra.Command{
 
 		defer log.Info("done")
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
 		client, err := connectToInWorkspaceDaemonService(ctx)


### PR DESCRIPTION

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[workspacekit] Increase rin0 ws-daemon socket timeout
```
