### PR TITLE
[prebuilds] no prebuilds for inactive repos

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -356,6 +356,22 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         return workspaceRepo.find({ ownerId: userId });
     }
 
+    public async getWorkspaceCountByCloneURL(
+        cloneURL: string,
+        sinceLastDays: number = 7,
+        type: string = "regular",
+    ): Promise<number> {
+        const workspaceRepo = await this.getWorkspaceRepo();
+        const since = new Date();
+        since.setDate(since.getDate() - sinceLastDays);
+        return workspaceRepo
+            .createQueryBuilder("ws")
+            .where('context->"$.repository.cloneUrl" = :cloneURL', { cloneURL })
+            .andWhere("creationTime > :since", { since: since.toISOString() })
+            .andWhere("type = :type", { type })
+            .getCount();
+    }
+
     public async findCurrentInstance(workspaceId: string): Promise<MaybeWorkspaceInstance> {
         const workspaceInstanceRepo = await this.getWorkspaceInstanceRepo();
         const qb = workspaceInstanceRepo

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -9,7 +9,7 @@ const expect = chai.expect;
 import { suite, test, timeout } from "mocha-typescript";
 import { fail } from "assert";
 
-import { WorkspaceInstance, Workspace, PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
+import { WorkspaceInstance, Workspace, PrebuiltWorkspace, CommitContext } from "@gitpod/gitpod-protocol";
 import { testContainer } from "./test-container";
 import { TypeORMWorkspaceDBImpl } from "./typeorm/workspace-db-impl";
 import { TypeORM } from "./typeorm/typeorm";
@@ -537,6 +537,52 @@ class WorkspaceDBSpec {
         const minuteAgo = secondsBefore(now.toISOString(), 60);
         const unabortedCount = await this.db.countUnabortedPrebuildsSince(cloneURL, new Date(minuteAgo));
         expect(unabortedCount).to.eq(1);
+    }
+
+    @test(timeout(10000))
+    public async testGetWorkspaceCountForCloneURL() {
+        const now = new Date();
+        const eightDaysAgo = new Date();
+        eightDaysAgo.setDate(eightDaysAgo.getDate() - 8);
+        const activeRepo = "http://github.com/myorg/active.git";
+        const inactiveRepo = "http://github.com/myorg/inactive.git";
+        await Promise.all([
+            this.db.store({
+                id: "12345",
+                creationTime: eightDaysAgo.toISOString(),
+                description: "something",
+                contextURL: "http://github.com/myorg/inactive",
+                ownerId: "1221423",
+                context: <CommitContext>{
+                    title: "my title",
+                    repository: {
+                        cloneUrl: inactiveRepo,
+                    },
+                },
+                config: {},
+                type: "regular",
+            }),
+            this.db.store({
+                id: "12346",
+                creationTime: now.toISOString(),
+                description: "something",
+                contextURL: "http://github.com/myorg/active",
+                ownerId: "1221423",
+                context: <CommitContext>{
+                    title: "my title",
+                    repository: {
+                        cloneUrl: activeRepo,
+                    },
+                },
+                config: {},
+                type: "regular",
+            }),
+        ]);
+
+        const inactiveCount = await this.db.getWorkspaceCountByCloneURL(inactiveRepo, 7, "regular");
+        expect(inactiveCount).to.eq(0, "there should be no regular workspaces in the past 7 days");
+        const activeCount = await this.db.getWorkspaceCountByCloneURL(activeRepo, 7, "regular");
+        expect(activeCount).to.eq(1, "there should be exactly one regular workspace");
     }
 
     private async storePrebuiltWorkspace(pws: PrebuiltWorkspace) {

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -125,6 +125,7 @@ export interface WorkspaceDB {
     findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
+    getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;
     getInstanceCount(type?: string): Promise<number>;
 
     findAllWorkspaceInstances(

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -195,6 +195,11 @@ export class PrebuildManager {
                 prebuild.error =
                     "Project is inactive. Please start a new workspace for this project to re-enable prebuilds.";
                 await this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild);
+            } else if (!project && (await this.shouldSkipInactiveRepository({ span }, cloneURL))) {
+                prebuild.state = "aborted";
+                prebuild.error =
+                    "Repository is inactive. Please create a project for this repository to re-enable prebuilds.";
+                await this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild);
             } else {
                 span.setTag("starting", true);
                 const projectEnvVars = await projectEnvVarsPromise;
@@ -355,5 +360,19 @@ export class PrebuildManager {
         const lastUse = new Date(usage.lastWorkspaceStart).getTime();
         const inactiveProjectTime = 1000 * 60 * 60 * 24 * 7 * 1; // 1 week
         return now - lastUse > inactiveProjectTime;
+    }
+
+    private async shouldSkipInactiveRepository(ctx: TraceContext, cloneURL: string): Promise<boolean> {
+        const span = TraceContext.startSpan("shouldSkipInactiveRepository", ctx);
+        try {
+            return (
+                (await this.workspaceDB
+                    .trace({ span })
+                    .getWorkspaceCountByCloneURL(cloneURL, 7 /* last week */, "regular")) === 0
+            );
+        } catch (error) {
+            log.error("cannot compute activity for repository", { cloneURL }, error);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Description
This change prevents prebuilds for repositories that have been inactive (no regular workspace starts) for at least a week.
This would have prevented 98835 unnecessary prebuilds in the last 11 days (vs. 28174 prebuilds on repos without projects that are still active).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See also my comment here https://github.com/gitpod-io/gitpod/issues/9898#issuecomment-1123787585

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```