### PR TITLE
Fixing (missing) traces

### DIFF
--- a/components/common-go/tracing/tracing.go
+++ b/components/common-go/tracing/tracing.go
@@ -110,7 +110,8 @@ func ApplyOWI(span opentracing.Span, owi logrus.Fields) {
 	}
 }
 
-// GetTraceID extracts the ueber-trace-id from the context
+// GetTraceID extracts the uber-trace-id from the context which encodes
+// {trace-id}:{span-id}:{parent-span-id}:{flags}
 func GetTraceID(span opentracing.Span) string {
 	var buf bytes.Buffer
 	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.Binary, &buf)

--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -60,8 +60,9 @@ func (e *EmptyInitializer) Run(ctx context.Context, mappings []archive.IDMapping
 type CompositeInitializer []Initializer
 
 // Run calls run on all child initializers
-func (e CompositeInitializer) Run(ctx context.Context, mappings []archive.IDMapping) (csapi.WorkspaceInitSource, error) {
-	_, ctx = opentracing.StartSpanFromContext(ctx, "CompositeInitializer.Run")
+func (e CompositeInitializer) Run(ctx context.Context, mappings []archive.IDMapping) (_ csapi.WorkspaceInitSource, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CompositeInitializer.Run")
+	defer tracing.FinishSpan(span, &err)
 	for _, init := range e {
 		_, err := init.Run(ctx, mappings)
 		if err != nil {

--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -112,6 +112,7 @@ func runGitInit(ctx context.Context, gInit *GitInitializer) (err error) {
 		tracelog.String("IsWorkingCopy", fmt.Sprintf("%v", git.IsWorkingCopy(gInit.Location))),
 		tracelog.String("location", fmt.Sprintf("%v", gInit.Location)),
 	)
+	defer tracing.FinishSpan(span, &err)
 	if git.IsWorkingCopy(gInit.Location) {
 		out, err := gInit.GitWithOutput(ctx, "stash", "push", "-u")
 		if err != nil {

--- a/components/server/ee/src/monitoring-endpoint-ee.ts
+++ b/components/server/ee/src/monitoring-endpoint-ee.ts
@@ -64,6 +64,7 @@ async function checkWorkspaceHealth(
         timestamp: Date.now(),
     };
     if (extra && numUnhealthy > 0) {
+        span.finish();
         return {
             ...returnValue,
             extra: {

--- a/components/server/ee/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-app.ts
@@ -45,9 +45,17 @@ export class BitbucketServerApp {
                         // we should send a UNAUTHORIZED signal.
                         res.statusCode = 401;
                         res.send();
+                        span.finish();
                         return;
                     }
-                    await this.handlePushHook({ span }, user, payload);
+                    try {
+                        await this.handlePushHook({ span }, user, payload);
+                    } catch (err) {
+                        TraceContext.setError({ span }, err);
+                        throw err;
+                    } finally {
+                        span.finish();
+                    }
                 } else {
                     console.warn(`Ignoring unsupported BBS event.`, { headers: req.headers });
                 }

--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -45,14 +45,24 @@ export class GitHubEnterpriseApp {
                 try {
                     user = await this.findUser({ span }, payload, req);
                 } catch (error) {
+                    TraceContext.setError({ span }, error);
                     log.error("Cannot find user.", error, {});
                 }
                 if (!user) {
                     res.statusCode = 401;
                     res.send();
+                    span.finish();
                     return;
                 }
-                await this.handlePushHook({ span }, payload, user);
+
+                try {
+                    await this.handlePushHook({ span }, payload, user);
+                } catch (err) {
+                    TraceContext.setError({ span }, err);
+                    throw err;
+                } finally {
+                    span.finish();
+                }
             } else {
                 log.info("Unknown GitHub Enterprise event received", { event });
             }

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -331,6 +331,7 @@ export class ConfigProvider {
         span.setTag("repo", `${repository.owner}/${repository.name}`);
 
         if (this.config.definitelyGpDisabled) {
+            span.finish();
             return {
                 content: undefined,
                 basePath: `${repository.name}`,

--- a/components/ws-manager-api/typescript/src/promisified-client.ts
+++ b/components/ws-manager-api/typescript/src/promisified-client.ts
@@ -78,6 +78,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
                     if (attempt < 3 && err.message.indexOf('already exists') !== -1) {
                         // lets wait a bit more
                     } else {
+                        TraceContext.setError(ctx, err);
                         reject(err);
                     }
                 } else {
@@ -94,6 +95,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.stopWorkspace(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -109,6 +111,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.markActive(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -124,6 +127,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.setTimeout(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -139,6 +143,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.controlPort(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -154,6 +159,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.describeWorkspace(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -169,6 +175,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.getWorkspaces(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -185,6 +192,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.takeSnapshot(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -201,6 +209,7 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             this.client.controlAdmission(request, withTracing({span}), this.getDefaultUnaryOptions(), (err, resp) => {
                 span.finish();
                 if (err) {
+                    TraceContext.setError(ctx, err);
                     reject(err);
                 } else {
                     resolve(resp);
@@ -215,7 +224,10 @@ export class PromisifiedWorkspaceManagerClient implements Disposable {
             try {
                 resolve(this.client.subscribe(request, withTracing({span})));
             } catch(err) {
+                TraceContext.setError(ctx, err);
                 reject(err);
+            } finally {
+                span.finish()
             }
         });
     }

--- a/components/ws-manager-bridge/src/wsman-subscriber.ts
+++ b/components/ws-manager-bridge/src/wsman-subscriber.ts
@@ -65,7 +65,14 @@ export class WsmanSubscriber implements Disposable {
                             try {
                                 callbacks.onStatusUpdate({ span }, status);
                             } catch (err) {
+                                if (span) {
+                                    TraceContext.setError({ span }, err);
+                                }
                                 log.error("Error handling onStatusUpdate", err, payload);
+                            } finally {
+                                if (span) {
+                                    span.finish();
+                                }
                             }
                         }
                     });

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -881,6 +881,7 @@ func (m *Manager) newStartWorkspaceContext(ctx context.Context, req *api.StartWo
 
 	workspaceSpan := opentracing.StartSpan("workspace", opentracing.FollowsFrom(opentracing.SpanFromContext(ctx).Context()))
 	traceID := tracing.GetTraceID(workspaceSpan)
+	defer tracing.FinishSpan(workspaceSpan, &err)
 
 	clsName := req.Spec.Class
 	if _, ok := m.Config.WorkspaceClasses[req.Spec.Class]; clsName == "" || !ok {


### PR DESCRIPTION
## Description

### TL;DR 
This PR resolves the mystery of the (missing) parent spans that we have seen in Honeycomb. If you don't close a span, the span will never be sent to the tracing backend (Honeycomb) and thus, for all children of the span, Honeycomb will see that the spans contains a parent ID that points to a span it never received and will render the parent as (missing). So to fix the issue, we "simply" have to ensure that we **always** close spans.

This PR fixes a lot of such cases but not all.

### Context
This has been a long-standing issue. Since migrating to Honeycomb from Jaeger we've noticed the problem more as Honeycomb displays these kinds of error more prominently, but this issue has existed since the start of time[^1], it's just that Jaeger didn't call it out as much - see comment with a screenshot comparing Jaeger and Honeycomb [here](https://github.com/gitpod-io/ops/issues/385#issuecomment-984633422).

### Details

This PR contains a lot of fixes for places where we forgot to close spans in some circumstances. I wasn't able to track down all the places but I'm opening up this PR now as this already produces considerable improvements to the "createWorkspace" trace.

See a [trace before](https://ui.honeycomb.io/gitpod/datasets/preview-environments/result/qE8ttJtvjBH/trace/BgMYToxuVJy?span=daa8a5408ac1549f) and [trace after](https://ui.honeycomb.io/gitpod/datasets/preview-environments/result/naqtGFVAwev/trace/uJ1jkUyqhWd?span=fca7b94d1f2681fe) -- you'll notice that the trace looks much cleaner now. That's because before Honeycomb didn't know where in the trace to inject the spans since the parent was missing, so they were all just being rendered as children of the root span. Now that we have the parent they can be placed correctly so we get trace that's much more meaningful and easier to navigate. One nice example of this is the "sub-tree" of `/ws-manager/startWorkspace` as shown below:

Before

![Screenshot 2022-05-27 at 12 10 47](https://user-images.githubusercontent.com/83561/170679953-0c4b89bf-780c-4b61-bb9e-9501e7257ba0.png)

After

![Screenshot 2022-05-27 at 12 10 40](https://user-images.githubusercontent.com/83561/170679961-f6bf925b-6563-4c5b-be43-e23c1c5c66e5.png)


### What (missing) spans are left

I wasn't able to track down a few missing spans still, mostly around the content-initializer, messagebus part of server, and one or two MySQL queries (see screenshots below). We can tackle these in a follow up PR.

![Screenshot 2022-05-27 at 12 16 52](https://user-images.githubusercontent.com/83561/170681017-371ec9ef-ea7d-4d64-86a8-e72b7b2b281b.png)
![Screenshot 2022-05-27 at 12 16 56](https://user-images.githubusercontent.com/83561/170681022-f8134272-0d3f-41d7-b008-8c30f107cce7.png)
![Screenshot 2022-05-27 at 12 17 04](https://user-images.githubusercontent.com/83561/170681025-f4d7153c-090c-41e5-b3c1-dab34455b7b4.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2318

## How to test
<!-- Provide steps to test this PR -->

I have been testing this in a regular preview environment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

[^1]: The start of time in our case is of course https://github.com/gitpod-io/gitpod/commit/24f7b609bf79b247d72d1841282639726bcd5891