### PR TITLE
[jb-backend] add jb_active_language tracking

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
@@ -8,7 +8,11 @@ import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.client.ClientProjectSession
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileTypes.LanguageFileType
 import io.gitpod.gitpodprotocol.api.entities.RemoteTrackMessage
+import io.gitpod.supervisor.api.Info
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
@@ -18,25 +22,59 @@ class GitpodClientProjectSessionTracker(
 ) {
 
     private val manager = service<GitpodManager>()
+
+    private lateinit var info: Info.WorkspaceInfoResponse
+    private val versionName = ApplicationInfo.getInstance().versionName
+    private val fullVersion = ApplicationInfo.getInstance().fullVersion
+
     init {
         GlobalScope.launch {
-            val info = manager.pendingInfo.await()
-            val event = RemoteTrackMessage().apply {
-                event = "jb_session"
-                properties = mapOf(
-                        "sessionId" to session.clientId.value,
-                        "instanceId" to info.instanceId,
-                        "workspaceId" to info.workspaceId,
-                        "appName" to ApplicationInfo.getInstance().versionName,
-                        "appVersion" to ApplicationInfo.getInstance().fullVersion,
-                        "timestamp" to System.currentTimeMillis()
-                )
+            info = manager.pendingInfo.await()
+            trackEvent("jb_session", mapOf())
+            registerActiveLanguageAnalytics()
+        }
+    }
+
+    private fun registerActiveLanguageAnalytics() {
+        val activeLanguages = mutableSetOf<String>()
+        session.project.messageBus.connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, object : FileEditorManagerListener {
+            override fun selectionChanged(event: FileEditorManagerEvent) {
+                super.selectionChanged(event)
+                if (event.manager.selectedEditor == null) {
+                    return
+                }
+                val file = event.manager.selectedEditor!!.file
+                val ext = file.extension
+                val fileType = file.fileType
+                var lang = "plaintext"
+                if (fileType is LanguageFileType) {
+                    lang = fileType.language.id
+                }
+                if (activeLanguages.contains(lang)) {
+                    return
+                }
+                activeLanguages.add(lang)
+                trackEvent("jb_active_language", mapOf("lang" to lang, "ext" to ext))
             }
-            if (manager.devMode) {
-                thisLogger().warn("gitpod: $event")
-            } else {
-                manager.client.server.trackEvent(event)
-            }
+        })
+    }
+
+    fun trackEvent(eventName: String, props: Map<String, Any?>) {
+        val event = RemoteTrackMessage().apply {
+            event = eventName
+            properties = mapOf(
+                    "sessionId" to session.clientId.value,
+                    "instanceId" to info.instanceId,
+                    "workspaceId" to info.workspaceId,
+                    "appName" to versionName,
+                    "appVersion" to fullVersion,
+                    "timestamp" to System.currentTimeMillis()
+            ).plus(props)
+        }
+        if (manager.devMode) {
+            thisLogger().warn("gitpod: $event")
+        } else {
+            manager.client.server.trackEvent(event)
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add analytic for the language of opened files

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
Related https://github.com/gitpod-io/gitpod/issues/9967

## How to test
<!-- Provide steps to test this PR -->
1. Use JetBrains IDE
2. Open or create some files with lang ext like `a.md` `b.go` etc
3. Go to [segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger), search with `jb_active_language`, see track log details

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Todo
- [x] Add doc to tracking plan

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe