### PR TITLE
[installer] Add flag to configure strict config parsing

### DIFF
--- a/install/installer/cmd/mirror_kots.go
+++ b/install/installer/cmd/mirror_kots.go
@@ -33,7 +33,7 @@ https://docs.replicated.com/reference/custom-resource-application#additionalimag
 	Example: "gitpod-installer mirror kots --file ../kots/manifests/kots-app.yaml",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Build a virtual config file
-		rawCfg, cfgVersion, err := config.Load("")
+		rawCfg, cfgVersion, err := config.Load("", rootOpts.StrictConfigParse)
 		if err != nil {
 			return err
 		}

--- a/install/installer/cmd/render.go
+++ b/install/installer/cmd/render.go
@@ -114,7 +114,7 @@ func loadConfig(cfgFN string) (rawCfg interface{}, cfgVersion string, cfg *confi
 		overrideConfig = string(cfgBytes)
 	}
 
-	rawCfg, cfgVersion, err = config.Load(overrideConfig)
+	rawCfg, cfgVersion, err = config.Load(overrideConfig, rootOpts.StrictConfigParse)
 	if err != nil {
 		err = fmt.Errorf("error loading config: %w", err)
 		return

--- a/install/installer/cmd/root.go
+++ b/install/installer/cmd/root.go
@@ -23,11 +23,13 @@ func Execute() {
 }
 
 var rootOpts struct {
-	VersionMF string
+	VersionMF         string
+	StrictConfigParse bool
 }
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&rootOpts.VersionMF, "debug-version-file", "", "path to a version manifest - not intended for production use")
+	rootCmd.PersistentFlags().BoolVar(&rootOpts.StrictConfigParse, "strict-parse", true, "toggle strict configuration parsing")
 }
 
 type kubeConfig struct {

--- a/install/installer/pkg/config/loader.go
+++ b/install/installer/pkg/config/loader.go
@@ -76,7 +76,7 @@ func LoadConfigVersion(version string) (ConfigVersion, error) {
 // Load takes a config string and overrides that onto the default
 // config for that version (passed in the config). If no config version
 // is passed, It overrides it onto the default CurrentVersion of the binary
-func Load(overrideConfig string) (cfg interface{}, version string, err error) {
+func Load(overrideConfig string, strict bool) (cfg interface{}, version string, err error) {
 	var overrideVS struct {
 		APIVersion string `json:"apiVersion"`
 	}
@@ -110,7 +110,11 @@ func Load(overrideConfig string) (cfg interface{}, version string, err error) {
 	overrideConfig = apiVersionRegexp.ReplaceAllString(overrideConfig, "")
 
 	// Override passed configuration onto the default
-	err = yaml.UnmarshalStrict([]byte(overrideConfig), cfg)
+	if strict {
+		err = yaml.UnmarshalStrict([]byte(overrideConfig), cfg)
+	} else {
+		err = yaml.Unmarshal([]byte(overrideConfig), cfg)
+	}
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To make it possible to run config validation in non-strict mode. [Internal context](https://gitpod.slack.com/archives/C032A46PWR0/p1653896011997109).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```bash
$ cd installer/install
$ go run main.go init > config.yaml

# set domain
$ yq w -i config.yaml '.domain = "foo.bar"' 

$ echo "foo: bar" >> config.yaml

$ go run main.go validate config --config ./config.yaml
# expected failure, the current and default behaviour
go run main.go validate config --config ./config.yaml
Error: error loading config: error unmarshaling JSON: while decoding JSON: json: unknown field "foo"

$  go run main.go validate config --config ./config.yaml --strict-parse=false 
{
  "valid": true
}

```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Command line flag to configure strict config parsing
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE