### PR TITLE
Fix gateway referrer won't set default IDE

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -101,7 +101,9 @@ export class TypeORMUserDBImpl implements UserDB {
             creationDate: new Date().toISOString(),
             identities: [],
             additionalData: {
-                ideSettings: {},
+                // Please DO NOT add ideSettings prop, it'll broke onboarding of JetBrains Gateway
+                // If you want to do it, ping IDE team
+                // ideSettings: {},
                 emailNotificationSettings: {
                     allowsChangelogMail: true,
                     allowsDevXMail: true,


### PR DESCRIPTION
## Description
Fix gateway referrer won't set default IDE

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. ~~Configure Gateway with prev env host~~
2. ~~Open workspace via Gateway~~
3. Open with this URL to do same thing like step1 step2 https://hw-fix-gw-ide.staging.gitpod-dev.com/#referrer:jetbrains-gateway:pycharm/https://github.com/gitpod-io/template-python-flask
4. User setting should be the one you choose in gateway
5. No [onboarding Modal](https://github.com/gitpod-io/gitpod/pull/9432) in /workspaces page

We need to do other tests like

1. won't register just access `<host>/#<repo>` to see if workspace starts with `code`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
