### PR TITLE
Fix Supervisor sending empty port names and descriptions

### DIFF
--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -72,7 +72,10 @@ type Image_object struct {
 // PortsItems
 type PortsItems struct {
 
-	// Port name (deprecated).
+	// A description to identify what is this port used for.
+	Description string `yaml:"description,omitempty"`
+
+	// Port name.
 	Name string `yaml:"name,omitempty"`
 
 	// What to do when a service on this port was detected. 'notify' (default) will show a notification asking the user what to do. 'open-browser' will open a new browser tab. 'open-preview' will open in the preview on the right of the IDE. 'ignore' will do nothing.
@@ -84,7 +87,7 @@ type PortsItems struct {
 	// The protocol to be used. (deprecated)
 	Protocol string `yaml:"protocol,omitempty"`
 
-	// Whether the port visibility should be private or public. 'public' (default) will allow everyone with the port URL to access the port. 'private' will only allow users with workspace access to access the port.
+	// Whether the port visibility should be private or public. 'private' (default) will only allow users with workspace access to access the port. 'public' will allow everyone with the port URL to access the port.
 	Visibility string `yaml:"visibility,omitempty"`
 }
 

--- a/components/supervisor/pkg/ports/ports-config.go
+++ b/components/supervisor/pkg/ports/ports-config.go
@@ -74,9 +74,11 @@ func (configs *Configs) Get(port uint32) (*gitpod.PortConfig, ConfigKind, bool) 
 	for _, rangeConfig := range configs.instanceRangeConfigs {
 		if rangeConfig.Start <= port && port <= rangeConfig.End {
 			return &gitpod.PortConfig{
-				Port:       float64(port),
-				OnOpen:     rangeConfig.OnOpen,
-				Visibility: rangeConfig.Visibility,
+				Port:        float64(port),
+				OnOpen:      rangeConfig.OnOpen,
+				Visibility:  rangeConfig.Visibility,
+				Description: rangeConfig.Description,
+				Name:        rangeConfig.Name,
 			}, RangeConfigKind, true
 		}
 	}
@@ -197,9 +199,11 @@ func parseInstanceConfigs(ports []*gitpod.PortsItems) (portConfigs map[uint32]*g
 			_, exists := portConfigs[port]
 			if !exists {
 				portConfigs[port] = &gitpod.PortConfig{
-					OnOpen:     config.OnOpen,
-					Port:       float64(Port),
-					Visibility: config.Visibility,
+					OnOpen:      config.OnOpen,
+					Port:        float64(Port),
+					Visibility:  config.Visibility,
+					Description: config.Description,
+					Name:        config.Name,
 				}
 			}
 			continue

--- a/components/supervisor/pkg/ports/ports-config_test.go
+++ b/components/supervisor/pkg/ports/ports-config_test.go
@@ -29,17 +29,21 @@ func TestPortsConfig(t *testing.T) {
 			Desc: "workspace port config",
 			WorkspacePorts: []*gitpod.PortConfig{
 				{
-					Port:       9229,
-					OnOpen:     "ignore",
-					Visibility: "public",
+					Port:        9229,
+					OnOpen:      "ignore",
+					Visibility:  "public",
+					Name:        "Nice Port Name",
+					Description: "Nice Port Description",
 				},
 			},
 			Expectation: &PortConfigTestExpectations{
 				WorkspaceConfigs: []*gitpod.PortConfig{
 					{
-						Port:       9229,
-						OnOpen:     "ignore",
-						Visibility: "public",
+						Port:        9229,
+						OnOpen:      "ignore",
+						Visibility:  "public",
+						Name:        "Nice Port Name",
+						Description: "Nice Port Description",
 					},
 				},
 			},
@@ -49,18 +53,22 @@ func TestPortsConfig(t *testing.T) {
 			GitpodConfig: &gitpod.GitpodConfig{
 				Ports: []*gitpod.PortsItems{
 					{
-						Port:       9229,
-						OnOpen:     "ignore",
-						Visibility: "public",
+						Port:        9229,
+						OnOpen:      "ignore",
+						Visibility:  "public",
+						Name:        "Nice Port Name",
+						Description: "Nice Port Description",
 					},
 				},
 			},
 			Expectation: &PortConfigTestExpectations{
 				InstancePortConfigs: []*gitpod.PortConfig{
 					{
-						Port:       9229,
-						OnOpen:     "ignore",
-						Visibility: "public",
+						Port:        9229,
+						OnOpen:      "ignore",
+						Visibility:  "public",
+						Name:        "Nice Port Name",
+						Description: "Nice Port Description",
 					},
 				},
 			},
@@ -70,9 +78,11 @@ func TestPortsConfig(t *testing.T) {
 			GitpodConfig: &gitpod.GitpodConfig{
 				Ports: []*gitpod.PortsItems{
 					{
-						Port:       "9229-9339",
-						OnOpen:     "ignore",
-						Visibility: "public",
+						Port:        "9229-9339",
+						OnOpen:      "ignore",
+						Visibility:  "public",
+						Name:        "Nice Port Name",
+						Description: "Nice Port Description",
 					},
 				},
 			},
@@ -80,9 +90,11 @@ func TestPortsConfig(t *testing.T) {
 				InstanceRangeConfigs: []*RangeConfig{
 					{
 						PortsItems: &gitpod.PortsItems{
-							Port:       "9229-9339",
-							OnOpen:     "ignore",
-							Visibility: "public",
+							Port:        "9229-9339",
+							OnOpen:      "ignore",
+							Visibility:  "public",
+							Description: "Nice Port Description",
+							Name:        "Nice Port Name",
 						},
 						Start: 9229,
 						End:   9339,

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -411,6 +411,12 @@ func (pm *Manager) nextState(ctx context.Context) map[uint32]*managedPort {
 
 		var public bool
 		config, kind, exists := pm.configs.Get(mp.LocalhostPort)
+		if exists {
+			mp.Name = config.Name
+			mp.Description = config.Description
+			mp.OnExposed = getOnExposedAction(config, mp.LocalhostPort)
+		}
+
 		configured := exists && kind == PortConfigKind
 		if mp.Exposed || configured {
 			public = mp.Visibility == api.PortVisibility_public


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, supervisor send empty name and description of ports to editor(code) which make tooltip in code not works (see also https://github.com/gitpod-io/gitpod/issues/9262#issuecomment-1100738991).

This PR fix it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
https://github.com/gitpod-io/gitpod/issues/9262#issuecomment-1100738991

## How to test
<!-- Provide steps to test this PR -->

Note that port with range will work only when ports are opened

#### Init with .gitpod.yml

- Open a repo which contains ports define in `.gitpod.yml` with name and descripts like this one https://github.com/mustard-mh/test/tree/hw/port-name
- Choose VSCode as IDE in preference
- Start workspace with that repo https://vn-fix-emp45629038ff.preview.gitpod-dev.com/#https://github.com/mustard-mh/test/tree/hw/port-name
- Check if port explorer got name and description with port with tooltip (hover)

#### Watch .gitpod.yml

- Change `.gitpod.yml` in your workspace, the tooltip in `port explorer` should reflect to `yml` file

|Image|
|-|
|![image](https://user-images.githubusercontent.com/20944364/169961262-8174f163-ca79-4c06-9942-a088c09b85b6.png)|

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix port name and description not showing up on Gitpod VS Code Extension sidebar.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
