### PR TITLE
Add pipefail to workspace integration test

### DIFF
--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -51,7 +51,7 @@ pod:
     - bash
     - -c
     - |
-      set -euo
+      set -euo pipefail
 
       BRANCH="inte-test/"$(date +%Y%m%d%H%M%S)
       export WERFT_CREDENTIAL_HELPER=/workspace/dev/preview/werft-credential-helper.sh
@@ -123,8 +123,9 @@ pod:
           echo "running integration for ${TEST_NAME}" | werft log slice "test-${TEST_NAME}"
 
           cd "${TEST_PATH}"
+          set +e
           go test -v ./... "${args[@]}" 2>&1 | tee "${TEST_NAME}".log | werft log slice "test-${TEST_NAME}"
-
+          set -e
 
           if [ "${PIPESTATUS[0]}" -ne "0" ]; then
             FAILURE_COUNT=$((FAILURE_COUNT+1))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add pipefail to workspace integration test to catch the errors on preparing the preview environment.
Also, disable the error when running the integration test to avoid the test exit immediately once an error occurs when performing the test.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```shell
werft run github -j .werft/workspace-run-integration-tests.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A
