### PR TITLE
[installer, ws-manager]: Use installation shortname in URL templates

### DIFF
--- a/install/installer/pkg/components/ws-manager/configmap.go
+++ b/install/installer/pkg/components/ws-manager/configmap.go
@@ -113,6 +113,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
+	installationShortNameSuffix := ""
+	if ctx.Config.Metadata.InstallationShortname != "" {
+		installationShortNameSuffix = "-" + ctx.Config.Metadata.InstallationShortname
+	}
+
 	wsmcfg := config.ServiceConfiguration{
 		Manager: config.Configuration{
 			Namespace:      ctx.Namespace,
@@ -137,8 +142,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			InitProbe: config.InitProbeConfiguration{
 				Timeout: (1 * time.Second).String(),
 			},
-			WorkspaceURLTemplate:     fmt.Sprintf("https://{{ .Prefix }}.ws.%s", ctx.Config.Domain),
-			WorkspacePortURLTemplate: fmt.Sprintf("https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.%s", ctx.Config.Domain),
+			WorkspaceURLTemplate:     fmt.Sprintf("https://{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain),
+			WorkspacePortURLTemplate: fmt.Sprintf("https://{{ .WorkspacePort }}-{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain),
 			WorkspaceHostPath:        wsdaemon.HostWorkingArea,
 			Timeouts: config.WorkspaceTimeoutConfiguration{
 				AfterClose:          timeoutAfterClose,

--- a/install/installer/pkg/components/ws-manager/configmap_test.go
+++ b/install/installer/pkg/components/ws-manager/configmap_test.go
@@ -5,12 +5,16 @@
 package wsmanager
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
 	wsmancfg "github.com/gitpod-io/gitpod/ws-manager/api/config"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -130,6 +134,61 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 			if diff := cmp.Diff(test.Expectation, act); diff != "" {
 				t.Errorf("Expectation mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestWorkspaceURLTemplates(t *testing.T) {
+	tests := []struct {
+		Name                             string
+		Domain                           string
+		InstallationShortname            string
+		ExpectedWorkspaceUrlTemplate     string
+		ExpectedWorkspacePortURLTemplate string
+	}{
+		{
+			Name:                             "With an installation shortname",
+			Domain:                           "example.com",
+			InstallationShortname:            "eu02",
+			ExpectedWorkspaceUrlTemplate:     "https://{{ .Prefix }}.ws-eu02.example.com",
+			ExpectedWorkspacePortURLTemplate: "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws-eu02.example.com",
+		},
+		{
+			Name:                             "Without an installation shortname",
+			Domain:                           "example.com",
+			InstallationShortname:            "",
+			ExpectedWorkspaceUrlTemplate:     "https://{{ .Prefix }}.ws.example.com",
+			ExpectedWorkspacePortURLTemplate: "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.example.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			ctx, err := common.NewRenderContext(config.Config{
+				Domain: test.Domain,
+				Metadata: configv1.Metadata{
+					InstallationShortname: test.InstallationShortname,
+				},
+				ObjectStorage: configv1.ObjectStorage{
+					InCluster: pointer.Bool(true),
+				},
+			}, versions.Manifest{}, "test_namespace")
+			require.NoError(t, err)
+
+			objs, err := configmap(ctx)
+			require.NoError(t, err)
+
+			cfgmap, ok := objs[0].(*corev1.ConfigMap)
+			require.Truef(t, ok, "configmap function did not return a configmap")
+
+			configJson, ok := cfgmap.Data["config.json"]
+			require.Truef(t, ok, "configmap data did not contain %q key", "config.json")
+
+			serviceConfig := wsmancfg.ServiceConfiguration{}
+			json.Unmarshal([]byte(configJson), &serviceConfig)
+
+			require.Equal(t, test.ExpectedWorkspaceUrlTemplate, serviceConfig.Manager.WorkspaceURLTemplate)
+			require.Equal(t, test.ExpectedWorkspacePortURLTemplate, serviceConfig.Manager.WorkspacePortURLTemplate)
 		})
 	}
 }


### PR DESCRIPTION
## Description

As described in https://github.com/gitpod-io/gitpod/issues/9875, failing image builds currently fail to produce any useful output. A possible cause, as described in [this comment](https://github.com/gitpod-io/gitpod/issues/9875#issuecomment-1129924819), is that the format of the `ws-manager` `WorkspaceURLTemplate` strings is wrong. 

When we deployed with the old helm chart, these values were set in the relevant configmap like this:

https://github.com/gitpod-io/gitpod/blob/2f988c93499926bd34d6728defbd9d9c0964797e/chart/templates/ws-manager-configmap.yaml#L74-L75

ie, they included a suffix after the `ws`. 

This PR tailors the installer output to produce these URLs in the same way the old helm chart did. Installation short name suffixes like `eu-02` are set here:

https://github.com/gitpod-io/ops/blob/main/deploy/production/meta-eu02/app/installer-config.yaml#L6

so the URLs will now look like `https://{{ .Prefix }}.ws-eu02.example.com`.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/9875

## How to test

I've tested this change in staging by editing the `ws-manager` configmap in staging to contain the correct URLs, restarting `ws-manager` and running an image build. I was able to see image build logs as expected:

<img width="1719" alt="image" src="https://user-images.githubusercontent.com/8225907/169295310-9c430081-f4d6-4560-bc7c-f00314abf966.png">


## Release Notes
```release-note
[installer] Use installation shortname when constructing ws-manager URL templates
```

## Documentation
None