### PR TITLE
content-service: ignore the error of `user.overlay.(impure|origin)` attributes

### DIFF
--- a/components/content-service/pkg/archive/tar.go
+++ b/components/content-service/pkg/archive/tar.go
@@ -198,10 +198,7 @@ func remapFile(name string, uid, gid int, xattrs map[string]string) error {
 			if err == syscall.ENOTSUP || err == syscall.EPERM {
 				continue
 			}
-
-			log.WithField("name", key).WithField("value", value).WithField("file", name).WithError(err).Error("restoring extended attributes")
-
-			return err
+			log.WithField("name", key).WithField("value", value).WithField("file", name).WithError(err).Warn("restoring extended attributes")
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`user.overlay.(impure|origin)` attributes is a marker to match inodes for overlayfs, such as when an upper layer copies a lower layer file in overlayfs.
However, when restoring content, the container in the workspace is not always running, so there is no problem ignoring the failure.
https://github.com/hisilicon/overlayfs-progs/blob/e10ef686570d9c7eff42f52461593a5c15da56bd/README#L62

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10108

## How to test
<!-- Provide steps to test this PR -->

No errors including logs with the following steps

1. Open https://to-impure-dir.preview.gitpod-dev.com/#https://github.com/utam0k/gitpod-playground/tree/prebuild-docker
2. Stop the workspace when opening the workspace is completely
3. Reopen the workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
content-service: Ignore errors in attributes settings
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
