### PR TITLE
Rename UsePodAffinity to UsePodAntiAffinity

### DIFF
--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -98,7 +98,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	var podAntiAffinity *corev1.PodAntiAffinity
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.UsePodAffinity {
+		if cfg.WebApp != nil && cfg.WebApp.UsePodAntiAffinity {
 			podAntiAffinity = &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
 					Weight: 100,

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -166,7 +166,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	var podAntiAffinity *corev1.PodAntiAffinity
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.UsePodAffinity {
+		if cfg.WebApp != nil && cfg.WebApp.UsePodAntiAffinity {
 			podAntiAffinity = &corev1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
 					Weight: 100,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -81,9 +81,9 @@ type WorkspaceTemplates struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI      *PublicAPIConfig `json:"publicApi,omitempty"`
-	Server         *ServerConfig    `json:"server,omitempty"`
-	UsePodAffinity bool             `json:"usePodAffinity"`
+	PublicAPI          *PublicAPIConfig `json:"publicApi,omitempty"`
+	Server             *ServerConfig    `json:"server,omitempty"`
+	UsePodAntiAffinity bool             `json:"usePodAntiAffinity"`
 }
 
 type ServerConfig struct {


### PR DESCRIPTION
## Description

Make a small change to how a field is named in the experimental installer config, in response to [this comment](
https://github.com/gitpod-io/gitpod/pull/9558#discussion_r860811373).

## Related Issue(s)

Part of #9097 

## How to test

## Release Notes

```release-note
NONE
```

## Documentation

none