### PR TITLE
[public api] Implement GetOwnerToken rpc

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -23,6 +23,7 @@ import (
 
 // APIInterface wraps the
 type APIInterface interface {
+	GetOwnerToken(ctx context.Context, workspaceID string) (res string, err error)
 	AdminBlockUser(ctx context.Context, req *AdminBlockUserRequest) (err error)
 	GetLoggedInUser(ctx context.Context) (res *User, err error)
 	UpdateLoggedInUser(ctx context.Context, user *User) (res *User, err error)
@@ -85,6 +86,8 @@ type APIInterface interface {
 type FunctionName string
 
 const (
+	// FunctionGetOwnerToken is the name of the getOwnerToken function
+	FunctionGetOwnerToken FunctionName = "getOwnerToken"
 	// FunctionAdminBlockUser is the name of the adminBlockUser function
 	FunctionAdminBlockUser FunctionName = "adminBlockUser"
 	// FunctionGetLoggedInUser is the name of the getLoggedInUser function
@@ -334,6 +337,23 @@ func (gp *APIoverJSONRPC) handler(ctx context.Context, conn *jsonrpc2.Conn, req 
 		}
 	}
 
+	return
+}
+
+func (gp *APIoverJSONRPC) GetOwnerToken(ctx context.Context, workspaceID string) (res string, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	var _params []interface{}
+	_params = append(_params, workspaceID)
+
+	var _result string
+	err = gp.C.Call(ctx, "getOwnerToken", _params, &_result)
+	if err != nil {
+		return "", err
+	}
+	res = _result
 	return
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
@@ -285,6 +285,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetFeaturedRepositories(ctx interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeaturedRepositories", reflect.TypeOf((*MockAPIInterface)(nil).GetFeaturedRepositories), ctx)
 }
 
+// GetGitpodTokenScopes mocks base method.
+func (m *MockAPIInterface) GetGitpodTokenScopes(ctx context.Context, tokenHash string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGitpodTokenScopes", ctx, tokenHash)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGitpodTokenScopes indicates an expected call of GetGitpodTokenScopes.
+func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokenScopes(ctx, tokenHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitpodTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GetGitpodTokenScopes), ctx, tokenHash)
+}
+
 // GetGitpodTokens mocks base method.
 func (m *MockAPIInterface) GetGitpodTokens(ctx context.Context) ([]*APIToken, error) {
 	m.ctrl.T.Helper()
@@ -360,6 +375,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetOwnAuthProviders(ctx interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnAuthProviders", reflect.TypeOf((*MockAPIInterface)(nil).GetOwnAuthProviders), ctx)
 }
 
+// GetOwnerToken mocks base method.
+func (m *MockAPIInterface) GetOwnerToken(ctx context.Context, workspaceID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwnerToken", ctx, workspaceID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOwnerToken indicates an expected call of GetOwnerToken.
+func (mr *MockAPIInterfaceMockRecorder) GetOwnerToken(ctx, workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnerToken", reflect.TypeOf((*MockAPIInterface)(nil).GetOwnerToken), ctx, workspaceID)
+}
+
 // GetPortAuthenticationToken mocks base method.
 func (m *MockAPIInterface) GetPortAuthenticationToken(ctx context.Context, workspaceID string) (*Token, error) {
 	m.ctrl.T.Helper()
@@ -388,21 +418,6 @@ func (m *MockAPIInterface) GetSnapshots(ctx context.Context, workspaceID string)
 func (mr *MockAPIInterfaceMockRecorder) GetSnapshots(ctx, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshots", reflect.TypeOf((*MockAPIInterface)(nil).GetSnapshots), ctx, workspaceID)
-}
-
-// GetGitpodTokenScopes indicates an expected call of GetGitpodTokenScopes.
-func (mr *MockAPIInterfaceMockRecorder) GetGitpodTokenScopes(ctx, tokenHash interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitpodTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GetGitpodTokenScopes), ctx, tokenHash)
-}
-
-// GetGitpodTokenScopes mocks base method.
-func (m *MockAPIInterface) GetGitpodTokenScopes(ctx context.Context, tokenHash string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGitpodTokenScopes", ctx, tokenHash)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
 }
 
 // GetToken mocks base method.
@@ -523,20 +538,6 @@ func (m *MockAPIInterface) GuessGitTokenScopes(ctx context.Context, params *Gues
 func (mr *MockAPIInterfaceMockRecorder) GuessGitTokenScopes(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuessGitTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).GuessGitTokenScopes), ctx, params)
-}
-
-// TrackEvent indicates an expected call of TrackEvent.
-func (m *MockAPIInterface) TrackEvent(ctx context.Context, params *RemoteTrackMessage) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TrackEvent", ctx, params)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// TrackEvent indicates an expected call of TrackEvent.
-func (mr *MockAPIInterfaceMockRecorder) TrackEvent(ctx, params interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuessGitTokenScopes", reflect.TypeOf((*MockAPIInterface)(nil).TrackEvent), ctx, params)
 }
 
 // HasPermission mocks base method.
@@ -758,18 +759,18 @@ func (mr *MockAPIInterfaceMockRecorder) TakeSnapshot(ctx, options interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeSnapshot", reflect.TypeOf((*MockAPIInterface)(nil).TakeSnapshot), ctx, options)
 }
 
-// WaitForSnapshot mocks base method.
-func (m *MockAPIInterface) WaitForSnapshot(ctx context.Context, snapshotId string) error {
+// TrackEvent mocks base method.
+func (m *MockAPIInterface) TrackEvent(ctx context.Context, event *RemoteTrackMessage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForSnapshot", ctx, snapshotId)
+	ret := m.ctrl.Call(m, "TrackEvent", ctx, event)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WaitForSnapshot indicates an expected call of WaitForSnapshot.
-func (mr *MockAPIInterfaceMockRecorder) WaitForSnapshot(ctx, options interface{}) *gomock.Call {
+// TrackEvent indicates an expected call of TrackEvent.
+func (mr *MockAPIInterfaceMockRecorder) TrackEvent(ctx, event interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForSnapshot", reflect.TypeOf((*MockAPIInterface)(nil).WaitForSnapshot), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackEvent", reflect.TypeOf((*MockAPIInterface)(nil).TrackEvent), ctx, event)
 }
 
 // UpdateLoggedInUser mocks base method.
@@ -827,6 +828,20 @@ func (m *MockAPIInterface) UpdateWorkspaceUserPin(ctx context.Context, id string
 func (mr *MockAPIInterfaceMockRecorder) UpdateWorkspaceUserPin(ctx, id, action interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspaceUserPin", reflect.TypeOf((*MockAPIInterface)(nil).UpdateWorkspaceUserPin), ctx, id, action)
+}
+
+// WaitForSnapshot mocks base method.
+func (m *MockAPIInterface) WaitForSnapshot(ctx context.Context, snapshotId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForSnapshot", ctx, snapshotId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForSnapshot indicates an expected call of WaitForSnapshot.
+func (mr *MockAPIInterfaceMockRecorder) WaitForSnapshot(ctx, snapshotId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForSnapshot", reflect.TypeOf((*MockAPIInterface)(nil).WaitForSnapshot), ctx, snapshotId)
 }
 
 // WatchWorkspaceImageBuildLogs mocks base method.

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -157,6 +157,10 @@ func (f *FakeGitpodAPI) GetWorkspace(ctx context.Context, id string) (res *gitpo
 	return w, nil
 }
 
+func (f *FakeGitpodAPI) GetOwnerToken(ctx context.Context, workspaceID string) (res string, err error) {
+	panic("implement me")
+}
+
 func (f *FakeGitpodAPI) AdminBlockUser(ctx context.Context, req *gitpod.AdminBlockUserRequest) (err error) {
 	panic("implement me")
 }

--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -22,6 +22,11 @@ func ConvertError(err error) error {
 	}
 
 	// components/gitpod-protocol/src/messaging/error.ts
+	if strings.Contains(s, "code 403") {
+		return status.Error(codes.PermissionDenied, s)
+	}
+
+	// components/gitpod-protocol/src/messaging/error.ts
 	if strings.Contains(s, "code 404") {
 		return status.Error(codes.NotFound, s)
 	}


### PR DESCRIPTION
## Description

Implement the `GetOwnerToken` public API RPC.

## Related Issue(s)
Closes #9923

## How to test

1. Obtain a stable preview environment like the one for this branch (https://af-impleme89b9aedbc7.preview.gitpod-dev.com/workspaces) (could try to use `main.preview.gitpod-dev.com` but it gets reset all the time).

2. Run the public API, proxying the `server` JSON RPC API from the preview branch:
```bash
cd components/public-api-server
go run . --gitpod-api-url wss://af-impleme89b9aedbc7.preview.gitpod-dev.com/api/v1
```

3. Start a workspace on the preview env.

5. Run `gpctl` against the public API to get the owner token for the workspace we just started:

```bash
cd dev/gpctl
go run . api --address localhost:9501 --insecure --token $TOKEN workspaces ownertoken --id $WORKSPACE_ID
```

where `$TOKEN` is obtained by running:

```js
await window._gp.gitpodService.server.generateNewGitpodToken({ type: 1, scopes: ["function:getGitpodTokenScopes",
	"function:getWorkspace",
	"function:getWorkspaces",
        "function:getOwnerToken",
	"function:listenForWorkspaceInstanceUpdates",
	"resource:default",]})
```
in the preview environment web console and `$WORKSPACE_ID` is the id of the workspace we started in step 3.

The command should return the owner token for the workspace running in the preview environment:

```json
{"token":"O-8bE5VSR6a7G_LVNF.JMEv76iylSKOr"}
```

## Release Notes

```release-note
Implement `GetOwnerToken` rpc on the public api
```

## Documentation

None
