### PR TITLE
Use a special domain name for SSH Gateway

### DIFF
--- a/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
+++ b/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
@@ -55,7 +55,10 @@ interface SSHProps {
 }
 
 function SSHView(props: SSHProps) {
-    const sshCommand = `ssh ${props.workspaceId}#${props.ownerToken}@${props.ideUrl}`;
+    const sshCommand = `ssh ${props.workspaceId}#${props.ownerToken}@${props.ideUrl.replace(
+        props.workspaceId,
+        props.workspaceId + ".ssh",
+    )}`;
     return (
         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-6">
             <div className="mt-1 mb-4">

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -217,6 +217,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                             thinClientJob = launch {
                                 try {
                                     val ideUrl = URL(update.ideUrl);
+                                    val sshHostUrl = URL(update.ideUrl.replace(update.workspaceId, "${update.workspaceId}.ssh"));
                                     val hostKeys = resolveHostKeys(ideUrl, connectParams)
                                     if (hostKeys.isNullOrEmpty()) {
                                         setErrorMessage("${connectParams.gitpodHost} installation does not allow SSH access, public keys cannot be found")
@@ -224,7 +225,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                     }
                                     val ownerToken = client.server.getOwnerToken(update.workspaceId).await()
                                     val credentials =
-                                        resolveCredentials(ideUrl, update.workspaceId, ownerToken, hostKeys)
+                                        resolveCredentials(sshHostUrl, update.workspaceId, ownerToken, hostKeys)
                                     val joinLink = resolveJoinLink(ideUrl, ownerToken, connectParams)
                                     val connector = ClientOverSshTunnelConnector(
                                         connectionLifetime,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use a special domain name for SSH Gateway, This has a big advantage for self-hosted users, who can set up another loadbalancer for this separate domain without breaking their original loadbalancer or ingress

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Download this special Gateway Plugin https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/172691
2. Open a workspace with any Jetbrains Client
3. Click More Action -> Connect via SSH, make sure hostname part of ssh command is `workspaceId.ssh.pd-simple-ssh-host.preview.gitpod-dev.com`
4. 
![image](https://user-images.githubusercontent.com/8299500/166887697-9e127fe5-dab2-4f4f-9cf6-6e578fef3d98.png)

![image](https://user-images.githubusercontent.com/8299500/166887732-c9840c6b-9c0f-41c7-b773-46e1c4da4d31.png)

5. Click Open with xxx Jetbrains IDE to open Jetbrains Gateway to ensure everything should works as normal


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use a special domain name for SSH Gateway
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
