### PR TITLE
Update spacing between theme options

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -63,7 +63,7 @@ export default function Preferences() {
                 <SelectIDE />
                 <h3 className="mt-12">Theme</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
-                <div className="mt-4 space-x-4 flex">
+                <div className="mt-4 space-x-3 flex">
                     <SelectableCardSolid
                         className="w-36 h-32"
                         title="Light"


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/10111, minor spacing update between theme options. ☺️ 

## How to test
Go to theme preferences and notice the spacing between the theme options when compared with the editor options.

## Screenshots 

| BEFORE | AFTER |
|-|-|
| <img width="621" alt="theme-before" src="https://user-images.githubusercontent.com/120486/169377096-5f946c9b-ea0d-41e4-8ffb-8aac7019e5ad.png"> | <img width="621" alt="theme-after" src="https://user-images.githubusercontent.com/120486/169377101-e44b73de-cb66-4159-8166-b5a06e932a6e.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update spacing between theme options
```