### PR TITLE
[public-api] Add role binding for kube-rbac-proxy to auth metric scrapes

### DIFF
--- a/install/installer/pkg/components/public-api-server/rolebinding.go
+++ b/install/installer/pkg/components/public-api-server/rolebinding.go
@@ -15,21 +15,42 @@ import (
 )
 
 func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return []runtime.Object{&rbacv1.RoleBinding{
-		TypeMeta: common.TypeMetaRoleBinding,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    common.DefaultLabels(Component),
+	labels := common.DefaultLabels(Component)
+
+	return []runtime.Object{
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: common.TypeMetaClusterRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("%s-%s-rb-kube-rbac-proxy", ctx.Namespace, Component),
+				Labels: labels,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     fmt.Sprintf("%s-kube-rbac-proxy", ctx.Namespace),
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      Component,
+				Namespace: ctx.Namespace,
+			}},
 		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
-			APIGroup: "rbac.authorization.k8s.io",
+		&rbacv1.RoleBinding{
+			TypeMeta: common.TypeMetaRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    common.DefaultLabels(Component),
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind: "ServiceAccount",
+				Name: Component,
+			}},
 		},
-		Subjects: []rbacv1.Subject{{
-			Kind: "ServiceAccount",
-			Name: Component,
-		}},
-	}}, nil
+	}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`kube-rbac-proxy` conatiner in `public-api-server` pod is throwing:
```
E0511 07:01:22.113210       1 webhook.go:111] Failed to make webhook authenticator request: tokenreviews.authentication.k8s.io is forbidden: User "system:serviceaccount:default:public-api-server" cannot create resource "tokenreviews" in API group "authentication.k8s.io" at the cluster scope
E0511 07:01:22.113274       1 proxy.go:73] Unable to authenticate the request due to an error: tokenreviews.authentication.k8s.io is forbidden: User "system:serviceaccount:default:public-api-server" cannot create resource "tokenreviews" in API group "authentication.k8s.io" at the cluster scope
```
That's because there's a missing role binding, this PR adds it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE