### PR TITLE
Enable build cache for gradle tasks and run them in parallel when possible, to reduce their duration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,9 +37,8 @@ tasks:
       exit 0
   - name: Java
     init: |
-      leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
-      leeway exec --package components/ide/jetbrains/backend-plugin:plugin -- ./gradlew buildPlugin
-      leeway exec --package components/ide/jetbrains/gateway-plugin:publish -- ./gradlew buildPlugin
+      leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew --build-cache build
+      leeway exec --package components/ide/jetbrains/backend-plugin:plugin --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew --build-cache buildPlugin
   - name: TypeScript
     before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Enable build cache for gradle tasks and run them in parallel when possible, to reduce their duration.

Reference: [Gradle Docs: Enable the Build Cache](https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_enable)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/issues/9874

## How to test
<!-- Provide steps to test this PR -->
Observe the Prebuild logs on Gitpod Dashboard and compare with previous ones. The Java tasks should be a little bit faster.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.