### PR TITLE
[server] blocklist repositories

### DIFF
--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -269,6 +269,16 @@ export class UserService {
         return false;
     }
 
+    async blockUser(targetUserId: string, block: boolean): Promise<User> {
+        const target = await this.userDb.findUserById(targetUserId);
+        if (!target) {
+            throw new Error("Not found.");
+        }
+
+        target.blocked = !!block;
+        return await this.userDb.storeUser(target);
+    }
+
     async findUserForLogin(params: { candidate: Identity }) {
         let user = await this.userDb.findUserByIdentity(params.candidate);
         return user;


### PR DESCRIPTION
This PR adds the `blockedRepositories` attribute to the configuration of the server component. 

Fixes #9639

```release-notes
NONE
```

<img width="804" alt="Screen Shot 2022-05-04 at 17 48 39" src="https://user-images.githubusercontent.com/914497/166720160-ae11aa57-b308-45cb-a3a0-881bad41807e.png">
