### PR TITLE
[pre-commit] Add license header check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,11 @@ repos:
     hooks:
       - id: go-fmt
       - id: go-mod-tidy
+
+  - repo: local
+    hooks:
+      - id: license-header
+        name: license-header
+        entry: leeway run components:update-license-header
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Run `leeway run components:update-license-header` automatically as part of pre-commit to avoid empty CI cycles because license header was omitted.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create a new file, `git add .` and try to commit.
Observe the license header is added.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE