### PR TITLE
[integration-test] Enable tests to run from local

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -69,5 +69,4 @@ To run the tests:
      -enterprise=<true|false> \
      -gitlab=<true|false>
    ```
-3. Tests `TestUploadDownloadBlob` and `TestUploadDownloadBlobViaServer` will fail when testing locally, as they are trying to connect to cluster local resources directly. To test them use docker image instead that runs within the cluster.
-4. If you want to run specific test, add `-run <test>` before `-kubeconfig` parameter.
+3. If you want to run specific test, add `-run <test>` before `-kubeconfig` parameter.

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -215,7 +215,7 @@ func Instrument(component ComponentType, agentName string, namespace string, kub
 		}
 	}()
 
-	fwdReady, fwdErr := common.ForwardPort(ctx, kubeconfig, namespace, podName, strconv.Itoa(localAgentPort))
+	fwdReady, fwdErr := common.ForwardPortOfPod(ctx, kubeconfig, namespace, podName, strconv.Itoa(localAgentPort))
 	select {
 	case <-fwdReady:
 	case err := <-execErrs:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update `TestUploadDownloadBlobViaServer` and `TestUploadDownloadBlob` so that they can run outside gitpod's kubernetes cluster.

### Notable changes
* Determine if the storage provider service is cluster local.
* If it is then create a port forward of the service to localhost.
* Update test methods to add original URL's host as `Host` header. Without this storage provider service such is minio will complain about signature mismatch.
* Rename `ForwardPort` function to `ForwardPortOfPod` and create a new function `ForwardPortOfService`. Both uses common function `forwardPort`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9953

## How to test
<!-- Provide steps to test this PR -->

```console
gitpod /workspace/gitpod/test (princerachit/enhance-the-workspace-9953) $ go test -v ./...   -run "^TestUploadDownloadBlob*"   -kubeconfig /home/gitpod/.kube/config   -namespace default   -username princerachit
?       github.com/gitpod-io/gitpod/test/pkg/agent/daemon       [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/agent/daemon/api   [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/agent/workspace    [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api        [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/integration        [no test files]
?       github.com/gitpod-io/gitpod/test/pkg/integration/common [no test files]
=== RUN   TestUploadDownloadBlob
=== RUN   TestUploadDownloadBlob/UploadDownloadBlob
=== RUN   TestUploadDownloadBlob/UploadDownloadBlob/it_should_upload_and_download_blob
    content-service_test.go:199: upload URL: http://localhost:43975/gitpod-user-00000000-0000-0000-0000-000000000000/blobs/test-blob?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=bPggFJB.sPVlgG7oMIWG%2F20220513%2Flocal%2Fs3%2Faws4_request&X-Amz-Date=20220513T114845Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=df246ac5ed45be663e84cecf856069bce1c180e00a9351b70f7bbd7fbe84a20f
    content-service_test.go:212: download URL: http://localhost:41427/gitpod-user-00000000-0000-0000-0000-000000000000/blobs/test-blob?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=bPggFJB.sPVlgG7oMIWG%2F20220513%2Flocal%2Fs3%2Faws4_request&X-Amz-Date=20220513T114847Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=0e08269d26c3f84d6c497aef7d23b131fefc2479401d0f98697c61297e047fa0
--- PASS: TestUploadDownloadBlob (6.70s)
    --- PASS: TestUploadDownloadBlob/UploadDownloadBlob (6.70s)
        --- PASS: TestUploadDownloadBlob/UploadDownloadBlob/it_should_upload_and_download_blob (6.70s)
=== RUN   TestUploadDownloadBlobViaServer
=== RUN   TestUploadDownloadBlobViaServer/UploadDownloadBlobViaServer
=== RUN   TestUploadDownloadBlobViaServer/UploadDownloadBlobViaServer/it_should_uploads_a_blob_via_server_→_content-server_and_downloads_it_afterwards
    content-service_test.go:255: upload URL: http://localhost:40895/gitpod-user-builtin-user-agent-smith-0000000/blobs/test-blob?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=bPggFJB.sPVlgG7oMIWG%2F20220513%2Flocal%2Fs3%2Faws4_request&X-Amz-Date=20220513T114857Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=f379120c7d485d2ed911fc939c423c08faa7de5965047c4fdbe2dc16c6646a46
    content-service_test.go:268: download URL: http://localhost:40985/gitpod-user-builtin-user-agent-smith-0000000/blobs/test-blob?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=bPggFJB.sPVlgG7oMIWG%2F20220513%2Flocal%2Fs3%2Faws4_request&X-Amz-Date=20220513T114859Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=98840aa0471ebb00c81997fc2fa1059c8a0bd0c605fb9c16829a74ba68cac6b9
    content-service_test.go:275: Uploading and downloading blob to content store succeeded.
--- PASS: TestUploadDownloadBlobViaServer (12.67s)
    --- PASS: TestUploadDownloadBlobViaServer/UploadDownloadBlobViaServer (12.67s)
        --- PASS: TestUploadDownloadBlobViaServer/UploadDownloadBlobViaServer/it_should_uploads_a_blob_via_server_→_content-server_and_downloads_it_afterwards (12.67s)
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/content-service       22.256s
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/database      2.846s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/image-builder 2.883s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/server        2.848s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/ws-daemon     2.885s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/components/ws-manager    2.852s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/ide/jetbrains    2.960s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/ide/vscode       2.901s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/gitpod-io/gitpod/test/tests/workspace        2.907s [no tests to run]
?       github.com/gitpod-io/gitpod/test/tests/workspace/common [no test files]
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
