### PR TITLE
Fixing the inte-test branch does not clean up

### DIFF
--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -97,7 +97,7 @@ pod:
         werft log result "slack notification" "${PIPESTATUS[0]}"
 
         werft log phase "clean up" "clean up"
-        git push origin "${BRANCH}" | werft log slice "clean up"
+        git push origin :"${BRANCH}" | werft log slice "clean up"
         werft log slice "clean up" --done
       }
 

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -53,7 +53,7 @@ pod:
     - |
       set -euo pipefail
 
-      BRANCH="inte-test/"$(date +%Y%m%d%H%M%S)
+      BRANCH="wk-inte-test/"$(date +%Y%m%d%H%M%S)
       FAILURE_COUNT=0
       RUN_COUNT=0
       declare -A FAILURE_TESTS


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixing the `inte-test` branch does not clean up, also adding prefix `wk-` to the inte-test branch name.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A