### PR TITLE
[server] Reduce XL cluster experiment to eligible Team Unleashed plans, not individual plans

### DIFF
--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -7,7 +7,13 @@
 import { inject, injectable } from "inversify";
 import { TeamSubscriptionDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { TokenProvider } from "../../../src/user/token-provider";
-import { User, WorkspaceTimeoutDuration, WorkspaceInstance, WORKSPACE_TIMEOUT_DEFAULT_LONG, WORKSPACE_TIMEOUT_DEFAULT_SHORT } from "@gitpod/gitpod-protocol";
+import {
+    User,
+    WorkspaceTimeoutDuration,
+    WorkspaceInstance,
+    WORKSPACE_TIMEOUT_DEFAULT_LONG,
+    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
+} from "@gitpod/gitpod-protocol";
 import { RemainingHours } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Plans, MAX_PARALLEL_WORKSPACES } from "@gitpod/gitpod-protocol/lib/plans";
@@ -286,14 +292,9 @@ export class EligibilityService {
             user,
             new Date().toISOString(),
         );
-        const eligblePlans = [
-            Plans.PROFESSIONAL_EUR,
-            Plans.PROFESSIONAL_USD,
-            Plans.TEAM_PROFESSIONAL_EUR,
-            Plans.TEAM_PROFESSIONAL_USD,
-        ].map((p) => p.chargebeeId);
+        const eligiblePlans = [Plans.TEAM_PROFESSIONAL_EUR, Plans.TEAM_PROFESSIONAL_USD].map((p) => p.chargebeeId);
 
-        const relevantSubscriptions = subscriptions.filter((s) => eligblePlans.includes(s.planId!));
+        const relevantSubscriptions = subscriptions.filter((s) => eligiblePlans.includes(s.planId!));
         if (relevantSubscriptions.length === 0) {
             // user has no subscription that grants "more resources"
             return false;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reduce XL cluster experiment to eligible Team Unleashed plans, not individual plans.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2346#issuecomment-1134497452

## How to test
<!-- Provide steps to test this PR -->

1. I'm not sure how to test this (there is no XL experiment in preview environments right? 🤷)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment=true