### PR TITLE
Fix link to Code of Conduct in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ To this end we've developed a number of open source projects including:
 ## Code of Conduct
 
 We want to create a welcoming environment for everyone who is interested in contributing to Gitpod or participating in discussions with the Gitpod community.
-This project has adopted the [Contributor Covenant Code of Conduct](https://github.com/gitpod-io/gitpod/blob/master/CODE_OF_CONDUCT.md), [version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+This project has adopted the [Contributor Covenant Code of Conduct](https://github.com/gitpod-io/.github/blob/main/CODE_OF_CONDUCT.md), [version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).


### PR DESCRIPTION
## Description
This fixes the link to the Code of Conduct in the README as it was removed at some point in this repo. The new link is to the Code of Conduct in the `.github` project.

Perhaps linking indirectly through https://gitpod.io/code-of-conduct is better though?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
