### PR TITLE
[image-builder] Fix error when secret is a json

### DIFF
--- a/components/image-builder-bob/pkg/proxy/auth.go
+++ b/components/image-builder-bob/pkg/proxy/auth.go
@@ -61,6 +61,7 @@ func (a MapAuthorizer) AddIfNotExists(other MapAuthorizer) MapAuthorizer {
 	}
 	for k, v := range other {
 		if _, ok := a[k]; ok {
+			log.Infof("Skip adding key: %s to MapAuthorizer as it already exists", k)
 			continue
 		}
 		res[k] = v

--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -208,9 +208,9 @@ func (a AllowedAuthFor) additionalAuth(domain string) *Authentication {
 	dec, err := base64.StdEncoding.DecodeString(ath)
 	if err == nil {
 		segs := strings.Split(string(dec), ":")
-		if len(segs) == 2 {
+		if len(segs) > 1 {
 			res.Username = segs[0]
-			res.Password = segs[1]
+			res.Password = strings.Join(segs[1:], ":")
 		}
 	}
 	return res


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The credentials from decoded auth string should be split in such a way that the first substring is treated as username and the rest of the string as password/secret. This is in conformance with what we have in [image-builder-bob](https://github.com/gitpod-io/gitpod/blob/39049b30572807d871a2fdbc6fe8c30e814cb33e/components/image-builder-bob/pkg/proxy/auth.go#L45-L51).
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8938

## How to test
<!-- Provide steps to test this PR -->
Prefer testing in workspace-preview due to known issues (see following `Known Caveats` section)
The json key secret is used in GAR/GCR. It allows you to use your service account key as a json key secret for docker login. Read more [here](https://cloud.google.com/artifact-registry/docs/docker/authentication#json-key).
I am not aware of any other such registry services which accepts a json key as a secret. In any case this PR should solve any issues whether a registry service accepts a json key or a yaml or a plain string.


1. Create a Google Artifact Registry in us region (There is a conflict of keys in preview env with europe region, to be fixed by followup PR)
2. Create a service account with registry writer permission
3. Create a key for above service account
4. Rename the key to key.json
5. Run the following command: `cat key.json | docker login us-docker.pkg.dev -u _json_key --password-stdin`
6. Push an image to the registry (prefer retagging a workspace image e.g. gitpod/workspace-go:latest)
7. Configure your repo to use above image in `.gitpod.yml`
8. Open docker config (`~/.docker/config`) and copy the auth base64encoded string and use it as per instructions of [this PR](https://github.com/gitpod-io/gitpod/pull/8550). Your workspace should start now. 


### Working example
<img width="2558" alt="image" src="https://user-images.githubusercontent.com/32481722/168971533-3926231a-2dbf-4a00-93dd-73174586eba3.png">

### Known Caveats
* The default behaviour of image-build is to use an existing auth if it exists. e.g. in preview env we configure `europe-docker.pkg.dev` and `eu.gcr.io` in our pull secrets. If you create a private registry in any of these registries then your image build will fail due to incorrect key.
* I will raise a follow up PR to solve this issue. Whereas, we can always ignore the existing creds and use the additional auth supplied by user, this will not work well with eu.gcr.io because that is where we pushed the built images.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix credential errors when json key is used as secret in image-builder-mk3 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
