### PR TITLE
[baseserver] Expose gRPC prometheus metrics

### DIFF
--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -34,12 +34,13 @@ type config struct {
 
 func defaultConfig() *config {
 	return &config{
-		logger:        log.New(),
-		hostname:      "localhost",
-		httpPort:      9000,
-		grpcPort:      9001,
-		closeTimeout:  5 * time.Second,
-		healthHandler: healthcheck.NewHandler(),
+		logger:          log.New(),
+		hostname:        "localhost",
+		httpPort:        9000,
+		grpcPort:        9001,
+		closeTimeout:    5 * time.Second,
+		healthHandler:   healthcheck.NewHandler(),
+		metricsRegistry: prometheus.NewRegistry(),
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, prometheus metrics are not part of our default interceptors used across all gRPC servers. This is because every server handles is slightly differently. As part of ongoing WIP migration of existing gRPC servers onto base-server, it's necessary to be able to expose gRPC metrics with configurable prometheus registry.

This PR ensures that with, or without, a custom `prometheus.Registry`, gRPC metrics are exposed as long as the server serves gRPC traffic.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

or

1. Start public-api-server on this branch with `cd components/public-api-server && go run main.go`
2. Hit the server with a CLI `cd dev/gpctl && go run main.go api workspaces get --id 123 --token foo --address localhost:9501 --insecure` - the token here doesn't matter, we just need to hit it even with bad auth
3. Grab the server exposed metrics with `curl localhost:9500/metrics` and observe at least the following metrics: `"grpc_server_handled_total", "grpc_server_handling_seconds", "grpc_server_started_total"`



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE