### PR TITLE
[ws-daemon] update git safe directory at init workspace phase

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -257,6 +257,11 @@ func (s *WorkspaceService) InitWorkspace(ctx context.Context, req *api.InitWorks
 		}
 	}
 
+	err = workspace.UpdateGitSafeDirectory(ctx)
+	if err != nil {
+		log.WithError(err).WithField("workspaceId", req.Id).Warn("cannot update git safe directory")
+	}
+
 	// Tell the world we're done
 	err = workspace.MarkInitDone(ctx)
 	if err != nil {

--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -257,6 +257,28 @@ func (s *Workspace) SetGitStatus(status *csapi.GitStatus) error {
 	return s.persist()
 }
 
+func (s *Workspace) UpdateGitSafeDirectory(ctx context.Context) (err error) {
+	loc := s.Location
+	if loc == "" {
+		log.WithField("loc", loc).WithFields(s.OWI()).Debug("not updating Git safe directory of FWB workspace")
+		return nil
+	}
+
+	loc = filepath.Join(loc, s.CheckoutLocation)
+	if !git.IsWorkingCopy(loc) {
+		log.WithField("loc", loc).WithField("checkout location", s.CheckoutLocation).WithFields(s.OWI()).Warn("did not find a Git working copy - not updating safe directory")
+		return nil
+	}
+
+	c := git.Client{Location: loc}
+
+	err = c.Git(ctx, "config", "--global", "--add", "safe.directory", loc)
+	if err != nil {
+		log.WithError(err).WithFields(s.OWI()).Warn("cannot add safe directory into git global config")
+	}
+	return err
+}
+
 // UpdateGitStatus attempts to update the LastGitStatus from the workspace's local working copy.
 func (s *Workspace) UpdateGitStatus(ctx context.Context) (res *csapi.GitStatus, err error) {
 	loc := s.Location
@@ -280,12 +302,6 @@ func (s *Workspace) UpdateGitStatus(ctx context.Context) (res *csapi.GitStatus, 
 	}
 
 	c := git.Client{Location: loc}
-
-	err = c.Git(ctx, "config", "--global", "--add", "safe.directory", loc)
-	if err != nil {
-		log.WithError(err).WithFields(s.OWI()).Warn("cannot persist latest Git status")
-		err = nil
-	}
 
 	stat, err := c.Status(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
