### PR TITLE
K3s in preview envs: authenticate with docker hub to avoid rate limit

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -45,6 +45,9 @@ pod:
   - name: harvester-vm-ssh-keys
     secret:
       secretName: harvester-vm-ssh-keys
+  - name: harvester-k3s-dockerhub-pull-account
+    secret:
+      secretName: harvester-k3s-dockerhub-pull-account
   - name: fluent-bit-external
     secret:
       secretName: fluent-bit-external
@@ -101,6 +104,8 @@ pod:
       mountPath: /mnt/secrets/harvester-kubeconfig
     - name: harvester-vm-ssh-keys
       mountPath: /mnt/secrets/harvester-vm-ssh-keys
+    - name: harvester-k3s-dockerhub-pull-account
+      mountPath: /mnt/secrets/harvester-k3s-dockerhub-pull-account
     - name: fluent-bit-external
       mountPath: /mnt/fluent-bit-external
     # - name: deploy-key


### PR DESCRIPTION
## Description
Avoid the Docker hub rate limit by configuring a docker hub account for contianerd in preview environments. 

## Related Issue(s)
Fixes # #8746

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
