### PR TITLE
ws-daemon: Apply the xfs limit in stages

### DIFF
--- a/components/ws-daemon/pkg/quota/xfs.go
+++ b/components/ws-daemon/pkg/quota/xfs.go
@@ -86,7 +86,7 @@ func (xfs *XFS) getUsedProjectIDs() ([]int, error) {
 }
 
 // SetQuota sets the quota for a path
-func (xfs *XFS) SetQuota(path string, quota Size) (projectID int, err error) {
+func (xfs *XFS) SetQuota(path string, quota Size, isHard bool) (projectID int, err error) {
 	xfs.mu.Lock()
 	var (
 		prjID = prjidLow
@@ -117,7 +117,13 @@ func (xfs *XFS) SetQuota(path string, quota Size) (projectID int, err error) {
 	if err != nil {
 		return 0, err
 	}
-	_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bhard=%d %d", quota, prjID))
+
+	if isHard {
+		_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bhard=%d %d", quota, prjID))
+	} else {
+		_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bsoft=%d bhard=%d %d", quota, quota, prjID))
+	}
+
 	if err != nil {
 		return 0, err
 	}

--- a/components/ws-daemon/pkg/quota/xfs.go
+++ b/components/ws-daemon/pkg/quota/xfs.go
@@ -117,7 +117,7 @@ func (xfs *XFS) SetQuota(path string, quota Size) (projectID int, err error) {
 	if err != nil {
 		return 0, err
 	}
-	_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bsoft=%d bhard=%d %d", quota, quota, prjID))
+	_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bhard=%d %d", quota, prjID))
 	if err != nil {
 		return 0, err
 	}

--- a/components/ws-daemon/pkg/quota/xfs_test.go
+++ b/components/ws-daemon/pkg/quota/xfs_test.go
@@ -89,13 +89,15 @@ func TestSetQuota(t *testing.T) {
 	tests := []struct {
 		Name        string
 		Size        Size
+		IsHard      bool
 		ExecErr     func(cmd string) error
 		ProjectIDs  []int
 		Expectation Expectation
 	}{
 		{
-			Name: "happpy path",
-			Size: 100 * Kilobyte,
+			Name:   "happpy path",
+			Size:   100 * Kilobyte,
+			IsHard: true,
 			Expectation: Expectation{
 				ProjectID:  1000,
 				ProjectIDs: []int{1000},
@@ -106,8 +108,22 @@ func TestSetQuota(t *testing.T) {
 			},
 		},
 		{
+			Name:   "with soft limit",
+			Size:   100 * Kilobyte,
+			IsHard: false,
+			Expectation: Expectation{
+				ProjectID:  1000,
+				ProjectIDs: []int{1000},
+				Execs: []string{
+					"project -s -d 1 -p /foo 1000",
+					"limit -p bsoft=102400 bhard=102400 1000",
+				},
+			},
+		},
+		{
 			Name:       "with other prj",
 			Size:       100 * Kilobyte,
+			IsHard:     true,
 			ProjectIDs: []int{1000},
 			Expectation: Expectation{
 				ProjectID:  1001,
@@ -119,8 +135,9 @@ func TestSetQuota(t *testing.T) {
 			},
 		},
 		{
-			Name: "prj creation failure",
-			Size: 100 * Kilobyte,
+			Name:   "prj creation failure",
+			Size:   100 * Kilobyte,
+			IsHard: true,
 			ExecErr: func(cmd string) error {
 				if strings.Contains(cmd, "project") {
 					return fmt.Errorf("failed to create project")
@@ -159,7 +176,7 @@ func TestSetQuota(t *testing.T) {
 				xfs.projectIDs[prjid] = struct{}{}
 			}
 
-			act.ProjectID, err = xfs.SetQuota("/foo", test.Size)
+			act.ProjectID, err = xfs.SetQuota("/foo", test.Size, test.IsHard)
 			if err != nil {
 				act.Error = err.Error()
 			}

--- a/components/ws-daemon/pkg/quota/xfs_test.go
+++ b/components/ws-daemon/pkg/quota/xfs_test.go
@@ -101,7 +101,7 @@ func TestSetQuota(t *testing.T) {
 				ProjectIDs: []int{1000},
 				Execs: []string{
 					"project -s -d 1 -p /foo 1000",
-					"limit -p bsoft=102400 bhard=102400 1000",
+					"limit -p bhard=102400 1000",
 				},
 			},
 		},
@@ -114,7 +114,7 @@ func TestSetQuota(t *testing.T) {
 				ProjectIDs: []int{1000, 1001},
 				Execs: []string{
 					"project -s -d 1 -p /foo 1001",
-					"limit -p bsoft=102400 bhard=102400 1001",
+					"limit -p bhard=102400 1001",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Apply the xfs limit in stages because ws-daemon uses some disk space at startup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10329

## How to test
<!-- Provide steps to test this PR -->

1. Open the workspace
2. Full the disk(Recommend use `docker`)
3. Stop the workspace
4. Reopen the workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
ws-daemon: Apply the xfs limit in stages.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No
