### PR TITLE
[kots] Fix s3 secret typo in gitpod installer job

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -190,7 +190,7 @@ spec:
                   echo "Gitpod: configuring storage for S3"
 
                   yq e -i ".objectStorage.s3.endpoint = \"{{repl ConfigOption "store_s3_endpoint" }}\"" "${CONFIG_FILE}"
-                  yq e -i ".objectStorage.s3.credentials.secret = \"secret\"" "${CONFIG_FILE}"
+                  yq e -i ".objectStorage.s3.credentials.kind = \"secret\"" "${CONFIG_FILE}"
                   yq e -i ".objectStorage.s3.credentials.name = \"storage-s3\"" "${CONFIG_FILE}"
                 fi
               fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`kind: secret` is miswritten in `secret: secret`, causing installer render to fail
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9911

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
