### PR TITLE
[server] Make account deletion for fault tolerant

### DIFF
--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -154,7 +154,7 @@ export class UserDeletionService {
         const workspaces = await this.workspaceDb.findWorkspacesByUser(userId);
 
         await Promise.all(
-            workspaces.map((ws) => async () => {
+            workspaces.map(async (ws) => {
                 this.anonymizeWorkspace(ws);
                 await this.workspaceDb.store(ws);
             }),

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -98,13 +98,37 @@ export class UserDeletionService {
         const runningWorkspaces = await this.workspaceDb.findRunningInstancesWithWorkspaces(undefined, user.id);
 
         await Promise.all(
-            runningWorkspaces.map(async (wsi) => {
+            runningWorkspaces.map(async (info) => {
+                const wsi = info.latestInstance;
+
                 const req = new StopWorkspaceRequest();
-                req.setId(wsi.latestInstance.id);
+                req.setId(wsi.id);
                 req.setPolicy(StopWorkspacePolicy.NORMALLY);
 
-                const manager = await this.workspaceManagerClientProvider.get(wsi.latestInstance.region);
-                await manager.stopWorkspace({}, req);
+                try {
+                    const manager = await this.workspaceManagerClientProvider.get(wsi.region);
+                    await manager.stopWorkspace({}, req);
+                } catch (err) {
+                    log.debug(
+                        {
+                            userId: info.workspace.ownerId,
+                            workspaceId: info.workspace.id,
+                            instanceId: wsi.id,
+                        },
+                        "Unable to stop workspace on account deletion",
+                        err,
+                    );
+
+                    // We cannot find a workspace manager client for this instances' region, or there is any other error while stopping that workspace properly.
+                    // This might be the case if the workspace cluster which we try to stop an instance on is no longer registered.
+                    // This is bad state, but might happen anyway. Instead of failing, we mark the workspace instance as stopped.
+                    await this.workspaceDb.updateInstancePartial(wsi.id, {
+                        status: {
+                            ...wsi.status,
+                            phase: "stopped",
+                        },
+                    });
+                }
             }),
         );
     }


### PR DESCRIPTION
## Description
#9645 revealed that we might fail during account deletion in face of (rare) bad data cases. This PR fixes that.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9645

## How to test
 - connect to DB
   - create workspace on this branch
   - `kubectl port-forward mysql-0 3306`
   - `mysql -u gitpod -h 127.0.0.1 -p`, `use gitpod;`
 - `select * from d_b_user;` , copy your userId
 - `INSERT INTO d_b_workspace SET id = < some ws id>, ownerId = < your userId >, creationTime = '2022-04-29 13:53:14.251075', contextUrl = 'http://example.org', description = '', context = '{}', config = '{}';`
 - `INSERT INTO d_b_workspace_instance SET id = < randomstromg >, workspaceId = < your ws id >, creationTime = '2022-04-29 13:53:14.251075', ideUrl = 'http://example.org', workspaceImage = 'some-image', region = 'does-not-exist', status ='{"phase": "pending"}', phasePersisted = 'pending';`
 - run `select phasePersisted from d_b_workspace_instance;`
 - note how all entries are 'stopped' now :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix account deletion failing on bad DB state
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


 - [x] /werft with-vm=true
