### PR TITLE
[code]: Generate stable images for 1.67

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: bf3c9e080df9c63500d99f4f47ff0f3a289260dd
+  codeCommit: 30d694d1f41945af7f8d757d3ddf176b283752cb
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.1.tar.gz"


### PR DESCRIPTION
## Description
Update code to `1.67.0`

## How to test

- Switch to VS Code Insiders in settings.
- Start a workspace.
- Test following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
     - [x] diff editor should be operatable
     - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. F1 → type Gitpod prefix
  - [x] that a PR view is preloaded on the PR URL
  - [x] test `gp open` and `gp preview`
  - [x] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [x] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe
