### PR TITLE
Fix go mod verify failed in test folder

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -139,8 +139,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
-
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.2
 
 replace github.com/gitpod-io/gitpod/common-go => ../components/common-go // leeway


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The `sigs.k8s.io/controller-runtime` duplicate in the go.mod, remove the duplicate one.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No

## How to test
<!-- Provide steps to test this PR -->
```shell
# Go to the test folder
cd test/
# Verfiy go module
go mod verify
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No