### PR TITLE
Revert "[installer, ws-manager]: Use installation shortname in URL templates"

### DIFF
--- a/install/installer/pkg/components/ws-manager/configmap.go
+++ b/install/installer/pkg/components/ws-manager/configmap.go
@@ -113,11 +113,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
-	installationShortNameSuffix := ""
-	if ctx.Config.Metadata.InstallationShortname != "" {
-		installationShortNameSuffix = "-" + ctx.Config.Metadata.InstallationShortname
-	}
-
 	wsmcfg := config.ServiceConfiguration{
 		Manager: config.Configuration{
 			Namespace:      ctx.Namespace,
@@ -142,8 +137,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			InitProbe: config.InitProbeConfiguration{
 				Timeout: (1 * time.Second).String(),
 			},
-			WorkspaceURLTemplate:     fmt.Sprintf("https://{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain),
-			WorkspacePortURLTemplate: fmt.Sprintf("https://{{ .WorkspacePort }}-{{ .Prefix }}.ws%s.%s", installationShortNameSuffix, ctx.Config.Domain),
+			WorkspaceURLTemplate:     fmt.Sprintf("https://{{ .Prefix }}.ws.%s", ctx.Config.Domain),
+			WorkspacePortURLTemplate: fmt.Sprintf("https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.%s", ctx.Config.Domain),
 			WorkspaceHostPath:        wsdaemon.HostWorkingArea,
 			Timeouts: config.WorkspaceTimeoutConfiguration{
 				AfterClose:          timeoutAfterClose,

--- a/install/installer/pkg/components/ws-manager/configmap_test.go
+++ b/install/installer/pkg/components/ws-manager/configmap_test.go
@@ -5,16 +5,12 @@
 package wsmanager
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
 	wsmancfg "github.com/gitpod-io/gitpod/ws-manager/api/config"
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -134,61 +130,6 @@ func TestBuildWorkspaceTemplates(t *testing.T) {
 			if diff := cmp.Diff(test.Expectation, act); diff != "" {
 				t.Errorf("Expectation mismatch (-want +got):\n%s", diff)
 			}
-		})
-	}
-}
-
-func TestWorkspaceURLTemplates(t *testing.T) {
-	tests := []struct {
-		Name                             string
-		Domain                           string
-		InstallationShortname            string
-		ExpectedWorkspaceUrlTemplate     string
-		ExpectedWorkspacePortURLTemplate string
-	}{
-		{
-			Name:                             "With an installation shortname",
-			Domain:                           "example.com",
-			InstallationShortname:            "eu02",
-			ExpectedWorkspaceUrlTemplate:     "https://{{ .Prefix }}.ws-eu02.example.com",
-			ExpectedWorkspacePortURLTemplate: "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws-eu02.example.com",
-		},
-		{
-			Name:                             "Without an installation shortname",
-			Domain:                           "example.com",
-			InstallationShortname:            "",
-			ExpectedWorkspaceUrlTemplate:     "https://{{ .Prefix }}.ws.example.com",
-			ExpectedWorkspacePortURLTemplate: "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.example.com",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			ctx, err := common.NewRenderContext(config.Config{
-				Domain: test.Domain,
-				Metadata: configv1.Metadata{
-					InstallationShortname: test.InstallationShortname,
-				},
-				ObjectStorage: configv1.ObjectStorage{
-					InCluster: pointer.Bool(true),
-				},
-			}, versions.Manifest{}, "test_namespace")
-			require.NoError(t, err)
-
-			objs, err := configmap(ctx)
-			require.NoError(t, err)
-
-			cfgmap, ok := objs[0].(*corev1.ConfigMap)
-			require.Truef(t, ok, "configmap function did not return a configmap")
-
-			configJson, ok := cfgmap.Data["config.json"]
-			require.Truef(t, ok, "configmap data did not contain %q key", "config.json")
-
-			serviceConfig := wsmancfg.ServiceConfiguration{}
-			json.Unmarshal([]byte(configJson), &serviceConfig)
-
-			require.Equal(t, test.ExpectedWorkspaceUrlTemplate, serviceConfig.Manager.WorkspaceURLTemplate)
-			require.Equal(t, test.ExpectedWorkspacePortURLTemplate, serviceConfig.Manager.WorkspacePortURLTemplate)
 		})
 	}
 }


### PR DESCRIPTION
Reverts gitpod-io/gitpod#10127
As it broke preview environment due to incorrect certs.

## Release Notes
```release-note
none
```
