### PR TITLE
[server] Remove logLevel from server config

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -67,12 +67,14 @@ export class GithubApp {
         @inject(PrebuildStatusMaintainer) protected readonly statusMaintainer: PrebuildStatusMaintainer,
     ) {
         if (config.githubApp?.enabled) {
+            const logLevel = LogrusLogLevel.getFromEnv() ?? "info";
+
             this.server = new Server({
                 Probot: Probot.defaults({
                     appId: config.githubApp.appId,
                     privateKey: GithubApp.loadPrivateKey(config.githubApp.certPath),
                     secret: config.githubApp.webhookSecret,
-                    logLevel: GithubApp.mapToGitHubLogLevel(config.logLevel),
+                    logLevel: GithubApp.mapToGitHubLogLevel(logLevel),
                     baseUrl: config.githubApp.baseUrl,
                 }),
             });

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -14,7 +14,7 @@ import { CodeSyncConfig } from "./code-sync/code-sync-service";
 import { ChargebeeProviderOptions, readOptionsFromFile } from "@gitpod/gitpod-payment-endpoint/lib/chargebee";
 import * as fs from "fs";
 import * as yaml from "js-yaml";
-import { log, LogrusLogLevel } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 
 export const Config = Symbol("Config");
@@ -52,7 +52,6 @@ export interface ConfigSerialized {
     installationShortname: string;
     devBranch?: string;
     insecureNoDomain: boolean;
-    logLevel: LogrusLogLevel;
 
     // Use one or other - licenseFile reads from a file and populates license
     license?: string;


### PR DESCRIPTION
## Description

Remove `logLevel` from the `server` config and take it from the environment instead. `server` deployments in Gitpod releases installed with the installer have the `LOG_LEVEL` env var set here:

https://github.com/gitpod-io/gitpod/blob/1f3919ea76d70e11a2989b7346bd3c885f6580ea/install/installer/pkg/components/server/deployment.go#L74

and applied here:

https://github.com/gitpod-io/gitpod/blob/1f3919ea76d70e11a2989b7346bd3c885f6580ea/install/installer/pkg/components/server/deployment.go#L279

## Related Issue(s)
Part of #9097 

## How to test

## Release Notes

```release-note
NONE
```

## Documentation

none