### PR TITLE
[observability] Add alerts for pending phase

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -104,6 +104,36 @@
               rate(gitpod_ws_manager_workspace_startup_seconds_sum{type="REGULAR"}[1m]) == 0
             |||,
           },
+          {
+            alert: 'GitpodTooManyWorkspacesInPending',
+            labels: {
+              severity: 'critical',
+            },
+            'for': '15m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyWorkspacesInPending.md',
+              summary: 'workspaces are in pending phase',
+              description: 'regular workspaces are stuck in pending phase',
+            },
+            expr: |||
+              gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="REGULAR"} > 20
+            |||,
+          },
+          {
+            alert: 'GitpodTooManyPrebuildsInPending',
+            labels: {
+              severity: 'critical',
+            },
+            'for': '15m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodTooManyPrebuildsInPending.md',
+              summary: 'workspaces are in pending phase',
+              description: 'prebuilds are stuck in pending phase',
+            },
+            expr: |||
+              gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="PREBUILD"} > 20
+            |||,
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add alert which triggers when prebuild/regular workspaces are stuck in pending state. This is a follow up item from incident https://app.incident.io/incidents/143

This alert would have triggered ~15 times in last 30 days.

## PREBUILD
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/32481722/166198872-a1328702-2d12-469d-a063-256bf6761858.png">

## REGULAR
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/32481722/166198891-056f7647-9254-455a-829c-0f81f595e333.png">

Prefer merging https://github.com/gitpod-io/runbooks/pull/340 before this PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9674

## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
