### PR TITLE
Use configured reverse proxy port rather than fixed port

### DIFF
--- a/dev/preview/ssh-proxy-command.sh
+++ b/dev/preview/ssh-proxy-command.sh
@@ -24,7 +24,7 @@ kubectl \
 # Wait for the port to be read
 while true; do
     sleep 1
-    if [[ "$(netcat -z localhost 8022)" -eq 0 ]]; then
+    if [[ "$(netcat -z localhost "${PORT}")" -eq 0 ]]; then
         break
     fi
 done


### PR DESCRIPTION
## Description
The reverse proxy port is passed into the script `ssh-proxy-command.sh`, it shouldn't be a fixed port `8022`.
<!-- Describe your changes in detail -->

## Related Issue(s)
No
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
No
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No