### PR TITLE
Preivew Envs: Change with-vm from opt-in to opt-out

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -98,7 +98,8 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     if (repository.branch.startsWith(refsPrefix)) {
         repository.branch = repository.branch.substring(refsPrefix.length);
     }
-    const withVM = ("with-vm" in buildConfig || repository.branch.includes("with-vm")) && !mainBuild;
+    const withoutVM = "without-vm" in buildConfig;
+    const withVM = !withoutVM || mainBuild;
 
     const previewName = previewNameFromBranchName(repository.branch)
     const previewEnvironmentNamespace = withVM ? `default` : `staging-${previewName}`;


### PR DESCRIPTION
## Description
This PR enables preview envs on Harvester by default and replaces the `with-vm` Werft annotation with a `without-vm` annotation. 

The `repository.branch.includes("with-vm")` check should no longer be necessary because we only need it to activate `with-vm` in load tests - an with this PR it's always activated.

## Related Issue(s)
Fixes #

## How to test
* `werft run github` will deploy the preview env on Harvester.
* `werft run github -a wihtout-vm=true` will deploy the preview environment to the core-dev cluster.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
