### PR TITLE
[db] enable overriding of expiryDate on tokens

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -339,8 +339,15 @@ export class TypeORMUserDBImpl implements UserDB {
         if (tokenEntries.length === 0) {
             return undefined;
         }
-        return tokenEntries.sort((a, b) => `${a.token.updateDate}`.localeCompare(`${b.token.updateDate}`)).reverse()[0]
-            ?.token;
+        const latestTokenEntry = tokenEntries
+            .sort((a, b) => `${a.token.updateDate}`.localeCompare(`${b.token.updateDate}`))
+            .reverse()[0];
+        if (latestTokenEntry) {
+            if (latestTokenEntry.expiryDate !== latestTokenEntry.token.expiryDate) {
+                log.info(`Overriding 'expiryDate' of token to get refreshed on demand.`, { identity });
+            }
+            return { ...latestTokenEntry.token, expiryDate: latestTokenEntry.expiryDate };
+        }
     }
 
     public async findTokensForIdentity(identity: Identity, includeDeleted?: boolean): Promise<TokenEntry[]> {


### PR DESCRIPTION
### How to test

1. sign-in with gitlab.com.
2. update `d_b_token_entry` table and set an older date (-1d) for `expiryDate`.
3. reload `/integrations` page.
4. verify that `INFO: Token refreshed and updated.` is logged in server.


```release-notes
NONE
```