### PR TITLE
[ws-daemon] fix restore from snapshot not working

### DIFF
--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -192,7 +192,7 @@ func (rs *DirectGCPStorage) download(ctx context.Context, destination string, bk
 
 	rc, _, err := rs.ObjectAccess(ctx, bkt, obj)
 	if rc == nil {
-		return false, nil
+		return false, err
 	}
 	defer rc.Close()
 

--- a/components/content-service/pkg/storage/minio.go
+++ b/components/content-service/pkg/storage/minio.go
@@ -205,7 +205,7 @@ func (rs *DirectMinIOStorage) download(ctx context.Context, destination string, 
 
 	rc, err := rs.ObjectAccess(ctx, bkt, obj)
 	if rc == nil {
-		return false, nil
+		return false, err
 	}
 	defer rc.Close()
 

--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -77,7 +77,19 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 		rc[storage.DefaultBackup] = *backup
 	}
 
-	if si := initializer.GetSnapshot(); si != nil {
+	si := initializer.GetSnapshot()
+	pi := initializer.GetPrebuild()
+	if ci := initializer.GetComposite(); ci != nil {
+		for _, c := range ci.Initializer {
+			if c.GetSnapshot() != nil {
+				si = c.GetSnapshot()
+			}
+			if c.GetPrebuild() != nil {
+				pi = c.GetPrebuild()
+			}
+		}
+	}
+	if si != nil {
 		bkt, obj, err := storage.ParseSnapshotName(si.Snapshot)
 		if err != nil {
 			return nil, err
@@ -92,8 +104,8 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 
 		rc[si.Snapshot] = *info
 	}
-	if si := initializer.GetPrebuild(); si != nil && si.Prebuild != nil && si.Prebuild.Snapshot != "" {
-		bkt, obj, err := storage.ParseSnapshotName(si.Prebuild.Snapshot)
+	if pi != nil && pi.Prebuild != nil && pi.Prebuild.Snapshot != "" {
+		bkt, obj, err := storage.ParseSnapshotName(pi.Prebuild.Snapshot)
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +115,7 @@ func collectRemoteContent(ctx context.Context, rs storage.DirectAccess, ps stora
 		} else if err != nil {
 			return nil, xerrors.Errorf("cannot find prebuild: %w", err)
 		} else {
-			rc[si.Prebuild.Snapshot] = *info
+			rc[pi.Prebuild.Snapshot] = *info
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixed restore from snapshot not working due to not handling composite initializers correctly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9244 

## How to test
<!-- Provide steps to test this PR -->
Open this repo in gitpod: https://github.com/jldec/date-plus
Create snapshot.
Open new repo from that snapshot.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-daemon] fix restore from snapshot not working
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
