### PR TITLE
Overwrite existing k3s entries in the kubectx in install-k3s-kubeconfig.sh

### DIFF
--- a/dev/preview/install-k3s-kubeconfig.sh
+++ b/dev/preview/install-k3s-kubeconfig.sh
@@ -47,7 +47,7 @@ set-up-ssh
     > "${K3S_KUBECONFIG_PATH}"
 
 log "Merging kubeconfig files ${KUBECONFIG_PATH} ${K3S_KUBECONFIG_PATH} into ${MERGED_KUBECONFIG_PATH}"
-KUBECONFIG="${KUBECONFIG_PATH}:${K3S_KUBECONFIG_PATH}" \
+KUBECONFIG="${K3S_KUBECONFIG_PATH}:${KUBECONFIG_PATH}" \
     kubectl config view --flatten --merge > "${MERGED_KUBECONFIG_PATH}"
 
 log "Overwriting ${KUBECONFIG_PATH}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently install-k3s-kubeconfig.sh would not update the .kube/config if it already had an entry to the k3s cluster. This means that your kubectx config can become stale if you change branches or use with-clean-slate-deployment.

The fix was the ensure that K3S_KUBECONFIG_PATH entries takes precedence over KUBECONFIG_PATH when merging the kubeconfig.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, was reported in our internal Slack [here](https://gitpod.slack.com/archives/C032A46PWR0/p1651044970509919).

## How to test
<!-- Provide steps to test this PR -->

I tested this manually by using two branches with VMs and re-running the script after having changed branches. Before this changeset it didn't update the kubectx after the first invocation. With this changeset it did.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A