### PR TITLE
Temporary fix for sporadic SSH connection issues

### DIFF
--- a/dev/preview/ssh-proxy-command.sh
+++ b/dev/preview/ssh-proxy-command.sh
@@ -29,5 +29,15 @@ while true; do
     fi
 done
 
+# There seems to be a race condition somewhere. If we don't sleep a bit here
+# we're seeing sporadic SSH connection failure with the following messages
+#
+#    kex_exchange_identification: Connection closed by remote host
+#
+# We have created an issue to debug further and remove this fixed sleep
+#
+#    https://github.com/gitpod-io/ops/issues/1984
+sleep 10s
+
 # Use netcat as SSH expects ProxyCommand to read and write using stdin/stdout
 netcat -X connect localhost "${PORT}"


### PR DESCRIPTION
/werft with-vm=true

## Description

Sometimes establishing the SSH connection to VM-based preview environments fails with `kex_exchange_identification: Connection closed by remote host`.

This PR adds a temporary workaround that fixed the issues when Prince and I encountered it today. I have created a follow up issue to investigate further and find a proper solution here https://github.com/gitpod-io/ops/issues/1984

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/ops/issues/1984

## How to test
<!-- Provide steps to test this PR -->
Start a VM-based preview environment and 
- [x] Verify that SSHing to it using the script works
- [x] Verify that installing the k3s kubectx using the script works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A