### PR TITLE
[installer] Allow configuration of affinity for server and proxy components

### DIFF
--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -14,6 +14,7 @@ import (
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
 	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -163,6 +164,28 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		env = append(env, *envv)
 	}
 
+	var podAntiAffinity *corev1.PodAntiAffinity
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.UsePodAffinity {
+			podAntiAffinity = &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      "component",
+								Operator: "In",
+								Values:   []string{Component},
+							}},
+						},
+						TopologyKey: cluster.AffinityLabelMeta,
+					},
+				}},
+			}
+		}
+		return nil
+	})
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
@@ -185,7 +208,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
+						Affinity: &corev1.Affinity{
+							NodeAffinity:    common.NodeAffinity(cluster.AffinityLabelMeta).NodeAffinity,
+							PodAntiAffinity: podAntiAffinity,
+						},
 						PriorityClassName:  common.SystemNodeCritical,
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -65,8 +65,9 @@ type WorkspaceConfig struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI *PublicAPIConfig `json:"publicApi,omitempty"`
-	Server    *ServerConfig    `json:"server,omitempty"`
+	PublicAPI      *PublicAPIConfig `json:"publicApi,omitempty"`
+	Server         *ServerConfig    `json:"server,omitempty"`
+	UsePodAffinity bool             `json:"usePodAffinity"`
 }
 
 type ServerConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

~~This PR adds the ability to configure the affinities (both node and inter-pod) for all components.~~

Following discussion, we now only allow the `server` and `proxy` components to configure their pod anti-affinity via a simple boolean toggle (`experimental.webapp.usePodAffinity`) in the installer config.

## Related Issue(s)

Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    usePodAffinity: true
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The rendered output will set anti-affinity for the `server`  and `proxy` components.

All other components are unaffected and have their hard coded (node-)affinities.

## Release Notes

```release-note
Allow pod affinities for `server` and `proxy` to be configurable through the installer
```

## Documentation

None.
