### PR TITLE
[installer] Make blocked repositories configurable

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -98,6 +98,19 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	var blockedRepositories []BlockedRepository
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && len(cfg.WebApp.Server.BlockedRepositories) > 0 {
+			for _, repo := range cfg.WebApp.Server.BlockedRepositories {
+				blockedRepositories = append(blockedRepositories, BlockedRepository{
+					UrlRegExp: repo.UrlRegExp,
+					BlockUser: repo.BlockUser,
+				})
+			}
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -161,6 +174,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		MaxConcurrentPrebuildsPerRef:      10,
 		IncrementalPrebuilds:              IncrementalPrebuilds{CommitHistory: 100, RepositoryPasslist: []string{}},
 		BlockNewUsers:                     ctx.Config.BlockNewUsers,
+		BlockedRepositories:               blockedRepositories,
 		MakeNewUsersAdmin:                 false,
 		DefaultBaseImageRegistryWhitelist: defaultBaseImageRegistryWhitelist,
 		RunDbDeleter:                      runDbDeleter,

--- a/install/installer/pkg/components/server/configmap_test.go
+++ b/install/installer/pkg/components/server/configmap_test.go
@@ -138,3 +138,25 @@ func TestConfigMap(t *testing.T) {
 
 	assert.Equal(t, expectation, actual)
 }
+
+func TestInvalidBlockedRepositoryRegularExpressions(t *testing.T) {
+	const invalidRegexp = "["
+
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				Server: &experimental.ServerConfig{
+					BlockedRepositories: []experimental.BlockedRepository{{
+						UrlRegExp: invalidRegexp,
+						BlockUser: false,
+					}},
+				},
+			},
+		},
+	}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	_, err = configmap(ctx)
+
+	require.Error(t, err, "expected to fail when rendering configmap with invalid blocked repo regexp %q", invalidRegexp)
+}

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -42,12 +42,18 @@ type ConfigSerialized struct {
 	AuthProviderConfigFiles    []string                   `json:"authProviderConfigFiles"`
 	IncrementalPrebuilds       IncrementalPrebuilds       `json:"incrementalPrebuilds"`
 	BlockNewUsers              config.BlockNewUsers       `json:"blockNewUsers"`
+	BlockedRepositories        []BlockedRepository        `json:"blockedRepositories,omitempty"`
 	OAuthServer                OAuthServer                `json:"oauthServer"`
 	RateLimiter                RateLimiter                `json:"rateLimiter"`
 	CodeSync                   CodeSync                   `json:"codeSync"`
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
 	PrebuildLimiter map[string]int `json:"prebuildLimiter"`
+}
+
+type BlockedRepository struct {
+	UrlRegExp string `json:"urlRegExp"`
+	BlockUser bool   `json:"blockUser"`
 }
 
 type CodeSyncResources struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -132,16 +132,22 @@ type WsManagerBridgeConfig struct {
 }
 
 type ServerConfig struct {
-	WorkspaceDefaults                 WorkspaceDefaults `json:"workspaceDefaults"`
-	OAuthServer                       OAuthServer       `json:"oauthServer"`
-	Session                           Session           `json:"session"`
-	GithubApp                         *GithubApp        `json:"githubApp"`
-	ChargebeeSecret                   string            `json:"chargebeeSecret"`
-	DisableDynamicAuthProviderLogin   bool              `json:"disableDynamicAuthProviderLogin"`
-	EnableLocalApp                    *bool             `json:"enableLocalApp"`
-	RunDbDeleter                      *bool             `json:"runDbDeleter"`
-	DefaultBaseImageRegistryWhiteList []string          `json:"defaultBaseImageRegistryWhitelist"`
-	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
+	WorkspaceDefaults                 WorkspaceDefaults   `json:"workspaceDefaults"`
+	OAuthServer                       OAuthServer         `json:"oauthServer"`
+	Session                           Session             `json:"session"`
+	GithubApp                         *GithubApp          `json:"githubApp"`
+	ChargebeeSecret                   string              `json:"chargebeeSecret"`
+	DisableDynamicAuthProviderLogin   bool                `json:"disableDynamicAuthProviderLogin"`
+	EnableLocalApp                    *bool               `json:"enableLocalApp"`
+	RunDbDeleter                      *bool               `json:"runDbDeleter"`
+	DefaultBaseImageRegistryWhiteList []string            `json:"defaultBaseImageRegistryWhitelist"`
+	DisableWorkspaceGarbageCollection bool                `json:"disableWorkspaceGarbageCollection"`
+	BlockedRepositories               []BlockedRepository `json:"blockedRepositories,omitempty"`
+}
+
+type BlockedRepository struct {
+	UrlRegExp string `json:"urlRegExp"`
+	BlockUser bool   `json:"blockUser"`
 }
 
 type ProxyConfig struct {


### PR DESCRIPTION
## Description

One of the Webapp team's [epics for Q2](https://github.com/gitpod-io/gitpod/issues/9097) is to use the Gitpod installer to deploy to Gitpod SaaS. In order to do that we will need to add additional configuration to the installer to make the output suitable for a SaaS deployment as opposed to a self-hosted deployment.
 
This PR makes it possible to configure blocked repositories for the server component:

* Add a `blockedRepositories` field to the server configmap struct to match https://github.com/gitpod-io/gitpod/blob/main/components/server/src/config.ts#L164.
* Add a new `experimental.webapp.server.blockedRepositories` config field to the installer to set the field in the configmap.

## Related Issue(s)
Part of #9097 

## How to test

Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    server:
      blockedRepositories:
      - urlRegExp: "https://github.com/some-user/some-bad-repo"
        blockUser: true
      - urlRegExp: "https://github.com/some-other-user/another-bad-repo"
        blockUser: false
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `blockedRepositories` field in the server config map will reflect the value set in the installer config.

## Release Notes

```release-note
Add `disableWorkspaceGarbageCollection` experimental installer config flag
```

## Documentation

None.