### PR TITLE
[payment] Set excludeFromMoreResources to true by default for new legacy Team Plans

### DIFF
--- a/components/ee/payment-endpoint/src/chargebee/team-subscription-handler.ts
+++ b/components/ee/payment-endpoint/src/chargebee/team-subscription-handler.ts
@@ -89,7 +89,7 @@ export class TeamSubscriptionHandler implements EventHandler<chargebee.Subscript
                     startDate: getStartDate(chargebeeSubscription),
                     endDate: chargebeeSubscription.cancelled_at ? getCancelledAt(chargebeeSubscription) : undefined,
                     quantity,
-                    excludeFromMoreResources: false,
+                    excludeFromMoreResources: true,
                 });
                 await db.storeTeamSubscriptionEntry(ts);
                 await this.service.addSlots(ts, quantity);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Set excludeFromMoreResources to true by default for new legacy Team Plans.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2346

## How to test
<!-- Provide steps to test this PR -->

1. Create a new legacy Team Plan in https://jx-exclude-from-xl.preview.gitpod-dev.com/teams
2. Verify in the DB that `excludeFromMoreResources` is set to `1`

To connect to the DB:
1. Open this PR in Gitpod: https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/10104
2. Run the VM dev script `./dev/preview/install-k3s-kubeconfig.sh` _manually (🙄 🙄 🙄)_
3. Run `kubectl port-forward mysql-0 3306 &`
4. Run `mysql -h 127.0.0.1 -pjBzVMe2w4Yi7GagadsyB gitpod`
5. Run `select id, ownerId, planId, quantity, excludeFromMoreResources from d_b_team_subscription;`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment=true