### PR TITLE
Update bug label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-labels: "bug"
+labels: "type: bug"
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
## Description

Minor label change in the bug issue template.

See issue for ~**[bug](https://github.com/gitpod-io/gitpod/issues?q=is%3Aissue+is%3Aopen+label%3Abug)** and ~**[type: bug](https://github.com/gitpod-io/gitpod/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+bug%22)** labels, as well as **[Issue Labels](https://www.notion.so/gitpod/type-ad7e263e7601400b8a03bf91fe8e5f54)** (internal) in our handbook.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```