### PR TITLE
[licensor] allow invalid domain in professional license

### DIFF
--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -150,6 +150,8 @@ var defaultLicense = LicensePayload{
 	// Domain, ValidUntil are free for all
 }
 
+// we match domains only for `gitpod` license and not with replicated license.
+// In the case of replicated this ensures faster client onboarding
 func matchesDomain(pattern, domain string) bool {
 	if pattern == "" {
 		return true

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -126,9 +126,9 @@ func (test *licenseTest) Run(t *testing.T) {
 			})
 
 			if test.License == nil {
-				eval = newReplicatedEvaluator(client, domain)
+				eval = newReplicatedEvaluator(client)
 			} else {
-				eval = newReplicatedEvaluator(client, test.License.Domain)
+				eval = newReplicatedEvaluator(client)
 			}
 		} else {
 			t.Fatalf("unknown license type: '%s'", test.Type)

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -92,7 +92,7 @@ func defaultReplicatedLicense() *Evaluator {
 }
 
 // newReplicatedEvaluator exists to allow mocking of client
-func newReplicatedEvaluator(client *http.Client, domain string) (res *Evaluator) {
+func newReplicatedEvaluator(client *http.Client) (res *Evaluator) {
 	resp, err := client.Get(replicatedLicenseApiEndpoint)
 	if err != nil {
 		return &Evaluator{invalid: fmt.Sprintf("cannot query kots admin, %q", err)}
@@ -121,10 +121,6 @@ func newReplicatedEvaluator(client *http.Client, domain string) (res *Evaluator)
 		}
 	}
 
-	if !matchesDomain(lic.Domain, domain) {
-		return defaultReplicatedLicense()
-	}
-
 	if replicatedPayload.ExpirationTime != nil {
 		lic.ValidUntil = *replicatedPayload.ExpirationTime
 
@@ -141,6 +137,6 @@ func newReplicatedEvaluator(client *http.Client, domain string) (res *Evaluator)
 }
 
 // NewReplicatedEvaluator gets the license data from the kots admin panel
-func NewReplicatedEvaluator(domain string) (res *Evaluator) {
-	return newReplicatedEvaluator(&http.Client{Timeout: replicatedLicenseApiTimeout}, domain)
+func NewReplicatedEvaluator() (res *Evaluator) {
+	return newReplicatedEvaluator(&http.Client{Timeout: replicatedLicenseApiTimeout})
 }

--- a/components/licensor/typescript/ee/main.go
+++ b/components/licensor/typescript/ee/main.go
@@ -25,7 +25,7 @@ func Init(key *C.char, domain *C.char) (id int) {
 	id = nextID
 	switch os.Getenv("GITPOD_LICENSE_TYPE") {
 	case string(licensor.LicenseTypeReplicated):
-		instances[id] = licensor.NewReplicatedEvaluator(C.GoString(domain))
+		instances[id] = licensor.NewReplicatedEvaluator()
 		break
 	default:
 		instances[id] = licensor.NewGitpodEvaluator([]byte(C.GoString(key)), C.GoString(domain))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, in replicated professional license, we match the domain in the license to be same as the installation domain. This was intended to avoid the re-use of license for multiple installations. But this seems to increase the on-boarding time due to the requirement to know the installation domain beforehand.

This PR removes the matching of domains in the case of replicated license.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9937 

## How to test
<!-- Provide steps to test this PR -->
On a self-hosted setup, a `prod` license created with empty domain, will still have all the features for paid license listed in the `Lincese` page.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
