### PR TITLE
[server] log less errors

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-file-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-file-provider.ts
@@ -48,7 +48,7 @@ export class BitbucketServerFileProvider implements FileProvider {
             const result = await this.api.fetchContent(user, `/${repoKind}/${owner}/repos/${name}/raw/${path}`);
             return result;
         } catch (err) {
-            console.error({ userId: user.id }, err);
+            console.debug({ userId: user.id }, err);
         }
     }
 }

--- a/components/server/src/bitbucket/bitbucket-file-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-file-provider.ts
@@ -63,7 +63,7 @@ export class BitbucketFileProvider implements FileProvider {
             ).data;
             return contents as string;
         } catch (err) {
-            log.error({ userId: user.id }, err);
+            log.debug({ userId: user.id }, err);
         }
     }
 }

--- a/components/server/src/github/file-provider.ts
+++ b/components/server/src/github/file-provider.ts
@@ -65,7 +65,7 @@ export class GithubFileProvider implements FileProvider {
             );
             return contents;
         } catch (err) {
-            log.error(err);
+            log.debug(err);
         }
     }
 }

--- a/components/server/src/gitlab/file-provider.ts
+++ b/components/server/src/gitlab/file-provider.ts
@@ -53,7 +53,7 @@ export class GitlabFileProvider implements FileProvider {
             const result = await this.gitlabApi.getRawContents(user, org, name, commitish, path);
             return result;
         } catch (error) {
-            log.error(error);
+            log.debug(error);
         }
     }
 }


### PR DESCRIPTION
`FileProvider.getFileContent` is super noisy with 404 NOT FOUND errors when trying to find/read `.gitpod.yml`. This PR should tune down the noise. If we need to investigate any issue in that area, we'd change log-level of server.


```release-notes
NONE
```