### PR TITLE
Update installer readme

### DIFF
--- a/install/installer/README.md
+++ b/install/installer/README.md
@@ -8,7 +8,7 @@
 
 # Installer
 
-The best way to get started with Gitpod
+The best way to get started with Gitpod is by using our recommended & default installation method [described in our documentation](https://www.gitpod.io/docs/self-hosted/latest/getting-started). In fact, our default installation method actually wraps this installer into a UI that helps you manage, update and configure Gitpod in a streamlined way. This document describes how to use the installer directly.
 
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/from-referrer/)
 
@@ -17,7 +17,7 @@ The best way to get started with Gitpod
 - A machine running Linux
     - MacOS and Windows are not currently supported, but may be in future
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
-- A [Kubernetes cluster configured](https://www.gitpod.io/docs/self-hosted/latest/installation)
+- A [Kubernetes cluster configured](https://www.gitpod.io/docs/self-hosted/latest)
 - A [TLS certificate](#tls-certificates)
 
 Or, [open a Gitpod workspace](https://gitpod.io/from-referrer/)


### PR DESCRIPTION
## Description
Changed the wording to point to the default installation method we want people to use.

Related to https://github.com/gitpod-io/website/pull/1975

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
