### PR TITLE
Support more containerd runtime dir

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -45,6 +45,10 @@ spec:
               value: /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io
             - name: CONTAINERD_SOCKET_K3S
               value: /run/k3s/containerd/containerd.sock
+            - name: CONTAINERD_DIR_AL
+              value: /run/containerd/io.containerd.runtime.v2.task/k8s.io
+            - name: CONTAINERD_SOCKET_AL
+              value: /run/containerd/containerd.sock
             - name: GITPOD_OBJECTS
               value: /tmp/gitpod
           command:
@@ -92,12 +96,20 @@ spec:
                 echo "Gitpod: containerd dir detected as k3s"
 
                 yq e -i ".workspace.runtime.containerdRuntimeDir = \"${CONTAINERD_DIR_K3S}\"" "${CONFIG_FILE}"
+              elif [ -d "/mnt/node0${CONTAINERD_DIR_AL}" ]; then
+                echo "Gitpod: containerd dir detected as ${CONTAINERD_DIR_AL}"
+
+                yq e -i ".workspace.runtime.containerdRuntimeDir = \"${CONTAINERD_DIR_AL}\"" "${CONFIG_FILE}"
               fi
 
               if [ -S "/mnt/node0${CONTAINERD_SOCKET_K3S}" ]; then
                 echo "Gitpod: containerd socket detected as k3s"
 
                 yq e -i ".workspace.runtime.containerdSocket = \"${CONTAINERD_SOCKET_K3S}\"" "${CONFIG_FILE}"
+              elif [ -S "/mnt/node0${CONTAINERD_SOCKET_AL}" ]; then
+                echo "Gitpod: containerd socket detected as ${CONTAINERD_SOCKET_AL}"
+
+                yq e -i ".workspace.runtime.containerdSocket = \"${CONTAINERD_SOCKET_AL}\"" "${CONFIG_FILE}"
               fi
 
               echo "Gitpod: Inject the Replicated variables into the config"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds support to auto-detect another containerd runtime which is commonly found in Amazon Linux.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10103 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
