### PR TITLE
[baseserver] Add rate limits to interceptors by default

### DIFF
--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -5,6 +5,7 @@
 package baseserver
 
 import (
+	gitpod_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,6 +24,9 @@ func TestOptions(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	health := healthcheck.NewHandler()
 	grpcHealthService := &grpc_health_v1.UnimplementedHealthServer{}
+	rateLimits := map[string]gitpod_grpc.RateLimit{
+		"/grpc.health.v1.Health/Check": {},
+	}
 
 	var opts = []Option{
 		WithHostname(hostname),
@@ -33,6 +37,7 @@ func TestOptions(t *testing.T) {
 		WithMetricsRegistry(registry),
 		WithHealthHandler(health),
 		WithGRPCHealthService(grpcHealthService),
+		WithRateLimits(rateLimits),
 	}
 	cfg, err := evaluateOptions(defaultConfig(), opts...)
 	require.NoError(t, err)
@@ -46,6 +51,7 @@ func TestOptions(t *testing.T) {
 		metricsRegistry: registry,
 		healthHandler:   health,
 		grpcHealthCheck: grpcHealthService,
+		rateLimits:      rateLimits,
 	}, cfg)
 }
 

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -249,6 +249,7 @@ func (s *Server) initializeGRPC() error {
 	}
 
 	unary := []grpc.UnaryServerInterceptor{
+		gitpod_grpc.NewRatelimitingInterceptor(s.cfg.rateLimits).UnaryInterceptor(),
 		grpc_logrus.UnaryServerInterceptor(s.Logger()),
 		grpcMetrics.UnaryServerInterceptor(),
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Out of the box, the server has rate-limiting middleware configured. The actual rate limits are configurable when starting the server. This is needed to be able to port `ws-manager` to baseserver.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE