### PR TITLE
Fix ws-manager test case error

### DIFF
--- a/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
@@ -21,7 +21,9 @@
             "class": "default"
         },
         "phase": 6,
-        "conditions": {},
+        "conditions": {
+            "volume_snapshot": {}
+        },
         "runtime": {
             "node_name": "to-failed-ws-start",
             "pod_name": "ws-7b26a643-d588-4346-bc9e-b46e70831078",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
.golden file is generated by exec `go test -timeout 30s -run ^TestGetWorkspaceStatusWithFixtures$ github.com/gitpod-io/gitpod/ws-manager/pkg/manager --force --update`

This PR fix test cases error which affect our werft build https://werft.gitpod-dev.com/job/gitpod-build-me-cmctl.1 (https://github.com/gitpod-io/gitpod/pull/10240)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft no-preview=true