### PR TITLE
Run integration tests nightly against main for workspace components

### DIFF
--- a/.werft/parse.sh
+++ b/.werft/parse.sh
@@ -1,0 +1,5 @@
+title=":x: *Workspace integration test failed*"
+body=$(grep "\-\-\- FAIL: " entrypoing.sh.log)
+echo "${title}"
+echo "${body}"
+# echo "[int-tests|FAIL]"

--- a/.werft/workspace-integration-tests-startup-cron.yaml
+++ b/.werft/workspace-integration-tests-startup-cron.yaml
@@ -1,0 +1,111 @@
+pod:
+  serviceAccount: werft
+  nodeSelector:
+    dev/workload: builds
+  imagePullSecrets:
+  - name: eu-gcr-io-pull-secret
+  volumes:
+  - name: gcp-sa
+    secret:
+      secretName: gcp-sa-gitpod-dev-deployer
+  - name: config
+    emptyDir: {}
+  containers:
+  - name: gcloud
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.4
+    workingDir: /workspace
+    imagePullPolicy: Always
+    env:
+    - name: NODENAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: ROBOQUAT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-roboquat-automatic-changelog
+          key: token
+    volumeMounts:
+    - name: gcp-sa
+      mountPath: /mnt/secrets/gcp-sa
+      readOnly: true
+    - name: config
+      mountPath: /config
+      readOnly: false
+    command:
+    - bash
+    - -c
+    - |
+      set -euo pipefail
+
+      BRANCH="inte-test/"$(date +%Y%m%d%H%M%S)
+
+      function cleanup ()
+      {
+        git push origin :$BRANCH
+      }
+
+      source ./dev/preview/util/preview-name-from-branch.sh
+
+      echo "preparing config." | werft log slice prepare
+      sudo chown -R gitpod:gitpod /workspace
+      gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
+      export GOOGLE_APPLICATION_CREDENTIALS="/home/gitpod/.config/gcloud/legacy_credentials/cd-gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json"
+
+      git config --global user.name roboquat
+      git config --global user.email roboquat@gitpod.io
+      git remote set-url origin https://oauth2:$ROBOQUAT_TOKEN@github.com/gitpod-io/gitpod.git
+
+      echo "copied config..." | werft log slice prepare
+      go install github.com/csweichel/oci-tool@latest 2>&1 | werft log slice prepare
+      werft log slice prepare --done
+
+      werft log phase "build preview environment" "build preview environment"
+      echo integration test >> README.md
+      git checkout -B $BRANCH
+      git add README.md
+      git commit -m "integration test"
+      git push --set-upstream origin $BRANCH
+      trap cleanup SIGINT SIGTERM EXIT
+
+      BUILD_ID=$(werft job list repo.ref==refs/heads/${BRANCH} -o yaml | yq r - "result[0].name")
+      until [ "$BUILD_ID" != "" ]
+      do
+          sleep 1
+          BUILD_ID=$(werft job list repo.ref==refs/heads/${BRANCH} -o yaml | yq r - "result[0].name")
+      done
+      echo "start build preview environment, job name: ${BUILD_ID}, this will take long time" | werft log slice "build test environment"
+      werft log result -d "build job" url "https://werft.gitpod-dev.com/job/${BUILD_ID}"
+
+      if ! werft job logs ${BUILD_ID} | werft log slice "build test environment";
+      then
+          echo "build failed" | werft log slice "build test environment"
+          exit 1
+      fi
+      echo "build success" | werft log slice "build test environment"
+      werft log slice "build test environment" --done
+
+      werft log phase "integration test" "integration test"
+
+      oci-tool fetch file eu.gcr.io/gitpod-core-dev/build/versions:${BUILD_ID:13} versions.yaml
+      INTEGRATION_VERSION=$(cat versions.yaml | yq r - 'components.integrationTest.version')
+
+      echo "using integration-test image: ${INTEGRATION_VERSION}" | werft log slice "test"
+
+      NAMESPACE="$(preview-name-from-branch)"
+
+      WORKSPACE_TEST_LIST=(content-service.test image-builder.test workspace.test ws-daemon.test ws-manager.test)
+      BUILD_ID_LIST=()
+
+      for TEST in "${WORKSPACE_TEST_LIST[@]}"
+      do
+          TEST_BUILD_ID=$(werft run github -a version=${INTEGRATION_VERSION} -a namespace=staging-${NAMESPACE} --remote-job-path .werft/workspace-run-integration-tests.yaml -a testPattern=${TEST})
+          echo "running integration for ${TEST}, job name: ${TEST_BUILD_ID}" | werft log slice "test-${TEST}"
+          werft log result -d "integration test for ${TEST} job" url "https://werft.gitpod-dev.com/job/${TEST_BUILD_ID}"
+          werft job logs ${TEST_BUILD_ID} | werft log slice "test-${TEST}" &
+          BUILD_ID_LIST[${#BUILD_ID_LIST[@]}]=$TEST_BUILD_ID
+          sleep 2
+      done
+      wait
+plugins:
+  cron: "@midnight"

--- a/.werft/workspace-integration-tests-startup-cron.yaml
+++ b/.werft/workspace-integration-tests-startup-cron.yaml
@@ -14,7 +14,7 @@ pod:
   - name: gcloud
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.4
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
     - name: NODENAME
       valueFrom:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -27,7 +27,7 @@ pod:
   - name: gcloud
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.4
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -104,7 +104,7 @@ pod:
       [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
       echo "[prep|DONE]"
 
-      /entrypoint.sh "${args[@]}" 2>&1 | ts "[int-tests] "
+      /entrypoint.sh "${args[@]}" 2>&1 | tee entrypoint.sh.log | ts "[int-tests] "
 
       RC=${PIPESTATUS[0]}
       context_name={{ .Name }}
@@ -112,17 +112,24 @@ pod:
       werftJobUrl="https://werft.gitpod-dev.com/job/${context_name}"
 
       if [ $RC -eq 1 ]; then
-        title=":X: *Workspace integration test failure*"
-        body="Some Workspace integration test failed, please check the werf job logs and fix them"
+        title=":x: *Workspace integration test fail*"
+
+        title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}\n_TestPattern_: {{ .Annotations.testPattern }}"
+        errors=$(grep "\-\-\- FAIL: " entrypoint.sh.log)
+        BODY="{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${title}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\":werft: Go to Werft\",\"emoji\":true},\"value\":\"click_me_123\",\"url\":\"${werftJobUrl}\",\"action_id\":\"button-action\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"\`\`\`\\n${errors}\\n\`\`\`\"}}]}"
+
         echo "[int-tests|FAIL]"
       else
-        title=":white_check_mark: *Workspace integration test success*";
-        body="test success"
+        title=":white_check_mark: *Workspace integration test pass*"
+
+        title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}\n_TestPattern_: {{ .Annotations.testPattern }}"
+        BODY="{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${title}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\":werft: Go to Werft\",\"emoji\":true},\"value\":\"click_me_123\",\"url\":\"${werftJobUrl}\",\"action_id\":\"button-action\"}}]}"
+
         echo "[int-tests|DONE]"
       fi
-      title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}\n_TestPattern_: {{ .Annotations.testPattern }}";
+
       curl -X POST \
           -H 'Content-type: application/json' \
-          -d "{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${title}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\":werft: Go to Werft\",\"emoji\":true},\"value\":\"click_me_123\",\"url\":\"${werftJobUrl}\",\"action_id\":\"button-action\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"\`\`\`\\n${body}\\n\`\`\`\"}}]}" \
+          -d "${BODY}" \
           "https://hooks.slack.com/${SLACK_NOTIFICATION_PATH}"
       exit $RC

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -1,0 +1,128 @@
+args:
+- name: version
+  desc: "The version of the integration tests to use"
+  required: true
+- name: namespace
+  desc: "The namespace to run the integration test against"
+  required: true
+- name: testPattern
+  desc: "The test file pattern to filter the tests to run"
+  required: false
+pod:
+  serviceAccount: werft
+  nodeSelector:
+    dev/workload: builds
+  imagePullSecrets:
+  - name: eu-gcr-io-pull-secret
+  volumes:
+  - name: gcp-sa
+    secret:
+      secretName: gcp-sa-gitpod-dev-deployer
+  - name: integration-test-user
+    secret:
+      secretName: integration-test-user
+  - name: config
+    emptyDir: {}
+  initContainers:
+  - name: gcloud
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.4
+    workingDir: /workspace
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: gcp-sa
+      mountPath: /mnt/secrets/gcp-sa
+      readOnly: true
+    - name: config
+      mountPath: /config
+      readOnly: false
+    command:
+    - bash
+    - -c
+    - |
+
+      echo "[prep] preparing config."
+
+      gcloud auth activate-service-account --key-file /mnt/secrets/gcp-sa/service-account.json
+      cp -R /home/gitpod/.config/gcloud /config/gcloud
+      cp /home/gitpod/.kube/config /config/kubeconfig
+
+      echo "[prep] copied config..."
+  containers:
+  - name: tests
+    image: eu.gcr.io/gitpod-core-dev/build/integration-tests:{{ .Annotations.version }}
+    workingDir: /workspace
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: config
+      mountPath: /config
+      readOnly: true
+    env:
+    - name: USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-user
+          key: username
+    - name: USER_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-user
+          key: token
+    - name: ROBOQUAT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-roboquat-automatic-changelog
+          key: token
+    - name: SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: workspace_jobs
+    command:
+    - /bin/bash
+    - -c
+    - |
+      set -euo
+
+      printf '{{ toJson .Annotations }}' > context.json
+
+      echo "[prep] receiving config..."
+      export GOOGLE_APPLICATION_CREDENTIALS="/config/gcloud/legacy_credentials/cd-gitpod-deployer@gitpod-core-dev.iam.gserviceaccount.com/adc.json"
+      echo "[prep] received config."
+
+      echo "[prep] using username: $USERNAME"
+
+      TEST_PATTERN="{{ .Annotations.testPattern }}"
+      if [[ "$TEST_PATTERN" == "<no value>" ]]; then
+        TEST_PATTERN=""
+      fi
+      echo "[prep] using testPattern: $TEST_PATTERN"
+
+      args=()
+      [[ "$TEST_PATTERN" != "" ]] && args+=( "-testPattern=$TEST_PATTERN" )
+      args+=( '-kubeconfig=/config/kubeconfig' )
+      args+=( "-namespace={{ .Annotations.namespace }}" )
+      [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
+      echo "[prep|DONE]"
+
+      /entrypoint.sh "${args[@]}" 2>&1 | ts "[int-tests] "
+
+      RC=${PIPESTATUS[0]}
+      context_name={{ .Name }}
+      context_repo={{ .Repository.Repo }}
+      werftJobUrl="https://werft.gitpod-dev.com/job/${context_name}"
+
+      if [ $RC -eq 1 ]; then
+        title=":X: *Workspace integration test failure*"
+        body="Some Workspace integration test failed, please check the werf job logs and fix them"
+        echo "[int-tests|FAIL]"
+      else
+        title=":white_check_mark: *Workspace integration test success*";
+        body="test success"
+        echo "[int-tests|DONE]"
+      fi
+      title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}\n_TestPattern_: {{ .Annotations.testPattern }}";
+      curl -X POST \
+          -H 'Content-type: application/json' \
+          -d "{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${title}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\":werft: Go to Werft\",\"emoji\":true},\"value\":\"click_me_123\",\"url\":\"${werftJobUrl}\",\"action_id\":\"button-action\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"\`\`\`\\n${body}\\n\`\`\`\"}}]}" \
+          "https://hooks.slack.com/${SLACK_NOTIFICATION_PATH}"
+      exit $RC


### PR DESCRIPTION
## Description
Run integration tests nightly against main for workspace components.
After the E2E tests succeeded/failed, it'd send the slack notification via the Slack webhook URL, the Slack webhook URL in defined in the secret `slack-webhook-urls`, key `workspace_jobs` in the `werft` namespace.
```shell
$ kubectl get secret slack-webhook-urls -n werft 
NAME                 TYPE     DATA   AGE
slack-webhook-urls   Opaque   2      50d
```

Example result which sends Slack notification to my personal Slack channel
<img width="473" alt="image" src="https://user-images.githubusercontent.com/49380831/165906269-bbd55fd7-f976-4397-95df-a6009eea2424.png">

<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9597

## How to test
```shell
werft run github -j .werft/workspace-integration-tests-startup-cron.yaml -f
```
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A