### PR TITLE
[workspace-instance] Deprecate deployedTime field

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -40,6 +40,7 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
     })
     startedTime?: string;
 
+    // DEPRECATED
     @Column({
         default: "",
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -291,10 +291,6 @@ export class WorkspaceManagerBridge implements Disposable {
                 };
             }
 
-            if (instance.status.conditions.deployed && !instance.deployedTime) {
-                instance.deployedTime = new Date().toISOString();
-            }
-
             let lifecycleHandler: (() => Promise<void>) | undefined;
             switch (status.phase) {
                 case WorkspacePhase.PENDING:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Unused since November 2021. Removes usage and marks column as deprecated. Can be removed from TypeORM model in subsequent PR. [Internal context](https://gitpod.slack.com/archives/C02EN94AEPL/p1654069993040349).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[db] Deprecate WorkspaceInstance.deployedTime field
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE