### PR TITLE
[dashboard] fix workspace start stuck in checking during ide onboarding

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -150,6 +150,7 @@ function App() {
 
     const [loading, setLoading] = useState<boolean>(true);
     const [isWhatsNewShown, setWhatsNewShown] = useState(false);
+    const [showUserIdePreference, setShowUserIdePreference] = useState(false);
     const [isSetupRequired, setSetupRequired] = useState(false);
     const history = useHistory();
 
@@ -492,16 +493,23 @@ function App() {
     // Prefix with `/#referrer` will specify an IDE for workspace
     // We don't need to show IDE preference in this case
     const shouldUserIdePreferenceShown = User.isOnboardingUser(user) && !hash.startsWith(ContextURL.REFERRER_PREFIX);
+    if (shouldUserIdePreferenceShown !== showUserIdePreference) {
+        setShowUserIdePreference(shouldUserIdePreferenceShown);
+    }
 
     const isCreation = window.location.pathname === "/" && hash !== "";
     const isWsStart = /\/start\/?/.test(window.location.pathname) && hash !== "";
     if (isWhatsNewShown) {
         toRender = <WhatsNew onClose={() => setWhatsNewShown(false)} />;
     } else if (isCreation) {
-        if (shouldUserIdePreferenceShown) {
+        if (showUserIdePreference) {
             toRender = (
                 <StartPage phase={StartPhase.Checking}>
-                    <SelectIDEModal />
+                    <SelectIDEModal
+                        onClose={() => {
+                            setShowUserIdePreference(false);
+                        }}
+                    />
                 </StartPage>
             );
         } else {


### PR DESCRIPTION
## Description
Workspace start will stuck in `checking` phase during ide awareness onboarding, this PR will fix it by add `state` to ask react to re-render after close Modal

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Access preview env via https://hw-fix-ob-stuck.preview.gitpod-dev.com/#https://github.com/gitpod-io/template-sveltejs
2. Login 
3. Choose IDE like intellj click continue
4. See if workspace start

See also https://github.com/gitpod-io/gitpod/pull/9663

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
