### PR TITLE
[ws-daemon] Add mapped gitpod user to passwd

### DIFF
--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -26,6 +26,8 @@ RUN addgroup -g 33333 gitpod \
     && echo "gitpod:gitpod" | chpasswd
 # Add gitpodmp user for operations in the mapped UID/GID space
 RUN echo "gitpodmp:x:133332:133332::/home/gitpod:/bin/bash" >> /etc/passwd
+# Add missing known_hosts entry
+RUN mkdir /home/gitpod/.ssh && echo $(ssh-keyscan -t rsa github.com) > /home/gitpod/.ssh/known_hosts
 
 COPY components-ws-daemon--app/ws-daemon /app/ws-daemond
 COPY components-ws-daemon--content-initializer/ws-daemon /app/content-initializer

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -24,6 +24,8 @@ COPY --from=dl /dl/runc.amd64 /usr/bin/runc
 RUN addgroup -g 33333 gitpod \
     && adduser -D -h /home/gitpod -s /bin/sh -u 33333 -G gitpod gitpod \
     && echo "gitpod:gitpod" | chpasswd
+# Add gitpodmp user for operations in the mapped UID/GID space
+RUN echo "gitpodmp:x:133332:133332::/home/gitpod:/bin/bash" >> /etc/passwd
 
 COPY components-ws-daemon--app/ws-daemon /app/ws-daemond
 COPY components-ws-daemon--content-initializer/ws-daemon /app/content-initializer


### PR DESCRIPTION
## Description
Adds a duplicate of the Gitpod user to `/etc/passwd` to make `getpwuid` work in ws-daemon's content init activities (e.g. git checkout).
Using `echo` rather than `adduser` because we don't really need to create a new home directory.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9280

## How to test
Try and run an incremental prebuild

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix incremental prebuilds with submodules
```

## Thanks

Thanks @princerachit for chasing this bug and testing this possible solution
