### PR TITLE
[bridge] Extracting updating of prebuilds into PrebuildUpdater (2/3)

### DIFF
--- a/components/ws-manager-bridge/ee/src/container-module.ts
+++ b/components/ws-manager-bridge/ee/src/container-module.ts
@@ -5,9 +5,9 @@
  */
 
 import { ContainerModule } from "inversify";
-import { WorkspaceManagerBridgeEE } from "./bridge";
-import { WorkspaceManagerBridge } from "../../src/bridge";
+import { PrebuildUpdater } from "../../src/prebuild-updater";
+import { PrebuildUpdaterDB } from "./prebuild-updater-db";
 
 export const containerModuleEE = new ContainerModule((bind, unbind, isBound, rebind) => {
-    rebind(WorkspaceManagerBridge).to(WorkspaceManagerBridgeEE).inRequestScope();
+    rebind(PrebuildUpdater).to(PrebuildUpdaterDB).inSingletonScope();
 });

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -37,6 +37,7 @@ import { WorkspaceCluster } from "@gitpod/gitpod-protocol/lib/workspace-cluster"
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
 import { PreparingUpdateEmulator, PreparingUpdateEmulatorFactory } from "./preparing-update-emulator";
 import { performance } from "perf_hooks";
+import { PrebuildUpdater } from "./prebuild-updater";
 
 export const WorkspaceManagerBridgeFactory = Symbol("WorkspaceManagerBridgeFactory");
 
@@ -72,6 +73,9 @@ export class WorkspaceManagerBridge implements Disposable {
 
     @inject(IAnalyticsWriter)
     protected readonly analytics: IAnalyticsWriter;
+
+    @inject(PrebuildUpdater)
+    protected readonly prebuildUpdater: PrebuildUpdater;
 
     protected readonly disposables = new DisposableCollection();
     protected readonly queues = new Map<string, Queue>();
@@ -348,7 +352,7 @@ export class WorkspaceManagerBridge implements Disposable {
             span.setTag("after", JSON.stringify(instance));
 
             // now notify all prebuild listeners about updates - and update DB if needed
-            await this.updatePrebuiltWorkspace({ span }, userId, status, writeToDB);
+            await this.prebuildUpdater.updatePrebuiltWorkspace({ span }, userId, status, writeToDB);
 
             // update volume snapshot information
             if (
@@ -462,22 +466,9 @@ export class WorkspaceManagerBridge implements Disposable {
             instance.stoppedTime = new Date().toISOString();
             promises.push(this.workspaceDB.trace({}).storeInstance(instance));
             promises.push(this.onInstanceStopped({}, ri.workspace.ownerId, instance));
-            promises.push(this.stopPrebuildInstance(ctx, instance));
+            promises.push(this.prebuildUpdater.stopPrebuildInstance(ctx, instance));
         }
         await Promise.all(promises);
-    }
-
-    protected async updatePrebuiltWorkspace(
-        ctx: TraceContext,
-        userId: string,
-        status: WorkspaceStatus.AsObject,
-        writeToDB: boolean,
-    ) {
-        // prebuilds are an EE feature - we just need the hook here
-    }
-
-    protected async stopPrebuildInstance(ctx: TraceContext, instance: WorkspaceInstance): Promise<void> {
-        // prebuilds are an EE feature - we just need the hook here
     }
 
     protected async onInstanceStopped(

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -34,6 +34,7 @@ import { IClientCallMetrics } from "@gitpod/content-service/lib/client-call-metr
 import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
 import { PreparingUpdateEmulator, PreparingUpdateEmulatorFactory } from "./preparing-update-emulator";
 import { PrebuildStateMapper } from "./prebuild-state-mapper";
+import { PrebuildUpdater, PrebuildUpdaterNoOp } from "./prebuild-updater";
 
 export const containerModule = new ContainerModule((bind) => {
     bind(MessagebusConfiguration).toSelf().inSingletonScope();
@@ -83,4 +84,5 @@ export const containerModule = new ContainerModule((bind) => {
     bind(PreparingUpdateEmulatorFactory).toAutoFactory(PreparingUpdateEmulator);
 
     bind(PrebuildStateMapper).toSelf().inSingletonScope();
+    bind(PrebuildUpdater).to(PrebuildUpdaterNoOp).inSingletonScope();
 });

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { WorkspaceStatus } from "@gitpod/ws-manager/lib";
+import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { injectable } from "inversify";
+
+export const PrebuildUpdater = Symbol("PrebuildUpdater");
+
+export interface PrebuildUpdater {
+    updatePrebuiltWorkspace(
+        ctx: TraceContext,
+        userId: string,
+        status: WorkspaceStatus.AsObject,
+        writeToDB: boolean,
+    ): Promise<void>;
+
+    stopPrebuildInstance(ctx: TraceContext, instance: WorkspaceInstance): Promise<void>;
+}
+
+@injectable()
+export class PrebuildUpdaterNoOp implements PrebuildUpdater {
+    async updatePrebuiltWorkspace(
+        ctx: TraceContext,
+        userId: string,
+        status: WorkspaceStatus.AsObject,
+        writeToDB: boolean,
+    ): Promise<void> {}
+
+    async stopPrebuildInstance(ctx: TraceContext, instance: WorkspaceInstance): Promise<void> {}
+}


### PR DESCRIPTION
## Description

This PR extract all logic related to updating prebuilds from src/ee/bridge behind a new interface `PrebuildUpdater` with two implementations: Noop (non-ee version) and DB (ee version) (2/3 in the chain)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: https://github.com/gitpod-io/gitpod/issues/9395

## How to test
 - start a workspace on this branch
 - start a workspace in the preview env
 - check the logs `kubectl logs ws-manager-bridge- ws-manager-bridge`
 - note how:
   - everything is working as expected
   - bridge logs show no errors

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
