### PR TITLE
[dashboard] Add Usage-Based feature flag and empty Billing page

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -26,6 +26,7 @@ import { Experiment } from "./experiments";
 import { workspacesPathMain } from "./workspaces/workspaces.routes";
 import {
     settingsPathAccount,
+    settingsPathBilling,
     settingsPathIntegrations,
     settingsPathMain,
     settingsPathNotifications,
@@ -53,6 +54,7 @@ const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "./workspaces/Workspaces"));
 const Account = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Account"));
 const Notifications = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Notifications"));
+const Billing = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Billing"));
 const Plans = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Plans"));
 const Teams = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/Teams"));
 const EnvironmentVariables = React.lazy(() => import(/* webpackPrefetch: true */ "./settings/EnvironmentVariables"));
@@ -359,6 +361,7 @@ function App() {
                     <Route path={settingsPathAccount} exact component={Account} />
                     <Route path={settingsPathIntegrations} exact component={Integrations} />
                     <Route path={settingsPathNotifications} exact component={Notifications} />
+                    <Route path={settingsPathBilling} exact component={Billing} />
                     <Route path={settingsPathPlans} exact component={Plans} />
                     <Route path={settingsPathVariables} exact component={EnvironmentVariables} />
                     <Route path={settingsPathPreferences} exact component={Preferences} />

--- a/components/dashboard/src/experiments/client.ts
+++ b/components/dashboard/src/experiments/client.ts
@@ -4,22 +4,26 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-// Attributes define attributes which can be used to segment audiences.
-// Set the attributes which you want to use to group audiences into.
+import { Team } from "@gitpod/gitpod-protocol";
 import { newNonProductionConfigCatClient, newProductionConfigCatClient } from "./configcat";
 import { newAlwaysReturningDefaultValueClient } from "./always-default";
 
+// Attributes define attributes which can be used to segment audiences.
+// Set the attributes which you want to use to group audiences into.
 export interface Attributes {
-    userID?: string;
+    userId?: string;
     email?: string;
 
-    // Gitpod Project ID
-    projectID?: string;
+    // Currently selected Gitpod Project ID
+    projectId?: string;
 
-    // Gitpod Team ID
-    teamID?: string;
-    // Gitpod Team Name
+    // Currently selected Gitpod Team ID
+    teamId?: string;
+    // Currently selected Gitpod Team Name
     teamName?: string;
+
+    // All the Gitpod Teams that the user is a member (or owner) of
+    teams?: Array<Team>;
 }
 
 export interface Client {
@@ -52,4 +56,6 @@ export function getExperimentsClient(): Client {
 
 export const PROJECT_ID_ATTRIBUTE = "project_id";
 export const TEAM_ID_ATTRIBUTE = "team_id";
+export const TEAM_IDS_ATTRIBUTE = "team_ids";
 export const TEAM_NAME_ATTRIBUTE = "team_name";
+export const TEAM_NAMES_ATTRIBUTE = "team_names";

--- a/components/dashboard/src/experiments/configcat.ts
+++ b/components/dashboard/src/experiments/configcat.ts
@@ -7,7 +7,15 @@
 import * as configcat from "configcat-js";
 import { IConfigCatClient } from "configcat-common/lib/ConfigCatClient";
 import { User } from "configcat-common/lib/RolloutEvaluator";
-import { Attributes, Client, PROJECT_ID_ATTRIBUTE, TEAM_ID_ATTRIBUTE, TEAM_NAME_ATTRIBUTE } from "./client";
+import {
+    Attributes,
+    Client,
+    PROJECT_ID_ATTRIBUTE,
+    TEAM_IDS_ATTRIBUTE,
+    TEAM_ID_ATTRIBUTE,
+    TEAM_NAMES_ATTRIBUTE,
+    TEAM_NAME_ATTRIBUTE,
+} from "./client";
 
 // newProductionConfigCatClient constructs a new ConfigCat client with production configuration.
 // DO NOT USE DIRECTLY! Use getExperimentsClient() instead.
@@ -51,19 +59,23 @@ class ConfigCatClient implements Client {
 }
 
 function attributesToUser(attributes: Attributes): User {
-    const userID = attributes.userID || "";
+    const userId = attributes.userId || "";
     const email = attributes.email || "";
 
     const custom: { [key: string]: string } = {};
-    if (attributes.projectID) {
-        custom[PROJECT_ID_ATTRIBUTE] = attributes.projectID;
+    if (attributes.projectId) {
+        custom[PROJECT_ID_ATTRIBUTE] = attributes.projectId;
     }
-    if (attributes.teamID) {
-        custom[TEAM_ID_ATTRIBUTE] = attributes.teamID;
+    if (attributes.teamId) {
+        custom[TEAM_ID_ATTRIBUTE] = attributes.teamId;
     }
     if (attributes.teamName) {
         custom[TEAM_NAME_ATTRIBUTE] = attributes.teamName;
     }
+    if (attributes.teams) {
+        custom[TEAM_NAMES_ATTRIBUTE] = attributes.teams.map((t) => t.name).join(",");
+        custom[TEAM_IDS_ATTRIBUTE] = attributes.teams.map((t) => t.id).join(",");
+    }
 
-    return new User(userID, email, "", custom);
+    return new User(userId, email, "", custom);
 }

--- a/components/dashboard/src/payment-context.tsx
+++ b/components/dashboard/src/payment-context.tsx
@@ -10,6 +10,8 @@ import { Currency } from "@gitpod/gitpod-protocol/lib/plans";
 const PaymentContext = createContext<{
     showPaymentUI?: boolean;
     setShowPaymentUI: React.Dispatch<boolean>;
+    showUsageBasedUI?: boolean;
+    setShowUsageBasedUI: React.Dispatch<boolean>;
     currency: Currency;
     setCurrency: React.Dispatch<Currency>;
     isStudent?: boolean;
@@ -18,6 +20,7 @@ const PaymentContext = createContext<{
     setIsChargebeeCustomer: React.Dispatch<boolean>;
 }>({
     setShowPaymentUI: () => null,
+    setShowUsageBasedUI: () => null,
     currency: "USD",
     setCurrency: () => null,
     setIsStudent: () => null,
@@ -26,6 +29,7 @@ const PaymentContext = createContext<{
 
 const PaymentContextProvider: React.FC = ({ children }) => {
     const [showPaymentUI, setShowPaymentUI] = useState<boolean>();
+    const [showUsageBasedUI, setShowUsageBasedUI] = useState<boolean>();
     const [currency, setCurrency] = useState<Currency>("USD");
     const [isStudent, setIsStudent] = useState<boolean>();
     const [isChargebeeCustomer, setIsChargebeeCustomer] = useState<boolean>();
@@ -35,6 +39,8 @@ const PaymentContextProvider: React.FC = ({ children }) => {
             value={{
                 showPaymentUI,
                 setShowPaymentUI,
+                showUsageBasedUI,
+                setShowUsageBasedUI,
                 currency,
                 setCurrency,
                 isStudent,

--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -16,7 +16,7 @@ import { PaymentContext } from "../payment-context";
 
 export default function Account() {
     const { user } = useContext(UserContext);
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
 
     const [modal, setModal] = useState(false);
     const [typedEmail, setTypedEmail] = useState("");
@@ -56,7 +56,7 @@ export default function Account() {
             </ConfirmationModal>
 
             <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI })}
+                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
                 title="Account"
                 subtitle="Manage account and Git configuration."
             >

--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext } from "react";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { PaymentContext } from "../payment-context";
+import getSettingsMenu from "./settings-menu";
+
+export default function Billing() {
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
+
+    return (
+        <PageWithSubMenu
+            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
+            title="Billing"
+            subtitle="Usage-Based Billing."
+        >
+            <h3>Billing</h3>
+        </PageWithSubMenu>
+    );
+}

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -145,7 +145,7 @@ function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
 }
 
 export default function EnvVars() {
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const [envVars, setEnvVars] = useState([] as UserEnvVarValue[]);
     const [currentEnvVar, setCurrentEnvVar] = useState({
         name: "",
@@ -207,7 +207,7 @@ export default function EnvVars() {
 
     return (
         <PageWithSubMenu
-            subMenu={getSettingsMenu({ showPaymentUI })}
+            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
             title="Variables"
             subtitle="Configure environment variables for all workspaces."
         >

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -26,12 +26,12 @@ import { SelectAccountModal } from "./SelectAccountModal";
 import getSettingsMenu from "./settings-menu";
 
 export default function Integrations() {
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
 
     return (
         <div>
             <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI })}
+                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
                 title="Integrations"
                 subtitle="Manage permissions for Git providers and integrations."
             >

--- a/components/dashboard/src/settings/Notifications.tsx
+++ b/components/dashboard/src/settings/Notifications.tsx
@@ -15,7 +15,7 @@ import { PaymentContext } from "../payment-context";
 
 export default function Notifications() {
     const { user, setUser } = useContext(UserContext);
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const [isOnboardingMail, setOnboardingMail] = useState(
         !!user?.additionalData?.emailNotificationSettings?.allowsOnboardingMail,
     );
@@ -84,7 +84,7 @@ export default function Notifications() {
     return (
         <div>
             <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI })}
+                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
                 title="Notifications"
                 subtitle="Choose when to be notified."
             >

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -45,7 +45,8 @@ type TeamClaimModal =
 
 export default function () {
     const { user } = useContext(UserContext);
-    const { showPaymentUI, currency, setCurrency, isStudent, isChargebeeCustomer } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI, currency, setCurrency, isStudent, isChargebeeCustomer } =
+        useContext(PaymentContext);
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
     const [availableCoupons, setAvailableCoupons] = useState<PlanCoupon[]>();
     const [appliedCoupons, setAppliedCoupons] = useState<PlanCoupon[]>();
@@ -636,7 +637,7 @@ export default function () {
     return (
         <div>
             <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI })}
+                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
                 title="Plans"
                 subtitle="Manage account usage and billing."
             >

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -20,7 +20,7 @@ type Theme = "light" | "dark" | "system";
 
 export default function Preferences() {
     const { user } = useContext(UserContext);
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const { setIsDark } = useContext(ThemeContext);
 
     const [theme, setTheme] = useState<Theme>(localStorage.theme || "system");
@@ -54,7 +54,7 @@ export default function Preferences() {
     return (
         <div>
             <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI })}
+                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
                 title="Preferences"
                 subtitle="Configure user preferences."
             >

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -26,12 +26,12 @@ import { Disposable } from "@gitpod/gitpod-protocol";
 import { PaymentContext } from "../payment-context";
 
 export default function Teams() {
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
 
     return (
         <div>
             <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI })}
+                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
                 title="Team Plans"
                 subtitle="View and manage subscriptions for your team with one centralized billing."
             >

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -4,39 +4,59 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-export default function getSettingsMenu(params: { showPaymentUI?: boolean }) {
+import {
+    settingsPathAccount,
+    settingsPathBilling,
+    settingsPathIntegrations,
+    settingsPathMain,
+    settingsPathNotifications,
+    settingsPathPlans,
+    settingsPathPreferences,
+    settingsPathTeams,
+    settingsPathVariables,
+} from "./settings.routes";
+
+export default function getSettingsMenu(params: { showPaymentUI?: boolean; showUsageBasedUI?: boolean }) {
     return [
         {
             title: "Account",
-            link: ["/account", "/settings"],
+            link: [settingsPathAccount, settingsPathMain],
         },
         {
             title: "Notifications",
-            link: ["/notifications"],
+            link: [settingsPathNotifications],
         },
         ...(params.showPaymentUI
             ? [
+                  ...(params.showUsageBasedUI
+                      ? [
+                            {
+                                title: "Billing",
+                                link: [settingsPathBilling],
+                            },
+                        ]
+                      : []),
                   {
                       title: "Plans",
-                      link: ["/plans"],
+                      link: [settingsPathPlans],
                   },
                   {
                       title: "Team Plans",
-                      link: ["/teams"],
+                      link: [settingsPathTeams],
                   },
               ]
             : []),
         {
             title: "Variables",
-            link: ["/variables"],
+            link: [settingsPathVariables],
         },
         {
             title: "Integrations",
-            link: ["/integrations", "/access-control"],
+            link: [settingsPathIntegrations, "/access-control"],
         },
         {
             title: "Preferences",
-            link: ["/preferences"],
+            link: [settingsPathPreferences],
         },
     ];
 }

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -9,6 +9,7 @@ export const settingsPathMain = "/settings";
 export const settingsPathAccount = "/account";
 export const settingsPathIntegrations = "/integrations";
 export const settingsPathNotifications = "/notifications";
+export const settingsPathBilling = "/billing";
 export const settingsPathPlans = "/plans";
 export const settingsPathPreferences = "/preferences";
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add Usage-Based feature flag and empty Billing page in user settings.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Verify that the [Settings](https://jx-usage-flag.preview.gitpod-dev.com/settings) menu has `Plans` + `Team Plans`, but no `Billing` item
2. Join the "Gitpod" team ([invite link](https://jx-usage-flag.preview.gitpod-dev.com/teams/join?inviteId=bbfeb74e-ab2a-4c8c-87b6-00f8ec488df0))
3. Verify that the [Settings](https://jx-usage-flag.preview.gitpod-dev.com/settings) menu now has `Billing` + `Plans` + `Team Plans`
4. (You can now visit the Billing page, but there's nothing in it yet)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Introduce an experimental usage-based billing feature flag (off by default)
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment=true