### PR TITLE
Remove beta label from dotfiles in settings

### DIFF
--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -118,9 +118,6 @@ export default function Preferences() {
 
                 <h3 className="mt-12">
                     Dotfiles{" "}
-                    <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
-                        Beta
-                    </PillLabel>
                 </h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
                 <div className="mt-4 max-w-xl">


### PR DESCRIPTION
## Description

This will remove the beta label from dotfiles in settings, matching the upcoming updates in https://github.com/gitpod-io/website/pull/2152. Cc @loujaybee 

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="600" alt="Screenshot 2022-06-01 at 10 53 11 AM (2)" src="https://user-images.githubusercontent.com/120486/171355609-a0978465-af7d-4c3f-8d39-86e54abb95ef.png"> | <img width="600" alt="Screenshot 2022-06-01 at 10 53 18 AM (2)" src="https://user-images.githubusercontent.com/120486/171355617-159a7c17-28b1-4581-8890-7b6b82092b99.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove beta label from dotfiles in settings
```