### PR TITLE
[public-api] Set config in installer

### DIFF
--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -44,8 +44,13 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						RestartPolicy:                 "Always",
 						TerminationGracePeriodSeconds: pointer.Int64(30),
 						Containers: []corev1.Container{{
-							Name:            Component,
-							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.PublicAPIServer.Version),
+							Name:  Component,
+							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.PublicAPIServer.Version),
+							Args: []string{
+								fmt.Sprintf("--http-port=%d", HTTPContainerPort),
+								fmt.Sprintf("--grpc-port=%d", GRPCContainerPort),
+								fmt.Sprintf("--gitpod-api-url=wss://%s/api/v1", ctx.Config.Domain),
+							},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -20,3 +20,23 @@ func TestDeployment(t *testing.T) {
 	dpl := objects[0].(*appsv1.Deployment)
 	require.Len(t, dpl.Spec.Template.Spec.Containers, 2, "must render 2 containers")
 }
+
+func TestDeployment_ServerArguments(t *testing.T) {
+	ctx := renderContextWithPublicAPIEnabled(t)
+
+	objects, err := deployment(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render only one object")
+
+	dpl := objects[0].(*appsv1.Deployment)
+	containers := dpl.Spec.Template.Spec.Containers
+	require.Equal(t, Component, containers[0].Name)
+
+	apiContainer := containers[0]
+	require.EqualValues(t, []string{
+		"--http-port=9000",
+		"--grpc-port=9001",
+		`--gitpod-api-url=wss://test.domain.everything.awesome.is/api/v1`,
+	}, apiContainer.Args)
+}

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -31,6 +31,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 
 func renderContextWithPublicAPIEnabled(t *testing.T) *common.RenderContext {
 	ctx, err := common.NewRenderContext(config.Config{
+		Domain: "test.domain.everything.awesome.is",
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
 				PublicAPI: &experimental.PublicAPIConfig{Enabled: true},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set config for public API explicitly instead of relying on defaults, ensures easier debugging when issues arise, also parametrizes gitpod API url

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229
* Depends on https://github.com/gitpod-io/gitpod/pull/9720

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/hold