### PR TITLE
[server] reduce project inactivity time to 1 week (was 10)

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -353,7 +353,7 @@ export class PrebuildManager {
         }
         const now = Date.now();
         const lastUse = new Date(usage.lastWorkspaceStart).getTime();
-        const inactiveProjectTime = 1000 * 60 * 60 * 24 * 7 * 10; // 10 weeks
+        const inactiveProjectTime = 1000 * 60 * 60 * 24 * 7 * 1; // 1 week
         return now - lastUse > inactiveProjectTime;
     }
 }


### PR DESCRIPTION
This PR marks projects as inactive when there has been no workspace for more than a week. As a result, Gitpod will stop preparing workspaces through prebuilds.

I believe we can and should be more aggressive here, to not waste money (and energy). If there are pushes but no workspaces for a repo we can consider it inactive.

```release-notes
Projects are considered inactive after one week without a workspace. After that, incoming push events will no longer trigger prebuilds until a regular workspace has been started again.
```