### PR TITLE
[registry-facade] Return content directly from IPFS

### DIFF
--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -18,6 +18,8 @@ import (
 	"github.com/containerd/containerd/remotes"
 	distv2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/gorilla/handlers"
+	files "github.com/ipfs/go-ipfs-files"
+	icorepath "github.com/ipfs/interface-go-ipfs-core/path"
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opentracing/opentracing-go"
@@ -120,6 +122,11 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var srcs []BlobSource
+
+		if bh.IPFS != nil {
+			srcs = append(srcs, ipfsBlobSource{source: bh.IPFS})
+		}
+
 		srcs = append(srcs, storeBlobSource{Store: bh.Store})
 		srcs = append(srcs, proxyingBlobSource{Fetcher: fetcher, Blobs: manifest.Layers})
 		srcs = append(srcs, &configBlobSource{Fetcher: fetcher, Spec: bh.Spec, Manifest: manifest, ConfigModifier: bh.ConfigModifier})
@@ -127,10 +134,10 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 
 		var src BlobSource
 		for _, s := range srcs {
-			if !s.HasBlob(ctx, bh.Spec, bh.Digest) {
-				continue
+			if s.HasBlob(ctx, bh.Spec, bh.Digest) {
+				src = s
+				break
 			}
-			src = s
 		}
 		if src == nil {
 			return distv2.ErrorCodeBlobUnknown
@@ -143,6 +150,7 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 		if rc != nil {
 			defer rc.Close()
 		}
+
 		if url != "" {
 			http.Redirect(w, r, url, http.StatusPermanentRedirect)
 			return nil
@@ -164,6 +172,12 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 
 		bh.Metrics.BlobDownloadSpeedHist.Observe(float64(n) / time.Since(t0).Seconds())
 
+		// we are returning a file from IPFS.
+		if _, ok := src.(ipfsBlobSource); ok {
+			log.WithField("digest", bh.Digest).Debug("skipping update of blob that already exists in IPFS")
+			return nil
+		}
+
 		go func() {
 			// we can do this only after the io.Copy above. Otherwise we might expect the blob
 			// to be in the blobstore when in reality it isn't.
@@ -176,7 +190,7 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 				log.WithField("digest", bh.Digest).Warn("cannot push to IPFS - blob is nil")
 				return
 			}
-			err = bh.IPFS.Store(context.Background(), bh.Digest, rc)
+			err = bh.IPFS.Store(context.Background(), bh.Digest, rc, mediaType)
 			if err != nil {
 				log.WithError(err).WithField("digest", bh.Digest).Warn("cannot push to IPFS")
 			}
@@ -333,4 +347,56 @@ func (pbs *configBlobSource) getConfig(ctx context.Context) (rawCfg []byte, err 
 
 	rawCfg, err = json.Marshal(cfg)
 	return
+}
+
+type ipfsBlobSource struct {
+	source *IPFSBlobCache
+}
+
+func (sbs ipfsBlobSource) HasBlob(ctx context.Context, spec *api.ImageSpec, dgst digest.Digest) bool {
+	_, err := sbs.source.Redis.Get(ctx, dgst.String()).Result()
+	return err == nil
+}
+
+func (sbs ipfsBlobSource) GetBlob(ctx context.Context, spec *api.ImageSpec, dgst digest.Digest) (mediaType string, url string, data io.ReadCloser, err error) {
+	log := log.WithField("digest", dgst)
+
+	var ipfsCID string
+	ipfsCID, err = sbs.source.Redis.Get(ctx, dgst.String()).Result()
+	if err != nil {
+		log.WithError(err).Error("unable to get blob details from Redis")
+		err = distv2.ErrorCodeBlobUnknown
+		return
+	}
+
+	ipfsFile, err := sbs.source.IPFS.Unixfs().Get(ctx, icorepath.New(ipfsCID))
+	if err != nil {
+		log.WithError(err).Error("unable to get blob from IPFS")
+		err = distv2.ErrorCodeBlobUnknown
+		return
+	}
+
+	f, ok := ipfsFile.(interface {
+		files.File
+		io.ReaderAt
+	})
+	if !ok {
+		log.WithError(err).Error("IPFS file does not support io.ReaderAt")
+		err = distv2.ErrorCodeBlobUnknown
+		return
+	}
+
+	mediaType, err = sbs.source.Redis.Get(ctx, mediaTypeKeyFromDigest(dgst)).Result()
+	if err != nil {
+		log.WithError(err).Error("cannot get media type from Redis")
+		err = distv2.ErrorCodeBlobUnknown
+		return
+	}
+
+	log.Debug("returning blob from IPFS")
+	return mediaType, "", f, nil
+}
+
+func mediaTypeKeyFromDigest(dgst digest.Digest) string {
+	return "mtype:" + dgst.String()
 }

--- a/components/registry-facade/pkg/registry/cache.go
+++ b/components/registry-facade/pkg/registry/cache.go
@@ -74,7 +74,7 @@ func (store *IPFSBlobCache) Get(ctx context.Context, dgst digest.Digest) (ipfsUR
 }
 
 // Store stores a blob in IPFS. Will happily overwrite/re-upload a blob.
-func (store *IPFSBlobCache) Store(ctx context.Context, dgst digest.Digest, content io.Reader) (err error) {
+func (store *IPFSBlobCache) Store(ctx context.Context, dgst digest.Digest, content io.Reader, mediaType string) (err error) {
 	if store == nil || store.IPFS == nil || store.Redis == nil {
 		return nil
 	}
@@ -91,7 +91,10 @@ func (store *IPFSBlobCache) Store(ctx context.Context, dgst digest.Digest, conte
 		return err
 	}
 
-	res := store.Redis.Set(ctx, dgst.String(), p.Cid().String(), 0)
+	res := store.Redis.MSet(ctx,
+		dgst.String(), p.Cid().String(),
+		mediaTypeKeyFromDigest(dgst), mediaType,
+	)
 	if err := res.Err(); err != nil {
 		return err
 	}

--- a/components/registry-facade/pkg/registry/manifest.go
+++ b/components/registry-facade/pkg/registry/manifest.go
@@ -52,13 +52,12 @@ func (reg *Registry) handleManifest(ctx context.Context, r *http.Request) http.H
 	}
 
 	manifestHandler := &manifestHandler{
-		Context:          ctx,
-		Name:             name,
-		Spec:             spec,
-		Resolver:         reg.Resolver(),
-		Store:            reg.Store,
-		ConfigModifier:   reg.ConfigModifier,
-		ManifestModifier: reg.ipfsManifestModifier,
+		Context:        ctx,
+		Name:           name,
+		Spec:           spec,
+		Resolver:       reg.Resolver(),
+		Store:          reg.Store,
+		ConfigModifier: reg.ConfigModifier,
 	}
 	reference := getReference(ctx)
 	dgst, err := digest.Parse(reference)
@@ -87,11 +86,10 @@ func (reg *Registry) handleManifest(ctx context.Context, r *http.Request) http.H
 type manifestHandler struct {
 	Context context.Context
 
-	Spec             *api.ImageSpec
-	Resolver         remotes.Resolver
-	Store            BlobStore
-	ConfigModifier   ConfigModifier
-	ManifestModifier func(*ociv1.Manifest) error
+	Spec           *api.ImageSpec
+	Resolver       remotes.Resolver
+	Store          BlobStore
+	ConfigModifier ConfigModifier
 
 	Name   string
 	Tag    string
@@ -209,14 +207,6 @@ func (mh *manifestHandler) getManifest(w http.ResponseWriter, r *http.Request) {
 				err = w.Commit(ctx, 0, cfgDgst, content.WithLabels(contentTypeLabel(manifest.Config.MediaType)))
 				if err != nil {
 					log.WithError(err).WithFields(logFields).Warn("cannot commit config to store - we'll regenerate it on demand")
-				}
-			}
-
-			// We might have additional modifications, e.g. adding IPFS URLs to the layers
-			if mh.ManifestModifier != nil {
-				err = mh.ManifestModifier(manifest)
-				if err != nil {
-					log.WithError(err).WithFields(logFields).Warn("cannot modify manifest")
 				}
 			}
 

--- a/components/registry-facade/pkg/registry/mock/layersource_mock.go
+++ b/components/registry-facade/pkg/registry/mock/layersource_mock.go
@@ -58,14 +58,15 @@ func (mr *MockLayerSourceMockRecorder) Envs(arg0, arg1 interface{}) *gomock.Call
 }
 
 // GetBlob mocks base method.
-func (m *MockLayerSource) GetBlob(arg0 context.Context, arg1 *api.ImageSpec, arg2 digest.Digest) (string, string, io.ReadCloser, error) {
+func (m *MockLayerSource) GetBlob(arg0 context.Context, arg1 *api.ImageSpec, arg2 digest.Digest) (bool, string, string, io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlob", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(io.ReadCloser)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[0].(string)
+	ret2, _ := ret[1].(string)
+	ret3, _ := ret[2].(io.ReadCloser)
+	ret4, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // GetBlob indicates an expected call of GetBlob.


### PR DESCRIPTION
## Description

Add a new `BlobSource` for IPFS and additional check to avoid pushing the content multiple times.

## How to test

1. Start a workspace-preview and ssh to the VM
2. Start IPFS

```
/usr/local/bin/ipfs-bootstrap.sh
kubectl apply -f /var/lib/gitpod/manifests/ipfs.yaml 
```

3. Start Redis

```
REDIS_PASSWORD="$(openssl rand -hex 15)"
kubectl create secret generic redis-credentials --namespace=default --from-literal=password=$REDIS_PASSWORD --dry-run=client -o yaml | kubectl replace --force -f -
kubectl create secret generic redis-credentials --namespace=storage --from-literal=password=$REDIS_PASSWORD --dry-run=client -o yaml | kubectl replace --force -f -

kubectl apply -f /var/lib/gitpod/manifests/redis.yaml 
```

4. Update registry-facade configuration

- Update configmap 
```
        "ipfs": {
          "enabled": true,
          "ipfsAddr": "/dns4/ipfs.storage/tcp/9095"
        },
        "redis": {
          "enabled": true,
          "masterName": "kumquat",
          "sentinelAddrs": [
            "redis-node-0.redis-headless.storage.svc.cluster.local:26379",
            "redis-node-1.redis-headless.storage.svc.cluster.local:26379",
            "redis-node-2.redis-headless.storage.svc.cluster.local:26379"
          ],
          "username": "default"
        }
```

- Update daemonset env section adding
```
        - name: REDIS_PASSWORD
          valueFrom:
            secretKeyRef:
              key: password
              name: redis-credentials
```

And also increase the log level of registry-facade to debug.

5. Open a workspace
6. Open a new one and check the `registry-facade` logs. You should see at least one output of `returning blob from IPFS`
7. Use `nerdct -n k8s.io rmi` to remove all the images from the node with the expression `reg.*`
8. Open a workspace and check registry-facade logs

```

{"digest":"sha256:a26c43a8eeef4519ed33009190c2260b087bded92ed32e6e9276f525af33249f","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:21Z"}
{"digest":"sha256:58e3bf159343ec746b4186eef70d1c176f5970cb7fd8c2997832bc34afbfcdf4","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:21Z"}
{"digest":"sha256:bcb5b0afab2893e0c1885b29825f17ee1c1aed370d7f73e12f5fae1fe6b2a692","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:21Z"}
{"digest":"sha256:a51c3556612d1feeddcea584c608282a4365788957e8ca313d8a0aa0fbb08db1","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:21Z"}
{"digest":"sha256:0e39234fb8b7b9e4e441fc69a967c6e3bf52ee26ffc5e010121b969d82914cdb","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:21Z"}
{"digest":"sha256:32760d83355a9b7eb86677f9d0ae12b3f837c4822f1e46c392ef01f811e299ba","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:21Z"}
{"digest":"sha256:37f21cd47fec9b193e2a19f7529bbfcafc153dbfcfc5a4172057e4d65f551a97","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:22Z"}
{"digest":"sha256:fb39e626ef3b6d37b6b45495798e1e0f48664d42aac59903cb99a612c33b6157","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:22Z"}
{"digest":"sha256:649bbb6544500aa169744e911995eec56cb635a430320ef0964bd0bd32bc5756","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:22Z"}
{"digest":"sha256:66c94af97eb5233a8e332e6bebbfbecb62a38023e29eadddf8564915760efdd0","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:22Z"}
{"digest":"sha256:d00b9ca7bcc18a52536304e0d28e65749bfe36c7b4d82687c5242b377ff63078","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:22Z"}
{"digest":"sha256:6616d0fdd6dd05b2515b5c83800740fd633a514238fe7caa3f7eeda7f89ad988","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:22Z"}
{"digest":"sha256:09b29758555d877dd38fa3f46e38f937ac6c233f7f6de432fcca01eb61a17fb8","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:23Z"}
{"digest":"sha256:8b03b0e893c0e42f014f67a20020c133704bbe6ec6bc9f0e710d496e95eb6b8c","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:23Z"}
{"digest":"sha256:f2881b961cb14f4fd700d36e1a3c45e62fb089f11c47e92268710eb8cf92bfea","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:23Z"}
{"digest":"sha256:ea8e07a0b42357c838ce762b3799264fc8174efd67edff04f16f35106cf96c5a","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:23Z"}
{"digest":"sha256:643504072b7bf42d8a4ab318b4773c52697253f1b2030d12d62dd91a9aa4a9b7","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:24Z"}
{"digest":"sha256:bea988a348bcd30eab4436feaf3c79546f917214d9d4d29ab4e2d0cc173449c5","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:24Z"}
{"digest":"sha256:6cde8dbf4b18efaa0b014f3ee3fa2da6a45c5057cf30e34f651154a03497a34e","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:24Z"}
{"digest":"sha256:9c8d3cca9ddbecf0a3a246b0d881ac725d25c2f555c67361798f4aecb16c5e41","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:24Z"}
{"digest":"sha256:7e0a9148f7cce20a4e3d4c3e15021c222a0c5fed25a7e9452a0273482c6e8cf1","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:25Z"}
{"digest":"sha256:34602ca6b925d580a71c504224d2210f57e60455c630826046b638b6faeabbf4","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:26Z"}
{"digest":"sha256:601c703a153f0ad2b0285680b74cba31e8247f83137851a798e4ae5d4fde60d5","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:28Z"}
{"digest":"sha256:0e80040487d213461736711d2c287bc9a8c6521bf916a756a247125266c86250","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:28Z"}
{"digest":"sha256:5b246ac5e7946f3a1eb709745bd3e5e8145ab8dd79198fccf726bd681ae35752","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:28Z"}
{"digest":"sha256:57dcd2d72a038379cf9fcbea353e97dab603591d6aa91ea4757622af8a6f7029","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:28Z"}
{"digest":"sha256:7be34259e75c2a9b638bdd6f8fd0611e0e369e6287843db7f3b746518a4b89b4","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:28Z"}
{"digest":"sha256:195eeaffe447ab9d8b93d5c1a97d04a80020d1d353b64cf32abd83d860571759","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:28Z"}
{"digest":"sha256:d7454e08af22289ea366fd5eae9bae42b9fb93a0199e341f5ab616221dad62a9","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:30Z"}
{"digest":"sha256:8ffd2587e948d948534bfbc4373be4758c32e9f511e20242396f8b3a1dcae7ed","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:30Z"}
{"digest":"sha256:7fde2d3ca2de27d1a0059198e2c4852ace1ea2c875af0429547bdc82a8c76e74","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:30Z"}
{"digest":"sha256:ee04b7c44edaf05d4d13798739372c9d5d253c9dcdf08acc4eb28e7e610d5bd5","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:30Z"}
{"digest":"sha256:0f16004ed0edb34e41abb7b4d5b854f336b9cd0d04f3294e0c88b89957752655","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:30Z"}
{"digest":"sha256:843ca1e3a25475535e6f68f31190c074794bd7c912da8b7b5039ab1f562cdcd3","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:30Z"}
{"digest":"sha256:6bce0256173681c4935cb799ea77525b1cf02ba15b351c0b8d9e856ed5161f3f","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:31Z"}
{"digest":"sha256:27e2529000263e69866f484188c1eeaa7785d349321a4eb731fad9b06064d584","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:31Z"}
{"digest":"sha256:9fbde7203865e6c6ef14d3c8455a0e2db15c70b54d4378c3db05ad9c97d092ed","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:31Z"}
{"digest":"sha256:4776a26e5f73443bd6639d6c9ed2e9ef784f8f7e8916cd02b819dad97c0ae56a","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:31Z"}
{"digest":"sha256:142088eafd1e76260e80cf9b0f40aac85b36825b5f2cb7fb0b91bb53585cb509","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:31Z"}
{"digest":"sha256:d11fd99b47b2e5ed025ef2cd75eea324c120736b44ffb5f68622374795fbfe09","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:31Z"}
{"digest":"sha256:309e6f5c4666215b3824f7c6afd7d84605127284832554263f8d23ac14b9c63d","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:32Z"}
{"digest":"sha256:671e257a317015e471f9e781f9c137e15a7f5e764c14c0ae0a3a9bb3f0e49c84","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:32Z"}
{"digest":"sha256:a51e175eeb077dd4606583443b069df6f2366441235597ca3fe7be8490e9fd4a","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:32Z"}
{"digest":"sha256:60a737dcaa7edd85315ead0480e32e98ce303987821d29ce60f04f60a0fc6abb","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:32Z"}
{"digest":"sha256:93c43255c7bddbf73323488f2ea34ef8d5318a22447496179eb9d5ac62227490","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:32Z"}
{"digest":"sha256:72a9f0f14197055018d6d7549012b19170b6c6d66844d54998733d10b10ef967","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:32Z"}
{"digest":"sha256:604e677dfdc185ed4fb38bfe6434a64185d95b7a5c95858ae0d03ea56a1d124b","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:33Z"}
{"digest":"sha256:93260ee05d1c596fe33d3a6f67b09d07899a1f52e1d0ba597fe1b07fe8a7138b","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:33Z"}
{"digest":"sha256:208dc8540c844a0081e106153606c47dabb51dc186937bd400ef7cc5e4611352","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
{"digest":"sha256:78fd7691c4b411311163df0a776e2254637c97b4813abf926362cee56053804b","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
{"digest":"sha256:5852c2300406827c6784669f8104244ba62869d599219193d9caf36ceb1835b6","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
{"digest":"sha256:4d87935a36307cd12e5d501158933ef716683f88fbab6f3e3e2d38b96fe890f4","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
{"digest":"sha256:e38264f43e0e09f3f50942b6769743c37ea1b3231812b034244c8ad1dd2179ab","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
{"digest":"sha256:34744723adbabe538c708c14cc03cba110100a97862d83c8e9f64235bc3332d3","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
{"digest":"sha256:b7b3f71619c7523ca4a37c4e753d24618cc7e4049e936f57c40bc10c0a7090f4","level":"debug","message":"returning blob from IPFS","serviceContext":{"service":"registry-facade","version":"commit-b5a4797cc07d773cba33915f471145dc4bb963db"},"severity":"DEBUG","time":"2022-05-31T08:13:35Z"}
```` 

```
0s          Normal    Pulled                    pod/ws-c5bf7512-8906-4a3b-bc4b-d1516d0bdde6                        Successfully pulled image "reg.g5826d3b02a5c604998e580.workspace-preview.gitpod-io-dev.com:20000/remote/c5bf7512-8906-4a3b-bc4b-d1516d0bdde6" in 1m20.642414654s
```




## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[registry-facade] Return content directly from IPFS
```
