### PR TITLE
Validate scopes per client

### DIFF
--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -67,6 +67,9 @@ function createVSCodeClient(protocol: "vscode" | "vscode-insiders"): OAuthClient
             { name: "function:getGitpodTokenScopes" },
             { name: "function:getLoggedInUser" },
             { name: "function:accessCodeSyncStorage" },
+            { name: "function:getOwnerToken" },
+            { name: "function:getWorkspace" },
+            { name: "function:getWorkspaces" },
             { name: "resource:default" },
         ],
     };

--- a/components/server/src/oauth-server/repository.ts
+++ b/components/server/src/oauth-server/repository.ts
@@ -48,6 +48,11 @@ export const inMemoryScopeRepository: OAuthScopeRepository = {
         client: OAuthClient,
         user_id?: string,
     ): Promise<OAuthScope[]> {
-        return scopes;
+        const clientScopes = client.scopes.map((s) => s.name);
+        if (scopes.every((s) => clientScopes.includes(s.name))) {
+            return scopes;
+        }
+
+        throw new Error("Requested scopes not allowed");
     },
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Requesting an oauth token with a scope not listed in the scopes list of a client scopes should fail

## How to test
<!-- Provide steps to test this PR -->
1. Tested directly using gitpod-desktop extension by modifying source code and requesting for an invalid scope

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```