### PR TITLE
Wait the Guest Client to be connected to the workspace before executing "gp preview" on JetBrains IDEs.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,15 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
+      <module name="io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol" target="11" />
+      <module name="io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.main" target="11" />
+      <module name="io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.test" target="11" />
+      <module name="io.gitpod.api.jetbrains-backend-plugin.supervisor-api" target="11" />
+      <module name="io.gitpod.api.jetbrains-backend-plugin.supervisor-api.main" target="11" />
+      <module name="io.gitpod.api.jetbrains-backend-plugin.supervisor-api.test" target="11" />
+      <module name="io.gitpod.jetbrains.jetbrains-backend-plugin" target="11" />
+      <module name="io.gitpod.jetbrains.jetbrains-backend-plugin.main" target="11" />
+      <module name="io.gitpod.jetbrains.jetbrains-backend-plugin.test" target="11" />
       <module name="jetbrains-backend-plugin" target="11" />
       <module name="jetbrains-backend-plugin.gitpod-protocol" target="11" />
       <module name="jetbrains-backend-plugin.gitpod-protocol.main" target="11" />

--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -39,4 +39,14 @@ export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
 # Enable host status endpoint
 export CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod
 
+# Build and move idea-cli, then overwrite environment variables initially defined by `components/ide/jetbrains/image/leeway.Dockerfile`
+IDEA_CLI_DEV_PATH=/ide-desktop/bin/idea-cli-dev
+(cd ../cli && go build -o $IDEA_CLI_DEV_PATH)
+export EDITOR="$IDEA_CLI_DEV_PATH open"
+export VISUAL="$EDITOR"
+export GP_OPEN_EDITOR="$EDITOR"
+export GIT_EDITOR="$EDITOR --wait"
+export GP_PREVIEW_BROWSER="$IDEA_CLI_DEV_PATH preview"
+export GP_EXTERNAL_BROWSER="$IDEA_CLI_DEV_PATH preview"
+
 $TEST_BACKEND_DIR/bin/remote-dev-server.sh run $TEST_DIR

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
@@ -7,6 +7,7 @@ package io.gitpod.jetbrains.remote
 import com.intellij.codeWithMe.ClientId
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.CommandLineProcessor
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.client.ClientSession
 import com.intellij.openapi.client.ClientSessionsManager
 import com.intellij.openapi.diagnostic.thisLogger
@@ -20,7 +21,7 @@ import org.jetbrains.ide.RestService
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 
-
+@Suppress("UnstableApiUsage")
 class GitpodCLIService : RestService() {
 
     override fun getServiceName() = SERVICE_NAME
@@ -54,22 +55,34 @@ class GitpodCLIService : RestService() {
     }
 
     private fun withClient(request: FullHttpRequest, context: ChannelHandlerContext, action: (project: Project?) -> Unit): String? {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            getClientSessionAndProjectAsync().let { (session, project) ->
+                ClientId.withClientId(session.clientId) {
+                    action(project)
+                    sendOk(request, context)
+                }
+            }
+        }
+        return null
+    }
+
+    private data class ClientSessionAndProject(val session: ClientSession, val project: Project?)
+
+    private tailrec fun getClientSessionAndProjectAsync(): ClientSessionAndProject {
         val project = getLastFocusedOrOpenedProject()
         var session: ClientSession? = null
         if (project != null) {
-            session = ClientSessionsManager.getProjectSessions(project, false).first()
+            session = ClientSessionsManager.getProjectSessions(project, false).firstOrNull()
         }
         if (session == null) {
-            session = ClientSessionsManager.getAppSessions(false).first()
+            session = ClientSessionsManager.getAppSessions(false).firstOrNull()
         }
-        if (session == null) {
-            return "no client"
+        return if (session != null) {
+            ClientSessionAndProject (session, project)
+        } else {
+            Thread.sleep(1000L)
+            getClientSessionAndProjectAsync()
         }
-        ClientId.withClientId(session.clientId) {
-            action(project)
-        }
-        sendOk(request, context)
-        return null
     }
 
     private fun parseFilePath(path: String): Path? {

--- a/components/ide/jetbrains/cli/cmd/open.go
+++ b/components/ide/jetbrains/cli/cmd/open.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -25,10 +24,7 @@ var openCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		url, err := url.Parse("http://localhost:63342/api/gitpod/cli")
-		if err != nil {
-			log.Fatal(err)
-		}
+		url := getCliApiUrl()
 		query := url.Query()
 		query.Add("op", "open")
 		query.Add("file", file)

--- a/components/ide/jetbrains/cli/cmd/preview.go
+++ b/components/ide/jetbrains/cli/cmd/preview.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"log"
 	"net/http"
-	"net/url"
 
 	"github.com/spf13/cobra"
 )
@@ -15,10 +14,7 @@ import (
 var previewCmd = &cobra.Command{
 	Use: "preview",
 	Run: func(cmd *cobra.Command, args []string) {
-		url, err := url.Parse("http://localhost:63342/api/gitpod/cli")
-		if err != nil {
-			log.Fatal(err)
-		}
+		url := getCliApiUrl()
 		query := url.Query()
 		query.Add("op", "preview")
 		query.Add("url", args[0])

--- a/components/ide/jetbrains/cli/cmd/root.go
+++ b/components/ide/jetbrains/cli/cmd/root.go
@@ -5,7 +5,11 @@
 package cmd
 
 import (
+	"errors"
+	"log"
+	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -19,6 +23,18 @@ func Execute() {
 	if err != nil {
 		os.Exit(1)
 	}
+}
+
+func getCliApiUrl() *url.URL {
+	var backendPort = 63342
+	if _, fileStatError := os.Stat("/ide-desktop/bin/idea-cli-dev"); !errors.Is(fileStatError, os.ErrNotExist) {
+		backendPort = backendPort + 1
+	}
+	parsedUrl, urlParseError := url.Parse("http://localhost:" + strconv.Itoa(backendPort) + "/api/gitpod/cli")
+	if urlParseError != nil {
+		log.Fatal(urlParseError)
+	}
+	return parsedUrl
 }
 
 func init() {}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Wait the Guest Client to be connected to the workspace before executing "gp preview" on JetBrains IDEs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10118

## How to test
<!-- Provide steps to test this PR -->
- Access the following URL to open Jenkins Design Library in Gitpod's Preview Environment in IntelliJ IDEA:
  https://vn-10118-j8f802b11df.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/jenkinsci/design-library-plugin/tree/73f12733d95932c333ba4155521ff78b4ed40dfc
- As soon as the IDE opens, it stats building the project. Meanwhile, if you want, you can use `gp tasks attach` to attach to "Preview" task. (See the project's [.gitpod.yml](https://github.com/jenkinsci/design-library-plugin/blob/73f12733d95932c333ba4155521ff78b4ed40dfc/.gitpod.yml))
- After the build completes, port 8080 will be available, and at this moment, the IDE should ask if you want to open the browser at the address `$(gp url 8080)/jenkins/`.
    ![image](https://user-images.githubusercontent.com/418083/169329030-bc716eb9-b373-4b91-abca-aa3fadfc695f.png)
    <img width="985" alt="image" src="https://user-images.githubusercontent.com/418083/169325329-0656b6c3-869f-47cb-b14a-82a8c838c3c4.png">
    Note: Sometimes the project build fails with messages like `java: error reading /workspace/m2-repository/jaxen/jaxen/1.2.0/jaxen-1.2.0.jar; zip file is empty` and the only solution is to manually delete the dependency folder (`rm -rf /workspace/m2-repository/jaxen/`) and then run `mvn hpi:run` again.
- Stop the workspace and restart it. Now the build will happen pretty quickly, as all dependencies are already downloaded. So as soon as you open the workspace on IntelliJ you should see the popup asking if you want to open Jenkins URL in the browser.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed a bug that was preventing "gp preview" to work in JetBrains IDEs when executed as a task in ".gitpod.yml".
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.