### PR TITLE
[gitpod-db] fix tables.ts

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -263,7 +263,7 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_team_subscription2;",
+            name: "d_b_team_subscription2",
             primaryKeys: ["id"],
             deletionColumn: "deleted",
             timeColumn: "_lastModified",


### PR DESCRIPTION
Fix a typo in the `GitpodTableDescriptionProvider` (aka tables.ts)

```release-notes
NONE
```