### PR TITLE
[installer] Add `serviceAnnotations` config to `proxy`

### DIFF
--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -134,7 +134,8 @@ type ServerConfig struct {
 }
 
 type ProxyConfig struct {
-	StaticIP string `json:"staticIP"`
+	StaticIP           string            `json:"staticIP"`
+	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
 }
 
 type PublicAPIConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR allows for extra annotations to configured on the `proxy` component so that we can configure GCP annotations for Gitpod SaaS.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    proxy:
      serviceAnnotations:
        hello: world
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `Service` resource for `proxy` will contain the extra annotation.

## Release Notes

```release-note
Allow setting `proxy` service annotations via the installer.
```

## Documentation

None.