### PR TITLE
Revert "[prebuilds] no prebuilds for inactive repos"

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -356,22 +356,6 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         return workspaceRepo.find({ ownerId: userId });
     }
 
-    public async getWorkspaceCountByCloneURL(
-        cloneURL: string,
-        sinceLastDays: number = 7,
-        type: string = "regular",
-    ): Promise<number> {
-        const workspaceRepo = await this.getWorkspaceRepo();
-        const since = new Date();
-        since.setDate(since.getDate() - sinceLastDays);
-        return workspaceRepo
-            .createQueryBuilder("ws")
-            .where('context->"$.repository.cloneUrl" = :cloneURL', { cloneURL })
-            .andWhere("creationTime > :since", { since: since.toISOString() })
-            .andWhere("type = :type", { type })
-            .getCount();
-    }
-
     public async findCurrentInstance(workspaceId: string): Promise<MaybeWorkspaceInstance> {
         const workspaceInstanceRepo = await this.getWorkspaceInstanceRepo();
         const qb = workspaceInstanceRepo

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -9,7 +9,7 @@ const expect = chai.expect;
 import { suite, test, timeout } from "mocha-typescript";
 import { fail } from "assert";
 
-import { WorkspaceInstance, Workspace, PrebuiltWorkspace, CommitContext } from "@gitpod/gitpod-protocol";
+import { WorkspaceInstance, Workspace, PrebuiltWorkspace } from "@gitpod/gitpod-protocol";
 import { testContainer } from "./test-container";
 import { TypeORMWorkspaceDBImpl } from "./typeorm/workspace-db-impl";
 import { TypeORM } from "./typeorm/typeorm";
@@ -537,52 +537,6 @@ class WorkspaceDBSpec {
         const minuteAgo = secondsBefore(now.toISOString(), 60);
         const unabortedCount = await this.db.countUnabortedPrebuildsSince(cloneURL, new Date(minuteAgo));
         expect(unabortedCount).to.eq(1);
-    }
-
-    @test(timeout(10000))
-    public async testGetWorkspaceCountForCloneURL() {
-        const now = new Date();
-        const eightDaysAgo = new Date();
-        eightDaysAgo.setDate(eightDaysAgo.getDate() - 8);
-        const activeRepo = "http://github.com/myorg/active.git";
-        const inactiveRepo = "http://github.com/myorg/inactive.git";
-        await Promise.all([
-            this.db.store({
-                id: "12345",
-                creationTime: eightDaysAgo.toISOString(),
-                description: "something",
-                contextURL: "http://github.com/myorg/inactive",
-                ownerId: "1221423",
-                context: <CommitContext>{
-                    title: "my title",
-                    repository: {
-                        cloneUrl: inactiveRepo,
-                    },
-                },
-                config: {},
-                type: "regular",
-            }),
-            this.db.store({
-                id: "12346",
-                creationTime: now.toISOString(),
-                description: "something",
-                contextURL: "http://github.com/myorg/active",
-                ownerId: "1221423",
-                context: <CommitContext>{
-                    title: "my title",
-                    repository: {
-                        cloneUrl: activeRepo,
-                    },
-                },
-                config: {},
-                type: "regular",
-            }),
-        ]);
-
-        const inactiveCount = await this.db.getWorkspaceCountByCloneURL(inactiveRepo, 7, "regular");
-        expect(inactiveCount).to.eq(0, "there should be no regular workspaces in the past 7 days");
-        const activeCount = await this.db.getWorkspaceCountByCloneURL(activeRepo, 7, "regular");
-        expect(activeCount).to.eq(1, "there should be exactly one regular workspace");
     }
 
     private async storePrebuiltWorkspace(pws: PrebuiltWorkspace) {

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -125,7 +125,6 @@ export interface WorkspaceDB {
     findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
-    getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;
     getInstanceCount(type?: string): Promise<number>;
 
     findAllWorkspaceInstances(


### PR DESCRIPTION
Reverts gitpod-io/gitpod#9936

We're in doubt about perf implications of this change. So temporarily reverting and testing it again to make sure we're not risking an incident.

```release-notes
NONE
```