### PR TITLE
[installer] Allow `proxy` to configure a static IP 

### DIFF
--- a/install/installer/pkg/components/proxy/objects.go
+++ b/install/installer/pkg/components/proxy/objects.go
@@ -5,11 +5,7 @@
 package proxy
 
 import (
-	"fmt"
-
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var Objects = common.CompositeRenderFunc(
@@ -17,32 +13,6 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
-	func(cfg *common.RenderContext) ([]runtime.Object, error) {
-		ports := map[string]common.ServicePort{
-			ContainerHTTPName: {
-				ContainerPort: ContainerHTTPPort,
-				ServicePort:   ContainerHTTPPort,
-			},
-			ContainerHTTPSName: {
-				ContainerPort: ContainerHTTPSPort,
-				ServicePort:   ContainerHTTPSPort,
-			},
-			MetricsContainerName: {
-				ContainerPort: PrometheusPort,
-				ServicePort:   PrometheusPort,
-			},
-		}
-		if cfg.Config.SSHGatewayHostKey != nil {
-			ports[ContainerSSHName] = common.ServicePort{
-				ContainerPort: ContainerSSHPort,
-				ServicePort:   ContainerSSHPort,
-			}
-		}
-		return common.GenerateService(Component, ports, func(service *corev1.Service) {
-			service.Spec.Type = corev1.ServiceTypeLoadBalancer
-			service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", cfg.Config.Domain, cfg.Config.Domain, cfg.Config.Domain)
-			service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
-		})(cfg)
-	},
+	service,
 	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/proxy/service.go
+++ b/install/installer/pkg/components/proxy/service.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	ports := map[string]common.ServicePort{
+		ContainerHTTPName: {
+			ContainerPort: ContainerHTTPPort,
+			ServicePort:   ContainerHTTPPort,
+		},
+		ContainerHTTPSName: {
+			ContainerPort: ContainerHTTPSPort,
+			ServicePort:   ContainerHTTPSPort,
+		},
+		MetricsContainerName: {
+			ContainerPort: PrometheusPort,
+			ServicePort:   PrometheusPort,
+		},
+	}
+	if ctx.Config.SSHGatewayHostKey != nil {
+		ports[ContainerSSHName] = common.ServicePort{
+			ContainerPort: ContainerSSHPort,
+			ServicePort:   ContainerSSHPort,
+		}
+	}
+
+	return common.GenerateService(Component, ports, func(service *corev1.Service) {
+		service.Spec.Type = corev1.ServiceTypeLoadBalancer
+		service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", ctx.Config.Domain, ctx.Config.Domain, ctx.Config.Domain)
+		service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
+	})(ctx)
+}

--- a/install/installer/pkg/components/proxy/service.go
+++ b/install/installer/pkg/components/proxy/service.go
@@ -8,12 +8,21 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	loadBalancerIP := ""
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.ProxyConfig != nil && cfg.WebApp.ProxyConfig.StaticIP != "" {
+			loadBalancerIP = cfg.WebApp.ProxyConfig.StaticIP
+		}
+		return nil
+	})
+
 	ports := map[string]common.ServicePort{
 		ContainerHTTPName: {
 			ContainerPort: ContainerHTTPPort,
@@ -37,6 +46,7 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	return common.GenerateService(Component, ports, func(service *corev1.Service) {
 		service.Spec.Type = corev1.ServiceTypeLoadBalancer
+		service.Spec.LoadBalancerIP = loadBalancerIP
 		service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", ctx.Config.Domain, ctx.Config.Domain, ctx.Config.Domain)
 		service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
 	})(ctx)

--- a/install/installer/pkg/components/proxy/service_test.go
+++ b/install/installer/pkg/components/proxy/service_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestServiceLoadBalancerIP(t *testing.T) {
+	const loadBalancerIP = "123.456.789.0"
+	ctx := renderContextWithLoadBalancerIP(t, loadBalancerIP)
+
+	objects, err := service(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render only one object")
+
+	svc := objects[0].(*corev1.Service)
+	require.Equal(t, loadBalancerIP, svc.Spec.LoadBalancerIP)
+}
+
+func renderContextWithLoadBalancerIP(t *testing.T, loadBalancerIp string) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				ProxyConfig: &experimental.ProxyConfig{
+					StaticIP: loadBalancerIp,
+				},
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			PublicAPIServer: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -93,6 +93,7 @@ type WorkspaceTemplates struct {
 type WebAppConfig struct {
 	PublicAPI          *PublicAPIConfig `json:"publicApi,omitempty"`
 	Server             *ServerConfig    `json:"server,omitempty"`
+	ProxyConfig        *ProxyConfig     `json:"proxy,omitempty"`
 	UsePodAntiAffinity bool             `json:"usePodAntiAffinity"`
 }
 
@@ -130,6 +131,10 @@ type ServerConfig struct {
 	EnableLocalApp                    *bool             `json:"enableLocalApp"`
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DefaultBaseImageRegistryWhiteList []string          `json:"defaultBaseImageRegistryWhitelist"`
+}
+
+type ProxyConfig struct {
+	StaticIP string `json:"staticIP"`
 }
 
 type PublicAPIConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.

This PR allows the `proxy` component to configure a static IP address in its `LoadBalancer` service.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    proxy:
      staticIP: "123.456.789.0"
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `proxy` service will have a `LoadBalancerIP` configured:

```yaml
apiVersion: v1
kind: Service
...
spec:
  loadBalancerIP: 123.456.789.0
...
```

## Release Notes

```release-note
Allow `proxy` service to configure a static IP via the installer
```

## Documentation

None.
