### PR TITLE
Add example dashboard for Monitoring Self-hosted

### DIFF
--- a/operations/observability/mixins/dashboards.jsonnet
+++ b/operations/observability/mixins/dashboards.jsonnet
@@ -8,7 +8,8 @@ local dashboards =
   (import 'cross-teams/mixin.libsonnet').grafanaDashboards +
   (import 'IDE/mixin.libsonnet').grafanaDashboards +
   (import 'meta/mixin.libsonnet').grafanaDashboards +
-  (import 'workspace/mixin.libsonnet').grafanaDashboards
+  (import 'workspace/mixin.libsonnet').grafanaDashboards +
+  (import 'self-hosted/mixin.libsonnet').grafanaDashboards
 ;
 
 {

--- a/operations/observability/mixins/self-hosted/dashboards.libsonnet
+++ b/operations/observability/mixins/self-hosted/dashboards.libsonnet
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  grafanaDashboards+:: {
+    // Import raw json files here.
+    // Example:
+    // 'my-new-dashboard.json': (import 'dashboards/components/new-component.json'),
+    'gitpod-sh-example-overview.json': (import 'dashboards/examples/overview.json'),
+  },
+}

--- a/operations/observability/mixins/self-hosted/dashboards/examples/overview.json
+++ b/operations/observability/mixins/self-hosted/dashboards/examples/overview.json
@@ -1,0 +1,420 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.5.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1653570217342,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 5,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.5.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "cluster",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:119",
+          "alias": "REGULAR",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:120",
+          "alias": "PREBUILD",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:122",
+          "alias": "Pending workspaces",
+          "color": "#FADE2A"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(gitpod_ws_manager_workspace_phase_total{phase=\"RUNNING\"}) by (type)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ type }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(gitpod_ws_manager_workspace_activity_total{active=\"false\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Pending workspaces",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Running Workspaces",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "none",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 5,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.5.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "cluster",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:179",
+          "alias": "REGULAR",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:180",
+          "alias": "PREBUILD",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:181",
+          "alias": "PROBE",
+          "color": "#B877D9"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(\n  rate(gitpod_ws_manager_workspace_stops_total{reason=\"failed\"}[5m])\n) by (cluster, type)\n",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Workspace Failures per second",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "none",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGreens",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 4,
+      "legend": {
+        "show": false
+      },
+      "repeat": "cluster",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type=\"REGULAR\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "intervalFactor": 2,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Regular Workspace Startup time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "s",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "gitpod-mixin"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "[Example] Gitpod Self-hosted / Overview",
+  "uid": "gitpod-selfhosted-overview-example",
+  "version": 1,
+  "weekStart": ""
+}

--- a/operations/observability/mixins/self-hosted/mixin.libsonnet
+++ b/operations/observability/mixins/self-hosted/mixin.libsonnet
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+(import './dashboards.libsonnet')


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Continuing the work being done at https://github.com/gitpod-io/website/pull/2110, this PR adds a minimal example dashboard for monitoring Gitpod selfhosted.

We're adding this dashboard to this repository for 2 reasons:
1. Provide a stable link to a Grafana dashboard that operators of Gitpod self-hosted can use as a quick baseline to monitor workspace performance.
2. Although we're not offering support for dashboards focused on self-hosted, we want to deploy this dashboard to production so we can easily notice if we change metrics in a way that will break our examples.


The panels added to this dashboards are only the ones documented in the mentioned PR (https://github.com/gitpod-io/website/pull/2110)

![image](https://user-images.githubusercontent.com/24193764/170514238-6efa8c34-2013-4803-a428-5858abe9bb91.png)



## How to test
<!-- Provide steps to test this PR -->
* Open a workspace from this PR
* Run `werft run github -f -a withObservabilityBranch="as/sh-dashboard"`
* Run `./dev/preview/util/portforward-monitoring-satellite-harvester.sh` and Grafana link
![image](https://user-images.githubusercontent.com/24193764/170512620-1c072595-90f5-4178-b675-63942255e9c1.png)

* Go to https://`<your-grafana-url>`/d/gitpod-selfhosted-overview-example

You can also start some workspaces in the preview environment so the dashboard is populated with extra data 🙂 



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
