### PR TITLE
Use link component class for the editor selection modal

### DIFF
--- a/components/dashboard/src/settings/SelectIDEModal.tsx
+++ b/components/dashboard/src/settings/SelectIDEModal.tsx
@@ -36,10 +36,7 @@ export default function () {
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
                 <p className="text-gray-500 text-base pb-3">
                     Choose the editor for opening workspaces. You can always change later the editor in{" "}
-                    <Link
-                        to={"/preferences"}
-                        className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                    >
+                    <Link to={"/preferences"} className="gp-link">
                         user preferences
                     </Link>
                     .


### PR DESCRIPTION
## Description

Following up the changes from https://github.com/gitpod-io/gitpod/pull/9432 (Cc @andreafalzetti @mustard-mh), this will replace some CSS classes with the link component class which is using proper text color for light and dark theme.

## Screenshots
| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-05-03 at 9 31 28 PM" src="https://user-images.githubusercontent.com/120486/166519994-674de2b8-ece9-437d-b24f-e2d96aecbeff.png"> | <img width="1440" alt="Screenshot 2022-05-03 at 9 31 39 PM" src="https://user-images.githubusercontent.com/120486/166519999-7672b524-de65-428f-8730-97845a405771.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use link component class for the editor selection modal
```
