### PR TITLE
[kots]: improve installer job failure recovery

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -239,8 +239,15 @@ spec:
               echo "Gitpod: Escape any Golang template values"
               sed -i -r 's/(.*\{\{.*)/{{`\1`}}/' "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
+              # If certificate secret already exists, set the timeout to 5m
+              CERT_SECRET=$(kubectl get secrets -n {{repl Namespace }} https-certificates -o jsonpath='{.metadata.name}' || echo '')
+              HELM_TIMEOUT="5m"
+              if [ "${CERT_SECRET}" = "" ]; then
+                HELM_TIMEOUT="1h"
+              fi
+
               # The long timeout is to ensure the TLS cert is created (if required)
-              echo "Gitpod: Apply the Kubernetes objects"
+              echo "Gitpod: Apply the Kubernetes objects with timeout of ${HELM_TIMEOUT}"
               helm upgrade \
                 --atomic \
                 --cleanup-on-fail \
@@ -248,7 +255,7 @@ spec:
                 --install \
                 --namespace="{{repl Namespace }}" \
                 --reset-values \
-                --timeout 1h \
+                --timeout "${HELM_TIMEOUT}" \
                 --wait \
                 gitpod \
                 "${GITPOD_OBJECTS}"

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -14,6 +14,7 @@ metadata:
     component: gitpod-installer
     cursor: "{{repl Cursor }}"
 spec:
+  backoffLimit: 1
   ttlSecondsAfterFinished: 0
   template:
     metadata:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If the `https-certificates` secret exists, it sets the `helm upgrade` timeout to 5 minutes. Otherwise, it keeps it at 1 hour. This means that an update has a shorter timeout than an fresh install and allows for users to regain control of their "(re)deploy" button sooner

Also set the `backoffLimit` to `1` to avoid it restarting out of control. If a restart is required, this can be achieved by the user pressing "(re)deploy)

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: improve installer job failure recovery
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
