### PR TITLE
[Analytics] Add team properties to team_joined call

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2028,6 +2028,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             event: "team_joined",
             properties: {
                 team_id: invite.teamId,
+                team_name: team?.name,
+                team_slug: team?.slug,
                 invite_id: inviteId,
             },
         });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds team name and slug properties to the `team_joined` track call in order to use them downstream in marketing automation tools.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No related issue, see [internal analytics task for context](https://www.notion.so/gitpod/Add-team_slug-as-property-to-team_joined-track-call-e174e76b54ff436a97e3d7864c628239)

## How to test
<!-- Provide steps to test this PR -->

1. Open a preview environment, sign up, create a team and an invite url.
2. open the invite url with a second account to join the team
3. Go to the [debugger of Staging Untrusted](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)
and ensure that the `team_joined` call includes the slug and name of the team in its properties.
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe