### PR TITLE
[ws-daemon] Remove stray "cannot write limit" errors

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
@@ -179,7 +179,7 @@ func (c *IOLimiterV1) produceLimits(kind string, value int64, useCache bool) []s
 		return val.([]string)
 	}
 
-	lines := make([]string, len(c.devices))
+	lines := make([]string, 0, len(c.devices))
 	for _, dev := range c.devices {
 		lines = append(lines, fmt.Sprintf("%s %d", dev, value))
 	}
@@ -196,6 +196,9 @@ func writeLimit(limitPath string, content []string) error {
 	}
 
 	for _, l := range content {
+		if l == "" {
+			continue
+		}
 		err = os.WriteFile(limitPath, []byte(l), 0644)
 		if err != nil {
 			log.WithError(err).WithField("limitPath", limitPath).WithField("line", l).Warn("cannot write limit")


### PR DESCRIPTION
## Description
Removes stray "cannot write limit" from ws-daemon's IO limiter.
Notice the empty "line" in the warning below:
```
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"write /mnt/node-cgroups/blkio/kubepods/burstable/pod218cffe4-64a5-457a-8027-184afd8c5896/e407d0384db46e299febd26c6de18f7a1397cba52e92e9bcca9e2963e3b2f849/blkio.throttle.read_iops_device: invalid argument","level":"warning","limitPath":"/mnt/node-cgroups/blkio/kubepods/burstable/pod218cffe4-64a5-457a-8027-184afd8c5896/e407d0384db46e299febd26c6de18f7a1397cba52e92e9bcca9e2963e3b2f849/blkio.throttle.read_iops_device","line":"","message":"cannot write limit","serviceContext":{"service":"ws-daemon","version":"commit-57d2b4cc75ac7c5bf27d6bafe6e6edc5e4f8f07f"},"severity":"WARNING","time":"2022-05-13T09:09:12Z"}
```

## How to test
Run ws-daemon

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-daemon] Remove stray IO limiter warnings
```
