### PR TITLE
[server] Start XL workspaces with internal-xl class

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1294,6 +1294,11 @@ export class WorkspaceStarter {
             ideImage = ideConfig.ideOptions.options[ideConfig.ideOptions.defaultIde].image;
         }
 
+        let workspaceClass: string = "";
+        if (await this.userService.userGetsMoreResources(user)) {
+            workspaceClass = "gitpodio-internal-xl";
+        }
+
         const spec = new StartWorkspaceSpec();
         await createGitpodTokenPromise;
         spec.setEnvvarsList(envvars);
@@ -1309,6 +1314,7 @@ export class WorkspaceStarter {
         spec.setWorkspaceImage(instance.workspaceImage);
         spec.setWorkspaceLocation(workspace.config.workspaceLocation || checkoutLocation);
         spec.setFeatureFlagsList(this.toWorkspaceFeatureFlags(featureFlags));
+        spec.setClass(workspaceClass);
         if (workspace.type === "regular") {
             spec.setTimeout(this.userService.workspaceTimeoutToDuration(await userTimeoutPromise));
         }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1294,7 +1294,7 @@ export class WorkspaceStarter {
             ideImage = ideConfig.ideOptions.options[ideConfig.ideOptions.defaultIde].image;
         }
 
-        let workspaceClass: string = "";
+        let workspaceClass: string = "default";
         if (await this.userService.userGetsMoreResources(user)) {
             workspaceClass = "gitpodio-internal-xl";
         }


### PR DESCRIPTION
## Description
This change starts workspaces which should get more resources using the `gitpodio-internal-xl` class.
Note: we have to deploy workspace clusters which support this class first.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
