### PR TITLE
[observability] add horizontal line for load avg panel

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.libsonnet
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.libsonnet
@@ -82,6 +82,12 @@ local wsNodeLoadAverageGraph =
       topk(5, sum(nodepool:node_load1:normalized{%(clusterLabel)s=~"$cluster", nodepool=~".*workspace.*"}) by (node))
     ||| % _config, legendFormat='{{node}}'
   ))
+  .addTarget(prometheus.target(
+    |||
+      1
+    ||| % _config, legendFormat='Node Max Load Avg'
+  ))
+  .addSeriesOverride({ alias: 'Node Max Load Avg', color: '#FF0000' })
 ;
 
 local workspaceStartupTimeHeatMap =


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently when viewing load average per cluster, due to dynamic scaling, it is very difficult to see when the cluster is starting to experience high load avg, as you have to constantly look at the left axis to see the actual numbers. That is cumbersome.
I propose adding horizontal line at value `1`. Why `1? Because it will help greatly with cluster that have very low load, and comparing them to other clusters.
If we change node types, we would need to update this panel in the future.

Compare old way:
![image](https://user-images.githubusercontent.com/18602811/169617775-9b807e86-4dcb-4a43-9d9f-c91c086c8261.png)

vs new way:
![image](https://user-images.githubusercontent.com/18602811/169617798-1f13e582-1bac-49be-b1f4-8a52b2a71508.png)

I believe it shows a much clearer picture.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
