### PR TITLE
[public-api] Default local server run to port 9001, same as installer config

### DIFF
--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -62,7 +62,7 @@ func command() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&gitpodAPIURL, "gitpod-api-url", "wss://main.preview.gitpod-dev.com/api/v1", "URL for existing Gitpod Websocket API")
-	cmd.Flags().IntVar(&grpcPort, "grpc-port", 9501, "Port for serving gRPC traffic")
+	cmd.Flags().IntVar(&grpcPort, "grpc-port", 9001, "Port for serving gRPC traffic")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Toggle verbose logging (debug level)")
 
 	return cmd


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To reduce confusion between local and actually deployed config

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE