### PR TITLE
[ws-manager] show why pod entered completed state

### DIFF
--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -595,7 +595,7 @@ func extractFailure(wso workspaceObjects) (string, *api.WorkspacePhase) {
 					// default way for headless workspaces to be done
 					return "", nil
 				}
-				return fmt.Sprintf("container %s completed; containers of a workspace pod are not supposed to do that. error msg: %s", cs.Name, terminationState.Message), nil
+				return fmt.Sprintf("container %s completed; containers of a workspace pod are not supposed to do that. Reason: %s", cs.Name, terminationState.Message), nil
 			} else if !isPodBeingDeleted(pod) && terminationState.ExitCode != containerUnknownExitCode {
 				// if a container is terminated and it wasn't because of either:
 				//  - regular shutdown

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -595,7 +595,7 @@ func extractFailure(wso workspaceObjects) (string, *api.WorkspacePhase) {
 					// default way for headless workspaces to be done
 					return "", nil
 				}
-				return fmt.Sprintf("container %s completed; containers of a workspace pod are not supposed to do that", cs.Name), nil
+				return fmt.Sprintf("container %s completed; containers of a workspace pod are not supposed to do that. error msg: %s", cs.Name, terminationState.Message), nil
 			} else if !isPodBeingDeleted(pod) && terminationState.ExitCode != containerUnknownExitCode {
 				// if a container is terminated and it wasn't because of either:
 				//  - regular shutdown

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
@@ -16,7 +16,7 @@
         },
         "phase": 3,
         "conditions": {
-            "failed": "container sync completed; containers of a workspace pod are not supposed to do that",
+            "failed": "container sync completed; containers of a workspace pod are not supposed to do that. error msg: ",
             "volume_snapshot": {}
         },
         "message": "workspace initializer is running",

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
@@ -16,7 +16,7 @@
         },
         "phase": 3,
         "conditions": {
-            "failed": "container sync completed; containers of a workspace pod are not supposed to do that. error msg: ",
+            "failed": "container sync completed; containers of a workspace pod are not supposed to do that. Reason: ",
             "volume_snapshot": {}
         },
         "message": "workspace initializer is running",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Whenever workspace fails due to pod entered completed state, show an error message, so that it is easier for user to understand what went wrong.
Example:
![image](https://user-images.githubusercontent.com/18602811/171519844-1f81174e-7a98-4a95-9713-efac19f9ea83.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Try to open this workspace:
https://github.com/atduarte/test-new

You should see a clear error why it failed. 
Here is a PR that also improved that specific error to be more clear: https://github.com/gitpod-io/gitpod/pull/10413

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] show why pod entered completed state
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
