### PR TITLE
Install gitpod.gitpod-theme as builtin extension

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 64ebb59829c0d3998ebf6b69308aafd49362d29c
+  codeCommit: 9d98f338d0c8584b66195fceb555bb7223c755bc
   codeQuality: stable
   jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.1.tar.gz"

--- a/components/ide/code/codehelper/main.go
+++ b/components/ide/code/codehelper/main.go
@@ -51,7 +51,7 @@ func main() {
 	log.WithField("cost", time.Now().Local().Sub(startTime).Milliseconds()).Info("content available")
 
 	// code server args install extension with id
-	args := []string{"--start-server"}
+	args := []string{}
 
 	// install extension with filepath
 	extPathArgs := []string{}
@@ -59,6 +59,8 @@ func main() {
 	if os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true" {
 		args = append(args, "--inspect", "--log=trace")
 	}
+
+	args = append(args, "--install-builtin-extension", "gitpod.gitpod-theme")
 
 	wsContextUrl := wsInfo.GetWorkspaceContextUrl()
 	if ctxUrl, err := url.Parse(wsContextUrl); err == nil {
@@ -107,6 +109,7 @@ func main() {
 	// install extensions and run code server with exec
 	args = append(args, os.Args[1:]...)
 	args = append(args, "--do-not-sync")
+	args = append(args, "--start-server")
 	log.WithField("cost", time.Now().Local().Sub(startTime).Milliseconds()).Info("starting server")
 	if err := syscall.Exec(Code, append([]string{"gitpod-code"}, args...), os.Environ()); err != nil {
 		log.WithError(err).Error("install ext and start code server failed")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The extension is already bundled when building vscode, this will only update the extension to a newer version if any exist.
If there's no access to openvsx for some reason (self-hosted case) bundled version will be used.

Fixes https://github.com/gitpod-io/gitpod/issues/9950

## How to test
<!-- Provide steps to test this PR -->
1. Select insiders
2. Open workspace
3. Check gitpod theme is installed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```