### PR TITLE
Add meta ID and owner to find workspace image-build Pod

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -166,6 +166,8 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	case api.WorkspaceType_IMAGEBUILD:
 		wss, err := m.GetWorkspaces(ctx, &api.GetWorkspacesRequest{
 			MustMatch: &api.MetadataFilter{
+				Owner:       req.Metadata.Owner,
+				MetaId:      req.Metadata.MetaId,
 				Annotations: req.Metadata.Annotations,
 			},
 		})


### PR DESCRIPTION
## Description
Add meta ID (workspace ID) and owner to find the workspace image-build Pod.

The integration test `TestParallelBaseImageBuild` did not hit this issue on `core-dev` env but it always happens on `preview-environment`.

The integration test calls image-builder-mk3 [Build](https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/test/tests/components/image-builder/builder_test.go#L144-L151) twice with the same [dockerfile](https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/test/tests/components/image-builder/builder_test.go#L121-L141). The image-builder-mk3 requests the ws-manager to create the image-builder Pod for building the container image. If the image-builder Pod always exists, the ws-manager returns the existed image-builder Pod to the image-builder-mk3.

In `core-dev`, the 2nd image-build `Build` call would not hit this code block However, in `preview-environment`, the 2nd image-build `Build` call would hit this code block. It seems to be a race condition.
- In `core-dev`, the ws-manager can receives the [StartWorkspace](https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/components/ws-manager/pkg/manager/manager.go#L151) call simultaneously.
- In `preview-environment`, the ws-manager receives the 2nd [StartWorkspace](https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/components/ws-manager/pkg/manager/manager.go#L151) call after the 1st image build Pod [created](https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/components/ws-manager/pkg/manager/manager.go#L247).
https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/components/ws-manager/pkg/manager/manager.go#L176-L182

In general, to find the corresponding workspace Pods, we should add the meta ID (workspace ID) as well as the owner name.
Otherwise, the 2nd image-build `Build` call will not launch a new Pod to execute the image build because the 1st image-build Pod matches the [annotations](https://github.com/gitpod-io/gitpod/blob/6b5f345e2d47ebadfbe334bd6df05067b2c0050d/components/ws-manager/pkg/manager/manager.go#L169).

<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9782

## How to test
<!-- Provide steps to test this PR -->
```shell
./dev/preview/install-k3s-kubeconfig.sh
cd test

go test -v ./... \
  -kubeconfig=/home/gitpod/.kube/config \
  -namespace=default \
  -run=TestParallelBaseImageBuild
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A