### PR TITLE
[ws-manager] add a metric to track volume snapshot time

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -795,8 +795,9 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	hist, errHist := m.manager.metrics.initializeTimeHistVec.GetMetricWithLabelValues(wsType)
 	if errHist != nil {
 		log.WithError(errHist).WithField("type", wsType).Warn("cannot get initialize time histogram metric")
+	} else {
+		hist.Observe(time.Since(t).Seconds())
 	}
-	hist.Observe(time.Since(t).Seconds())
 	if err != nil {
 		return xerrors.Errorf("cannot initialize workspace: %w", err)
 	}
@@ -1023,8 +1024,9 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 				hist, err := m.manager.metrics.volumeSnapshotTimeHistVec.GetMetricWithLabelValues(wsType)
 				if err != nil {
 					log.WithError(err).WithField("type", wsType).Warn("cannot get volume snapshot time histogram metric")
+				} else {
+					hist.Observe(time.Since(volumeSnapshotTime).Seconds())
 				}
-				hist.Observe(time.Since(volumeSnapshotTime).Seconds())
 			}
 			if readyVolumeSnapshot && !markVolumeSnapshotAnnotation {
 				log = log.WithField("VolumeSnapshotContent.Name", pvcVolumeSnapshotContentName)
@@ -1167,8 +1169,9 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 	hist, err := m.manager.metrics.finalizeTimeHistVec.GetMetricWithLabelValues(wsType)
 	if err != nil {
 		log.WithError(err).WithField("type", wsType).Warn("cannot get finalize time histogram metric")
+	} else {
+		hist.Observe(time.Since(t).Seconds())
 	}
-	hist.Observe(time.Since(t).Seconds())
 
 	disposalStatus = &workspaceDisposalStatus{
 		BackupComplete: true,


### PR DESCRIPTION
## Description
Add a metric to track the volume snapshot time (the time it takes to create the volume snapshot of a workspace content).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially #10195 (will have a PR for volume restore time)

## How to test
<!-- Provide steps to test this PR -->
- Bootstrap a new workspace preview environment using the installer from this PR.
- Add Git integration to GitHub.
- Enable the feature flag `persistent_volume_claim`.
- Create a new workspace, create a large file in the workspace and stop the workspace.
  ```shell
  dd if=/dev/urandom of=1G.random bs=16M count=64
  ```
- Port forward metrics port of the ws-manager and look for new metrics.
  ```shell
  kubectl port-forward <ws-manager-pod-name> 9500:9500
  curl -XGET localhost:9500/metrics
  ```
- The reported time `gitpod_ws_manager_volume_snapshot_seconds_xxx` should match the time it took to perform the volume snapshot.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[experimental] add a metric to track volume snapshot time
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
