### PR TITLE
Edit kots advanced mode wording

### DIFF
--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -343,18 +343,18 @@ spec:
             Add the domain only (eg, `gitpod.io`). Separate multiple domains with spaces.
 
     - name: advanced
-      title: Advanced customizations (Expert Mode)
-      description: Use with care! Enable only when you know what you are doing!
+      title: Additional Options
+      description: Here are additional options that you should only make use of in coordination with us or when you know what you are doing.
       items:
         - name: advanced_mode_enabled
-          title: Enable advanced mode
+          title: Enable additional options
           type: bool
           default: "0"
-          help_text: Enables advanced customization options. Enable only when you know what you are doing!
+          help_text: Enables additional customization options. Enable only when you know what you are doing!
 
         - name: config_patch
           title: Gitpod config patch (YAML file)
           type: file
           required: false
           when: '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}'
-          help_text: A file with Gitpod config that will be used to patch the generated Gitpod config.
+          help_text: A file with Gitpod config that will be used to patch the generated Gitpod config. Usually provided by Gitpod as a way to tailor your installation.


### PR DESCRIPTION
## Description
Changed wording within KOTS (installer) config to better explain how we expect support patches to be used. 

## Related Issue(s)
Should me merged together with https://github.com/gitpod-io/website/pull/1984

## How to test
? Build KOTS installer?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
