### PR TITLE
Enable git integrations of Bitbucket for self-hosted Gitpod

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -47,6 +47,7 @@ import { StartWorkspaceModal } from "./workspaces/StartWorkspaceModal";
 import { parseProps } from "./start/StartWorkspace";
 import SelectIDEModal from "./settings/SelectIDEModal";
 import { StartPage, StartPhase } from "./start/StartPage";
+import { isGitpodIo } from "./utils";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "./workspaces/Workspaces"));
@@ -84,15 +85,6 @@ const License = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/Lic
 
 function Loading() {
     return <></>;
-}
-
-function isGitpodIo() {
-    return (
-        window.location.hostname === "gitpod.io" ||
-        window.location.hostname === "gitpod-staging.com" ||
-        window.location.hostname.endsWith("gitpod-dev.com") ||
-        window.location.hostname.endsWith("gitpod-io-dev.com")
-    );
 }
 
 function isWebsiteSlug(pathName: string) {

--- a/components/dashboard/src/admin/License.tsx
+++ b/components/dashboard/src/admin/License.tsx
@@ -19,6 +19,7 @@ import { ReactComponent as CheckSvg } from "../images/check.svg";
 import { ReactComponent as LinkSvg } from "../images/external-link.svg";
 import SolidCard from "../components/SolidCard";
 import Card from "../components/Card";
+import { isGitpodIo } from "../utils";
 
 export default function License() {
     const { license, setLicense } = useContext(LicenseContext);
@@ -211,8 +212,4 @@ function communityPlan(userCount: number, seats: number, fallbackAllowed: boolea
     const aboveLimit: boolean = seats === 0 ? false : userCount > seats;
 
     return [licenseLevel("Community"), additionalLicenseInfo("Free"), alertMessage(aboveLimit)];
-}
-
-function isGitpodIo() {
-    return window.location.hostname === "gitpod.io" || window.location.hostname === "gitpod-staging.com";
 }

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -13,6 +13,7 @@ import { getGitpodService } from "../service/service";
 import { adminMenu } from "./admin-menu";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
+import { isGitpodIo } from "../utils";
 
 export default function Settings() {
     const { adminSettings, setAdminSettings } = useContext(AdminContext);
@@ -68,8 +69,4 @@ export default function Settings() {
             </PageWithSubMenu>
         </div>
     );
-}
-
-function isGitpodIo() {
-    return window.location.hostname === "gitpod.io" || window.location.hostname === "gitpod-staging.com";
 }

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -696,11 +696,11 @@ export function GitIntegrationModal(
         return (
             <span>
                 Use this redirect URL to update the OAuth application. Go to{" "}
-                <a href={`https://${settingsUrl}`} target="_blank" rel="noopener" className="gp-link">
+                <a href={`https://${settingsUrl}`} target="_blank" rel="noreferrer noopener" className="gp-link">
                     developer settings
                 </a>{" "}
                 and setup the OAuth application.&nbsp;
-                <a href={docsUrl} target="_blank" rel="noopener" className="gp-link">
+                <a href={docsUrl} target="_blank" rel="noreferrer noopener" className="gp-link">
                     Learn more
                 </a>
                 .
@@ -716,6 +716,8 @@ export function GitIntegrationModal(
                 return "gitlab.example.com";
             case "BitbucketServer":
                 return "bitbucket.example.com";
+            case "Bitbucket":
+                return "bitbucket.org";
             default:
                 return "";
         }
@@ -762,6 +764,7 @@ export function GitIntegrationModal(
                             >
                                 <option value="GitHub">GitHub</option>
                                 <option value="GitLab">GitLab</option>
+                                <option value="Bitbucket">Bitbucket</option>
                                 <option value="BitbucketServer">Bitbucket Server</option>
                             </select>
                         </div>
@@ -785,7 +788,7 @@ export function GitIntegrationModal(
                         </label>
                         <input
                             name="hostName"
-                            disabled={mode === "edit"}
+                            disabled={mode === "edit" || type === "Bitbucket"}
                             type="text"
                             placeholder={getPlaceholderForIntegrationType(type)}
                             value={host}

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -21,6 +21,7 @@ import { PaymentContext } from "../payment-context";
 import { openAuthorizeWindow } from "../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
+import { isGitpodIo } from "../utils";
 import { SelectAccountModal } from "./SelectAccountModal";
 import getSettingsMenu from "./settings-menu";
 
@@ -553,6 +554,13 @@ export function GitIntegrationModal(
         validate();
     }, [clientId, clientSecret, type]);
 
+    // "bitbucket.org" is set as host value whenever "Bitbucket" is selected
+    useEffect(() => {
+        if (props.mode === "new") {
+            updateHostValue(type === "Bitbucket" ? "bitbucket.org" : "");
+        }
+    }, [type]);
+
     const onClose = () => props.onClose && props.onClose();
     const onUpdate = () => props.onUpdate && props.onUpdate();
 
@@ -764,7 +772,7 @@ export function GitIntegrationModal(
                             >
                                 <option value="GitHub">GitHub</option>
                                 <option value="GitLab">GitLab</option>
-                                <option value="Bitbucket">Bitbucket</option>
+                                {!isGitpodIo() && <option value="Bitbucket">Bitbucket</option>}
                                 <option value="BitbucketServer">Bitbucket Server</option>
                             </select>
                         </div>

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -48,3 +48,12 @@ export const poll = async <T>(
         }
     }
 };
+
+export function isGitpodIo() {
+    return (
+        window.location.hostname === "gitpod.io" ||
+        window.location.hostname === "gitpod-staging.com" ||
+        window.location.hostname.endsWith("gitpod-dev.com") ||
+        window.location.hostname.endsWith("gitpod-io-dev.com")
+    );
+}

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from "uuid";
 import { oauthUrls as githubUrls } from "../github/github-urls";
 import { oauthUrls as gitlabUrls } from "../gitlab/gitlab-urls";
 import { oauthUrls as bbsUrls } from "../bitbucket-server/bitbucket-server-urls";
+import { oauthUrls as bbUrls } from "../bitbucket/bitbucket-urls";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
@@ -122,6 +123,9 @@ export class AuthProviderService {
                 break;
             case "BitbucketServer":
                 urls = bbsUrls(host);
+                break;
+            case "Bitbucket":
+                urls = bbUrls(host);
                 break;
         }
         if (!urls) {

--- a/components/server/src/bitbucket/bitbucket-urls.ts
+++ b/components/server/src/bitbucket/bitbucket-urls.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+// cf. https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/
+//
+export function oauthUrls(host: string) {
+    return {
+        authorizationUrl: `https://${host}/site/oauth2/authorize`,
+        tokenUrl: `https://${host}/site/oauth2/access_token`,
+        settingsUrl: `https://${host}/account/settings/app-authorizations/`,
+    };
+}


### PR DESCRIPTION
Fixes #9172

### How to test
1. First, log in using GitHub/GitLab
2. Switch to Integrations and create a custom Git Integration for bitbucket.org

```release-notes
Enable git integrations of Bitbucket for self-hosted Gitpod.
```

### Note for reviewers

Initially the branch of this PR contains an extra commit (3007c911bbdaf58f38df1af33385607e131120fa) which is meant to be removed after testing. 