### PR TITLE
Revert "Rename gray color palette name"

### DIFF
--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
     theme: {
         extend: {
             colors: {
-                gray: colors.stone,
+                gray: colors.warmGray,
                 green: colors.lime,
                 orange: colors.amber,
                 blue: {


### PR DESCRIPTION
Reverts gitpod-io/gitpod#10276.

Until we update to Tailwind 3 we need to stay with this color palette as this change is changing the warm gray colors we're using to complement our branding colors and defaults to using the gray palette.

See relevant discussion (internal).

| BEFORE the color update | AFTER  the color update |
|-|-|
| <img width="1440" alt="light-theme-before" src="https://user-images.githubusercontent.com/120486/170512971-e093f14a-99e3-4177-b8b0-066840ccf2bc.png"> | <img width="1440" alt="light-theme-after" src="https://user-images.githubusercontent.com/120486/170512978-c35147a5-9912-45a7-a2b6-63ec3d7a7379.png"> |
| <img width="1440" alt="dark-theme-before" src="https://user-images.githubusercontent.com/120486/170512990-3d76670a-4b22-4628-afe1-ea3ca5fc0afb.png"> | <img width="1440" alt="dark-theme-after" src="https://user-images.githubusercontent.com/120486/170513003-d803f4af-85c3-4741-8e7e-93a2f285fd25.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
