### PR TITLE
[kots]: fix typo in CA cert extract command

### DIFF
--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -265,7 +265,7 @@ spec:
             certificate and install it to your browser.
 
             To download the certificate, run
-            `kubectl get secrets -n {{repl Namespace }}  ca-issuer-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > ~/ca.crt`
+            `kubectl get secrets -n {{repl Namespace }}  ca-issuer-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > ./ca.crt`
 
         - name: cert_manager_enabled
           title: Use cert-manager


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Spotted typo in command to extract CA cert - replace `~` with `.`

## How to test
<!-- Provide steps to test this PR -->
Deploy with KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: fix typo in CA cert extract command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
