### PR TITLE
Add previewctl/gpctl autocompletion to workspace image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -71,7 +71,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/ide-integration-tests-startup-jetbrains.yaml
+++ b/.werft/ide-integration-tests-startup-jetbrains.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-integration-tests-startup-vscode.yaml
+++ b/.werft/ide-integration-tests-startup-vscode.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-run-integration-tests.yaml
+++ b/.werft/ide-run-integration-tests.yaml
@@ -25,7 +25,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -27,7 +27,7 @@ pod:
       secretName: harvester-vm-ssh-keys
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-gh-cli-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:as-previewctl-completion.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -17,6 +17,7 @@ packages:
     deps:
       - dev/gpctl:app
       - dev/kubecdl:app
+      - dev/preview/previewctl:cli
     argdeps:
       - imageRepoBase
     config:

--- a/dev/image/BUILD.yaml
+++ b/dev/image/BUILD.yaml
@@ -4,6 +4,7 @@ packages:
     deps:
       - dev/gpctl:app
       - dev/kubecdl:app
+      - dev/preview/previewctl:cli
     argdeps:
       - imageRepoBase
     srcs:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -244,4 +244,8 @@ ENV WERFT_CREDENTIAL_HELPER=/workspace/gitpod/dev/preview/werft-credential-helpe
 
 # Copy our own tools
 ENV NEW_KUBECDL=1
-COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl /usr/bin/
+COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl dev-preview-previewctl--cli/previewctl /usr/bin/
+
+# Configure our tools' autocompletion
+RUN bash -c "echo . \<\(gpctl completion bash\) >> ~/.bashrc" && \
+    bash -c "echo . \<\(previewctl completion bash\) >> ~/.bashrc"

--- a/dev/leeway.Dockerfile
+++ b/dev/leeway.Dockerfile
@@ -4,4 +4,4 @@
 
 FROM scratch
 
-COPY dev-gpctl--app/gpctl dev-kubecdl--app/kubecdl /app/
+COPY dev-gpctl--app/gpctl dev-kubecdl--app/kubecdl dev-preview-previewctl--cli/previewctl /app/


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Adds auto-completion of our tools to the workspace image

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10389

## How to test
<!-- Provide steps to test this PR -->
Open a workspace from this PR and try:
* Type `previewctl` and press [TAB] twice
* Type `gpctl` and press [TAB] twice

For both, you should receive completion suggestions

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```