### PR TITLE
Update dotfiles layout in user preferences

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -123,23 +123,26 @@ export default function Preferences() {
                     </PillLabel>
                 </h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
-                <div className="mt-4 max-w-md">
+                <div className="mt-4 max-w-xl">
                     <h4>Repository URL</h4>
-                    <input
-                        type="text"
-                        value={dotfileRepo}
-                        className="w-full"
-                        placeholder="e.g. https://github.com/username/dotfiles"
-                        onChange={(e) => setDotfileRepo(e.target.value)}
-                    />
+                    <span className="flex">
+                        <input
+                            type="text"
+                            value={dotfileRepo}
+                            className="w-96 h-9"
+                            placeholder="e.g. https://github.com/username/dotfiles"
+                            onChange={(e) => setDotfileRepo(e.target.value)}
+                        />
+                        <button className="secondary ml-2" onClick={() => actuallySetDotfileRepo(dotfileRepo)}>
+                            Save Changes
+                        </button>
+                    </span>
                     <div className="mt-1">
                         <p className="text-gray-500 dark:text-gray-400">
-                            Add a repository URL that includes dotfiles. Gitpod will clone and install your dotfiles for
-                            every new workspace.
+                            Add a repository URL that includes dotfiles. Gitpod will
+                            <br />
+                            clone and install your dotfiles for every new workspace.
                         </p>
-                    </div>
-                    <div className="mt-4 max-w-md">
-                        <button onClick={() => actuallySetDotfileRepo(dotfileRepo)}>Save Changes</button>
                     </div>
                 </div>
             </PageWithSubMenu>


### PR DESCRIPTION
## Description

In the spirit of [minimum viable changes](https://www.notion.so/gitpod/Core-Values-Differentiators-2ed4c2f93c84499b98e3b5389980992e#0c2e0d6c8a99404b97ccdc206b573d72) and [shipping](https://www.notion.so/gitpod/Core-Values-Differentiators-2ed4c2f93c84499b98e3b5389980992e#d766b4a2f4664dea9905ac29e65a5ccf), this will update the dotfiles layout in user preferences. 🛹 

Cc @filiptronicek @sagor999 @andreafalzetti @loujaybee because #7639

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7639

## How to test
Go to **/preferences** and notice the improved usability of the dotfiles section along the rest of the preferences options.

## Screenshots
| BEFORE | AFTER |
|-|-|
| <img width="479" alt="dotfiles-before" src="https://user-images.githubusercontent.com/120486/169385722-75960cf3-f79b-4a46-8e70-4ad47384ae42.png"> | <img width="479" alt="dotfiles-after" src="https://user-images.githubusercontent.com/120486/169385725-daf3eacf-45ba-4d9d-9df1-e92b5b247e7f.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update dotfiles layout
```