### PR TITLE
[dashboard] Re-use PrebuildLogs on StartWorkspace

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -24,7 +24,7 @@ import { v4 } from "uuid";
 import Arrow from "../components/Arrow";
 import ContextMenu from "../components/ContextMenu";
 import PendingChangesDropdown from "../components/PendingChangesDropdown";
-import { watchHeadlessLogs } from "../components/PrebuildLogs";
+import PrebuildLogs from "../components/PrebuildLogs";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
 import ConnectToSSHModal from "../workspaces/ConnectToSSHModal";
@@ -440,7 +440,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             // or as a headless workspace.
             case "running":
                 if (isHeadless) {
-                    return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
+                    return PrebuildInProgress({ workspaceId: this.state.workspaceInstance.workspaceId });
                 }
                 if (!this.state.desktopIde) {
                     phase = StartPhase.Running;
@@ -567,7 +567,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
             case "stopping":
                 if (isHeadless) {
-                    return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
+                    return PrebuildInProgress({ workspaceId: this.state.workspaceInstance.workspaceId });
                 }
                 phase = StartPhase.Stopping;
                 statusMessage = (
@@ -717,27 +717,10 @@ function ImageBuildView(props: ImageBuildViewProps) {
     );
 }
 
-function HeadlessWorkspaceView(props: { instanceId: string }) {
-    const logsEmitter = new EventEmitter();
-
-    useEffect(() => {
-        const disposables = watchHeadlessLogs(
-            props.instanceId,
-            (chunk) => logsEmitter.emit("logs", chunk),
-            async () => {
-                return false;
-            },
-        );
-        return function cleanup() {
-            disposables.dispose();
-        };
-    }, []);
-
+function PrebuildInProgress(props: { workspaceId: string }) {
     return (
         <StartPage title="Prebuild in Progress">
-            <Suspense fallback={<div />}>
-                <WorkspaceLogs logsEmitter={logsEmitter} />
-            </Suspense>
+            <PrebuildLogs workspaceId={props.workspaceId} />
         </StartPage>
     );
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8195 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix auto-forwarding on start workspace when a prebuild becomes available
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

 - [x] /werft with-vm=true