### PR TITLE
[integration-test] Partially fix TestRegularWorkspaceTasks

### DIFF
--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -46,7 +46,6 @@ func NewPodExec(config rest.Config, clientset *kubernetes.Clientset) *PodExec {
 	config.APIPath = "/api"                                   // Make sure we target /api and not just /
 	config.GroupVersion = &schema.GroupVersion{Version: "v1"} // this targets the core api groups so the url path will be /api/v1
 	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
-	config.TLSClientConfig = rest.TLSClientConfig{Insecure: true}
 	return &PodExec{
 		RestConfig: &config,
 		Clientset:  clientset,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Disable Supervisor test for now and fix the other part of test which failed due to incorrect value of TLSConfig.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially Fixes https://github.com/gitpod-io/gitpod/issues/9575

## How to test
<!-- Provide steps to test this PR -->
```
gitpod /workspace/gitpod/test (prs/fix-partial-test) $ go test -v ./... \
>    -kubeconfig=/home/gitpod/.kube/config \
>    -namespace=default \
>    -run=TestRegularWorkspaceTasks
?       github.com/gitpod-io/gitpod/test/pkg/agent/daemon       [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/agent/daemon/api   [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/agent/workspace    [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api        [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/integration        [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/integration/common [no test files]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/content-service       3.068s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/database      3.166s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/image-builder 3.152s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/server        3.161s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/ws-daemon     3.350s [no tests to run]
=== RUN   TestRegularWorkspaceTasks
=== RUN   TestRegularWorkspaceTasks/ws-manager
=== RUN   TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks
=== RUN   TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks/init
    tasks_test.go:99: file in workspace: .cargo
    tasks_test.go:99: file in workspace: .gitpod
    tasks_test.go:99: file in workspace: .vscode-remote
    tasks_test.go:99: file in workspace: init-ran
=== RUN   TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks/before
    tasks_test.go:99: file in workspace: .cargo
    tasks_test.go:99: file in workspace: .gitpod
    tasks_test.go:99: file in workspace: .vscode-remote
    tasks_test.go:99: file in workspace: before-ran
=== RUN   TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks/command
    tasks_test.go:99: file in workspace: .cargo
    tasks_test.go:99: file in workspace: .gitpod
    tasks_test.go:99: file in workspace: .vscode-remote
    tasks_test.go:99: file in workspace: command-ran
--- PASS: TestRegularWorkspaceTasks (60.07s)
    --- PASS: TestRegularWorkspaceTasks/ws-manager (60.07s)
        --- PASS: TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks (60.07s)
            --- PASS: TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks/init (25.76s)
            --- PASS: TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks/before (16.82s)
            --- PASS: TestRegularWorkspaceTasks/ws-manager/it_can_run_workspace_tasks/command (17.49s)
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/ws-manager    63.224s
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/ide/jetbrains    2.858s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/ide/vscode       2.872s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/workspace        2.900s [no tests to run]
?       github.com/gitpod-io/gitpod/test/tests/workspace/common [no test files]

```
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
