### PR TITLE
Update $id property from Gitpod JSON Schema with the current URL

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://gitpod.io/gitpod.schema.json",
+    "$id": "https://gitpod.io/schemas/gitpod-schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Gitpod Config",
     "type": "object",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

I've noticed Gitpod JSON Schema is available at https://gitpod.io/schemas/gitpod-schema.json but in itself ("$id" property) it points to https://gitpod.io/gitpod.schema.json (which when accessed in an anonymous browser tab, displays the Gitpod Login Screen)

![image](https://user-images.githubusercontent.com/418083/167259682-ba38d842-0273-4da8-a91c-3d0d342cbf95.png)

![image](https://user-images.githubusercontent.com/418083/167259691-20329d31-4e5f-4196-b6c1-c70b3e2b75ca.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
Nothing to test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.