### PR TITLE
[installer] Make `ws-manager-bridge` configurable

### DIFF
--- a/install/installer/pkg/components/ws-manager-bridge/objects.go
+++ b/install/installer/pkg/components/ws-manager-bridge/objects.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 )
 
 var Objects = common.CompositeRenderFunc(
@@ -20,9 +20,17 @@ var Objects = common.CompositeRenderFunc(
 )
 
 func WSManagerList(ctx *common.RenderContext) []WorkspaceCluster {
+	skipSelf := false
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.WorkspaceManagerBridge != nil {
+			skipSelf = cfg.WebApp.WorkspaceManagerBridge.SkipSelf
+		}
+		return nil
+	})
+
 	// Registering a local cluster ws-manager only makes sense when we actually deploy one,
 	// (ie when we are doing a full self hosted installation rather than a SaaS install to gitpod.io).
-	if ctx.Config.Kind != config.InstallationFull {
+	if skipSelf {
 		return []WorkspaceCluster{}
 	}
 

--- a/install/installer/pkg/components/ws-manager-bridge/objects_test.go
+++ b/install/installer/pkg/components/ws-manager-bridge/objects_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package wsmanagerbridge
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestWorkspaceManagerList_WhenSkipSelfIsSet(t *testing.T) {
+	testCases := []struct {
+		SkipSelf                bool
+		ExpectWorkspaceClusters bool
+	}{
+		{SkipSelf: true, ExpectWorkspaceClusters: false},
+		{SkipSelf: false, ExpectWorkspaceClusters: true},
+	}
+
+	for _, testCase := range testCases {
+		ctx := renderContextWithConfig(t, testCase.SkipSelf)
+
+		wsclusters := WSManagerList(ctx)
+		if testCase.ExpectWorkspaceClusters {
+			require.NotEmptyf(t, wsclusters, "expected to render workspace clusters when skipSelf=%v", testCase.SkipSelf)
+		} else {
+			require.Emptyf(t, wsclusters, "expected not to render workspace clusters when skipSelf=%v", testCase.SkipSelf)
+		}
+	}
+}
+
+func renderContextWithConfig(t *testing.T, skipSelf bool) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				WorkspaceManagerBridge: &experimental.WsManagerBridgeConfig{
+					SkipSelf: skipSelf,
+				},
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			PublicAPIServer: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -91,10 +91,11 @@ type WorkspaceTemplates struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI          *PublicAPIConfig `json:"publicApi,omitempty"`
-	Server             *ServerConfig    `json:"server,omitempty"`
-	ProxyConfig        *ProxyConfig     `json:"proxy,omitempty"`
-	UsePodAntiAffinity bool             `json:"usePodAntiAffinity"`
+	PublicAPI              *PublicAPIConfig       `json:"publicApi,omitempty"`
+	Server                 *ServerConfig          `json:"server,omitempty"`
+	ProxyConfig            *ProxyConfig           `json:"proxy,omitempty"`
+	WorkspaceManagerBridge *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
+	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
 }
 
 type WorkspaceDefaults struct {
@@ -119,6 +120,10 @@ type GithubApp struct {
 	MarketplaceName string `json:"marketplaceName"`
 	WebhookSecret   string `json:"webhookSecret"`
 	CertSecretName  string `json:"certSecretName"`
+}
+
+type WsManagerBridgeConfig struct {
+	SkipSelf bool `json:"skipSelf"`
 }
 
 type ServerConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR allows the `ws-manager-bridge` component to control whether or not it should register itself as a workspace cluster. For self hosted installations it should do so but for SaaS, where we run separate workspace clusters, it should not.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    wsManagerBridge:
      skipSelf: true
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `ws-manager-bridge` config will contain the following when `skipSelf` is `false`:
```yaml
  ws-manager-bridge.json: |-
    {
      "installation": "default",
      "staticBridges": [
        {
          "name": "default",
          "url": "dns:///ws-manager:8080",
          "tls": {
            "ca": "/ws-manager-client-tls-certs/ca.crt",
            "crt": "/ws-manager-client-tls-certs/tls.crt",
            "key": "/ws-manager-client-tls-certs/tls.key"
          },
          "state": "available",
          "maxScore": 100,
          "score": 50,
          "govern": true,
          "admissionConstraints": null
        }
      ],

```

and the `staticBridges` key will be `[]` when `skipSelf` is `true`.

Likewise the `WSMAN_CFG_MANAGERS` env var in the `server` component will change according to the value of `skipSelf` (but the json is bas64 encoded).

## Release Notes

```release-note
Allow `ws-manager-bridge` service to skip registering itself as a workspace, via the installer.
```

## Documentation

None.
