### PR TITLE
[public-api] Extract BearerToken from request

### DIFF
--- a/components/public-api-server/integration_test.go
+++ b/components/public-api-server/integration_test.go
@@ -12,12 +12,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"testing"
 )
 
 func TestPublicAPIServer_v1_WorkspaceService(t *testing.T) {
-	ctx := context.Background()
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "some-token")
 	srv := baseserver.NewForTests(t)
 
 	require.NoError(t, register(srv))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
First phase of adding authentication to public API
* We check that a token exists, but otherwise do no extra validation. This is acceptable, as we're only returning mock data at this point.
* Eventually, this will move into a middleware and will automatically attach extracted user context into the request context, but we don't yet need this.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
* Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE