### PR TITLE
[dashboard] increase IDE awareness for onboarding users when starting workspace

### DIFF
--- a/components/dashboard/src/settings/SelectIDEModal.tsx
+++ b/components/dashboard/src/settings/SelectIDEModal.tsx
@@ -11,7 +11,7 @@ import SelectIDE, { updateUserIDEInfo } from "./SelectIDE";
 import Modal from "../components/Modal";
 import { UserContext } from "../user-context";
 
-export default function () {
+export default function (props: { onClose?: () => void }) {
     const { user, setUser } = useContext(UserContext);
     const [visible, setVisible] = useState(true);
 
@@ -23,11 +23,13 @@ export default function () {
     const handleContinue = async () => {
         setVisible(false);
         if (!user || User.hasPreferredIde(user)) {
+            props.onClose && props.onClose();
             return;
         }
         // TODO: We need to get defaultIde in ideOptions..
         const defaultIde = "code";
         await actualUpdateUserIDEInfo(user, defaultIde, false);
+        props.onClose && props.onClose();
     };
 
     return (


### PR DESCRIPTION
## Description

🧪 This is a PLG experiment that aims to increase the awareness of IDE/editor variety on Gitpod, for first-time users. 

With https://github.com/gitpod-io/gitpod/pull/9432, we've introduced the IDE/editor selection as one of the very first steps for new users. However, some users start using Gitpod without going through the Dashboard - for example by using the context URL: `gitpod.io#REPO-URL`

With this PR, we introduce the same modal UI component, but in the "Create Workspace" page (aka landing page when a context URL is used). This is only impacting users who want to start their first workspace, but don't have a preferred IDE/editor.

See GIF below, to preview the new UI

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9534
Relates to #6707

## How to test
<!-- Provide steps to test this PR -->

Using this preview env: `https://hw-9534-onboarding.staging.gitpod-dev.com#<REPO_URL>`

Open workspace via URL 
1. `[After Reset Account]` Default prefix `/#` will wait until Modal close or choose. After select, will open workspace with choosed IDE.
   - Popup Modal and wait until close or select or continue
   - Detail cases see **TestCases** section
   - i.e. https://hw-9534-onboarding.staging.gitpod-dev.com/#https://github.com/gitpod-io/template-sveltejs
2. `[After Reset Account]` Prefix with special IDE `/#referrer` will set up user's defaultIde if it's **not been set yet**. Open with `/#referrer` is behave like open <repo> via JetBrains Gateway UI with choosen IDE. 
    - No modal, because gateway specified one
    - If no `defaultIde` for user's setting, go with the one specified in URL
    - If have `defaultIde` behave like before
    - i.e. https://hw-9534-onboarding.staging.gitpod-dev.com/#referrer:jetbrains-gateway:pycharm/https://github.com/gitpod-io/template-python-flask (this one go with `pycharm`)
3. `[After Reset Account]` Prefix with special IDE `/#referrer` but args not correctly fit referrer required will use default ide `code` to start workspace
    - No modal, because hash starts with referrer
    - Workspace starts with IDE `code`
    - User ideSettings still undefined
    - Will show ide selection next time start a workspace too
    - i.e. https://hw-9534-onboarding.staging.gitpod-dev.com/#referrer:/https://github.com/gitpod-io/template-python-flask
4.  After setup defaultIde via prefix workspace starting page, onboarding aware on page `/workspaces` will not appear.
    - Detail `/workspaces` PR see https://github.com/gitpod-io/gitpod/pull/9432

### Test Cases

**Every selection from user will change User setting immediately**

1. Choose nothing, refresh page will see modal again
2. Choose nothing and click `continue` or `X`, DB go with `code latest:false`
6. Check `use latest` and click continue or `X`, DB go with `code latest:true`
7. Choose any IDE, DB will change

#### FYI: Check and reset your ide option

**Check**: go to preferences page to see current selection IDE

**Reset**: delete account on settings account page.

**OR**

```mysql
# check
SELECT id, name, additionalData->'$.ideSettings' FROM d_b_user WHERE id = '<your_user_id>';

# reset
UPDATE d_b_user SET additionalData='{"emailNotificationSettings":{"allowsChangelogMail":true,"allowsDevXMail":true,"allowsOnboardingMail":true}}' WHERE id = '<your_user_id>';
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Prompt onboarding users to choose default IDE during workspace starting
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Screenshots / GIF

<img height="400" src="https://user-images.githubusercontent.com/2318450/166697307-2378f785-5ad9-4dce-90ed-aa502651e54a.gif">

- [x] /werft without-vm=true