### PR TITLE
[gp-cli] Display the Gitpod Task ID instead of the Working Directory of the running task

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -195,12 +195,10 @@ func (tm *tasksManager) init(ctx context.Context) {
 	for i, config := range *tasks {
 		id := strconv.Itoa(i)
 		presentation := &api.TaskPresentation{}
-		title := ""
 		if config.Name != nil {
 			presentation.Name = *config.Name
-			title = *config.Name
 		} else {
-			presentation.Name = tm.terminalService.DefaultWorkdir
+			presentation.Name = "Gitpod Task " + strconv.Itoa(i+1)
 		}
 		if config.OpenIn != nil {
 			presentation.OpenIn = *config.OpenIn
@@ -216,7 +214,7 @@ func (tm *tasksManager) init(ctx context.Context) {
 			},
 			config:      config,
 			successChan: make(chan taskSuccess, 1),
-			title:       title,
+			title:       presentation.Name,
 		}
 		task.command = getCommand(task, tm.config.isHeadless(), tm.contentSource, tm.storeLocation)
 		if tm.config.isHeadless() && task.command == "exit" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Display the Gitpod Task ID instead of the Working Directory of the running task, on the list from `gp tasks attach` command.

To avoid confusion when more than two tasks are running in the same directory and haven't been named on .gitpod.yml.


Taking [Phaser's .gitpod.yml](https://github.com/photonstorm/phaser/blob/27ebe928b5ef35ffbe48213d6823261ca5e11d05/.gitpod.yml) config as example, which contains two tasks without the `name` property set:
```yml
tasks:
  - init: >
            npm install &&
            npm run build
    command: npm run watch
  - init: >
            cd ../ &&
            git clone https://github.com/photonstorm/phaser3-examples.git &&
            cd phaser3-examples &&
            npm install && npm start
```

When user opens [Phaser's repo](https://github.com/photonstorm/phaser) now, the terminal shows:

<img width="713" alt="image" src="https://user-images.githubusercontent.com/418083/165767509-966256fb-80c7-4dca-b934-8d6f10160e2e.png">

This PR changes it to be displayed as the following:

<img width="708" alt="image" src="https://user-images.githubusercontent.com/418083/165768822-df951b4d-c037-4a7e-a0f5-86c75066a298.png">

Here's how terminal names are displayed on VS Code Terminal now:

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/418083/165777660-de503d63-6009-4e10-b607-f67c3e16697f.png">

And `gp tasks lists` output is displayed like this:

```
gitpod /workspace/phaser (master) $ gp tasks list
|             TERMINAL ID              |     NAME      |  STATE  |
|--------------------------------------|---------------|---------|
| fafe9af7-caf4-41f5-9998-3a713c24d4ed | Gitpod Task 1 | running |
| 62339a91-d078-4d92-9c7e-27c891a31867 | Gitpod Task 2 | running |
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
- Open any repository that contains two or more tasks that keep running on background after the workspace starts and don't have a task name defined in .gitpod.yml. For example: [Phaser's repo](https://github.com/photonstorm/phaser)
- Confirm if unamed tasks from .gitpod.yml are displayed as `Gitpod Task <ID>` when `gp tasks attach` is executed.
- Note: `gp tasks attach` is executed automatically during the Welcome Message on JetBrains IDEs Terminals, that's what you see on the screenshots from the description of this PR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The `gp tasks attach` command now shows the Gitpod Task ID instead of the working directory of the task, to avoid duplicated items in the list of running tasks, as most of the tasks runs in the root directory of the project.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.