### PR TITLE
[loadgen] Adjust workspace count in default load test

### DIFF
--- a/dev/loadgen/prod-benchmark.yaml
+++ b/dev/loadgen/prod-benchmark.yaml
@@ -1,7 +1,7 @@
 ## start with
 ##    loadgen benchmark prod-benchmark.yaml
 
-workspaces: 500
+workspaces: 60
 ideImage: eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ff263e14024f00d0ed78386b4417dfa6bcd4ae2f
 repos:
   - cloneURL: https://github.com/gitpod-io/template-typescript-node


### PR DESCRIPTION
## Description

The default loadgen scenario should focus on Gitpod, not cluster autoscaler.

## Release Notes
```release-note
[loadgen] Adjust workspace count in the default load test
```
