### PR TITLE
[dashboard] Tell users prebuild is uploading

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -340,7 +340,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             return;
         }
 
-        if (workspaceInstance.status.phase === "building" || workspaceInstance.status.phase == "preparing") {
+        if (workspaceInstance.status.phase === "building" || workspaceInstance.status.phase === "preparing") {
             this.setState({ hasImageBuildLogs: true });
         }
 
@@ -567,7 +567,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
             case "stopping":
                 if (isHeadless) {
-                    return <HeadlessWorkspaceView instanceId={this.state.workspaceInstance.id} />;
+                    return (
+                        <HeadlessWorkspaceView
+                            instanceId={this.state.workspaceInstance.id}
+                            title="Uploading the prebuild ..."
+                        />
+                    );
                 }
                 phase = StartPhase.Stopping;
                 statusMessage = (
@@ -717,7 +722,7 @@ function ImageBuildView(props: ImageBuildViewProps) {
     );
 }
 
-function HeadlessWorkspaceView(props: { instanceId: string }) {
+function HeadlessWorkspaceView(props: { instanceId: string; title?: string }) {
     const logsEmitter = new EventEmitter();
 
     useEffect(() => {
@@ -734,7 +739,7 @@ function HeadlessWorkspaceView(props: { instanceId: string }) {
     }, []);
 
     return (
-        <StartPage title="Prebuild in Progress">
+        <StartPage title={props.title || "Prebuild in Progress"}>
             <Suspense fallback={<div />}>
                 <WorkspaceLogs logsEmitter={logsEmitter} />
             </Suspense>


### PR DESCRIPTION
## Description
Tell users that a workspace is uploading

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
