### PR TITLE
Give more resources to build

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -74,6 +74,13 @@ pod:
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.4
     workingDir: /workspace
     imagePullPolicy: Always
+    resources:
+      requests:
+        memory: "10Gi"
+        cpu: "3500m"
+      limits:
+        memory: "20Gi"
+        cpu: "10000m"
     volumeMounts:
     - name: monitoring-satellite-stackdriver-credentials
       mountPath: /mnt/secrets/monitoring-satellite-stackdriver-credentials


### PR DESCRIPTION
## Description
We want to make leeway builds faster by making more CPU/RAM available.

So far, the build jobs did not specify resource limits/requests.

This PR introduces resource limits/requests to fit up to four simultaneous builds onto one n2-standard-16 node.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
