### PR TITLE
[installer] Increase ws-daemon FailureThreshold

### DIFF
--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -287,7 +287,7 @@ fi
 					PeriodSeconds:       10,
 					TimeoutSeconds:      1,
 					SuccessThreshold:    1,
-					FailureThreshold:    3,
+					FailureThreshold:    5,
 				},
 				Lifecycle: &corev1.Lifecycle{
 					PostStart: &corev1.LifecycleHandler{


### PR DESCRIPTION
## Description

When backups are being created, ws-daemon can take some time to answer live probes on time


## Release Notes
```release-note
[installer] Increase ws-daemon FailureThreshold
```
