### PR TITLE
[public api] Add `gpctl api workspace ownertoken` command

### DIFF
--- a/dev/gpctl/cmd/api/root.go
+++ b/dev/gpctl/cmd/api/root.go
@@ -37,7 +37,7 @@ func NewCommand() *cobra.Command {
 }
 
 func newConn(connOpts *connectionOptions) (*grpc.ClientConn, error) {
-	log.Log.Infof("Estabilishing gRPC connection against %s", connOpts.address)
+	log.Log.Infof("Establishing gRPC connection against %s", connOpts.address)
 
 	opts := []grpc.DialOption{
 		// attach token to requests to auth
@@ -61,13 +61,26 @@ func newConn(connOpts *connectionOptions) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
+func validateAndConnect(connOpts *connectionOptions) (*grpc.ClientConn, error) {
+	if err := connOpts.validate(); err != nil {
+		return nil, fmt.Errorf("invalid connection options: %w", err)
+	}
+
+	conn, err := newConn(connOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to establish gRPC connection: %w", err)
+	}
+
+	return conn, nil
+}
+
 type connectionOptions struct {
 	address  string
 	insecure bool
 	token    string
 }
 
-func (o *connectionOptions) Validate() error {
+func (o *connectionOptions) validate() error {
 	if o.address == "" {
 		return fmt.Errorf("empty connection address")
 	}

--- a/dev/gpctl/cmd/api/workspaces-get.go
+++ b/dev/gpctl/cmd/api/workspaces-get.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+func newWorkspacesGetCommand() *cobra.Command {
+	var workspaceID string
+
+	cmd := &cobra.Command{
+		Use:     "get",
+		Short:   "Retrieve details about a workspace by ID",
+		Example: "  get --id 1234",
+		Run: func(cmd *cobra.Command, args []string) {
+			if workspaceID == "" {
+				log.Log.Fatal("no workspace id specified, use --id to set it")
+			}
+
+			conn, err := validateAndConnect(connOpts)
+			if err != nil {
+				log.Log.WithError(err).Fatal()
+			}
+
+			workspace, err := getWorkspace(cmd.Context(), conn, workspaceID)
+
+			log.Log.WithError(err).WithField("workspace", workspace.String()).Debugf("Workspace response")
+			if err != nil {
+				log.Log.WithError(err).Fatal("Failed to retrieve workspace.")
+				return
+			}
+
+			if err := printProtoMsg(os.Stdout, workspace); err != nil {
+				log.Log.WithError(err).Fatal("Failed to serialize proto message and print it.")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&workspaceID, "id", "", "Workspace ID")
+
+	return cmd
+}
+
+func getWorkspace(ctx context.Context, conn *grpc.ClientConn, workspaceID string) (*v1.GetWorkspaceResponse, error) {
+	service := v1.NewWorkspacesServiceClient(conn)
+
+	log.Log.Debugf("Retrieving workspace ID: %s", workspaceID)
+	resp, err := service.GetWorkspace(ctx, &v1.GetWorkspaceRequest{WorkspaceId: workspaceID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workspace (ID: %s): %w", workspaceID, err)
+	}
+
+	return resp, nil
+}

--- a/dev/gpctl/cmd/api/workspaces-ownertoken.go
+++ b/dev/gpctl/cmd/api/workspaces-ownertoken.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+func newWorkspacesOwnerTokenCommand() *cobra.Command {
+	var workspaceID string
+
+	cmd := &cobra.Command{
+		Use:     "ownertoken",
+		Short:   "Retrieve the owner token for a given workspace ID",
+		Example: "  ownertoken --id 1234",
+		Run: func(cmd *cobra.Command, args []string) {
+			if workspaceID == "" {
+				log.Log.Fatal("no workspace id specified, use --id to set it")
+			}
+
+			conn, err := validateAndConnect(connOpts)
+			if err != nil {
+				log.Log.WithError(err).Fatal()
+			}
+
+			ownerToken, err := getOwnerToken(cmd.Context(), conn, workspaceID)
+
+			log.Log.WithError(err).WithField("ownertoken", ownerToken.String()).Debugf("Owner token response")
+			if err != nil {
+				log.Log.WithError(err).Fatal("Failed to retrieve owner token.")
+				return
+			}
+
+			if err := printProtoMsg(os.Stdout, ownerToken); err != nil {
+				log.Log.WithError(err).Fatal("Failed to serialize proto message and print it.")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&workspaceID, "id", "", "Workspace ID")
+
+	return cmd
+}
+
+func getOwnerToken(ctx context.Context, conn *grpc.ClientConn, workspaceID string) (*v1.GetOwnerTokenResponse, error) {
+	service := v1.NewWorkspacesServiceClient(conn)
+
+	log.Log.Debugf("Retrieving owner token from workspace ID: %s", workspaceID)
+	resp, err := service.GetOwnerToken(ctx, &v1.GetOwnerTokenRequest{WorkspaceId: workspaceID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workspace (ID: %s): %w", workspaceID, err)
+	}
+
+	return resp, nil
+}

--- a/dev/gpctl/cmd/api/workspaces.go
+++ b/dev/gpctl/cmd/api/workspaces.go
@@ -5,16 +5,12 @@
 package api
 
 import (
-	"context"
 	"fmt"
-	"github.com/gitpod-io/gitpod/common-go/log"
-	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"io"
+
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"io"
-	"os"
 )
 
 func newWorkspacesCommand() *cobra.Command {
@@ -24,60 +20,9 @@ func newWorkspacesCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newWorkspacesGetCommand())
+	cmd.AddCommand(newWorkspacesOwnerTokenCommand())
 
 	return cmd
-}
-
-func newWorkspacesGetCommand() *cobra.Command {
-	var workspaceID string
-
-	cmd := &cobra.Command{
-		Use:     "get",
-		Short:   "Retrieve details about a workspace by ID",
-		Example: "  get --id 1234",
-		Run: func(cmd *cobra.Command, args []string) {
-			if workspaceID == "" {
-				log.Log.Fatal("no workspace id specified, use --id to set it")
-			}
-
-			if err := connOpts.Validate(); err != nil {
-				log.Log.WithError(err).Fatal("Invalid connections options.")
-			}
-
-			conn, err := newConn(connOpts)
-			if err != nil {
-				log.Log.WithError(err).Fatal("Failed to establish gRPC connection")
-			}
-
-			workspace, err := getWorkspace(cmd.Context(), conn, workspaceID)
-
-			log.Log.WithError(err).WithField("workspace", workspace.String()).Debugf("Workspace response")
-			if err != nil {
-				log.Log.WithError(err).Fatal("Failed to retrieve workspace.")
-				return
-			}
-
-			if err := printProtoMsg(os.Stdout, workspace); err != nil {
-				log.Log.WithError(err).Fatal("Failed to serialize proto message and print it.")
-			}
-		},
-	}
-
-	cmd.Flags().StringVar(&workspaceID, "id", "", "Workspace ID")
-
-	return cmd
-}
-
-func getWorkspace(ctx context.Context, conn *grpc.ClientConn, workspaceID string) (*v1.GetWorkspaceResponse, error) {
-	service := v1.NewWorkspacesServiceClient(conn)
-
-	log.Log.Debugf("Retrieving workspace ID: %s", workspaceID)
-	resp, err := service.GetWorkspace(ctx, &v1.GetWorkspaceRequest{WorkspaceId: workspaceID})
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve workspace (ID: %s): %w", workspaceID, err)
-	}
-
-	return resp, nil
 }
 
 func printProtoMsg(w io.Writer, m proto.Message) error {

--- a/scripts/protoc-generator.sh
+++ b/scripts/protoc-generator.sh
@@ -20,7 +20,7 @@ install_dependencies() {
 lint() {
     local PROTO_DIR=${1:-.}
 
-    docker run --volume "$PWD/$PROTO_DIR:/workspace" --workdir /workspace bufbuild/buf lint || exit 1
+    docker run --rm --volume "$PWD/$PROTO_DIR:/workspace" --workdir /workspace bufbuild/buf lint || exit 1
 }
 
 go_protoc() {


### PR DESCRIPTION
## Description

Add a `gpctl api workspace ownertoken` command to get the ownertoken from a given workspace id.

This builds on #9966 and #9970.

## Related Issue(s)
Part of #9923

## How to test

1. Start the public API server (talking to the existing API from the preview environment for this branch):

```
go run . --gitpod-api-url wss://af-add-ownbe4c0ee3bb.preview.gitpod-dev.com/api/v1
```

2. Run `gpctl` against the public API:

```
go run . api workspaces ownertoken --id $GITPOD_WORKSPACE_ID --token $TOKEN --insecure --address localhost:9501
```

(the value of  `$GITPOD_WORKSPACE_ID` or `$TOKEN` don't matter as the gRPC endpoint returns a canned response)

The output of `gpctl` should be:

```
INFO[0000] Establishing gRPC connection against localhost:9501
{"token":"some-owner-token"}⏎
```

## Release Notes

```release-note
NONE
```

## Documentation
None

/hold