### PR TITLE
Add signals section in epic template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -102,3 +102,12 @@ body:
     placeholder: Useful if you want to spend the extra time to get stakeholders, the team, or customers excited.
   validations:
     required: false
+- type: textarea
+  id: signals
+  attributes:
+    label: Signals (internal)
+    description: Links to signals from [`gitpod-io/customers`](https://github.com/gitpod-io/customers/issues).
+    placeholder: Optional, add links to any existing signal.
+  validations:
+    required: false
+


### PR DESCRIPTION
## Description

Intentionally add a signals section in the epic template to provide a space for use to link back to any internal signals in [`gitpod-io/customers`](https://github.com/gitpod-io/customers/issues).

## How to test
See the [existing template](https://github.com/gitpod-io/gitpod/blob/main/.github/ISSUE_TEMPLATE/epic.yml) v. [proposed template](https://github.com/gitpod-io/gitpod/blob/98b627fded1ff8c888a4ba2b940dfaeca71eabf7/.github/ISSUE_TEMPLATE/epic.yml).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```