### PR TITLE
[installer] Make the `server` mount the Github App secret

### DIFF
--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -15,6 +15,7 @@ const (
 	authProviderFilePath  = "/gitpod/auth-providers"
 	licenseFilePath       = "/gitpod/license"
 	chargebeeMountPath    = "/chargebee"
+	githubAppCertSecret   = "github-app-cert-secret"
 	PrometheusPort        = 9500
 	PrometheusPortName    = "metrics"
 	InstallationAdminPort = common.ServerInstallationAdminPort

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -164,10 +164,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		env = append(env, envv...)
 	}
 
-	chargebeeSecret := ""
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.ChargebeeSecret != "" {
-			chargebeeSecret = cfg.WebApp.Server.ChargebeeSecret
+			chargebeeSecret := cfg.WebApp.Server.ChargebeeSecret
 
 			volumes = append(volumes,
 				corev1.Volume{

--- a/install/installer/pkg/components/server/render_test.go
+++ b/install/installer/pkg/components/server/render_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestServerDeployment_MountsGithubAppSecret(t *testing.T) {
+	ctx := renderContext(t)
+
+	objects, err := deployment(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objects, 1, "must render only one object")
+
+	deployment := objects[0].(*appsv1.Deployment)
+
+	foundVol := false
+	for _, vol := range deployment.Spec.Template.Spec.Volumes {
+		if vol.Name == githubAppCertSecret {
+			foundVol = true
+		}
+	}
+
+	require.Truef(t, foundVol, "failed to find expected volume %q on server pod", githubAppCertSecret)
+
+	serverContainer := deployment.Spec.Template.Spec.Containers[0]
+	foundMount := false
+	for _, vol := range serverContainer.VolumeMounts {
+		if vol.Name == githubAppCertSecret {
+			foundMount = true
+		}
+	}
+
+	require.Truef(t, foundMount, "failed to find expected volume mount %q on server container", githubAppCertSecret)
+}
+
+func renderContext(t *testing.T) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Database: config.Database{
+			InCluster: pointer.Bool(true),
+		},
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				Server: &experimental.ServerConfig{
+					GithubApp: &experimental.GithubApp{
+						AppId:           0,
+						AuthProviderId:  "",
+						BaseUrl:         "",
+						CertPath:        "/some/cert/path",
+						Enabled:         false,
+						LogLevel:        "",
+						MarketplaceName: "",
+						WebhookSecret:   "",
+						CertSecretName:  "some-secret-name",
+					},
+				},
+			},
+		},
+	}, versions.Manifest{
+		Components: versions.Components{
+			ServiceWaiter: versions.Versioned{
+				Version: "arbitrary",
+			},
+			Server: versions.Versioned{
+				Version: "arbitrary",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR adds an an extra volume and volume mount to the `server` component to allow it to mount the github app secret, when a github app is specified in the installer config. The ability to add github app config was added in https://github.com/gitpod-io/gitpod/pull/9297.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
      githubApp:
        appId: 123
        authProviderId: 'someAuthProviderId'
        baseUrl: 'someBaseUrl'
        certPath: 'someCertpath'
        enabled: true
        logLevel: 'someLogLevel'
        marketplaceName: 'someMarketPlacename'
        webhookSecret: 'somewebhookSecret'
        certSecretName: 'certSecretName'
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `server` component will have an extra volume and volume mount

## Release Notes

```release-note
Make sure the server mounts the github app secret when an app is specified in the installer
```

## Documentation

None.