### PR TITLE
[baseserver] Failed certificate setup errors, instead of exiting

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 
 	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
-	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -284,7 +283,7 @@ func (s *Server) initializeGRPC() error {
 			common_grpc.WithServerName(s.Name),
 		)
 		if err != nil {
-			log.WithError(err).Fatal("cannot load ws-manager certs")
+			return fmt.Errorf("failed to load certificates: %w", err)
 		}
 
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Instead of exiting directly, we return the error so the regular error handling reports it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE