### PR TITLE
Revert "[jb] enable connect button only when JetBrains Client not activated"

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -9,9 +9,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.ide.BrowserUtil
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.remote.RemoteCredentialsHolder
 import com.intellij.ssh.AskAboutHostKey
@@ -22,7 +20,6 @@ import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
-import com.intellij.util.EventDispatcher
 import com.intellij.util.application
 import com.intellij.util.io.DigestUtil
 import com.intellij.util.ui.JBFont
@@ -35,8 +32,6 @@ import com.jetbrains.gateway.ssh.ClientOverSshTunnelConnector
 import com.jetbrains.gateway.thinClientLink.ThinClientHandle
 import com.jetbrains.rd.util.URI
 import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.lifetime.isAlive
-import com.jetbrains.rd.util.lifetime.onTermination
 import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
 import io.gitpod.jetbrains.icons.GitpodIcons
 import kotlinx.coroutines.*
@@ -56,26 +51,6 @@ import kotlin.coroutines.coroutineContext
 class GitpodConnectionProvider : GatewayConnectionProvider {
 
     private val gitpod = service<GitpodConnectionService>()
-
-    companion object {
-        var jetbrainsClientMap: MutableMap<String, ThinClientHandle> = mutableMapOf()
-
-        private val dispatcher = EventDispatcher.create(Listener::class.java)
-
-        private interface Listener : EventListener {
-            fun didChange()
-        }
-
-        fun addListener(listener: () -> Unit): Disposable {
-            val internalListener = object : Listener {
-                override fun didChange() {
-                    listener()
-                }
-            }
-            dispatcher.addListener(internalListener);
-            return Disposable { dispatcher.removeListener(internalListener) }
-        }
-    }
 
     private val httpClient = HttpClient.newBuilder()
         .followRedirects(HttpClient.Redirect.ALWAYS)
@@ -259,27 +234,18 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                     )
                                     val client = connector.connect()
                                     client.clientClosed.advise(connectionLifetime) {
-                                        thisLogger().d("clientClosed, ${client.prettyPrint()}")
                                         application.invokeLater {
-                                            connectionLifetime.onTermination {
-                                                thisLogger().d("clientTermination, clientClosed didChange fired, ${client.prettyPrint()}")
-                                                dispatcher.multicaster.didChange()
-                                            }
                                             connectionLifetime.terminate()
                                         }
                                     }
                                     client.onClientPresenceChanged.advise(connectionLifetime) {
-                                        thisLogger().d("presenceChanged, ${client.prettyPrint()}")
                                         application.invokeLater {
-                                            thisLogger().d("clientPresenceChanged didChange fired, ${client.prettyPrint()}")
-                                            dispatcher.multicaster.didChange()
                                             if (client.clientPresent) {
                                                 statusMessage.text = ""
                                             }
                                         }
                                     }
                                     thinClient = client
-                                    jetbrainsClientMap[update.workspaceId] = client
                                 } catch (t: Throwable) {
                                     if (t is CancellationException) {
                                         throw t
@@ -477,12 +443,4 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
 
     private data class SSHHostKey(val type: String, val hostKey: String)
 
-}
-
-fun ThinClientHandle.prettyPrint(): String {
-    return "uid=${uid}, clientPresent=${clientPresent}, lifeTime={status=${lifetime.status}, alive=${lifetime.isAlive}}"
-}
-
-fun Logger.d(message: String) {
-    thisLogger().info("[jb-gw] $message")
 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -168,13 +168,6 @@ class GitpodWorkspacesView(
     init {
         refresh()
         loggedIn.addListener { refresh() }
-        GitpodConnectionProvider.addListener {
-            thisLogger().d("WorkspaceView refresh, " +
-                    GitpodConnectionProvider.jetbrainsClientMap
-                        .map { "[wsId=${it.key}, ${it.value.prettyPrint()}]" }
-                        .joinToString("; "))
-            refresh()
-        }
     }
 
     private fun startUpdateLoop(lifetime: Lifetime, workspacesPane: JBScrollPane): () -> Unit {
@@ -300,10 +293,7 @@ class GitpodWorkspacesView(
                                     )
                                 }
                                 label(getRelativeTimeSpan(info.latestInstance.creationTime))
-                                val jbClientConnected = GitpodConnectionProvider.jetbrainsClientMap[info.workspace.id]
-                                    ?.lifetime?.isAlive ?: false
-                                val btnText = if (jbClientConnected) "Connected" else "Connect"
-                                button(btnText) {
+                                button("Connect") {
                                     if (!canConnect) {
                                         BrowserUtil.browse(info.latestInstance.ideUrl)
                                     } else {
@@ -314,7 +304,7 @@ class GitpodWorkspacesView(
                                             )
                                         )
                                     }
-                                }.enabled(!jbClientConnected)
+                                }
                                 cell()
                             }.layout(RowLayout.PARENT_GRID)
                         }


### PR DESCRIPTION
Reverts gitpod-io/gitpod#10177 as suggested by @akosyakov in https://github.com/gitpod-io/gitpod/issues/10216#issuecomment-1138403888:

> I wonder is it really a solution? You can still get with multiple connection windows while workspace is starting or stopping?
> 
> I still was able to cause such conditions as from browser as from GW if i click several times while workspace is starting. I think the proper fix is to ensure that there is only connection at the time, not a client.


## Release Notes
```release-note
NONE
```