### PR TITLE
[ws-manager] Add workspace class to metrics

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -341,7 +341,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 		OwnerToken: startContext.OwnerToken,
 	}
 
-	m.metrics.OnWorkspaceStarted(req.Type)
+	m.metrics.OnWorkspaceStarted(req.Type, req.Spec.Class)
 
 	return okResponse, nil
 }

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -791,8 +791,9 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	} else {
 		err = handleGRPCError(ctx, err)
 	}
-	wsType := pod.Labels[wsk8s.TypeLabel]
-	hist, errHist := m.manager.metrics.initializeTimeHistVec.GetMetricWithLabelValues(wsType)
+	wsType := strings.ToUpper(pod.Labels[wsk8s.TypeLabel])
+	wsClass := pod.Labels[workspaceClassLabel]
+	hist, errHist := m.manager.metrics.initializeTimeHistVec.GetMetricWithLabelValues(wsType, wsClass)
 	if errHist != nil {
 		log.WithError(errHist).WithField("type", wsType).Warn("cannot get initialize time histogram metric")
 	} else {
@@ -1166,7 +1167,7 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 		break
 	}
 
-	hist, err := m.manager.metrics.finalizeTimeHistVec.GetMetricWithLabelValues(wsType)
+	hist, err := m.manager.metrics.finalizeTimeHistVec.GetMetricWithLabelValues(wsType, wso.Pod.Labels[workspaceClassLabel])
 	if err != nil {
 		log.WithError(err).WithField("type", wsType).Warn("cannot get finalize time histogram metric")
 	} else {


### PR DESCRIPTION
## Description
This PR adds the workspace class to some of the ws-manager metrics. This way, we can see how many workspaces of a given class are currently running.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/3210701/171139159-0814e181-8b9a-40f3-a01f-eba636d47465.png">


## How to test
- start a workspace
- observe the `gitpod_ws_manager_workspace_phase_total` metric and ensure the `class` label is present

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
