### PR TITLE
[code] build stable image for 1.67.0 with active language tracking and ide alias fix

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 85a18060d91c11ff6de8ba44e02c6c31a5cd907c
+  codeCommit: 64ebb59829c0d3998ebf6b69308aafd49362d29c
   codeQuality: stable
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.1.tar.gz"


### PR DESCRIPTION
## Description
Updates stable VS Code Web to 1.67.0 with 
- proxy active language tracking https://github.com/gitpod-io/openvscode-server/commit/0fee61dca53e89290e45b08cc03e5a1afb1a6590
- IDE alias fix https://github.com/gitpod-io/openvscode-server/commit/af7420545a24e6c29665aff020951d4505210123

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Use `latest` code
2. Open workspace 
3. Check if code commit hash is `64ebb59829c0d3998ebf6b69308aafd49362d29c` and name ends with `Insiders`

Active language tested here https://github.com/gitpod-io/openvscode-server/pull/348#issue-1234339316 you can test it again if you want

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe