### PR TITLE
[kots]: automatically enable shiftfs support if cluster supports it

### DIFF
--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -113,6 +113,12 @@ function publishKots(werft: Werft, jobConfig: JobConfig) {
     exec(`yq w -i ${REPLICATED_YAML_DIR}/gitpod-installer-job.yaml ${INSTALLER_JOB_IMAGE} ${image}:${jobConfig.version}`, { slice: phases.PUBLISH_KOTS });
     exec(`yq w -i ${REPLICATED_YAML_DIR}/gitpod-installation-status.yaml ${INSTALLER_JOB_IMAGE} ${image}:${jobConfig.version}`, { slice: phases.PUBLISH_KOTS });
 
+    // Set the ShiftFS Module Loader tag to version defined in Installer
+    const shiftFsImageAndTag = exec(`yq r ${REPLICATED_YAML_DIR}/gitpod-shiftfs-module-loader.yaml ${INSTALLER_JOB_IMAGE}`);
+    const [shiftFsImage] = shiftFsImageAndTag.split(':');
+    const shiftfsModuleLoaderVersion = exec(`/tmp/installer version | yq r - 'components.wsDaemon.userNamespaces.shiftfsModuleLoader.version'`);
+    exec(`yq w -i ${REPLICATED_YAML_DIR}/gitpod-shiftfs-module-loader.yaml ${INSTALLER_JOB_IMAGE} ${shiftFsImage}:${shiftfsModuleLoaderVersion}`, { slice: phases.PUBLISH_KOTS });
+
     // Generate the logo
     exec(`make logo -C ${REPLICATED_DIR}`, { slice: phases.PUBLISH_KOTS });
 

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -76,6 +76,16 @@ spec:
               echo "Gitpod: Generate the base Installer config"
               /app/installer init > "${CONFIG_FILE}"
 
+              echo "Gitpod: auto-detecting ShiftFS support on host machine"
+              kubectl wait job -n {{repl Namespace }} --for=condition=complete -l component=shiftfs-module-loader --timeout=30s || true
+              ENABLE_SHIFTFS=$(kubectl get jobs.batch -n {{repl Namespace }} -l component=shiftfs-module-loader -o jsonpath='{.items[0].status.succeeded}')
+
+              if [ "${ENABLE_SHIFTFS}" = "1" ]; then
+                echo "Gitpod: enabling ShiftFS support"
+
+                yq e -i '.workspace.runtime.fsShiftMethod = "shiftfs"' "${CONFIG_FILE}"
+              fi
+
               echo "Gitpod: auto-detecting containerd location on host machine"
               if [ -d "/mnt/node0${CONTAINERD_DIR_K3S}" ]; then
                 echo "Gitpod: containerd dir detected as k3s"

--- a/install/kots/manifests/gitpod-shiftfs-module-loader.yaml
+++ b/install/kots/manifests/gitpod-shiftfs-module-loader.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+# This job is allowed to fail as will default to fuse
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: shiftfs-module-loader-{{repl Cursor }}
+  labels:
+    app: gitpod
+    component: shiftfs-module-loader
+spec:
+  ttlSecondsAfterFinished: 60
+  activeDeadlineSeconds: 30
+  backoffLimit: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: gitpod
+        component: shiftfs-module-loader
+    spec:
+      serviceAccountName: installer
+      restartPolicy: Never
+      containers:
+        - name: shiftfs-module-loader
+          # This is the current valid tag. This will be auto-updated by the Werft job
+          image: eu.gcr.io/gitpod-core-dev/build/shiftfs-module-loader:commit-ab235e8bc00f2c1ac70232cea17e5df9a9d262fa
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /usr/src_node
+              name: node-linux-src
+              readOnly: true
+      volumes:
+        - name: node-linux-src
+          hostPath:
+            path: /usr/src
+            type: Directory


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a PR with a proposed change to perform a check to see if we can enable ShiftFS support. This adds the `shiftfs-module-loader` image as a job and the Installer checks whether it's completed. It only switches to ShiftFS if it's passed, otherwise it sticks with Fuse.

I think the first question that needs to be answered - is this a sensible way of performing this check? I've tried it in GKE (with ShiftFS available) and K3s (without ShiftFS available) and I get the desired results.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8883

## How to test
<!-- Provide steps to test this PR -->
Install Gitpod on

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: automatically enable shiftfs support if cluster supports it
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
