### PR TITLE
[JetBrains] Show notification when port becomes available 🔔

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/GitpodServer.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/GitpodServer.java
@@ -34,4 +34,7 @@ public interface GitpodServer {
 
     @JsonRequest
     CompletableFuture<IDEOptions> getIDEOptions();
+
+    @JsonRequest
+    CompletableFuture<WorkspaceInstancePort> openPort(String workspaceId, WorkspaceInstancePort port);
 }

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/PortVisibility.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/PortVisibility.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.gitpodprotocol.api.entities;
+
+public enum PortVisibility {
+    PUBLIC("public"), PRIVATE("private");
+
+    private final String toString;
+
+    private PortVisibility(String toString) {
+        this.toString = toString;
+    }
+
+    public String toString() {
+        return toString;
+    }
+}

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceInstancePort.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceInstancePort.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.gitpodprotocol.api.entities;
+
+public class WorkspaceInstancePort {
+    private Number port;
+    private String visibility;
+    private String url;
+
+    public void setPort(Number port) {
+        this.port = port;
+    }
+
+    public void setVisibility(String visibility) {
+        this.visibility = visibility;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Number getPort() { return this.port; }
+
+    public String getVisibility() { return this.visibility; }
+
+    public String getUrl() { return this.url; }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
@@ -4,6 +4,12 @@
 
 package io.gitpod.jetbrains.remote
 
+import com.intellij.codeWithMe.ClientId
+import com.intellij.ide.BrowserUtil
+import com.intellij.idea.StartupUtil
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.client.ClientProjectSession
 import com.intellij.openapi.components.service
@@ -11,27 +17,178 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.remoteDev.util.onTerminationOrNow
+import com.intellij.util.application
+import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.gitpodprotocol.api.entities.RemoteTrackMessage
+import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstancePort
 import io.gitpod.supervisor.api.Info
-import kotlinx.coroutines.GlobalScope
+import io.gitpod.supervisor.api.Status
+import io.gitpod.supervisor.api.Status.PortVisibility
+import io.gitpod.supervisor.api.Status.PortsStatus
+import io.gitpod.supervisor.api.StatusServiceGrpc
+import io.grpc.stub.ClientCallStreamObserver
+import io.grpc.stub.ClientResponseObserver
+import kotlinx.coroutines.*
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.launch
+import org.jetbrains.ide.BuiltInServerManager
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
 
 class GitpodClientProjectSessionTracker(
         private val session: ClientProjectSession
-) {
+) : Disposable {
 
     private val manager = service<GitpodManager>()
 
     private lateinit var info: Info.WorkspaceInfoResponse
     private val versionName = ApplicationInfo.getInstance().versionName
     private val fullVersion = ApplicationInfo.getInstance().fullVersion
+    private val lifetime = Lifetime.Eternal.createNested()
+
+    override fun dispose() {
+        lifetime.terminate()
+    }
 
     init {
         GlobalScope.launch {
             info = manager.pendingInfo.await()
             trackEvent("jb_session", mapOf())
             registerActiveLanguageAnalytics()
+        }
+    }
+
+    private fun isExposedServedPort(port: Status.PortsStatus?) : Boolean {
+        if (port === null) {
+            return false
+        }
+        return port.served && port.hasExposed()
+    }
+
+    private fun showOpenServiceNotification(port: PortsStatus, offerMakePublic: Boolean = false) {
+        val message = "A service is available on port ${port.localPort}"
+        val notification = manager.notificationGroup.createNotification(message, NotificationType.INFORMATION)
+
+        val openBrowserAction = NotificationAction.createSimple("Open Browser") {
+            openBrowser(port.exposed.url)
+        }
+        notification.addAction(openBrowserAction)
+
+        if (offerMakePublic) {
+            val makePublicLambda = {
+                runBlocking {
+                    makePortPublic(info.workspaceId, port)
+                }
+            }
+            val makePublicAction = NotificationAction.createSimple("Make Public", makePublicLambda)
+            notification.addAction(makePublicAction)
+        }
+
+        ClientId.withClientId(session.clientId) {
+            notification.notify(null)
+        }
+    }
+
+    private suspend fun makePortPublic(workspaceId: String, port: PortsStatus) {
+        val p = WorkspaceInstancePort()
+        p.port = port.localPort
+        p.visibility = io.gitpod.gitpodprotocol.api.entities.PortVisibility.PUBLIC.toString()
+        p.url = port.exposed.url
+
+        try {
+            manager.client.server.openPort(workspaceId, p).await()
+        } catch (e: Exception) {
+            thisLogger().error("gitpod: failed to open port ${port.localPort}: ", e)
+        }
+    }
+
+    private fun openBrowser(url: String) {
+        ClientId.withClientId(session.clientId) {
+            BrowserUtil.browse(url)
+        }
+    }
+
+    private val portsObserveJob = GlobalScope.launch {
+        if (application.isHeadlessEnvironment) {
+            return@launch
+        }
+
+        // Ignore ports that aren't actually used by the user (e.g. ports used internally by JetBrains IDEs)
+        val backendPort = BuiltInServerManager.getInstance().waitForStart().port
+        val serverPort = StartupUtil.getServerFuture().await().port
+        val ignorePorts = listOf(backendPort, serverPort, 5990)
+        val portsStatus = hashMapOf<Int, Status.PortsStatus>()
+
+        val status = StatusServiceGrpc.newStub(GitpodManager.supervisorChannel)
+        while (isActive) {
+            try {
+                val f = CompletableFuture<Void>()
+                status.portsStatus(
+                        Status.PortsStatusRequest.newBuilder().setObserve(true).build(),
+                        object : ClientResponseObserver<Status.PortsStatusRequest, Status.PortsStatusResponse> {
+
+                            override fun beforeStart(requestStream: ClientCallStreamObserver<Status.PortsStatusRequest>) {
+                                lifetime.onTerminationOrNow {
+                                    requestStream.cancel(null, null)
+                                }
+                            }
+
+                            override fun onNext(ps: Status.PortsStatusResponse) {
+                                for (port in ps.portsList) {
+                                    // Avoiding undesired notifications
+                                    if (ignorePorts.contains(port.localPort)) {
+                                        continue
+                                    }
+
+                                    val previous = portsStatus[port.localPort]
+                                    portsStatus[port.localPort] = port
+
+                                    val shouldSendNotification = !isExposedServedPort(previous) && isExposedServedPort(port)
+
+                                    if (shouldSendNotification) {
+                                        if (port.exposed.onExposed.number == Status.OnPortExposedAction.ignore_VALUE) {
+                                            continue
+                                        }
+
+                                        if (port.exposed.onExposed.number == Status.OnPortExposedAction.open_browser_VALUE || port.exposed.onExposed.number == Status.OnPortExposedAction.open_preview_VALUE) {
+                                            openBrowser(port.exposed.url)
+                                            continue
+                                        }
+
+                                        if (port.exposed.onExposed.number == Status.OnPortExposedAction.notify_VALUE) {
+                                            showOpenServiceNotification(port)
+                                            continue
+                                        }
+
+                                        if (port.exposed.onExposed.number == Status.OnPortExposedAction.notify_private_VALUE) {
+                                            showOpenServiceNotification(port, port.exposed.visibilityValue !== PortVisibility.public_visibility_VALUE)
+                                            continue
+                                        }
+                                    }
+                                }
+                            }
+
+                            override fun onError(t: Throwable) {
+                                f.completeExceptionally(t)
+                            }
+
+                            override fun onCompleted() {
+                                f.complete(null)
+                            }
+                        })
+                f.await()
+            } catch (t: Throwable) {
+                if (t is CancellationException) {
+                    throw t
+                }
+                thisLogger().error("gitpod: failed to stream ports status: ", t)
+            }
+            delay(1000L)
+        }
+    }
+    init {
+        lifetime.onTerminationOrNow {
+            portsObserveJob.cancel()
         }
     }
 

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
@@ -133,7 +133,7 @@ class GitpodManager : Disposable {
         GitVcsApplicationSettings.getInstance().isUseCredentialHelper = true
     }
 
-    private val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("Gitpod Notifications")
+    val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("Gitpod Notifications")
     private val notificationsJob = GlobalScope.launch {
         if (application.isHeadlessEnvironment) {
             return@launch
@@ -234,6 +234,7 @@ class GitpodManager : Disposable {
                     .setHost(info.gitpodApi.host)
                     .addScope("function:sendHeartBeat")
                     .addScope("function:trackEvent")
+                    .addScope("function:openPort")
                     .setKind("gitpod")
                     .build()
 


### PR DESCRIPTION
## Description
This PR introduces ports notification in JetBrains IDEs. 🔔 

### Context
Currently, when ports become available (e.g. a web server is ready to handle requests and the port is exposed to the internet), in VS Code you get a toast notification within the IDE, to inform you. Additionally, you get an action within the notification to open the browser or the preview (specifically for VS Code, as it supports preview windows). While, for JetBrains IDEs, we didn't yet show any notification when ports became available.

Example notification in VS Code

<img width="474" alt="Screenshot 2022-05-25 at 15 41 49" src="https://user-images.githubusercontent.com/2318450/170363925-4178f33b-7972-4b24-af49-4183ba26b1b0.png">

### Approach

The approach used is to listen to supervisor ports status updates (see [status.proto](https://github.com/gitpod-io/gitpod/blob/main/components/supervisor-api/status.proto)).

Gitpod's JetBrains backend-plugin already integrates with supervisor generic notification, so this feature leverages the existing integration and re-uses the same notification group.

After this change, the notifications will appear in the native notifications panel. See example below:

<img width="448" alt="Screenshot 2022-05-25 at 16 35 29" src="https://user-images.githubusercontent.com/2318450/170371388-43125179-6e1a-4a74-b838-f441ca43434c.png">


Additionally, we offer to "Make Public" a port when its visibility is _private_.

![Screenshot 2022-05-26 at 22 00 33](https://user-images.githubusercontent.com/2318450/170620474-76add0dc-1f9e-4767-993a-1c8d42ff0fab.png)


Notes
- To avoid noise and undesired notifications, certain ports are explicitly ignored. Most of those are ports used internally by the IDE itself.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9908 

## How to test
1. Start a workspace using the following link: https://afalz-9908c5dfc24116.staging.gitpod-dev.com/#https://github.com/andreafalzetti/gitpod-experiments-b
1. Choose a JetBrains product as your preferred editor
1. Notice a prompt to open the browser on port 8080
1. Notice a notification for port 8081 being available
1. Notice a notification for port 8083 being available (set to be `notify` in `.gitpod.yml`)
1. Port 8082 should not trigger a notification (set to be ignored in `.gitpod.yml`)
1. Try exposing a new port, make it public, verify that it's accessible

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[JetBrains] Show notification when port becomes available
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

--- 
- [ ] /werft with-vm
- [x] /werft without-vm
- [x] /werft with-clean-slate-deployment
