### PR TITLE
[public api] Enable gRPC reflection

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
 func New(name string, opts ...Option) (*Server, error) {
@@ -290,6 +291,8 @@ func (s *Server) initializeGRPC() error {
 	}
 
 	s.grpc = grpc.NewServer(opts...)
+
+	reflection.Register(s.grpc)
 
 	// Register health service by default
 	grpc_health_v1.RegisterHealthServer(s.grpc, s.options.grpcHealthCheck)


### PR DESCRIPTION
## Description

* ~~Add a `WithReflection` option to `baseserver` to allow enabling [gRPC reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md).~~
* ~~Use `WithReflection` in the public API server.~~

EDIT: No `WithReflection` option in the baseserver anymore; it's just enabled with no option to toggle. See [this comment](https://github.com/gitpod-io/gitpod/pull/10060#issuecomment-1128702835).

Enabling reflection in the public api makes the API more discoverable and self documenting for consumers.

It also makes it easier for engineers to work with the API in development (using tools such as [grpcurl](https://github.com/fullstorydev/grpcurl) and [evans](https://github.com/ktr0731/evans)).

## Related Issue(s)

Part of #7900

## How to test

1. Run the `public-api-server`:

```
cd components/public-api-server
go run .
```

2. Use a gRPC CLI like [evans](https://github.com/ktr0731/evans) to discover the services exposed by the API:
```
evans -p 9501 -r repl
```

<img src="https://user-images.githubusercontent.com/8225907/168788669-b20390c7-a06e-46c8-b88b-4043b2da87f4.png">


## Release Notes

```release-note
Enable gRPC reflection for the public API
```

## Documentation

None
