### PR TITLE
[baseserver] gRPC Health service

### DIFF
--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"testing"
 	"time"
 )
@@ -21,6 +22,7 @@ func TestOptions(t *testing.T) {
 	hostname := "another_hostname"
 	registry := prometheus.NewRegistry()
 	health := healthcheck.NewHandler()
+	grpcHealthService := &grpc_health_v1.UnimplementedHealthServer{}
 
 	var opts = []Option{
 		WithHostname(hostname),
@@ -30,6 +32,7 @@ func TestOptions(t *testing.T) {
 		WithCloseTimeout(timeout),
 		WithMetricsRegistry(registry),
 		WithHealthHandler(health),
+		WithGRPCHealthService(grpcHealthService),
 	}
 	cfg, err := evaluateOptions(defaultConfig(), opts...)
 	require.NoError(t, err)
@@ -42,6 +45,7 @@ func TestOptions(t *testing.T) {
 		closeTimeout:    timeout,
 		metricsRegistry: registry,
 		healthHandler:   health,
+		grpcHealthCheck: grpcHealthService,
 	}, cfg)
 }
 

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"net"
 	"net/http"
 	"os"
@@ -257,6 +258,9 @@ func (s *Server) initializeGRPC() error {
 	}
 
 	s.grpc = grpc.NewServer(gitpod_grpc.ServerOptionsWithInterceptors(stream, unary)...)
+
+	// Register health service by default
+	grpc_health_v1.RegisterHealthServer(s.grpc, s.cfg.grpcHealthCheck)
 
 	return nil
 }

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -89,10 +89,6 @@ func TestServer_Metrics_gRPC(t *testing.T) {
 
 	// At this point, there must be metrics registry available for use
 	require.NotNil(t, srv.MetricsRegistry())
-
-	// To actually get gRPC metrics, we need to invoke an RPC, let's use a built-in health service as a mock
-	grpc_health_v1.RegisterHealthServer(srv.GRPC(), &HealthService{})
-
 	// Let's start our server up
 	baseserver.StartServerForTests(t, srv)
 
@@ -101,7 +97,7 @@ func TestServer_Metrics_gRPC(t *testing.T) {
 	require.NoError(t, err)
 	client := grpc_health_v1.NewHealthClient(conn)
 
-	// Invoke the RPC
+	// By default the server runs a Health service, we can use it for our purposes
 	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 	require.NoError(t, err)
 
@@ -113,12 +109,4 @@ func TestServer_Metrics_gRPC(t *testing.T) {
 	count, err := testutil.GatherAndCount(registry, expected...)
 	require.NoError(t, err)
 	require.Equal(t, len(expected)*1, count, "expected 1 count for each metric")
-}
-
-type HealthService struct {
-	grpc_health_v1.UnimplementedHealthServer
-}
-
-func (h *HealthService) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In order to configure our GCP LoadBalancer to HealthCheck HTTP 2, we need a service for this. This service can be accessed on `/grpc.health.v1.Health/Check` and is a standard service that gRPC servers can expose.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE