### PR TITLE
ws-daemon: Record the signal when terminating.

### DIFF
--- a/components/ws-daemon/cmd/run.go
+++ b/components/ws-daemon/cmd/run.go
@@ -134,13 +134,13 @@ var runCmd = &cobra.Command{
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 		log.Info("🧫 ws-daemon is up and running. Stop with SIGINT or CTRL+C")
-		<-sigChan
+		receiveSig := <-sigChan
 		server.Stop()
 		err = dmn.Stop()
 		if err != nil {
 			log.WithError(err).Error("cannot shut down gracefully")
 		}
-		log.Info("Received SIGINT - shutting down")
+		log.Infof("Received %s - shutting down", receiveSig.String())
 	},
 }
 


### PR DESCRIPTION
## Description
ws-daemon: Record the signal when terminating. Since it is unclear whether it is really sigint.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate: https://github.com/gitpod-io/gitpod/issues/9893#issue-1230919250

## How to test
<!-- Provide steps to test this PR -->
* Pass the tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
* No
