### PR TITLE
Fix cannot initialize workspace: no backup found

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -288,7 +288,7 @@ func (s *WorkspaceService) DisposeWorkspace(ctx context.Context, req *api.Dispos
 
 	sess := s.store.Get(req.Id)
 	if sess == nil {
-		return nil, status.Error(codes.NotFound, "workspace does not exist")
+		return nil, status.Error(codes.NotFound, "cannot find workspace during DisposeWorkspace")
 	}
 
 	// We were asked to do a backup of a session that was never ready. There seems to have been some state drift here - tell the caller.
@@ -643,7 +643,7 @@ func (s *WorkspaceService) WaitForInit(ctx context.Context, req *api.WaitForInit
 
 	session := s.store.Get(req.Id)
 	if session == nil {
-		return nil, status.Error(codes.NotFound, "workspace does not exist")
+		return nil, status.Error(codes.NotFound, "cannot find workspace during WaitForInit")
 	}
 
 	// the next call will block until the workspace is initialized
@@ -664,7 +664,7 @@ func (s *WorkspaceService) TakeSnapshot(ctx context.Context, req *api.TakeSnapsh
 
 	sess := s.store.Get(req.Id)
 	if sess == nil {
-		return nil, status.Error(codes.NotFound, "workspace does not exist")
+		return nil, status.Error(codes.NotFound, "cannot find workspace during TakeSnapshot")
 	}
 	if !sess.IsReady() {
 		return nil, status.Error(codes.FailedPrecondition, "workspace is not ready")
@@ -725,7 +725,7 @@ func (s *WorkspaceService) BackupWorkspace(ctx context.Context, req *api.BackupW
 		// i.e. location = /mnt/disks/ssd0/workspaces- + req.Id
 		// It would also need to setup the remote storagej
 		// ... but in the worse case we *could* backup locally and then upload manually
-		return nil, status.Error(codes.NotFound, "workspace does not exist")
+		return nil, status.Error(codes.NotFound, "cannot find workspace during BackupWorkspace")
 	}
 	if sess.RemoteStorageDisabled {
 		return nil, status.Errorf(codes.FailedPrecondition, "workspace has no remote storage")

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -376,8 +376,9 @@ func actOnPodEvent(ctx context.Context, m actingManager, status *api.WorkspaceSt
 		}
 
 		_, gone := wso.Pod.Annotations[wsk8s.ContainerIsGoneAnnotation]
+		_, alreadyFinalized := wso.Pod.Annotations[disposalStatusAnnotation]
 
-		if terminated || gone {
+		if (terminated || gone) && !alreadyFinalized {
 			// We start finalizing the workspace content only after the container is gone. This way we ensure there's
 			// no process modifying the workspace content as we create the backup.
 			go m.finalizeWorkspaceContent(ctx, wso)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes log message to be more unique so that it is easier to track where it is coming from
And fix `cannot initialize workspace: no backup found; last backup failed: workspace does not exist.` error that can happen if disposeWorkspace is called more then once.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9598 

## How to test
<!-- Provide steps to test this PR -->
Launch workspace and shut it down. It should shutdown without any errors.
Since original error happens rarely, it might be difficult to repro original error.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix 'last backup failed: workspace does not exist.' error when shutting down workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
