### PR TITLE
[gpctl] Fix parsing error when running `gpctl workspaces describe <instanceID>`

### DIFF
--- a/dev/gpctl/cmd/workspaces-describe.go
+++ b/dev/gpctl/cmd/workspaces-describe.go
@@ -54,7 +54,6 @@ Conditions:
 {{- if not (eq .Conditions.Failed "") }}  Failed:	{{ .Conditions.Failed }}{{ end }}
 {{- if not (eq .Conditions.Timeout "") }}  Timeout:	{{ .Conditions.Timeout }}{{ end }}
   PullingImages:	{{ .Conditions.PullingImages }}
-  ServiceExists:	{{ .Conditions.ServiceExists }}
   Deployed:	{{ .Conditions.Deployed }}
   FinalBackupComplete:	{{ .Conditions.FinalBackupComplete }}
 Spec:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Removes `ServiceExists:	{{ .Conditions.ServiceExists }}` from the template. 

`.Conditions.ServiceExists` was deprecated/removed in [#6462](https://github.com/gitpod-io/gitpod/pull/6462/files#diff-29ec8368c6c111e8e0f244adf61b5638b6b6057a23e638f6aed78c0d7b95fe3cL347-R348)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9274

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gpctl] Fix parsing error when running gpctl workspaces describe <instanceID>
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
