### PR TITLE
Rename gray color palette name

### DIFF
--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
     theme: {
         extend: {
             colors: {
-                gray: colors.warmGray,
+                gray: colors.stone,
                 green: colors.lime,
                 orange: colors.amber,
                 blue: {


### PR DESCRIPTION
## Description

This will update the gray color palette name, see relevant discussion (internal). 🌬️ 

Thanks for bringing this up @nandajavarma!

No visual changes expected.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```