### PR TITLE
Laushinka/server logs incoming 9556

### DIFF
--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/public-api-server/middleware"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/apiv1"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
 	"net/http"
@@ -33,12 +34,16 @@ func main() {
 }
 
 func register(srv *baseserver.Server) error {
-	srv.HTTPMux().HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`hello world`))
-	})
+	logger := log.New()
+	m := middleware.NewLoggingMiddleware(logger)
+	srv.HTTPMux().Handle("/", m(http.HandlerFunc(HelloWorldHandler)))
 
 	v1.RegisterWorkspacesServiceServer(srv.GRPC(), apiv1.NewWorkspaceService())
 	v1.RegisterPrebuildsServiceServer(srv.GRPC(), v1.UnimplementedPrebuildsServiceServer{})
 
 	return nil
+}
+
+func HelloWorldHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte(`hello world`))
 }

--- a/components/public-api-server/middleware/logging.go
+++ b/components/public-api-server/middleware/logging.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package middleware
+
+import (
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+)
+
+type Middleware func(handler http.Handler) http.Handler
+
+func NewLoggingMiddleware(l *logrus.Entry) Middleware {
+
+	return func(next http.Handler) http.Handler {
+		logging := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			uri := r.RequestURI
+			method := r.Method
+			duration := time.Since(start)
+			next.ServeHTTP(w, r)
+
+			l.WithFields(logrus.Fields{
+				"uri":      uri,
+				"method":   method,
+				"duration": duration,
+			}).Infof("Handled HTTP request %s %s", method, uri)
+		})
+
+		return logging
+	}
+}

--- a/components/public-api-server/middleware/logging_test.go
+++ b/components/public-api-server/middleware/logging_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package middleware
+
+import (
+	"bytes"
+	"github.com/sirupsen/logrus"
+	_ "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggingMiddleware(t *testing.T) {
+	logInMemory := &bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetOutput(logInMemory)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+
+	expectedBody := `hello world`
+
+	someHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(expectedBody))
+	})
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder() // this records the response
+
+	m := NewLoggingMiddleware(logrus.NewEntry(logger))
+	wrappedHandler := m(someHandler)
+	wrappedHandler.ServeHTTP(rec, req)
+
+	require.HTTPStatusCode(t, someHandler, http.MethodGet, "/", nil, http.StatusOK)
+	require.HTTPBodyContains(t, someHandler, http.MethodGet, "/", nil, "hello")
+}


### PR DESCRIPTION
## Description
Implements a middleware to log incoming requests.
This is an initial PR to prep for a follow-up PR that implements an external middleware library that has what we need out of the box.

## Related Issue(s)
Fixes #9556 

## How to test
Under `/component/public-api-server` run `go test ./...`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
