### PR TITLE
[public-api] Do not use localhost as address, not reachable in containers/k8s

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -347,13 +347,13 @@ type builtinServices struct {
 func newBuiltinServices(server *Server) *builtinServices {
 	healthAddr := fmt.Sprintf(":%d", BuiltinHealthPort)
 	if server.options.underTest {
-		healthAddr = "localhost:0"
+		healthAddr = ":0"
 	}
 
 	return &builtinServices{
 		underTest: server.options.underTest,
 		Debug: &http.Server{
-			Addr:    fmt.Sprintf("localhost:%d", BuiltinDebugPort),
+			Addr:    fmt.Sprintf(":%d", BuiltinDebugPort),
 			Handler: pprof.Handler(),
 		},
 		Health: &http.Server{
@@ -361,7 +361,7 @@ func newBuiltinServices(server *Server) *builtinServices {
 			Handler: server.healthEndpoint(),
 		},
 		Metrics: &http.Server{
-			Addr:    fmt.Sprintf("localhost:%d", BuiltinMetricsPort),
+			Addr:    fmt.Sprintf(":%d", BuiltinMetricsPort),
 			Handler: server.metricsEndpoint(),
 		},
 	}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -20,7 +20,7 @@ func Start(logger *logrus.Entry, cfg Config) error {
 
 	srv, err := baseserver.New("public_api_server",
 		baseserver.WithLogger(logger),
-		baseserver.WithGRPC(&baseserver.ServerConfiguration{Address: fmt.Sprintf("localhost:%d", cfg.GRPCPort)}),
+		baseserver.WithGRPC(&baseserver.ServerConfiguration{Address: fmt.Sprintf(":%d", cfg.GRPCPort)}),
 		baseserver.WithMetricsRegistry(registry),
 	)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Address can't be localhost, as it can't be reached when in a container. The change ensures that the server listens on any address, not just localhost.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```
cd dev/gpctl
➜ go run main.go api workspaces get --id 123 --token foo --address api.mp-public-68262df4fb.preview.gitpod-dev.com:443
INFO[0000] Establishing gRPC connection against api.mp-public-68262df4fb.preview.gitpod-dev.com:443
FATA[0032] Failed to retrieve workspace.                 error="failed to retrieve workspace (ID: 123): rpc error: code = PermissionDenied desc = insufficient permission to access workspace"
exit status 1
```
The above shows that the service is in fact reachable.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE