### PR TITLE
[code] update stable image 1.67.0 with active language tracking and i…

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-824abc8f79ba1a1772d66a59e6fdaed184d3ceea" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-64cd59a5d2bb36c818c09f455775edfa5e679b16" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates stable VS Code Web to 1.67.0 with 
- Active language tracking https://github.com/gitpod-io/openvscode-server/commit/0fee61dca53e89290e45b08cc03e5a1afb1a6590
- IDE alias fix https://github.com/gitpod-io/openvscode-server/commit/af7420545a24e6c29665aff020951d4505210123

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Tested here https://github.com/gitpod-io/gitpod/pull/10056

1. Use `stable` code
2. Open workspace 
3. Check if code commit hash is `64ebb59829c0d3998ebf6b69308aafd49362d29c` ~~and name ends with `Insiders`~~ No, prev environment will always incorrect

Active language tested here https://github.com/gitpod-io/openvscode-server/pull/348#issue-1234339316 you can test it again if you want

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[code] fix code insiders about dialog don't show `insiders` label
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe