### PR TITLE
[image-builder-bob] Introduce URL processing for non docker api urls

### DIFF
--- a/components/image-builder-bob/pkg/proxy/proxy_test.go
+++ b/components/image-builder-bob/pkg/proxy/proxy_test.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestRewriteNonDockerAPIURL(t *testing.T) {
+	type input struct {
+		u          url.URL
+		fromPrefix string
+		toPrefix   string
+		host       string
+	}
+	tests := []struct {
+		Name string
+		in   input
+		u    url.URL
+	}{
+		{
+			Name: "toPrefix is empty",
+			in: input{
+				fromPrefix: "base",
+				toPrefix:   "",
+				host:       "europe-docker.pkg.dev",
+				u: url.URL{
+					Host: "localhost.com",
+					Path: "/base/artifacts-uploads/namespaces/prince-tf-experiments/repositories/dazzle/uploads/somedata",
+				},
+			},
+			u: url.URL{
+				Host: "europe-docker.pkg.dev",
+				Path: "/artifacts-uploads/namespaces/prince-tf-experiments/repositories/dazzle/uploads/somedata",
+			},
+		},
+		{
+			Name: "fromPrefix is empty",
+			in: input{
+				fromPrefix: "",
+				toPrefix:   "base",
+				host:       "localhost.com",
+				u: url.URL{
+					Host: "europe-docker.pkg.dev",
+					Path: "/artifacts-uploads/namespaces/prince-tf-experiments/repositories/dazzle/uploads/somedata",
+				},
+			},
+			u: url.URL{
+				Host: "localhost.com",
+				Path: "/base/artifacts-uploads/namespaces/prince-tf-experiments/repositories/dazzle/uploads/somedata",
+			},
+		},
+		{
+			Name: "fromPrefix and toPrefix are not empty",
+			in: input{
+				fromPrefix: "from",
+				toPrefix:   "to",
+				host:       "localhost.com",
+				u: url.URL{
+					Host: "example.com",
+					Path: "/from/some/random/path",
+				},
+			},
+			u: url.URL{
+				Host: "localhost.com",
+				Path: "/to/some/random/path",
+			},
+		},
+		{
+			Name: "fromPrefix and toPrefix are empty",
+			in: input{
+				fromPrefix: "",
+				toPrefix:   "",
+				host:       "localhost.com",
+				u: url.URL{
+					Host: "example.com",
+					Path: "/some/random/path",
+				},
+			},
+			u: url.URL{
+				Host: "localhost.com",
+				Path: "/some/random/path",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			rewriteNonDockerAPIURL(&test.in.u, test.in.fromPrefix, test.in.toPrefix, test.in.host)
+			if test.in.u.Path != test.u.Path {
+				t.Errorf("expected path: %s but got %s", test.u.Path, test.in.u.Path)
+			}
+			if test.in.u.Host != test.u.Host {
+				t.Errorf("expected Host: %s but got %s", test.u.Host, test.in.u.Host)
+			}
+			if test.in.u.RawPath != test.u.RawPath {
+				t.Errorf("expected RawPath: %s but got %s", test.u.RawPath, test.in.u.RawPath)
+			}
+		})
+	}
+
+}
+
+func TestRewriteDockerAPIURL(t *testing.T) {
+	type input struct {
+		u        url.URL
+		fromRepo string
+		toRepo   string
+		host     string
+		tag      string
+	}
+	tests := []struct {
+		Name string
+		in   input
+		u    url.URL
+	}{
+		{
+			Name: "remote to localhost",
+			in: input{
+				fromRepo: "base-images",
+				toRepo:   "base",
+				host:     "localhost.com",
+				tag:      "",
+				u: url.URL{
+					Host: "prince.azurecr.io",
+					Path: "/v2/base-images/some/random/path",
+				},
+			},
+			u: url.URL{
+				Host: "localhost.com",
+				Path: "/v2/base/some/random/path",
+			},
+		},
+		{
+			Name: "localhost to remote",
+			in: input{
+				fromRepo: "base",
+				toRepo:   "base-images",
+				host:     "prince.azurecr.io",
+				tag:      "",
+				u: url.URL{
+					Host: "localhost.com",
+					Path: "/v2/base/some/random/path",
+				},
+			},
+			u: url.URL{
+				Host: "prince.azurecr.io",
+				Path: "/v2/base-images/some/random/path",
+			},
+		},
+		{
+			Name: "manifest reference update with tag",
+			in: input{
+				fromRepo: "base",
+				toRepo:   "base-images",
+				host:     "prince.azurecr.io",
+				tag:      "tag12345",
+				u: url.URL{
+					Host: "localhost.com",
+					Path: "/v2/base/uploads/manifests/manifest12345",
+				},
+			},
+			u: url.URL{
+				Host: "prince.azurecr.io",
+				Path: "/v2/base-images/uploads/manifests/tag12345",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			rewriteDockerAPIURL(&test.in.u, test.in.fromRepo, test.in.toRepo, test.in.host, test.in.tag)
+			if test.in.u.Path != test.u.Path {
+				t.Errorf("expected path: %s but got %s", test.u.Path, test.in.u.Path)
+			}
+			if test.in.u.Host != test.u.Host {
+				t.Errorf("expected Host: %s but got %s", test.u.Host, test.in.u.Host)
+			}
+			if test.in.u.RawPath != test.u.RawPath {
+				t.Errorf("expected RawPath: %s but got %s", test.u.RawPath, test.in.u.RawPath)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Introduce a new function `rewriteNonDockerAPIURL` which can be used to rewrite URLs in bob proxy when the URL endpoint is NOT a docker api endpoint. See all docker registry endpoints [here](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints), it must start with `/v2/`.

As a side effect of this change gitpod will support Google Artifact Registry as a container registry.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10241

## How to test
<!-- Provide steps to test this PR -->

### Pre requisite
You need a self hosted version of gitpod to test out GAR and Azure. You will need to setup [container registry](https://github.com/gitpod-io/gitpod/tree/main/install/installer#container-registry) during installation.

### GAR
For GAR you will need to create a GAR in a google project e.g. playground and then create a service account which has write permission to that registry. After that create a key for the service account and use it to login locally in your workspace.

Example below. You can read more [here](https://cloud.google.com/artifact-registry/docs/docker/authentication#json-key)
```
cat my-svc-acc-key.json | docker login -u _json_key --password-stdin https://europe-docker.pkg.dev
```

1. You can also use workspace-preview cluster to test this.
2. Create a cluster and then copy the `gitpod-config.yml` from instance to your local workspace. You need to update the container registry config in this file before rendering using `reapply.sh`. See example gitpod-config.yaml [change here](https://gist.github.com/princerachit/c065365ad48f3964020f60a9800b1a61).
3. Configure your `kubeconfig` to point to this cluster. Better remove any other entry from your kubeconfig.
4. Create a Script called [`reapply.sh`](https://gist.github.com/princerachit/d738f0472d4ad9fbd603fc86992005d9)
5. Create a file [`proxy-patch.json`](https://gist.github.com/princerachit/434b377e74254d057ee15b70af48dd35)
6. Create a file [`trim.py`](https://gist.github.com/princerachit/52189a0112a346b306ac917d1095ea58). This will help in faster iteration of gitpod installation update'
7. Render kubectl manifests: `./reapply.sh render`. Make Sure to update the reapply.sh file secret creation step first.
8. Deploy/Update gitpod using: `./reapply.sh deploy`. Wait for a minute or two for the pods to come up.
9. Start a workspace in your preview env.


I have tested with following registries:
1.  ✅ Azure - Workspace-preview cluster - See [Loom Video](https://www.loom.com/share/fc4faf6f831c4c1797b4e49c71b00002)
2. ✅ GAR - Workspace-preview cluster - See [Loom Video](https://www.loom.com/share/54c6eb70717a43cf92828fc7a4857d29)
3. ✅ GCR - Preview env. Through the werft build of this PR - See [Loom Video](https://www.loom.com/share/2c97667771044b1a8f703d35a30e1a17)

### Logs
Sample log from Image Build pod:

```
{"level":"info","message":"serving request","req":"/v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545","serviceContext":{"service":"bob","version":""},"severity":"INFO","time":"2022-05-26T13:03:20Z"}
2022/05/26 13:03:20 [DEBUG] HEAD https://europe-docker.pkg.dev/v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545
{"host":"europe-docker.pkg.dev","level":"info","message":"authorizing registry access","serviceContext":{"service":"bob","version":""},"severity":"INFO","time":"2022-05-26T13:03:20Z","user":"_json_key"}
2022/05/26 13:03:20 [DEBUG] HEAD https://europe-docker.pkg.dev/v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545 (status: 401): retrying in 1s (3 left)
#5 pushing layers 14.4s done
#5 pushing manifest for localhost:8080/target:latest@sha256:3c93c7fc99a4471887ca128f0e18481e30b65ee6c63ae200697c11d3a1ffab84
{"grpc.code":"OK","grpc.method":"ContentStatus","grpc.service":"supervisor.StatusService","grpc.start_time":"2022-05-26T13:03:21Z","grpc.time_ms":0.037,"level":"info","message":"finished unary call with code OK","serviceContext":{"service":"supervisor","version":"commit-ab3f40db9e68ca471596056126f2d856ae59afe3"},"severity":"INFO","span.kind":"server","system":"grpc","time":"2022-05-26T13:03:21Z"}
{"level":"info","message":"serving request","req":"/v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545","serviceContext":{"service":"bob","version":""},"severity":"INFO","time":"2022-05-26T13:03:21Z"}
2022/05/26 13:03:21 [DEBUG] PUT https://europe-docker.pkg.dev/v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545
{"host":"europe-docker.pkg.dev","level":"info","message":"authorizing registry access","serviceContext":{"service":"bob","version":""},"severity":"INFO","time":"2022-05-26T13:03:22Z","user":"_json_key"}
2022/05/26 13:03:22 [DEBUG] PUT https://europe-docker.pkg.dev/v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545 (status: 401): retrying in 1s (3 left)
{"grpc.code":"OK","grpc.method":"ContentStatus","grpc.service":"supervisor.StatusService","grpc.start_time":"2022-05-26T13:03:22Z","grpc.time_ms":0.035,"level":"info","message":"finished unary call with code OK","serviceContext":{"service":"supervisor","version":"commit-ab3f40db9e68ca471596056126f2d856ae59afe3"},"severity":"INFO","span.kind":"server","system":"grpc","time":"2022-05-26T13:03:22Z"}
{"level":"info","message":"Original location: /v2/prince-tf-experiments/dazzle/workspace-images/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545","serviceContext":{"service":"bob","version":""},"severity":"INFO","time":"2022-05-26T13:03:23Z"}
{"level":"info","message":"Rewrote location: http://localhost:8080/v2/target/manifests/d260bb6ec50dd5b70a2acd883afb5cb39d9ad508dd0ddb5b2d25bdf8d9a87545","serviceContext":{"service":"bob","version":""},"severity":"INFO","time":"2022-05-26T13:03:23Z"}
#5 pushing manifest for localhost:8080/target:latest@sha256:3c93c7fc99a4471887ca128f0e18481e30b65ee6c63ae200697c11d3a1ffab84 2.5s done
#5 DONE 16.9s
exit
{"alias":"5f7d75b3-73a1-44ed-a1b5-9417d0d8f666","level":"info","message":"closing terminal","serviceContext":{"service":"supervisor","version":"commit-ab3f40db9e68ca471596056126f2d856ae59afe3"},"severity":"INFO","time":"2022-05-26T13:03:23Z"}
{"level":"info","message":"received SIGTERM (or shutdown) - tearing down","serviceContext":{"service":"supervisor","version":"commit-ab3f40db9e68ca471596056126f2d856ae59afe3"},"severity":"INFO","time":"2022-05-26T13:03:23Z"}
{"level":"info","message":"shutting down API endpoint","serviceContext":{"service":"supervisor","version":"commit-ab3f40db9e68ca471596056126f2d856ae59afe3"},"severity":"INFO","time":"2022-05-26T13:03:23Z"}
{"alias":"5f7d75b3-73a1-44ed-a1b5-9417d0d8f666","level":"info","message":"terminal client left","serviceContext":{"service":"supervisor","version":"commit-ab3f40db9e68ca471596056126f2d856ae59afe3"},"severity":"INFO","time":"2022-05-26T13:03:23Z"}

🤙 This task ran as a workspace prebuild
🎉 Well done on saving 3 minutes
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add Support for Google Artifact Registry as Container Registry
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
https://github.com/gitpod-io/website/issues/2128

