### PR TITLE
[public-api] Align command structure with other servers

### DIFF
--- a/components/public-api-server/cmd/root.go
+++ b/components/public-api-server/cmd/root.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// ServiceName is the name we use for tracing/logging
+	ServiceName = "public-api-server"
+	// Version of this service - set during build
+	Version = ""
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   ServiceName,
+	Short: "Serves public API services",
+}
+
+func Execute() {
+	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
+		log.WithError(err).Error("Failed to execute command.")
+		os.Exit(1)
+	}
+}

--- a/components/public-api-server/cmd/run.go
+++ b/components/public-api-server/cmd/run.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/public-api-server/pkg/server"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"net/url"
+)
+
+func init() {
+	rootCmd.AddCommand(run())
+}
+
+func run() *cobra.Command {
+	var (
+		gitpodAPIURL string
+		grpcPort     int
+		verbose      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "run",
+		Short:   "Starts the service",
+		Version: Version,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Init(ServiceName, Version, true, verbose)
+			logger := log.Log
+
+			logger.WithField("config", flagsToLogFields(cmd.Flags())).Info("Starting with config.")
+
+			gitpodAPI, urlErr := url.Parse(gitpodAPIURL)
+			if urlErr != nil {
+				logger.WithError(urlErr).Fatal("Failed to parse Gitpod API URL.")
+			}
+
+			if err := server.Start(logger, server.Config{
+				GitpodAPI: gitpodAPI,
+				GRPCPort:  grpcPort,
+			}); err != nil {
+				logger.WithError(err).Fatal("Server errored.")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&gitpodAPIURL, "gitpod-api-url", "wss://main.preview.gitpod-dev.com/api/v1", "URL for existing Gitpod Websocket API")
+	cmd.Flags().IntVar(&grpcPort, "grpc-port", 9001, "Port for serving gRPC traffic")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Toggle verbose logging (debug level)")
+
+	return cmd
+}
+
+func flagsToLogFields(fs *pflag.FlagSet) logrus.Fields {
+	fields := logrus.Fields{}
+
+	fs.VisitAll(func(f *pflag.Flag) {
+		fields[f.Name] = f.Value
+	})
+
+	return fields
+}

--- a/components/public-api-server/main.go
+++ b/components/public-api-server/main.go
@@ -5,75 +5,9 @@
 package main
 
 import (
-	"context"
-	"net/url"
-
-	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/public-api-server/pkg/server"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-)
-
-const (
-	// Version is the current component version. Set during build time.
-	Version = ""
-	Service = "public-api-server"
+	"github.com/gitpod-io/gitpod/public-api-server/cmd"
 )
 
 func main() {
-	ctx := context.Background()
-	cmd := command()
-
-	if err := cmd.ExecuteContext(ctx); err != nil {
-		log.Log.WithError(err).Fatal("Failed to execute command.")
-	}
-}
-
-func command() *cobra.Command {
-	var (
-		gitpodAPIURL string
-		grpcPort     int
-		verbose      bool
-	)
-
-	cmd := &cobra.Command{
-		Use:     "public-api-server",
-		Short:   "Serves public API services",
-		Version: Version,
-		Run: func(cmd *cobra.Command, args []string) {
-			log.Init(Service, Version, true, verbose)
-			logger := log.Log
-
-			logger.WithField("config", flagsToLogFields(cmd.Flags())).Info("Starting with config.")
-
-			gitpodAPI, urlErr := url.Parse(gitpodAPIURL)
-			if urlErr != nil {
-				logger.WithError(urlErr).Fatal("Failed to parse Gitpod API URL.")
-			}
-
-			if err := server.Start(logger, server.Config{
-				GitpodAPI: gitpodAPI,
-				GRPCPort:  grpcPort,
-			}); err != nil {
-				logger.WithError(err).Fatal("Server errored.")
-			}
-		},
-	}
-
-	cmd.Flags().StringVar(&gitpodAPIURL, "gitpod-api-url", "wss://main.preview.gitpod-dev.com/api/v1", "URL for existing Gitpod Websocket API")
-	cmd.Flags().IntVar(&grpcPort, "grpc-port", 9001, "Port for serving gRPC traffic")
-	cmd.Flags().BoolVar(&verbose, "verbose", false, "Toggle verbose logging (debug level)")
-
-	return cmd
-}
-
-func flagsToLogFields(fs *pflag.FlagSet) logrus.Fields {
-	fields := logrus.Fields{}
-
-	fs.VisitAll(func(f *pflag.Flag) {
-		fields[f.Name] = f.Value
-	})
-
-	return fields
+	cmd.Execute()
 }

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -49,6 +49,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:  Component,
 							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.PublicAPIServer.Version),
 							Args: []string{
+								"run",
 								fmt.Sprintf("--grpc-port=%d", GRPCContainerPort),
 								fmt.Sprintf("--gitpod-api-url=wss://%s/api/v1", ctx.Config.Domain),
 							},

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -36,6 +36,7 @@ func TestDeployment_ServerArguments(t *testing.T) {
 
 	apiContainer := containers[0]
 	require.EqualValues(t, []string{
+		"run",
 		"--grpc-port=9001",
 		`--gitpod-api-url=wss://test.domain.everything.awesome.is/api/v1`,
 	}, apiContainer.Args)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR is a subset of https://github.com/gitpod-io/gitpod/pull/10009 to align public api with other packages

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```bash
cd dev/gpctl

go run main.go api workspaces get --id 123 --token foo --address  api.mp-public-ba9a8fb89b.preview.gitpod-dev.com:443 

# Expect to get an L7 response - Invalid credentials - this is success because the service continues to run
INFO[0000] Establishing gRPC connection against api.mp-public-ba9a8fb89b.preview.gitpod-dev.com:443 
FATA[0000] Failed to retrieve workspace.                 error="failed to retrieve workspace (ID: 123): rpc error: code = PermissionDenied desc = insufficient permission to access workspace"
exit status 1
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE