### PR TITLE
Build: never lose STDOUT or STDERR when processes fail

### DIFF
--- a/.werft/util/shell.ts
+++ b/.werft/util/shell.ts
@@ -26,12 +26,20 @@ export function exec(cmd: string, options?: ExecOptions): ChildProcess | shell.S
     }
 
     const handleResult = (result, options) => {
-        if (options && options.slice) {
-            werft.logOutput(options.slice, result.stderr || result.stdout);
+        let output = [];
+        if(result.stdout) {
+            output.push("STDOUT: " + result.stdout);
         }
-
+        if(result.stderr) {
+            output.push("STDERR: " + result.stderr);
+        }
+        if (options && options.slice) {
+            werft.logOutput(options.slice, output.join("\n"));
+            output = []; // don't show the same output as part of the exception again.
+        }
         if ((!options || !options.dontCheckRc) && result.code !== 0) {
-            throw new Error(`${cmd} exit with non-zero status code`);
+            output.unshift(`${cmd} exit with non-zero status code.`)
+            throw new Error(output.join("\n"));
         }
     };
 


### PR DESCRIPTION
## Description
When a Werft job fails, we always need to have all information available that hint at potential causes. 
Thus:
* don't lose STDOUT when there is STDERR.
* don't lose STDOUT and STDERR when no slice is given.

## Related Issue(s)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
