### PR TITLE
[jb] enable connect button only when JetBrains Client not activated (cont.)

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -168,13 +168,7 @@ class GitpodWorkspacesView(
     init {
         refresh()
         loggedIn.addListener { refresh() }
-        GitpodConnectionProvider.addListener {
-            thisLogger().d("WorkspaceView refresh, " +
-                    GitpodConnectionProvider.jetbrainsClientMap
-                        .map { "[wsId=${it.key}, ${it.value.prettyPrint()}]" }
-                        .joinToString("; "))
-            refresh()
-        }
+        GitpodConnectionProvider.addListener { refresh() }
     }
 
     private fun startUpdateLoop(lifetime: Lifetime, workspacesPane: JBScrollPane): () -> Unit {
@@ -300,9 +294,9 @@ class GitpodWorkspacesView(
                                     )
                                 }
                                 label(getRelativeTimeSpan(info.latestInstance.creationTime))
-                                val jbClientConnected = GitpodConnectionProvider.jetbrainsClientMap[info.workspace.id]
-                                    ?.lifetime?.isAlive ?: false
-                                val btnText = if (jbClientConnected) "Connected" else "Connect"
+                                val client = GitpodConnectionProvider.getClient(info.workspace.id)
+                                val connected = client?.lifetime?.isAlive ?: false
+                                val btnText = if (connected) "Connected" else "Connect"
                                 button(btnText) {
                                     if (!canConnect) {
                                         BrowserUtil.browse(info.latestInstance.ideUrl)
@@ -314,7 +308,7 @@ class GitpodWorkspacesView(
                                             )
                                         )
                                     }
-                                }.enabled(!jbClientConnected)
+                                }.enabled(!connected)
                                 cell()
                             }.layout(RowLayout.PARENT_GRID)
                         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

A cleanup PR for #10177

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR --> 

Build & Install the plugin following
https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/README.md#L8

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft no-preview=true