### PR TITLE
[server] Make Stripe settings optional even when payment is enabled

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -217,7 +217,11 @@ export namespace ConfigFile {
         );
         let stripeSettings: { publishableKey: string; secretKey: string } | undefined;
         if (config.enablePayment && config.stripeSettingsFile) {
-            stripeSettings = JSON.parse(fs.readFileSync(filePathTelepresenceAware(config.stripeSettingsFile), "utf-8"));
+            try {
+                stripeSettings = JSON.parse(fs.readFileSync(filePathTelepresenceAware(config.stripeSettingsFile), "utf-8"));
+            } catch (error) {
+                console.error("Could not load Stripe settings", error);
+            }
         }
         let license = config.license;
         const licenseFile = config.licenseFile;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make Stripe settings optional even when payment is enabled.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes `server` crash-loop when payment is enabled but no Stripe settings are configured:

```
Error: ENOENT: no such file or directory, open '/stripe/settings'
```

## How to test
<!-- Provide steps to test this PR -->

1. Merge this PR
2. Observe if this fixes `server` in staging

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
