### PR TITLE
Fix workspace integration failed due to the git safe.directory error

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -365,6 +365,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
+github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/test/pkg/integration/common/git-client.go
+++ b/test/pkg/integration/common/git-client.go
@@ -58,6 +58,22 @@ func (g GitClient) Add(dir string, files ...string) error {
 	return nil
 }
 
+func (g GitClient) ConfigSafeDirectory(dir string) error {
+	var resp agent.ExecResponse
+	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+		Dir:     dir,
+		Command: "git",
+		Args:    []string{"config", "--global", "--add", "safe.directory", dir},
+	}, &resp)
+	if err != nil {
+		return err
+	}
+	if resp.ExitCode != 0 {
+		return fmt.Errorf("config returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
+	}
+	return nil
+}
+
 func (g GitClient) ConfigUserName(dir string) error {
 	args := []string{"config", "--local", "user.name", "integration-test"}
 	var resp agent.ExecResponse

--- a/test/pkg/integration/common/git-client.go
+++ b/test/pkg/integration/common/git-client.go
@@ -5,10 +5,9 @@
 package common
 
 import (
+	"fmt"
 	"net/rpc"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 )
@@ -29,10 +28,10 @@ func (g GitClient) GetBranch(workspaceRoot string) (string, error) {
 		Args:    []string{"rev-parse", "--abbrev-ref", "HEAD"},
 	}, &resp)
 	if err != nil {
-		return "", xerrors.Errorf("getBranch error: %w", err)
+		return "", fmt.Errorf("getBranch error: %w", err)
 	}
 	if resp.ExitCode != 0 {
-		return "", xerrors.Errorf("getBranch rc!=0: %d", resp.ExitCode)
+		return "", fmt.Errorf("getBranch returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
 	}
 	return strings.Trim(resp.Stdout, " \t\n"), nil
 }
@@ -54,7 +53,7 @@ func (g GitClient) Add(dir string, files ...string) error {
 		return err
 	}
 	if resp.ExitCode != 0 {
-		return xerrors.Errorf("commit returned rc: %d", resp.ExitCode)
+		return fmt.Errorf("add returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
 	}
 	return nil
 }
@@ -71,7 +70,7 @@ func (g GitClient) ConfigUserName(dir string) error {
 		return err
 	}
 	if resp.ExitCode != 0 {
-		return xerrors.Errorf("config user name returned rc: %d", resp.ExitCode)
+		return fmt.Errorf("config user name returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
 	}
 	return nil
 }
@@ -88,7 +87,7 @@ func (g GitClient) ConfigUserEmail(dir string, files ...string) error {
 		return err
 	}
 	if resp.ExitCode != 0 {
-		return xerrors.Errorf("config user email returned rc: %d", resp.ExitCode)
+		return fmt.Errorf("config user email returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
 	}
 	return nil
 }
@@ -108,7 +107,7 @@ func (g GitClient) Commit(dir string, message string, all bool) error {
 		return err
 	}
 	if resp.ExitCode != 0 {
-		return xerrors.Errorf("commit returned rc: %d", resp.ExitCode)
+		return fmt.Errorf("commit returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
 	}
 	return nil
 }
@@ -131,7 +130,7 @@ func (g GitClient) Push(dir string, force bool, moreArgs ...string) error {
 		return err
 	}
 	if resp.ExitCode != 0 {
-		return xerrors.Errorf("commit returned rc: %d", resp.ExitCode)
+		return fmt.Errorf("push returned rc: %d err: %v", resp.ExitCode, resp.Stderr)
 	}
 	return nil
 }

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -143,6 +143,10 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 
 					// get actual from workspace
 					git := common.Git(rsa)
+					err = git.ConfigSafeDirectory(test.WorkspaceRoot)
+					if err != nil {
+						t.Fatal(err)
+					}
 					actBranch, err := git.GetBranch(test.WorkspaceRoot)
 					if err != nil {
 						t.Fatal(err)

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -41,7 +41,6 @@ func TestGitActions(t *testing.T) {
 			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/tree/integration-test/commit-and-push",
 			WorkspaceRoot: "/workspace/gitpod-test-repo",
 			Action: func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) (err error) {
-
 				var resp agent.ExecResponse
 				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 					Dir:     workspaceRoot,
@@ -51,6 +50,10 @@ func TestGitActions(t *testing.T) {
 						"echo \"another test run...\" >> file_to_commit.txt",
 					},
 				}, &resp)
+				if err != nil {
+					return err
+				}
+				err = git.ConfigSafeDirectory(workspaceRoot)
 				if err != nil {
 					return err
 				}
@@ -79,7 +82,6 @@ func TestGitActions(t *testing.T) {
 			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/tree/integration-test/commit-and-push",
 			WorkspaceRoot: "/workspace/gitpod-test-repo",
 			Action: func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) (err error) {
-
 				var resp agent.ExecResponse
 				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 					Dir:     workspaceRoot,
@@ -89,6 +91,10 @@ func TestGitActions(t *testing.T) {
 						"echo \"another test run...\" >> file_to_commit.txt",
 					},
 				}, &resp)
+				if err != nil {
+					return err
+				}
+				err = git.ConfigSafeDirectory(workspaceRoot)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Description
The workspace integration failed related to Git operation.
https://werft.gitpod-dev.com/job/gitpod-workspace-run-integration-tests-main.4

Recently, the Git 2.35.2 _or_ 2.36 changes the behavior on it's stricter checks the repository ownership
 https://github.blog/2022-04-18-highlights-from-git-2-36/

I think once this PR #10012 be deployed to production, we no longer need to manually configure the `safe.directory` manually in the code. 

<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
```shell
./dev/preview/install-k3s-kubeconfig.sh
cd test

TOKEN=`kubectl get secret integration-test-user -n werft -ojsonpath={.data.token} | base64 --decode`

USER_TOKEN=$TOKEN go test -v ./... -run=TestGitActions -kubeconfig=/home/gitpod/.kube/config -namespace=default -username=integration-test-user
USER_TOKEN=$TOKEN go test -v ./... -run=TestGitHubContexts -kubeconfig=/home/gitpod/.kube/config -namespace=default -username=integration-test-user
```
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A