### PR TITLE
[public-api] Add placeholder `GetOwnerToken` method to `WorkspaceService`

### DIFF
--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -59,6 +59,10 @@ func (w *WorkspaceService) GetWorkspace(ctx context.Context, r *v1.GetWorkspaceR
 	}, nil
 }
 
+func (w *WorkspaceService) GetOwnerToken(ctx context.Context, r *v1.GetOwnerTokenRequest) (*v1.GetOwnerTokenResponse, error) {
+	return &v1.GetOwnerTokenResponse{Token: "some-owner-token"}, nil
+}
+
 func bearerTokenFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -119,6 +119,25 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 
 }
 
+func TestWorkspaceService_GetOwnerToken(t *testing.T) {
+	srv := baseserver.NewForTests(t)
+	var connPool *FakeServerConnPool
+
+	v1.RegisterWorkspacesServiceServer(srv.GRPC(), NewWorkspaceService(connPool))
+	baseserver.StartServerForTests(t, srv)
+
+	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client := v1.NewWorkspacesServiceClient(conn)
+	ctx := context.Background()
+
+	actualOwnerId, err := client.GetOwnerToken(ctx, &v1.GetOwnerTokenRequest{WorkspaceId: "some-workspace-id"})
+	require.NoError(t, err)
+
+	require.Equal(t, "some-owner-token", actualOwnerId.Token)
+}
+
 type FakeServerConnPool struct {
 	api gitpod.APIInterface
 }


### PR DESCRIPTION
## Description

Add a placeholder `GetOwnerToken` method to `WorkspaceService` and a test to check that the method is accessible from the client.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/9923
## How to test

Run the test added.

## Release Notes

```release-note
NONE
```

## Documentation
none
