### PR TITLE
[dashboard] hide feedback form from self-hosted users 10296

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -27,6 +27,7 @@ import { getProjectSettingsMenu } from "./projects/ProjectSettings";
 import { ProjectContext } from "./projects/project-context";
 import { PaymentContext } from "./payment-context";
 import FeedbackFormModal from "./feedback-form/FeedbackModal";
+import { isGitpodIo } from "./utils";
 
 interface Entry {
     title: string;
@@ -376,9 +377,11 @@ export default function Menu() {
                                             />
                                         </li>
                                     ))}
-                                <li className="cursor-pointer">
-                                    <PillMenuItem name="Feedback" onClick={handleFeedbackFormClick} />
-                                </li>
+                                {isGitpodIo() && (
+                                    <li className="cursor-pointer">
+                                        <PillMenuItem name="Feedback" onClick={handleFeedbackFormClick} />
+                                    </li>
+                                )}
                             </ul>
                         </nav>
                         <div

--- a/components/dashboard/src/components/ErrorMessage.tsx
+++ b/components/dashboard/src/components/ErrorMessage.tsx
@@ -5,6 +5,7 @@
  */
 
 import FeedbackComponent from "../feedback-form/FeedbackComponent";
+import { isGitpodIo } from "../utils";
 
 function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string }) {
     return (
@@ -17,12 +18,14 @@ function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string 
                     <p className="text-gitpod-red text-sm">{props.message}</p>
                 </div>
             </div>
-            <FeedbackComponent
-                message={"Was this error message helpful?"}
-                initialSize={24}
-                isError={true}
-                isModal={false}
-            />
+            {isGitpodIo() && (
+                <FeedbackComponent
+                    message={"Was this error message helpful?"}
+                    initialSize={24}
+                    isError={true}
+                    isModal={false}
+                />
+            )}
         </>
     );
 }

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -24,6 +24,7 @@ import { SelectAccountModal } from "../settings/SelectAccountModal";
 import { watchHeadlessLogs } from "../components/PrebuildLogs";
 import CodeText from "../components/CodeText";
 import FeedbackComponent from "../feedback-form/FeedbackComponent";
+import { isGitpodIo } from "../utils";
 
 const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
 
@@ -433,7 +434,7 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
                 <CodeText>{repoFullName}</CodeText>
             </p>
             {statusMessage}
-            {p.error && (
+            {p.error && isGitpodIo() && (
                 <FeedbackComponent
                     isModal={false}
                     message={"Was this error message helpful?"}


### PR DESCRIPTION
## Description
Hides the feedback form from self-hosted users.

## Related Issue(s)
Fixes #10296

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Feedback form only shows for SaaS gitpod-io users.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
