### PR TITLE
Laushinka/error form 10062

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -22,6 +22,7 @@ import fresh from "./images/welcome/fresh.svg";
 import prebuild from "./images/welcome/prebuild.svg";
 import exclamation from "./images/exclamation.svg";
 import { getURLHash } from "./App";
+import ErrorMessage from "./components/ErrorMessage";
 
 function Item(props: { icon: string; iconSize?: string; text: string }) {
     const iconSize = props.iconSize || 28;
@@ -225,17 +226,7 @@ export function Login() {
                                     ))
                                 )}
                             </div>
-
-                            {errorMessage && (
-                                <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
-                                    <div className="pr-3 self-center w-6">
-                                        <img src={exclamation} />
-                                    </div>
-                                    <div className="flex-1 flex flex-col">
-                                        <p className="text-gitpod-red text-sm">{errorMessage}</p>
-                                    </div>
-                                </div>
-                            )}
+                            {errorMessage && <ErrorMessage imgSrc={exclamation} message={errorMessage} />}
                         </div>
                     </div>
                     <div className="flex-none mx-auto h-20 text-center">

--- a/components/dashboard/src/components/ErrorMessage.tsx
+++ b/components/dashboard/src/components/ErrorMessage.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import FeedbackComponent from "../feedback-form/FeedbackComponent";
+
+function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string }) {
+    return (
+        <>
+            <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
+                <div className="pr-3 self-center w-6">
+                    <img src={props.imgSrc} alt={props.imgAlt || "An error message"} />
+                </div>
+                <div className="flex-1 flex flex-col">
+                    <p className="text-gitpod-red text-sm">{props.message}</p>
+                </div>
+            </div>
+            <FeedbackComponent
+                message={"Was this error message helpful?"}
+                initialSize={24}
+                isError={true}
+                isModal={false}
+            />
+        </>
+    );
+}
+
+export default ErrorMessage;

--- a/components/dashboard/src/feedback-form/FeedbackComponent.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackComponent.tsx
@@ -11,12 +11,23 @@ import meh from "../images/feedback/meh-emoji.svg";
 import crying from "../images/feedback/crying-emoji.svg";
 import { trackEvent } from "../Analytics";
 
-function FeedbackComponent(props: { onClose: () => void; onSubmit: () => void; isModal: boolean }) {
+function FeedbackComponent(props: {
+    onClose?: () => void;
+    isModal: boolean;
+    isError: boolean;
+    message?: string;
+    initialSize?: number;
+}) {
     const [text, setText] = useState<string>("");
     const [selectedEmoji, setSelectedEmoji] = useState<number | undefined>();
+    const [isFeedbackSubmitted, setIsFeedbackSubmitted] = useState<boolean>(false);
 
-    const height = props.isModal ? "300px" : "";
-
+    const onClose = () => {
+        if (props.onClose) {
+            props.onClose();
+        }
+        setSelectedEmoji(undefined);
+    };
     const onSubmit = () => {
         if (selectedEmoji) {
             const feedbackObj = {
@@ -28,7 +39,7 @@ function FeedbackComponent(props: { onClose: () => void; onSubmit: () => void; i
             trackEvent("feedback_submitted", feedbackObj);
         }
 
-        props.onSubmit();
+        setIsFeedbackSubmitted(true);
     };
 
     const handleClick = (emojiScore: number) => {
@@ -54,12 +65,42 @@ function FeedbackComponent(props: { onClose: () => void; onSubmit: () => void; i
             </button>
         ));
     };
+
+    const minimisedFirstView = !selectedEmoji && !isFeedbackSubmitted;
+    const expandedWithTextView = selectedEmoji && !isFeedbackSubmitted;
+
     return (
         <>
-            <h3 className="mb-4">Send Feedback</h3>
-            {selectedEmoji ? (
+            {props.isModal && !isFeedbackSubmitted && <h3 className="mb-4">Send Feedback</h3>}
+            {minimisedFirstView && (
+                <div
+                    className={
+                        "flex flex-col justify-center px-6 py-4 border-gray-200 dark:border-gray-800 " +
+                        (props.isError ? "mt-20 bg-gray-100 dark:bg-gray-800 rounded-xl" : "border-t")
+                    }
+                >
+                    <p
+                        className={
+                            "text-center text-base mb-3 dark:text-gray-400 " +
+                            (props.isError ? "text-gray-400" : "text-gray-500")
+                        }
+                    >
+                        {props.message}
+                    </p>
+
+                    <div className="flex items-center justify-center w-full">{emojiGroup(props.initialSize || 50)}</div>
+                </div>
+            )}
+            {expandedWithTextView && (
                 <>
-                    <div className="flex flex-col -mx-6 px-6 py-4 border-t border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+                    <div
+                        className={
+                            "flex flex-col px-6 py-4 border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 " +
+                            (props.isError
+                                ? "w-96 mt-6 bg-gray-100 dark:bg-gray-800 rounded-xl"
+                                : "-mx-6 border-t border-b")
+                        }
+                    >
                         <div className="relative">
                             <div className="absolute flex bottom-5 right-5 -space-x-3">{emojiGroup(24)}</div>
                             <textarea
@@ -82,26 +123,27 @@ function FeedbackComponent(props: { onClose: () => void; onSubmit: () => void; i
                                 .
                             </p>
                         </div>
-                    </div>
-                    <div className="flex justify-end mt-6">
-                        <button className="secondary" onClick={props.onClose}>
-                            Cancel
-                        </button>
-                        <button className="ml-2" onClick={onSubmit}>
-                            Send Feedback
-                        </button>
+                        <div className="flex justify-end mt-6">
+                            <button className="secondary" onClick={onClose}>
+                                Cancel
+                            </button>
+                            <button className="ml-2" onClick={onSubmit}>
+                                Send Feedback
+                            </button>
+                        </div>
                     </div>
                 </>
-            ) : (
+            )}
+            {isFeedbackSubmitted && (
                 <div
-                    className="flex flex-col justify-center -mx-6 px-6 py-4 border-t border-gray-200 dark:border-gray-800"
-                    style={{ height: height }}
+                    className={
+                        "flex flex-col px-6 py-4 border-gray-200 dark:border-gray-800 " +
+                        (props.isError ? "mt-20 bg-gray-100 dark:bg-gray-800 rounded-xl" : "")
+                    }
                 >
-                    <p className="text-center text-lg mb-8 text-gray-500 dark:text-gray-400">
-                        We'd love to know what you think!
+                    <p className={"text-center text-base " + (props.isError ? "text-gray-400" : "text-gray-500")}>
+                        Thanks for your feedback, we appreciate it.
                     </p>
-
-                    <div className="flex items-center justify-center w-full space-x-3">{emojiGroup(50)}</div>
                 </div>
             )}
         </>

--- a/components/dashboard/src/feedback-form/FeedbackModal.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackModal.tsx
@@ -12,13 +12,14 @@ function FeedbackFormModal(props: { onClose: () => void }) {
         props.onClose();
     };
 
-    const onSubmit = () => {
-        props.onClose();
-    };
-
     return (
         <Modal visible={true} onClose={onClose}>
-            <FeedbackComponent onClose={onClose} onSubmit={onSubmit} isModal={true} />
+            <FeedbackComponent
+                onClose={onClose}
+                isModal={true}
+                isError={false}
+                message="We'd love to know what you think!"
+            />
         </Modal>
     );
 }

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -19,6 +19,7 @@ import moment from "moment";
 import { UserContext } from "../user-context";
 import { trackEvent } from "../Analytics";
 import exclamation from "../images/exclamation.svg";
+import ErrorMessage from "../components/ErrorMessage";
 
 export default function NewProject() {
     const location = useLocation();
@@ -744,16 +745,7 @@ function GitProviders(props: {
                     })}
                 </div>
 
-                {errorMessage && (
-                    <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
-                        <div className="pr-3 self-center w-6">
-                            <img src={exclamation} />
-                        </div>
-                        <div className="flex-1 flex flex-col">
-                            <p className="text-gitpod-red text-sm">{errorMessage}</p>
-                        </div>
-                    </div>
-                )}
+                {errorMessage && <ErrorMessage imgSrc={exclamation} message={errorMessage} />}
             </div>
         </div>
     );

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -23,6 +23,7 @@ import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { SelectAccountModal } from "../settings/SelectAccountModal";
 import { watchHeadlessLogs } from "../components/PrebuildLogs";
 import CodeText from "../components/CodeText";
+import FeedbackComponent from "../feedback-form/FeedbackComponent";
 
 const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
 
@@ -432,6 +433,14 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
                 <CodeText>{repoFullName}</CodeText>
             </p>
             {statusMessage}
+            {p.error && (
+                <FeedbackComponent
+                    isModal={false}
+                    message={"Was this error message helpful?"}
+                    isError={true}
+                    initialSize={24}
+                />
+            )}
         </StartPage>
     );
 }


### PR DESCRIPTION
## Description
Shows feedback component when there are error messages on:
- login
- create workspace

| MINIMISED | EXPANDED | THANKS |
| - | - | - |
| <img width="325" alt="Screenshot 2022-05-24 at 13 15 05" src="https://user-images.githubusercontent.com/8015191/170062090-5ca89107-036b-44c8-a99d-170eb6598f5a.png"> | <img width="353" alt="Screenshot 2022-05-24 at 13 06 15" src="https://user-images.githubusercontent.com/8015191/170062161-6645e6c4-584a-4b3a-8fb3-0fb23e2a1484.png"> |  <img width="339" alt="Screenshot 2022-05-24 at 13 19 55" src="https://user-images.githubusercontent.com/8015191/170062245-15c81321-6f33-4ab1-a8b6-04f9a79eb725.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10062

## How to test
(A bit tedious to make sure to get the error message, sorry)
1. Go to your user in the /admin page and remove the `repo` feature that gives permission for private repos.
2. Start a workspace for that private repo, i.e. `https://laushinka-f9a883104c.preview.gitpod-dev.com/#[YOUR_PRIVATE_REPO]`
3. See the feedback form below the error message.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Feedback form under error messages on login and starting workspaces.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe