### PR TITLE
[jb] don't mark deleted mvn modules as ignored in prebuilds

### DIFF
--- a/components/server/src/ide-service.ts
+++ b/components/server/src/ide-service.ts
@@ -42,6 +42,7 @@ tar -xf /tmp/backend/backend.tar.gz --strip-components=1 --directory /tmp/backen
 
 echo 'configuring JB system config and caches aligned with runtime...'
 printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend/bin/idea.properties"
+printf '\nmaven.modules.do.not.ignore.on.delete=true' >> "/tmp/backend/bin/idea.properties"
 unset JAVA_TOOL_OPTIONS
 export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains
 export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
@@ -64,6 +65,7 @@ tar -xf /tmp/backend-latest/backend-latest.tar.gz --strip-components=1 --directo
 
 echo 'configuring JB system config and caches aligned with runtime...'
 printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend-latest/bin/idea.properties"
+printf '\nmaven.modules.do.not.ignore.on.delete=true' >> "/tmp/backend-latest/bin/idea.properties"
 unset JAVA_TOOL_OPTIONS
 export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains-latest
 export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains-latest


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Some prebuilds with IntelliJ get stuck at the end of indexing of Maven project and it was proposed as a workaround.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
