### PR TITLE
[content-service] enable public read on gitpod repo root folder

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -70,7 +70,7 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 	}
 
 	gitClone := func() error {
-		if err := os.MkdirAll(ws.Location, 0770); err != nil {
+		if err := os.MkdirAll(ws.Location, 0775); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes permissions on gitpod repo to ensure it has public read enabled (breaks some workflows that relies on that).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/640

## How to test
<!-- Provide steps to test this PR -->
Start a new workspace in current production.
do `ls -la /workspace` and notice that permissions on gitpod repo are 0750.

Start a workspace from preview env of this PR
do `ls -la /workspace` and notice that permissions on gitpod repo are now set to correct 0755.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Ensure correct permissions are set on gitpod repo inside the workspace.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
