### PR TITLE
Revert "[image-builder-bob] Use separate auth for target and base"

### DIFF
--- a/components/image-builder-bob/cmd/proxy.go
+++ b/components/image-builder-bob/cmd/proxy.go
@@ -19,8 +19,8 @@ import (
 
 var proxyOpts struct {
 	BaseRef, TargetRef string
-	BaseAuth           string
-	TargetAuth         string
+	Auth               string
+	AdditionalAuth     string
 }
 
 // proxyCmd represents the build command
@@ -31,28 +31,15 @@ var proxyCmd = &cobra.Command{
 		log.Init("bob", "", true, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
 		log := log.WithField("command", "proxy")
 
-		// Base refers to the user's base image. We prefer user given auth
-		// for base ref
-		authBase, err := proxy.NewAuthorizerFromEnvVar(proxyOpts.BaseAuth)
+		authP, err := proxy.NewAuthorizerFromDockerEnvVar(proxyOpts.Auth)
 		if err != nil {
-			log.WithError(err).WithField("auth", proxyOpts.BaseAuth).Fatal("cannot unmarshal authBase")
+			log.WithError(err).WithField("auth", proxyOpts.Auth).Fatal("cannot unmarshal auth")
 		}
-		// Target refers to the target registry where we want to upload the built image.
-		// We prefer existing configuration for target auth
-		authTarget, err := proxy.NewAuthorizerFromDockerEnvVar(proxyOpts.TargetAuth)
+		authA, err := proxy.NewAuthorizerFromEnvVar(proxyOpts.AdditionalAuth)
 		if err != nil {
-			log.WithError(err).WithField("auth", proxyOpts.TargetAuth).Fatal("cannot unmarshal authTarget")
+			log.WithError(err).WithField("auth", proxyOpts.Auth).Fatal("cannot unmarshal auth")
 		}
-		// fallback: Add missing auth to authTarget from authBase
-		authTarget = authTarget.AddIfNotExists(authBase)
-
-		// Just reuse authBase as authTarget if authTarget has not been supplied
-		if authBase == nil {
-			authBase = authTarget
-		} else {
-			// fallback: Add missing auth to authBase from authTarget
-			authBase = authBase.AddIfNotExists(authTarget)
-		}
+		authP = authP.AddIfNotExists(authA)
 
 		baseref, err := reference.ParseNormalizedNamed(proxyOpts.BaseRef)
 		if err != nil {
@@ -71,22 +58,19 @@ var proxyCmd = &cobra.Command{
 			targettag = r.Tag()
 		}
 
-		authB := func() docker.Authorizer { return docker.NewDockerAuthorizer(docker.WithAuthCreds(authBase.Authorize)) }
-		authT := func() docker.Authorizer {
-			return docker.NewDockerAuthorizer(docker.WithAuthCreds(authTarget.Authorize))
-		}
+		auth := func() docker.Authorizer { return docker.NewDockerAuthorizer(docker.WithAuthCreds(authP.Authorize)) }
 		prx, err := proxy.NewProxy(&url.URL{Host: "localhost:8080", Scheme: "http"}, map[string]proxy.Repo{
 			"base": {
 				Host: reference.Domain(baseref),
 				Repo: reference.Path(baseref),
 				Tag:  basetag,
-				Auth: authB,
+				Auth: auth,
 			},
 			"target": {
 				Host: reference.Domain(targetref),
 				Repo: reference.Path(targetref),
 				Tag:  targettag,
-				Auth: authT,
+				Auth: auth,
 			},
 		})
 		if err != nil {
@@ -108,6 +92,6 @@ func init() {
 	// These env vars start with `WORKSPACEKIT_` so that they aren't passed on to ring2
 	proxyCmd.Flags().StringVar(&proxyOpts.BaseRef, "base-ref", os.Getenv("WORKSPACEKIT_BOBPROXY_BASEREF"), "ref of the base image")
 	proxyCmd.Flags().StringVar(&proxyOpts.TargetRef, "target-ref", os.Getenv("WORKSPACEKIT_BOBPROXY_TARGETREF"), "ref of the target image")
-	proxyCmd.Flags().StringVar(&proxyOpts.BaseAuth, "base-auth", os.Getenv("WORKSPACEKIT_BOBPROXY_AUTH"), "authentication to use for base ref")
-	proxyCmd.Flags().StringVar(&proxyOpts.TargetAuth, "target-auth", os.Getenv("WORKSPACEKIT_BOBPROXY_TARGETAUTH"), "authentication to use for target ref")
+	proxyCmd.Flags().StringVar(&proxyOpts.Auth, "auth", os.Getenv("WORKSPACEKIT_BOBPROXY_AUTH"), "authentication to use")
+	proxyCmd.Flags().StringVar(&proxyOpts.AdditionalAuth, "additional-auth", os.Getenv("WORKSPACEKIT_BOBPROXY_ADDITIONALAUTH"), "additional authentication to use")
 }

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -330,9 +330,9 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 		bobBaseref += ":latest"
 	}
 	wsref, err := reference.ParseNamed(wsrefstr)
-	var baseRefAuth []byte
+	var additionalAuth []byte
 	if err == nil {
-		baseRefAuth, err = json.Marshal(reqauth.GetImageBuildAuthFor([]string{
+		additionalAuth, err = json.Marshal(reqauth.GetImageBuildAuthFor([]string{
 			reference.Domain(wsref),
 		}))
 		if err != nil {
@@ -374,15 +374,15 @@ func (o *Orchestrator) Build(req *protocol.BuildRequest, resp protocol.ImageBuil
 					{Name: "WORKSPACEKIT_BOBPROXY_BASEREF", Value: baseref},
 					{Name: "WORKSPACEKIT_BOBPROXY_TARGETREF", Value: wsrefstr},
 					{
-						Name: "WORKSPACEKIT_BOBPROXY_TARGETAUTH",
+						Name: "WORKSPACEKIT_BOBPROXY_AUTH",
 						Secret: &wsmanapi.EnvironmentVariable_SecretKeyRef{
 							SecretName: o.Config.PullSecret,
 							Key:        ".dockerconfigjson",
 						},
 					},
 					{
-						Name:  "WORKSPACEKIT_BOBPROXY_AUTH",
-						Value: string(baseRefAuth),
+						Name:  "WORKSPACEKIT_BOBPROXY_ADDITIONALAUTH",
+						Value: string(additionalAuth),
 					},
 					{Name: "SUPERVISOR_DEBUG_ENABLE", Value: fmt.Sprintf("%v", log.Log.Logger.IsLevelEnabled(logrus.DebugLevel))},
 				},


### PR DESCRIPTION
Reverts gitpod-io/gitpod#10094


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
