### PR TITLE
Run cleanup job on each Werft build node

### DIFF
--- a/.werft/platform-clean-up-werft-build-node.yaml
+++ b/.werft/platform-clean-up-werft-build-node.yaml
@@ -1,3 +1,14 @@
+#
+# This job is responsible for cleaning up a single Werft build node.
+#
+# The nodeAffinity ensures this is executed on a specific node and we rely on
+# volume mounts for getting access to the disk
+#
+# This job is being triggered for each build node periodically by .werft/platform-trigger-werft-cleanup.yaml
+# but you can also run it manually for a specific node like so:
+#
+# werft job run github -j .werft/platform-clean-up-werft-build-node.yaml -a node=gke-core-dev-builds-0-294352e4-mxkv
+#
 pod:
   serviceAccount: werft
   affinity:
@@ -5,10 +16,10 @@ pod:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: dev/workload
+              - key: "kubernetes.io/hostname"
                 operator: In
                 values:
-                  - "builds"
+                  - "{{ .Annotations.node }}"
   volumes:
     - name: werft-build-caches
       hostPath:
@@ -43,5 +54,3 @@ pod:
 
           werft log phase werft-build-cache-prune "Cleaning up Werft build caches older than 12 hours"
           find /werft-build-caches/* -maxdepth 0 -mmin +720 -print -exec sudo rm -rf "{}" \; | werft log slice werft-build-cache-prune
-plugins:
-  cron: "@midnight"

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -1,0 +1,68 @@
+#
+# This job is responsible for triggering the .werft/platform-clean-up-werft-build-node.yaml job
+# for each node that has the dev/workload label set to "builds"
+#
+# It is a Werft cron job that runs periodically but you can always manually trigger it using
+#
+# werft job run github -j .werft/platform-trigger-werft-cleanup.yaml
+#
+pod:
+  serviceAccount: werft
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: dev/workload
+                operator: In
+                values:
+                  - "builds"
+  volumes:
+    # Needed to install the core-dev kubectl context to talk to Werft
+    - name: gcp-sa
+      secret:
+        secretName: gcp-sa-gitpod-dev-deployer
+  containers:
+    - name: build
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-werft-cred.0
+      workingDir: /workspace
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: WERFT_K8S_NAMESPACE
+          value: werft
+        - name: WERFT_DIAL_MODE
+          value: kubernetes
+        - name: WERFT_CREDENTIAL_HELPER
+          value: ""
+      volumeMounts:
+        - name: gcp-sa
+          mountPath: /mnt/secrets/gcp-sa
+          readOnly: true
+      command:
+        - bash
+        - -c
+        - |
+          sleep 1
+          set -Eeuo pipefail
+
+          # This is needed to run Werft jobs from Github
+          sudo chown -R gitpod:gitpod /workspace
+          git config --global user.name roboquat
+          git config --global user.email roboquat@gitpod.io
+
+          # Install core-dev context
+          gcloud auth activate-service-account --key-file "/mnt/secrets/gcp-sa/service-account.json"
+          gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev
+
+          echo "[Triggering clean up jobs|PHASE] Triggering the cleanup job for each node"
+
+          nodes=$(kubectl get nodes -l dev/workload=builds --no-headers -o custom-columns=":metadata.name")
+
+          for node in $nodes ; do
+            echo "[Cleanup up node $node] Triggering the cleanup job for $node"
+            werft job run github -j .werft/platform-clean-up-werft-build-node.yaml -a node="$node" \
+            | werft log slice "Cleanup up node $node"
+            echo "[Cleanup up node $node|DONE]"
+          done
+plugins:
+  cron: "@midnight"


### PR DESCRIPTION
/werft no-preview

## Description

This ensure we run the cleanup logic on each build node by splitting the job into two, one to perform the cleanup logic, and one to trigger it for each node.

1. Renamed `platform-clean-up-werft-build-nodes.yaml` to `platform-clean-up-werft-build-node.yaml` (singular) and changed the job spec so that the nodeAffinity is based on a job annotation.
1. Introduced a new job `.werft/platform-trigger-werft-cleanup.yaml` which lists all nodes with `dev/workload` label set to `builds` and triggers the `platform-clean-up-werft-build-node.yaml` job for that node.

In a follow up PR we'll change the `platform-clean-up-werft-build-node.yaml` to cordon the node if it is running too low on disk.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/2050

## How to test
<!-- Provide steps to test this PR -->

As described in the comments in the Werft job specs. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A