### PR TITLE
[db][payment][server] Implement TeamSubscription2.excludeFromMoreResources

### DIFF
--- a/components/ee/payment-endpoint/src/chargebee/team-subscription-handler.ts
+++ b/components/ee/payment-endpoint/src/chargebee/team-subscription-handler.ts
@@ -128,6 +128,7 @@ export class TeamSubscriptionHandler implements EventHandler<chargebee.Subscript
                     quantity: chargebeeSubscription.plan_quantity,
                     startDate: getStartDate(chargebeeSubscription),
                     endDate: chargebeeSubscription.cancelled_at ? getCancelledAt(chargebeeSubscription) : undefined,
+                    excludeFromMoreResources: true,
                 });
                 await db2.storeEntry(ts2);
                 await this.service2.addAllTeamMemberSubscriptions(ts2);

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -17,6 +17,7 @@ export interface TeamDB {
         searchTerm: string,
     ): Promise<{ total: number; rows: Team[] }>;
     findTeamById(teamId: string): Promise<Team | undefined>;
+    findTeamByMembershipId(membershipId: string): Promise<Team | undefined>;
     findMembersByTeam(teamId: string): Promise<TeamMemberInfo[]>;
     findTeamMembership(userId: string, teamId: string): Promise<DBTeamMembership | undefined>;
     findTeamsByUser(userId: string): Promise<Team[]>;

--- a/components/gitpod-db/src/typeorm/entity/db-team-subscription-2.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team-subscription-2.ts
@@ -46,6 +46,11 @@ export class DBTeamSubscription2 implements TeamSubscription2 {
     })
     cancellationDate?: string;
 
+    @Column({
+        default: true,
+    })
+    excludeFromMoreResources: boolean;
+
     // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;

--- a/components/gitpod-db/src/typeorm/migration/1653983151212-TS2MoreResources.ts
+++ b/components/gitpod-db/src/typeorm/migration/1653983151212-TS2MoreResources.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_team_subscription2";
+const COLUMN_NAME = "excludeFromMoreResources";
+
+export class TS2MoreResources1653983151212 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} tinyint(4) NOT NULL DEFAULT '1', ALGORITHM=INPLACE, LOCK=NONE `,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -64,6 +64,15 @@ export class TeamDBImpl implements TeamDB {
         return teamRepo.findOne({ id: teamId, deleted: false, markedDeleted: false });
     }
 
+    public async findTeamByMembershipId(membershipId: string): Promise<Team | undefined> {
+        const membershipRepo = await this.getMembershipRepo();
+        const membership = await membershipRepo.findOne({ id: membershipId, deleted: false });
+        if (!membership) {
+            return;
+        }
+        return this.findTeamById(membership.teamId);
+    }
+
     public async findMembersByTeam(teamId: string): Promise<TeamMemberInfo[]> {
         const membershipRepo = await this.getMembershipRepo();
         const userRepo = await this.getUserRepo();

--- a/components/gitpod-protocol/src/team-subscription-protocol.ts
+++ b/components/gitpod-protocol/src/team-subscription-protocol.ts
@@ -43,6 +43,7 @@ export interface TeamSubscription2 {
     /** The Chargebee subscription id */
     paymentReference: string;
     cancellationDate?: string;
+    excludeFromMoreResources: boolean;
 }
 
 export namespace TeamSubscription2 {

--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { inject, injectable } from "inversify";
-import { TeamSubscriptionDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { TeamDB, TeamSubscription2DB, TeamSubscriptionDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { TokenProvider } from "../../../src/user/token-provider";
 import {
     User,
@@ -50,11 +50,13 @@ export interface GitHubEducationPack {
 export class EligibilityService {
     @inject(Config) protected readonly config: Config;
     @inject(UserDB) protected readonly userDb: UserDB;
+    @inject(TeamDB) protected readonly teamDb: TeamDB;
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
     @inject(EMailDomainService) protected readonly domainService: EMailDomainService;
     @inject(TokenProvider) protected readonly tokenProvider: TokenProvider;
     @inject(AccountStatementProvider) protected readonly accountStatementProvider: AccountStatementProvider;
     @inject(TeamSubscriptionDB) protected readonly teamSubscriptionDb: TeamSubscriptionDB;
+    @inject(TeamSubscription2DB) protected readonly teamSubscription2Db: TeamSubscription2DB;
 
     /**
      * Whether the given user is recognized as a student within Gitpod
@@ -303,6 +305,17 @@ export class EligibilityService {
         // some TeamSubscriptions are marked with 'excludeFromMoreResources' to convey that those are _not_ receiving more resources
         const excludeFromMoreResources = await Promise.all(
             relevantSubscriptions.map(async (s): Promise<boolean> => {
+                if (s.teamMembershipId) {
+                    const team = await this.teamDb.findTeamByMembershipId(s.teamMembershipId);
+                    if (!team) {
+                        return true;
+                    }
+                    const ts2 = await this.teamSubscription2Db.findForTeam(team.id, new Date().toISOString());
+                    if (!ts2) {
+                        return true;
+                    }
+                    return ts2.excludeFromMoreResources;
+                }
                 if (!s.teamSubscriptionSlotId) {
                     return false;
                 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Align the new `TeamSubscription2` shape with legacy `TeamSubscription` by adding an equivalent `excludeFromMoreResources` DB flag.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2346

## How to test
<!-- Provide steps to test this PR -->

1. Create a Team
2. Go to Team Billing
3. Purchase a new Team Plan (either Professional or Unleashed) and wait for the plan to materialize successfully
4. Connect to the DB (e.g. by doing `./dev/preview/install-k3s-kubeconfig.sh` followed by `kubectl port-forward mysql-0 3306 &` and `mysql -h 127.0.0.1 -pjBzVMe2w4Yi7GagadsyB gitpod`)
5. Verify that `d_b_team_subscription2` has a `excludeFromMoreResources` column

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment