### PR TITLE
Change threshold for GitpodWsDaemonCrashLooping

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
@@ -20,6 +20,20 @@
               description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.',
             },
             expr: |||
+              increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m]) > 2
+            |||,
+          },
+          {
+            alert: 'GitpodWsDaemonRestarted',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonCrashLooping.md',
+              summary: 'Ws-daemon just restarted.',
+              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) restarted {{ printf "%.2f" $value }} times / 10 minutes.',
+            },
+            expr: |||
               increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m]) > 0
             |||,
           },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

### Context

Looking at the number of PagerDuty alerts ("Incidents") each month over the last year our current development isn't looking good.

![Screenshot 2022-05-31 at 13 59 41](https://user-images.githubusercontent.com/83561/171168230-54112857-6199-4d7d-a292-924a488c32b7.png)

I dug into the specific alerts in this PR https://github.com/gitpod-io/ops/pull/2518 and the alerts responsible for 2/3rd of the "incidents" in the last month were `GitpodWsDaemonCrashLooping (54)` and `GitpodNodeConntrackTableIsFull (50)`

### Implementation

This changes the threshold for GitpodWsDaemonCrashLooping to be more than 2 restarts in 10 minutes instead of the current value of 1 restart in 10 minutes. My reasoning is that if it just restarted once then the damage is done but there really isn't anything useful the on-caller can do at this point. Restarting more than 2 times might indicate that it's actually crash-looping and perhaps the on-caller should trigger an incident. I have introduced a warning alert for restarts too, in case the workspace team wants to investigate restarts during work hours.

Looking at the last 7 days we'd go from something like > 30 alerts to 3 alerts with this threshold.

Threshold > 0

![Screenshot 2022-05-31 at 13 45 51](https://user-images.githubusercontent.com/83561/171169011-04b01bab-c010-479b-b1d1-c3d0c792e857.png)

Threshold > 2

![Screenshot 2022-05-31 at 13 47 00](https://user-images.githubusercontent.com/83561/171169026-6703fd22-0a58-46e8-a92a-7a62cd15091c.png)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A