### PR TITLE
[server] Explicitely list teams getting XL resources

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -162,6 +162,13 @@ export interface ConfigSerialized {
      * `blockUser` attribute to control handling of the user's account.
      */
     blockedRepositories?: { urlRegExp: string; blockUser: boolean }[];
+
+    /**
+     * XL Teams lists all teams (by uuid) for which we have XL clusters/workspace classes enabled.
+     *
+     * This is a stop gap measure until we have usage-based pricing.
+     */
+    xlTeams: string[];
 }
 
 export namespace ConfigFile {

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -135,6 +135,15 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	var xlTeams []string
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp == nil {
+			return nil
+		}
+		xlTeams = cfg.WebApp.XLTeams
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -215,6 +224,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			// default limit for all cloneURLs
 			"*": 50,
 		},
+		XLTeams: xlTeams,
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -49,6 +49,9 @@ type ConfigSerialized struct {
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
 	PrebuildLimiter map[string]int `json:"prebuildLimiter"`
+
+	// XL Teams lists all teams (by uuid) for which we have XL clusters/workspace classes enabled.
+	XLTeams []string `json:"xlTeams"`
 }
 
 type BlockedRepository struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -102,6 +102,7 @@ type WebAppConfig struct {
 	Tracing                *Tracing               `json:"tracing,omitempty"`
 	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
 	DisableMigration       bool                   `json:"disableMigration"`
+	XLTeams                []string               `json:"xlTeams,omitempty"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description
This PR makes the decision which team/user gets "XL resources" explicitly configurable, as compared to tying it to the subscription. This will help us steer that experiment better while keeping cost under control.

- needs a follow-up ops PR which adds the actual teams

Issue: https://github.com/gitpod-io/ops/issues/2346

## How to test
(all set up on this branch)
- create a team
- add the team UUID to the `xlTeams` server config
- make sure server restarts
- add a cluster with the `has-more-resources` constraint
- check that the workspace on that team starts on that workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
