### PR TITLE
[public-api] Add network policy to allow connections from proxy

### DIFF
--- a/install/installer/pkg/components/public-api-server/networkpolicy.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package public_api_server
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.DefaultLabels(Component)
+
+	return []runtime.Object{
+		&networkingv1.NetworkPolicy{
+			TypeMeta: common.TypeMetaNetworkPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: labels},
+				PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: HTTPContainerPort},
+							},
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: GRPCContainerPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.ProxyComponent,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/public-api-server/networkpolicy_test.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.package public_api_server
+package public_api_server
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"testing"
+)
+
+func TestNetworkPolicy(t *testing.T) {
+	objects, err := networkpolicy(renderContextWithPublicAPIEnabled(t))
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+
+	policy, ok := objects[0].(*networkingv1.NetworkPolicy)
+	require.Truef(t, ok, "must cast object to network policy")
+
+	ingress := policy.Spec.Ingress
+	require.Len(t, ingress, 1, "must have only one ingress rule")
+
+	require.Equal(t, networkingv1.NetworkPolicyIngressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			{
+				Protocol: common.TCPProtocol,
+				Port:     &intstr.IntOrString{IntVal: HTTPContainerPort},
+			},
+			{
+				Protocol: common.TCPProtocol,
+				Port:     &intstr.IntOrString{IntVal: GRPCContainerPort},
+			},
+		},
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"component": common.ProxyComponent,
+					},
+				},
+			},
+		},
+	}, ingress[0])
+}

--- a/install/installer/pkg/components/public-api-server/objects.go
+++ b/install/installer/pkg/components/public-api-server/objects.go
@@ -22,6 +22,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		rolebinding,
 		common.DefaultServiceAccount(Component),
 		service,
+		networkpolicy,
 	)(ctx)
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Without this, proxy cannot reach the public api over k8s SRV records which are used as a reverse proxy target by caddy

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE
