### PR TITLE
[baseserver] fix CI lint failed

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -158,11 +158,9 @@ func (s *Server) ListenAndServe() error {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	// Await operating system signals, or server errors.
-	select {
-	case sig := <-signals:
-		s.Logger().Infof("Received system signal %s, closing server.", sig.String())
-		return nil
-	}
+	sig := <-signals
+	s.Logger().Infof("Received system signal %s, closing server.", sig.String())
+	return nil
 }
 
 func (s *Server) Close() error {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
After #10157 is merge, all builds is failed because below error, see detail in https://werft.gitpod-dev.com/job/gitpod-build-main.3323
```
baseserver/server.go:161:2: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
	select {
```

This PR fixes that, This is just a simplified fix, I see that the comments say that you also need to exit if you receive a server error, but I haven't had time to read the code yet @andrew-farries 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
see werft job is pass

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
