### PR TITLE
Add metrics to record backup/restore success/failure count

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -799,10 +799,24 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	} else {
 		hist.Observe(time.Since(t).Seconds())
 	}
+
 	if err != nil {
+		c, cErr := m.manager.metrics.totalRestoreFailureCounterVec.GetMetricWithLabelValues(wsType, wsClass)
+		if cErr != nil {
+			log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace restore failure counter")
+		} else {
+			c.Inc()
+		}
+
 		return xerrors.Errorf("cannot initialize workspace: %w", err)
 	}
 
+	c, cErr := m.manager.metrics.totalRestoreSuccessCounterVec.GetMetricWithLabelValues(wsType, wsClass)
+	if cErr != nil {
+		log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace restore success counter")
+	} else {
+		c.Inc()
+	}
 	return nil
 }
 
@@ -1179,6 +1193,13 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 		GitStatus:      gitStatus,
 	}
 	if backupError != nil {
+		c, cErr := m.manager.metrics.totalBackupFailureCounterVec.GetMetricWithLabelValues(wsType, wso.Pod.Labels[workspaceClassLabel])
+		if cErr != nil {
+			log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace backup failure metric")
+		} else {
+			c.Inc()
+		}
+
 		if dataloss {
 			disposalStatus.BackupFailure = backupError.Error()
 		} else {
@@ -1186,6 +1207,13 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 			// state management or cleanup. No need to worry the user.
 			log.WithError(backupError).WithFields(wso.GetOWI()).Warn("internal error while disposing workspace content")
 			tracing.LogError(span, backupError)
+		}
+	} else {
+		c, cErr := m.manager.metrics.totalBackupSuccessCounterVec.GetMetricWithLabelValues(wsType, wso.Pod.Labels[workspaceClassLabel])
+		if cErr != nil {
+			log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace backup success counter")
+		} else {
+			c.Inc()
 		}
 	}
 }


### PR DESCRIPTION
## Description
Add metrics to record workspace backup/restore success/failure count.

<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10330

## How to test
<!-- Provide steps to test this PR -->
- Launch a new workspace with the [preview env](https://jenting-wsc8ae3d0358.preview.gitpod-dev.com/workspaces).
- Create a new workspace, create a large file in the workspace and stop the workspace.
  ```shell
  dd if=/dev/urandom of=1G.random bs=16M count=64
  ```
- Port forward metrics port of the ws-manager and look for new metrics.
  ```shell
  kubectl port-forward <ws-manager-pod-name> 9500:9500
  curl -XGET localhost:9500/metrics
  ```
- The reported count should be correct.
  - `workspace_backups_success_total`
  - `workspace_backups_failure_total`
  - `workspace_restores_success_total`
  - `workspace_restores_failure_total`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] Add metrics to record backup success/failure count
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A