### PR TITLE
[dev] Add `gh` (Github CLI) to the dev image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -71,7 +71,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/ide-integration-tests-startup-jetbrains.yaml
+++ b/.werft/ide-integration-tests-startup-jetbrains.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-integration-tests-startup-vscode.yaml
+++ b/.werft/ide-integration-tests-startup-vscode.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-run-integration-tests.yaml
+++ b/.werft/ide-run-integration-tests.yaml
@@ -25,7 +25,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -24,7 +24,7 @@ pod:
       secretName: harvester-k3s-dockerhub-pull-account
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-cmctl.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -210,6 +210,10 @@ RUN sudo curl -fsSL https://uploader.codecov.io/latest/codecov-linux -o /usr/loc
 RUN sudo install-packages shellcheck \
     && sudo python3 -m pip install pre-commit
 
+# gh (Github CLI) binary:
+RUN cd /usr/bin && curl -L https://github.com/cli/cli/releases/download/v2.11.3/gh_2.11.3_linux_amd64.tar.gz \
+    | sudo tar xzv --strip-components=2 gh_2.11.3_linux_amd64/bin/gh
+
 # Install observability-related binaries
 ARG PROM_VERSION="2.30.0"
 RUN curl -LO https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz && \


### PR DESCRIPTION
## Description

Add [gh](https://cli.github.com/), the Github CLI, to the dev image.

This allows working with Github from the command line in a workspace. All that's required is for a user to have a `GH_TOKEN` environment variable set to a valid Github [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).


## Related Issue(s)


## How to test

## Release Notes

```release-note
NONE
```

## Documentation
