### PR TITLE
[server-ide] add label to desktop VSCode

### DIFF
--- a/chart/templates/server-ide-configmap.yaml
+++ b/chart/templates/server-ide-configmap.yaml
@@ -56,6 +56,7 @@ options:
     orderKey: "02"
     title: "VS Code"
     type: "desktop"
+    label: "Desktop"
     logo: "https://ide.{{ $.Values.hostname }}/image/ide-logo/vscode.svg"
     image: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.codeDesktop)) }}
     latestImage: {{ (include "gitpod.comp.imageFull" (dict "root" $ "gp" $gp "comp" $gp.components.workspace.desktopIdeImages.codeDesktopInsiders)) }}


### PR DESCRIPTION
## Description

Suggesting that we explicitly add a "DESKTOP" label on VSCode:

**Currently**

<img width="848" alt="Screen Shot 2022-05-10 at 10 16 26 am" src="https://user-images.githubusercontent.com/127353/167518464-5def38f8-d495-42fb-8365-78d03aa0fab4.png">

**Proposed:**

[pending screenshot]

## How to test

Start deployment and check the label is applied.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
