### PR TITLE
[ws-manager] add config setting that allows to debug workspaces

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -115,6 +115,8 @@ type Configuration struct {
 	WorkspaceClusterHost string `json:"workspaceClusterHost"`
 	// WorkspaceClasses provide different resource classes for workspaces
 	WorkspaceClasses map[string]*WorkspaceClass `json:"workspaceClass"`
+	// DebugWorkspacePod adds extra finalizer to workspace to prevent it from shutting down. Helps to debug.
+	DebugWorkspacePod bool `json:"debugWorkspacePod,omitempty"`
 }
 
 type WorkspaceClass struct {

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -518,6 +518,10 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 		},
 	}
 
+	if m.Config.DebugWorkspacePod {
+		pod.Finalizers = append(pod.Finalizers, "gitpod.io/debugfinalizer")
+	}
+
 	ffidx := make(map[api.WorkspaceFeatureFlag]struct{})
 	for _, feature := range startContext.Request.Spec.FeatureFlags {
 		if _, seen := ffidx[feature]; seen {

--- a/components/ws-manager/pkg/manager/create_test.go
+++ b/components/ws-manager/pkg/manager/create_test.go
@@ -54,7 +54,8 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 		CACertSecret string                    `json:"caCertSecret,omitempty"`
 		Classes      map[string]WorkspaceClass `json:"classes,omitempty"`
 
-		EnforceAffinity bool `json:"enforceAffinity,omitempty"`
+		EnforceAffinity   bool `json:"enforceAffinity,omitempty"`
+		DebugWorkspacePod bool `json:"debugWorkspacePod,omitempty"`
 	}
 	type gold struct {
 		Pod   corev1.Pod `json:"reason,omitempty"`
@@ -69,6 +70,7 @@ func TestCreateDefiniteWorkspacePod(t *testing.T) {
 
 			mgmtCfg := forTestingOnlyManagerConfig()
 			mgmtCfg.WorkspaceCACertSecret = fixture.CACertSecret
+			mgmtCfg.DebugWorkspacePod = fixture.DebugWorkspacePod
 
 			if fixture.Classes == nil {
 				fixture.Classes = make(map[string]WorkspaceClass)

--- a/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
@@ -1,0 +1,261 @@
+{
+    "reason": {
+        "metadata": {
+            "name": "ws-test",
+            "namespace": "default",
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/networkpolicy": "default",
+                "gitpod.io/workspaceClass": "default",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            },
+            "annotations": {
+                "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+                "container.apparmor.security.beta.kubernetes.io/workspace": "unconfined",
+                "gitpod.io/attemptingToCreate": "true",
+                "gitpod/admission": "admit_owner_only",
+                "gitpod/contentInitializer": "GmcKZXdvcmtzcGFjZXMvY3J5cHRpYy1pZC1nb2VzLWhlcmcvZmQ2MjgwNGItNGNhYi0xMWU5LTg0M2EtNGU2NDUzNzMwNDhlLnRhckBnaXRwb2QtZGV2LXVzZXItY2hyaXN0ZXN0aW5n",
+                "gitpod/id": "test",
+                "gitpod/imageSpec": "Cghzb21lLXJlZhI0ZXUuZ2NyLmlvL2dpdHBvZC1jb3JlLWRldi9idWlkL3RoZWlhLWlkZTpzb21ldmVyc2lvbg==",
+                "gitpod/never-ready": "true",
+                "gitpod/ownerToken": "%7J'[Of/8NDiWE+9F,I6^Jcj_1\u0026}-F8p",
+                "gitpod/servicePrefix": "foobarservice",
+                "gitpod/traceid": "",
+                "gitpod/url": "test-foobarservice-gitpod.io",
+                "seccomp.security.alpha.kubernetes.io/pod": "localhost/workspace-default"
+            },
+            "finalizers": [
+                "gitpod.io/finalizer",
+                "gitpod.io/debugfinalizer"
+            ]
+        },
+        "spec": {
+            "volumes": [
+                {
+                    "name": "vol-this-workspace",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test",
+                        "type": "DirectoryOrCreate"
+                    }
+                },
+                {
+                    "name": "daemon-mount",
+                    "hostPath": {
+                        "path": "/tmp/workspaces/test-daemon",
+                        "type": "DirectoryOrCreate"
+                    }
+                }
+            ],
+            "containers": [
+                {
+                    "name": "workspace",
+                    "image": "registry-facade:8080/remote/test",
+                    "command": [
+                        "/.supervisor/workspacekit",
+                        "ring0"
+                    ],
+                    "ports": [
+                        {
+                            "containerPort": 23000
+                        },
+                        {
+                            "name": "supervisor",
+                            "containerPort": 22999
+                        }
+                    ],
+                    "env": [
+                        {
+                            "name": "GITPOD_REPO_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_REPO_ROOTS",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_CLI_APITOKEN",
+                            "value": "Ab=5=rRA*9:C'T{;RRB\u003e]vK2p6`fFfrS"
+                        },
+                        {
+                            "name": "GITPOD_OWNER_ID",
+                            "value": "tester"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_ID",
+                            "value": "foobar"
+                        },
+                        {
+                            "name": "GITPOD_INSTANCE_ID",
+                            "value": "test"
+                        },
+                        {
+                            "name": "GITPOD_THEIA_PORT",
+                            "value": "23000"
+                        },
+                        {
+                            "name": "THEIA_WORKSPACE_ROOT",
+                            "value": "/workspace"
+                        },
+                        {
+                            "name": "GITPOD_HOST",
+                            "value": "gitpod.io"
+                        },
+                        {
+                            "name": "GITPOD_WORKSPACE_URL",
+                            "value": "test-foobarservice-gitpod.io"
+                        },
+                        {
+                            "name": "THEIA_SUPERVISOR_ENDPOINT",
+                            "value": ":22999"
+                        },
+                        {
+                            "name": "THEIA_WEBVIEW_EXTERNAL_ENDPOINT",
+                            "value": "webview-{{hostname}}"
+                        },
+                        {
+                            "name": "THEIA_MINI_BROWSER_HOST_PATTERN",
+                            "value": "browser-{{hostname}}"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_NAME",
+                            "value": "usernameGoesHere"
+                        },
+                        {
+                            "name": "GITPOD_GIT_USER_EMAIL",
+                            "value": "some@user.com"
+                        },
+                        {
+                            "name": "GITPOD_INTERVAL",
+                            "value": "30000"
+                        },
+                        {
+                            "name": "GITPOD_MEMORY",
+                            "value": "999"
+                        }
+                    ],
+                    "resources": {
+                        "limits": {
+                            "cpu": "900m",
+                            "memory": "1G"
+                        },
+                        "requests": {
+                            "cpu": "899m",
+                            "ephemeral-storage": "5Gi",
+                            "memory": "999M"
+                        }
+                    },
+                    "volumeMounts": [
+                        {
+                            "name": "vol-this-workspace",
+                            "mountPath": "/workspace",
+                            "mountPropagation": "HostToContainer"
+                        },
+                        {
+                            "name": "daemon-mount",
+                            "mountPath": "/.workspace",
+                            "mountPropagation": "HostToContainer"
+                        }
+                    ],
+                    "readinessProbe": {
+                        "httpGet": {
+                            "path": "/_supervisor/v1/status/content/wait/true",
+                            "port": 22999,
+                            "scheme": "HTTP"
+                        },
+                        "initialDelaySeconds": 2,
+                        "timeoutSeconds": 1,
+                        "periodSeconds": 1,
+                        "successThreshold": 1,
+                        "failureThreshold": 600
+                    },
+                    "terminationMessagePolicy": "File",
+                    "imagePullPolicy": "IfNotPresent",
+                    "securityContext": {
+                        "capabilities": {
+                            "add": [
+                                "AUDIT_WRITE",
+                                "FSETID",
+                                "KILL",
+                                "NET_BIND_SERVICE",
+                                "SYS_PTRACE"
+                            ],
+                            "drop": [
+                                "SETPCAP",
+                                "CHOWN",
+                                "NET_RAW",
+                                "DAC_OVERRIDE",
+                                "FOWNER",
+                                "SYS_CHROOT",
+                                "SETFCAP",
+                                "SETUID",
+                                "SETGID"
+                            ]
+                        },
+                        "privileged": false,
+                        "runAsUser": 33333,
+                        "runAsGroup": 33333,
+                        "runAsNonRoot": true,
+                        "readOnlyRootFilesystem": false,
+                        "allowPrivilegeEscalation": true
+                    }
+                }
+            ],
+            "restartPolicy": "Never",
+            "serviceAccountName": "workspace",
+            "automountServiceAccountToken": false,
+            "securityContext": {},
+            "hostname": "foobar",
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "gitpod.io/workload_workspace_regular",
+                                        "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
+                                        "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/registry-facade_ready_ns_default",
+                                        "operator": "Exists"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "tolerations": [
+                {
+                    "key": "node.kubernetes.io/disk-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/memory-pressure",
+                    "operator": "Exists",
+                    "effect": "NoExecute"
+                },
+                {
+                    "key": "node.kubernetes.io/network-unavailable",
+                    "operator": "Exists",
+                    "effect": "NoExecute",
+                    "tolerationSeconds": 30
+                }
+            ],
+            "enableServiceLinks": false
+        },
+        "status": {}
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.json
@@ -1,0 +1,18 @@
+{
+  "debugWorkspacePod": true,
+  "spec": {
+      "ideImage": {
+          "webRef": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion"
+      },
+      "workspaceImage": "some-ref",
+      "initializer": {
+          "snapshot": {
+              "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"
+          }
+      },
+      "git": {
+          "username": "usernameGoesHere",
+          "email": "some@user.com"
+      }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Sometimes workspace pods just shutdown without a way to debug\inspect them.
This PR adds support for adding an extra finalizer that prevents the pod from disappearing, so it is possible to debug\inspect it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
