### PR TITLE
Configure IDE to don't display text when there's no file opened in JetBrains editor

### DIFF
--- a/components/ide/jetbrains/image/leeway.Dockerfile
+++ b/components/ide/jetbrains/image/leeway.Dockerfile
@@ -10,6 +10,8 @@ RUN curl -sSLo backend.tar.gz "$JETBRAINS_BACKEND_URL" && tar -xf backend.tar.gz
 COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin/build/distributions/gitpod-remote-0.0.1.zip /workdir
 RUN unzip gitpod-remote-0.0.1.zip -d plugins/ && rm gitpod-remote-0.0.1.zip
 RUN printf '\n-Dgtw.disable.exit.dialog=true\n' >> $(find /workdir/bin/ -name "*64.vmoptions")
+# Configure it to don't display text when there's no file opened in the editor.
+RUN printf '\n-Deditor.paint.empty.text=false\n' >> $(find /workdir/bin/ -name "*64.vmoptions")
 # enable shared indexes by default
 RUN printf '\nshared.indexes.download.auto.consent=true' >> "/workdir/bin/idea.properties"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Configure IDE to don't display text when there's no file opened in JetBrains editor.

Currently the following text is displayed:
![image](https://user-images.githubusercontent.com/418083/166587511-aadf134b-f4ab-442d-b536-65424c531f30.png)

When this PR gets merged, it won't be displayed anymore.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
Open any JetBrains IDE and check if no text is displayed when there's no opened files on the editor.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.
