### PR TITLE
[installer]: Add server chargebee configuration to the installer

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -74,6 +74,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	chargebeeSecret := ""
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			chargebeeSecret = cfg.WebApp.Server.ChargebeeSecret
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -162,9 +170,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ImageBuilderAddr:             "image-builder-mk3:8080",
 		CodeSync:                     CodeSync{},
 		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
-		EnablePayment:                false,
+		EnablePayment:                chargebeeSecret != "",
+		ChargebeeProviderOptionsFile: fmt.Sprintf("%s/providerOptions", chargebeeMountPath),
 		InsecureNoDomain:             false,
-		ChargebeeProviderOptionsFile: "/chargebee/providerOptions",
 		PrebuildLimiter: map[string]int{
 			// default limit for all cloneURLs
 			"*": 50,

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -14,6 +14,7 @@ const (
 	ContainerPortName     = "http"
 	authProviderFilePath  = "/gitpod/auth-providers"
 	licenseFilePath       = "/gitpod/license"
+	chargebeeMountPath    = "/chargebee"
 	PrometheusPort        = 9500
 	PrometheusPortName    = "metrics"
 	InstallationAdminPort = common.ServerInstallationAdminPort

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -125,6 +125,7 @@ type ServerConfig struct {
 	OAuthServer                       OAuthServer       `json:"oauthServer"`
 	Session                           Session           `json:"session"`
 	GithubApp                         *GithubApp        `json:"githubApp"`
+	ChargebeeSecret                   string            `json:"chargebeeSecret"`
 	DisableDynamicAuthProviderLogin   bool              `json:"disableDynamicAuthProviderLogin"`
 	EnableLocalApp                    bool              `json:"enableLocalApp"`
 	DefaultBaseImageRegistryWhiteList []string          `json:"defaultBaseImageRegistryWhitelist"`


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR makes it possible to configure the `server` component's chargebee configuration via new configuration surface in the `experimental` section of the installer config that allows specifying the name of a secret containing chargebee config. For installations on which payments should be enabled, we expect there to be a secret present in the cluster containing this configuration. For Gitpod SaaS, this is achieved via terraform as a cluster prerequisite:

https://github.com/gitpod-io/ops/blob/8fb50515adbfa90a3435f2148660f7de8d70c219/terraform/modules/gitpod/main.tf#L31-L38

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    server:
      chargebeeSecret: "chargebee-config"
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `server` configmap will have `enablePayment` set to `true` and the `server` deployment will have an extra volume + volumemount:

```yaml
        - mountPath: /chargebee
          name: chargebee-config
          readOnly: true
```

```yaml
      - name: chargebee-config
        secret:
          secretName: chargebee-config
```

## Release Notes

```release-note
Allow chargebee payment config to be specified via the installer for SaaS installations.
```

## Documentation

None.
