### PR TITLE
dashboard: connect via ssh devx improvement

### DIFF
--- a/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
+++ b/components/dashboard/src/workspaces/ConnectToSSHModal.tsx
@@ -55,10 +55,10 @@ interface SSHProps {
 }
 
 function SSHView(props: SSHProps) {
-    const sshCommand = `ssh ${props.workspaceId}#${props.ownerToken}@${props.ideUrl.replace(
+    const sshCommand = `ssh '${props.workspaceId}#${props.ownerToken}@${props.ideUrl.replace(
         props.workspaceId,
         props.workspaceId + ".ssh",
-    )}`;
+    )}'`;
     return (
         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-6">
             <div className="mt-1 mb-4">


### PR DESCRIPTION
## Description

Feedback from @anaisbetts that the string that is copied to the clipboard may contain characters which are processed by shells such as bash. By single quoting the connection string this is prevented.

<img width="793" alt="Screen Shot 2022-06-01 at 3 38 23 pm" src="https://user-images.githubusercontent.com/127353/171335199-589bffcc-da13-41c2-8bcf-e5a1d660276e.png">

## How to test

I made this change in the GitHub editor and have not tested this change.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
dashboard: single quote connect via ssh connection string
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
