### PR TITLE
[Analytics] Fix Dotfile Tracking

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -40,13 +40,15 @@ export default function Preferences() {
     const [dotfileRepo, setDotfileRepo] = useState<string>(user?.additionalData?.dotfileRepo || "");
     const actuallySetDotfileRepo = async (value: string) => {
         const additionalData = user?.additionalData || {};
-        const prevDotfileRepo = additionalData.dotfileRepo;
+        const prevDotfileRepo = additionalData.dotfileRepo || "";
         additionalData.dotfileRepo = value;
         await getGitpodService().server.updateLoggedInUser({ additionalData });
-        trackEvent("dotfile_repo_changed", {
-            previous: prevDotfileRepo,
-            current: value,
-        });
+        if (value !== prevDotfileRepo) {
+            trackEvent("dotfile_repo_changed", {
+                previous: prevDotfileRepo,
+                current: value,
+            });
+        }
     };
 
     return (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
fixes bug that `dotfile_repo_changed` analytics event is sent every time when notifications are stored.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None, see [internal discussion](https://gitpod.slack.com/archives/C01KPEPKX0A/p1650635249151919?thread_ts=1650624816.730479&cid=C01KPEPKX0A) for context

## How to test
<!-- Provide steps to test this PR -->

1. Open a preview environment, sign up, and navigate to preferences
2. click on `Save Changes` without making any changes
3. Go to the [debugger of Staging Untrusted](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and ensure that no `dotfile_repo_changed` analytics event is sent yet
4. go back to prefences, enter something in the text field for Repository URL in the Dotfiles section, and save changes again
5. Ensure that the `dotfile_repo_changed` call is now tirggered by going back to the Segment Debugger once more.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe