### PR TITLE
refactor(components/server/ee): Show userfriendly error message when …

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -241,7 +241,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         if (!result.enoughCredits) {
             throw new ResponseError(
                 ErrorCodes.NOT_ENOUGH_CREDIT,
-                `Not enough monthly workspace hours. Please upgrade your account to get more hours for your workspaces.`,
+                `You ran out of hours for this month, please check ${this.config.hostUrl.asUpgradeSubscription}`,
             );
         }
         if (!!result.hitParallelWorkspaceLimit) {
@@ -2101,8 +2101,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             log.debug({ userId: user.id }, "Cannot find branch details.", { project, branchName });
             throw new ResponseError(
                 ErrorCodes.NOT_FOUND,
-                `Could not find ${!branchName ? "a default branch" : `branch '${branchName}'`} in repository ${
-                    project.cloneUrl
+                `Could not find ${!branchName ? "a default branch" : `branch '${branchName}'`} in repository ${project.cloneUrl
                 }`,
             );
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I've often seen users being confused with the "Not enough credits. Please book more" error message.
Examples:
<img width="622" alt="Screenshot 2022-04-26 at 8 49 11 PM" src="https://user-images.githubusercontent.com/39482679/165327952-039d8a57-9322-4ac6-af60-5208512c682b.png">
<img width="517" alt="Screenshot 2022-04-26 at 8 50 15 PM" src="https://user-images.githubusercontent.com/39482679/165328189-30b1e68a-8e85-4fc2-950e-4d1fe067b5a2.png">
[[1]](https://canary.discord.com/channels/816244985187008514/816246578594840586/966738121171562596)
And there are more on discord and frontapp, but two examples should be enough to visualise the confusion 🙏 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Have 0 hours remaining on account.
- Try to open a workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
refactor(components/server/ee): Show userfriendly error message for out-of-hours event
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
