### PR TITLE
[licensor] update fn parameter in license validator

### DIFF
--- a/components/licensor/ee/cmd/validate.go
+++ b/components/licensor/ee/cmd/validate.go
@@ -28,8 +28,7 @@ var validateCmd = &cobra.Command{
 		var e *licensor.Evaluator
 		switch licensorType {
 		case string(licensor.LicenseTypeReplicated):
-			e = licensor.NewReplicatedEvaluator(domain)
-			break
+			e = licensor.NewReplicatedEvaluator()
 		default:
 			var lic []byte
 			if len(args) == 0 {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In #10069 we updated the replicated evaluator to not do `domain` name validation. Unfortunately I missed to cleanup the function call in the `validator` code. This fixed the issue. Alongside, this removes a `break` statement which is reduntant since [it is implicit in Go](https://go.dev/tour/flowcontrol/9).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
The biggest effect this issue had was throwing a Problem in the editor when you open a workspace, this will remove the error.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
