### PR TITLE
[content-service] fix gcloud test

### DIFF
--- a/components/content-service/pkg/storage/gcloud_test.go
+++ b/components/content-service/pkg/storage/gcloud_test.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestObjectAccessToNonExistentObj(t *testing.T) {
 
 	var mappings []archive.IDMapping
 	found, err := storage.Download(context.Background(), "/tmp", "foo", mappings)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "object doesn't exist") {
 		t.Errorf("%+v", err)
 	}
 	if found {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
fix gcloud test error that was introduced by https://github.com/gitpod-io/gitpod/pull/9943
we are now bubbling up error instead of silently dropping it, and had to update the test to account for it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
