### PR TITLE
Change imagePullPolicy to IfNotPresent

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -73,7 +73,7 @@ pod:
   - name: build
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     resources:
       requests:
         memory: "10Gi"

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -55,7 +55,7 @@ pod:
   - name: build
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: monitoring-satellite-preview-token
       mountPath: /mnt/secrets/monitoring-satellite-preview-token

--- a/.werft/ide-integration-tests-startup-jetbrains.yaml
+++ b/.werft/ide-integration-tests-startup-jetbrains.yaml
@@ -14,7 +14,7 @@ pod:
   - name: gcloud
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
     - name: NODENAME
       valueFrom:

--- a/.werft/ide-integration-tests-startup-vscode.yaml
+++ b/.werft/ide-integration-tests-startup-vscode.yaml
@@ -14,7 +14,7 @@ pod:
   - name: gcloud
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
     - name: NODENAME
       valueFrom:

--- a/.werft/ide-run-integration-tests.yaml
+++ b/.werft/ide-run-integration-tests.yaml
@@ -27,7 +27,7 @@ pod:
   - name: gcloud
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa
@@ -51,7 +51,7 @@ pod:
   - name: tests
     image: eu.gcr.io/gitpod-core-dev/build/integration-tests:{{ .Annotations.version }}
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: config
       mountPath: /config

--- a/.werft/jobs/build/helm/values.dev.yaml
+++ b/.werft/jobs/build/helm/values.dev.yaml
@@ -9,7 +9,7 @@ imagePrefix: eu.gcr.io/gitpod-core-dev/build/
 certificatesSecret:
   secretName: proxy-config-certificates
 version: not-set
-imagePullPolicy: Always
+imagePullPolicy: IfNotPresent
 
 authProviders: []
 

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -26,7 +26,7 @@ pod:
   - name: build
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -24,7 +24,7 @@ pod:
   - name: gcloud
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa
@@ -48,7 +48,7 @@ pod:
   - name: tests
     image: eu.gcr.io/gitpod-core-dev/build/integration-tests:{{ .Annotations.version }}
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: config
       mountPath: /config

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -16,7 +16,7 @@ pod:
   - name: wipe-devstaging
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: gcp-sa
       mountPath: /mnt/secrets/gcp-sa

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -51,7 +51,7 @@ pod:
   - name: tests
     image: eu.gcr.io/gitpod-core-dev/build/integration-tests:{{ .Annotations.version }}
     workingDir: /workspace
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: config
       mountPath: /config


### PR DESCRIPTION
## Description
Change imagePullPolicy from Always to IfNotPresent.
We should minimize the traffic to pull container image from remote container image registry if it's already present in the cluster node.
This could avoid we hit the rate limit of the remote container image registry.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A