### PR TITLE
[licensor] force preinstall to build `liblicensor.a`

### DIFF
--- a/components/licensor/typescript/BUILD.yaml
+++ b/components/licensor/typescript/BUILD.yaml
@@ -10,6 +10,7 @@ packages:
     prep:
       - ["go", "mod", "init", "licensor"]
       - ["go", "mod", "edit", "-replace", "github.com/gitpod-io/gitpod/licensor=./components-licensor--lib"]
+      - ["rm", "-f", "ee/lib/liblicensor.a"]
       - ["yarn", "preinstall"]
     config:
       packaging: library

--- a/components/licensor/typescript/ee/src/api.ts
+++ b/components/licensor/typescript/ee/src/api.ts
@@ -15,7 +15,7 @@ export enum Feature {
 export interface LicenseData {
     type: LicenseType
     payload: LicensePayload
-    plan: string
+    plan: LicenseSubscriptionLevel
     fallbackAllowed: boolean
 }
 
@@ -31,6 +31,14 @@ export interface LicensePayload {
     seats: number
 }
 
+export enum LicenseSubscriptionLevel {
+    ReplicatedLicenseTypeCommunity = "community",
+    ReplicatedLicenseTypeDevelopment = "dev",
+    ReplicatedLicenseTypePaid = "prod",
+    ReplicatedLicenseTypeTrial = "trial",
+    CommunityLicense = "community",
+    ProfessionalLicense = "prod",
+}
 export enum LicenseType {
     LicenseTypeGitpod = "gitpod",
     LicenseTypeReplicated = "replicated",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes the current break in build when opening a workspace from `gitpod` main.

`licensor/typescript` currently do not rebuild since the build is triggered by the presence of a `.a` file. Since #9343 requires rebuild of the `liblicensor.a` file and `api.ts` (built using `genapi.go`), this PR deletes the `.a` file to force the rebuild.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Open a workspace from this branch, the errors in the build should be resolved.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
