### PR TITLE
[usage] Setup controller and reconciler

### DIFF
--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/relvacode/iso8601 v1.1.0
+	github.com/robfig/cron v1.2.0
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.0
 	gorm.io/datatypes v1.0.6

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -299,6 +299,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/relvacode/iso8601 v1.1.0 h1:2nV8sp0eOjpoKQ2vD3xSDygsjAx37NHG2UlZiCkDH4I=
 github.com/relvacode/iso8601 v1.1.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/components/usage/pkg/controller/controller.go
+++ b/components/usage/pkg/controller/controller.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package controller
+
+import (
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/robfig/cron"
+	"sync"
+	"time"
+)
+
+func New(schedule time.Duration, reconciler Reconciler) (*Controller, error) {
+	return &Controller{
+		schedule:   schedule,
+		reconciler: reconciler,
+		scheduler:  cron.NewWithLocation(time.UTC),
+	}, nil
+}
+
+type Controller struct {
+	schedule   time.Duration
+	reconciler Reconciler
+
+	scheduler *cron.Cron
+
+	runningJobs sync.WaitGroup
+}
+
+func (c *Controller) Start() error {
+	log.Info("Starting usage controller.")
+
+	err := c.scheduler.AddFunc(fmt.Sprintf("@every %s", c.schedule.String()), cron.FuncJob(func() {
+		log.Info("Starting usage reconciliation.")
+
+		c.runningJobs.Add(1)
+		defer c.runningJobs.Done()
+
+		err := c.reconciler.Reconcile()
+		if err != nil {
+			log.WithError(err).Errorf("Reconciliation run failed.")
+		} else {
+			log.Info("Completed usage reconciliation run without errors.")
+		}
+	}))
+	if err != nil {
+		return fmt.Errorf("failed to add function to scheduler: %w", err)
+	}
+
+	c.scheduler.Start()
+
+	return nil
+}
+
+// Stop terminates the Controller and awaits for all running jobs to complete.
+func (c *Controller) Stop() {
+	log.Info("Stopping usage controller.")
+	// Stop any new jobs from running
+	c.scheduler.Stop()
+
+	log.Info("Awaiting existing reconciliation runs to complete..")
+	// Wait for existing jobs to finish
+	c.runningJobs.Wait()
+}

--- a/components/usage/pkg/controller/controller_test.go
+++ b/components/usage/pkg/controller/controller_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package controller
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestController(t *testing.T) {
+	schedule := time.Second
+	triggered := false
+
+	ctrl, err := New(schedule, ReconcilerFunc(func() error {
+		triggered = true
+		return nil
+	}))
+	require.NoError(t, err)
+
+	require.NoError(t, ctrl.Start())
+	time.Sleep(schedule + 20*time.Millisecond)
+	require.True(t, triggered, "must trigger reconciler function")
+	ctrl.Stop()
+}
+
+func TestController_GracefullyHandlesPanic(t *testing.T) {
+	ctrl, err := New(20*time.Millisecond, ReconcilerFunc(func() error {
+		panic("pls help")
+	}))
+	require.NoError(t, err)
+
+	require.NoError(t, ctrl.Start())
+	ctrl.Stop()
+}

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package controller
+
+import "github.com/gitpod-io/gitpod/common-go/log"
+
+type Reconciler interface {
+	Reconcile() error
+}
+
+type ReconcilerFunc func() error
+
+func (f ReconcilerFunc) Reconcile() error {
+	return f()
+}
+
+func HelloWorldReconciler() error {
+	log.Info("Hello world reconciler!")
+	return nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The usage component needs to run a periodic job to read raw records (workspace, projects) and synchronise them. This PR adds initial setup for this job.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/10228

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE