### PR TITLE
[installer] Add `disableMigration` experimental config

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -341,6 +341,17 @@ func NodeAffinity(orLabels ...string) *corev1.Affinity {
 	}
 }
 
+func IsDatabaseMigrationDisabled(ctx *RenderContext) bool {
+	disableMigration := false
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil {
+			disableMigration = cfg.WebApp.DisableMigration
+		}
+		return nil
+	})
+	return disableMigration
+}
+
 func Replicas(ctx *RenderContext, component string) *int32 {
 	replicas := int32(1)
 

--- a/install/installer/pkg/components/database/incluster/configmap.go
+++ b/install/installer/pkg/components/database/incluster/configmap.go
@@ -20,6 +20,10 @@ import (
 var initScriptFiles embed.FS
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if disableMigration := common.IsDatabaseMigrationDisabled(ctx); disableMigration {
+		return nil, nil
+	}
+
 	initScripts, err := fs.ReadDir(initScriptFiles, initScriptDir)
 	if err != nil {
 		return nil, err

--- a/install/installer/pkg/components/database/incluster/render_test.go
+++ b/install/installer/pkg/components/database/incluster/render_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package incluster
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+)
+
+func TestConfigmap_IsNotRenderedWhenDisableMigrationIsTrue(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, true)
+
+	objects, err := configmap(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 0, "must not render any objects")
+}
+
+func TestConfigmap_IsRenderedWhenDisableMigrationIsFalse(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, false)
+
+	objects, err := configmap(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render one object")
+}
+
+func renderContextWithDisableMigration(t *testing.T, disableMigration bool) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Database: config.Database{
+			InCluster: pointer.Bool(true),
+		},
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				DisableMigration: disableMigration,
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			ServiceWaiter: versions.Versioned{
+				Version: "arbitary",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/components/database/init/configmap.go
+++ b/install/installer/pkg/components/database/init/configmap.go
@@ -7,8 +7,9 @@ package init
 import (
 	"embed"
 	"fmt"
-	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"io/fs"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,6 +19,10 @@ import (
 var initScriptFiles embed.FS
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if disableMigration := common.IsDatabaseMigrationDisabled(ctx); disableMigration {
+		return nil, nil
+	}
+
 	initScripts, err := fs.ReadDir(initScriptFiles, initScriptDir)
 	if err != nil {
 		return nil, err

--- a/install/installer/pkg/components/database/init/job.go
+++ b/install/installer/pkg/components/database/init/job.go
@@ -8,6 +8,7 @@ package init
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -19,6 +20,10 @@ import (
 )
 
 func job(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if disableMigration := common.IsDatabaseMigrationDisabled(ctx); disableMigration {
+		return nil, nil
+	}
+
 	objectMeta := metav1.ObjectMeta{
 		Name:      fmt.Sprintf("%s-session", Component),
 		Namespace: ctx.Namespace,

--- a/install/installer/pkg/components/database/init/render_test.go
+++ b/install/installer/pkg/components/database/init/render_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package init
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+)
+
+func TestJob_IsNotRenderedWhenDisableMigrationIsTrue(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, true)
+
+	objects, err := job(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 0, "must not render any objects")
+}
+
+func TestJob_IsRenderedWhenDisableMigrationIsFalse(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, false)
+
+	objects, err := job(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render one object")
+}
+
+func TestConfigmap_IsNotRenderedWhenDisableMigrationIsTrue(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, true)
+
+	objects, err := configmap(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 0, "must not render any objects")
+}
+
+func TestConfigmap_IsRenderedWhenDisableMigrationIsFalse(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, false)
+
+	objects, err := configmap(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render one object")
+}
+
+func renderContextWithDisableMigration(t *testing.T, disableMigration bool) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Database: config.Database{
+			InCluster: pointer.Bool(true),
+		},
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				DisableMigration: disableMigration,
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			ServiceWaiter: versions.Versioned{
+				Version: "arbitary",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/components/migrations/job.go
+++ b/install/installer/pkg/components/migrations/job.go
@@ -15,6 +15,10 @@ import (
 )
 
 func job(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if disableMigration := common.IsDatabaseMigrationDisabled(ctx); disableMigration {
+		return nil, nil
+	}
+
 	objectMeta := metav1.ObjectMeta{
 		Name:      Component,
 		Namespace: ctx.Namespace,

--- a/install/installer/pkg/components/migrations/render_test.go
+++ b/install/installer/pkg/components/migrations/render_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package migrations
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+)
+
+func TestJob_IsNotRenderedWhenDisableMigrationIsTrue(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, true)
+
+	objects, err := job(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 0, "must not render any objects")
+}
+
+func TestJob_IsRenderedWhenDisableMigrationIsFalse(t *testing.T) {
+	ctx := renderContextWithDisableMigration(t, false)
+
+	objects, err := job(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render one object")
+}
+
+func renderContextWithDisableMigration(t *testing.T, disableMigration bool) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Database: config.Database{
+			InCluster: pointer.Bool(true),
+		},
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				DisableMigration: disableMigration,
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			ServiceWaiter: versions.Versioned{
+				Version: "arbitary",
+			},
+			DBMigrations: versions.Versioned{
+				Version: "arbitary",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -96,6 +96,7 @@ type WebAppConfig struct {
 	ProxyConfig            *ProxyConfig           `json:"proxy,omitempty"`
 	WorkspaceManagerBridge *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
 	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
+	DisableMigration       bool                   `json:"disableMigration"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR adds an extra `disableDbMigration` config flag under `experimental.webapp`. When set, the flag causes the installer not to render:

* The `dbinit-session` job
* The `migrations` job
* The `db-init-scripts` configmaps

We do this because for Gitpod SaaS, Werft runs the migrations as part of the release process.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    disableMigration: true
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The resources mentioned above will not be part of the rendered output.

## Release Notes

```release-note
Add `disableDbMigration` config flag to the installer to disable db migrations
```

## Documentation

None.