### PR TITLE
[ws-daemon] Support GIT_SSL_CAINFO

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -181,6 +181,9 @@ func (c *Client) GitWithOutput(ctx context.Context, subcommand string, args ...s
 	if os.Getenv("https_proxy") != "" {
 		env = append(env, fmt.Sprintf("https_proxy=%s", os.Getenv("https_proxy")))
 	}
+	if v := os.Getenv("GIT_SSL_CAINFO"); v != "" {
+		env = append(env, fmt.Sprintf("GIT_SSL_CAINFO=%s", v))
+	}
 
 	cmd := exec.Command("git", fullArgs...)
 	cmd.Dir = c.Location

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -190,7 +190,7 @@ func RunInitializer(ctx context.Context, destination string, initializer *csapi.
 	spec.Process.User.GID = opts.GID
 	spec.Process.Args = []string{"/app/content-initializer"}
 	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "JAEGER_") {
+		if strings.HasPrefix(e, "JAEGER_") || strings.HasPrefix(e, "GIT_SSL_CAINFO=") {
 			spec.Process.Env = append(spec.Process.Env, e)
 		}
 	}

--- a/install/installer/pkg/common/ca.go
+++ b/install/installer/pkg/common/ca.go
@@ -57,7 +57,7 @@ func InternalCAContainer(ctx *RenderContext, mod ...func(*corev1.Container)) *co
 }
 
 // CustomCACertVolume produces the objects required to mount custom CA certificates
-func CustomCACertVolume(ctx *RenderContext) (vol *corev1.Volume, mnt *corev1.VolumeMount, env *corev1.EnvVar, ok bool) {
+func CustomCACertVolume(ctx *RenderContext) (vol *corev1.Volume, mnt *corev1.VolumeMount, env []corev1.EnvVar, ok bool) {
 	if ctx.Config.CustomCACert == nil {
 		return nil, nil, nil, false
 	}
@@ -86,9 +86,9 @@ func CustomCACertVolume(ctx *RenderContext) (vol *corev1.Volume, mnt *corev1.Vol
 		MountPath: mountPath,
 		SubPath:   "ca.crt",
 	}
-	env = &corev1.EnvVar{
-		Name:  "NODE_EXTRA_CA_CERTS",
-		Value: mountPath,
+	env = []corev1.EnvVar{
+		{Name: "NODE_EXTRA_CA_CERTS", Value: mountPath},
+		{Name: "GIT_SSL_CAINFO", Value: mountPath},
 	}
 	ok = true
 	return

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -160,7 +160,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	if vol, mnt, envv, ok := common.CustomCACertVolume(ctx); ok {
 		volumes = append(volumes, *vol)
 		volumeMounts = append(volumeMounts, *mnt)
-		env = append(env, *envv)
+		env = append(env, envv...)
 	}
 
 	return []runtime.Object{

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -340,10 +340,11 @@ fi
 		return nil, err
 	}
 
-	if vol, mnt, _, ok := common.CustomCACertVolume(ctx); ok {
+	if vol, mnt, env, ok := common.CustomCACertVolume(ctx); ok {
 		podSpec.Volumes = append(podSpec.Volumes, *vol)
 		pod := podSpec.Containers[0]
 		pod.VolumeMounts = append(pod.VolumeMounts, *mnt)
+		pod.Env = append(pod.Env, env...)
 		podSpec.Containers[0] = pod
 	}
 


### PR DESCRIPTION
## Description
Fixes custom CA certs during content init in ws-daemon.
Much simpler than https://github.com/gitpod-io/gitpod/pull/9609

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9604

## How to test
Use with an SCM with custom CA certs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support custom CA certs for SCM systems
```
