### PR TITLE
[dashboard] handle unlimited users condition in license page

### DIFF
--- a/components/dashboard/src/admin/License.tsx
+++ b/components/dashboard/src/admin/License.tsx
@@ -37,7 +37,7 @@ export default function License() {
     const features = license?.features;
 
     // if user seats is 0, it means that there is no user limit in the license
-    const userLimit = license?.seats == 0 ? "Unlimited" : license?.seats;
+    const userLimit = license?.seats === 0 ? "Unlimited" : license?.seats;
 
     const [licenseLevel, paid, statusMessage] = license ? getSubscriptionLevel(license) : defaultMessage();
 
@@ -155,7 +155,8 @@ function professionalPlan(userCount: number, seats: number, trial: boolean, vali
         );
     };
 
-    const aboveLimit: boolean = userCount > seats;
+    // seats === 0 means unlimited number of users
+    const aboveLimit: boolean = seats === 0 ? false : userCount > seats;
 
     const licenseTitle = () => {
         const expDate = new Date(validUntil);
@@ -202,7 +203,8 @@ function communityPlan(userCount: number, seats: number, fallbackAllowed: boolea
         }
     };
 
-    const aboveLimit: boolean = userCount > seats;
+    // seats === 0 means unlimited number of users
+    const aboveLimit: boolean = seats === 0 ? false : userCount > seats;
 
     return [licenseLevel("Community"), additionalLicenseInfo("Free"), alertMessage(aboveLimit)];
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In `gitpod.io` the unlimited number of users is specified by `seats === 0`. Currently in the License dashboard, this condition is not handled properly and hence gives the wrong alert message. This PR fixes this issue. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9763

## How to test
<!-- Provide steps to test this PR -->
Update the license to have user seats value `0`. I tested it by updating the user seats on a replicated license. One can ideally test it also on [preview environment by updating the Werft secret for license.
](https://www.notion.so/gitpod/Create-a-Gitpod-Self-Hosted-License-fef6b0e3548b4676a9d782f6d5a3df9a)
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
