### PR TITLE
Af/installer various server configs

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -56,6 +56,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	enableLocalApp := true
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			enableLocalApp = cfg.WebApp.Server.EnableLocalApp
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -103,7 +111,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MinAgeDays:                 14,
 			MinAgePrebuildDays:         7,
 		},
-		EnableLocalApp: true,
+		EnableLocalApp: enableLocalApp,
 		AuthProviderConfigFiles: func() []string {
 			providers := make([]string, 0)
 

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -64,6 +64,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	defaultBaseImageRegistryWhitelist := []string{}
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			if cfg.WebApp.Server.DefaultBaseImageRegistryWhiteList != nil {
+				defaultBaseImageRegistryWhitelist = cfg.WebApp.Server.DefaultBaseImageRegistryWhiteList
+			}
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -128,7 +138,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		IncrementalPrebuilds:              IncrementalPrebuilds{CommitHistory: 100, RepositoryPasslist: []string{}},
 		BlockNewUsers:                     ctx.Config.BlockNewUsers,
 		MakeNewUsersAdmin:                 false,
-		DefaultBaseImageRegistryWhitelist: []string{},
+		DefaultBaseImageRegistryWhitelist: defaultBaseImageRegistryWhitelist,
 		RunDbDeleter:                      true,
 		OAuthServer: OAuthServer{
 			Enabled:   true,

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -48,6 +48,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	disableDynamicAuthProviderLogin := false
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			disableDynamicAuthProviderLogin = cfg.WebApp.Server.DisableDynamicAuthProviderLogin
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -106,7 +114,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 			return providers
 		}(),
-		DisableDynamicAuthProviderLogin:   false,
+		DisableDynamicAuthProviderLogin:   disableDynamicAuthProviderLogin,
 		MaxEnvvarPerUserCount:             4048,
 		MaxConcurrentPrebuildsPerRef:      10,
 		IncrementalPrebuilds:              IncrementalPrebuilds{CommitHistory: 100, RepositoryPasslist: []string{}},

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -91,8 +91,9 @@ type ServerConfig struct {
 		WebhookSecret   string `json:"webhookSecret"`
 		CertSecretName  string `json:"certSecretName"`
 	} `json:"githubApp"`
-	DisableDynamicAuthProviderLogin bool `json:"disableDynamicAuthProviderLogin"`
-	EnableLocalApp                  bool `json:"enableLocalApp"`
+	DisableDynamicAuthProviderLogin   bool     `json:"disableDynamicAuthProviderLogin"`
+	EnableLocalApp                    bool     `json:"enableLocalApp"`
+	DefaultBaseImageRegistryWhiteList []string `json:"defaultBaseImageRegistryWhitelist"`
 }
 
 type PublicAPIConfig struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -92,6 +92,7 @@ type ServerConfig struct {
 		CertSecretName  string `json:"certSecretName"`
 	} `json:"githubApp"`
 	DisableDynamicAuthProviderLogin bool `json:"disableDynamicAuthProviderLogin"`
+	EnableLocalApp                  bool `json:"enableLocalApp"`
 }
 
 type PublicAPIConfig struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -91,6 +91,7 @@ type ServerConfig struct {
 		WebhookSecret   string `json:"webhookSecret"`
 		CertSecretName  string `json:"certSecretName"`
 	} `json:"githubApp"`
+	DisableDynamicAuthProviderLogin bool `json:"disableDynamicAuthProviderLogin"`
 }
 
 type PublicAPIConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR makes a few parts of the server config configurable that were previously hard-coded by the installer:

* `disableDynamicAuthProviderLogin`
* `enableLocalApp`
* `defaultBaseImageRegistryWhitelist`

## Related Issue(s)

Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    server:
      disableDynamicAuthProviderLogin: false
      enableLocalApp: true
      defaultBaseImageRegistryWhitelist:
      - https://index.docker.io/v1/
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The rendered output will have the values from the config for the relevant fields in the `server` ConfigMap (under the `config.json` key).

## Release Notes

```release-note
Allow `disableDynamicAuthProviderLogin`, `enableLocalApp` and `defaultBaseImageRegistryWhitelist` server config to be configurable via the installer
```

## Documentation

None.
