### PR TITLE
[werft] Configure payment with installer

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -317,8 +317,10 @@ async function deployToDevWithInstaller(werft: Werft, jobConfig: JobConfig, depl
         workspaceFeatureFlags: workspaceFeatureFlags,
         gitpodDaemonsetPorts: { registryFacade: registryNodePortMeta, wsDaemon: wsdaemonPortMeta },
         smithToken: token,
+        withPayment: deploymentConfig.withPayment,
     })
     try {
+        werft.log(phases.DEPLOY, "deploying using installer")
         installer.init(installerSlices.INSTALLER_INIT)
         installer.addPreviewConfiguration(installerSlices.PREVIEW_CONFIG)
         installer.validateConfiguration(installerSlices.VALIDATE_CONFIG)

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -28,8 +28,13 @@ echo "Use node pool index $NODE_POOL_INDEX"
 LICENSE=$(cat /tmp/license)
 # default, no, we do not add feature flags, file is empty
 DEFAULT_FEATURE_FLAGS=$(cat /tmp/defaultFeatureFlags)
-
-
+# if payment is configured: Append the YAML objects
+if [[ -f "/tmp/payment" ]] ; then
+   echo "found /tmp/payment, appending to k8s.yaml now"
+   # do not make any assumptions about new lines
+   printf \\n'---'\\n >> k8s.yaml
+   cat "/tmp/payment" >> k8s.yaml
+fi
 
 # count YAML like lines in the k8s manifest file
 MATCHES="$(grep -c -- --- k8s.yaml)"
@@ -379,9 +384,6 @@ while [ "$documentIndex" -le "$DOCS" ]; do
    #    # merge base into k8s.yaml
    #    yq m -x -i -d "$documentIndex" k8s.yaml /tmp/"$NAME"-"$KIND".yaml
    # fi
-
-   # TODO: integrate with chargebees
-   # won't fix now, use Helm
 
    documentIndex=$((documentIndex + 1))
 done

--- a/.werft/jobs/build/payment/chargebee-config-secret.yaml
+++ b/.werft/jobs/build/payment/chargebee-config-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  providerOptions: eyJzaXRlIjogImdpdHBvZC10ZXN0IiwiYXBpX2tleSI6ICJ0ZXN0X1hheTY0eVJYY2RHR2N1NG1haVhlSTNsY3VZNXlzTmVIWlFwIn0=
+kind: Secret
+metadata:
+  name: chargebee-config
+  namespace: ${NAMESPACE}
+type: Opaque

--- a/.werft/jobs/build/payment/payment-endpoint-deployment.yaml
+++ b/.werft/jobs/build/payment/payment-endpoint-deployment.yaml
@@ -1,0 +1,150 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: gitpod
+    component: payment-endpoint
+  name: payment-endpoint
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: payment-endpoint
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gitpod
+        component: payment-endpoint
+      name: payment-endpoint
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: gitpod.io/workload_meta
+                  operator: Exists
+      containers:
+      - env:
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: GITPOD_REGION
+          value: local
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: ""
+        - name: DB_HOST
+          value: mysql
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        - name: DB_DELETED_ENTRIES_GC_ENABLED
+          value: "false"
+        - name: CHARGEBEE_WEBHOOK
+          value: '{"id":"whv2_Hr55137RIX0bgV1e96","password":"0\"cR4M,;nV=$m9izAHEah","user":"chargebee"}'
+        - name: GITPOD_GITHUB_APP_ENABLED
+          value: "false"
+        # - name: GITPOD_GITHUB_APP_ID
+        #   value: "23613"
+        # - name: GITPOD_GITHUB_APP_WEBHOOK_SECRET
+        #   value: ea3t2QvbJqUFhGqrAJxCQQJ4mmABru
+        # - name: GITPOD_GITHUB_APP_AUTH_PROVIDER_ID
+        #   value: Public-GitHub
+        # - name: GITPOD_GITHUB_APP_CERT_PATH
+        #   value: /github-app-cert/cert
+        # - name: GITPOD_GITHUB_APP_MKT_NAME
+        #   value: gitpod-staging
+        - name: JAEGER_ENDPOINT
+          value: http://otel-collector.cluster-monitoring.svc:14268/api/traces
+        - name: JAEGER_SAMPLER_PARAM
+          value: "5.0"
+        - name: JAEGER_SAMPLER_TYPE
+          value: ratelimiting
+        - name: LOG_LEVEL
+          value: info
+        image: eu.gcr.io/gitpod-core-dev/build/payment-endpoint:${PAYMENT_ENDPOINT_VERSION}
+        name: main
+        ports:
+        - containerPort: 3002
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        # - mountPath: /github-app-cert
+        #   name: github-app-cert-secret
+        #   readOnly: true
+        - mountPath: /chargebee
+          name: chargebee-config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        - name: DB_HOST
+          value: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:${SERVICE_WAITER_VERSION}
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      securityContext:
+        runAsUser: 31006
+      serviceAccountName: payment-endpoint
+      terminationGracePeriodSeconds: 30
+      volumes:
+      # - name: github-app-cert-secret
+      #   secret:
+      #     secretName: github-app-cert
+      - name: chargebee-config
+        secret:
+          secretName: chargebee-config
+
+

--- a/.werft/jobs/build/payment/payment-endpoint-networkpolicy.yaml
+++ b/.werft/jobs/build/payment/payment-endpoint-networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: payment-endpoint-deny-all-allow-explicit
+  namespace: ${NAMESPACE}
+  labels:
+    app: gitpod
+    component: payment-endpoint
+spec:
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: payment-endpoint
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 3002
+    from:
+    # Allow ingress on port 3002 from component:
+    - podSelector:
+        matchLabels:
+          app: gitpod
+          component: proxy

--- a/.werft/jobs/build/payment/payment-endpoint-rolebinding.yaml
+++ b/.werft/jobs/build/payment/payment-endpoint-rolebinding.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: payment-endpoint
+  namespace: ${NAMESPACE}
+  labels:
+    app: gitpod
+    component: payment-endpoint
+subjects:
+- kind: ServiceAccount
+  name: payment-endpoint
+roleRef:
+  kind: ClusterRole
+  name: ${NAMESPACE}-ns-psp:unprivileged
+  apiGroup: rbac.authorization.k8s.io

--- a/.werft/jobs/build/payment/payment-endpoint-service-account.yaml
+++ b/.werft/jobs/build/payment/payment-endpoint-service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: payment-endpoint
+  namespace: ${NAMESPACE}
+  labels:
+    app: gitpod
+    component: payment-endpoint
+automountServiceAccountToken: false

--- a/.werft/jobs/build/payment/payment-endpoint-service.yaml
+++ b/.werft/jobs/build/payment/payment-endpoint-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: gitpod
+    component: payment-endpoint
+  name: payment-endpoint
+  namespace: ${NAMESPACE}
+spec:
+  ports:
+  - name: http
+    port: 3002
+    protocol: TCP
+    targetPort: 3002
+  selector:
+    app: gitpod
+    component: payment-endpoint
+  type: ClusterIP

--- a/.werft/jobs/build/payment/render.ts
+++ b/.werft/jobs/build/payment/render.ts
@@ -1,0 +1,22 @@
+const fs = require("fs");
+import * as path from "path";
+
+export function renderPayment(
+    namespace: string,
+    paymentEndpointVersion: String,
+    serviceAwaiterVersion: string,
+): string {
+    const output: string[] = [];
+    for (const file of fs.readdirSync(__dirname)) {
+        if (!file.endsWith(".yaml")) {
+            continue;
+        }
+        let content = fs.readFileSync(path.join(__dirname, file), { encoding: "utf-8" });
+        content = content
+            .replaceAll("${NAMESPACE}", namespace)
+            .replaceAll("${PAYMENT_ENDPOINT_VERSION}", paymentEndpointVersion)
+            .replaceAll("${SERVICE_WAITER_VERSION}", serviceAwaiterVersion);
+        output.push(content);
+    }
+    return output.join("\n---\n");
+}


### PR DESCRIPTION
## Description
This PR adds the `with-payment` build flag for `installer`-based preview-environments.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9855

## How to test

EDIT: From [Slack](https://gitpod.slack.com/archives/C02EN94AEPL/p1652165314891869?thread_ts=1652165113.148599&cid=C02EN94AEPL) (internal)

> As usual (I think we even have a "setup payment" steps notion page...? 🤔). Basically:
> - deploy with `with-payment=true`
> - configure the webhook with chargebee
> - see that you can buy a subscription

> ```
> werft job run github gitpod-io/gitpod:gpl/9855-payment -j .werft/build.yaml
> ```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

 - [x] /werft with-payment=true