### PR TITLE
Install the snapshotter CRDs and the snapshot controller in preview env

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -325,6 +325,10 @@ write_files:
       kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
       kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml
 
+      # install CSI snapshotter CRDs and snapshot controller
+      kubectl apply -f /var/lib/gitpod/manifests/csi-snapshotter-crd.yaml
+      kubectl apply -f /var/lib/gitpod/manifests/csi-snapshot-controller.yaml
+
       cat <<EOF >> /etc/bash.bashrc
       export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
       EOF


### PR DESCRIPTION
## Description
Install the snapshotter CRDs and the snapshot controller in preview env.
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10197

## How to test
<!-- Provide steps to test this PR -->
1. Create a preview env
2. Check the snapshotter CRDs are installed
```shell
$ kubectl get crds | grep snapshot.storage.k8s.io
volumesnapshotclasses.snapshot.storage.k8s.io
volumesnapshotcontents.snapshot.storage.k8s.io
volumesnapshots.snapshot.storage.k8s.io 
```
3. Check the snapshot controller is installed
```shell
$ kubectl get deploy snapshot-controller -n kube-system 
NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
snapshot-controller   1/1     1            1           7m35s
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A