### PR TITLE
Add a Stripe settings secret to server

### DIFF
--- a/.werft/jobs/build/helm/values.payment.yaml
+++ b/.werft/jobs/build/helm/values.payment.yaml
@@ -6,10 +6,16 @@ components:
       - name: chargebee-config
         mountPath: "/chargebee"
         readOnly: true
+      - name: stripe-config
+        mountPath: "/stripe"
+        readOnly: true
     volumes:
     - name: chargebee-config
       secret:
         secretName: chargebee-config
+    - name: stripe-config
+      secret:
+        secretName: stripe-config
 
   paymentEndpoint:
     disabled: false

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -79,6 +79,8 @@ export class Installer {
             if (this.options.withPayment) {
                 // let installer know that there is a chargbee config
                 exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.chargebeeSecret chargebee-config`, { slice: slice });
+                // let installer know that there is a stripe config
+                exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.stripeSecret stripe-config`, { slice: slice });
             }
 
         } catch (err) {

--- a/.werft/jobs/build/payment/stripe-config-secret.yaml
+++ b/.werft/jobs/build/payment/stripe-config-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  settings: eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfNTFLeHVyN0dhZFJYbTUwbzNJNXJKQTNvbnkxdGNmdTNkM0NOd3BUWFR6QURkWTJISmlvRk1XTGdTa2M1d2h0UkZRam85UG5kM3pYYUdlcktQcXRmN0REQ3kwMFhBb01kbjZhIiwic2VjcmV0S2V5Ijoic2tfdGVzdF81MUt4dXI3R2FkUlhtNTBvM0NtVFJWc1Q2Q0xqd0VlSlhsWWtmdjZHajREQm42aVlVeDJQWUlUNDhjVlI5dlNUS0s1b2hwQTVCdWdycU5NUU9WVzN0NVJIODAwS011T3lEZ1QifQo=
+kind: Secret
+metadata:
+  name: stripe-config
+  namespace: ${NAMESPACE}
+type: Opaque

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -20,11 +20,12 @@ import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 export const Config = Symbol("Config");
 export type Config = Omit<
     ConfigSerialized,
-    "blockedRepositories" | "hostUrl" | "chargebeeProviderOptionsFile" | "licenseFile"
+    "blockedRepositories" | "hostUrl" | "chargebeeProviderOptionsFile" | "stripeSettingsFile" | "licenseFile"
 > & {
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
     chargebeeProviderOptions?: ChargebeeProviderOptions;
+    stripeSettings?: { publishableKey: string; secretKey: string };
     builtinAuthProvidersConfigured: boolean;
     blockedRepositories: { urlRegExp: RegExp; blockUser: boolean }[];
     inactivityPeriodForRepos?: number;
@@ -150,6 +151,7 @@ export interface ConfigSerialized {
      * Payment related options
      */
     chargebeeProviderOptionsFile?: string;
+    stripeSettingsFile?: string;
     enablePayment?: boolean;
 
     /**
@@ -213,6 +215,10 @@ export namespace ConfigFile {
         const chargebeeProviderOptions = readOptionsFromFile(
             filePathTelepresenceAware(config.chargebeeProviderOptionsFile || ""),
         );
+        let stripeSettings: { publishableKey: string; secretKey: string } | undefined;
+        if (config.enablePayment && config.stripeSettingsFile) {
+            stripeSettings = JSON.parse(fs.readFileSync(filePathTelepresenceAware(config.stripeSettingsFile), "utf-8"));
+        }
         let license = config.license;
         const licenseFile = config.licenseFile;
         if (licenseFile) {
@@ -239,6 +245,7 @@ export namespace ConfigFile {
             authProviderConfigs,
             builtinAuthProvidersConfigured,
             chargebeeProviderOptions,
+            stripeSettings,
             license,
             workspaceGarbageCollection: {
                 ...config.workspaceGarbageCollection,

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -91,6 +91,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	stripeSecret := ""
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			stripeSecret = cfg.WebApp.Server.StripeSecret
+		}
+		return nil
+	})
+
 	disableWsGarbageCollection := false
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
@@ -208,8 +216,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ImageBuilderAddr:             "image-builder-mk3:8080",
 		CodeSync:                     CodeSync{},
 		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
-		EnablePayment:                chargebeeSecret != "",
+		EnablePayment:                chargebeeSecret != "" || stripeSecret != "",
 		ChargebeeProviderOptionsFile: fmt.Sprintf("%s/providerOptions", chargebeeMountPath),
+		StripeSettingsFile:           fmt.Sprintf("%s/settings", stripeMountPath),
 		InsecureNoDomain:             false,
 		PrebuildLimiter: map[string]int{
 			// default limit for all cloneURLs

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -15,6 +15,7 @@ const (
 	authProviderFilePath  = "/gitpod/auth-providers"
 	licenseFilePath       = "/gitpod/license"
 	chargebeeMountPath    = "/chargebee"
+	stripeMountPath       = "/stripe"
 	githubAppCertSecret   = "github-app-cert-secret"
 	PrometheusPort        = 9500
 	PrometheusPortName    = "metrics"

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -189,6 +189,29 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	})
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.StripeSecret != "" {
+			stripeSecret := cfg.WebApp.Server.StripeSecret
+
+			volumes = append(volumes,
+				corev1.Volume{
+					Name: "stripe-config",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: stripeSecret,
+						},
+					},
+				})
+
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      "stripe-config",
+				MountPath: stripeMountPath,
+				ReadOnly:  true,
+			})
+		}
+		return nil
+	})
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
 			volumes = append(volumes,
 				corev1.Volume{

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -32,6 +32,7 @@ type ConfigSerialized struct {
 	ImageBuilderAddr                  string   `json:"imageBuilderAddr"`
 	VSXRegistryUrl                    string   `json:"vsxRegistryUrl"`
 	ChargebeeProviderOptionsFile      string   `json:"chargebeeProviderOptionsFile"`
+	StripeSettingsFile                string   `json:"stripeSettingsFile"`
 	EnablePayment                     bool     `json:"enablePayment"`
 
 	WorkspaceHeartbeat         WorkspaceHeartbeat         `json:"workspaceHeartbeat"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -139,6 +139,7 @@ type ServerConfig struct {
 	Session                           Session             `json:"session"`
 	GithubApp                         *GithubApp          `json:"githubApp"`
 	ChargebeeSecret                   string              `json:"chargebeeSecret"`
+	StripeSecret                      string              `json:"stripeSecret"`
 	DisableDynamicAuthProviderLogin   bool                `json:"disableDynamicAuthProviderLogin"`
 	EnableLocalApp                    *bool               `json:"enableLocalApp"`
 	RunDbDeleter                      *bool               `json:"runDbDeleter"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add a Stripe settings secret to server, in order to provide the secret key for API calls.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Builds **without** payment should succeed (and **not** have a Stripe volume mounted on `server` pod)
- Build **with** payment should succeed, **and** have the Stripe volume mounted:

```
$ kubectl describe pod server-5995b76459-llfwg
[...]
Volumes:
[...]
  stripe-config:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  stripe-config
    Optional:    false
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-clean-slate-deployment
- [x] /werft with-payment=true