### PR TITLE
Fix dead link "root & docker" in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and 
 
 👯‍♀️ [Collaboration](https://www.gitpod.io/docs/sharing-and-collaboration/) - invite team members to your dev environment or snapshot any state of your dev environment to share it with your team asynchronously.
 
-🛠 Professional & customizable developer experience - a Gitpod workspace gives you the same capabilities (yes, even [root & docker](https://www.gitpod.io/docs/feature-preview/#root-access)) as your Linux machine - pre-configured and optimized for your individual development workflow. Install any [VS Code extension](https://www.gitpod.io/docs/vscode-extensions/) with one click on a user and/or team level.
+🛠 Professional & customizable developer experience - a Gitpod workspace gives you the same capabilities (yes, even [root & docker](https://www.gitpod.io/docs/config-docker#configure-a-custom-dockerfile)) as your Linux machine - pre-configured and optimized for your individual development workflow. Install any [VS Code extension](https://www.gitpod.io/docs/vscode-extensions/) with one click on a user and/or team level.
 
 [Learn more 👉](https://www.gitpod.io/)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and 
 
 ![browser-vscode](https://user-images.githubusercontent.com/22498066/135150975-23bba3a6-f099-48c5-83ed-a1a6627ff0e9.png)
 
-
 ## Features
 
 🏗 [Dev environments as code](https://www.gitpod.io/docs/#-dev-environments-as-code) - Gitpod applies lessons learned from infrastructure-as-code. Spinning up dev environments is easily repeatable and reproducible empowering you to automate, version-control and share dev environments across your team.
@@ -50,12 +49,12 @@ Gitpod is provided as a [managed Saas version](https://gitpod.io) with a free su
 ## Getting Started
 
 You can start using Gitpod in one or more of the following ways:
+
 1. Quickstart using an [Example Project](https://www.gitpod.io/docs/quickstart) or [OSS Project](https://contribute.dev/)
 1. Getting started with [one of your existing projects](https://www.gitpod.io/docs/getting-started)
 1. [Use a Prefixed URL](https://www.gitpod.io/docs/getting-started/#prefixed-url)
 1. [Install Browser Extension](https://www.gitpod.io/docs/getting-started#browser-extension)
 1. [Enable GitLab Integration](https://www.gitpod.io/docs/gitlab-integration#gitlab-integration)
-
 
 ## Documentation
 
@@ -79,8 +78,8 @@ You can upvote [popular feature requests](https://github.com/gitpod-io/gitpod/is
 
 We work with quarterly roadmaps in autonomous product teams.
 
- - [Gitpod Architecture](https://www.notion.so/gitpod/Architecture-0e39e570b10f4e8ba7b259629ee3cb74)
- - [Product Roadmap](https://github.com/orgs/gitpod-io/projects/27)
+-   [Gitpod Architecture](https://www.notion.so/gitpod/Architecture-0e39e570b10f4e8ba7b259629ee3cb74)
+-   [Product Roadmap](https://github.com/orgs/gitpod-io/projects/27)
 
 ### How do GitHub Issues get prioritised?
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix dead link "root & docker" in Readme.

The second commit (intentionally left separate) applies formatting changes made by Prettier, so next time readme.md is edited, Prettier won't complain.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8943

## How to test
<!-- Provide steps to test this PR -->
- Open [readme.md](https://github.com/gitpod-io/gitpod/blob/vn/8943-dead-link-in-readme/README.md#features) from this branch.
- Confirm if the link "root & docker" is leading to the correct page.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.
