### PR TITLE
Properly handle the workspace list when the workspace context ref is undefined

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceContext.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceContext.java
@@ -4,6 +4,8 @@
 
 package io.gitpod.gitpodprotocol.api.entities;
 
+import java.util.Optional;
+
 public class WorkspaceContext {
     private String normalizedContextURL;
     private String ref;
@@ -16,8 +18,8 @@ public class WorkspaceContext {
         this.normalizedContextURL = normalizedContextURL;
     }
 
-    public String getRef() {
-        return ref;
+    public Optional<String> getRef() {
+        return Optional.ofNullable(ref);
     }
 
     public void setRef(String ref) {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -878,6 +878,7 @@ export namespace ExternalImageConfigFile {
 
 export interface WorkspaceContext {
     title: string;
+    ref?: string;
     /** This contains the URL portion of the contextURL (which might contain other modifiers as well). It's optional because it's not set for older workspaces. */
     normalizedContextURL?: string;
     forceCreateNewWorkspace?: boolean;

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -283,7 +283,11 @@ class GitpodWorkspacesView(
                                         it.totalUncommitedFiles + it.totalUntrackedFiles + it.totalUnpushedCommits
                                     } ?: 0
                                     row {
-                                        label(info.workspace.context.ref)
+                                        if (info.workspace.context.ref.isPresent()) {
+                                            label(info.workspace.context.ref.get())
+                                        } else {
+                                            label("(detached)")
+                                        }
                                     }.rowComment(
                                         when {
                                             changes == 1 -> "<b>$changes Change</b>"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Properly handle the workspace list when the workspace context ref is undefined.

This fixes the issue on JetBrains Gateway preventing the workspace list from being displayed when a workspace had been created from a detached commit instead of a branch. For example, creating a workspace from https://github.com/jenkinsci/design-library-plugin/tree/73f12733d95932c333ba4155521ff78b4ed40dfc

This is the info that comes with this workspace, which does not contain the `workspace.context.ref`:
```json
{
    "jsonrpc": "2.0",
    "result": [
        {
            "workspace": {
                "context": {
                    "isFile": false,
                    "path": "",
                    "title": "jenkinsci/design-library-plugin - 73f12733:",
                    "revision": "73f12733d95932c333ba4155521ff78b4ed40dfc",
                    "repository": {
                        "cloneUrl": "https://github.com/jenkinsci/design-library-plugin.git",
                        "host": "github.com",
                        "name": "design-library-plugin",
                        "owner": "jenkinsci",
                        "private": false
                    },
                    "normalizedContextURL": "https://github.com/jenkinsci/design-library-plugin/tree/73f12733d95932c333ba4155521ff78b4ed40dfc",
                    "checkoutLocation": "design-library-plugin",
                    "referrer": "jetbrains-gateway",
                    "referrerIde": "intellij"
                }
            }
        }
    ]
}
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
- Create a workspace based on some detached commit from any repo. You can use this, for example: https://github.com/jenkinsci/design-library-plugin/tree/73f12733d95932c333ba4155521ff78b4ed40dfc
- Note that on the Gitpod Dashboard, it will display the workspace reference as "(detached"):
  <img width="749" alt="image" src="https://user-images.githubusercontent.com/418083/171152857-3924d194-02a8-43ad-bc4c-c5a4f7ce3b09.png">
- Now open JetBrains gateway using the [current stable version of the plugin](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/stable/177166). You should get the workspace list stuck in "Loading" state:
  ![image](https://user-images.githubusercontent.com/418083/171153238-f5a323e1-d4a3-4308-9e6a-1cce10576238.png)
- Download [Gitpod Gateway 0.0.1-vn-fix-undefined-context-ref-on-jb-gateway.3](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/180010) and manually install it on JetBrains Gateway
- Confirm if the Workspace list is displayed correctly and displaying the detached workspace correctly.
  ![image](https://user-images.githubusercontent.com/418083/171153804-fac6df1d-5467-457a-8048-ac2f3b8301c2.png)

## Extra Info

If you want to build the extension yourself and test it locally, please open this branch IntelliJ IDEA (running in your machine, not in Gitpod) and follow [these instructions](https://github.com/gitpod-io/gitpod/blob/main/components/ide/jetbrains/gateway-plugin/README.md#L8).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed an issue on JetBrains Gateway, preventing the workspace list from being displayed when a workspace had been created from a detached commit instead of a branch.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft no-preview=true