### PR TITLE
[workspacekit] improve logging when not able to connect to daemon

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -73,7 +73,7 @@ var ring0Cmd = &cobra.Command{
 
 		client, err := connectToInWorkspaceDaemonService(ctx)
 		if err != nil {
-			log.WithError(err).Error("cannot connect to daemon")
+			log.WithError(err).Error("cannot connect to daemon from ring0")
 			return
 		}
 
@@ -90,7 +90,7 @@ var ring0Cmd = &cobra.Command{
 
 			client, err := connectToInWorkspaceDaemonService(ctx)
 			if err != nil {
-				log.WithError(err).Error("cannot connect to daemon")
+				log.WithError(err).Error("cannot connect to daemon from ring0 in defer")
 				return
 			}
 			defer client.Close()
@@ -204,7 +204,7 @@ var ring1Cmd = &cobra.Command{
 		if !ring1Opts.MappingEstablished {
 			client, err := connectToInWorkspaceDaemonService(ctx)
 			if err != nil {
-				log.WithError(err).Error("cannot connect to daemon")
+				log.WithError(err).Error("cannot connect to daemon from ring1 when mappings not established")
 				return
 			}
 			defer client.Close()
@@ -397,7 +397,7 @@ var ring1Cmd = &cobra.Command{
 
 		client, err := connectToInWorkspaceDaemonService(ctx)
 		if err != nil {
-			log.WithError(err).Error("cannot connect to daemon")
+			log.WithError(err).Error("cannot connect to daemon from ring1")
 			return
 		}
 		_, err = client.MountProc(ctx, &daemonapi.MountProcRequest{
@@ -466,7 +466,7 @@ var ring1Cmd = &cobra.Command{
 
 		client, err = connectToInWorkspaceDaemonService(ctx)
 		if err != nil {
-			log.WithError(err).Error("cannot connect to daemon")
+			log.WithError(err).Error("cannot connect to daemon from ring1 after ring2")
 			return
 		}
 		_, err = client.SetupPairVeths(ctx, &daemonapi.SetupPairVethsRequest{Pid: int64(cmd.Process.Pid)})


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Improves logging to better understand when we fail to connect to daemon from workspacekit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/9835

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
