### PR TITLE
[kots] Fix typo in the s3 storage secret name

### DIFF
--- a/install/kots/manifests/gitpod-storage-s3-secret.yaml
+++ b/install/kots/manifests/gitpod-storage-s3-secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: storage-azure
+  name: storage-s3
   labels:
     app: gitpod
     component: gitpod-installer

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -242,18 +242,18 @@ spec:
           help_text: The endpoint used to connect to the S3 storage.
 
         - name: store_s3_access_key_id
-          title: Username
+          title: Access Key
           type: text
           required: true
           when: '{{repl (ConfigOptionEquals "store_provider" "s3") }}'
-          help_text: The username that has access to the S3 account. In AWS, this is an IAM user's credentials with `AmazonS3FullAccess` policy.
+          help_text: Access key of IAM user's credentials with `AmazonS3FullAccess` policy.
 
         - name: store_s3_secret_access_key
-          title: Password
+          title: Secret Key
           type: password
           required: true
           when: '{{repl (ConfigOptionEquals "store_provider" "s3") }}'
-          help_text: The password that has access to the S3 account. In AWS, this is an IAM user's credentials with `AmazonS3FullAccess` policy.
+          help_text: Secret key of IAM user's credentials with `AmazonS3FullAccess` policy.
 
     - name: certs
       title: TLS certificates


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`storage-s3` is miswritten as `storage-azure`, causing s3
to not work in the `kots` setup. This fixes that issue, while
also renaming the help fields to be less confusing and more
specific to aws.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fix https://github.com/gitpod-io/gitpod/issues/9911

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] Fix issue with s3 object storage
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
