### PR TITLE
[kots]: correctly escape params in installation configmap

### DIFF
--- a/install/kots/manifests/gitpod-installation.yaml
+++ b/install/kots/manifests/gitpod-installation.yaml
@@ -10,9 +10,9 @@ metadata:
     app: gitpod
     component: gitpod-installer
 data:
-  channelName: '{{repl ChannelName }}'
-  cursor: '{{repl Cursor }}'
-  isAirgap: '{{repl IsAirgap }}'
-  releaseNotes: '{{repl ReleaseNotes }}'
-  sequence: '{{repl Sequence }}'
-  version: '{{repl VersionLabel }}'
+  channelName: repl{{ ChannelName | quote }}
+  cursor: repl{{ Cursor | quote }}
+  isAirgap: repl{{ IsAirgap | quote }}
+  releaseNotes: repl{{ ReleaseNotes | quote }}
+  sequence: repl{{ Sequence | quote }}
+  version: repl{{ VersionLabel | quote }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Values in the `gitpod-installation` config map are incorrectly escaped. If a `'` was introduced into the release notes, this would cause the YAML to become invalid.

The escaping of these values has been amended to be applied correctly, and added the use of the `| quote` pipe (which works identically to Helm).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10348

## How to test
<!-- Provide steps to test this PR -->
Run the command:

```
replicated release create \
  --lint \
  --ensure-channel \
  --yaml-dir ./install/kots \
  --promote ${REPLICATED_DEV_CHANNEL} \
  --release-notes "some release's \" note" \
  --version="$(date +%s)"
```

This will push a new release to your dev channel. This will allow you to run "check for updates" in the KOTS dashboard and then you'll see beautifully escaped YAML when you "view files"

![image](https://user-images.githubusercontent.com/275848/171018193-16a471a9-6d23-4e3f-a42d-0c3e6b12f1a4.png) 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: correctly escape params in installation configmap
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
