### PR TITLE
Ensure deleteVM is idempotent

### DIFF
--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -19,9 +19,9 @@ EOF
 /**
  * Convenience function to kubectl delete a manifest from stdin.
  */
-function kubectlDeleteManifest(manifest: string, options?: { validate?: boolean }) {
+function kubectlDeleteManifest(manifest: string) {
     exec(`
-        cat <<EOF | kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} delete -f -
+        cat <<EOF | kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} delete --ignore-not-found=true -f -
 ${manifest}
 EOF
     `)
@@ -96,8 +96,7 @@ export function deleteVM(options: { name: string }) {
             vmName: options.name,
             claimName: `${options.name}-${Date.now()}`,
             userDataSecretName
-        }),
-        { validate: false }
+        })
     )
 
     kubectlDeleteManifest(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Jobs using `with-clean-slate-deployments` would fail if there was no VM for the branch. This has caused preview environment deployments to fail on main as we don't have a VM-based preview environment there yet.

This PR adds `--ignore-not-found=true` so that `kubectl delete` will succeed if the resource doesn't exist. That's the behaviour we want in this case.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9678

## How to test
<!-- Provide steps to test this PR -->

I could reproduce this by deleting the entire preview-* namespace for my branch.

```
kubectl delete ns preview-mads-9678-830ab3680f
```

And then trigger a new job

```
werft job run github -a with-clean-slate-deployment=true
```

It failed with the same error as described in the original issue, see [here](https://werft.gitpod-dev.com/job/gitpod-build-mads-9678-clean-slate.2/raw).

I ran a job with the code on this branch and it succeeded, see [here](https://werft.gitpod-dev.com/job/gitpod-build-mads-9678-clean-slate.3).

I also triggered a 2nd `with-clean-slate-deployment` job ([link](https://werft.gitpod-dev.com/job/gitpod-build-mads-9678-clean-slate.5)) to verify it still performs the deletion when the VM does exist ☺️

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A