### PR TITLE
Pass quality to code build process 

### DIFF
--- a/.github/workflows/code-nightly.yaml
+++ b/.github/workflows/code-nightly.yaml
@@ -33,7 +33,7 @@ jobs:
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
           headCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main)
           cd components/ide/code
-          leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit .:docker
+          leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit -DcodeQuality=insider .:docker
       - name: Slack Notification
         if: always()
         uses: rtCamp/action-slack-notify@v2

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,8 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 30d694d1f41945af7f8d757d3ddf176b283752cb
+  codeCommit: 85a18060d91c11ff6de8ba44e02c6c31a5cd907c
+  codeQuality: stable
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.1.tar.gz"

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -9,12 +9,14 @@ packages:
     argdeps:
       - imageRepoBase
       - codeCommit
+      - codeQuality
     config:
       dockerfile: leeway.Dockerfile
       metadata:
         helm-component: workspace.codeImage
       buildArgs:
         CODE_COMMIT: ${codeCommit}
+        CODE_QUALITY: ${codeQuality}
       image:
         - ${imageRepoBase}/ide/code:${version}
         - ${imageRepoBase}/ide/code:commit-${__git_commit}


### PR DESCRIPTION
## Description
Companion PR of https://github.com/gitpod-io/openvscode-server/pull/347

The editor name is misconfigured and not showing correctly when users are using the Insider version.

| Before | After |
|--------|-------|
|  <img width="568" alt="Screenshot 2022-05-12 at 16 49 03" src="https://user-images.githubusercontent.com/2318450/168103612-d2872059-2736-4db5-bee0-ba0db6ff75a9.png">      |   <img width="554" alt="Screenshot 2022-05-12 at 16 49 13" src="https://user-images.githubusercontent.com/2318450/168103669-4993bd8f-c192-40da-a1c0-1312c3cf6a2b.png">


Note: Ignore the light/dark mode

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9380

## How to test
https://gitpod.slack.com/archives/C01KGM9BH54/p1652369461003149?thread_ts=1652353405.265159&cid=C01KGM9BH54

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```