### PR TITLE
[baseserver] Use common interceptors

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -238,20 +238,16 @@ func (s *Server) newHTTPMux() *http.ServeMux {
 }
 
 func (s *Server) initializeGRPC() error {
-	var opts []grpc.ServerOption
-
 	gitpod_grpc.SetupLogging()
 
-	unary := grpc.ChainUnaryInterceptor(
+	unary := []grpc.UnaryServerInterceptor{
 		grpc_logrus.UnaryServerInterceptor(s.Logger()),
-	)
-	stream := grpc.ChainStreamInterceptor(
+	}
+	stream := []grpc.StreamServerInterceptor{
 		grpc_logrus.StreamServerInterceptor(s.Logger()),
-	)
+	}
 
-	opts = append(opts, unary, stream)
-
-	s.grpc = grpc.NewServer(opts...)
+	s.grpc = grpc.NewServer(gitpod_grpc.ServerOptionsWithInterceptors(stream, unary)...)
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Ensures baseserver uses common interceptors across our grpc servers

## How to test
<!-- Provide steps to test this PR -->
unit tests work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE
