### PR TITLE
[server] Remove superfluous config field builtinAuthProvidersConfigured

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -18,10 +18,11 @@ import { log, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 
 export const Config = Symbol("Config");
-export type Config = Omit<ConfigSerialized, "hostUrl" | "chargebeeProviderOptionsFile"> & {
+export type Config = Omit<ConfigSerialized, "hostUrl" | "chargebeeProviderOptionsFile" | "licenseFile"> & {
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
     chargebeeProviderOptions?: ChargebeeProviderOptions;
+    builtinAuthProvidersConfigured: boolean;
 };
 
 export interface WorkspaceDefaults {
@@ -87,7 +88,6 @@ export interface ConfigSerialized {
 
     authProviderConfigs: AuthProviderParams[];
     authProviderConfigFiles: string[];
-    builtinAuthProvidersConfigured: boolean;
     disableDynamicAuthProviderLogin: boolean;
 
     /**

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -106,7 +106,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 			return providers
 		}(),
-		BuiltinAuthProvidersConfigured:    len(ctx.Config.AuthProviders) > 0,
 		DisableDynamicAuthProviderLogin:   false,
 		MaxEnvvarPerUserCount:             4048,
 		MaxConcurrentPrebuildsPerRef:      10,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -22,7 +22,6 @@ type ConfigSerialized struct {
 	LicenseFile                       string   `json:"licenseFile"`
 	DefinitelyGpDisabled              bool     `json:"definitelyGpDisabled"`
 	EnableLocalApp                    bool     `json:"enableLocalApp"`
-	BuiltinAuthProvidersConfigured    bool     `json:"builtinAuthProvidersConfigured"`
 	DisableDynamicAuthProviderLogin   bool     `json:"disableDynamicAuthProviderLogin"`
 	MaxEnvvarPerUserCount             int32    `json:"maxEnvvarPerUserCount"`
 	MaxConcurrentPrebuildsPerRef      int32    `json:"maxConcurrentPrebuildsPerRef"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
