### PR TITLE
[installer] Make runDbDeleter configurable for the server component

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -64,6 +64,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	runDbDeleter := true
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.RunDbDeleter != nil {
+			runDbDeleter = *cfg.WebApp.Server.RunDbDeleter
+		}
+		return nil
+	})
+
 	defaultBaseImageRegistryWhitelist := []string{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
@@ -147,7 +155,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		BlockNewUsers:                     ctx.Config.BlockNewUsers,
 		MakeNewUsersAdmin:                 false,
 		DefaultBaseImageRegistryWhitelist: defaultBaseImageRegistryWhitelist,
-		RunDbDeleter:                      true,
+		RunDbDeleter:                      runDbDeleter,
 		OAuthServer: OAuthServer{
 			Enabled:   true,
 			JWTSecret: jwtSecret,

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -58,8 +58,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	enableLocalApp := true
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
-			enableLocalApp = cfg.WebApp.Server.EnableLocalApp
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.EnableLocalApp != nil {
+			enableLocalApp = *cfg.WebApp.Server.EnableLocalApp
 		}
 		return nil
 	})

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestConfigMap(t *testing.T) {
 	type Expectation struct {
 		EnableLocalApp                    bool
+		RunDbDeleter                      bool
 		DisableDynamicAuthProviderLogin   bool
 		DefaultBaseImageRegistryWhiteList []string
 		WorkspaceImage                    string
@@ -30,6 +32,7 @@ func TestConfigMap(t *testing.T) {
 	expectation := Expectation{
 		EnableLocalApp:                    true,
 		DisableDynamicAuthProviderLogin:   true,
+		RunDbDeleter:                      false,
 		DefaultBaseImageRegistryWhiteList: []string{"some-registry"},
 		WorkspaceImage:                    "some-workspace-image",
 		JWTSecret:                         "some-jwt-secret",
@@ -53,6 +56,7 @@ func TestConfigMap(t *testing.T) {
 				Server: &experimental.ServerConfig{
 					DisableDynamicAuthProviderLogin:   expectation.DisableDynamicAuthProviderLogin,
 					EnableLocalApp:                    expectation.EnableLocalApp,
+					RunDbDeleter:                      pointer.Bool(expectation.RunDbDeleter),
 					DefaultBaseImageRegistryWhiteList: expectation.DefaultBaseImageRegistryWhiteList,
 					WorkspaceDefaults: experimental.WorkspaceDefaults{
 						WorkspaceImage: expectation.WorkspaceImage,
@@ -94,6 +98,7 @@ func TestConfigMap(t *testing.T) {
 	actual := Expectation{
 		DisableDynamicAuthProviderLogin:   config.DisableDynamicAuthProviderLogin,
 		EnableLocalApp:                    config.EnableLocalApp,
+		RunDbDeleter:                      config.RunDbDeleter,
 		DefaultBaseImageRegistryWhiteList: config.DefaultBaseImageRegistryWhitelist,
 		WorkspaceImage:                    config.WorkspaceDefaults.WorkspaceImage,
 		JWTSecret:                         config.OAuthServer.JWTSecret,

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -55,7 +55,7 @@ func TestConfigMap(t *testing.T) {
 			WebApp: &experimental.WebAppConfig{
 				Server: &experimental.ServerConfig{
 					DisableDynamicAuthProviderLogin:   expectation.DisableDynamicAuthProviderLogin,
-					EnableLocalApp:                    expectation.EnableLocalApp,
+					EnableLocalApp:                    pointer.Bool(expectation.EnableLocalApp),
 					RunDbDeleter:                      pointer.Bool(expectation.RunDbDeleter),
 					DefaultBaseImageRegistryWhiteList: expectation.DefaultBaseImageRegistryWhiteList,
 					WorkspaceDefaults: experimental.WorkspaceDefaults{

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -127,7 +127,7 @@ type ServerConfig struct {
 	GithubApp                         *GithubApp        `json:"githubApp"`
 	ChargebeeSecret                   string            `json:"chargebeeSecret"`
 	DisableDynamicAuthProviderLogin   bool              `json:"disableDynamicAuthProviderLogin"`
-	EnableLocalApp                    bool              `json:"enableLocalApp"`
+	EnableLocalApp                    *bool             `json:"enableLocalApp"`
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DefaultBaseImageRegistryWhiteList []string          `json:"defaultBaseImageRegistryWhitelist"`
 }

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -128,6 +128,7 @@ type ServerConfig struct {
 	ChargebeeSecret                   string            `json:"chargebeeSecret"`
 	DisableDynamicAuthProviderLogin   bool              `json:"disableDynamicAuthProviderLogin"`
 	EnableLocalApp                    bool              `json:"enableLocalApp"`
+	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DefaultBaseImageRegistryWhiteList []string          `json:"defaultBaseImageRegistryWhitelist"`
 }
 


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR makes it possible to configure the `server` component's `runDbDeleter` config field, rather than hardcoding it to `true`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    server:
      runDbDeleter: false
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `server` configmap will have `runDbDeleter` set to `false`. Without the experimental config, it defaults to `true` as before.

## Release Notes

```release-note
Make `runDbDeleter` for the server configurable via the installer
```

## Documentation

None.
