### PR TITLE
Configures the pvc.spec.storageClassName when it's not empty

### DIFF
--- a/components/ws-manager/pkg/manager/testdata/cpwp_default_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_default_storage.golden
@@ -13,8 +13,7 @@
                 "requests": {
                     "storage": "30Gi"
                 }
-            },
-            "storageClassName": ""
+            }
         },
         "status": {}
     }

--- a/components/ws-manager/pkg/manager/testdata/cpwp_no_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_no_class.golden
@@ -13,8 +13,7 @@
                 "requests": {
                     "storage": "0"
                 }
-            },
-            "storageClassName": ""
+            }
         },
         "status": {}
     }

--- a/components/ws-manager/pkg/manager/testdata/cpwp_no_pvc.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_no_pvc.golden
@@ -13,8 +13,7 @@
                 "requests": {
                     "storage": "0"
                 }
-            },
-            "storageClassName": ""
+            }
         },
         "status": {}
     }

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -188,14 +188,6 @@ func TestMissingBackup(t *testing.T) {
 				{Name: "pvc", FF: []wsapi.WorkspaceFeatureFlag{wsapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}},
 			}
 			for _, test := range tests {
-				if test.Name == "pvc" {
-					// TODO(jenting): temporary skip the pvc test to make the integration test pass
-					// We should add this integration test back once these issues be fixed
-					// https://github.com/gitpod-io/gitpod/pull/9475
-					// https://github.com/gitpod-io/gitpod/issues/10017
-					t.Skip("temporary skip the pvc test")
-				}
-
 				t.Run(test.Name+"_backup_init", func(t *testing.T) {
 					testws, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(func(w *wsapi.StartWorkspaceRequest) error {
 						w.ServicePrefix = ws.Req.ServicePrefix


### PR DESCRIPTION
## Description
Configures the `pvc.spec.storageClassName` when it's not empty. Otherwise, the PVC requests empty storage class.
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10017
Fixes #9990

## How to test
<!-- Provide steps to test this PR -->
```go
./dev/preview/install-k3s-kubeconfig.sh
cd test
go test -v ./... -run=TestMissingBackup -kubeconfig=/home/gitpod/.kube/config -namespace=default
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[experimental] Workspace persistent volume claim (PVC) uses a default storage class within the Kubernetes cluster if the user does not configure it
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A