### PR TITLE
[installer] Separate webapp tracing config from workspace tracing config

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -62,7 +62,7 @@ func DefaultEnv(cfg *config.Config) []corev1.EnvVar {
 	}
 }
 
-func TracingEnv(context *RenderContext) (res []corev1.EnvVar) {
+func WorkspaceTracingEnv(context *RenderContext) (res []corev1.EnvVar) {
 	if context.Config.Observability.Tracing == nil {
 		res = append(res, corev1.EnvVar{Name: "JAEGER_DISABLED", Value: "true"})
 		return

--- a/install/installer/pkg/components/agent-smith/daemonset.go
+++ b/install/installer/pkg/components/agent-smith/daemonset.go
@@ -66,7 +66,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						}},
 						Env: common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
-							common.TracingEnv(ctx),
+							common.WorkspaceTracingEnv(ctx),
 							[]corev1.EnvVar{{
 								Name: "NODENAME",
 								ValueFrom: &corev1.EnvVarSource{

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -112,7 +112,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-								common.TracingEnv(ctx),
+								common.WorkspaceTracingEnv(ctx),
 							),
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      "config",

--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -67,7 +67,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Env: common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
-				common.TracingEnv(ctx),
+				common.WorkspaceTracingEnv(ctx),
 				[]corev1.EnvVar{{
 					Name:  "GRPC_GO_RETRY",
 					Value: "on",

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -151,7 +151,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 						Env: common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
-							common.TracingEnv(ctx),
+							common.WorkspaceTracingEnv(ctx),
 						),
 						Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -232,7 +232,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 						Env: common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
-							common.TracingEnv(ctx),
+							common.WorkspaceTracingEnv(ctx),
 							[]corev1.EnvVar{
 								{
 									Name:  "GRPC_GO_RETRY",

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -74,7 +74,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	env := common.MergeEnv(
 		common.DefaultEnv(&ctx.Config),
 		common.DatabaseEnv(&ctx.Config),
-		common.WorkspaceTracingEnv(ctx),
+		common.WebappTracingEnv(ctx),
 		common.AnalyticsEnv(&ctx.Config),
 		common.MessageBusEnv(&ctx.Config),
 		[]corev1.EnvVar{

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -74,7 +74,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	env := common.MergeEnv(
 		common.DefaultEnv(&ctx.Config),
 		common.DatabaseEnv(&ctx.Config),
-		common.TracingEnv(ctx),
+		common.WorkspaceTracingEnv(ctx),
 		common.AnalyticsEnv(&ctx.Config),
 		common.MessageBusEnv(&ctx.Config),
 		[]corev1.EnvVar{

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -203,7 +203,7 @@ fi
 				}},
 				Env: common.MergeEnv(
 					common.DefaultEnv(&cfg),
-					common.TracingEnv(ctx),
+					common.WorkspaceTracingEnv(ctx),
 					[]corev1.EnvVar{{
 						Name: "NODENAME",
 						ValueFrom: &corev1.EnvVarSource{

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -123,7 +123,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-								common.TracingEnv(ctx),
+								common.WorkspaceTracingEnv(ctx),
 								common.AnalyticsEnv(&ctx.Config),
 								common.MessageBusEnv(&ctx.Config),
 								common.DatabaseEnv(&ctx.Config),

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -54,7 +54,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Env: common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
-				common.TracingEnv(ctx),
+				common.WorkspaceTracingEnv(ctx),
 				[]corev1.EnvVar{{Name: "GRPC_GO_RETRY", Value: "on"}},
 			),
 			VolumeMounts: []corev1.VolumeMount{

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -138,7 +138,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-								common.TracingEnv(ctx),
+								common.WorkspaceTracingEnv(ctx),
 							),
 							ReadinessProbe: &corev1.Probe{
 								InitialDelaySeconds: int32(2),

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -99,6 +99,7 @@ type WebAppConfig struct {
 	Server                 *ServerConfig          `json:"server,omitempty"`
 	ProxyConfig            *ProxyConfig           `json:"proxy,omitempty"`
 	WorkspaceManagerBridge *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
+	Tracing                *Tracing               `json:"tracing,omitempty"`
 	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
 	DisableMigration       bool                   `json:"disableMigration"`
 }


### PR DESCRIPTION
## Description

Currently, the tracing related environment variables `JAEGER_SAMPLER_TYPE` and `JAEGER_SAMPLER_PARAM` are configured under `experimental.workspace.tracing` and are applied to these components:

```
pkg/components/agent-smith/daemonset.go
pkg/components/blobserve/deployment.go
pkg/components/content-service/deployment.go
pkg/components/image-builder-mk3/deployment.go
pkg/components/registry-facade/daemonset.go
pkg/components/server/deployment.go
pkg/components/ws-daemon/daemonset.go
pkg/components/ws-manager-bridge/deployment.go
pkg/components/ws-manager/deployment.go
pkg/components/ws-proxy/deployment.go
```

This PR makes the  `server` component take it's tracing config from a new `experimental.webapp.tracing` config, as it should not (necessarily) use the same config as the the workspace components.

See [this comment](https://github.com/gitpod-io/ops/pull/2197#issuecomment-1121991598).

## Related Issue(s)

Part of #9097 

## How to test
Create an installer config file containing this `experimental` section:

```yaml
experimental:
  webapp:
    tracing:
      samplerType: probabilistic
      samplerParam: 12.5
  workspace:
    tracing:
      samplerType: remote
      samplerParam: 10.5
```

Get a `versions.yaml` for use with the installer:

```
docker run -it --rm "eu.gcr.io/gitpod-core-dev/build/versions:${version}" cat versions.yaml > versions.yaml
```

Then invoke the installer as:

```
go run . render --debug-version-file versions.yaml --config /path/to/config --use-experimental-config
```

The `server` and workspace components will use the correct environment variables from the correct section of the config.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Separate tracing installer config for the server and workspace components
```

## Documentation

None
