### PR TITLE
[installer] Make workspace garbage collection configurable

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -90,6 +90,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	disableWsGarbageCollection := false
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			disableWsGarbageCollection = cfg.WebApp.Server.DisableWorkspaceGarbageCollection
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -133,7 +141,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ChunkLimit:                 1000,
 			ContentChunkLimit:          1000,
 			ContentRetentionPeriodDays: 21,
-			Disabled:                   false,
+			Disabled:                   disableWsGarbageCollection,
 			MinAgeDays:                 14,
 			MinAgePrebuildDays:         7,
 		},

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -22,6 +22,7 @@ func TestConfigMap(t *testing.T) {
 		EnableLocalApp                    bool
 		RunDbDeleter                      bool
 		DisableDynamicAuthProviderLogin   bool
+		DisableWorkspaceGarbageCollection bool
 		DefaultBaseImageRegistryWhiteList []string
 		WorkspaceImage                    string
 		JWTSecret                         string
@@ -33,6 +34,7 @@ func TestConfigMap(t *testing.T) {
 		EnableLocalApp:                    true,
 		DisableDynamicAuthProviderLogin:   true,
 		RunDbDeleter:                      false,
+		DisableWorkspaceGarbageCollection: true,
 		DefaultBaseImageRegistryWhiteList: []string{"some-registry"},
 		WorkspaceImage:                    "some-workspace-image",
 		JWTSecret:                         "some-jwt-secret",
@@ -57,6 +59,7 @@ func TestConfigMap(t *testing.T) {
 					DisableDynamicAuthProviderLogin:   expectation.DisableDynamicAuthProviderLogin,
 					EnableLocalApp:                    pointer.Bool(expectation.EnableLocalApp),
 					RunDbDeleter:                      pointer.Bool(expectation.RunDbDeleter),
+					DisableWorkspaceGarbageCollection: expectation.DisableWorkspaceGarbageCollection,
 					DefaultBaseImageRegistryWhiteList: expectation.DefaultBaseImageRegistryWhiteList,
 					WorkspaceDefaults: experimental.WorkspaceDefaults{
 						WorkspaceImage: expectation.WorkspaceImage,
@@ -99,6 +102,7 @@ func TestConfigMap(t *testing.T) {
 		DisableDynamicAuthProviderLogin:   config.DisableDynamicAuthProviderLogin,
 		EnableLocalApp:                    config.EnableLocalApp,
 		RunDbDeleter:                      config.RunDbDeleter,
+		DisableWorkspaceGarbageCollection: config.WorkspaceGarbageCollection.Disabled,
 		DefaultBaseImageRegistryWhiteList: config.DefaultBaseImageRegistryWhitelist,
 		WorkspaceImage:                    config.WorkspaceDefaults.WorkspaceImage,
 		JWTSecret:                         config.OAuthServer.JWTSecret,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -141,6 +141,7 @@ type ServerConfig struct {
 	EnableLocalApp                    *bool             `json:"enableLocalApp"`
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DefaultBaseImageRegistryWhiteList []string          `json:"defaultBaseImageRegistryWhitelist"`
+	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
 }
 
 type ProxyConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR makes workspace garbage collection configurable by adding a new `experimental.webapp.server.disableWorkspaceGarbageCollection` flag to the installer config.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    server:
      disableWorkspaceGarbageCollection: true
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `workspaceGarbageCollection.disabled` field in the server config map will reflect the value set in the installer config.

## Release Notes

```release-note
Add `disableWorkspaceGarbageCollection` experimental installer config flag
```

## Documentation

None.