### PR TITLE
[ws-manager] add cluster role needed for volume snapshots content access

### DIFF
--- a/install/installer/pkg/components/ws-manager/role.go
+++ b/install/installer/pkg/components/ws-manager/role.go
@@ -16,6 +16,32 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
 
 	return []runtime.Object{
+		&rbacv1.ClusterRole{
+			TypeMeta: common.TypeMetaClusterRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"snapshot.storage.k8s.io"},
+					Resources: []string{
+						"volumesnapshotcontents",
+					},
+					Verbs: []string{
+						"get",
+						"list",
+						"create",
+						"update",
+						"patch",
+						"watch",
+						"delete",
+						"deletecollection",
+					},
+				},
+			},
+		},
 		&rbacv1.Role{
 			TypeMeta: common.TypeMetaRole,
 			ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/ws-manager/rolebinding.go
+++ b/install/installer/pkg/components/ws-manager/rolebinding.go
@@ -37,6 +37,25 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: common.TypeMetaClusterRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   Component,
+				Labels: labels,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     Component,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      Component,
+					Namespace: ctx.Namespace,
+				},
+			},
+		},
 		&rbacv1.RoleBinding{
 			TypeMeta: common.TypeMetaRoleBinding,
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add cluster role needed for volume snapshots content access

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/pull/9475

## How to test
<!-- Provide steps to test this PR -->
Run installer and verify that it created cluster role and cluster role binding for ws-manager

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
