### PR TITLE
[usage] Add database-waiter

### DIFF
--- a/install/installer/pkg/components/usage/deployment.go
+++ b/install/installer/pkg/components/usage/deployment.go
@@ -46,6 +46,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						DNSPolicy:                     "ClusterFirst",
 						RestartPolicy:                 "Always",
 						TerminationGracePeriodSeconds: pointer.Int64(30),
+						InitContainers:                []corev1.Container{*common.DatabaseWaiterContainer(ctx)},
 						Containers: []corev1.Container{{
 							Name:  Component,
 							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Usage.Version),

--- a/install/installer/pkg/components/usage/objects_test.go
+++ b/install/installer/pkg/components/usage/objects_test.go
@@ -50,6 +50,9 @@ func renderContextWithUsageEnabled(t *testing.T) *common.RenderContext {
 			Usage: versions.Versioned{
 				Version: "commit-test-latest",
 			},
+			ServiceWaiter: versions.Versioned{
+				Version: "commit-test-latest",
+			},
 		},
 	}, "test-namespace")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds db-waiter to avoid crash-loop-backoff in preview envs when DB isn't ready.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
`usage` component starts in preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE