### PR TITLE
[dev] Separate ssh IP and ws-proxy IP

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -452,6 +452,13 @@ async function addVMDNSRecord(werft: Werft, name: string, domain: string) {
             domain: `*.ws.${domain}`,
             projectId: "gitpod-core-dev",
             dnsZone: 'preview-gitpod-dev-com',
+            IP: ingressIP,
+            slice: installerSlices.DNS_ADD_RECORD
+        }),
+        createDNSRecord({
+            domain: `*.ssh.ws.${domain}`,
+            projectId: "gitpod-core-dev",
+            dnsZone: 'preview-gitpod-dev-com',
             IP: proxyLBIP,
             slice: installerSlices.DNS_ADD_RECORD
         }),

--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -69,6 +69,7 @@ class HarvesterPreviewEnvironment {
     async removeDNSRecords(sliceID: string) {
         werft.log(sliceID, "Deleting harvester related DNS records for the preview environment")
         await Promise.all([
+            deleteDNSRecord('A', `*.ssh.ws.${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
             deleteDNSRecord('A', `*.ws.${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
             deleteDNSRecord('A', `*.${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
             deleteDNSRecord('A', `${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/gitpod/pull/9786 we introduce a special domain for ssh gateway
This PR change harvester base preview environment use this special domain
This has some benefit
1. Save some money, before, accessing workspace pages also required the use of loadbalancer, which consumed some unnecessary traffic, after this PR, all non-SSH traffic will no longer go through loadbalancer
2. To improve some stability, `kubectl port-forward` is not very stable, for example, vm sometimes need to rebuild, then `kubectl` will time out, and the pod will restart, this restart time will have exponential growth, we do not want to bring this instability to the users who do not use SSH Gateway

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace, open browser IDE it should work
2. connect with ssh, it should be work too

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
