### PR TITLE
fix grpc proto generation

### DIFF
--- a/scripts/protoc-generator.sh
+++ b/scripts/protoc-generator.sh
@@ -7,10 +7,6 @@
 install_dependencies() {
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
 
-    go get google.golang.org/protobuf/runtime/protoimpl@v1.28.0
-    go get google.golang.org/protobuf/reflect/protoreflect@v1.28.0
-	go get google.golang.org/protobuf/types/known/timestamppb@v1.28.0
-
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
     go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
```
gitpod /workspace/gitpod/components/content-service-api (pavel/9469) $ ./generate.sh 
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
This fixes this type of error when trying to run `generate.sh`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Run `generate.sh` for components that have `.proto` files

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
