### PR TITLE
[image-builder-bob] Prioritize using additional auth

### DIFF
--- a/components/image-builder-bob/cmd/proxy.go
+++ b/components/image-builder-bob/cmd/proxy.go
@@ -39,7 +39,7 @@ var proxyCmd = &cobra.Command{
 		if err != nil {
 			log.WithError(err).WithField("auth", proxyOpts.Auth).Fatal("cannot unmarshal auth")
 		}
-		authP = authP.AddIfNotExists(authA)
+		authP = authP.OverrideWith(authA)
 
 		baseref, err := reference.ParseNormalizedNamed(proxyOpts.BaseRef)
 		if err != nil {

--- a/components/image-builder-bob/pkg/proxy/auth.go
+++ b/components/image-builder-bob/pkg/proxy/auth.go
@@ -54,7 +54,7 @@ func (a MapAuthorizer) Authorize(host string) (user, pass string, err error) {
 	return
 }
 
-func (a MapAuthorizer) AddIfNotExists(other MapAuthorizer) MapAuthorizer {
+func (a MapAuthorizer) OverrideWith(other MapAuthorizer) MapAuthorizer {
 	res := make(map[string]authConfig)
 	for k, v := range a {
 		res[k] = v


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<del>This implements the PR https://github.com/gitpod-io/gitpod/pull/10094 in a different way. Instead of changing the names of env vars, override existing vars with additional auth. I am not sure how this will impact gitpod installations. AFAIK additional auth is only used in the context of user supplied auth, so using it instead of existing configured auth should make sense.</del>

Prefer merging https://github.com/gitpod-io/gitpod/pull/9337 first as that will give us more control in testing and debugging issues related to this PR or any changes related to image-builder in general without impacting production env.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
The initial revert was done due to an incident see: [INC-150](https://app.incident.io/incidents/150)
https://github.com/gitpod-io/gitpod/issues/10089

## How to test
<!-- Provide steps to test this PR -->
Refer to original PR https://github.com/gitpod-io/gitpod/pull/10094

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix conflicting auth selection for image-builder-bob
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
