### PR TITLE
Reduce memory requests of minio in preview envs

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -61,6 +61,7 @@ export class Installer {
             this.configureContainerRegistry(slice)
             this.configureDomain(slice)
             this.configureWorkspaces(slice)
+            this.configureObjectStorage(slice)
             this.configureIDE(slice)
             this.configureObservability(slice)
             this.configureAuthProviders(slice)
@@ -107,6 +108,10 @@ export class Installer {
     private configureWorkspaces(slice: string) {
         exec(`yq w -i ${this.options.installerConfigPath} workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: slice });
         exec(`yq w -i ${this.options.installerConfigPath} workspace.resources.requests.cpu "100m"`, { slice: slice });
+    }
+
+    private configureObjectStorage(slice: string) {
+        exec(`yq w -i ${this.options.installerConfigPath} objectStorage.resources.requests.memory "256Mi"`, { slice: slice });
     }
 
     private configureIDE(slice: string) {
@@ -181,7 +186,7 @@ export class Installer {
     }
 
     postProcessing(slice: string): void {
-        this.options.werft.log(slice, "Post processing YAML manfests");
+        this.options.werft.log(slice, "Post processing YAML manifests");
 
         this.configureLicense(slice)
         this.configureWorkspaceFeatureFlags(slice)

--- a/install/installer/example-config.yaml
+++ b/install/installer/example-config.yaml
@@ -18,6 +18,9 @@ metadata:
   shortname: default
 objectStorage:
   inCluster: true
+  resources:
+    requests:
+      memory: 2Gi
 observability:
   logLevel: info
 openVSX:
@@ -27,6 +30,7 @@ workspace:
   maxLifetime: 36h0m0s
   pvc:
     size: 30Gi
+    snapshotClass: ""
     storageClass: ""
   resources:
     requests:

--- a/install/installer/pkg/components/minio/helm.go
+++ b/install/installer/pkg/components/minio/helm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/components/minio/azure"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/minio/incluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/helm"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 )
 
@@ -23,6 +24,11 @@ var Helm = common.CompositeHelmFunc(
 			helm.ImagePullSecrets("minio.volumePermissions.image.pullSecrets", cfg),
 			helm.KeyValue("minio.volumePermissions.image.registry", ""),
 			helm.KeyValue("minio.volumePermissions.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/bitnami-shell")),
+		}
+
+		if cfg.Config.ObjectStorage.Resources.Requests.Memory() != nil {
+			memoryRequests := resource.MustParse(cfg.Config.ObjectStorage.Resources.Requests.Memory().String())
+			commonHelmValues = append(commonHelmValues, helm.KeyValue("minio.resources.requests.memory", memoryRequests.String()))
 		}
 
 		if pointer.BoolDeref(cfg.Config.ObjectStorage.InCluster, false) {

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -49,6 +49,9 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Metadata.Region = "local"
 	cfg.Metadata.InstallationShortname = "default" // TODO(gpl): we're tied to "default" here because that's what we put into static bridges in the past
 	cfg.ObjectStorage.InCluster = pointer.Bool(true)
+	cfg.ObjectStorage.Resources.Requests = corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}
 	cfg.ContainerRegistry.InCluster = pointer.Bool(true)
 	cfg.Workspace.Resources.Requests = corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("1000m"),
@@ -152,6 +155,7 @@ type ObjectStorage struct {
 	Azure              *ObjectStorageAzure        `json:"azure,omitempty"`
 	MaximumBackupCount *int                       `json:"maximumBackupCount,omitempty"`
 	BlobQuota          *int64                     `json:"blobQuota,omitempty"`
+	Resources          Resources                  `json:"resources,omitempty"`
 }
 
 type ObjectStorageS3 struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Average memory usage for `minio` seems to be ~100mb - I've left it a bit more just in case

```
kubectl top pods minio-859b8f94b5-xztxk --containers
POD                      NAME    CPU(cores)   MEMORY(bytes)   
minio-859b8f94b5-xztxk   minio   2m           87Mi   
```

```release-note
Reduce memory requests of minio in preview environments
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # https://github.com/gitpod-io/gitpod/issues/10028

