### PR TITLE
Fix 'gateway-plugin' not being detected as a project

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,10 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,6 +15,17 @@
           </set>
         </option>
       </GradleProjectSettings>
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
+        <option name="gradleJvm" value="11" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/components/gitpod-protocol/java" />
+            <option value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
+          </set>
+        </option>
+      </GradleProjectSettings>
     </option>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,15 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/gitpod.iml" filepath="$PROJECT_DIR$/.idea/gitpod.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.main.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.test.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/io.gitpod.api.jetbrains-backend-plugin.gitpod-protocol.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1017917334/io.gitpod.api.jetbrains-backend-plugin.supervisor-api.iml" filepath="$PROJECT_DIR$/.idea/modules/1017917334/io.gitpod.api.jetbrains-backend-plugin.supervisor-api.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1017917334/io.gitpod.api.jetbrains-backend-plugin.supervisor-api.main.iml" filepath="$PROJECT_DIR$/.idea/modules/1017917334/io.gitpod.api.jetbrains-backend-plugin.supervisor-api.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1017917334/io.gitpod.api.jetbrains-backend-plugin.supervisor-api.test.iml" filepath="$PROJECT_DIR$/.idea/modules/1017917334/io.gitpod.api.jetbrains-backend-plugin.supervisor-api.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/io.gitpod.jetbrains.jetbrains-backend-plugin.iml" filepath="$PROJECT_DIR$/.idea/modules/io.gitpod.jetbrains.jetbrains-backend-plugin.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/io.gitpod.jetbrains.jetbrains-backend-plugin.main.iml" filepath="$PROJECT_DIR$/.idea/modules/io.gitpod.jetbrains.jetbrains-backend-plugin.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/io.gitpod.jetbrains.jetbrains-backend-plugin.test.iml" filepath="$PROJECT_DIR$/.idea/modules/io.gitpod.jetbrains.jetbrains-backend-plugin.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/jetbrains-backend-plugin.iml" filepath="$PROJECT_DIR$/.idea/modules/jetbrains-backend-plugin.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-backend-plugin.gitpod-protocol.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-backend-plugin.gitpod-protocol.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-backend-plugin.gitpod-protocol.main.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-backend-plugin.gitpod-protocol.main.iml" />
@@ -12,6 +21,12 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/1017917334/jetbrains-backend-plugin.supervisor-api.main.iml" filepath="$PROJECT_DIR$/.idea/modules/1017917334/jetbrains-backend-plugin.supervisor-api.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/1017917334/jetbrains-backend-plugin.supervisor-api.test.iml" filepath="$PROJECT_DIR$/.idea/modules/1017917334/jetbrains-backend-plugin.supervisor-api.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/jetbrains-backend-plugin.test.iml" filepath="$PROJECT_DIR$/.idea/modules/jetbrains-backend-plugin.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/jetbrains-gateway-gitpod-plugin.iml" filepath="$PROJECT_DIR$/.idea/modules/jetbrains-gateway-gitpod-plugin.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-gateway-gitpod-plugin.gitpod-protocol.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-gateway-gitpod-plugin.gitpod-protocol.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-gateway-gitpod-plugin.gitpod-protocol.main.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-gateway-gitpod-plugin.gitpod-protocol.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-gateway-gitpod-plugin.gitpod-protocol.test.iml" filepath="$PROJECT_DIR$/.idea/modules/1099510149/jetbrains-gateway-gitpod-plugin.gitpod-protocol.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/jetbrains-gateway-gitpod-plugin.main.iml" filepath="$PROJECT_DIR$/.idea/modules/jetbrains-gateway-gitpod-plugin.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/jetbrains-gateway-gitpod-plugin.test.iml" filepath="$PROJECT_DIR$/.idea/modules/jetbrains-gateway-gitpod-plugin.test.iml" />
     </modules>
   </component>
 </project>


### PR DESCRIPTION
These updates on .idea config files fix the problem.

## Description
<!-- Describe your changes in detail -->
These updates on .idea config files fix the problem about 'gateway-plugin' not being detected as a project.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
- Open the branch of this PR on Gitpod IntelliJ IDEA: https://gitpod.io/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/gitpod/tree/vn/fix-gateway-plugin-not-being-detected-as-a-project
- Check if `gateway-plugin` now displays the blue icon, like `backend-plugin`:
  <img width="401" alt="image" src="https://user-images.githubusercontent.com/418083/171414289-2f0c4ca1-ea22-470d-9f20-c4fb80065470.png">
- Check if, after IntelliJ finishes indexing the project, you have the autocomplete for files inside `gateway-plugin` folder:
  <img width="761" alt="image" src="https://user-images.githubusercontent.com/418083/171414703-6bcb0636-df8e-477a-aa14-9558294ce44b.png">



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft --no-preview=true