### PR TITLE
Make the pods be removed when workspacekit fails.

### DIFF
--- a/components/common-go/util/const_string.go
+++ b/components/common-go/util/const_string.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package util
+
+const (
+	BooleanTrueString = "true"
+)

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -342,6 +342,11 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 			// While the pod is being deleted we do not care or want to know about any failure state.
 			// If the pod got stopped because it failed we will have sent out a Stopping status with a "failure"
 			result.Conditions.Failed = ""
+		} else {
+			if _, ok := pod.Annotations[workspaceNeverReadyAnnotation]; ok {
+				// The workspace is never ready, so there is no need for a stopping phase.
+				result.Phase = api.WorkspacePhase_STOPPED
+			}
 		}
 
 		var hasFinalizer bool

--- a/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
@@ -1,0 +1,18 @@
+{
+    "actions": [
+        {
+            "Func": "clearInitializerFromMap",
+            "Params": {
+                "podName": "ws-7b26a643-d588-4346-bc9e-b46e70831078"
+            }
+        },
+        {
+            "Func": "modifyFinalizer",
+            "Params": {
+                "add": false,
+                "finalizer": "gitpod.io/finalizer",
+                "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078"
+            }
+        }
+    ]
+}

--- a/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
@@ -1,0 +1,34 @@
+{
+    "status": {
+        "id": "7b26a643-d588-4346-bc9e-b46e70831078",
+        "status_version": 65536,
+        "metadata": {
+            "owner": "3dfdef07-76e2-46a6-b0d4-eb959befd0ab",
+            "meta_id": "gitpodio-templategolang-cdhvbek9fyg",
+            "started_at": {
+                "seconds": 1653358271
+            }
+        },
+        "spec": {
+            "workspace_image": "eu.gcr.io/gitpod-core-dev/build/workspace-images:8b57bd729e88889eca09e96051dea52300481b8561e3225140beae1a12d190f4",
+            "deprecated_ide_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-9e0960d85f0c30b1ce57c9d14e6a905bc46f427c",
+            "url": "https://gitpodio-templategolang-cdhvbek9fyg.ws.to-failed-ws-start.preview.gitpod-dev.com",
+            "timeout": "60m",
+            "ide_image": {
+                "web_ref": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-9e0960d85f0c30b1ce57c9d14e6a905bc46f427c",
+                "supervisor_ref": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-6d6849daab686ff22e610d57cdaf303eab7697b5"
+            },
+            "class": "default"
+        },
+        "phase": 6,
+        "conditions": {},
+        "runtime": {
+            "node_name": "to-failed-ws-start",
+            "pod_name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+            "node_ip": "10.0.2.2"
+        },
+        "auth": {
+            "owner_token": "yuvxCAtPRTShLfVETMXck-a71dphVi_u"
+        }
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.json
+++ b/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.json
@@ -1,0 +1,1062 @@
+{
+  "pod": {
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+      "namespace": "default",
+      "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+      "resourceVersion": "10935",
+      "creationTimestamp": "2022-05-24T02:11:11Z",
+      "deletionTimestamp": "2022-05-24T02:13:26Z",
+      "deletionGracePeriodSeconds": 0,
+      "labels": {
+        "app": "gitpod",
+        "component": "workspace",
+        "gitpod.io/networkpolicy": "default",
+        "gitpod.io/workspaceClass": "default",
+        "gpwsman": "true",
+        "headless": "false",
+        "metaID": "gitpodio-templategolang-cdhvbek9fyg",
+        "owner": "3dfdef07-76e2-46a6-b0d4-eb959befd0ab",
+        "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078",
+        "workspaceType": "regular"
+      },
+      "annotations": {
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+        "cni.projectcalico.org/containerID": "a2edebf3741f0e68bd3155d394625b4952adaa007b15d5894d037354b7bbfb97",
+        "cni.projectcalico.org/podIP": "10.20.75.21/32",
+        "cni.projectcalico.org/podIPs": "10.20.75.21/32",
+        "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+        "gitpod/admission": "admit_owner_only",
+        "gitpod/contentInitializer": "ErsBCjRodHRwczovL2dpdGh1Yi5jb20vZ2l0cG9kLWlvL3RlbXBsYXRlLWdvbGFuZy1jbGkuZ2l0GAIiBG1haW4qE3RlbXBsYXRlLWdvbGFuZy1jbGkyZhACKmJodHRwczovL3RvLWZhaWxlZC13cy1zdGFydC5wcmV2aWV3LmdpdHBvZC1kZXYuY29tL2FwaS9vdHMvZ2V0Lzc4MTIxMGNiLWNjN2ItNGZkZS04ZWVjLWY3OTYxNWVjYjI4Yg==",
+        "gitpod/customTimeout": "60m",
+        "gitpod/failedBeforeStopping": "true",
+        "gitpod/id": "7b26a643-d588-4346-bc9e-b46e70831078",
+        "gitpod/imageSpec": "CnFldS5nY3IuaW8vZ2l0cG9kLWNvcmUtZGV2L2J1aWxkL3dvcmtzcGFjZS1pbWFnZXM6OGI1N2JkNzI5ZTg4ODg5ZWNhMDllOTYwNTFkZWE1MjMwMDQ4MWI4NTYxZTMyMjUxNDBiZWFlMWExMmQxOTBmNBJYZXUuZ2NyLmlvL2dpdHBvZC1jb3JlLWRldi9idWlsZC9pZGUvY29kZTpjb21taXQtOWUwOTYwZDg1ZjBjMzBiMWNlNTdjOWQxNGU2YTkwNWJjNDZmNDI3YypaZXUuZ2NyLmlvL2dpdHBvZC1jb3JlLWRldi9idWlsZC9zdXBlcnZpc29yOmNvbW1pdC02ZDY4NDlkYWFiNjg2ZmYyMmU2MTBkNTdjZGFmMzAzZWFiNzY5N2I1",
+        "gitpod/never-ready": "true",
+        "gitpod/ownerToken": "yuvxCAtPRTShLfVETMXck-a71dphVi_u",
+        "gitpod/servicePrefix": "gitpodio-templategolang-cdhvbek9fyg",
+        "gitpod/traceid": "AAAAAAAAAACxLnRGpfZ3BiKYS0LaoAjLd3sIFe19nEkBAAAAAA==",
+        "gitpod/url": "https://gitpodio-templategolang-cdhvbek9fyg.ws.to-failed-ws-start.preview.gitpod-dev.com",
+        "prometheus.io/path": "/metrics",
+        "prometheus.io/port": "23000",
+        "prometheus.io/scrape": "true",
+        "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace_default_to-failed-ws-start.8.json"
+      },
+      "finalizers": [
+        "gitpod.io/finalizer"
+      ],
+      "managedFields": [
+        {
+          "manager": "calico",
+          "operation": "Update",
+          "apiVersion": "v1",
+          "time": "2022-05-24T02:11:11Z",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                "f:cni.projectcalico.org/containerID": {},
+                "f:cni.projectcalico.org/podIP": {},
+                "f:cni.projectcalico.org/podIPs": {}
+              }
+            }
+          },
+          "subresource": "status"
+        },
+        {
+          "manager": "Go-http-client",
+          "operation": "Update",
+          "apiVersion": "v1",
+          "time": "2022-05-24T02:11:26Z",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:status": {
+              "f:conditions": {
+                "k:{\"type\":\"ContainersReady\"}": {
+                  ".": {},
+                  "f:lastProbeTime": {},
+                  "f:lastTransitionTime": {},
+                  "f:message": {},
+                  "f:reason": {},
+                  "f:status": {},
+                  "f:type": {}
+                },
+                "k:{\"type\":\"Initialized\"}": {
+                  ".": {},
+                  "f:lastProbeTime": {},
+                  "f:lastTransitionTime": {},
+                  "f:status": {},
+                  "f:type": {}
+                },
+                "k:{\"type\":\"Ready\"}": {
+                  ".": {},
+                  "f:lastProbeTime": {},
+                  "f:lastTransitionTime": {},
+                  "f:message": {},
+                  "f:reason": {},
+                  "f:status": {},
+                  "f:type": {}
+                }
+              },
+              "f:containerStatuses": {},
+              "f:hostIP": {},
+              "f:phase": {},
+              "f:podIP": {},
+              "f:podIPs": {
+                ".": {},
+                "k:{\"ip\":\"10.20.75.21\"}": {
+                  ".": {},
+                  "f:ip": {}
+                }
+              },
+              "f:startTime": {}
+            }
+          },
+          "subresource": "status"
+        },
+        {
+          "manager": "ws-manager",
+          "operation": "Update",
+          "apiVersion": "v1",
+          "time": "2022-05-24T02:13:26Z",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:cluster-autoscaler.kubernetes.io/safe-to-evict": {},
+                "f:container.apparmor.security.beta.kubernetes.io/workspace": {},
+                "f:gitpod/admission": {},
+                "f:gitpod/contentInitializer": {},
+                "f:gitpod/customTimeout": {},
+                "f:gitpod/failedBeforeStopping": {},
+                "f:gitpod/id": {},
+                "f:gitpod/imageSpec": {},
+                "f:gitpod/never-ready": {},
+                "f:gitpod/ownerToken": {},
+                "f:gitpod/servicePrefix": {},
+                "f:gitpod/traceid": {},
+                "f:gitpod/url": {},
+                "f:prometheus.io/path": {},
+                "f:prometheus.io/port": {},
+                "f:prometheus.io/scrape": {},
+                "f:seccomp.security.alpha.kubernetes.io/pod": {}
+              },
+              "f:finalizers": {},
+              "f:labels": {
+                ".": {},
+                "f:app": {},
+                "f:component": {},
+                "f:gitpod.io/networkpolicy": {},
+                "f:gitpod.io/workspaceClass": {},
+                "f:gpwsman": {},
+                "f:headless": {},
+                "f:metaID": {},
+                "f:owner": {},
+                "f:workspaceID": {},
+                "f:workspaceType": {}
+              }
+            },
+            "f:spec": {
+              "f:affinity": {
+                ".": {},
+                "f:nodeAffinity": {
+                  ".": {},
+                  "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                }
+              },
+              "f:automountServiceAccountToken": {},
+              "f:containers": {
+                "k:{\"name\":\"workspace\"}": {
+                  ".": {},
+                  "f:command": {},
+                  "f:env": {
+                    ".": {},
+                    "k:{\"name\":\"GITPOD_CLI_APITOKEN\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_GIT_USER_EMAIL\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_GIT_USER_NAME\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_HOST\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_IDE_ALIAS\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_INSTANCE_ID\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_INTERVAL\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_MEMORY\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_OWNER_ID\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_REPO_ROOT\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_REPO_ROOTS\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_TASKS\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_THEIA_PORT\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_WORKSPACE_CLUSTER_HOST\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_WORKSPACE_CONTEXT\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_WORKSPACE_CONTEXT_URL\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_WORKSPACE_ID\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"GITPOD_WORKSPACE_URL\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"SUPERVISOR_ENVVAR_OTS\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"THEIA_MINI_BROWSER_HOST_PATTERN\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"THEIA_SUPERVISOR_ENDPOINT\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"THEIA_SUPERVISOR_TOKENS\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"THEIA_WEBVIEW_EXTERNAL_ENDPOINT\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"THEIA_WORKSPACE_ROOT\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    },
+                    "k:{\"name\":\"VSX_REGISTRY_URL\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:value": {}
+                    }
+                  },
+                  "f:image": {},
+                  "f:imagePullPolicy": {},
+                  "f:name": {},
+                  "f:ports": {
+                    ".": {},
+                    "k:{\"containerPort\":22999,\"protocol\":\"TCP\"}": {
+                      ".": {},
+                      "f:containerPort": {},
+                      "f:name": {},
+                      "f:protocol": {}
+                    },
+                    "k:{\"containerPort\":23000,\"protocol\":\"TCP\"}": {
+                      ".": {},
+                      "f:containerPort": {},
+                      "f:protocol": {}
+                    }
+                  },
+                  "f:readinessProbe": {
+                    ".": {},
+                    "f:failureThreshold": {},
+                    "f:httpGet": {
+                      ".": {},
+                      "f:path": {},
+                      "f:port": {},
+                      "f:scheme": {}
+                    },
+                    "f:initialDelaySeconds": {},
+                    "f:periodSeconds": {},
+                    "f:successThreshold": {},
+                    "f:timeoutSeconds": {}
+                  },
+                  "f:resources": {
+                    ".": {},
+                    "f:requests": {
+                      ".": {},
+                      "f:cpu": {},
+                      "f:memory": {}
+                    }
+                  },
+                  "f:securityContext": {
+                    ".": {},
+                    "f:allowPrivilegeEscalation": {},
+                    "f:capabilities": {
+                      ".": {},
+                      "f:add": {},
+                      "f:drop": {}
+                    },
+                    "f:privileged": {},
+                    "f:readOnlyRootFilesystem": {},
+                    "f:runAsGroup": {},
+                    "f:runAsNonRoot": {},
+                    "f:runAsUser": {}
+                  },
+                  "f:terminationMessagePath": {},
+                  "f:terminationMessagePolicy": {},
+                  "f:volumeMounts": {
+                    ".": {},
+                    "k:{\"mountPath\":\"/.workspace\"}": {
+                      ".": {},
+                      "f:mountPath": {},
+                      "f:mountPropagation": {},
+                      "f:name": {}
+                    },
+                    "k:{\"mountPath\":\"/workspace\"}": {
+                      ".": {},
+                      "f:mountPath": {},
+                      "f:mountPropagation": {},
+                      "f:name": {}
+                    }
+                  }
+                }
+              },
+              "f:dnsPolicy": {},
+              "f:enableServiceLinks": {},
+              "f:hostname": {},
+              "f:restartPolicy": {},
+              "f:schedulerName": {},
+              "f:securityContext": {},
+              "f:serviceAccount": {},
+              "f:serviceAccountName": {},
+              "f:terminationGracePeriodSeconds": {},
+              "f:tolerations": {},
+              "f:volumes": {
+                ".": {},
+                "k:{\"name\":\"daemon-mount\"}": {
+                  ".": {},
+                  "f:hostPath": {
+                    ".": {},
+                    "f:path": {},
+                    "f:type": {}
+                  },
+                  "f:name": {}
+                },
+                "k:{\"name\":\"vol-this-workspace\"}": {
+                  ".": {},
+                  "f:hostPath": {
+                    ".": {},
+                    "f:path": {},
+                    "f:type": {}
+                  },
+                  "f:name": {}
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "spec": {
+      "volumes": [
+        {
+          "name": "vol-this-workspace",
+          "hostPath": {
+            "path": "/var/gitpod/workspaces/7b26a643-d588-4346-bc9e-b46e70831078",
+            "type": "DirectoryOrCreate"
+          }
+        },
+        {
+          "name": "daemon-mount",
+          "hostPath": {
+            "path": "/var/gitpod/workspaces/7b26a643-d588-4346-bc9e-b46e70831078-daemon",
+            "type": "DirectoryOrCreate"
+          }
+        }
+      ],
+      "containers": [
+        {
+          "name": "workspace",
+          "image": "reg.to-failed-ws-start.preview.gitpod-dev.com:30933/remote/7b26a643-d588-4346-bc9e-b46e70831078",
+          "command": [
+            "/.supervisor/workspacekit",
+            "ring0"
+          ],
+          "ports": [
+            {
+              "containerPort": 23000,
+              "protocol": "TCP"
+            },
+            {
+              "name": "supervisor",
+              "containerPort": 22999,
+              "protocol": "TCP"
+            }
+          ],
+          "env": [
+            {
+              "name": "GITPOD_REPO_ROOT",
+              "value": "/workspace/template-golang-cli"
+            },
+            {
+              "name": "GITPOD_REPO_ROOTS",
+              "value": "/workspace/template-golang-cli"
+            },
+            {
+              "name": "GITPOD_CLI_APITOKEN",
+              "value": "lCmXiVnR83kt5QRo57DNGJ91DDGApmEd"
+            },
+            {
+              "name": "GITPOD_OWNER_ID",
+              "value": "3dfdef07-76e2-46a6-b0d4-eb959befd0ab"
+            },
+            {
+              "name": "GITPOD_WORKSPACE_ID",
+              "value": "gitpodio-templategolang-cdhvbek9fyg"
+            },
+            {
+              "name": "GITPOD_INSTANCE_ID",
+              "value": "7b26a643-d588-4346-bc9e-b46e70831078"
+            },
+            {
+              "name": "GITPOD_THEIA_PORT",
+              "value": "23000"
+            },
+            {
+              "name": "THEIA_WORKSPACE_ROOT",
+              "value": "/workspace/template-golang-cli"
+            },
+            {
+              "name": "GITPOD_HOST",
+              "value": "https://to-failed-ws-start.preview.gitpod-dev.com"
+            },
+            {
+              "name": "GITPOD_WORKSPACE_URL",
+              "value": "https://gitpodio-templategolang-cdhvbek9fyg.ws.to-failed-ws-start.preview.gitpod-dev.com"
+            },
+            {
+              "name": "GITPOD_WORKSPACE_CLUSTER_HOST",
+              "value": "ws.to-failed-ws-start.preview.gitpod-dev.com"
+            },
+            {
+              "name": "THEIA_SUPERVISOR_ENDPOINT",
+              "value": ":22999"
+            },
+            {
+              "name": "THEIA_WEBVIEW_EXTERNAL_ENDPOINT",
+              "value": "webview-{{hostname}}"
+            },
+            {
+              "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+              "value": "browser-{{hostname}}"
+            },
+            {
+              "name": "GITPOD_GIT_USER_NAME",
+              "value": "utam0k"
+            },
+            {
+              "name": "GITPOD_GIT_USER_EMAIL",
+              "value": "toru@gitpod.io"
+            },
+            {
+              "name": "SUPERVISOR_ENVVAR_OTS",
+              "value": "https://to-failed-ws-start.preview.gitpod-dev.com/api/ots/get/442acc6d-d38b-4e96-8fd4-8a3a55cb7dfd"
+            },
+            {
+              "name": "GITPOD_IDE_ALIAS",
+              "value": "code"
+            },
+            {
+              "name": "GITPOD_WORKSPACE_CONTEXT_URL",
+              "value": "https://github.com/gitpod-io/template-golang-cli"
+            },
+            {
+              "name": "GITPOD_WORKSPACE_CONTEXT",
+              "value": "{\"isFile\":false,\"path\":\"\",\"title\":\"gitpod-io/template-golang-cli - main\",\"ref\":\"main\",\"refType\":\"branch\",\"revision\":\"12ffbca961bbc13b598dcf694866987888e29ac6\",\"repository\":{\"cloneUrl\":\"https://github.com/gitpod-io/template-golang-cli.git\",\"host\":\"github.com\",\"name\":\"template-golang-cli\",\"owner\":\"gitpod-io\",\"private\":false},\"normalizedContextURL\":\"https://github.com/gitpod-io/template-golang-cli\",\"checkoutLocation\":\"template-golang-cli\"}"
+            },
+            {
+              "name": "GITPOD_TASKS",
+              "value": "[{\"init\":\"go get github.com/spf13/cobra/cobra\\ngo build\\n\",\"command\":\"./mycli --help\\n\"}]"
+            },
+            {
+              "name": "VSX_REGISTRY_URL",
+              "value": "https://open-vsx.to-failed-ws-start.preview.gitpod-dev.com"
+            },
+            {
+              "name": "THEIA_SUPERVISOR_TOKENS",
+              "value": "[{\"tokenOTS\":\"https://to-failed-ws-start.preview.gitpod-dev.com/api/ots/get/52d40c31-99d4-4540-95da-0f4541212b96\",\"token\":\"ots\",\"kind\":\"gitpod\",\"host\":\"to-failed-ws-start.preview.gitpod-dev.com\",\"scope\":[\"function:getWorkspace\",\"function:getLoggedInUser\",\"function:getPortAuthenticationToken\",\"function:getWorkspaceOwner\",\"function:getWorkspaceUsers\",\"function:isWorkspaceOwner\",\"function:controlAdmission\",\"function:setWorkspaceTimeout\",\"function:getWorkspaceTimeout\",\"function:sendHeartBeat\",\"function:getOpenPorts\",\"function:openPort\",\"function:closePort\",\"function:getLayout\",\"function:generateNewGitpodToken\",\"function:takeSnapshot\",\"function:waitForSnapshot\",\"function:storeLayout\",\"function:stopWorkspace\",\"function:getToken\",\"function:getGitpodTokenScopes\",\"function:getContentBlobUploadUrl\",\"function:getContentBlobDownloadUrl\",\"function:accessCodeSyncStorage\",\"function:guessGitTokenScopes\",\"function:getEnvVars\",\"function:setEnvVar\",\"function:deleteEnvVar\",\"function:trackEvent\",\"resource:workspace::gitpodio-templategolang-cdhvbek9fyg::get/update\",\"resource:workspaceInstance::7b26a643-d588-4346-bc9e-b46e70831078::get/update/delete\",\"resource:snapshot::ws-gitpodio-templategolang-cdhvbek9fyg::create\",\"resource:gitpodToken::*::create\",\"resource:userStorage::*::create/get/update\",\"resource:token::*::get\",\"resource:contentBlob::*::create/get\",\"resource:envVar::gitpod-io/template-golang-cli::create/get/update/delete\"],\"expiryDate\":\"2022-05-25T02:11:11.174Z\",\"reuse\":2}]"
+            },
+            {
+              "name": "GITPOD_INTERVAL",
+              "value": "30000"
+            },
+            {
+              "name": "GITPOD_MEMORY",
+              "value": "2147"
+            }
+          ],
+          "resources": {
+            "requests": {
+              "cpu": "100m",
+              "memory": "2Gi"
+            }
+          },
+          "volumeMounts": [
+            {
+              "name": "vol-this-workspace",
+              "mountPath": "/workspace",
+              "mountPropagation": "HostToContainer"
+            },
+            {
+              "name": "daemon-mount",
+              "mountPath": "/.workspace",
+              "mountPropagation": "HostToContainer"
+            }
+          ],
+          "readinessProbe": {
+            "httpGet": {
+              "path": "/_supervisor/v1/status/content/wait/true",
+              "port": 22999,
+              "scheme": "HTTP"
+            },
+            "initialDelaySeconds": 2,
+            "timeoutSeconds": 1,
+            "periodSeconds": 1,
+            "successThreshold": 1,
+            "failureThreshold": 600
+          },
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "imagePullPolicy": "IfNotPresent",
+          "securityContext": {
+            "capabilities": {
+              "add": [
+                "AUDIT_WRITE",
+                "FSETID",
+                "KILL",
+                "NET_BIND_SERVICE",
+                "SYS_PTRACE"
+              ],
+              "drop": [
+                "SETPCAP",
+                "CHOWN",
+                "NET_RAW",
+                "DAC_OVERRIDE",
+                "FOWNER",
+                "SYS_CHROOT",
+                "SETFCAP",
+                "SETUID",
+                "SETGID"
+              ]
+            },
+            "privileged": false,
+            "runAsUser": 33333,
+            "runAsGroup": 33333,
+            "runAsNonRoot": true,
+            "readOnlyRootFilesystem": false,
+            "allowPrivilegeEscalation": true
+          }
+        }
+      ],
+      "restartPolicy": "Never",
+      "terminationGracePeriodSeconds": 30,
+      "dnsPolicy": "ClusterFirst",
+      "serviceAccountName": "workspace",
+      "serviceAccount": "workspace",
+      "automountServiceAccountToken": false,
+      "nodeName": "to-failed-ws-start",
+      "securityContext": {
+        "seccompProfile": {
+          "type": "Localhost",
+          "localhostProfile": "workspace_default_to-failed-ws-start.8.json"
+        }
+      },
+      "hostname": "gitpodio-templategolang-cdhvbek9fyg",
+      "affinity": {
+        "nodeAffinity": {
+          "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [
+              {
+                "matchExpressions": [
+                  {
+                    "key": "gitpod.io/workload_workspace_regular",
+                    "operator": "Exists"
+                  },
+                  {
+                    "key": "gitpod.io/ws-daemon_ready_ns_default",
+                    "operator": "Exists"
+                  },
+                  {
+                    "key": "gitpod.io/registry-facade_ready_ns_default",
+                    "operator": "Exists"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "schedulerName": "default-scheduler",
+      "tolerations": [
+        {
+          "key": "node.kubernetes.io/disk-pressure",
+          "operator": "Exists",
+          "effect": "NoExecute"
+        },
+        {
+          "key": "node.kubernetes.io/memory-pressure",
+          "operator": "Exists",
+          "effect": "NoExecute"
+        },
+        {
+          "key": "node.kubernetes.io/network-unavailable",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 30
+        },
+        {
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+        },
+        {
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "effect": "NoExecute",
+          "tolerationSeconds": 300
+        }
+      ],
+      "priority": 0,
+      "enableServiceLinks": false,
+      "preemptionPolicy": "PreemptLowerPriority"
+    },
+    "status": {
+      "phase": "Failed",
+      "conditions": [
+        {
+          "type": "Initialized",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2022-05-24T02:11:11Z"
+        },
+        {
+          "type": "Ready",
+          "status": "False",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2022-05-24T02:11:11Z",
+          "reason": "ContainersNotReady",
+          "message": "containers with unready status: [workspace]"
+        },
+        {
+          "type": "ContainersReady",
+          "status": "False",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2022-05-24T02:11:11Z",
+          "reason": "ContainersNotReady",
+          "message": "containers with unready status: [workspace]"
+        },
+        {
+          "type": "PodScheduled",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2022-05-24T02:11:11Z"
+        }
+      ],
+      "hostIP": "10.0.2.2",
+      "podIP": "10.20.75.21",
+      "podIPs": [
+        {
+          "ip": "10.20.75.21"
+        }
+      ],
+      "startTime": "2022-05-24T02:11:11Z",
+      "containerStatuses": [
+        {
+          "name": "workspace",
+          "state": {
+            "terminated": {
+              "exitCode": 1,
+              "reason": "Error",
+              "startedAt": "2022-05-24T02:11:25Z",
+              "finishedAt": "2022-05-24T02:13:25Z",
+              "containerID": "containerd://8df1375d7629aba8ba32a7463fb2b9cdd0e1f4cdd57e345ef1bf7d6b05c0db2f"
+            }
+          },
+          "lastState": {},
+          "ready": false,
+          "restartCount": 0,
+          "image": "reg.to-failed-ws-start.preview.gitpod-dev.com:30933/remote/7b26a643-d588-4346-bc9e-b46e70831078:latest",
+          "imageID": "reg.to-failed-ws-start.preview.gitpod-dev.com:30933/remote/7b26a643-d588-4346-bc9e-b46e70831078@sha256:1d67c8dd98696c4ed1c0c703ff707d7972b333842295763bd01b0f48a872f9cd",
+          "containerID": "containerd://8df1375d7629aba8ba32a7463fb2b9cdd0e1f4cdd57e345ef1bf7d6b05c0db2f",
+          "started": false
+        }
+      ],
+      "qosClass": "Burstable"
+    }
+  },
+  "events": [
+    {
+      "metadata": {
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078.16f1e8967bfda529",
+        "namespace": "default",
+        "uid": "06198c7b-7e96-426e-a05a-d0d097f261ff",
+        "resourceVersion": "10567",
+        "creationTimestamp": "2022-05-24T02:11:11Z",
+        "managedFields": [
+          {
+            "manager": "k3s",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2022-05-24T02:11:11Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+        "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+        "apiVersion": "v1",
+        "resourceVersion": "10565"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/ws-7b26a643-d588-4346-bc9e-b46e70831078 to to-failed-ws-start",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2022-05-24T02:11:11.244634Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-to-failed-ws-start"
+    },
+    {
+      "metadata": {
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078.16f1e896aa235c4f",
+        "namespace": "default",
+        "uid": "54a1bfb6-1bcc-4735-bcd5-c8dbcb4c99d8",
+        "resourceVersion": "10576",
+        "creationTimestamp": "2022-05-24T02:11:12Z",
+        "managedFields": [
+          {
+            "manager": "k3s",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-05-24T02:11:12Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+        "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+        "apiVersion": "v1",
+        "resourceVersion": "10566",
+        "fieldPath": "spec.containers{workspace}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"reg.to-failed-ws-start.preview.gitpod-dev.com:30933/remote/7b26a643-d588-4346-bc9e-b46e70831078\"",
+      "source": {
+        "component": "kubelet",
+        "host": "to-failed-ws-start"
+      },
+      "firstTimestamp": "2022-05-24T02:11:12Z",
+      "lastTimestamp": "2022-05-24T02:11:12Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078.16f1e899d3dec449",
+        "namespace": "default",
+        "uid": "8f05c85b-caed-4b1c-be47-87348afb2c1b",
+        "resourceVersion": "10609",
+        "creationTimestamp": "2022-05-24T02:11:25Z",
+        "managedFields": [
+          {
+            "manager": "k3s",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-05-24T02:11:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+        "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+        "apiVersion": "v1",
+        "resourceVersion": "10566",
+        "fieldPath": "spec.containers{workspace}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"reg.to-failed-ws-start.preview.gitpod-dev.com:30933/remote/7b26a643-d588-4346-bc9e-b46e70831078\" in 13.585021481s",
+      "source": {
+        "component": "kubelet",
+        "host": "to-failed-ws-start"
+      },
+      "firstTimestamp": "2022-05-24T02:11:25Z",
+      "lastTimestamp": "2022-05-24T02:11:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078.16f1e899d95da342",
+        "namespace": "default",
+        "uid": "2356d900-ed28-49c6-86c7-043d021757ea",
+        "resourceVersion": "10610",
+        "creationTimestamp": "2022-05-24T02:11:25Z",
+        "managedFields": [
+          {
+            "manager": "k3s",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-05-24T02:11:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+        "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+        "apiVersion": "v1",
+        "resourceVersion": "10566",
+        "fieldPath": "spec.containers{workspace}"
+      },
+      "reason": "Created",
+      "message": "Created container workspace",
+      "source": {
+        "component": "kubelet",
+        "host": "to-failed-ws-start"
+      },
+      "firstTimestamp": "2022-05-24T02:11:25Z",
+      "lastTimestamp": "2022-05-24T02:11:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078.16f1e899e48b33c8",
+        "namespace": "default",
+        "uid": "8bb255e5-5419-4110-8df5-df617e2891a7",
+        "resourceVersion": "10612",
+        "creationTimestamp": "2022-05-24T02:11:25Z",
+        "managedFields": [
+          {
+            "manager": "k3s",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-05-24T02:11:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+        "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+        "apiVersion": "v1",
+        "resourceVersion": "10566",
+        "fieldPath": "spec.containers{workspace}"
+      },
+      "reason": "Started",
+      "message": "Started container workspace",
+      "source": {
+        "component": "kubelet",
+        "host": "to-failed-ws-start"
+      },
+      "firstTimestamp": "2022-05-24T02:11:25Z",
+      "lastTimestamp": "2022-05-24T02:11:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "metadata": {
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078.16f1e89a35fd8427",
+        "namespace": "default",
+        "uid": "7ae769fb-3301-486e-94a0-151e6cacf579",
+        "resourceVersion": "10684",
+        "creationTimestamp": "2022-05-24T02:11:27Z",
+        "managedFields": [
+          {
+            "manager": "k3s",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2022-05-24T02:11:27Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",
+        "uid": "c98f96a4-bc49-4d9f-a160-6b1f458938ee",
+        "apiVersion": "v1",
+        "resourceVersion": "10566",
+        "fieldPath": "spec.containers{workspace}"
+      },
+      "reason": "Unhealthy",
+      "message": "Readiness probe failed: Get \"http://10.20.75.21:22999/_supervisor/v1/status/content/wait/true\": dial tcp 10.20.75.21:22999: connect: connection refused",
+      "source": {
+        "component": "kubelet",
+        "host": "to-failed-ws-start"
+      },
+      "firstTimestamp": "2022-05-24T02:11:27Z",
+      "lastTimestamp": "2022-05-24T02:11:46Z",
+      "count": 21,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
There was a problem with workspace pendings due to finalizer not working properly when iws failed to start (or had a large delay). This PR avoids that by skipping the finalizer. Also, the workspace phase is now consistent with it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9673

## How to test
<!-- Provide steps to test this PR -->
- workspaces can normally start. You can confirm [this preview environment](https://to-conn-prob.preview.gitpod-dev.com/workspaces)
- Intentionally break communication between iws and ws-daemon, and when a workspace failed to start, confirm that  the workspace phase is properly stopped(NOTE: in this case, the stopping phase is skipped because we don't need to backup.) You can confirm it on [this preview environment](https://to-failed-ws-start.preview.gitpod-dev.com/workspaces)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
ws-manager: Make the pods be removed when workspacekit fails.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
