### PR TITLE
[baseserver] Change default metrics port to 9502 to not clash with kube-rbac-proxy

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -332,7 +332,7 @@ func (s *Server) GRPCAddress() string { return s.options.config.Services.GRPC.Ge
 
 const (
 	BuiltinDebugPort   = 6060
-	BuiltinMetricsPort = 9500
+	BuiltinMetricsPort = 9502
 	BuiltinHealthPort  = 9501
 )
 


### PR DESCRIPTION
Normally, we expose `kube-rbac-proxy` for metrics on port 9500. With https://github.com/gitpod-io/gitpod/pull/10099 we removed listening on localhost to avoid a pitfall where listening on localhost would be inaccessible from outside the container.

In this PR, the default port is updated to not clash with 9500 which we commonly use for metrics through `kube-rbac-proxy`. Currently, only usage is by `public-api-server` (which crash-loops due to this) and `content-service` which doesn't have `kube-rbac-proxy` deployed so this change is safe.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE