### PR TITLE
[public-api] Publish to NPM

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -86,6 +86,7 @@ packages:
       - components/supervisor-api/typescript-grpc:publish
       - components/supervisor-api/typescript-grpcweb:publish
       - components/ide/jetbrains/gateway-plugin:publish
+      - components/public-api/typescript:publish
   - name: all-apps
     type: generic
     deps:

--- a/components/public-api/typescript/BUILD.yaml
+++ b/components/public-api/typescript/BUILD.yaml
@@ -4,9 +4,9 @@ packages:
     deps:
       - components/gitpod-protocol:lib
     srcs:
-      - "src/*.ts"
-      - "src/*.js"
+      - src/**
       - package.json
+      - tsconfig.json
     config:
       packaging: library
       dontTest: true
@@ -14,3 +14,16 @@ packages:
         build: ["yarn", "build"]
       yarnLock: ${coreYarnLockBase}/../yarn.lock
       tsconfig: tsconfig.json
+
+  - name: publish
+    type: generic
+    env:
+      - DO_PUBLISH=${publishToNPM}
+    argdeps:
+      - npmPublishTrigger
+    deps:
+      - :lib
+      - components/gitpod-protocol:scripts
+    config:
+      commands:
+        - ["node", "components-gitpod-protocol--scripts/publish.js", "${version}", "components-public-api-typescript--lib/package"]

--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -1,10 +1,8 @@
 {
-  "private": true,
   "name": "@gitpod/public-api",
   "version": "0.1.5",
   "license": "UNLICENSED",
   "files": [
-    "client",
     "lib"
   ],
   "scripts": {
@@ -14,11 +12,9 @@
     "test:brk": "yarn test --inspect-brk"
   },
   "dependencies": {
-    "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
     "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.19.1",
-    "inversify": "^5.0.1",
     "opentracing": "^0.14.4"
   },
   "devDependencies": {

--- a/components/public-api/typescript/src/gitpod/v1/pagination_grpc_pb.js
+++ b/components/public-api/typescript/src/gitpod/v1/pagination_grpc_pb.js
@@ -1,1 +1,7 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // GENERATED CODE -- NO SERVICES IN PROTO

--- a/components/public-api/typescript/src/gitpod/v1/pagination_pb.d.ts
+++ b/components/public-api/typescript/src/gitpod/v1/pagination_pb.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // package: gitpod.v1
 // file: gitpod/v1/pagination.proto
 

--- a/components/public-api/typescript/src/gitpod/v1/pagination_pb.js
+++ b/components/public-api/typescript/src/gitpod/v1/pagination_pb.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // source: gitpod/v1/pagination.proto
 /**
  * @fileoverview

--- a/components/public-api/typescript/src/gitpod/v1/prebuilds_grpc_pb.d.ts
+++ b/components/public-api/typescript/src/gitpod/v1/prebuilds_grpc_pb.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // package: gitpod.v1
 // file: gitpod/v1/prebuilds.proto
 

--- a/components/public-api/typescript/src/gitpod/v1/prebuilds_grpc_pb.js
+++ b/components/public-api/typescript/src/gitpod/v1/prebuilds_grpc_pb.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';

--- a/components/public-api/typescript/src/gitpod/v1/prebuilds_pb.d.ts
+++ b/components/public-api/typescript/src/gitpod/v1/prebuilds_pb.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // package: gitpod.v1
 // file: gitpod/v1/prebuilds.proto
 

--- a/components/public-api/typescript/src/gitpod/v1/prebuilds_pb.js
+++ b/components/public-api/typescript/src/gitpod/v1/prebuilds_pb.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // source: gitpod/v1/prebuilds.proto
 /**
  * @fileoverview

--- a/components/public-api/typescript/src/gitpod/v1/workspaces_grpc_pb.d.ts
+++ b/components/public-api/typescript/src/gitpod/v1/workspaces_grpc_pb.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // package: gitpod.v1
 // file: gitpod/v1/workspaces.proto
 

--- a/components/public-api/typescript/src/gitpod/v1/workspaces_grpc_pb.js
+++ b/components/public-api/typescript/src/gitpod/v1/workspaces_grpc_pb.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';

--- a/components/public-api/typescript/src/gitpod/v1/workspaces_pb.d.ts
+++ b/components/public-api/typescript/src/gitpod/v1/workspaces_pb.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // package: gitpod.v1
 // file: gitpod/v1/workspaces.proto
 

--- a/components/public-api/typescript/src/gitpod/v1/workspaces_pb.js
+++ b/components/public-api/typescript/src/gitpod/v1/workspaces_pb.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
 // source: gitpod/v1/workspaces.proto
 /**
  * @fileoverview


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Publish public-api typescript defs to NPM so they can be consumed by IDE.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[public-api] Publish typescript definitions to NPM
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE