### PR TITLE
[registry-facade] Split off port for readiness probe

### DIFF
--- a/components/blobserve/cmd/run.go
+++ b/components/blobserve/cmd/run.go
@@ -127,7 +127,7 @@ var runCmd = &cobra.Command{
 			// Ensure we can resolve DNS queries, and can access the registry host
 			health := healthcheck.NewHandler()
 			health.AddReadinessCheck("dns", kubernetes.DNSCanResolveProbe(staticLayerHost, 1*time.Second))
-			health.AddReadinessCheck("registry", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("http://%v", repository)))
+			health.AddReadinessCheck("registry", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("https://%v", repository)))
 
 			go func() {
 				if err := http.ListenAndServe(cfg.ReadinessProbeAddr, health); err != nil && err != http.ErrServerClosed {

--- a/components/common-go/kubernetes/probes.go
+++ b/components/common-go/kubernetes/probes.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -37,7 +38,7 @@ func NetworkIsReachableProbe(url string) func() error {
 		}
 		resp.Body.Close()
 
-		if resp.StatusCode > 399 {
+		if resp.StatusCode > 499 {
 			log.WithField("url", url).WithField("statusCode", resp.StatusCode).WithError(err).Error("NetworkIsReachableProbe: unexpected status code checking URL")
 			return fmt.Errorf("returned status %d", resp.StatusCode)
 		}
@@ -48,6 +49,9 @@ func NetworkIsReachableProbe(url string) func() error {
 
 func DNSCanResolveProbe(host string, timeout time.Duration) func() error {
 	log.Infof("creating DNS check for host %v", host)
+
+	// remove port if there is one
+	host = strings.Split(host, ":")[0]
 
 	resolver := net.Resolver{}
 	return func() error {

--- a/components/registry-facade/cmd/run.go
+++ b/components/registry-facade/cmd/run.go
@@ -131,11 +131,11 @@ var runCmd = &cobra.Command{
 			// Ensure we can resolve DNS queries, and can access the registry host
 			health := healthcheck.NewHandler()
 			health.AddReadinessCheck("dns", kubernetes.DNSCanResolveProbe(staticLayerHost, 1*time.Second))
-			health.AddReadinessCheck("registry", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("http://%v", staticLayerRef)))
+			health.AddReadinessCheck("registry", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("https://%v", staticLayerRef)))
 			health.AddReadinessCheck("registry-facade", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("https://127.0.0.1:%v/%v/base/", cfg.Registry.Port, cfg.Registry.Prefix)))
 
 			health.AddLivenessCheck("dns", kubernetes.DNSCanResolveProbe(staticLayerHost, 1*time.Second))
-			health.AddLivenessCheck("registry", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("http://%v", staticLayerRef)))
+			health.AddLivenessCheck("registry", kubernetes.NetworkIsReachableProbe(fmt.Sprintf("https://%v", staticLayerRef)))
 
 			go func() {
 				if err := http.ListenAndServe(cfg.ReadinessProbeAddr, health); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
## Description
This PR removes the port from the domain when checking if a registry host is available.

## How to test
Run on a self-hosted installation where the artifact registry (not the one we push images to) is configured using a port, e.g. `my-registry.location.com:8080`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix readiness probe issue in registry-facace when configured registry address contains a port
```
