### PR TITLE
Update VS Code Stable to `1.67.2`

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-64cd59a5d2bb36c818c09f455775edfa5e679b16" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-d5b6d5fcb1d4c6bd2c8a30a8366ea400a96830ef" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates the stable version of VS Code Web to https://github.com/microsoft/vscode/releases/tag/1.67.2.

## Related Issue(s)
Tracked in https://github.com/gitpod-io/gitpod/issues/9667

## How to test
1. In the preview environment, select VS Code Web stable as the IDE.
2. Start a workspace
3. Check that the about dialog in VS Code says that you are on `1.67.2`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
