### PR TITLE
[common-go] Add file watcher

### DIFF
--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9

--- a/components/common-go/go.sum
+++ b/components/common-go/go.sum
@@ -82,6 +82,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/components/common-go/watch/file.go
+++ b/components/common-go/watch/file.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package watch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	"golang.org/x/xerrors"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+)
+
+type fileWatcher struct {
+	onChange func()
+
+	watcher *fsnotify.Watcher
+
+	hash string
+}
+
+func File(ctx context.Context, path string, onChange func()) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return xerrors.Errorf("unexpected error creating file watcher: %w", err)
+	}
+
+	fw := &fileWatcher{
+		watcher:  watcher,
+		onChange: onChange,
+	}
+
+	// initial hash of the file
+	hash, err := hashConfig(path)
+	if err != nil {
+		return xerrors.Errorf("cannot get hash of file %v: %w", path, err)
+	}
+
+	// visible files in a volume are symlinks to files in the writer's data directory.
+	// The files are stored in a hidden timestamped directory which is symlinked to by the data directory.
+	// The timestamped directory and data directory symlink are created in the writer's target dir.
+	// https://pkg.go.dev/k8s.io/kubernetes/pkg/volume/util#AtomicWriter
+	watchDir, _ := filepath.Split(path)
+	err = watcher.Add(watchDir)
+	if err != nil {
+		watcher.Close()
+		return xerrors.Errorf("unexpected error watching file %v: %w", path, err)
+	}
+
+	log.Infof("starting watch of file %v", path)
+
+	fw.hash = hash
+
+	go func() {
+		defer func() {
+			log.WithError(err).Error("stopping file watch")
+
+			err = watcher.Close()
+			if err != nil {
+				log.WithError(err).Error("unexpected error closing file watcher")
+			}
+		}()
+
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				if !eventOpIs(event, fsnotify.Create) && !eventOpIs(event, fsnotify.Remove) {
+					continue
+				}
+
+				currentHash, err := hashConfig(path)
+				if err != nil {
+					log.WithError(err).Warn("cannot check if config has changed")
+					return
+				}
+
+				// no change
+				if currentHash == fw.hash {
+					continue
+				}
+
+				log.WithField("path", path).Info("reloading file after change")
+
+				fw.hash = currentHash
+				fw.onChange()
+			case err := <-watcher.Errors:
+				log.WithError(err).Error("unexpected error watching event")
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func hashConfig(path string) (hash string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+
+	_, err = io.Copy(h, f)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func eventOpIs(event fsnotify.Event, op fsnotify.Op) bool {
+	return event.Op&op == op
+}

--- a/components/common-go/watch/file.go
+++ b/components/common-go/watch/file.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
-	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 )
@@ -29,7 +29,7 @@ type fileWatcher struct {
 func File(ctx context.Context, path string, onChange func()) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return xerrors.Errorf("unexpected error creating file watcher: %w", err)
+		return fmt.Errorf("unexpected error creating file watcher: %w", err)
 	}
 
 	fw := &fileWatcher{
@@ -40,7 +40,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 	// initial hash of the file
 	hash, err := hashConfig(path)
 	if err != nil {
-		return xerrors.Errorf("cannot get hash of file %v: %w", path, err)
+		return fmt.Errorf("cannot get hash of file %v: %w", path, err)
 	}
 
 	// visible files in a volume are symlinks to files in the writer's data directory.
@@ -51,7 +51,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 	err = watcher.Add(watchDir)
 	if err != nil {
 		watcher.Close()
-		return xerrors.Errorf("unexpected error watching file %v: %w", path, err)
+		return fmt.Errorf("unexpected error watching file %v: %w", path, err)
 	}
 
 	log.Infof("starting watch of file %v", path)
@@ -60,11 +60,11 @@ func File(ctx context.Context, path string, onChange func()) error {
 
 	go func() {
 		defer func() {
-			log.WithError(err).Error("stopping file watch")
+			log.WithError(err).Error("Stopping file watch")
 
 			err = watcher.Close()
 			if err != nil {
-				log.WithError(err).Error("unexpected error closing file watcher")
+				log.WithError(err).Error("Unexpected error closing file watcher")
 			}
 		}()
 
@@ -81,7 +81,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 
 				currentHash, err := hashConfig(path)
 				if err != nil {
-					log.WithError(err).Warn("cannot check if config has changed")
+					log.WithError(err).Warn("Cannot check if config has changed")
 					return
 				}
 
@@ -95,7 +95,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 				fw.hash = currentHash
 				fw.onChange()
 			case err := <-watcher.Errors:
-				log.WithError(err).Error("unexpected error watching event")
+				log.WithError(err).Error("Unexpected error watching event")
 			case <-ctx.Done():
 				return
 			}

--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-test/deep v1.0.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/components/service-waiter/go.mod
+++ b/components/service-waiter/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect

--- a/components/service-waiter/go.sum
+++ b/components/service-waiter/go.sum
@@ -38,8 +38,9 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -253,6 +254,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/gomodifytags v1.14.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-ozzo/ozzo-validation v3.5.0+incompatible // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect

--- a/components/ws-daemon/pkg/config/config.go
+++ b/components/ws-daemon/pkg/config/config.go
@@ -6,21 +6,15 @@ package config
 
 import (
 	"bytes"
-	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
-	"io"
 	"os"
-	"time"
 
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
-	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/daemon"
 )
 
@@ -39,63 +33,6 @@ func Read(fn string) (*Config, error) {
 	}
 
 	return &cfg, nil
-}
-
-// watchConfig watches the configuration file and if changed reloads the static layer
-func Watch(fn string, cb func(context.Context, *daemon.Config) error) {
-	hashConfig := func() (hash string, err error) {
-		f, err := os.Open(fn)
-		if err != nil {
-			return "", err
-		}
-		defer f.Close()
-
-		h := sha256.New()
-		_, err = io.Copy(h, f)
-		if err != nil {
-			return "", err
-		}
-
-		return hex.EncodeToString(h.Sum(nil)), nil
-	}
-	reloadConfig := func() error {
-		cfg, err := Read(fn)
-		if err != nil {
-			return err
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
-
-		return cb(ctx, &cfg.Daemon)
-	}
-
-	var (
-		tick    = time.NewTicker(30 * time.Second)
-		oldHash string
-	)
-	defer tick.Stop()
-	for range tick.C {
-		currentHash, err := hashConfig()
-		if err != nil {
-			log.WithError(err).Warn("cannot check if config has changed")
-		}
-
-		if oldHash == "" {
-			oldHash = currentHash
-		}
-		if currentHash == oldHash {
-			continue
-		}
-		oldHash = currentHash
-
-		err = reloadConfig()
-		if err == nil {
-			log.Info("configuration was updated - reloaded static layer config")
-		} else {
-			log.WithError(err).Error("cannot reload config - config hot reloading did not work")
-		}
-	}
 }
 
 type Config struct {


### PR DESCRIPTION
## Description

Refactor watch of configuration files and reload and remove duplication

## How to test
- Change `ws-daemon` or `ws-daemon` configmap and check the reload message appears in the log

```
{"level":"info","message":"reloading file after change","path":"/config/config.json","serviceContext":{"service":"ws-daemon","version":"commit-5de52b5daf5c35fe22f46adcff90cbaca78b075b"},"severity":"INFO","time":"2022-05-16T05:23:37Z"}}
```

## Release Notes
```release-note
[common-go] Add file watcher
[registry-facade] Refactor watch of configuration file
[ws-daemon] Refactor watch of configuration file
```
