### PR TITLE
Fix Help link

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -398,7 +398,7 @@ export default function Menu() {
                                     },
                                     {
                                         title: "Help",
-                                        link: "https://www.gitpod.io/support",
+                                        href: "https://www.gitpod.io/support",
                                         separator: true,
                                     },
                                     {


### PR DESCRIPTION
## Description
Fixes the `Help` link.

## Related Issue(s)
Fixes #10150

## How to test
Open the [preview env](https://laushinka-b3960b058d.preview.gitpod-dev.com/workspaces), click on the User nav, and click on `Help`.
It should redirect to `https://www.gitpod.io/support`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
