### PR TITLE
Fix to stopping and snapshot state

### DIFF
--- a/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.spec.ts
@@ -53,11 +53,8 @@ class TestPrebuildStateMapper {
                 },
             },
             {
-                name: "failed - no snapshot",
-                expected: {
-                    state: "failed",
-                    hasError: true,
-                },
+                name: "Stopping and no snapshot yet",
+                expected: undefined,
                 status: {
                     id,
                     phase: WorkspacePhase.STOPPING,

--- a/components/ws-manager-bridge/src/prebuild-state-mapper.ts
+++ b/components/ws-manager-bridge/src/prebuild-state-mapper.ts
@@ -64,17 +64,12 @@ export class PrebuildStateMapper {
                     update: {
                         state: "available",
                         snapshot: status.conditions!.snapshot,
+                        error: "",
                     },
                 };
             } else if (!status.conditions!.snapshot) {
-                // STOPPING && no snapshot? Definitely an error case
-                return {
-                    type: HeadlessWorkspaceEventType.Failed,
-                    update: {
-                        state: "failed",
-                        error: "error while taking snapshot",
-                    },
-                };
+                // STOPPING && no snapshot is an intermediate state that we are choosing to ignore.
+                return undefined;
             } else {
                 log.error({ instanceId: status.id }, "unhandled prebuild status update", {
                     phase: status.phase,


### PR DESCRIPTION
## Description
1. Removes error when state is available and snapshot is available.
2. Removes the assumption that a stopping phase without a snapshot is an error. This is most likely an intermediate state where it will turn into something else, therefore we do nothing here.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10054 

## How to test
In the preview environment, add a project and run a prebuild.
Once `Ready`, it should not switch to `Failed`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
