### PR TITLE
Use slices instead of maps for service ports to control ordering

### DIFF
--- a/install/installer/pkg/common/objects.go
+++ b/install/installer/pkg/common/objects.go
@@ -40,17 +40,18 @@ func DefaultServiceAccount(component string) RenderFunc {
 }
 
 type ServicePort struct {
+	Name          string
 	ContainerPort int32
 	ServicePort   int32
 }
 
-func GenerateService(component string, ports map[string]ServicePort, mod ...func(spec *corev1.Service)) RenderFunc {
+func GenerateService(component string, ports []ServicePort, mod ...func(spec *corev1.Service)) RenderFunc {
 	return func(cfg *RenderContext) ([]runtime.Object, error) {
 		var servicePorts []corev1.ServicePort
-		for name, port := range ports {
+		for _, port := range ports {
 			servicePorts = append(servicePorts, corev1.ServicePort{
 				Protocol:   *TCPProtocol,
-				Name:       name,
+				Name:       port.Name,
 				Port:       port.ServicePort,
 				TargetPort: intstr.IntOrString{IntVal: port.ContainerPort},
 			})

--- a/install/installer/pkg/components/blobserve/objects.go
+++ b/install/installer/pkg/components/blobserve/objects.go
@@ -11,8 +11,9 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		ServicePortName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          ServicePortName,
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},

--- a/install/installer/pkg/components/content-service/objects.go
+++ b/install/installer/pkg/components/content-service/objects.go
@@ -11,12 +11,14 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		RPCServiceName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          RPCServiceName,
 			ContainerPort: RPCPort,
 			ServicePort:   RPCPort,
 		},
-		PrometheusName: {
+		{
+			Name:          PrometheusName,
 			ContainerPort: PrometheusPort,
 			ServicePort:   PrometheusPort,
 		},

--- a/install/installer/pkg/components/dashboard/objects.go
+++ b/install/installer/pkg/components/dashboard/objects.go
@@ -10,8 +10,9 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		PortName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          PortName,
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},

--- a/install/installer/pkg/components/database/cloudsql/objects.go
+++ b/install/installer/pkg/components/database/cloudsql/objects.go
@@ -14,8 +14,9 @@ var Objects = common.CompositeRenderFunc(
 	dbinit.Objects,
 	rolebinding,
 	common.DefaultServiceAccount(Component),
-	common.GenerateService(Component, map[string]common.ServicePort{
-		Component: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          Component,
 			ContainerPort: Port,
 			ServicePort:   Port,
 		},

--- a/install/installer/pkg/components/ide-proxy/service.go
+++ b/install/installer/pkg/components/ide-proxy/service.go
@@ -21,8 +21,9 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
-	ports := map[string]common.ServicePort{
-		PortName: {
+	ports := []common.ServicePort{
+		{
+			Name:          PortName,
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},

--- a/install/installer/pkg/components/image-builder-mk3/objects.go
+++ b/install/installer/pkg/components/image-builder-mk3/objects.go
@@ -12,8 +12,9 @@ var Objects = common.CompositeRenderFunc(
 	deployment,
 	networkpolicy,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		RPCPortName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          RPCPortName,
 			ContainerPort: RPCPort,
 			ServicePort:   RPCPort,
 		},

--- a/install/installer/pkg/components/openvsx-proxy/service.go
+++ b/install/installer/pkg/components/openvsx-proxy/service.go
@@ -21,12 +21,14 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
-	ports := map[string]common.ServicePort{
-		PortName: {
+	ports := []common.ServicePort{
+		{
+			Name:          PortName,
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},
-		PrometheusPortName: {
+		{
+			Name:          PrometheusPortName,
 			ContainerPort: PrometheusPort,
 			ServicePort:   PrometheusPort,
 		},

--- a/install/installer/pkg/components/proxy/service.go
+++ b/install/installer/pkg/components/proxy/service.go
@@ -31,25 +31,29 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
-	ports := map[string]common.ServicePort{
-		ContainerHTTPName: {
+	ports := []common.ServicePort{
+		{
+			Name:          ContainerHTTPName,
 			ContainerPort: ContainerHTTPPort,
 			ServicePort:   ContainerHTTPPort,
 		},
-		ContainerHTTPSName: {
+		{
+			Name:          ContainerHTTPSName,
 			ContainerPort: ContainerHTTPSPort,
 			ServicePort:   ContainerHTTPSPort,
 		},
-		MetricsContainerName: {
+		{
+			Name:          MetricsContainerName,
 			ContainerPort: PrometheusPort,
 			ServicePort:   PrometheusPort,
 		},
 	}
 	if ctx.Config.SSHGatewayHostKey != nil {
-		ports[ContainerSSHName] = common.ServicePort{
+		ports = append(ports, common.ServicePort{
+			Name:          ContainerSSHName,
 			ContainerPort: ContainerSSHPort,
 			ServicePort:   ContainerSSHPort,
-		}
+		})
 	}
 
 	return common.GenerateService(Component, ports, func(service *corev1.Service) {

--- a/install/installer/pkg/components/public-api-server/service.go
+++ b/install/installer/pkg/components/public-api-server/service.go
@@ -9,8 +9,9 @@ import (
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return common.GenerateService(Component, map[string]common.ServicePort{
-		GRPCPortName: {
+	return common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          GRPCPortName,
 			ContainerPort: GRPCContainerPort,
 			ServicePort:   GRPCServicePort,
 		},

--- a/install/installer/pkg/components/registry-facade/objects.go
+++ b/install/installer/pkg/components/registry-facade/objects.go
@@ -16,8 +16,9 @@ var Objects = common.CompositeRenderFunc(
 	podsecuritypolicy,
 	rolebinding,
 	certificate,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		ContainerPortName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          ContainerPortName,
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},

--- a/install/installer/pkg/components/server/objects.go
+++ b/install/installer/pkg/components/server/objects.go
@@ -16,24 +16,29 @@ var Objects = common.CompositeRenderFunc(
 	networkpolicy,
 	role,
 	rolebinding,
-	common.GenerateService(Component, map[string]common.ServicePort{
-		ContainerPortName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          ContainerPortName,
 			ContainerPort: ContainerPort,
 			ServicePort:   ServicePort,
 		},
-		PrometheusPortName: {
+		{
+			Name:          PrometheusPortName,
 			ContainerPort: PrometheusPort,
 			ServicePort:   PrometheusPort,
 		},
-		InstallationAdminName: {
+		{
+			Name:          InstallationAdminName,
 			ContainerPort: InstallationAdminPort,
 			ServicePort:   InstallationAdminPort,
 		},
-		DebugPortName: {
+		{
+			Name:          DebugPortName,
 			ContainerPort: common.DebugPort,
 			ServicePort:   common.DebugPort,
 		},
-		DebugNodePortName: {
+		{
+			Name:          DebugNodePortName,
 			ContainerPort: common.DebugNodePort,
 			ServicePort:   common.DebugNodePort,
 		},

--- a/install/installer/pkg/components/ws-manager/objects.go
+++ b/install/installer/pkg/components/ws-manager/objects.go
@@ -15,8 +15,9 @@ var Objects = common.CompositeRenderFunc(
 	role,
 	rolebinding,
 	common.DefaultServiceAccount(Component),
-	common.GenerateService(Component, map[string]common.ServicePort{
-		RPCPortName: {
+	common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          RPCPortName,
 			ContainerPort: RPCPort,
 			ServicePort:   RPCPort,
 		},

--- a/install/installer/pkg/components/ws-proxy/objects.go
+++ b/install/installer/pkg/components/ws-proxy/objects.go
@@ -18,20 +18,24 @@ var Objects = common.CompositeRenderFunc(
 	rolebinding,
 	role,
 	func(cfg *common.RenderContext) ([]runtime.Object, error) {
-		ports := map[string]common.ServicePort{
-			HTTPProxyPortName: {
+		ports := []common.ServicePort{
+			{
+				Name:          HTTPProxyPortName,
 				ContainerPort: HTTPProxyPort,
 				ServicePort:   HTTPProxyPort,
 			},
-			HTTPSProxyPortName: {
+			{
+				Name:          HTTPSProxyPortName,
 				ContainerPort: HTTPSProxyPort,
 				ServicePort:   HTTPSProxyPort,
 			},
-			MetricsPortName: {
+			{
+				Name:          MetricsPortName,
 				ContainerPort: MetricsPort,
 				ServicePort:   MetricsPort,
 			},
-			SSHPortName: {
+			{
+				Name:          SSHPortName,
 				ContainerPort: SSHTargetPort,
 				ServicePort:   SSHServicePort,
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This changes the structure from `map[string]ServicePort` to `[]ServicePort` and then extends the `ServicePort` struct with a `Name`. This ensure that the ordering of ports is stable and that we have full control over the ordering.

We need to be able to control the ordering as the order of ports need to match how Kubernetes will order to ports to avoid creating constant "out of sync" applications in ArgoCD ([see internal ticket](https://github.com/gitpod-io/ops/issues/2472) for specific use-case).

This PR doesn't change the ordering yet. Once this is merged and applied in staging I will go over the resulting ArgoCD diff drift and open a new PR that fixes the ordering.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/2472

## How to test
<!-- Provide steps to test this PR -->

I used the Gitpod Installer from this branch on a branch in gitpod-io/ops and verified that the ArgoCD diff produced a valid diff (e.g. that I didn't somehow break the manifests generated by the Installer).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A