### PR TITLE
[licensor] cleanup duplicate license types

### DIFF
--- a/components/licensor/ee/pkg/licensor/gitpod.go
+++ b/components/licensor/ee/pkg/licensor/gitpod.go
@@ -21,7 +21,7 @@ func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 		return &Evaluator{
 			lic:           defaultLicense,
 			allowFallback: true,
-			plan:          CommunityLicense,
+			plan:          LicenseTypeCommunity,
 		}
 	}
 
@@ -64,7 +64,7 @@ func NewGitpodEvaluator(key []byte, domain string) (res *Evaluator) {
 
 	return &Evaluator{
 		lic:           lic.LicensePayload,
-		allowFallback: false,               // Gitpod licenses cannot fallback - assume these are always paid-for
-		plan:          ProfessionalLicense, //  This essentially means "paid" license
+		allowFallback: false,           // Gitpod licenses cannot fallback - assume these are always paid-for
+		plan:          LicenseTypePaid, //  This essentially means "paid" license
 	}
 }

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -29,8 +29,10 @@ const (
 type LicenseSubscriptionLevel string
 
 const (
-	CommunityLicense    LicenseSubscriptionLevel = "community"
-	ProfessionalLicense LicenseSubscriptionLevel = "prod"
+	LicenseTypeCommunity   LicenseSubscriptionLevel = "community"
+	LicenseTypePaid        LicenseSubscriptionLevel = "prod"
+	LicenseTypeTrial       LicenseSubscriptionLevel = "trial"
+	LicenseTypeDevelopment LicenseSubscriptionLevel = "dev"
 )
 
 // LicenseData has type specific info about the license

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -79,7 +79,7 @@ func (test *licenseTest) Run(t *testing.T) {
 				payload, err := json.Marshal(replicatedLicensePayload{
 					LicenseType: func() LicenseSubscriptionLevel {
 						if test.ReplicatedLicenseType == nil {
-							return ReplicatedLicenseTypePaid
+							return LicenseTypePaid
 						}
 						return *test.ReplicatedLicenseType
 					}(),
@@ -210,8 +210,8 @@ func TestSeats(t *testing.T) {
 }
 
 func TestFeatures(t *testing.T) {
-	replicatedCommunity := ReplicatedLicenseTypeCommunity
-	replicatedPaid := ReplicatedLicenseTypePaid
+	replicatedCommunity := LicenseTypeCommunity
+	replicatedPaid := LicenseTypePaid
 
 	tests := []struct {
 		Name                  string

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -23,14 +23,6 @@ type replicatedFields struct {
 	Value interface{} `json:"value"` // This is of type "fieldType"
 }
 
-// variable names are what Replicated calls them in the vendor portal
-const (
-	ReplicatedLicenseTypeCommunity   LicenseSubscriptionLevel = "community"
-	ReplicatedLicenseTypeDevelopment LicenseSubscriptionLevel = "dev"
-	ReplicatedLicenseTypePaid        LicenseSubscriptionLevel = "prod"
-	ReplicatedLicenseTypeTrial       LicenseSubscriptionLevel = "trial"
-)
-
 // replicatedLicensePayload exists to convert the JSON structure to a LicensePayload
 type replicatedLicensePayload struct {
 	LicenseID      string                   `json:"license_id"`
@@ -95,7 +87,7 @@ func defaultReplicatedLicense() *Evaluator {
 	return &Evaluator{
 		lic:           defaultLicense,
 		allowFallback: true,
-		plan:          ReplicatedLicenseTypeCommunity,
+		plan:          LicenseTypeCommunity,
 	}
 }
 
@@ -143,7 +135,7 @@ func newReplicatedEvaluator(client *http.Client, domain string) (res *Evaluator)
 
 	return &Evaluator{
 		lic:           lic,
-		allowFallback: replicatedPayload.LicenseType == ReplicatedLicenseTypeCommunity, // Only community licenses are allowed to fallback
+		allowFallback: replicatedPayload.LicenseType == LicenseTypeCommunity, // Only community licenses are allowed to fallback
 		plan:          replicatedPayload.LicenseType,
 	}
 }

--- a/components/licensor/typescript/ee/src/api.ts
+++ b/components/licensor/typescript/ee/src/api.ts
@@ -32,12 +32,10 @@ export interface LicensePayload {
 }
 
 export enum LicenseSubscriptionLevel {
-    ReplicatedLicenseTypeCommunity = "community",
-    ReplicatedLicenseTypeDevelopment = "dev",
-    ReplicatedLicenseTypePaid = "prod",
-    ReplicatedLicenseTypeTrial = "trial",
-    CommunityLicense = "community",
-    ProfessionalLicense = "prod",
+    LicenseTypeCommunity = "community",
+    LicenseTypePaid = "prod",
+    LicenseTypeTrial = "trial",
+    LicenseTypeDevelopment = "dev",
 }
 export enum LicenseType {
     LicenseTypeGitpod = "gitpod",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a tiny PR that removes the redundancy in Licence type names. Currently, we have different enum constants for Replicated and the original(gitpod) license. This is unnecessary and there is no use case of having separate values for this. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
This PR makes no functionality changes

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
