### PR TITLE
[installer] Allow extra service annotations for `ide-proxy` and `openvsx-proxy`

### DIFF
--- a/install/installer/pkg/components/ide-proxy/objects.go
+++ b/install/installer/pkg/components/ide-proxy/objects.go
@@ -9,11 +9,6 @@ import "github.com/gitpod-io/gitpod/installer/pkg/common"
 var Objects = common.CompositeRenderFunc(
 	deployment,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		PortName: {
-			ContainerPort: ContainerPort,
-			ServicePort:   ServicePort,
-		},
-	}),
+	service,
 	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/ide-proxy/service.go
+++ b/install/installer/pkg/components/ide-proxy/service.go
@@ -6,15 +6,31 @@ package ide_proxy
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return common.GenerateService(Component, map[string]common.ServicePort{
+	var annotations map[string]string
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.IDE != nil && cfg.IDE.IDEProxyConfig != nil {
+			annotations = cfg.IDE.IDEProxyConfig.ServiceAnnotations
+		}
+		return nil
+	})
+
+	ports := map[string]common.ServicePort{
 		PortName: {
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},
+	}
+
+	return common.GenerateService(Component, ports, func(service *corev1.Service) {
+		for k, v := range annotations {
+			service.Annotations[k] = v
+		}
 	})(ctx)
 }

--- a/install/installer/pkg/components/ide-proxy/service.go
+++ b/install/installer/pkg/components/ide-proxy/service.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package ide_proxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.GenerateService(Component, map[string]common.ServicePort{
+		PortName: {
+			ContainerPort: ContainerPort,
+			ServicePort:   ServicePort,
+		},
+	})(ctx)
+}

--- a/install/installer/pkg/components/ide-proxy/service_test.go
+++ b/install/installer/pkg/components/ide-proxy/service_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package ide_proxy
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestServiceAnnotations(t *testing.T) {
+	annotations := map[string]string{"hello": "world"}
+
+	ctx := renderContextWithIDEProxyConfig(t, &experimental.IDEProxyConfig{ServiceAnnotations: annotations})
+
+	objects, err := service(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render only one object")
+
+	svc := objects[0].(*corev1.Service)
+	for k, v := range annotations {
+		require.Equalf(t, annotations[k], svc.Annotations[k],
+			"expected to find annotation %q:%q on ide-proxy service, but found %q:%q", k, v, k, svc.Annotations[k])
+	}
+}
+
+func renderContextWithIDEProxyConfig(t *testing.T, proxyConfig *experimental.IDEProxyConfig) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			IDE: &experimental.IDEConfig{
+				IDEProxyConfig: proxyConfig,
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			PublicAPIServer: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/components/openvsx-proxy/objects.go
+++ b/install/installer/pkg/components/openvsx-proxy/objects.go
@@ -13,15 +13,6 @@ var Objects = common.CompositeRenderFunc(
 	networkpolicy,
 	rolebinding,
 	statefulset,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		PortName: {
-			ContainerPort: ContainerPort,
-			ServicePort:   ServicePort,
-		},
-		PrometheusPortName: {
-			ContainerPort: PrometheusPort,
-			ServicePort:   PrometheusPort,
-		},
-	}),
+	service,
 	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/openvsx-proxy/service.go
+++ b/install/installer/pkg/components/openvsx-proxy/service.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package openvsx_proxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.GenerateService(Component, map[string]common.ServicePort{
+		PortName: {
+			ContainerPort: ContainerPort,
+			ServicePort:   ServicePort,
+		},
+		PrometheusPortName: {
+			ContainerPort: PrometheusPort,
+			ServicePort:   PrometheusPort,
+		},
+	})(ctx)
+}

--- a/install/installer/pkg/components/openvsx-proxy/service_test.go
+++ b/install/installer/pkg/components/openvsx-proxy/service_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package openvsx_proxy
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestServiceAnnotations(t *testing.T) {
+	annotations := map[string]string{"hello": "world"}
+
+	ctx := renderContextWithVSXProxyConfig(t, &experimental.VSXProxyConfig{ServiceAnnotations: annotations})
+
+	objects, err := service(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render only one object")
+
+	svc := objects[0].(*corev1.Service)
+	for k, v := range annotations {
+		require.Equalf(t, annotations[k], svc.Annotations[k],
+			"expected to find annotation %q:%q on openvsx-proxy service, but found %q:%q", k, v, k, svc.Annotations[k])
+	}
+}
+
+func renderContextWithVSXProxyConfig(t *testing.T, proxyConfig *experimental.VSXProxyConfig) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			IDE: &experimental.IDEConfig{
+				VSXProxyConfig: proxyConfig,
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			PublicAPIServer: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -149,7 +149,17 @@ type PublicAPIConfig struct {
 
 type IDEConfig struct {
 	// Disable resolution of latest images and use bundled latest versions instead
-	ResolveLatest *bool `json:"resolveLatest,omitempty"`
+	ResolveLatest  *bool           `json:"resolveLatest,omitempty"`
+	IDEProxyConfig *IDEProxyConfig `json:"ideProxy,omitempty"`
+	VSXProxyConfig *VSXProxyConfig `json:"openvsxProxy,omitempty"`
+}
+
+type IDEProxyConfig struct {
+	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
+}
+
+type VSXProxyConfig struct {
+	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
 }
 
 type TracingSampleType string


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR allows for extra annotations to configured on the `ide-proxy` and `openvsx-proxy` components so that we can configure GCP annotations for Gitpod SaaS.

It's exactly the same as #9773 but for the `ide-proxy` and `openvsx-proxy`  components.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  ide:
    ideProxy:
      serviceAnnotations:
        someKey: someValue
    openvsxProxy:
       serviceAnnotations:
        someKey2: someValue2
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `Service` resources for `ide-proxy` and `openvsx-proxy` will contain the extra annotation.

## Release Notes

```release-note
Allow setting `ide-proxy` and `openvsx-proxy` service annotations via the installer.
```

## Documentation

None.