### PR TITLE
[server] Don't skip prebuilds if .gitpod.yml has a 'before' task but no 'init' task

### DIFF
--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -77,9 +77,14 @@ export class GitHubEnterpriseApp {
     ): Promise<User> {
         const span = TraceContext.startSpan("GitHubEnterpriseApp.findUser", ctx);
         try {
-            const host = req.header("X-Github-Enterprise-Host");
+            let host = req.header("X-Github-Enterprise-Host");
+            if (!host) {
+                // If the GitHub installation doesn't identify itself, we fall back to the hostname from the repository URL.
+                const repoUrl = new URL(payload.repository.url);
+                host = repoUrl.hostname;
+            }
             const hostContext = this.hostContextProvider.get(host || "");
-            if (!host || !hostContext) {
+            if (!hostContext) {
                 throw new Error("Unsupported GitHub Enterprise host: " + host);
             }
             const { authProviderId } = hostContext.authProvider;

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -257,7 +257,7 @@ export class PrebuildManager {
             return false;
         }
 
-        const hasPrebuildTask = !!config.tasks && config.tasks.find((t) => !!t.init || !!t.prebuild);
+        const hasPrebuildTask = !!config.tasks && config.tasks.find((t) => !!t.before || !!t.init || !!t.prebuild);
         if (!hasPrebuildTask) {
             return false;
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Don't skip prebuilds if .gitpod.yml has a `before` task but no `init` task.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10336

Drive-by fix:
- [x] When GitHub (Enterprise) sends webhooks without a host header, fall back to the hostname from the repository URL (fixes `Unsupported GitHub Enterprise host: undefined` error preventing prebuild trigger with webhooks from `github.com` and various GitHub Enterprise versions)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix: Don't skip prebuilds if .gitpod.yml has a 'before' task but no 'init' task
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
