### PR TITLE
Fix hanging "Prebuild in Progress" page

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -461,9 +461,9 @@ interface RunningPrebuildViewProps {
 }
 
 function RunningPrebuildView(props: RunningPrebuildViewProps) {
-    const logsEmitter = new EventEmitter();
-    let pollTimeout: NodeJS.Timeout | undefined;
-    let prebuildDoneTriggered: boolean = false;
+    const [logsEmitter] = useState(new EventEmitter());
+    const [pollTimeout, setPollTimeout] = useState<NodeJS.Timeout | undefined>();
+    const [prebuildDoneTriggered, setPrebuildDoneTriggered] = useState<boolean>(false);
 
     useEffect(() => {
         const checkIsPrebuildDone = async (): Promise<boolean> => {
@@ -476,7 +476,7 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
             if (done) {
                 // note: this treats "done" as "available" which is not equivalent.
                 // This works because the backend ignores prebuilds which are not "available", and happily starts a workspace as if there was no prebuild at all.
-                prebuildDoneTriggered = true;
+                setPrebuildDoneTriggered(true);
                 props.onPrebuildSucceeded();
                 return true;
             }
@@ -485,7 +485,7 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
         const pollIsPrebuildDone = async () => {
             clearTimeout(pollTimeout!);
             await checkIsPrebuildDone();
-            pollTimeout = setTimeout(pollIsPrebuildDone, 10000);
+            setPollTimeout(setTimeout(pollIsPrebuildDone, 10000));
         };
 
         const disposables = watchHeadlessLogs(

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -131,7 +131,13 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
 
         try {
-            this.toDispose.push(getGitpodService().registerClient(this));
+            this.toDispose.push(
+                getGitpodService().registerClient({
+                    notifyDidOpenConnection: () => this.fetchWorkspaceInfo(undefined),
+                    onInstanceUpdate: (workspaceInstance: WorkspaceInstance) =>
+                        this.onInstanceUpdate(workspaceInstance),
+                }),
+            );
         } catch (error) {
             console.error(error);
             this.setState({ error });
@@ -295,10 +301,6 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     protected async fetchIDEOptions() {
         const ideOptions = await getGitpodService().server.getIDEOptions();
         this.setState({ ideOptions });
-    }
-
-    notifyDidOpenConnection() {
-        this.fetchWorkspaceInfo(undefined);
     }
 
     async onInstanceUpdate(workspaceInstance: WorkspaceInstance) {

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -19,7 +19,7 @@ import { IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import EventEmitter from "events";
 import * as queryString from "query-string";
-import React, { Suspense, useEffect } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { v4 } from "uuid";
 import Arrow from "../components/Arrow";
 import ContextMenu from "../components/ContextMenu";
@@ -661,7 +661,7 @@ interface ImageBuildViewProps {
 }
 
 function ImageBuildView(props: ImageBuildViewProps) {
-    const logsEmitter = new EventEmitter();
+    const [logsEmitter] = useState(new EventEmitter());
 
     useEffect(() => {
         let registered = false;
@@ -669,11 +669,12 @@ function ImageBuildView(props: ImageBuildViewProps) {
             if (registered) {
                 return;
             }
+            registered = true;
 
             getGitpodService()
                 .server.watchWorkspaceImageBuildLogs(props.workspaceId)
-                .then(() => (registered = true))
                 .catch((err) => {
+                    registered = false;
                     if (err?.code === ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE) {
                         // wait, and then retry
                         setTimeout(watchBuild, 5000);
@@ -718,7 +719,7 @@ function ImageBuildView(props: ImageBuildViewProps) {
 }
 
 function HeadlessWorkspaceView(props: { instanceId: string }) {
-    const logsEmitter = new EventEmitter();
+    const [logsEmitter] = useState(new EventEmitter());
 
     useEffect(() => {
         const disposables = watchHeadlessLogs(

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -754,7 +754,9 @@ export interface PrebuiltWorkspace {
 
 export namespace PrebuiltWorkspace {
     export function isDone(pws: PrebuiltWorkspace) {
-        return pws.state === "available" || pws.state === "timeout" || pws.state === "aborted";
+        return (
+            pws.state === "available" || pws.state === "timeout" || pws.state === "aborted" || pws.state === "failed"
+        );
     }
 
     export function isAvailable(pws: PrebuiltWorkspace) {


### PR DESCRIPTION
This PR fixes an issue with the hanging "Prebuild in Progress" page.
This PR does not fix missing image builder logs from this very page.

### How to test
* clone https://gitlab.com/alex736/gitpod-large-image into your account
* create a project for it using the preview environment from this PR
* push a change which modifies a) the Dockerfile and/or b) the init script in the .gitpod.yml file
* quickly switch to the project's page and start a workspace when you see the prebuild being started
* now you should see the "Prebuild in Progress" page
* depending on the time "configured" in the Dockerfile of the repo (modification a) you should eventually see the transition to the following workspace creation pages

Fixes https://github.com/gitpod-io/gitpod/issues/8195 and more.

```release-notes
Fix hanging "Prebuild in Progress" page.
```