### PR TITLE
[public-api] Simple CLI tool to interact with Public API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,6 +71,7 @@
 /components/ws-manager @gitpod-io/engineering-workspace
 /components/ws-proxy @gitpod-io/engineering-workspace
 /dev/gpctl @gitpod-io/engineering-workspace
+/dev/gpctl/api/ @gitpod-io/engineering-webapp
 /dev/loadgen @gitpod-io/engineering-workspace
 /dev/preview @gitpod-io/platform
 /operations/observability/mixins @gitpod-io/platform

--- a/dev/gpctl/BUILD.yaml
+++ b/dev/gpctl/BUILD.yaml
@@ -13,6 +13,7 @@ packages:
       - components/ws-daemon-api/go:lib
       - components/ws-manager-api/go:lib
       - components/ws-manager-bridge-api/go:lib
+      - components/public-api/go:lib
     env:
       - CGO_ENABLED=0
     config:

--- a/dev/gpctl/cmd/api/root.go
+++ b/dev/gpctl/cmd/api/root.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	connOpts = &connectionOptions{}
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "api",
+		Short: "Interact with Public API services",
+	}
+
+	cmd.PersistentFlags().StringVar(&connOpts.address, "address", "api.main.preview.gitpod-dev.com:443", "Address of the API endpoint. Must be in the form <host>:<port>.")
+	cmd.PersistentFlags().BoolVar(&connOpts.insecure, "insecure", false, "Disable TLS when making requests against the API. For testing purposes only.")
+
+	cmd.PersistentFlags().StringVar(&connOpts.token, "token", "", "Authentication token to interact with the API")
+
+	cmd.AddCommand(newWorkspacesCommand())
+
+	return cmd
+}
+
+func newConn(connOpts *connectionOptions) (*grpc.ClientConn, error) {
+	log.Log.Infof("Estabilishing gRPC connection against %s", connOpts.address)
+
+	opts := []grpc.DialOption{
+		// attach token to requests to auth
+		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			withAuth := metadata.AppendToOutgoingContext(ctx, "authorization", connOpts.token)
+			return invoker(withAuth, method, req, reply, cc, opts...)
+		}),
+	}
+
+	if connOpts.insecure {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+	}
+
+	conn, err := grpc.Dial(connOpts.address, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial %s: %w", connOpts.address, err)
+	}
+
+	return conn, nil
+}
+
+type connectionOptions struct {
+	address  string
+	insecure bool
+	token    string
+}
+
+func (o *connectionOptions) Validate() error {
+	if o.address == "" {
+		return fmt.Errorf("empty connection address")
+	}
+
+	if o.token == "" {
+		return fmt.Errorf("empty connection token")
+	}
+
+	return nil
+}

--- a/dev/gpctl/cmd/api/workspaces.go
+++ b/dev/gpctl/cmd/api/workspaces.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"io"
+	"os"
+)
+
+func newWorkspacesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workspaces",
+		Short: "Retrieve information about workspaces",
+	}
+
+	cmd.AddCommand(newWorkspacesGetCommand())
+
+	return cmd
+}
+
+func newWorkspacesGetCommand() *cobra.Command {
+	var workspaceID string
+
+	cmd := &cobra.Command{
+		Use:     "get",
+		Short:   "Retrieve details about a workspace by ID",
+		Example: "  get --workspace-id 1234",
+		Run: func(cmd *cobra.Command, args []string) {
+			if workspaceID == "" {
+				log.Log.Fatal("no workspace id specified, use --id to set it")
+			}
+
+			if err := connOpts.Validate(); err != nil {
+				log.Log.WithError(err).Fatal("Invalid connections options.")
+			}
+
+			conn, err := newConn(connOpts)
+			if err != nil {
+				log.Log.WithError(err).Fatal("Failed to establish gRPC connection")
+			}
+
+			workspace, err := getWorkspace(cmd.Context(), conn, workspaceID)
+
+			log.Log.WithError(err).WithField("workspace", workspace.String()).Debugf("Workspace response")
+			if err != nil {
+				log.Log.WithError(err).Fatal("Failed to retrieve workspace.")
+				return
+			}
+
+			if err := printProtoMsg(os.Stdout, workspace); err != nil {
+				log.Log.WithError(err).Fatal("Failed to serialize proto message and print it.")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&workspaceID, "id", "", "Workspace ID")
+
+	return cmd
+}
+
+func getWorkspace(ctx context.Context, conn *grpc.ClientConn, workspaceID string) (*v1.GetWorkspaceResponse, error) {
+	service := v1.NewWorkspacesServiceClient(conn)
+
+	log.Log.Debugf("Retrieving workspace ID: %s", workspaceID)
+	resp, err := service.GetWorkspace(ctx, &v1.GetWorkspaceRequest{WorkspaceId: workspaceID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workspace (ID: %s): %w", workspaceID, err)
+	}
+
+	return resp, nil
+}
+
+func printProtoMsg(w io.Writer, m proto.Message) error {
+	b, err := protojson.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("failed to marshal proto object: %w", err)
+	}
+
+	if _, err := fmt.Fprint(w, string(b)); err != nil {
+		return fmt.Errorf("failed to write proto object to writer: %w", err)
+	}
+
+	return nil
+}

--- a/dev/gpctl/cmd/api/workspaces.go
+++ b/dev/gpctl/cmd/api/workspaces.go
@@ -34,7 +34,7 @@ func newWorkspacesGetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get",
 		Short:   "Retrieve details about a workspace by ID",
-		Example: "  get --workspace-id 1234",
+		Example: "  get --id 1234",
 		Run: func(cmd *cobra.Command, args []string) {
 			if workspaceID == "" {
 				log.Log.Fatal("no workspace id specified, use --id to set it")

--- a/dev/gpctl/cmd/root.go
+++ b/dev/gpctl/cmd/root.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/gpctl/cmd/api"
 	"os"
 	"path/filepath"
 
@@ -42,6 +43,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringP("output-format", "o", "template", "Output format. One of: string|json|jsonpath|template")
 	rootCmd.PersistentFlags().String("output-template", "", "Output format Go template or jsonpath. Use with -o template or -o jsonpath")
+
+	rootCmd.AddCommand(api.NewCommand())
 }
 
 func getKubeconfig() (*rest.Config, string, error) {

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -24,6 +24,8 @@ require (
 	k8s.io/client-go v0.0.0
 )
 
+require github.com/gitpod-io/gitpod/public-api v0.0.0-00010101000000-000000000000
+
 require (
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -86,6 +88,8 @@ replace github.com/gitpod-io/gitpod/common-go => ../../components/common-go // l
 replace github.com/gitpod-io/gitpod/content-service/api => ../../components/content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/image-builder/api => ../../components/image-builder-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/public-api => ../../components/public-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/registry-facade/api => ../../components/registry-facade-api/go // leeway
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds `api workspaces get --id 123 --token "foo-bar" to interact with Public API. Creates a dir `api` under `cmd` and gives code-ownership to WebApp.

```bash
 ./gpctl 
Gpctl controls a Gitpod installation

Usage:
  gpctl [command]

Available Commands:
  api         Interact with Public API services
  clusters    Controls and inspects cluster
  completion  Generate completion script
  debug       Helps with debugging a component
  help        Help about any command
  imagebuilds Controls and inspects workspace Docker image builds
  workspaces  Controls and inspects workspaces in the Gitpod installation

Flags:
  -h, --help                     help for gpctl
  -c, --kubeconfig string        Path to the kubeconfig file used for connecting to the cluster (default "$HOME/.kube/config")
  -o, --output-format string     Output format. One of: string|json|jsonpath|template (default "template")
      --output-template string   Output format Go template or jsonpath. Use with -o template or -o jsonpath

Use "gpctl [command] --help" for more information about a command.

```

```bash
./gpctl api workspaces get --id 123 --token foo-bar --address api.mp-papi-cmd-yolo.staging.gitpod-dev.com:443
INFO[0000] Estabilishing gRPC connection against api.mp-papi-cmd-yolo.staging.gitpod-dev.com:443 
{"result":{"workspaceId":"123","ownerId":"mock_owner","projectId":"mock_project_id","context"{"contextUrl":"https://github.com/gitpod-io/gitpod"},"description":"This is a mock response"}}%  
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
**Test the CLI works**
```
cd dev/gpctl
go run main.go api workspaces get --id 123 --token foo-bar --address api.mp-papi-cmd-yolo.staging.gitpod-dev.com:443
```

**Test with a local instance of Public API**
1. Navigate to [preview env on main](https://main.preview.gitpod-dev.com/workspaces)
2. Open dev console and run 
```js
await window._gp.gitpodService.server.generateNewGitpodToken({ type: 1, scopes: ["function:getGitpodTokenScopes",
	"function:getWorkspace",
	"function:getWorkspaces",
	"function:listenForWorkspaceInstanceUpdates",
	"resource:default",]})
```
, this will obtain a token you can use to access the through a CLI
4. Start the Public API locally with `cd components/public-api-server && go run main.go`
5. Hit the local API using the CLI, here we need to use `--insecure` because we're not serving TLS certs
```
go run main.go api workspaces get --id $WORKSPACE_ID --token $TOKEN --insecure --address localhost:9501
```
You'll likely get Not Found. To get a response, start a workspace on the main preview env and use its ID as `$WORKSPACE_ID`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/uncc

- [x] /werft without-vm=true