### PR TITLE
Only end the span if it exists

### DIFF
--- a/.werft/util/werft.ts
+++ b/.werft/util/werft.ts
@@ -71,6 +71,13 @@ export class Werft {
      */
     public fail(slice, err) {
         const span = this.sliceSpans[slice];
+
+        if (span) {
+            span.end()
+        } else {
+            console.log(`[${slice}] tracing warning: No slice span by name ${slice}`)
+        }
+
         // Set the status on the span for the slice and also propagate the status to the phase and root span
         // as well so we can query on all phases that had an error regardless of which slice produced the error.
         [span, this.rootSpan, this.currentPhaseSpan].forEach((span: Span) => {
@@ -82,8 +89,6 @@ export class Werft {
                 message: err
             })
         })
-
-        span.end()
 
         console.log(`[${slice}|FAIL] ${err}`);
         throw err;


### PR DESCRIPTION
## Description

If you call werft.fail with a slice ID that doesn't exist we currently produce an unhelpful stack trace. This fixes that so we log a warning to the slice instead.

See example here: https://werft.gitpod-io-dev.com/job/ops-custom-main.1657

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A