### PR TITLE
Add S3 bucket name to kots config

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -202,6 +202,7 @@ spec:
                   echo "Gitpod: configuring storage for S3"
 
                   yq e -i ".objectStorage.s3.endpoint = \"{{repl ConfigOption "store_s3_endpoint" }}\"" "${CONFIG_FILE}"
+                  yq e -i ".objectStorage.s3.bucket = \"{{repl ConfigOption "store_s3_bucket" }}\"" "${CONFIG_FILE}"
                   yq e -i ".objectStorage.s3.credentials.kind = \"secret\"" "${CONFIG_FILE}"
                   yq e -i ".objectStorage.s3.credentials.name = \"storage-s3\"" "${CONFIG_FILE}"
                 fi

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -246,7 +246,7 @@ spec:
           type: text
           required: false
           when: '{{repl (ConfigOptionEquals "store_provider" "s3") }}'
-          help_text: Name of the S3 bucket to be used as storage. If left empty, buckets will be created by Gitpod using the provided credentials.
+          help_text: Name of S3 bucket to be used as storage. If left empty, Gitpod will create bucket per each user. If set, then all data will be stored inside one bucket.
 
         - name: store_s3_access_key_id
           title: Access Key

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -241,6 +241,13 @@ spec:
           when: '{{repl (ConfigOptionEquals "store_provider" "s3") }}'
           help_text: The endpoint used to connect to the S3 storage.
 
+        - name: store_s3_bucket
+          title: S3 bucket name
+          type: text
+          required: false
+          when: '{{repl (ConfigOptionEquals "store_provider" "s3") }}'
+          help_text: Name of the S3 bucket to be used as storage. If left empty, buckets will be created by Gitpod using the provided credentials.
+
         - name: store_s3_access_key_id
           title: Access Key
           type: text


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As a follow up to #10073 , this PR adds the bucket name option to the KOTS config. This PR depends on the following PRs for proper working:
- #10073 
- #10083 
- #9942 

The resulting UI would have the following content:

![s3-bucket](https://user-images.githubusercontent.com/2624550/169846423-87530c7c-71ba-41da-b95b-bdb10d5525ed.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10100

## How to test
<!-- Provide steps to test this PR -->
Setting up replicated with the changes from this PR and the above mentioned PRs will give the option to provide bucket name.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] Add `S3 bucket name` option to KOTS config  
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
