### PR TITLE
Laushinka/add metrics for server 9824

### DIFF
--- a/components/public-api-server/pkg/proxy/conn.go
+++ b/components/public-api-server/pkg/proxy/conn.go
@@ -10,6 +10,7 @@ import (
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"net/url"
+	"time"
 )
 
 type ServerConnectionPool interface {
@@ -26,6 +27,10 @@ type NoConnectionPool struct {
 func (p *NoConnectionPool) Get(ctx context.Context, token string) (gitpod.APIInterface, error) {
 	logger := ctxlogrus.Extract(ctx)
 
+	start := time.Now()
+	defer func() {
+		reportConnectionDuration(time.Since(start))
+	}()
 	server, err := gitpod.ConnectToServer(p.ServerAPI.String(), gitpod.ConnectToServerOpts{
 		Context: ctx,
 		Token:   token,

--- a/components/public-api-server/pkg/proxy/prometheusmetrics.go
+++ b/components/public-api-server/pkg/proxy/prometheusmetrics.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+func reportConnectionDuration(d time.Duration) {
+	proxyConnectionCreateDurationSeconds.Observe(d.Seconds())
+}
+
+var proxyConnectionCreateDurationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: "gitpod",
+	Name:      "public_api_proxy_connection_create_duration_seconds",
+	Help:      "Histogram of connection time in seconds",
+})
+
+func RegisterMetrics(registry *prometheus.Registry) {
+	registry.MustRegister(proxyConnectionCreateDurationSeconds)
+}

--- a/components/public-api-server/pkg/proxy/prometheusmetrics_test.go
+++ b/components/public-api-server/pkg/proxy/prometheusmetrics_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"context"
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"testing"
+)
+
+func TestConnectionCreationWasTracked(t *testing.T) {
+	// Set up server
+	srv := baseserver.NewForTests(t)
+	baseserver.StartServerForTests(t, srv)
+
+	// Set up Prometheus registry
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(proxyConnectionCreateDurationSeconds)
+
+	// Set up Workspace client
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "some-token")
+	conn, _ := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	client := v1.NewWorkspacesServiceClient(conn)
+
+	// Call GetWorkspace
+	client.GetWorkspace(ctx, &v1.GetWorkspaceRequest{
+		WorkspaceId: "some-ID",
+	})
+
+	count, err := testutil.GatherAndCount(registry)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+}

--- a/components/public-api-server/pkg/server/integration_test.go
+++ b/components/public-api-server/pkg/server/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -21,11 +22,12 @@ import (
 func TestPublicAPIServer_v1_WorkspaceService(t *testing.T) {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "some-token")
 	srv := baseserver.NewForTests(t)
+	registry := prometheus.NewRegistry()
 
 	gitpodAPI, err := url.Parse("wss://main.preview.gitpod-dev.com/api/v1")
 	require.NoError(t, err)
 
-	require.NoError(t, register(srv, Config{GitpodAPI: gitpodAPI}))
+	require.NoError(t, register(srv, Config{GitpodAPI: gitpodAPI}, registry))
 	baseserver.StartServerForTests(t, srv)
 
 	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -67,11 +69,12 @@ func TestPublicAPIServer_v1_WorkspaceService(t *testing.T) {
 func TestPublicAPIServer_v1_PrebuildService(t *testing.T) {
 	ctx := context.Background()
 	srv := baseserver.NewForTests(t)
+	registry := prometheus.NewRegistry()
 
 	gitpodAPI, err := url.Parse("wss://main.preview.gitpod-dev.com/api/v1")
 	require.NoError(t, err)
 
-	require.NoError(t, register(srv, Config{GitpodAPI: gitpodAPI}))
+	require.NoError(t, register(srv, Config{GitpodAPI: gitpodAPI}, registry))
 
 	baseserver.StartServerForTests(t, srv)
 


### PR DESCRIPTION
## Description
Sets up metric for how long a connection takes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9824 

## How to test
1. Under `/components/public-api-server` run `go run main.go`
2. Run `curl localhost:9500/metrics`
3. See the custom metrics exposed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
