### PR TITLE
[baseserver] Support common config struct

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,6 @@
 
 /components/blobserve @gitpod-io/engineering-workspace
 /components/common-go @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp
-/components/common-go/baseserver @gitpod-io/engineering-webapp
 /components/content-service-api @csweichel @geropl
 /components/content-service @gitpod-io/engineering-workspace
 /components/dashboard @gitpod-io/engineering-webapp

--- a/components/common-go/baseserver/config.go
+++ b/components/common-go/baseserver/config.go
@@ -27,7 +27,7 @@ func (s *ServerConfiguration) GetAddress() string {
 }
 
 type TLSConfiguration struct {
-	CA   string `json:"ca" yaml:"ca"`
-	Cert string `json:"cert" yaml:"cert"`
-	Key  string `json:"key" yaml:"key"`
+	CAPath   string `json:"caPath" yaml:"caPath"`
+	CertPath string `json:"certPath" yaml:"certPath"`
+	KeyPath  string `json:"keyPath" yaml:"keyPath"`
 }

--- a/components/common-go/baseserver/config.go
+++ b/components/common-go/baseserver/config.go
@@ -9,9 +9,8 @@ type Configuration struct {
 }
 
 type ServicesConfiguration struct {
-	Debug *ServerConfiguration `json:"debug,omitempty" yaml:"debug,omitempty"`
-	GRPC  *ServerConfiguration `json:"grpc,omitempty" yaml:"grpc,omitempty"`
-	HTTP  *ServerConfiguration `json:"http,omitempty" yaml:"http,omitempty"`
+	GRPC *ServerConfiguration `json:"grpc,omitempty" yaml:"grpc,omitempty"`
+	HTTP *ServerConfiguration `json:"http,omitempty" yaml:"http,omitempty"`
 }
 
 type ServerConfiguration struct {

--- a/components/common-go/baseserver/config.go
+++ b/components/common-go/baseserver/config.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package baseserver
+
+type Configuration struct {
+	Services ServicesConfiguration `json:"services" yaml:"services"`
+}
+
+type ServicesConfiguration struct {
+	Debug *ServerConfiguration `json:"debug,omitempty" yaml:"debug,omitempty"`
+	GRPC  *ServerConfiguration `json:"grpc,omitempty" yaml:"grpc,omitempty"`
+	HTTP  *ServerConfiguration `json:"http,omitempty" yaml:"http,omitempty"`
+}
+
+type ServerConfiguration struct {
+	Address string            `json:"address" yaml:"address"`
+	TLS     *TLSConfiguration `json:"tls" yaml:"tls"`
+}
+
+// GetAddress returns the configured address or an empty string of s is nil
+func (s *ServerConfiguration) GetAddress() string {
+	if s == nil {
+		return ""
+	}
+	return s.Address
+}
+
+type TLSConfiguration struct {
+	CA   string `json:"ca" yaml:"ca"`
+	Cert string `json:"cert" yaml:"cert"`
+	Key  string `json:"key" yaml:"key"`
+}

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -77,23 +77,17 @@ func WithUnderTest() Option {
 }
 
 // WithHTTP configures and enables the HTTP server.
-func WithHTTP(addr string, tls *TLSConfiguration) Option {
+func WithHTTP(cfg *ServerConfiguration) Option {
 	return func(opts *options) error {
-		opts.config.Services.HTTP = &ServerConfiguration{
-			Address: addr,
-			TLS:     tls,
-		}
+		opts.config.Services.HTTP = cfg
 		return nil
 	}
 }
 
 // WithGRPC configures and enables the GRPC server.
-func WithGRPC(addr string, tls *TLSConfiguration) Option {
+func WithGRPC(cfg *ServerConfiguration) Option {
 	return func(opts *options) error {
-		opts.config.Services.GRPC = &ServerConfiguration{
-			Address: addr,
-			TLS:     tls,
-		}
+		opts.config.Services.GRPC = cfg
 		return nil
 	}
 }

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -7,25 +7,19 @@ package baseserver
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"time"
 )
 
-type config struct {
+type options struct {
 	logger *logrus.Entry
 
-	// hostname is the hostname on which our servers will listen.
-	hostname string
-	// debugPort is the port we listen on for metrics, pprof, readiness and livenss checks
-	debugPort int
-	// grpcPort is the port we listen on for gRPC traffic
-	grpcPort int
-	// httpPort is the port we listen on for HTTP traffic
-	httpPort int
+	config *Configuration
 
 	// closeTimeout is the amount we allow for the server to shut down cleanly
 	closeTimeout time.Duration
@@ -38,13 +32,19 @@ type config struct {
 	grpcHealthCheck grpc_health_v1.HealthServer
 }
 
-func defaultConfig() *config {
-	return &config{
-		logger:          log.New(),
-		hostname:        "localhost",
-		httpPort:        -1, // disabled by default
-		grpcPort:        -1, // disabled by default
-		debugPort:       9500,
+func defaultOptions() *options {
+	return &options{
+		logger: log.New(),
+		config: &Configuration{
+			Services: ServicesConfiguration{
+				GRPC: nil, // disabled by default
+				HTTP: nil, // disabled by default
+				Debug: &ServerConfiguration{
+					Address: "localhost:9500",
+				},
+			},
+		},
+
 		closeTimeout:    5 * time.Second,
 		healthHandler:   healthcheck.NewHandler(),
 		metricsRegistry: prometheus.NewRegistry(),
@@ -52,97 +52,104 @@ func defaultConfig() *config {
 	}
 }
 
-type Option func(cfg *config) error
+type Option func(opts *options) error
 
-func WithHostname(hostname string) Option {
-	return func(cfg *config) error {
-		cfg.hostname = hostname
+// WithConfig uses a config struct to initialise the services
+func WithConfig(config *Configuration) Option {
+	return func(opts *options) error {
+		opts.config = config
 		return nil
 	}
 }
 
-// WithHTTPPort sets the port to use for an HTTP server. Setting WithHTTPPort also enables an HTTP server on the baseserver.
-func WithHTTPPort(port int) Option {
-	return func(cfg *config) error {
-		cfg.httpPort = port
-		return nil
-	}
-}
-
-// WithGRPCPort sets the port to use for an HTTP server. Setting WithGRPCPort also enables a gRPC server on the baseserver.
-func WithGRPCPort(port int) Option {
-	return func(cfg *config) error {
-		cfg.grpcPort = port
-		return nil
-	}
-}
-
-func WithDebugPort(port int) Option {
-	return func(cfg *config) error {
-		if port < 0 {
-			return fmt.Errorf("grpc port must not be negative, got: %d", port)
+// WithHTTP configures and enables the HTTP server.
+func WithHTTP(addr string, tls *TLSConfiguration) Option {
+	return func(opts *options) error {
+		opts.config.Services.HTTP = &ServerConfiguration{
+			Address: addr,
+			TLS:     tls,
 		}
+		return nil
+	}
+}
 
-		cfg.debugPort = port
+// WithGRPC configures and enables the GRPC server.
+func WithGRPC(addr string, tls *TLSConfiguration) Option {
+	return func(opts *options) error {
+		opts.config.Services.GRPC = &ServerConfiguration{
+			Address: addr,
+			TLS:     tls,
+		}
+		return nil
+	}
+}
+
+// WithDebug configures and enables the debug server.
+func WithDebug(addr string, tls *TLSConfiguration) Option {
+	return func(opts *options) error {
+		opts.config.Services.Debug = &ServerConfiguration{
+			Address: addr,
+			TLS:     tls,
+		}
 		return nil
 	}
 }
 
 func WithLogger(logger *logrus.Entry) Option {
-	return func(cfg *config) error {
+	return func(opts *options) error {
 		if logger == nil {
 			return fmt.Errorf("nil logger specified")
 		}
 
-		cfg.logger = logger
+		opts.logger = logger
 		return nil
 	}
 }
 
 func WithCloseTimeout(d time.Duration) Option {
-	return func(cfg *config) error {
-		cfg.closeTimeout = d
+	return func(opts *options) error {
+		opts.closeTimeout = d
 		return nil
 	}
 }
 
 func WithMetricsRegistry(r *prometheus.Registry) Option {
-	return func(cfg *config) error {
+	return func(opts *options) error {
 		if r == nil {
 			return fmt.Errorf("nil prometheus registry received")
 		}
 
-		cfg.metricsRegistry = r
+		opts.metricsRegistry = r
 		return nil
 	}
 }
 
 func WithHealthHandler(handler healthcheck.Handler) Option {
-	return func(cfg *config) error {
+	return func(opts *options) error {
 		if handler == nil {
 			return fmt.Errorf("nil healthcheck handler provided")
 		}
 
-		cfg.healthHandler = handler
+		opts.healthHandler = handler
 		return nil
 	}
 }
 
 func WithGRPCHealthService(svc grpc_health_v1.HealthServer) Option {
-	return func(cfg *config) error {
+	return func(opts *options) error {
 		if svc == nil {
 			return fmt.Errorf("nil healthcheck handler provided")
 		}
 
-		cfg.grpcHealthCheck = svc
+		opts.grpcHealthCheck = svc
 		return nil
 	}
 }
 
-func evaluateOptions(cfg *config, opts ...Option) (*config, error) {
+func evaluateOptions(cfg *options, opts ...Option) (*options, error) {
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {
-			return nil, fmt.Errorf("failed to evaluate config: %w", err)
+			return nil, fmt.Errorf("failed to evaluate options: %w", err)
 		}
 	}
 

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -24,8 +24,7 @@ type options struct {
 	// closeTimeout is the amount we allow for the server to shut down cleanly
 	closeTimeout time.Duration
 
-	noBuiltinServices bool
-	underTest         bool
+	underTest bool
 
 	// metricsRegistry configures the metrics registry to use for exporting metrics. When not set, the default prometheus registry is used.
 	metricsRegistry *prometheus.Registry
@@ -58,13 +57,6 @@ type Option func(opts *options) error
 func WithConfig(config *Configuration) Option {
 	return func(opts *options) error {
 		opts.config = config
-		return nil
-	}
-}
-
-func WithoutBuiltinServices() Option {
-	return func(opts *options) error {
-		opts.noBuiltinServices = true
 		return nil
 	}
 }

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -24,6 +24,9 @@ type options struct {
 	// closeTimeout is the amount we allow for the server to shut down cleanly
 	closeTimeout time.Duration
 
+	noBuiltinServices bool
+	underTest         bool
+
 	// metricsRegistry configures the metrics registry to use for exporting metrics. When not set, the default prometheus registry is used.
 	metricsRegistry *prometheus.Registry
 
@@ -39,9 +42,6 @@ func defaultOptions() *options {
 			Services: ServicesConfiguration{
 				GRPC: nil, // disabled by default
 				HTTP: nil, // disabled by default
-				Debug: &ServerConfiguration{
-					Address: "localhost:9500",
-				},
 			},
 		},
 
@@ -62,6 +62,20 @@ func WithConfig(config *Configuration) Option {
 	}
 }
 
+func WithoutBuiltinServices() Option {
+	return func(opts *options) error {
+		opts.noBuiltinServices = true
+		return nil
+	}
+}
+
+func WithUnderTest() Option {
+	return func(opts *options) error {
+		opts.underTest = true
+		return nil
+	}
+}
+
 // WithHTTP configures and enables the HTTP server.
 func WithHTTP(addr string, tls *TLSConfiguration) Option {
 	return func(opts *options) error {
@@ -77,17 +91,6 @@ func WithHTTP(addr string, tls *TLSConfiguration) Option {
 func WithGRPC(addr string, tls *TLSConfiguration) Option {
 	return func(opts *options) error {
 		opts.config.Services.GRPC = &ServerConfiguration{
-			Address: addr,
-			TLS:     tls,
-		}
-		return nil
-	}
-}
-
-// WithDebug configures and enables the debug server.
-func WithDebug(addr string, tls *TLSConfiguration) Option {
-	return func(opts *options) error {
-		opts.config.Services.Debug = &ServerConfiguration{
 			Address: addr,
 			TLS:     tls,
 		}

--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -21,12 +21,10 @@ func TestOptions(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	health := healthcheck.NewHandler()
 	grpcHealthService := &grpc_health_v1.UnimplementedHealthServer{}
-	debugCfg := ServerConfiguration{Address: "localhost:9500"}
 	httpCfg := ServerConfiguration{Address: "localhost:8080"}
 	grpcCfg := ServerConfiguration{Address: "localhost:8081"}
 
 	var opts = []Option{
-		WithDebug(debugCfg.Address, debugCfg.TLS),
 		WithHTTP(httpCfg.Address, httpCfg.TLS),
 		WithGRPC(grpcCfg.Address, grpcCfg.TLS),
 		WithLogger(logger),
@@ -42,9 +40,8 @@ func TestOptions(t *testing.T) {
 		logger: logger,
 		config: &Configuration{
 			Services: ServicesConfiguration{
-				Debug: &debugCfg,
-				GRPC:  &grpcCfg,
-				HTTP:  &httpCfg,
+				GRPC: &grpcCfg,
+				HTTP: &httpCfg,
 			},
 		},
 		closeTimeout:    timeout,

--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -25,8 +25,8 @@ func TestOptions(t *testing.T) {
 	grpcCfg := ServerConfiguration{Address: "localhost:8081"}
 
 	var opts = []Option{
-		WithHTTP(httpCfg.Address, httpCfg.TLS),
-		WithGRPC(grpcCfg.Address, grpcCfg.TLS),
+		WithHTTP(&httpCfg),
+		WithGRPC(&grpcCfg),
 		WithLogger(logger),
 		WithCloseTimeout(timeout),
 		WithMetricsRegistry(registry),

--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -5,105 +5,58 @@
 package baseserver
 
 import (
+	"testing"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"testing"
-	"time"
 )
 
 func TestOptions(t *testing.T) {
 	logger := log.New()
-	httpPort := 8080
-	grpcPort := 8081
-	debugPort := 8082
 	timeout := 10 * time.Second
-	hostname := "another_hostname"
 	registry := prometheus.NewRegistry()
 	health := healthcheck.NewHandler()
 	grpcHealthService := &grpc_health_v1.UnimplementedHealthServer{}
+	debugCfg := ServerConfiguration{Address: "localhost:9500"}
+	httpCfg := ServerConfiguration{Address: "localhost:8080"}
+	grpcCfg := ServerConfiguration{Address: "localhost:8081"}
 
 	var opts = []Option{
-		WithHostname(hostname),
-		WithDebugPort(debugPort),
-		WithHTTPPort(httpPort),
-		WithGRPCPort(grpcPort),
+		WithDebug(debugCfg.Address, debugCfg.TLS),
+		WithHTTP(httpCfg.Address, httpCfg.TLS),
+		WithGRPC(grpcCfg.Address, grpcCfg.TLS),
 		WithLogger(logger),
 		WithCloseTimeout(timeout),
 		WithMetricsRegistry(registry),
 		WithHealthHandler(health),
 		WithGRPCHealthService(grpcHealthService),
 	}
-	cfg, err := evaluateOptions(defaultConfig(), opts...)
+	actual, err := evaluateOptions(defaultOptions(), opts...)
 	require.NoError(t, err)
 
-	require.Equal(t, &config{
-		logger:          logger,
-		hostname:        hostname,
-		grpcPort:        grpcPort,
-		httpPort:        httpPort,
-		debugPort:       debugPort,
+	expected := &options{
+		logger: logger,
+		config: &Configuration{
+			Services: ServicesConfiguration{
+				Debug: &debugCfg,
+				GRPC:  &grpcCfg,
+				HTTP:  &httpCfg,
+			},
+		},
 		closeTimeout:    timeout,
 		metricsRegistry: registry,
 		healthHandler:   health,
 		grpcHealthCheck: grpcHealthService,
-	}, cfg)
-}
-
-func TestWithHTTPPort(t *testing.T) {
-	for _, scenario := range []struct {
-		Port     int
-		Expected int
-	}{
-		{Port: -1, Expected: -1},
-		{Port: 0, Expected: 0},
-		{Port: 9000, Expected: 9000},
-	} {
-		cfg, err := evaluateOptions(defaultConfig(), WithHTTPPort(scenario.Port))
-		require.NoError(t, err)
-		require.Equal(t, scenario.Expected, cfg.httpPort)
 	}
-}
 
-func TestWithGRPCPort(t *testing.T) {
-	for _, scenario := range []struct {
-		Port     int
-		Expected int
-	}{
-		{Port: -1, Expected: -1},
-		{Port: 0, Expected: 0},
-		{Port: 9000, Expected: 9000},
-	} {
-		cfg, err := evaluateOptions(defaultConfig(), WithGRPCPort(scenario.Port))
-		require.NoError(t, err)
-		require.Equal(t, scenario.Expected, cfg.grpcPort)
-	}
-}
-
-func TestWithDebugPort(t *testing.T) {
-	for _, scenario := range []struct {
-		Port int
-
-		Errors   bool
-		Expected int
-	}{
-		{Port: -1, Errors: true},
-		{Port: 0, Expected: 0},
-		{Port: 9000, Expected: 9000},
-	} {
-		cfg, err := evaluateOptions(defaultConfig(), WithDebugPort(scenario.Port))
-		if scenario.Errors {
-			require.Error(t, err)
-			continue
-		}
-
-		require.Equal(t, scenario.Expected, cfg.debugPort)
-	}
+	require.Equal(t, expected, actual)
 }
 
 func TestLogger_ErrorsWithNilLogger(t *testing.T) {
-	_, err := evaluateOptions(defaultConfig(), WithLogger(nil))
+	_, err := evaluateOptions(defaultOptions(), WithLogger(nil))
 	require.Error(t, err)
 }

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -93,7 +93,7 @@ func serveHTTP(cfg *ServerConfiguration, srv *http.Server, l net.Listener) (err 
 	if cfg.TLS == nil {
 		err = srv.Serve(l)
 	} else {
-		err = srv.ServeTLS(l, cfg.TLS.Cert, cfg.TLS.Key)
+		err = srv.ServeTLS(l, cfg.TLS.CertPath, cfg.TLS.KeyPath)
 	}
 	return
 }
@@ -272,7 +272,7 @@ func (s *Server) initializeGRPC() error {
 	opts := common_grpc.ServerOptionsWithInterceptors(stream, unary)
 	if cfg := s.options.config.Services.GRPC; cfg != nil && cfg.TLS != nil {
 		tlsConfig, err := common_grpc.ClientAuthTLSConfig(
-			cfg.TLS.CA, cfg.TLS.Cert, cfg.TLS.Key,
+			cfg.TLS.CAPath, cfg.TLS.CertPath, cfg.TLS.KeyPath,
 			common_grpc.WithSetClientCAs(true),
 			common_grpc.WithServerName(s.Name),
 		)

--- a/components/common-go/baseserver/server_test.go
+++ b/components/common-go/baseserver/server_test.go
@@ -21,8 +21,8 @@ func TestServer_StartStop(t *testing.T) {
 	// We don't use the helper NewForTests, because we want to control stopping ourselves.
 	srv, err := baseserver.New("server_test",
 		baseserver.WithUnderTest(),
-		baseserver.WithHTTP("localhost:8765", nil),
-		baseserver.WithGRPC("localhost:8766", nil),
+		baseserver.WithHTTP(&baseserver.ServerConfiguration{Address: "localhost:8765"}),
+		baseserver.WithGRPC(&baseserver.ServerConfiguration{Address: "localhost:8766"}),
 	)
 	require.NoError(t, err)
 	baseserver.StartServerForTests(t, srv)
@@ -48,11 +48,15 @@ func TestServer_ServerCombinations_StartsAndStops(t *testing.T) {
 			var opts []baseserver.Option
 			opts = append(opts, baseserver.WithUnderTest())
 			if test.StartHTTP {
-				opts = append(opts, baseserver.WithHTTP(fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)), nil))
+				opts = append(opts, baseserver.WithHTTP(&baseserver.ServerConfiguration{
+					Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+				}))
 			}
 
 			if test.StartGRPC {
-				opts = append(opts, baseserver.WithGRPC(fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)), nil))
+				opts = append(opts, baseserver.WithGRPC(&baseserver.ServerConfiguration{
+					Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+				}))
 			}
 
 			srv, err := baseserver.New("test_server", opts...)
@@ -79,7 +83,9 @@ func TestServer_ServerCombinations_StartsAndStops(t *testing.T) {
 
 func TestServer_Metrics_gRPC(t *testing.T) {
 	ctx := context.Background()
-	srv := baseserver.NewForTests(t)
+	srv := baseserver.NewForTests(t, baseserver.WithGRPC(&baseserver.ServerConfiguration{
+		Address: fmt.Sprintf("localhost:%d", baseserver.MustFindFreePort(t)),
+	}))
 
 	// At this point, there must be metrics registry available for use
 	require.NotNil(t, srv.MetricsRegistry())

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -21,8 +21,6 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 
 	defaultTestOpts := []Option{
 		WithUnderTest(),
-		WithGRPC(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
-		WithHTTP(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
 		WithCloseTimeout(1 * time.Second),
 	}
 

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -20,7 +20,7 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 	t.Helper()
 
 	defaultTestOpts := []Option{
-		WithDebug(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
+		WithUnderTest(),
 		WithGRPC(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
 		WithHTTP(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
 		WithCloseTimeout(1 * time.Second),
@@ -82,7 +82,7 @@ func waitForServerToBeReachable(t *testing.T, srv *Server, timeout time.Duration
 	}
 
 	for {
-		healthURL := fmt.Sprintf("%s/ready", srv.DebugAddress())
+		healthURL := fmt.Sprintf("%s/ready", srv.HealthAddr())
 
 		select {
 		case <-ctx.Done():

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -7,10 +7,12 @@ package baseserver
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
+	"net"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // NewForTests constructs a *baseserver.Server which is automatically closed after the test finishes.
@@ -18,9 +20,9 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 	t.Helper()
 
 	defaultTestOpts := []Option{
-		WithGRPCPort(0),
-		WithHTTPPort(0),
-		WithDebugPort(0),
+		WithDebug(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
+		WithGRPC(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
+		WithHTTP(fmt.Sprintf("localhost:%d", MustFindFreePort(t)), nil),
 		WithCloseTimeout(1 * time.Second),
 	}
 
@@ -33,6 +35,25 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 	})
 
 	return srv
+}
+
+func MustFindFreePort(t *testing.T) int {
+	t.Helper()
+
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("cannot find free port: %v", err)
+		return 0
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatalf("cannot find free port: %v", err)
+		return 0
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port
 }
 
 // StartServerForTests starts the server for test purposes.
@@ -61,12 +82,13 @@ func waitForServerToBeReachable(t *testing.T, srv *Server, timeout time.Duration
 	}
 
 	for {
+		healthURL := fmt.Sprintf("%s/ready", srv.DebugAddress())
+
 		select {
 		case <-ctx.Done():
-			require.Failf(t, "server did not become reachable in %s", timeout.String())
+			t.Fatalf("server did not become reachable in %s on %s", timeout.String(), healthURL)
 		case <-ticker.C:
 			// We retrieve the URL on each tick, because the HTTPAddress is only available once the server is listening.
-			healthURL := fmt.Sprintf("%s/ready", srv.DebugAddress())
 			_, err := client.Get(healthURL)
 			if err != nil {
 				continue

--- a/components/common-go/baseserver/testing.go
+++ b/components/common-go/baseserver/testing.go
@@ -37,6 +37,14 @@ func NewForTests(t *testing.T, opts ...Option) *Server {
 	return srv
 }
 
+func MustUseRandomLocalAddress(t *testing.T) *ServerConfiguration {
+	t.Helper()
+
+	return &ServerConfiguration{
+		Address: fmt.Sprintf("localhost:%d", MustFindFreePort(t)),
+	}
+}
+
 func MustFindFreePort(t *testing.T) int {
 	t.Helper()
 

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -27,6 +27,7 @@ require (
 require (
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/components/common-go/go.sum
+++ b/components/common-go/go.sum
@@ -399,6 +399,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gitpod-io/gitpod/public-api v0.0.0-00010101000000-000000000000
 	github.com/google/go-cmp v0.5.7
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
@@ -30,12 +31,12 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect

--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -334,6 +334,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -6,12 +6,13 @@ package main
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/server"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"net/url"
 )
 
 const (
@@ -31,9 +32,9 @@ func main() {
 
 func command() *cobra.Command {
 	var (
-		gitpodAPIURL        string
-		debugPort, grpcPort int
-		verbose             bool
+		gitpodAPIURL string
+		grpcPort     int
+		verbose      bool
 	)
 
 	cmd := &cobra.Command{
@@ -53,7 +54,6 @@ func command() *cobra.Command {
 
 			if err := server.Start(logger, server.Config{
 				GitpodAPI: gitpodAPI,
-				DebugPort: debugPort,
 				GRPCPort:  grpcPort,
 			}); err != nil {
 				logger.WithError(err).Fatal("Server errored.")
@@ -62,7 +62,6 @@ func command() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&gitpodAPIURL, "gitpod-api-url", "wss://main.preview.gitpod-dev.com/api/v1", "URL for existing Gitpod Websocket API")
-	cmd.Flags().IntVar(&debugPort, "debug-port", 9500, "Port for serving debug endpoints")
 	cmd.Flags().IntVar(&grpcPort, "grpc-port", 9501, "Port for serving gRPC traffic")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Toggle verbose logging (debug level)")
 

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -7,6 +7,8 @@ package apiv1
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
@@ -18,7 +20,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
-	"testing"
 )
 
 func TestWorkspaceService_GetWorkspace(t *testing.T) {
@@ -30,7 +31,9 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 		description      = "This is the description"
 	)
 
-	srv := baseserver.NewForTests(t)
+	srv := baseserver.NewForTests(t,
+		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+	)
 
 	connPool := &FakeServerConnPool{
 		api: &FakeGitpodAPI{workspaces: map[string]*gitpod.WorkspaceInfo{
@@ -113,7 +116,9 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 }
 
 func TestWorkspaceService_GetOwnerToken(t *testing.T) {
-	srv := baseserver.NewForTests(t)
+	srv := baseserver.NewForTests(t,
+		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+	)
 	var connPool *FakeServerConnPool
 
 	v1.RegisterWorkspacesServiceServer(srv.GRPC(), NewWorkspaceService(connPool))

--- a/components/public-api-server/pkg/proxy/prometheusmetrics_test.go
+++ b/components/public-api-server/pkg/proxy/prometheusmetrics_test.go
@@ -6,6 +6,8 @@ package proxy
 
 import (
 	"context"
+	"testing"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,12 +16,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
-	"testing"
 )
 
 func TestConnectionCreationWasTracked(t *testing.T) {
 	// Set up server
-	srv := baseserver.NewForTests(t)
+	srv := baseserver.NewForTests(t,
+		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+	)
 	baseserver.StartServerForTests(t, srv)
 
 	// Set up Prometheus registry

--- a/components/public-api-server/pkg/server/config.go
+++ b/components/public-api-server/pkg/server/config.go
@@ -9,6 +9,5 @@ import "net/url"
 type Config struct {
 	GitpodAPI *url.URL
 
-	GRPCPort  int
-	DebugPort int
+	GRPCPort int
 }

--- a/components/public-api-server/pkg/server/integration_test.go
+++ b/components/public-api-server/pkg/server/integration_test.go
@@ -6,6 +6,9 @@ package server
 
 import (
 	"context"
+	"net/url"
+	"testing"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,13 +18,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"net/url"
-	"testing"
 )
 
 func TestPublicAPIServer_v1_WorkspaceService(t *testing.T) {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "some-token")
-	srv := baseserver.NewForTests(t)
+	srv := baseserver.NewForTests(t,
+		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+	)
 	registry := prometheus.NewRegistry()
 
 	gitpodAPI, err := url.Parse("wss://main.preview.gitpod-dev.com/api/v1")
@@ -68,7 +71,7 @@ func TestPublicAPIServer_v1_WorkspaceService(t *testing.T) {
 
 func TestPublicAPIServer_v1_PrebuildService(t *testing.T) {
 	ctx := context.Background()
-	srv := baseserver.NewForTests(t)
+	srv := baseserver.NewForTests(t, baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)))
 	registry := prometheus.NewRegistry()
 
 	gitpodAPI, err := url.Parse("wss://main.preview.gitpod-dev.com/api/v1")

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -6,6 +6,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/apiv1"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/proxy"
@@ -19,8 +20,8 @@ func Start(logger *logrus.Entry, cfg Config) error {
 
 	srv, err := baseserver.New("public_api_server",
 		baseserver.WithLogger(logger),
-		baseserver.WithDebugPort(cfg.DebugPort),
-		baseserver.WithGRPCPort(cfg.GRPCPort),
+		baseserver.WithDebug(fmt.Sprintf("localhost:%d", cfg.DebugPort), nil),
+		baseserver.WithGRPC(fmt.Sprintf("localhost:%d", cfg.GRPCPort), nil),
 		baseserver.WithMetricsRegistry(registry),
 	)
 	if err != nil {

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -20,7 +20,6 @@ func Start(logger *logrus.Entry, cfg Config) error {
 
 	srv, err := baseserver.New("public_api_server",
 		baseserver.WithLogger(logger),
-		baseserver.WithDebug(fmt.Sprintf("localhost:%d", cfg.DebugPort), nil),
 		baseserver.WithGRPC(fmt.Sprintf("localhost:%d", cfg.GRPCPort), nil),
 		baseserver.WithMetricsRegistry(registry),
 	)

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -20,7 +20,7 @@ func Start(logger *logrus.Entry, cfg Config) error {
 
 	srv, err := baseserver.New("public_api_server",
 		baseserver.WithLogger(logger),
-		baseserver.WithGRPC(fmt.Sprintf("localhost:%d", cfg.GRPCPort), nil),
+		baseserver.WithGRPC(&baseserver.ServerConfiguration{Address: fmt.Sprintf("localhost:%d", cfg.GRPCPort)}),
 		baseserver.WithMetricsRegistry(registry),
 	)
 	if err != nil {

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -131,6 +131,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/install/installer/go.sum
+++ b/install/installer/go.sum
@@ -843,6 +843,8 @@ github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoI
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -2638,6 +2640,7 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -7,10 +7,6 @@ package public_api_server
 const (
 	Component = "public-api-server"
 
-	DebugPortName      = "debug"
-	DebugContainerPort = 9000
-	DebugServicePort   = 9000
-
 	GRPCPortName      = "grpc"
 	GRPCContainerPort = 9001
 	GRPCServicePort   = 9001

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -4,9 +4,10 @@
 package public_api_server
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	"testing"
 )
 
 func TestDeployment(t *testing.T) {
@@ -35,7 +36,6 @@ func TestDeployment_ServerArguments(t *testing.T) {
 
 	apiContainer := containers[0]
 	require.EqualValues(t, []string{
-		"--debug-port=9000",
 		"--grpc-port=9001",
 		`--gitpod-api-url=wss://test.domain.everything.awesome.is/api/v1`,
 	}, apiContainer.Args)

--- a/install/installer/pkg/components/public-api-server/networkpolicy.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy.go
@@ -31,10 +31,6 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Protocol: common.TCPProtocol,
-								Port:     &intstr.IntOrString{IntVal: DebugContainerPort},
-							},
-							{
-								Protocol: common.TCPProtocol,
 								Port:     &intstr.IntOrString{IntVal: GRPCContainerPort},
 							},
 						},

--- a/install/installer/pkg/components/public-api-server/networkpolicy_test.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy_test.go
@@ -4,12 +4,13 @@
 package public_api_server
 
 import (
+	"testing"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"testing"
 )
 
 func TestNetworkPolicy(t *testing.T) {
@@ -25,10 +26,6 @@ func TestNetworkPolicy(t *testing.T) {
 
 	require.Equal(t, networkingv1.NetworkPolicyIngressRule{
 		Ports: []networkingv1.NetworkPolicyPort{
-			{
-				Protocol: common.TCPProtocol,
-				Port:     &intstr.IntOrString{IntVal: DebugContainerPort},
-			},
 			{
 				Protocol: common.TCPProtocol,
 				Port:     &intstr.IntOrString{IntVal: GRPCContainerPort},

--- a/install/installer/pkg/components/public-api-server/service.go
+++ b/install/installer/pkg/components/public-api-server/service.go
@@ -10,10 +10,6 @@ import (
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return common.GenerateService(Component, map[string]common.ServicePort{
-		DebugPortName: {
-			ContainerPort: DebugContainerPort,
-			ServicePort:   DebugServicePort,
-		},
 		GRPCPortName: {
 			ContainerPort: GRPCContainerPort,
 			ServicePort:   GRPCServicePort,


### PR DESCRIPTION
## Description
This PR refactors baseserver so that it's easy to integrate into the existing components, all the while harmonising the RPC/debug/HTTP configuration surface.

There's a stack of follow-up PRs which demonstrate the use of these changes in the real world:
- https://github.com/gitpod-io/gitpod/pull/10005
- https://github.com/gitpod-io/gitpod/pull/10007

## How to test
See unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft no-preview