### PR TITLE
Fix ObjectStorage resources block required even when empty

### DIFF
--- a/install/installer/pkg/components/minio/helm.go
+++ b/install/installer/pkg/components/minio/helm.go
@@ -26,7 +26,7 @@ var Helm = common.CompositeHelmFunc(
 			helm.KeyValue("minio.volumePermissions.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/bitnami-shell")),
 		}
 
-		if cfg.Config.ObjectStorage.Resources.Requests.Memory() != nil {
+		if cfg.Config.ObjectStorage.Resources != nil && cfg.Config.ObjectStorage.Resources.Requests.Memory() != nil {
 			memoryRequests := resource.MustParse(cfg.Config.ObjectStorage.Resources.Requests.Memory().String())
 			commonHelmValues = append(commonHelmValues, helm.KeyValue("minio.resources.requests.memory", memoryRequests.String()))
 		}

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -49,8 +49,10 @@ func (v version) Defaults(in interface{}) error {
 	cfg.Metadata.Region = "local"
 	cfg.Metadata.InstallationShortname = "default" // TODO(gpl): we're tied to "default" here because that's what we put into static bridges in the past
 	cfg.ObjectStorage.InCluster = pointer.Bool(true)
-	cfg.ObjectStorage.Resources.Requests = corev1.ResourceList{
-		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	cfg.ObjectStorage.Resources = &Resources{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
 	}
 	cfg.ContainerRegistry.InCluster = pointer.Bool(true)
 	cfg.Workspace.Resources.Requests = corev1.ResourceList{
@@ -155,7 +157,7 @@ type ObjectStorage struct {
 	Azure              *ObjectStorageAzure        `json:"azure,omitempty"`
 	MaximumBackupCount *int                       `json:"maximumBackupCount,omitempty"`
 	BlobQuota          *int64                     `json:"blobQuota,omitempty"`
-	Resources          Resources                  `json:"resources,omitempty"`
+	Resources          *Resources                 `json:"resources,omitempty"`
 }
 
 type ObjectStorageS3 struct {


### PR DESCRIPTION
## Description

This should fix the issue with generating the configuration for `kots`: https://werft.gitpod-dev.com/job/gitpod-build-main.3347 introduced in https://github.com/gitpod-io/gitpod/pull/10158

```
STDOUT: make: Entering directory '/workspace/install/kots'
Generating Base64 logo and saving to manifests/kots-app.yaml
make: Leaving directory '/workspace/install/kots'

STDERR: {
  "valid": false,
  "fatal": [
    "Field 'Config.ObjectStorage.Resources.Requests' is required"
  ]
}
configuration is invalid
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

