### PR TITLE
Use the builds nodepool. Workload is going away

### DIFF
--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -5,7 +5,7 @@ args:
 pod:
   serviceAccount: werft
   nodeSelector:
-    dev/workload: workload
+    dev/workload: builds
   imagePullSecrets:
   - name: eu-gcr-io-pull-secret
   volumes:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The workload nodepool is going away in favour of using the builds nodepool

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/2183

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A