### PR TITLE
[public-api] Convert server errors to appropriate RPC errors

### DIFF
--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"strings"
+)
+
+func ConvertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	s := err.Error()
+
+	if strings.Contains(s, "code 401") {
+		return status.Error(codes.PermissionDenied, s)
+	}
+
+	// components/gitpod-protocol/src/messaging/error.ts
+	if strings.Contains(s, "code 404") {
+		return status.Error(codes.NotFound, s)
+	}
+
+	// components/gitpod-messagebus/src/jsonrpc-server.ts#47
+	if strings.Contains(s, "code -32603") {
+		return status.Error(codes.Internal, s)
+	}
+
+	return status.Error(codes.Internal, s)
+}

--- a/components/public-api-server/pkg/proxy/errors_test.go
+++ b/components/public-api-server/pkg/proxy/errors_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"testing"
+)
+
+func TestConvertError(t *testing.T) {
+	scenarios := []struct {
+		WebsocketError error
+		ExpectedStatus codes.Code
+	}{
+		{
+			WebsocketError: errors.New("reconnecting-ws: bad handshake: code 401 - URL: wss://main.preview.gitpod-dev.com/api/v1 - headers: map[Authorization:[Bearer foo] Origin:[http://main.preview.gitpod-dev.com/]]"),
+			ExpectedStatus: codes.PermissionDenied,
+		},
+		{
+			WebsocketError: errors.New("jsonrpc2: code -32603 message: Request getWorkspace failed with message: No workspace with id 'some-id' found."),
+			ExpectedStatus: codes.Internal,
+		},
+	}
+
+	for _, s := range scenarios {
+		converted := ConvertError(s.WebsocketError)
+		require.Equal(t, s.ExpectedStatus, status.Code(converted))
+		// the error message should remain the same
+		require.Equal(t, s.WebsocketError.Error(), status.Convert(converted).Message())
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Server errors are returned largely as string errors into the library we're using. We need to parse them somewhat to know what to return to the caller.

In this PR, we first extract info from the server errors and wrap them with a corresponding gRPC status code, we then take this on the GetWorkspace handler to return meaningful user facing errors out, without the underlying protocol errors. In effect, we have `internal` and `public` errors, and the internal details shouldn't be returned the caller.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/9229

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE