### PR TITLE
[code] Serve webview resources using blobserve

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 9d98f338d0c8584b66195fceb555bb7223c755bc
+  codeCommit: 32d5576921d1fb2a4891adb67f5003c554b04125
   codeQuality: stable
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.1.tar.gz"

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -46,24 +46,20 @@ RUN yarn --frozen-lockfile --network-timeout 180000
 RUN rm -rf remote/node_modules/
 COPY --from=dependencies_builder /gp-code/remote/node_modules/ /gp-code/remote/node_modules/
 
+# update product.json
 RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     nameLong=$(jq --raw-output '.nameLong' product.json) && \
-    echo $CODE_QUALITY && \
     if [ "$CODE_QUALITY" = "insider" ]; then \
         nameShort="$nameShort - Insiders" \
         nameLong="$nameLong - Insiders" \
     ; fi  && \
-    setQuality='setpath(["quality"]; $codeQuality)' && \
-    setNameShort='setpath(["nameShort"]; $nameShort)' && \
-    setNameLong='setpath(["nameLong"]; $nameLong)' && \
+    setQuality="setpath([\"quality\"]; \"$CODE_QUALITY\")" && \
+    setNameShort="setpath([\"nameShort\"]; \"$nameShort\")" && \
+    setNameLong="setpath([\"nameLong\"]; \"$nameLong\")" && \
     jqCommands="${setQuality} | ${setNameShort} | ${setNameLong}" && \
-    cat product.json | jq \
-        --arg codeQuality "$CODE_QUALITY" \
-        --arg nameShort "$nameShort" \
-        --arg nameLong "$nameLong" \
-         "${jqCommands}" > product.json.tmp && \
+    cat product.json | jq "${jqCommands}" > product.json.tmp && \
     mv product.json.tmp product.json && \
-    cat product.json
+    jq '{quality,nameLong,nameShort}' product.json
 
 RUN yarn --cwd extensions compile \
     && yarn gulp vscode-web-min \

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -326,19 +326,6 @@ https://*.*.{$GITPOD_DOMAIN} {
 		}
 	}
 
-	# REMOVE this once all workspaces have updated to new vscode version
-	# old foreign content route used by vscode to serve webview and webworker resources
-	# origin should be decoupled from the workspace (port) origin but the workspace (port) prefix should be the path root for routing
-	@foreign_content header_regexp host Host ^.+-foreign.ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
-	handle @foreign_content {
-		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
-			import workspace_transport
-			import upstream_headers
-
-			header_up X-WSProxy-Host       {http.request.host}
-		}
-	}
-
 	# foreign content route used by vscode to serve webview and webworker resources of the form
 	# https://{{hash_base_32}}.<cluster>.<gitpod_domain> or https://v--{{hash_base_32}}.<cluster>.<gitpod_domain>
 	# e.g:

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -94,15 +94,6 @@ func installWorkspaceRoutes(r *mux.Router, config *RouteHandlerConfig, ip Worksp
 	})
 	routes.HandleSupervisorFrontendRoute(faviconRouter.NewRoute())
 
-	// Theia has a bunch of special routes it probably requires.
-	// TODO(cw): figure out if these routes are still required, and how we deal with specialties of other IDEs.
-	for _, pp := range []string{"/services", "/file-upload"} {
-		routes.HandleDirectIDERoute(r.Path(pp))
-	}
-	for _, pp := range []string{"/mini-browser", "/file", "/files", "/hostedPlugin", "/webview"} {
-		routes.HandleDirectIDERoute(r.PathPrefix(pp))
-	}
-
 	routes.HandleSupervisorFrontendRoute(enableCompression(r).PathPrefix("/_supervisor/frontend"))
 
 	routes.HandleDirectSupervisorRoute(r.PathPrefix("/_supervisor/v1/status/supervisor"), false)

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -580,26 +580,6 @@ func TestRoutes(t *testing.T) {
 				Body:   "blobserve hit: /blobserve/gitpod-io/supervisor:latest/main.js\nreadOnly: true\n",
 			},
 		},
-		{
-			Desc: "extensions route GET",
-			Request: modifyRequest(httptest.NewRequest("GET", "https://extensions-foreign.test-domain.com/"+workspaces[0].WorkspaceID+"/extensions.js", nil),
-				addHostHeader,
-				addHeader("Origin", config.GitpodInstallation.HostName),
-				addOwnerToken(workspaces[0].InstanceID, workspaces[0].Auth.OwnerToken),
-			),
-			Expectation: Expectation{
-				Status: http.StatusOK,
-				Header: http.Header{
-					"Access-Control-Allow-Credentials": {"true"},
-					"Access-Control-Allow-Origin":      {"test-domain.com"},
-					"Access-Control-Expose-Headers":    {"Authorization"},
-					"Content-Length":                   {"30"},
-					"Content-Type":                     {"text/plain; charset=utf-8"},
-					"Vary":                             {"Accept-Encoding"},
-				},
-				Body: "workspace hit: /extensions.js\n",
-			},
-		},
 	}
 
 	log.Init("ws-proxy-test", "", false, true)

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -85,8 +85,10 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 	}
 
 	r := regexp.MustCompile("^" + regexPrefix + wsHostSuffix)
-	foreignContentHostR := regexp.MustCompile("^(.+)(?:foreign)" + wsHostSuffix)
+
+	// REMOVE this once all workspaces have updated to new vscode version
 	foreignContentHost2R := regexp.MustCompile("^((?:v--)?[0-9a-v]+)" + wsHostSuffix)
+
 	foreignContentPathR := regexp.MustCompile("^/" + regexPrefix + "(/.*)")
 	return func(req *http.Request, m *mux.RouteMatch) bool {
 		hostname := headerProvider(req)
@@ -95,21 +97,23 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 		}
 
 		var workspaceID, workspacePort, foreignOrigin, foreignPath string
-		matches := foreignContentHostR.FindStringSubmatch(hostname)
-		if len(matches) == 0 {
-			matches = foreignContentHost2R.FindStringSubmatch(hostname)
-		}
+		matches := foreignContentHost2R.FindStringSubmatch(hostname)
 		if len(matches) == 2 {
 			foreignOrigin = matches[1]
+			if strings.Contains(req.URL.Path, "/__files__/") {
+				// REMOVE this once all workspaces have updated to new vscode version
+				// Don't match if path contains `/__files__/` (blobserve image separator)
+				return false
+			}
 			matches = foreignContentPathR.FindStringSubmatch(req.URL.Path)
 			if matchPort {
 				if len(matches) < 4 {
 					return false
 				}
-				// https://extensions-foreign.ws-eu10.gitpod.io/3000-coral-dragon-ilr0r6eq/index.html
+				// https://0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-eu10.gitpod.io/3000-coral-dragon-ilr0r6eq/index.html
 				// workspaceID: coral-dragon-ilr0r6eq
 				// workspacePort: 3000
-				// foreignOrigin: extensions-
+				// foreignOrigin: 0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk
 				// foreignPath: /index.html
 				workspaceID = matches[2]
 				workspacePort = matches[1]
@@ -118,10 +122,10 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 				if len(matches) < 3 {
 					return false
 				}
-				// https://extensions-foreign.ws-eu10.gitpod.io/coral-dragon-ilr0r6eq/index.html
+				// https://0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-eu10.gitpod.io/coral-dragon-ilr0r6eq/index.html
 				// workspaceID: coral-dragon-ilr0r6eq
 				// workspacePort:
-				// foreignOrigin: extensions-
+				// foreignOrigin: 0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk
 				// foreignPath: /index.html
 				workspaceID = matches[1]
 				foreignPath = matches[2]
@@ -180,6 +184,7 @@ func matchWorkspaceHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 
 func matchBlobserveHostHeader(wsHostSuffix string, headerProvider hostHeaderProvider) mux.MatcherFunc {
 	r := regexp.MustCompile("^blobserve" + wsHostSuffix)
+	r2 := regexp.MustCompile("^(?:v--)?[0-9a-v]+" + wsHostSuffix)
 	return func(req *http.Request, m *mux.RouteMatch) bool {
 		hostname := headerProvider(req)
 		if hostname == "" {
@@ -187,7 +192,18 @@ func matchBlobserveHostHeader(wsHostSuffix string, headerProvider hostHeaderProv
 		}
 
 		matches := r.FindStringSubmatch(hostname)
-		return len(matches) >= 1
+		if len(matches) >= 1 {
+			return true
+		}
+
+		matches = r2.FindStringSubmatch(hostname)
+		if len(matches) >= 1 && strings.Contains(req.URL.Path, "/__files__/") {
+			// Check if path contains `/__files__/` for now as it could be using an
+			// old vscode version serving webview resources from workspace
+			return true
+		}
+
+		return false
 	}
 }
 

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -157,39 +157,17 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			HostHeader: "",
 		},
 		{
+			Name:       "no match 2",
+			HostHeader: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
+			Path:       "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly@sha256:41aeea688aa0943bd746cb70c4ed378910f7c7ecf56f5f53ccb2b76c6b68e1a7/__files__/index.html",
+		},
+		{
 			Name:       "workspace match",
 			HostHeader: "amaranth-smelt-9ba20cc1" + wsHostSuffix,
 			Expected: matchResult{
 				MatchesWorkspace: true,
 				WorkspaceVars: map[string]string{
 					workspaceIDIdentifier: "amaranth-smelt-9ba20cc1",
-				},
-			},
-		},
-		{
-			Name:       "unique webview workspace match",
-			HostHeader: "ad859a83-b5a8-43ef-8e82-cfbf36cafacb-webview-foreign" + wsHostSuffix,
-			Path:       "/amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesWorkspace: true,
-				WorkspaceVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					foreignOriginIdentifier: "ad859a83-b5a8-43ef-8e82-cfbf36cafacb-webview-",
-					foreignPathIdentifier:   "/index.html",
-				},
-			},
-		},
-		{
-			Name:       "unique webview port match",
-			HostHeader: "ad859a83-b5a8-43ef-8e82-cfbf36cafacb-webview-foreign" + wsHostSuffix,
-			Path:       "/8080-amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesPort: true,
-				PortVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					workspacePortIdentifier: "8080",
-					foreignOriginIdentifier: "ad859a83-b5a8-43ef-8e82-cfbf36cafacb-webview-",
-					foreignPathIdentifier:   "/index.html",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Serve webview resources using blobserve, this will allow as to update gp-code nightly as there were some breaking changes for us upstream

## How to test
<!-- Provide steps to test this PR -->
You need to test this for both stable and insiders vscode to ensure changes are backwards compatible
1. Open a workspace
2. Check webviews work, e.g simple browser
3. Install vim extension, check it activates sucessfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

