### PR TITLE
[dashboard] fix onboarding modal show with workspaces exists

### DIFF
--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -35,7 +35,8 @@ export default function () {
     const [activeWorkspaces, setActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [inactiveWorkspaces, setInactiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [workspaceModel, setWorkspaceModel] = useState<WorkspaceModel>();
-    const { setIsStartWorkspaceModalVisible } = useContext(StartWorkspaceModalContext);
+    const [hasWorkspaces, setHasWorkspaces] = useState(false);
+    const { setIsStartWorkspaceModalVisible, isStartWorkspaceModalVisible } = useContext(StartWorkspaceModalContext);
 
     useEffect(() => {
         (async () => {
@@ -44,139 +45,147 @@ export default function () {
         })();
     }, [teams, location]);
 
+    useEffect(() => {
+        setHasWorkspaces(!!activeWorkspaces.length || !!inactiveWorkspaces.length);
+    }, [activeWorkspaces, inactiveWorkspaces]);
+
     const isOnboardingUser = user && User.isOnboardingUser(user);
 
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
 
-            {isOnboardingUser && <SelectIDEModal />}
-
-            {workspaceModel?.initialized &&
-                (activeWorkspaces.length > 0 || inactiveWorkspaces.length > 0 || workspaceModel.searchTerm ? (
-                    <>
-                        <div className="app-container py-2 flex">
-                            <div className="flex">
-                                <div className="py-4">
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        fill="none"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        height="16"
-                                    >
-                                        <path
-                                            fill="#A8A29E"
-                                            d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+            {workspaceModel?.initialized && (
+                <>
+                    {isOnboardingUser && !hasWorkspaces && !isStartWorkspaceModalVisible && <SelectIDEModal />}
+                    {hasWorkspaces || workspaceModel?.searchTerm ? (
+                        <>
+                            <div className="app-container py-2 flex">
+                                <div className="flex">
+                                    <div className="py-4">
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            fill="none"
+                                            viewBox="0 0 16 16"
+                                            width="16"
+                                            height="16"
+                                        >
+                                            <path
+                                                fill="#A8A29E"
+                                                d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                            />
+                                        </svg>
+                                    </div>
+                                    <input
+                                        type="search"
+                                        className="text-sm"
+                                        placeholder="Search Workspaces"
+                                        onChange={(v) => {
+                                            if (workspaceModel) workspaceModel.setSearch(v.target.value);
+                                        }}
+                                    />
+                                </div>
+                                <div className="flex-1" />
+                                <div className="py-3"></div>
+                                <div className="py-3 pl-3">
+                                    <DropDown
+                                        prefix="Limit: "
+                                        contextMenuWidth="w-32"
+                                        activeEntry={workspaceModel ? workspaceModel?.limit + "" : undefined}
+                                        entries={[
+                                            {
+                                                title: "50",
+                                                onClick: () => {
+                                                    if (workspaceModel) workspaceModel.limit = 50;
+                                                },
+                                            },
+                                            {
+                                                title: "100",
+                                                onClick: () => {
+                                                    if (workspaceModel) workspaceModel.limit = 100;
+                                                },
+                                            },
+                                            {
+                                                title: "200",
+                                                onClick: () => {
+                                                    if (workspaceModel) workspaceModel.limit = 200;
+                                                },
+                                            },
+                                        ]}
+                                    />
+                                </div>
+                                <button onClick={() => setIsStartWorkspaceModalVisible(true)} className="ml-2">
+                                    New Workspace{" "}
+                                    <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
+                                </button>
+                            </div>
+                            <ItemsList className="app-container pb-40">
+                                <div className="border-t border-gray-200 dark:border-gray-800"></div>
+                                {activeWorkspaces.map((e) => {
+                                    return (
+                                        <WorkspaceEntry
+                                            key={e.workspace.id}
+                                            desc={e}
+                                            model={workspaceModel}
+                                            stopWorkspace={(wsId) => getGitpodService().server.stopWorkspace(wsId)}
                                         />
-                                    </svg>
-                                </div>
-                                <input
-                                    type="search"
-                                    className="text-sm"
-                                    placeholder="Search Workspaces"
-                                    onChange={(v) => {
-                                        if (workspaceModel) workspaceModel.setSearch(v.target.value);
-                                    }}
-                                />
-                            </div>
-                            <div className="flex-1" />
-                            <div className="py-3"></div>
-                            <div className="py-3 pl-3">
-                                <DropDown
-                                    prefix="Limit: "
-                                    contextMenuWidth="w-32"
-                                    activeEntry={workspaceModel ? workspaceModel?.limit + "" : undefined}
-                                    entries={[
-                                        {
-                                            title: "50",
-                                            onClick: () => {
-                                                if (workspaceModel) workspaceModel.limit = 50;
-                                            },
-                                        },
-                                        {
-                                            title: "100",
-                                            onClick: () => {
-                                                if (workspaceModel) workspaceModel.limit = 100;
-                                            },
-                                        },
-                                        {
-                                            title: "200",
-                                            onClick: () => {
-                                                if (workspaceModel) workspaceModel.limit = 200;
-                                            },
-                                        },
-                                    ]}
-                                />
-                            </div>
-                            <button onClick={() => setIsStartWorkspaceModalVisible(true)} className="ml-2">
-                                New Workspace{" "}
-                                <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
-                            </button>
-                        </div>
-                        <ItemsList className="app-container pb-40">
-                            <div className="border-t border-gray-200 dark:border-gray-800"></div>
-                            {activeWorkspaces.map((e) => {
-                                return (
-                                    <WorkspaceEntry
-                                        key={e.workspace.id}
-                                        desc={e}
-                                        model={workspaceModel}
-                                        stopWorkspace={(wsId) => getGitpodService().server.stopWorkspace(wsId)}
-                                    />
-                                );
-                            })}
-                            {activeWorkspaces.length > 0 && <div className="py-6"></div>}
-                            {inactiveWorkspaces.length > 0 && (
-                                <div className="p-3 text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl text-sm text-center">
-                                    Unpinned workspaces that have been inactive for more than 14 days will be
-                                    automatically deleted.{" "}
-                                    <a
-                                        className="gp-link"
-                                        href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
-                                    >
-                                        Learn more
-                                    </a>
-                                </div>
-                            )}
-                            {inactiveWorkspaces.map((e) => {
-                                return (
-                                    <WorkspaceEntry
-                                        key={e.workspace.id}
-                                        desc={e}
-                                        model={workspaceModel}
-                                        stopWorkspace={(wsId) => getGitpodService().server.stopWorkspace(wsId)}
-                                    />
-                                );
-                            })}
-                        </ItemsList>
-                    </>
-                ) : (
-                    <div className="app-container flex flex-col space-y-2">
-                        <div className="px-6 py-3 flex flex-col text-gray-400 border-t border-gray-200 dark:border-gray-800">
-                            <div className="flex flex-col items-center justify-center h-96 w-96 mx-auto">
-                                <>
-                                    <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Workspaces</h3>
-                                    <div className="text-center pb-6 text-gray-500">
-                                        Prefix any Git repository URL with {window.location.host}/# or create a new
-                                        workspace for a recently used project.{" "}
-                                        <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">
+                                    );
+                                })}
+                                {activeWorkspaces.length > 0 && <div className="py-6"></div>}
+                                {inactiveWorkspaces.length > 0 && (
+                                    <div className="p-3 text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl text-sm text-center">
+                                        Unpinned workspaces that have been inactive for more than 14 days will be
+                                        automatically deleted.{" "}
+                                        <a
+                                            className="gp-link"
+                                            href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
+                                        >
                                             Learn more
                                         </a>
                                     </div>
-                                    <span>
-                                        <button onClick={() => setIsStartWorkspaceModalVisible(true)}>
-                                            New Workspace{" "}
-                                            <span className="opacity-60 hidden md:inline">
-                                                {StartWorkspaceModalKeyBinding}
-                                            </span>
-                                        </button>
-                                    </span>
-                                </>
+                                )}
+                                {inactiveWorkspaces.map((e) => {
+                                    return (
+                                        <WorkspaceEntry
+                                            key={e.workspace.id}
+                                            desc={e}
+                                            model={workspaceModel}
+                                            stopWorkspace={(wsId) => getGitpodService().server.stopWorkspace(wsId)}
+                                        />
+                                    );
+                                })}
+                            </ItemsList>
+                        </>
+                    ) : (
+                        <div className="app-container flex flex-col space-y-2">
+                            <div className="px-6 py-3 flex flex-col text-gray-400 border-t border-gray-200 dark:border-gray-800">
+                                <div className="flex flex-col items-center justify-center h-96 w-96 mx-auto">
+                                    <>
+                                        <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">
+                                            No Workspaces
+                                        </h3>
+                                        <div className="text-center pb-6 text-gray-500">
+                                            Prefix any Git repository URL with {window.location.host}/# or create a new
+                                            workspace for a recently used project.{" "}
+                                            <a className="gp-link" href="https://www.gitpod.io/docs/getting-started/">
+                                                Learn more
+                                            </a>
+                                        </div>
+                                        <span>
+                                            <button onClick={() => setIsStartWorkspaceModalVisible(true)}>
+                                                New Workspace{" "}
+                                                <span className="opacity-60 hidden md:inline">
+                                                    {StartWorkspaceModalKeyBinding}
+                                                </span>
+                                            </button>
+                                        </span>
+                                    </>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                ))}
+                    )}
+                </>
+            )}
         </>
     );
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Go with origin proposal, onboarding Modal in `/workspaces` page will only show with

- User is onboarding user(not select IDE yet)
- No workspaces in `/workspaces` page

See also https://github.com/gitpod-io/gitpod/pull/9624#issuecomment-1112395133

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Go to `/workspaces` verify that the IDE selection modal is visible, do not interact with it, just close the browser tab
2. Launch a new workspace via `/#<repo_url>`
3. Go to `/workspaces` verify that the modal  **does not show**
4. Delete your workspace created by step 2
5. Go back to `/workspaces` and verify that the modal is showing again

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
