### PR TITLE
Add CertManager's cmctl to dev env

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -71,7 +71,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/ide-integration-tests-startup-jetbrains.yaml
+++ b/.werft/ide-integration-tests-startup-jetbrains.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-integration-tests-startup-vscode.yaml
+++ b/.werft/ide-integration-tests-startup-vscode.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-run-integration-tests.yaml
+++ b/.werft/ide-run-integration-tests.yaml
@@ -25,7 +25,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -24,7 +24,7 @@ pod:
       secretName: harvester-k3s-dockerhub-pull-account
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-rebuild-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -50,6 +50,9 @@ RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key
 ### MySQL client ###
 RUN install-packages mysql-client
 
+### CertManager's cmctl
+RUN cd /usr/bin && curl -L cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-linux-amd64.tar.gz | tar xzv cmctl
+
 # gokart
 RUN cd /usr/bin && curl -L https://github.com/praetorian-inc/gokart/releases/download/v0.4.0/gokart_0.4.0_linux_x86_64.tar.gz | tar xzv gokart
 


### PR DESCRIPTION
## Description
Add CertManager's `cmctl` to the dev env. This helps to debug cert renewal and to manually renew certs.

see https://cert-manager.io/docs/usage/cmctl/

more context: https://gitpod.slack.com/archives/C01KGM9EBD4/p1652698881554549?thread_ts=1652432265.637629&cid=C01KGM9EBD4

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. Open this PR with gitpod.io
2. Run `cmctl`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
