### PR TITLE
[alerts] add alert when autoscaler adds nodes rapidly

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -22,6 +22,18 @@
             },
             expr: 'nodepool:node_load1:normalized{nodepool=~".*workspace.*"} > 3',
           },
+          {
+            alert: 'AutoscalerAddsNodesTooFast',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/AutoscalerAddsNodesTooFast.md',
+              summary: "Autoscaler is adding new nodes rapidly",
+              description: 'Autoscaler in cluster {{ $labels.cluster }} is rapidly adding new nodes.',
+            },
+            expr: '((sum(cluster_autoscaler_nodes_count) by (cluster)) - (sum(cluster_autoscaler_nodes_count offset 10m) by (cluster))) > 15',
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9946

## How to test
<!-- Provide steps to test this PR -->
Test alert expression in grafana

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
