### PR TITLE
Remove unneeded privileges for server

### DIFF
--- a/install/installer/pkg/components/server/role.go
+++ b/install/installer/pkg/components/server/role.go
@@ -31,8 +31,6 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"update",
 					"patch",
 					"watch",
-					"delete",
-					"deletecollection",
 				},
 			},
 			{
@@ -45,8 +43,6 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"update",
 					"patch",
 					"watch",
-					"delete",
-					"deletecollection",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
A security scan highlighted that `verbs` `"delete","deletecollection"` should only be granted via k8s Roles when necessary. See the linked issue for details. 

Our `server` component has these verbs and I assume it does not need them because I assume it's `ws-manger` that creates and deletes k8s services and pods. However, maybe I'm overlooking something. If I do, please close this PR.

## Related Issue(s)
Fixes # https://github.com/gitpod-io/security/issues/39

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improved security by removing unneeded privileges from the server component.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
