### PR TITLE
ws-daemon: improve start up time of iws for workspacekit

### DIFF
--- a/components/ws-daemon/pkg/content/hooks.go
+++ b/components/ws-daemon/pkg/content/hooks.go
@@ -26,15 +26,15 @@ func workspaceLifecycleHooks(cfg Config, kubernetesNamespace string, workspaceEx
 
 	return map[session.WorkspaceState][]session.WorkspaceLivecycleHook{
 		session.WorkspaceInitializing: {
-			hookSetupRemoteStorage(cfg),
 			hookSetupWorkspaceLocation,
+			startIWS, // workspacekit is waiting for starting IWS, so it needs to start as soon as possible.
+			hookSetupRemoteStorage(cfg),
 			hookInstallQuota(xfs),
-			startIWS,
 		},
 		session.WorkspaceReady: {
+			startIWS,
 			hookSetupRemoteStorage(cfg),
 			hookInstallQuota(xfs),
-			startIWS,
 		},
 		session.WorkspaceDisposed: {
 			iws.StopServingWorkspace,


### PR DESCRIPTION
## Description

workspacekit waits for IWS to start with a timeout, so run it as soon as possible

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate: #9673 

## How to test
<!-- Provide steps to test this PR -->

- Open the preview env
- Open a  Workspace

If you set the limit of storage, you can check these commands to confirm the behavior of  the xfs installed hook
On the workspace
```console
$ df -h
```
On the node
```console
$ xfs_quota -x -c 'report -h' 
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

No