### PR TITLE
[bridge] Fix wrong mapping of WorkspaceStatus to prebuild when "snapshot" is missing

### DIFF
--- a/components/ws-manager-bridge/BUILD.yaml
+++ b/components/ws-manager-bridge/BUILD.yaml
@@ -4,6 +4,7 @@ packages:
     srcs:
       - "**/*.ts"
       - package.json
+      - mocha.opts
     deps:
       - components/content-service-api/typescript:lib
       - components/gitpod-db:lib
@@ -16,7 +17,8 @@ packages:
       packaging: offline-mirror
       yarnLock: ${coreYarnLockBase}/yarn.lock
       tsconfig: tsconfig.json
-      dontTest: true
+      commands:
+        test: ["yarn", "test"]
   - name: docker
     type: docker
     deps:

--- a/components/ws-manager-bridge/mocha.opts
+++ b/components/ws-manager-bridge/mocha.opts
@@ -1,0 +1,6 @@
+--require ts-node/register
+--require reflect-metadata/Reflect
+--require source-map-support/register
+--reporter spec
+--watch-extensions ts
+--exit

--- a/components/ws-manager-bridge/package.json
+++ b/components/ws-manager-bridge/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node ./dist/src/index.js",
     "start-ee": "node ./dist/ee/src/index.js",
+    "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
     "prepare": "yarn clean && yarn build",
     "build": "npx tsc",
     "build:clean": "yarn clean && yarn build",
@@ -36,8 +37,15 @@
   },
   "devDependencies": {
     "@types/amqplib": "^0.8.2",
+    "@types/chai": "^4.2.21",
     "@types/express": "^4.17.13",
     "@types/google-protobuf": "^3.7.4",
+    "@types/mocha": "^2.2.45",
+    "chai": "^4.3.4",
+    "expect": "^1.20.2",
+    "mocha": "^5.0.0",
+    "mocha-typescript": "^1.1.11",
+    "ts-node": "<7.0.0",
     "tslint": "^5.9.1",
     "typescript": "~4.4.2",
     "watch": "^1.0.2"

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -33,6 +33,7 @@ import { MetaInstanceController } from "./meta-instance-controller";
 import { IClientCallMetrics } from "@gitpod/content-service/lib/client-call-metrics";
 import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
 import { PreparingUpdateEmulator, PreparingUpdateEmulatorFactory } from "./preparing-update-emulator";
+import { PrebuildStateMapper } from "./prebuild-state-mapper";
 
 export const containerModule = new ContainerModule((bind) => {
     bind(MessagebusConfiguration).toSelf().inSingletonScope();
@@ -80,4 +81,6 @@ export const containerModule = new ContainerModule((bind) => {
 
     bind(PreparingUpdateEmulator).toSelf().inRequestScope();
     bind(PreparingUpdateEmulatorFactory).toAutoFactory(PreparingUpdateEmulator);
+
+    bind(PrebuildStateMapper).toSelf().inSingletonScope();
 });

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "mocha-typescript";
+import * as chai from "chai";
+import { PrebuildStateMapper } from "./prebuild-state-mapper";
+import { WorkspaceConditionBool, WorkspacePhase, WorkspaceStatus } from "@gitpod/ws-manager/lib";
+import { PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
+
+const expect = chai.expect;
+
+@suite
+class TestPrebuildStateMapper {
+    @test public testAll() {
+        const id = "12345";
+        const snapshot = "some-valid-snapshot";
+        const failed = "some system error";
+        const headlessTaskFailed = "some user/content error";
+
+        const table: {
+            name: string;
+            status: Pick<WorkspaceStatus.AsObject, "id" | "phase"> & {
+                conditions: Partial<WorkspaceStatus.AsObject["conditions"]>;
+            };
+            expected: (Omit<Partial<PrebuiltWorkspace>, "error"> & { hasError?: boolean }) | undefined;
+        }[] = [
+            {
+                name: "STOPPED",
+                expected: undefined,
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPED,
+                    conditions: {
+                        snapshot,
+                    },
+                },
+            },
+            {
+                name: "failed",
+                expected: {
+                    state: "failed",
+                    hasError: true,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        failed,
+                    },
+                },
+            },
+            {
+                name: "failed - no snapshot",
+                expected: {
+                    state: "failed",
+                    hasError: true,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        snapshot: "",
+                    },
+                },
+            },
+            {
+                name: "aborted",
+                expected: {
+                    state: "aborted",
+                    hasError: true,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        stoppedByRequest: WorkspaceConditionBool.TRUE,
+                    },
+                },
+            },
+            {
+                name: "user/content error",
+                expected: {
+                    state: "available",
+                    hasError: true,
+                    snapshot,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        headlessTaskFailed,
+                        snapshot,
+                    },
+                },
+            },
+            {
+                name: "available and no error",
+                expected: {
+                    state: "available",
+                    hasError: false,
+                    snapshot,
+                },
+                status: {
+                    id,
+                    phase: WorkspacePhase.STOPPING,
+                    conditions: {
+                        snapshot,
+                    },
+                },
+            },
+        ];
+
+        for (const test of table) {
+            const cut = new PrebuildStateMapper();
+            const actual = cut.mapWorkspaceStatusToPrebuild(test.status as WorkspaceStatus.AsObject);
+            expect(!!actual?.update.error, test.name + ": hasError").to.be.equal(!!test.expected?.hasError);
+            delete actual?.update.error;
+            delete test.expected?.hasError;
+            expect(actual?.update, test.name).to.deep.equal(test.expected);
+        }
+    }
+}
+module.exports = new TestPrebuildStateMapper(); // Only to circumvent no usage warning :-/

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { HeadlessWorkspaceEventType, PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { WorkspacePhase, WorkspaceStatus } from "@gitpod/ws-manager/lib";
+import { injectable } from "inversify";
+
+export interface PrebuildUpdate {
+    type: HeadlessWorkspaceEventType;
+    update: Partial<PrebuiltWorkspace>;
+}
+
+@injectable()
+export class PrebuildStateMapper {
+    mapWorkspaceStatusToPrebuild(status: WorkspaceStatus.AsObject): PrebuildUpdate | undefined {
+        if (status.phase === WorkspacePhase.STOPPED) {
+            // Ideally, we'd love to hande STOPPED identical to STOPPING, because we want to assume that all conditions are stable.
+            // For reliabilies sake we don't do it because experiences shows that unstable conditions are one of the most common sources of errors.
+            return undefined;
+        }
+
+        if (status.phase === WorkspacePhase.STOPPING) {
+            if (!!status.conditions!.timeout) {
+                return {
+                    type: HeadlessWorkspaceEventType.AbortedTimedOut,
+                    update: {
+                        state: "timeout",
+                        error: status.conditions!.timeout,
+                    },
+                };
+            } else if (!!status.conditions!.failed) {
+                return {
+                    type: HeadlessWorkspaceEventType.Failed,
+                    update: {
+                        state: "failed",
+                        error: status.conditions!.failed,
+                    },
+                };
+            } else if (!!status.conditions!.stoppedByRequest) {
+                return {
+                    type: HeadlessWorkspaceEventType.Aborted,
+                    update: {
+                        state: "aborted",
+                        error: "Cancelled",
+                    },
+                };
+            } else if (!!status.conditions!.headlessTaskFailed) {
+                const result: PrebuildUpdate = {
+                    type: HeadlessWorkspaceEventType.FinishedButFailed,
+                    update: {
+                        state: "available",
+                        snapshot: status.conditions!.snapshot,
+                        error: status.conditions!.headlessTaskFailed,
+                    },
+                };
+                return result;
+            } else if (!!status.conditions!.snapshot) {
+                return {
+                    type: HeadlessWorkspaceEventType.FinishedSuccessfully,
+                    update: {
+                        state: "available",
+                        snapshot: status.conditions!.snapshot,
+                    },
+                };
+            } else if (!status.conditions!.snapshot) {
+                // STOPPING && no snapshot? Definitely an error case
+                return {
+                    type: HeadlessWorkspaceEventType.Failed,
+                    update: {
+                        state: "failed",
+                        error: "error while taking snapshot",
+                    },
+                };
+            } else {
+                log.error({ instanceId: status.id }, "unhandled prebuild status update", {
+                    phase: status.phase,
+                    conditions: status.phase,
+                });
+                return undefined;
+            }
+        }
+
+        return {
+            type: HeadlessWorkspaceEventType.Started,
+            update: {
+                state: "building",
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Description
Does what is says in the title, plus adding tests for the mapping. :lotus_position: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9676

## How to test
 1. `cd components/ws-manager-bridge && yarn test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix prebuild state mapping bug in face of missing snapshot (& add tests for it)
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
