### PR TITLE
[baseserver] Dedicated debug server

### DIFF
--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -20,6 +20,8 @@ type config struct {
 
 	// hostname is the hostname on which our servers will listen.
 	hostname string
+	// debugPort is the port we listen on for metrics, pprof, readiness and livenss checks
+	debugPort int
 	// grpcPort is the port we listen on for gRPC traffic
 	grpcPort int
 	// httpPort is the port we listen on for HTTP traffic
@@ -40,8 +42,9 @@ func defaultConfig() *config {
 	return &config{
 		logger:          log.New(),
 		hostname:        "localhost",
-		httpPort:        9000,
-		grpcPort:        9001,
+		httpPort:        -1, // disabled by default
+		grpcPort:        -1, // disabled by default
+		debugPort:       9500,
 		closeTimeout:    5 * time.Second,
 		healthHandler:   healthcheck.NewHandler(),
 		metricsRegistry: prometheus.NewRegistry(),
@@ -58,24 +61,29 @@ func WithHostname(hostname string) Option {
 	}
 }
 
+// WithHTTPPort sets the port to use for an HTTP server. Setting WithHTTPPort also enables an HTTP server on the baseserver.
 func WithHTTPPort(port int) Option {
 	return func(cfg *config) error {
-		if port < 0 {
-			return fmt.Errorf("http must not be negative, got: %d", port)
-		}
-
 		cfg.httpPort = port
 		return nil
 	}
 }
 
+// WithGRPCPort sets the port to use for an HTTP server. Setting WithGRPCPort also enables a gRPC server on the baseserver.
 func WithGRPCPort(port int) Option {
+	return func(cfg *config) error {
+		cfg.grpcPort = port
+		return nil
+	}
+}
+
+func WithDebugPort(port int) Option {
 	return func(cfg *config) error {
 		if port < 0 {
 			return fmt.Errorf("grpc port must not be negative, got: %d", port)
 		}
 
-		cfg.grpcPort = port
+		cfg.debugPort = port
 		return nil
 	}
 }

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -34,28 +34,59 @@ func New(name string, opts ...Option) (*Server, error) {
 		cfg:  cfg,
 	}
 
-	if initErr := server.initializeHTTP(); initErr != nil {
-		return nil, fmt.Errorf("failed to initialize http server: %w", initErr)
+	if initErr := server.initializeDebug(); initErr != nil {
+		return nil, fmt.Errorf("failed to initialize debug server: %w", initErr)
 	}
-	if initErr := server.initializeGRPC(); initErr != nil {
-		return nil, fmt.Errorf("failed to initialize grpc server: %w", initErr)
+
+	if server.isHTTPEnabled() {
+		httpErr := server.initializeHTTP()
+		if httpErr != nil {
+			return nil, fmt.Errorf("failed to initialize http server: %w", httpErr)
+		}
+	}
+
+	if server.isGRPCEnabled() {
+		grpcErr := server.initializeGRPC()
+		if grpcErr != nil {
+			return nil, fmt.Errorf("failed to initialize grpc server: %w", grpcErr)
+		}
 	}
 
 	return server, nil
 }
 
+// Server is a packaged server with batteries included. It is designed to be standard across components where it makes sense.
+// Server implements graceful shutdown making it suitable for usage in integration tests. See server_test.go.
+//
+// Server is composed of the following:
+// 	* Debug server which serves observability and debug endpoints
+//		- /metrics for Prometheus metrics
+//		- /pprof for Golang profiler
+//		- /ready for kubernetes readiness check
+//		- /live for kubernetes liveness check
+//	* (optional) gRPC server with standard interceptors and configuration
+//		- Started when baseserver is configured WithGRPCPort (port is non-negative)
+//		- Use Server.GRPC() to get access to the underlying grpc.Server and register services
+//	* (optional) HTTP server
+//		- Currently does not come with any standard HTTP middlewares
+//		- Started when baseserver is configured WithHTTPPort (port is non-negative)
+// 		- Use Server.HTTPMux() to get access to the root handler and register your endpoints
 type Server struct {
 	// Name is the name of this server, used for logging context
 	Name string
 
 	cfg *config
 
-	// http is an http Server
+	// debug is an HTTP server for debug endpoints - metrics, pprof, readiness & liveness.
+	debug         *http.Server
+	debugListener net.Listener
+
+	// http is an http Server, only used when port is specified in cfg
 	http         *http.Server
 	httpMux      *http.ServeMux
 	httpListener net.Listener
 
-	// grpc is a grpc Server
+	// grpc is a grpc Server, only used when port is specified in cfg
 	grpc         *grpc.Server
 	grpcListener net.Listener
 
@@ -65,25 +96,35 @@ type Server struct {
 
 func (s *Server) ListenAndServe() error {
 	var err error
-	s.grpcListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.grpcPort))
+
+	s.debugListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.debugPort))
 	if err != nil {
-		return fmt.Errorf("failed to acquire port %d", s.cfg.grpcPort)
+		return fmt.Errorf("failed to acquire port %d", s.cfg.debugPort)
 	}
 
-	s.httpListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.httpPort))
-	if err != nil {
-		return fmt.Errorf("failed to acquire port %d", s.cfg.httpPort)
+	if s.isGRPCEnabled() {
+		s.grpcListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.grpcPort))
+		if err != nil {
+			return fmt.Errorf("failed to acquire port %d", s.cfg.grpcPort)
+		}
+	}
+
+	if s.isHTTPEnabled() {
+		s.httpListener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.httpPort))
+		if err != nil {
+			return fmt.Errorf("failed to acquire port %d", s.cfg.httpPort)
+		}
 	}
 
 	errors := make(chan error)
 	defer close(errors)
 	s.listening = make(chan struct{})
 
+	// Always start the debug server, we should always have metrics and other debug information.
 	go func() {
-		s.Logger().
-			WithField("protocol", "grpc").
-			Infof("Serving gRPC on %s", s.grpcListener.Addr().String())
-		if serveErr := s.grpc.Serve(s.grpcListener); serveErr != nil {
+		s.Logger().WithField("protocol", "http").Infof("Serving debug server on %s", s.debugListener.Addr().String())
+		serveErr := s.debug.Serve(s.debugListener)
+		if serveErr != nil {
 			if s.isClosing() {
 				return
 			}
@@ -92,18 +133,31 @@ func (s *Server) ListenAndServe() error {
 		}
 	}()
 
-	go func() {
-		s.Logger().
-			WithField("protocol", "http").
-			Infof("Serving http on %s", s.httpListener.Addr().String())
-		if serveErr := s.http.Serve(s.httpListener); serveErr != nil {
-			if s.isClosing() {
-				return
-			}
+	if s.isGRPCEnabled() {
+		go func() {
+			s.Logger().WithField("protocol", "grpc").Infof("Serving gRPC on %s", s.grpcListener.Addr().String())
+			if serveErr := s.grpc.Serve(s.grpcListener); serveErr != nil {
+				if s.isClosing() {
+					return
+				}
 
-			errors <- serveErr
-		}
-	}()
+				errors <- serveErr
+			}
+		}()
+	}
+
+	if s.isHTTPEnabled() {
+		go func() {
+			s.Logger().WithField("protocol", "http").Infof("Serving http on %s", s.httpListener.Addr().String())
+			if serveErr := s.http.Serve(s.httpListener); serveErr != nil {
+				if s.isClosing() {
+					return
+				}
+
+				errors <- serveErr
+			}
+		}()
+	}
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
@@ -160,6 +214,15 @@ func (s *Server) GRPCAddress() string {
 	return fmt.Sprintf("%s:%d", s.cfg.hostname, addr.Port)
 }
 
+func (s *Server) DebugAddress() string {
+	if s.debugListener == nil {
+		return ""
+	}
+	protocol := "http"
+	addr := s.debugListener.Addr().(*net.TCPAddr)
+	return fmt.Sprintf("%s://%s:%d", protocol, s.cfg.hostname, addr.Port)
+}
+
 func (s *Server) HTTPMux() *http.ServeMux {
 	return s.httpMux
 }
@@ -185,17 +248,29 @@ func (s *Server) close(ctx context.Context) error {
 	s.Logger().Info("Received graceful shutdown request.")
 	close(s.listening)
 
-	s.grpc.GracefulStop()
-	// s.grpc.GracefulStop() also closes the underlying net.Listener, we just release the reference.
-	s.grpcListener = nil
-	s.Logger().Info("GRPC server terminated.")
+	if s.isGRPCEnabled() {
+		s.grpc.GracefulStop()
+		// s.grpc.GracefulStop() also closes the underlying net.Listener, we just release the reference.
+		s.grpcListener = nil
+		s.Logger().Info("GRPC server terminated.")
+	}
 
-	if err := s.http.Shutdown(ctx); err != nil {
-		return fmt.Errorf("failed to close http server: %w", err)
+	if s.isHTTPEnabled() {
+		if err := s.http.Shutdown(ctx); err != nil {
+			return fmt.Errorf("failed to close http server: %w", err)
+		}
+		// s.http.Shutdown() also closes the underlying net.Listener, we just release the reference.
+		s.httpListener = nil
+		s.Logger().Info("HTTP server terminated.")
+	}
+
+	// Always terminate debug server last, we want to keep it running for as long as possible
+	if err := s.debug.Shutdown(ctx); err != nil {
+		return fmt.Errorf("failed to close debug server: %w", err)
 	}
 	// s.http.Shutdown() also closes the underlying net.Listener, we just release the reference.
-	s.httpListener = nil
-	s.Logger().Info("HTTP server terminated.")
+	s.debugListener = nil
+	s.Logger().Info("Debug server terminated.")
 
 	return nil
 }
@@ -211,7 +286,7 @@ func (s *Server) isClosing() bool {
 }
 
 func (s *Server) initializeHTTP() error {
-	s.httpMux = s.newHTTPMux()
+	s.httpMux = http.NewServeMux()
 	s.http = &http.Server{
 		Addr:    fmt.Sprintf(":%d", s.cfg.httpPort),
 		Handler: s.httpMux,
@@ -220,13 +295,16 @@ func (s *Server) initializeHTTP() error {
 	return nil
 }
 
-func (s *Server) newHTTPMux() *http.ServeMux {
+func (s *Server) initializeDebug() error {
+	logger := s.Logger().WithField("protocol", "debug")
+
 	mux := http.NewServeMux()
+
 	mux.HandleFunc("/ready", s.cfg.healthHandler.ReadyEndpoint)
-	s.Logger().WithField("protocol", "http").Debug("Serving readiness handler on /ready")
+	logger.Debug("Serving readiness handler on /ready")
 
 	mux.HandleFunc("/live", s.cfg.healthHandler.LiveEndpoint)
-	s.Logger().WithField("protocol", "http").Debug("Serving liveliness handler on /live")
+	logger.Debug("Serving liveliness handler on /live")
 
 	mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
 		s.cfg.metricsRegistry, promhttp.HandlerFor(s.cfg.metricsRegistry, promhttp.HandlerOpts{}),
@@ -234,9 +312,14 @@ func (s *Server) newHTTPMux() *http.ServeMux {
 	s.Logger().WithField("protocol", "http").Debug("Serving metrics on /metrics")
 
 	mux.Handle(pprof.Path, pprof.Handler())
-	s.Logger().WithField("protocol", "http").Debug("Serving profiler on /debug/pprof")
+	logger.Debug("Serving profiler on /debug/pprof")
 
-	return mux
+	s.debug = &http.Server{
+		Addr:    fmt.Sprintf(":%d", s.cfg.debugPort),
+		Handler: mux,
+	}
+
+	return nil
 }
 
 func (s *Server) initializeGRPC() error {
@@ -263,4 +346,12 @@ func (s *Server) initializeGRPC() error {
 	grpc_health_v1.RegisterHealthServer(s.grpc, s.cfg.grpcHealthCheck)
 
 	return nil
+}
+
+func (s *Server) isGRPCEnabled() bool {
+	return s.cfg.grpcPort >= 0
+}
+
+func (s *Server) isHTTPEnabled() bool {
+	return s.cfg.httpPort >= 0
 }

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -20,6 +20,7 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 	defaultTestOpts := []Option{
 		WithGRPCPort(0),
 		WithHTTPPort(0),
+		WithDebugPort(0),
 		WithCloseTimeout(1 * time.Second),
 	}
 
@@ -65,7 +66,7 @@ func waitForServerToBeReachable(t *testing.T, srv *Server, timeout time.Duration
 			require.Failf(t, "server did not become reachable in %s", timeout.String())
 		case <-ticker.C:
 			// We retrieve the URL on each tick, because the HTTPAddress is only available once the server is listening.
-			healthURL := fmt.Sprintf("%s/ready", srv.HTTPAddress())
+			healthURL := fmt.Sprintf("%s/ready", srv.DebugAddress())
 			_, err := client.Get(healthURL)
 			if err != nil {
 				continue

--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -31,9 +31,9 @@ func main() {
 
 func command() *cobra.Command {
 	var (
-		gitpodAPIURL       string
-		httpPort, grpcPort int
-		verbose            bool
+		gitpodAPIURL        string
+		debugPort, grpcPort int
+		verbose             bool
 	)
 
 	cmd := &cobra.Command{
@@ -53,7 +53,7 @@ func command() *cobra.Command {
 
 			if err := server.Start(logger, server.Config{
 				GitpodAPI: gitpodAPI,
-				HTTPPort:  httpPort,
+				DebugPort: debugPort,
 				GRPCPort:  grpcPort,
 			}); err != nil {
 				logger.WithError(err).Fatal("Server errored.")
@@ -62,7 +62,7 @@ func command() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&gitpodAPIURL, "gitpod-api-url", "wss://main.preview.gitpod-dev.com/api/v1", "URL for existing Gitpod Websocket API")
-	cmd.Flags().IntVar(&httpPort, "http-port", 9500, "Port for serving HTTP traffic")
+	cmd.Flags().IntVar(&debugPort, "debug-port", 9500, "Port for serving debug endpoints")
 	cmd.Flags().IntVar(&grpcPort, "grpc-port", 9501, "Port for serving gRPC traffic")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Toggle verbose logging (debug level)")
 

--- a/components/public-api-server/pkg/server/config.go
+++ b/components/public-api-server/pkg/server/config.go
@@ -9,6 +9,6 @@ import "net/url"
 type Config struct {
 	GitpodAPI *url.URL
 
-	HTTPPort int
-	GRPCPort int
+	GRPCPort  int
+	DebugPort int
 }

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -7,9 +7,9 @@ package public_api_server
 const (
 	Component = "public-api-server"
 
-	HTTPPortName      = "http"
-	HTTPContainerPort = 9000
-	HTTPServicePort   = 9000
+	DebugPortName      = "debug"
+	DebugContainerPort = 9000
+	DebugServicePort   = 9000
 
 	GRPCPortName      = "grpc"
 	GRPCContainerPort = 9001

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -47,7 +47,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:  Component,
 							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.PublicAPIServer.Version),
 							Args: []string{
-								fmt.Sprintf("--http-port=%d", HTTPContainerPort),
+								fmt.Sprintf("--debug-port=%d", DebugContainerPort),
 								fmt.Sprintf("--grpc-port=%d", GRPCContainerPort),
 								fmt.Sprintf("--gitpod-api-url=wss://%s/api/v1", ctx.Config.Domain),
 							},
@@ -60,8 +60,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							}),
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: HTTPContainerPort,
-									Name:          HTTPPortName,
+									ContainerPort: DebugContainerPort,
+									Name:          DebugPortName,
 								},
 								{
 									ContainerPort: GRPCContainerPort,
@@ -78,7 +78,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path:   "/live",
-										Port:   intstr.IntOrString{IntVal: HTTPContainerPort},
+										Port:   intstr.IntOrString{IntVal: DebugContainerPort},
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -90,7 +90,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path:   "/ready",
-										Port:   intstr.IntOrString{IntVal: HTTPContainerPort},
+										Port:   intstr.IntOrString{IntVal: DebugContainerPort},
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -99,7 +99,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								TimeoutSeconds:   1,
 							},
 						},
-							*common.KubeRBACProxyContainerWithConfig(ctx, 9500, fmt.Sprintf("http://127.0.0.1:%d/", HTTPContainerPort)),
+							*common.KubeRBACProxyContainerWithConfig(ctx, 9500, fmt.Sprintf("http://127.0.0.1:%d/", DebugContainerPort)),
 						},
 					},
 				},

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -35,7 +35,7 @@ func TestDeployment_ServerArguments(t *testing.T) {
 
 	apiContainer := containers[0]
 	require.EqualValues(t, []string{
-		"--http-port=9000",
+		"--debug-port=9000",
 		"--grpc-port=9001",
 		`--gitpod-api-url=wss://test.domain.everything.awesome.is/api/v1`,
 	}, apiContainer.Args)

--- a/install/installer/pkg/components/public-api-server/networkpolicy.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy.go
@@ -31,7 +31,7 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Protocol: common.TCPProtocol,
-								Port:     &intstr.IntOrString{IntVal: HTTPContainerPort},
+								Port:     &intstr.IntOrString{IntVal: DebugContainerPort},
 							},
 							{
 								Protocol: common.TCPProtocol,

--- a/install/installer/pkg/components/public-api-server/networkpolicy_test.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy_test.go
@@ -27,7 +27,7 @@ func TestNetworkPolicy(t *testing.T) {
 		Ports: []networkingv1.NetworkPolicyPort{
 			{
 				Protocol: common.TCPProtocol,
-				Port:     &intstr.IntOrString{IntVal: HTTPContainerPort},
+				Port:     &intstr.IntOrString{IntVal: DebugContainerPort},
 			},
 			{
 				Protocol: common.TCPProtocol,

--- a/install/installer/pkg/components/public-api-server/service.go
+++ b/install/installer/pkg/components/public-api-server/service.go
@@ -10,9 +10,9 @@ import (
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return common.GenerateService(Component, map[string]common.ServicePort{
-		HTTPPortName: {
-			ContainerPort: HTTPContainerPort,
-			ServicePort:   HTTPServicePort,
+		DebugPortName: {
+			ContainerPort: DebugContainerPort,
+			ServicePort:   DebugServicePort,
 		},
 		GRPCPortName: {
 			ContainerPort: GRPCContainerPort,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a dedicated debug server to baseserver. This splits up the existing HTTP server into 2.

The debug server is always started, but the HTTP server (intended for serving non debug endpoints - ie actual traffic) is only started when configured. This aligns it more closely with existing components we run.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

/hold