### PR TITLE
[installer-diff] Adjust filter to include db and messagebus

### DIFF
--- a/dev/installer-diff/cmd/filter.go
+++ b/dev/installer-diff/cmd/filter.go
@@ -182,7 +182,7 @@ func sortContainersAndEnvVars(containers []corev1.Container) {
 func filterSpecificObjects(obj *unstructured.Unstructured) (filter bool, err error) {
 	// TODO(gpl) revise later: generic
 	switch obj.GetKind() {
-	case "Certificate", "ClusterRole", "ClusterRoleBinding", "RoleBinding", "Role":
+	case "Certificate", "ClusterRole", "ClusterRoleBinding", "RoleBinding", "Role", "NetworkPolicy":
 		return false, nil
 	}
 
@@ -192,21 +192,16 @@ func filterSpecificObjects(obj *unstructured.Unstructured) (filter bool, err err
 		return false, nil
 	}
 
-	// TODO(gpl) revise later: workspace stack
+	// TODO(gpl) we filter out workspace stack to look at it separately
 	switch obj.GetLabels()["component"] {
 	case "agent-smith", "ws-daemon", "registry-facade", "ws-manager", "blobserve", "image-builder-mk3", "ws-proxy", "workspace":
 		return false, nil
 	}
 	switch obj.GetName() {
-	case "blobserve-config", "image-builder-mk3-config", "default-ns-registry-facade":
+	case "blobserve-config", "image-builder-mk3-config", "default-ns-registry-facade", "ws-daemon-config", "ws-proxy-config":
 		return false, nil
 	}
 
-	// TODO(gpl) revise later: messagebus, db-sync, payment-endpoint, dbinit, migrations
-	switch obj.GetLabels()["component"] {
-	case "messagebus", "db-sync", "payment-endpoint", "dbinit", "migrations":
-		return false, nil
-	}
 
 	// filter/format individual fields
 	id := fmt.Sprintf("%s:%s", obj.GetKind(), obj.GetName())


### PR DESCRIPTION
## Description
This change helps us ensure that DB and messagebus are aligned during for the installer migration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
