### PR TITLE
Speed up edit-compile-run loop for workspace components

### DIFF
--- a/components/blobserve/debug.sh
+++ b/components/blobserve/debug.sh
@@ -4,4 +4,4 @@
 # See License-AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment image-builder-mk3
+source /workspace/gitpod/scripts/ws-deploy.sh deployment blobserve

--- a/components/content-service/debug.sh
+++ b/components/content-service/debug.sh
@@ -3,5 +3,6 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+
 set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment image-builder-mk3
+source /workspace/gitpod/scripts/ws-deploy.sh deployment content-service

--- a/components/ee/agent-smith/debug.sh
+++ b/components/ee/agent-smith/debug.sh
@@ -4,4 +4,4 @@
 # See License-AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment image-builder-mk3
+source /workspace/gitpod/scripts/ws-deploy.sh daemonset agent-smith

--- a/components/registry-facade/debug.sh
+++ b/components/registry-facade/debug.sh
@@ -4,4 +4,4 @@
 # See License-AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment image-builder-mk3
+source /workspace/gitpod/scripts/ws-deploy.sh daemonset registry-facade

--- a/components/ws-daemon/debug.sh
+++ b/components/ws-daemon/debug.sh
@@ -1,21 +1,4 @@
 #!/bin/bash
 
-# ws-daemon runs as daemonset on each node which renders telepresence useless for debugging.
-# This script builds ws-daemon locally, puts it in a Dockerfile, builds the image, pushes it,
-# patches the daemonset and restarts all pods.
-#
-# This way you can test out your changes with a 30 sec turnaround.
-#
-# BEWARE: the properly built version of ws-daemon may behave differently.
-
 set -Eeuo pipefail
-
-docker ps &> /dev/null || (echo "You need a working Docker daemon. Maybe set DOCKER_HOST?"; exit 1)
-
-version=dev-0
-leeway build .:docker -Dversion="$version" -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev
-devImage=eu.gcr.io/gitpod-core-dev/dev/ws-daemon:"$version"
-
-kubectl set image daemonset ws-daemon ws-daemon="$devImage"
-kubectl annotate daemonset ws-daemon kubernetes.io/change-cause="$version"
-kubectl rollout restart daemonset ws-daemon
+source /workspace/gitpod/scripts/ws-deploy.sh daemonset ws-daemon

--- a/components/ws-manager/debug.sh
+++ b/components/ws-manager/debug.sh
@@ -4,4 +4,5 @@
 # See License-AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment image-builder-mk3
+
+source /workspace/gitpod/scripts/ws-deploy.sh deployment ws-manager

--- a/components/ws-proxy/debug.sh
+++ b/components/ws-proxy/debug.sh
@@ -4,4 +4,4 @@
 # See License-AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
-source /workspace/gitpod/scripts/ws-deploy.sh deployment image-builder-mk3
+source /workspace/gitpod/scripts/ws-deploy.sh deployment ws-proxy false

--- a/scripts/ws-deploy.sh
+++ b/scripts/ws-deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+# This script builds a workspace component and updates the cluster
+
+set -Eeuo pipefail
+
+resource_type=$1
+resource_name=$2
+enable_debug=${3:-true}
+version="dev-$(date +%F_T"%H-%M-%S")"
+dev_image=eu.gcr.io/gitpod-core-dev/dev/$resource_name:"$version"
+
+docker ps &> /dev/null || (echo "You need a working Docker daemon. Maybe set DOCKER_HOST?"; exit 1)
+leeway build .:docker -Dversion="$version" -DimageRepoBase=eu.gcr.io/gitpod-core-dev/dev
+
+kubectl set image "$resource_type" "$resource_name" "$resource_name"="$dev_image"
+kubectl rollout restart "$resource_type" "$resource_name"
+kubectl annotate "$resource_type" "$resource_name" kubernetes.io/change-cause="$version"
+kubectl rollout status -w "$resource_type" "$resource_name"
+
+while kubectl get pods -l component="$resource_name" | grep -q Terminating;
+do
+    echo "Waiting for old pods to terminate"
+    sleep 3
+done
+if [[ "$enable_debug" = true ]]; then
+    gpctl debug logs "$resource_name" > /dev/null
+fi


### PR DESCRIPTION
## Description
Speed up edit-compile-run loop for workspace components. Each workspace component has a script that will
- Build a timestamped docker image for the component
- Update the running instance with the new image
- Set the change cause so that it can be easily identified in the rollout history
- Wait for the rollout to finish
- Enable debug logs

## Related Issue(s)
n.a.

## How to test
- Open workspace
- Execute one of the debug.sh scripts
- The component will be build and the running instance in your namespace will be updated

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```