### PR TITLE
[gitpod-db] Improve d_b_workspace cloneURL DB migration performance

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1652365883273-CloneUrlIndexed.ts
+++ b/components/gitpod-db/src/typeorm/migration/1652365883273-CloneUrlIndexed.ts
@@ -16,7 +16,7 @@ export class CloneUrlIndexed1652365883273 implements MigrationInterface {
         if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
             await queryRunner.query(
                 `ALTER TABLE ${TABLE_NAME}
-                ADD COLUMN ${COLUMN_NAME} VARCHAR(255) NOT NULL DEFAULT ''`,
+                ADD COLUMN ${COLUMN_NAME} VARCHAR(255) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE`,
             );
         }
         if (!(await indexExists(queryRunner, TABLE_NAME, TYPE_INDEX_NAME))) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes ~50min DB migration on `d_b_workspace` when there are millions of rows

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
