### PR TITLE
[ws-daemon] Remove workspaceSizeLimit

### DIFF
--- a/chart/templates/ws-daemon-configmap.yaml
+++ b/chart/templates/ws-daemon-configmap.yaml
@@ -21,9 +21,6 @@ daemon:
   content:
     workingArea: "/mnt/workingarea"
     workingAreaNode: {{ $comp.hostWorkspaceArea | quote }}
-    {{- if (and $comp.workspaceSizeLimit (not (eq $comp.workspaceSizeLimit ""))) }}
-    workspaceSizeLimit: {{ ($comp.workspaceSizeLimit | default "0g") | quote }}
-    {{- end }}
     tempDir: {{ $comp.backupTempDir | default "/tmp" }}
 {{ include "gitpod.remoteStorage.config" (dict "root" . "remoteStorage" .Values.components.contentService.remoteStorage) | indent 4 }}
     backup:


### PR DESCRIPTION
## Description
Removes the outdated `workspaceSizeLimit` field from ws-daemon's configuration in the helm chart

## How to test
- Install using helm-chart
- Make sure ws-daemon still starts

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft without-vm
/werft with-helm