### PR TITLE
[ws-proxy] fix miss parameter when SSH connection is successful

### DIFF
--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -156,7 +156,7 @@ func New(signers []ssh.Signer, workspaceInfoProvider p.WorkspaceInfoProvider, he
 
 func ReportSSHAttemptMetrics(err error) {
 	if err == nil {
-		SSHAttemptTotal.WithLabelValues("success").Inc()
+		SSHAttemptTotal.WithLabelValues("success", "").Inc()
 		return
 	}
 	errorType := "OTHERS"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a bug from https://github.com/gitpod-io/gitpod/pull/10179
The metrics need 2 parameters, but if ssh connect is successful, we only pass 1 `ws-proxy` is crash

```
panic: inconsistent label cardinality: expected 2 label values but got 1 in []string{"success"}

goroutine 402 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues(0x1866a2c?, {0xc000673c40?, 0xc00042d320?, 0x0?})
        github.com/prometheus/client_golang@v1.12.1/prometheus/counter.go:252 +0x85
github.com/gitpod-io/gitpod/ws-proxy/pkg/sshproxy.ReportSSHAttemptMetrics({0x0?, 0x0?})
```

This PR fixes that

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open a workspace
2. test ssh it will work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
