### PR TITLE
Change google project for preview DNS's

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -390,21 +390,21 @@ async function addDNSRecord(werft: Werft, namespace: string, domain: string, isL
     await Promise.all([
         createDNSRecord({
             domain,
-            projectId: "gitpod-dev",
+            projectId: "gitpod-core-dev",
             dnsZone: 'gitpod-dev-com',
             IP: coreDevIngressIP,
             slice: installerSlices.DNS_ADD_RECORD
         }),
         createDNSRecord({
             domain: `*.${domain}`,
-            projectId: "gitpod-dev",
+            projectId: "gitpod-core-dev",
             dnsZone: 'gitpod-dev-com',
             IP: coreDevIngressIP,
             slice: installerSlices.DNS_ADD_RECORD
         }),
         createDNSRecord({
             domain: `*.ws-dev.${domain}`,
-            projectId: "gitpod-dev",
+            projectId: "gitpod-core-dev",
             dnsZone: 'gitpod-dev-com',
             IP: wsProxyLBIP,
             slice: installerSlices.DNS_ADD_RECORD

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -58,7 +58,7 @@ function createCertificateResource(werft: Werft, shellOpts: ExecOptions, params:
     && yq w -i cert.yaml metadata.name '${params.certName}' \
     && yq w -i cert.yaml spec.secretName '${params.certName}' \
     && yq w -i cert.yaml metadata.namespace '${params.certNamespace}' \
-    && yq w -i cert.yaml spec.issuerRef.name '${params.withVM ? 'letsencrypt-issuer-gitpod-core-dev' : 'letsencrypt-issuer'}' \
+    && yq w -i cert.yaml spec.issuerRef.name 'letsencrypt-issuer-gitpod-core-dev' \
     ${subdomains.map(s => `&& yq w -i cert.yaml spec.dnsNames[+] '${s + params.domain}'`).join('  ')} \
     && kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} apply -f cert.yaml`;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`gitpod-dev` is one of our oldest google projects that was used to manage all kinds of cloud resources in the past. 

We're working towards more fine-grained billing cost allocations and one of the changes is that DNS records from preview environments will now be handled in the `gitpod-core-dev` project.

This particular PR does only one of the many steps necessary for the DNS migration and should be merged only when @meysholdt and I perform the migration. (Probably next Saturday 4/06)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
One of the steps for https://github.com/gitpod-io/ops/issues/2533

## How to test
<!-- Provide steps to test this PR -->
When performing the migration, a werft job should be run from this PR to make sure it is configured correctly. Make sure to use core-dev during the test, and not our default harvester previews

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```