### PR TITLE
[kots] ensure secret creation for inCluster registry backend

### DIFF
--- a/install/kots/manifests/gitpod-registry-s3-backend.yaml
+++ b/install/kots/manifests/gitpod-registry-s3-backend.yaml
@@ -9,7 +9,7 @@ metadata:
     app: gitpod
     component: gitpod-installer
   annotations:
-    kots.io/when: '{{repl and (ConfigOptionEquals "reg_incluster" "0") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+    kots.io/when: '{{repl ConfigOptionEquals "reg_incluster_storage" "s3" }}'
 data:
   s3AccessKey: '{{repl ConfigOption "reg_incluster_storage_s3_accesskey" | Base64Encode }}'
   s3SecretKey: '{{repl ConfigOption "reg_incluster_storage_s3_secretkey" | Base64Encode }}'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This fixes the currently existing bug, which prevents creation of secret for `s3` when once chooses `s3` for `inCluster` registry storage backend.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Currently if you try to use `s3` as the storage backend for `inCluster` registry, you will get an error when creating workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
