### PR TITLE
[KOTS]: configure blockNewUsers

### DIFF
--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:main.2968"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:release-2022.04.1.2"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:main.2968"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:release-2022.04.1.2"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -206,6 +206,18 @@ spec:
                 yq e -i '.customCACert.name = "ca-certificate"' "${CONFIG_FILE}"
               fi
 
+              if [ '{{repl ConfigOptionEquals "user_management_block_enabled" "1" }}' = "true" ];
+              then
+                echo "Gitpod: Adding blockNewUsers to config"
+                yq e -i '.blockNewUsers.enabled = true' "${CONFIG_FILE}"
+
+                for domain in {{repl ConfigOption "user_management_block_passlist" }}
+                do
+                  echo "Gitpod: Adding domain \"${domain}\" to blockNewUsers config"
+                  yq e -i ".blockNewUsers.passlist += \"${domain}\"" "${CONFIG_FILE}"
+                done
+              fi
+
               echo "Gitpod: Patch Gitpod config"
               base64 -d "${CONFIG_PATCH_FILE}" > /tmp/patch.yaml
               config_patch=$(cat /tmp/patch.yaml)

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -324,6 +324,24 @@ spec:
           default: "0"
           help_text: 'Enabling the SSH gateway allows use of additional desktop IDEs. IMPORTANT: This uses port 22 on your Kubernetes nodes. When enabled, this will prevent login to the cluster via SSH. If you wish to maintain SSH access to your cluster, please configure another SSH port on your nodes.'
 
+    - name: user_management
+      title: User management
+      items:
+        - name: user_management_block_enabled
+          title: Limit user registration
+          type: bool
+          default: "0"
+          help_text: New registrations can be limited to users in specific domains.
+
+        - name: user_management_block_passlist
+          title: Allow registration for domain(s)
+          type: text
+          when: '{{repl (ConfigOptionEquals "user_management_block_enabled" "1") }}'
+          help_text: |
+            Enable users with email addresses in these domains to register for this service. This must be the primary email address set for the provider.
+
+            Add the domain only (eg, `gitpod.io`). Separate multiple domains with spaces.
+
     - name: advanced
       title: Advanced customizations (Expert Mode)
       description: Use with care! Enable only when you know what you are doing!


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The Installed exposes a `blockNewUsers` block in the config which limits who can create a new account in the installation. This PR adds this to the KOTS config and injects it in if configured - this is in a new section at the bottom called "User management".

By default, this is not enabled:

![image](https://user-images.githubusercontent.com/275848/166446175-595b51f9-9360-4279-b6fa-6e5931d01bf2.png)

If enabled, it exposes a list of domains that can be added.

![image](https://user-images.githubusercontent.com/275848/166446207-04166a87-dcd1-4510-bd63-46c8e7bc2583.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8906

## How to test
<!-- Provide steps to test this PR -->
Install `dev-sje` via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[KOTS]: configure blockNewUsers
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
