### PR TITLE
Preview environment CLI

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,6 +31,11 @@ ports:
   # Dev Theia
   - port: 13444
 tasks:
+  - name: Install Preview Environment kube-context
+    command: |
+      (cd dev/preview/previewctl && go install .)
+      previewctl install-context
+      exit
   - name: Add Harvester kubeconfig
     command: |
       ./dev/preview/util/download-and-merge-harvester-kubeconfig.sh

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -11,6 +11,7 @@ packages:
       - dev/blowtorch:app
       - dev/gpctl:app
       - dev/loadgen:app
+      - dev/preview/previewctl:cli
   - name: dev-utils
     type: docker
     deps:

--- a/dev/preview/install-k3s-kubeconfig.sh
+++ b/dev/preview/install-k3s-kubeconfig.sh
@@ -6,29 +6,34 @@ THIS_DIR="$(dirname "$0")"
 
 source "$THIS_DIR/util/preview-name-from-branch.sh"
 
-if [[ -z "${VM_NAME:-}" ]]; then
-    VM_NAME="$(preview-name-from-branch)"
-fi
-
 PRIVATE_KEY=$HOME/.ssh/vm_id_rsa
 PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub
 USER="ubuntu"
+BRANCH=""
 
 KUBECONFIG_PATH="/home/gitpod/.kube/config"
 K3S_KUBECONFIG_PATH="$(mktemp)"
 MERGED_KUBECONFIG_PATH="$(mktemp)"
 
-K3S_CONTEXT="${VM_NAME}"
-K3S_ENDPOINT="${VM_NAME}.kube.gitpod-dev.com"
-
-while getopts n:p:u: flag
+while getopts n:p:u:b: flag
 do
     case "${flag}" in
         u) USER="${OPTARG}";;
+        b) BRANCH="${2}";;
         *) ;;
     esac
 done
 
+if [[ "${BRANCH}" == "" ]]; then
+    VM_NAME="$(preview-name-from-branch)"
+else
+    VM_NAME="$(preview-name-from-branch "$BRANCH")"
+fi
+
+echo "Installing context from VM: $VM_NAME"
+
+K3S_CONTEXT="${VM_NAME}"
+K3S_ENDPOINT="${VM_NAME}.kube.gitpod-dev.com"
 
 function log {
     echo "[$(date)] $*"

--- a/dev/preview/previewctl/.gitignore
+++ b/dev/preview/previewctl/.gitignore
@@ -1,0 +1,1 @@
+previewctl

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: cli
+    type: go
+    srcs:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+    env:
+      - CGO_ENABLED=0
+    config:
+      packaging: app
+      dontTest: false

--- a/dev/preview/previewctl/cmd/get_name.go
+++ b/dev/preview/previewctl/cmd/get_name.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
+	"github.com/spf13/cobra"
+)
+
+func getNameCmd() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "get-name",
+		Short: "Returns the name of the preview for the corresponding branch.",
+		Run: func(cmd *cobra.Command, args []string) {
+			p := preview.New(branch)
+
+			fmt.Println(p.GetPreviewName())
+		},
+	}
+
+	return cmd
+}

--- a/dev/preview/previewctl/cmd/install_context.go
+++ b/dev/preview/previewctl/cmd/install_context.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
+	"github.com/spf13/cobra"
+)
+
+var (
+	watch = false
+)
+
+func installContextCmd() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "install-context",
+		Short: "Installs the kubectl context of a preview environment.",
+		Run: func(cmd *cobra.Command, args []string) {
+			p := preview.New(branch)
+
+			err := p.InstallContext(watch)
+			if err != nil {
+				log.Fatalf("Couldn't install context for the '%s' preview", p.Branch)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&watch, "watch", false, "If wait is enabled, previewctl will keep trying to install the kube-context every 30 seconds.")
+	return cmd
+}

--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -23,6 +23,7 @@ func RootCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		installContextCmd(),
+		getNameCmd(),
 	)
 	return cmd
 }

--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	branch = ""
+)
+
+func RootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "previewctl",
+		Short: "Your best friend when interacting with Preview Environments :)",
+		Long:  `previewctl is your best friend when interacting with Preview Environments :)`,
+	}
+
+	cmd.PersistentFlags().StringVar(&branch, "branch", "", "From which branch's preview previewctl should interact with. By default it will use the result of \"git rev-parse --abbrev-ref HEAD\"")
+
+	cmd.AddCommand(
+		installContextCmd(),
+	)
+	return cmd
+}

--- a/dev/preview/previewctl/go.mod
+++ b/dev/preview/previewctl/go.mod
@@ -1,0 +1,10 @@
+module github.com/gitpod-io/gitpod/previewctl
+
+go 1.18
+
+require github.com/spf13/cobra v1.4.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/dev/preview/previewctl/go.sum
+++ b/dev/preview/previewctl/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/dev/preview/previewctl/main.go
+++ b/dev/preview/previewctl/main.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"log"
+
+	"github.com/gitpod-io/gitpod/previewctl/cmd"
+)
+
+func main() {
+	root := cmd.RootCmd()
+	if err := root.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/dev/preview/previewctl/pkg/preview/preview.go
+++ b/dev/preview/previewctl/pkg/preview/preview.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package preview
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"log"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type Preview struct {
+	Branch string
+}
+
+func New(branch string) *Preview {
+	if branch == "" {
+		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+		if err != nil {
+			log.Fatalf("Could not retrieve branch name, err: %v", err)
+		}
+		branch = string(out)
+	} else {
+		_, err := exec.Command("git", "rev-parse", "--verify", branch).Output()
+		if err != nil {
+			log.Fatalf("Branch '%s' does not exist", branch)
+		}
+	}
+
+	return &Preview{
+		Branch: branch,
+	}
+}
+
+func (p *Preview) InstallContext(watch bool) error {
+	if watch {
+		// The most precise implementation for a watch-loop would be to implement
+		// a pub-sub like logic where previewctl would react to changes of a preview IP address.
+		// For now just an infinite loop will do!
+		installTicker := time.NewTicker(30 * time.Second)
+
+		// nolint:gosimple
+		for {
+			select {
+			case <-installTicker.C:
+				if err := installContext(p.Branch); err == nil {
+					// No error means successful context installation
+					return nil
+				}
+			}
+		}
+	}
+
+	return installContext(p.Branch)
+}
+
+func installContext(branch string) error {
+	return exec.Command("bash", "/workspace/gitpod/dev/preview/install-k3s-kubeconfig.sh", "-b", branch).Run()
+}
+
+func (p *Preview) GetPreviewName() string {
+	withoutRefsHead := strings.Replace(p.Branch, "/refs/heads/", "", 1)
+	lowerCased := strings.ToLower(withoutRefsHead)
+
+	var re = regexp.MustCompile(`[^-a-z0-9]`)
+	sanitizedBranch := re.ReplaceAllString(lowerCased, `$1-$2`)
+
+	if len(sanitizedBranch) > 20 {
+		h := sha256.New()
+		h.Write([]byte(sanitizedBranch))
+		hashedBranch := hex.EncodeToString(h.Sum(nil))
+
+		sanitizedBranch = sanitizedBranch[0:10] + hashedBranch[0:10]
+	}
+
+	return sanitizedBranch
+}

--- a/dev/preview/previewctl/pkg/preview/preview_test.go
+++ b/dev/preview/previewctl/pkg/preview/preview_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package preview_test
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
+)
+
+func TestInstallContext(t *testing.T) {
+	fmt.Println("Test not implemented")
+}
+
+func TestGetPreviewName(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		branch         string
+		expectedResult string
+	}{
+		{
+			testName:       "Short branch without special characters",
+			branch:         "/refs/heads/testing",
+			expectedResult: "testing",
+		},
+		{
+			testName:       "Upper to lower case",
+			branch:         "/refs/heads/SCREAMMING",
+			expectedResult: "screamming",
+		},
+		{
+			testName:       "Special characters",
+			branch:         "/refs/heads/as/test&123.4",
+			expectedResult: "as-test-123-4",
+		},
+		{
+			testName:       "Hashed long branch",
+			branch:         "/refs/heads/this-is-a-long-branch-that-should-be-replaced-with-a-hash",
+			expectedResult: "this-is-a-a868caa3c3",
+		},
+	}
+
+	for _, tc := range testCases {
+		preview := &preview.Preview{
+			Branch: tc.branch,
+		}
+
+		previewName := preview.GetPreviewName()
+
+		if tc.expectedResult != previewName {
+			log.Fatalf("Test '%s' failed. Expected '%s' but got '%s'", tc.testName, tc.expectedResult, previewName)
+		}
+	}
+}

--- a/dev/preview/util/preview-name-from-branch.sh
+++ b/dev/preview/util/preview-name-from-branch.sh
@@ -8,7 +8,16 @@
 #        See the file for implementation notes.
 #
 function preview-name-from-branch {
-    branch_name=$(git symbolic-ref HEAD 2>&1) || error "Cannot get current branch"
+    set +u
+    local BRANCH="$1"
+
+    if [ "$BRANCH" == "" ]; then
+        branch_name=$(git symbolic-ref HEAD 2>&1) || error "Cannot get current branch"
+    else
+        branch_name=$BRANCH
+    fi
+
+
     sanitizedd_branch_name=$(echo "$branch_name" | awk '{ sub(/^refs\/heads\//, ""); $0 = tolower($0); gsub(/[^-a-z0-9]/, "-"); print }')
     length=$(echo -n "$sanitizedd_branch_name" | wc -c)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Following our [internal RFC](https://www.notion.so/gitpod/A-Go-based-CLI-for-interacting-with-Preview-Environments-1834aa90bc104a0b836dd523e22f9e93), the work done in this CLI was to make sure it is easily extendable with new commands and that the architecture makes it easy to test.

It also introduces the first command asked in Milestone 1(see [important notes](#Important-notes)) of that same RFC. Which makes it possible to install the kube-context of different preview environments.

## Important notes

### `install-k3s-context.sh` was not re-implemented in Go yet.

The implementation is not easy and I think it would delay this PR too much. Our current implementation in bash uses SSH tunneling and I'm not sure how to implement/replace that in Go. I'm also not sure how to write a good test for such implementation 😬.

If possible, I'd like to convert this into a separate issue and tackle the re-implementation and testing into a separate PR.

### `install-k3s-context.sh` was modified to install context from custom branches.

Since one of the requirements was the ability to install context from different branches, I extended our bash script to install context from custom branches 🙂 

### `install-k3s-context.sh` doesn't exit with code != 0 when preview doesn't exist.

And as a consequence, `previewctl install-context <unexisting-branch>` succeeds even with a broken context. I'm on the fence if this bug should be a blocker for this PR or not, but I've already spent a good time trying to solve this one without success 😅. The options that I see are:

* Since users of this CLI are mostly interested in their own previews(which works), this bug could be tackled in a separate issue/PR.

Or

* We shouldn't merge this PR until the bug is fixed, therefore I need some extra help 😝 

### Code walkthrough

https://www.loom.com/share/6da6cf3b6b61457e8c0f17736e716434

## How to test
<!-- Provide steps to test this PR -->
A couple of options to try

* Start a workspace from this pull request - The right context should be already installed
* Try installing the context from another existing branch by running `previewctl install-context --branch <branch-name>`
* Create a new branch from this PR, commit something, open a new workspace from the new branch/commit, the context should be installed when starting the workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
