### PR TITLE
[ws-manager] fix calling dispose multiple times

### DIFF
--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -66,6 +66,10 @@ const (
 	// pvcWorkspaceFeatureAnnotation is set on workspaces which are using persistent_volume_claim feature
 	pvcWorkspaceFeatureAnnotation = "gitpod.io/pvcFeature"
 
+	// startedDisposalAnnotation sets to true when finalizeWorkspaceContent is called to prevent finalize from
+	// being called more then once, which can happen due to race between disposalStatusAnnotation update and actOnPodEvent
+	startedDisposalAnnotation = "gitpod.io/startedDisposal"
+
 	// gitpodFinalizerName is the name of the Gitpod finalizer we use to clean up a workspace
 	gitpodFinalizerName = "gitpod.io/finalizer"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Correct fix for sometimes calling dispose multiple times, which can result in incorrect error about backup failed error.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/pull/9475
Fixes https://github.com/gitpod-io/gitpod/issues/9598
Fixes https://github.com/gitpod-io/gitpod/issues/8326

## How to test
<!-- Provide steps to test this PR -->
Start and stop workspaces. They should always shutdown correctly now, previously sometimes they would error out with failed backup error due to race condition.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] fix sometimes workspaces fail with backup not found error
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
