### PR TITLE
Fix monitoring-satellite deployment

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -64,6 +64,7 @@ export async function installMonitoringSatellite(params: InstallMonitoringSatell
             },
         },
         kubescape: {},
+        pyrra: {},
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
     find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/observability/pull/115, a new component was added to monitoring-satellite. It is an optional component, so you have to explicitly say that you want this component to be rendered.

The upstream PR also made a change to the deployment script(`hack/deploy-satellite.sh`). Which is supposed to be used only for development purposes in the upstream project. The problematic change is :
```
kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/
```

Which will give an exit code different than 0 if the directory is empty or nonexistent. This PR just makes sure we're rendering this new component to make sure the deployment script works.

**_The ideal solution would be to re-implement [this method](https://github.com/gitpod-io/gitpod/blob/e09c6996d847f92b8bab204caadda72f830a0d03/.werft/observability/monitoring-satellite.ts#L82) to not depend on hacky upstream scripts_**

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None, it was reported in slack

## How to test
<!-- Provide steps to test this PR -->
Create a new branch from this PR and start a preview `with-vm`, monitoring-satellite should be deployed successfully and should not break the job.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```