### PR TITLE
[dev-image] Add MySQL Server to workspace image

### DIFF
--- a/dev/image/BUILD.yaml
+++ b/dev/image/BUILD.yaml
@@ -9,6 +9,7 @@ packages:
     srcs:
       - gcloud-default-config
       - kubeconfig.yaml
+      - mysql/*
     config:
       dockerfile: Dockerfile
       image:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full-vnc:latest
 
-ENV TRIGGER_REBUILD 18
+ENV TRIGGER_REBUILD 19
 
 USER root
 

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -50,6 +50,20 @@ RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key
 ### MySQL client ###
 RUN install-packages mysql-client
 
+### MySQL Server ###
+RUN install-packages mysql-server \
+ && mkdir -p /var/run/mysqld /var/log/mysql \
+ && chown -R gitpod:gitpod /etc/mysql /var/run/mysqld /var/log/mysql /var/lib/mysql /var/lib/mysql-files /var/lib/mysql-keyring /var/lib/mysql-upgrade
+
+# Install our own MySQL config
+COPY mysql/mysql.cnf /etc/mysql/mysql.conf.d/mysqld.cnf
+
+# Install default-login for MySQL clients
+COPY mysql/client.cnf /etc/mysql/mysql.conf.d/client.cnf
+
+COPY mysql/mysql-bashrc-launch.sh /etc/mysql/mysql-bashrc-launch.sh
+
+
 ### CertManager's cmctl
 RUN cd /usr/bin && curl -L cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cmctl-linux-amd64.tar.gz | tar xzv cmctl
 
@@ -241,3 +255,6 @@ ENV WERFT_CREDENTIAL_HELPER=/workspace/gitpod/dev/preview/werft-credential-helpe
 # Copy our own tools
 ENV NEW_KUBECDL=1
 COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl /usr/bin/
+
+# MySQL Server launch
+RUN echo "/etc/mysql/mysql-bashrc-launch.sh" >> /home/gitpod/.bashrc.d/100-mysql-launch

--- a/dev/image/mysql/client.cnf
+++ b/dev/image/mysql/client.cnf
@@ -1,0 +1,10 @@
+[client]
+host     = localhost
+user     = root
+password =
+socket   = /var/run/mysqld/mysqld.sock
+[mysql_upgrade]
+host     = localhost
+user     = root
+password =
+socket   = /var/run/mysqld/mysqld.sock

--- a/dev/image/mysql/mysql-bashrc-launch.sh
+++ b/dev/image/mysql/mysql-bashrc-launch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# this script is intended to be called from .bashrc
+# This is a workaround for not having something like supervisord
+
+if [ ! -e /var/run/mysqld/gitpod-init.lock ]; then
+	touch /var/run/mysqld/gitpod-init.lock
+
+	# initialize database structures on disk, if needed
+	[ ! -d /workspace/mysql ] && mysqld --initialize-insecure
+
+	# launch database, if not running
+	[ ! -e /var/run/mysqld/mysqld.pid ] && mysqld --daemonize
+
+	rm /var/run/mysqld/gitpod-init.lock
+fi

--- a/dev/image/mysql/mysql-bashrc-launch.sh
+++ b/dev/image/mysql/mysql-bashrc-launch.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
 
 # this script is intended to be called from .bashrc
 # This is a workaround for not having something like supervisord

--- a/dev/image/mysql/mysql.cnf
+++ b/dev/image/mysql/mysql.cnf
@@ -1,0 +1,26 @@
+[mysqld_safe]
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+
+[mysqld]
+user		= gitpod
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /workspace/mysql
+tmpdir		= /tmp
+lc-messages-dir	= /usr/share/mysql
+skip-external-locking
+bind-address		= 127.0.0.1
+
+key_buffer_size		= 16M
+max_allowed_packet	= 16M
+thread_stack		= 192K
+thread_cache_size   = 8
+
+myisam-recover-options  = BACKUP
+
+general_log_file        = /var/log/mysql/mysql.log
+general_log             = 1
+log_error               = /var/log/mysql/error.log


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds MySQL server to our workspace image. This allows us to run unit-tests against a local instance of MySQL instead of always depending on a preview environment (once tests are updated to use it).

The setup mirrors the container image in our [gitpodify guide](https://www.gitpod.io/blog/gitpodify#mysql). 
There may be a cleaner way, and I'm all ears :)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE