### PR TITLE
[installer] Allow the use of a static password for the message bus

### DIFF
--- a/install/installer/pkg/common/render.go
+++ b/install/installer/pkg/common/render.go
@@ -150,9 +150,18 @@ func (r *RenderContext) generateValues() error {
 	}
 	r.Values.InternalRegistryPassword = internalRegistryPassword
 
-	messageBusPassword, err := RandomString(20)
-	if err != nil {
-		return err
+	messageBusPassword := ""
+	_ = r.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.Common != nil {
+			messageBusPassword = cfg.Common.StaticMessagebusPassword
+		}
+		return nil
+	})
+	if messageBusPassword == "" {
+		messageBusPassword, err = RandomString(20)
+		if err != nil {
+			return err
+		}
 	}
 	r.Values.MessageBusPassword = messageBusPassword
 

--- a/install/installer/pkg/common/render_test.go
+++ b/install/installer/pkg/common/render_test.go
@@ -183,6 +183,32 @@ func TestResourceRequirements(t *testing.T) {
 	}
 }
 
+func TestStaticMessagebusPassword(t *testing.T) {
+	const expectedPassword = "some-password"
+
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			Common: &experimental.CommonConfig{
+				StaticMessagebusPassword: expectedPassword,
+			},
+		},
+	}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	actualPassword := ctx.Values.MessageBusPassword
+
+	require.Equal(t, expectedPassword, actualPassword)
+}
+
+func TestDynamicMessagebusPassword(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	actualPassword := ctx.Values.MessageBusPassword
+
+	require.NotEmpty(t, actualPassword)
+}
+
 func TestRepoName(t *testing.T) {
 	type Expectation struct {
 		Result string

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -24,7 +24,8 @@ type Config struct {
 }
 
 type CommonConfig struct {
-	PodConfig map[string]*PodConfig `json:"podConfig,omitempty"`
+	PodConfig                map[string]*PodConfig `json:"podConfig,omitempty"`
+	StaticMessagebusPassword string                `json:"staticMessagebusPassword"`
 }
 
 type PodConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR adds an `experimental.common.staticMessagebusPassword` field to set a message bus password, rather than having the installer render a fresh password on every invocation. cf [this comment](https://github.com/gitpod-io/gitpod/blob/66e60f0609b95af7dc1c35b019bbe51334cdb729/install/installer/pkg/common/render.go#L127) from @MrSimonEmms.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  common:
    staticMessagebusPassword: "some-password"
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The message bus password will be the value set in the config. If the `experimental` config section is omitted, or the `staticMessagebusPassword` is set to an empty string, a password will be generated.

## Release Notes

```release-note
Add `staticMessagebusPassword` config flag to use a fixed message bus password in the installer
```

## Documentation

None.