### PR TITLE
[image-builder-bob] Use separate auth for target and base

### DIFF
--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -330,9 +330,9 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 		bobBaseref += ":latest"
 	}
 	wsref, err := reference.ParseNamed(wsrefstr)
-	var additionalAuth []byte
+	var baseRefAuth []byte
 	if err == nil {
-		additionalAuth, err = json.Marshal(reqauth.GetImageBuildAuthFor([]string{
+		baseRefAuth, err = json.Marshal(reqauth.GetImageBuildAuthFor([]string{
 			reference.Domain(wsref),
 		}))
 		if err != nil {
@@ -374,15 +374,15 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 					{Name: "WORKSPACEKIT_BOBPROXY_BASEREF", Value: baseref},
 					{Name: "WORKSPACEKIT_BOBPROXY_TARGETREF", Value: wsrefstr},
 					{
-						Name: "WORKSPACEKIT_BOBPROXY_AUTH",
+						Name: "WORKSPACEKIT_BOBPROXY_TARGETAUTH",
 						Secret: &wsmanapi.EnvironmentVariable_SecretKeyRef{
 							SecretName: o.Config.PullSecret,
 							Key:        ".dockerconfigjson",
 						},
 					},
 					{
-						Name:  "WORKSPACEKIT_BOBPROXY_ADDITIONALAUTH",
-						Value: string(additionalAuth),
+						Name:  "WORKSPACEKIT_BOBPROXY_AUTH",
+						Value: string(baseRefAuth),
 					},
 					{Name: "SUPERVISOR_DEBUG_ENABLE", Value: fmt.Sprintf("%v", log.Log.Logger.IsLevelEnabled(logrus.DebugLevel))},
 				},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use terms such `base` and `target` to distinguish between image source (base) and built image (target).

Use separate auth for target and base so that when the target and base images are both in the same registry provider, correct auth is used.

e.g. User wants to use an image from their private gcr but we want to push the built image to gitpod's private gcr.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10089

## How to test
<!-- Provide steps to test this PR -->
Follow Reproduce steps from this issue https://github.com/gitpod-io/gitpod/issues/10089. Error should not be reproducible.

I already tested this in the preview env of this branch.

### Image builds

<img width="2558" alt="image" src="https://user-images.githubusercontent.com/32481722/169051600-f82fe48f-061f-4168-8792-1c566045e1b1.png">


### Workspace Starts

<img width="2558" alt="image" src="https://user-images.githubusercontent.com/32481722/169052926-651820a1-37dc-4e78-8af9-d20e1ccec4d0.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix conflicting auth selection for image-builder-bob
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
