### PR TITLE
Clean preview envs after two days of no new commits

### DIFF
--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -311,7 +311,7 @@ async function determineStalePreviewEnvironments(options: {previews: PreviewEnvi
     werft.log(SLICES.CHECKING_FOR_STALE_BRANCHES, `Checking commit activity on ${branches.length} branches`)
     const previewNamespaceBasedOnStaleBranches = new Set(branches
         .filter(branch => {
-            const lastCommit = exec(`git log origin/${branch} --since=$(date +%Y-%m-%d -d "5 days ago")`, { silent: true })
+            const lastCommit = exec(`git log origin/${branch} --since=$(date +%Y-%m-%d -d "2 days ago")`, { silent: true })
             const hasRecentCommits = lastCommit.length > 1
             werft.log(SLICES.CHECKING_FOR_STALE_BRANCHES, `${branch} has-recent-commits=${hasRecentCommits}`)
             return !hasRecentCommits


### PR DESCRIPTION
## Description
To ensure the number of preview envs on our Harvester cluster remains within the limits of our capacity, clean them after two days of no-commit activity instead of five days. 

Once https://github.com/gitpod-io/gitpod/issues/9891 is implemented, we can relax this number again.

## Related Issue(s)
Fixes #

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
