### PR TITLE
Update theme selection components

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -7,7 +7,7 @@
 import { useContext, useState } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
-import SelectableCard from "../components/SelectableCard";
+import SelectableCardSolid from "../components/SelectableCardSolid";
 import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
@@ -64,7 +64,7 @@ export default function Preferences() {
                 <h3 className="mt-12">Theme</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
                 <div className="mt-4 space-x-4 flex">
-                    <SelectableCard
+                    <SelectableCardSolid
                         className="w-36 h-32"
                         title="Light"
                         selected={theme === "light"}
@@ -78,8 +78,8 @@ export default function Preferences() {
                                 <rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" />
                             </svg>
                         </div>
-                    </SelectableCard>
-                    <SelectableCard
+                    </SelectableCardSolid>
+                    <SelectableCardSolid
                         className="w-36 h-32"
                         title="Dark"
                         selected={theme === "dark"}
@@ -93,8 +93,8 @@ export default function Preferences() {
                                 <rect width="32" height="16" y="48" fill="#737373" rx="8" />
                             </svg>
                         </div>
-                    </SelectableCard>
-                    <SelectableCard
+                    </SelectableCardSolid>
+                    <SelectableCardSolid
                         className="w-36 h-32"
                         title="System"
                         selected={theme === "system"}
@@ -112,7 +112,7 @@ export default function Preferences() {
                                 <rect width="32" height="16" y="48" fill="#C4C4C4" rx="8" />
                             </svg>
                         </div>
-                    </SelectableCard>
+                    </SelectableCardSolid>
                 </div>
 
                 <h3 className="mt-12">


### PR DESCRIPTION
## Description

This will update the theme selection components with the new selectable component.

## How to test
Go to **[/preferences](https://gt-test.preview.gitpod-dev.com/preferences)** and notice the new selectable card component.

### Screenshots 

| BEFORE | AFTER |
|-|-|
| <img width="526" alt="theme-light-before" src="https://user-images.githubusercontent.com/120486/169163271-a6b2ba0e-acf6-4383-be5b-7b942d8540b5.png"> | <img width="526" alt="theme-light-after" src="https://user-images.githubusercontent.com/120486/169163275-ca9a2b9d-314e-4f71-be48-0dcb18114dc9.png"> |
| <img width="526" alt="theme-dark-before" src="https://user-images.githubusercontent.com/120486/169163277-83f7c023-f560-42f9-9ae3-b437bde61e15.png"> | <img width="526" alt="theme-dark-after" src="https://user-images.githubusercontent.com/120486/169163280-dd628c1b-b934-4a43-af14-dfd285c5e53d.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update theme selection components
```