### PR TITLE
[ws-daemon] Support custom CA cert during Git init

### DIFF
--- a/components/ws-daemon/pkg/content/config.go
+++ b/components/ws-daemon/pkg/content/config.go
@@ -92,4 +92,7 @@ type InitializerConfig struct {
 
 	// Args are additional arguments to pass to the CI runtime
 	Args []string `json:"args"`
+
+	// CustomCACertPath points to a custom cert which Git needs to use for its operations
+	CustomCACertPath string `json:"customCACertPath,omitempty"`
 }

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -230,6 +230,7 @@ func (s *WorkspaceService) InitWorkspace(ctx context.Context, req *api.InitWorks
 				WorkspaceID: req.Metadata.MetaId,
 				InstanceID:  req.Id,
 			},
+			CustomCACertPath: s.config.Initializer.CustomCACertPath,
 		}
 
 		err = RunInitializer(ctx, workspace.Location, req.Initializer, remoteContent, opts)

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -62,6 +62,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	var customCACertPath string
+	if _, mnt, _, ok := common.CustomCACertVolume(ctx); ok {
+		customCACertPath = mnt.MountPath
+	}
+
 	wsdcfg := wsdconfig.Config{
 		Daemon: daemon.Config{
 			Runtime: daemon.RuntimeConfig{
@@ -92,7 +97,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Attempts: 3,
 				},
 				Initializer: content.InitializerConfig{
-					Command: "/app/content-initializer",
+					Command:          "/app/content-initializer",
+					CustomCACertPath: customCACertPath,
 				},
 			},
 			Uidmapper: iws.UidmapperConfig{


### PR DESCRIPTION
## Description
Fixes custom CA certs during content init in ws-daemon

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9604

## How to test
WIP

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support custom CA certs for SCM systems
```
