### PR TITLE
[code] Update stable to 1.67

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -357,7 +357,7 @@ components:
       version: "latest"
     codeImage:
       imageName: "ide/code"
-      stableVersion: "commit-148bd78e649771328e130f2c05b3f112ba51f442"
+      stableVersion: "commit-824abc8f79ba1a1772d66a59e6fdaed184d3ceea"
       insidersVersion: "nightly"
     desktopIdeImages:
       codeDesktop:

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-148bd78e649771328e130f2c05b3f112ba51f442" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-824abc8f79ba1a1772d66a59e6fdaed184d3ceea" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates stable VS Code version to 1.67.0. This is done ahead of Microsoft's release this time. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9667 

## How to test
Switch to stable in the preview environment and in the about dialog confirm you are running 1.67

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
