### PR TITLE
Remove intellij to avoid generating large gradle

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -68,7 +68,3 @@ jetbrains:
   goland:
     prebuilds:
       version: stable
-  intellij:
-    prebuilds:
-      version: stable
-


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Right now, Gitpod repo prebuild will generate a .grandle folder with 12G of storage. This PR remove `intellij` in `.gitpod.yml` file to avoid pre-indexing of intellij, to save time of download rebuild and workspace storage

![image](https://user-images.githubusercontent.com/20944364/167141565-e3c797b0-51ec-48e8-aed6-4ce380cafd96.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Start Gitpod with this branch https://gitpod.io/#https://github.com/gitpod-io/gitpod/tree/hw/remove-intellij
2. Exec `du -d 1 -h /workspace`, you'll see something like these below
```
36M     /workspace/.cache
0       /workspace/.cargo
4.0K    /workspace/.config
396K    /workspace/.gitpod
5.9G    /workspace/.gradle
1.4G    /workspace/gitpod
30M     /workspace/go
446M    /workspace/.vscode-remote
7.8G    /workspace
```
Another part of .gradle is gen by https://github.com/gitpod-io/gitpod/blob/main/.gitpod.yml#L38-L42 we have other plan about it, like move JetBrains related to another repo, see [internal chat](https://gitpod.slack.com/archives/C01KGM9BH54/p1651844869166919?thread_ts=1651172017.770269&cid=C01KGM9BH54)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft without-preview=true
