### PR TITLE
Fix runbook URL

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -28,7 +28,7 @@
               severity: 'critical',
             },
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/AutoscalerAddsNodesTooFast.md',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscalerAddsNodesTooFast.md',
               summary: "Autoscaler is adding new nodes rapidly",
               description: 'Autoscaler in cluster {{ $labels.cluster }} is rapidly adding new nodes.',
             },


### PR DESCRIPTION
## Description
Fix a broken runbook URL.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```