### PR TITLE
Expose a new environment variable `JETBRAINS_GITPOD_WORKSPACE_HOST` to be displayed on JB IDE Hostname widget

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
@@ -13,7 +13,7 @@ import javax.swing.Icon
 
 class GitpodGatewayClientCustomizationProvider : GatewayClientCustomizationProvider {
     override val icon: Icon = GitpodIcons.Logo
-    override val title: String = DefaultGatewayControlCenterProvider().getHostnameShort()
+    override val title: String = System.getenv("JETBRAINS_GITPOD_WORKSPACE_HOST") ?: DefaultGatewayControlCenterProvider().getHostnameShort()
 
     override val controlCenter: GatewayControlCenterProvider = object : GatewayControlCenterProvider {
         override fun getHostnameDisplayKind() = GatewayHostnameDisplayKind.ShowHostnameOnNavbar
@@ -21,4 +21,3 @@ class GitpodGatewayClientCustomizationProvider : GatewayClientCustomizationProvi
         override fun getHostnameLong() = title
     }
 }
-

--- a/components/ide/jetbrains/image/status/main.go
+++ b/components/ide/jetbrains/image/status/main.go
@@ -225,6 +225,10 @@ func run(wsInfo *supervisor.WorkspaceInfoResponse) {
 	args = append(args, "run")
 	args = append(args, wsInfo.GetCheckoutLocation())
 	cmd := remoteDevServerCmd(args)
+	workspaceUrl, err := url.Parse(wsInfo.WorkspaceUrl)
+	if err == nil {
+		cmd.Env = append(cmd.Env, "JETBRAINS_GITPOD_WORKSPACE_HOST="+workspaceUrl.Hostname())
+	}
 	// Enable host status endpoint
 	cmd.Env = append(cmd.Env, "CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod")
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Expose a new environment variable `JETBRAINS_GITPOD_WORKSPACE_HOST` to be displayed on JB IDE Hostname widget.

![image](https://user-images.githubusercontent.com/418083/168123001-043cb638-0769-4554-bb18-ef0093db264d.png)

Note: The screenshot above is from the Preview Environment, but on production, the hostname will be something like this: `gitpodio-gitpod-khhiqub2fgv.ws-us43xl.gitpod.io`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #9814

## How to test
<!-- Provide steps to test this PR -->
- Open a new workspace on Preview Environment of this PR in IntelliJ: https://vn-9814.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/gitpod/pull/9949
- Check if the Hostname Widget on top-left of JB IDE is displaying the correct hostname, which should be the same value of the new exposed environment variable `JETBRAINS_GITPOD_WORKSPACE_HOST`.
  - `$ env | grep JETBRAINS_GITPOD_WORKSPACE_HOST`
  - <img width="760" alt="image" src="https://user-images.githubusercontent.com/418083/168123768-cc08a41f-a454-470d-b294-feeb3b197a51.png">



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.