### PR TITLE
Update `registry-facade` to use `https-certificate`

### DIFF
--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -37,33 +37,34 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		volumeMounts []corev1.VolumeMount
 	)
 
-	name := "config-certificates"
-	volumes = append(volumes, corev1.Volume{
-		Name: name,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: common.RegistryFacadeTLSCertSecret,
-			},
-		},
-	})
-
-	volumeMounts = append(volumeMounts, corev1.VolumeMount{
-		Name:      name,
-		MountPath: "/mnt/certificates",
-	})
-
-	// Attach the proxy CA certificate as registry-facade seems to talk to
-	// the registry through the `proxy`
 	if ctx.Config.Certificate.Name != "" {
-		volumeName := "proxy-ca-cert"
+		name := "config-certificates"
+		volumes = append(volumes, corev1.Volume{
+			Name: name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: ctx.Config.Certificate.Name,
+				},
+			},
+		})
+
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      name,
+			MountPath: "/mnt/certificates",
+		})
+	}
+	if ctx.Config.CustomCACert != nil && ctx.Config.CustomCACert.Name != "" {
+		// Attach the custom CA certificate as registry-facade seems to talk to
+		// the registry through the `proxy`
+		volumeName := "custom-ca-cert"
 		volumes = append(volumes, corev1.Volume{
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: ctx.Config.Certificate.Name,
+					SecretName: ctx.Config.CustomCACert.Name,
 					Items: []corev1.KeyToPath{
 						{
-							Key:  "tls.crt",
+							Key:  "ca.crt",
 							Path: "ca.crt",
 						},
 					},
@@ -90,7 +91,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
-	name = "pull-secret"
+	name := "pull-secret"
 	var secretName string
 	if pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
 		secretName = dockerregistry.BuiltInRegistryAuth
@@ -145,6 +146,44 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
+	initContainers := []corev1.Container{
+		*common.InternalCAContainer(ctx),
+	}
+	// Load `customCACert` into Kubelet's only if its self-signed
+	if ctx.Config.CustomCACert != nil && ctx.Config.CustomCACert.Name != "" {
+		initContainers = append(initContainers,
+			*common.InternalCAContainer(ctx, func(c *corev1.Container) {
+				c.Name = "update-containerd-certificates"
+				c.Env = append(c.Env,
+					corev1.EnvVar{
+						Name: "GITPOD_CA_CERT",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								Key: "ca.crt",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: ctx.Config.CustomCACert.Name,
+								},
+							},
+						},
+					},
+					corev1.EnvVar{
+						// Install gitpod ca.crt in containerd to allow pulls from the host
+						// https://github.com/containerd/containerd/blob/main/docs/hosts.md
+						Name:  "SETUP_SCRIPT",
+						Value: fmt.Sprintf(`TARGETS="docker containerd";for TARGET in $TARGETS;do mkdir -p /mnt/dst/etc/$TARGET/certs.d/reg.%s:%v && echo "$GITPOD_CA_CERT" > /mnt/dst/etc/$TARGET/certs.d/reg.%s:%v/ca.crt && echo "OK";done`, ctx.Config.Domain, ServicePort, ctx.Config.Domain, ServicePort),
+					},
+				)
+				c.VolumeMounts = append(c.VolumeMounts,
+					corev1.VolumeMount{
+						Name:      "hostfs",
+						MountPath: "/mnt/dst",
+					},
+				)
+				c.Command = []string{"sh", "-c", "$(SETUP_SCRIPT)"}
+			}),
+		)
+	}
+
 	return []runtime.Object{&appsv1.DaemonSet{
 		TypeMeta: common.TypeMetaDaemonset,
 		ObjectMeta: metav1.ObjectMeta{
@@ -170,38 +209,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					DNSPolicy:                     "ClusterFirst",
 					RestartPolicy:                 "Always",
 					TerminationGracePeriodSeconds: pointer.Int64(30),
-					InitContainers: []corev1.Container{
-						*common.InternalCAContainer(ctx),
-						*common.InternalCAContainer(ctx, func(c *corev1.Container) {
-							c.Name = "update-containerd-certificates"
-							c.Env = append(c.Env,
-								corev1.EnvVar{
-									Name: "GITPOD_CA_CERT",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											Key: "ca.crt",
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: common.RegistryFacadeTLSCertSecret,
-											},
-										},
-									},
-								},
-								corev1.EnvVar{
-									// Install gitpod ca.crt in containerd to allow pulls from the host
-									// https://github.com/containerd/containerd/blob/main/docs/hosts.md
-									Name:  "SETUP_SCRIPT",
-									Value: fmt.Sprintf(`TARGETS="docker containerd";for TARGET in $TARGETS;do mkdir -p /mnt/dst/etc/$TARGET/certs.d/reg.%s:%v && echo "$GITPOD_CA_CERT" > /mnt/dst/etc/$TARGET/certs.d/reg.%s:%v/ca.crt && echo "OK";done`, ctx.Config.Domain, ServicePort, ctx.Config.Domain, ServicePort),
-								},
-							)
-							c.VolumeMounts = append(c.VolumeMounts,
-								corev1.VolumeMount{
-									Name:      "hostfs",
-									MountPath: "/mnt/dst",
-								},
-							)
-							c.Command = []string{"sh", "-c", "$(SETUP_SCRIPT)"}
-						}),
-					},
+					InitContainers:                initContainers,
 					Containers: []corev1.Container{{
 						Name:            Component,
 						Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.RegistryFacade.Version),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This updates the `GITPOD_CA_CERT` loading to also use the same customCA
cert, instead of loading `builtin-registry-facade-cert` which is not
used anywhere for now.

This is done to fix the GKE regression of loading certs into
`docker` and `containerd`.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes the current issues in the preview environment 

Follow up to https://github.com/gitpod-io/gitpod/pull/9518

## How to test
<!-- Provide steps to test this PR -->

Preview Environments should work as expected!

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
