### PR TITLE
kots: Support s3 backend with incluster registry

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -139,12 +139,12 @@ spec:
                 yq e -i ".containerRegistry.external.url = \"{{repl ConfigOption "reg_url" }}\"" "${CONFIG_FILE}"
                 yq e -i ".containerRegistry.external.certificate.kind = \"secret\"" "${CONFIG_FILE}"
                 yq e -i ".containerRegistry.external.certificate.name = \"container-registry\"" "${CONFIG_FILE}"
-
-                if [ '{{repl ConfigOptionEquals "reg_s3storage" "1" }}' = "true" ];
+              else
+                if [ '{{repl ConfigOptionEquals "reg_incluster_storage" "s3" }}' = "true" ];
                 then
                   echo "Gitpod: configuring container registry S3 backend"
 
-                  yq e -i ".containerRegistry.s3storage.bucket = \"{{repl ConfigOption "reg_bucketname" }}\"" "${CONFIG_FILE}"
+                  yq e -i ".containerRegistry.s3storage.bucket = \"{{repl ConfigOption "reg_incluster_storage_s3_bucketname" }}\"" "${CONFIG_FILE}"
                   yq e -i ".containerRegistry.s3storage.certificate.kind = \"secret\"" "${CONFIG_FILE}"
                   yq e -i ".containerRegistry.s3storage.certificate.name = \"container-registry-s3-backend\"" "${CONFIG_FILE}"
                 fi

--- a/install/kots/manifests/gitpod-registry-s3-backend.yaml
+++ b/install/kots/manifests/gitpod-registry-s3-backend.yaml
@@ -9,7 +9,7 @@ metadata:
     app: gitpod
     component: gitpod-installer
   annotations:
-    kots.io/when: '{{repl and (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_s3storage" "1") }}'
+    kots.io/when: '{{repl and (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
 data:
-  s3AccessKey: '{{repl ConfigOption "reg_accesskey" | Base64Encode }}'
-  s3SecretKey: '{{repl ConfigOption "reg_secretkey" | Base64Encode }}'
+  s3AccessKey: '{{repl ConfigOption "reg_incluster_storage_s3_accesskey" | Base64Encode }}'
+  s3SecretKey: '{{repl ConfigOption "reg_incluster_storage_s3_secretkey" | Base64Encode }}'

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -33,6 +33,39 @@ spec:
           help_text: You may either use an in-cluster container registry or configure your own external container registry for better performance. This container registry must be accessible from your Kubernetes cluster.
           recommended: false
 
+        - name: reg_incluster_storage
+          title: In-cluster Storage provider
+          type: select_one
+          when: '{{repl (ConfigOptionEquals "reg_incluster" "1") }}'
+          default: none
+          help_text: You may configure your Docker registry to use an external storage backend. This setting is recommended for AWS users instead of using Elastic Container Registry.
+          items:
+            - name: none
+              title: None
+            - name: s3
+              title: S3
+
+        - name: reg_incluster_storage_s3_bucketname
+          title: S3 bucket name
+          type: text
+          required: true
+          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          help_text: The name of the bucket to act as your S3 storage backend.
+
+        - name: reg_incluster_storage_s3_accesskey
+          title: S3 access key
+          type: text
+          required: true
+          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          help_text: The access key to use for authentication of your S3 storage backend.
+
+        - name: reg_incluster_storage_s3_secretkey
+          title: S3 secret key
+          type: password
+          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          required: true
+          help_text: The secret key to use for authentication of your S3 storage backend.
+
         - name: reg_url
           title: Container registry URL
           type: text
@@ -59,34 +92,6 @@ spec:
           when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") }}'
           required: true
           help_text: The password for your container registry.
-
-        - name: reg_s3storage
-          title: Use S3 storage for your container registry
-          type: bool
-          default: "0"
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") }}'
-          help_text: If using AWS as your container registry, you must configure an S3 storage backend.
-
-        - name: reg_bucketname
-          title: S3 bucket name
-          type: text
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_s3storage" "1") }}'
-          required: true
-          help_text: The name of the bucket to act as your S3 storage backend.
-
-        - name: reg_accesskey
-          title: S3 access key
-          type: text
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_s3storage" "1") }}'
-          required: true
-          help_text: The access key to use for authentication of your S3 storage backend.
-
-        - name: reg_secretkey
-          title: S3 secret key
-          type: password
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_s3storage" "1") }}'
-          required: true
-          help_text: The secret key to use for authentication of your S3 storage backend.
 
     - name: database
       title: Database


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, There seems to be a configuration issue, around
s3 backend, and docker registry. The s3 option is available
when `incluster` is disabled, which is confusing as s3
backend is supported when `incluster` registry is enabled.

This PR fixes that by having this configured correctly.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->

With `kots`, You should now see an Storage backend option when incluster
registry is enabled.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] support s3 backend in incluster registry
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
