### PR TITLE
[server] Two small `startPrebuild` fixes

### DIFF
--- a/components/server/ee/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-app.ts
@@ -102,6 +102,12 @@ export class BitbucketServerApp {
             const cloneUrl = context.repository.cloneUrl;
             const commit = context.revision;
             const projectAndOwner = await this.findProjectAndOwner(cloneUrl, user);
+            if (projectAndOwner.project) {
+                /* tslint:disable-next-line */
+                /** no await */ this.projectDB.updateProjectUsage(projectAndOwner.project.id, {
+                    lastWebhookReceived: new Date().toISOString(),
+                });
+            }
             const config = await this.prebuildManager.fetchConfig({ span }, user, context);
             if (!this.prebuildManager.shouldPrebuild(config)) {
                 console.log("Bitbucket push event: No config. No prebuild.");

--- a/components/server/ee/src/prebuilds/github-app-rules.ts
+++ b/components/server/ee/src/prebuilds/github-app-rules.ts
@@ -44,11 +44,6 @@ export class GithubAppRules {
             return false;
         }
 
-        const hasPrebuildTask = !!config.tasks && config.tasks.find((t) => !!t.before || !!t.init || !!t.prebuild);
-        if (!hasPrebuildTask) {
-            return false;
-        }
-
         const prebuildCfg = this.mergeWithDefaultConfig(config).prebuilds!;
         if (isPR) {
             if (isFork) {

--- a/components/server/ee/src/prebuilds/github-app.spec.ts
+++ b/components/server/ee/src/prebuilds/github-app.spec.ts
@@ -26,17 +26,6 @@ describe("GitHub app", () => {
         chai.assert.isFalse(rules.shouldRunPrebuild(undefined, false, true, true));
     });
 
-    it("should not run prebuilds without tasks to execute", async () => {
-        const noTaskConfig: WorkspaceConfig = {
-            tasks: [],
-        };
-        const rules = container.get(GithubAppRules) as GithubAppRules;
-        chai.assert.isFalse(rules.shouldRunPrebuild(noTaskConfig, true, false, false));
-        chai.assert.isFalse(rules.shouldRunPrebuild(noTaskConfig, false, true, false));
-        chai.assert.isFalse(rules.shouldRunPrebuild(noTaskConfig, false, false, false));
-        chai.assert.isFalse(rules.shouldRunPrebuild(noTaskConfig, false, true, true));
-    });
-
     it("should behave well with individual configuration", async () => {
         const rules = container.get(GithubAppRules) as GithubAppRules;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Comparing all call-sites of `prebuildManager.startPrebuild` yielded interesting insights:

<details><summary>(compare every call-site)</summary>

https://github.com/gitpod-io/gitpod/blob/ed30d9696fd1c0ca5775a2d44d6b4a9e5709ba63/components/server/ee/src/prebuilds/bitbucket-app.ts#L98-L131

https://github.com/gitpod-io/gitpod/blob/e8fa6d20d2c18cdb0f02ff2cfd483388c5c5dac9/components/server/ee/src/prebuilds/bitbucket-server-app.ts#L104-L123

https://github.com/gitpod-io/gitpod/blob/5509d9eec9c1dd47330f22be1e588ac756785c35/components/server/ee/src/prebuilds/github-app.ts#L244-L288

https://github.com/gitpod-io/gitpod/blob/ed30d9696fd1c0ca5775a2d44d6b4a9e5709ba63/components/server/ee/src/prebuilds/github-enterprise-app.ts#L120-L148

https://github.com/gitpod-io/gitpod/blob/ed30d9696fd1c0ca5775a2d44d6b4a9e5709ba63/components/server/ee/src/prebuilds/gitlab-app.ts#L110-L138

</details>

- [x] The BitBucket Server integration does not update `d_b_project_usage` (fixed here)
- [x] The GitHub App happily triggers prebuilds for repositories that don't have prebuild tasks, or even a `.gitpod.yml`(!)

The second point is actually quite bad, because users may accidentally:
- Install the GitHub App for all their repositories
- Maintain some fully-automated repositories with high-frequency commits/pushes/PRs
- This scenario can cause a very high volume of prebuilds, and for example produce our [biggest GCP storage bucket](https://github.com/gitpod-io/ops/issues/2087#issuecomment-1115135240) (internal), among other things

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Skip GitHub App prebuilds when the repository has no prebuild task(s) or .gitpod.yml
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
