### PR TITLE
Bump MinI, MySQL and RabbitMQ helm dependencies to latest version

### DIFF
--- a/install/installer/third_party/charts/minio/Chart.yaml
+++ b/install/installer/third_party/charts/minio/Chart.yaml
@@ -8,5 +8,5 @@ name: minio
 version: 1.0.0
 dependencies:
   - name: minio
-    version: 9.0.6
+    version: 11.6.3
     repository: https://charts.bitnami.com/bitnami

--- a/install/installer/third_party/charts/mysql/Chart.yaml
+++ b/install/installer/third_party/charts/mysql/Chart.yaml
@@ -8,5 +8,5 @@ name: mysql
 version: 1.0.0
 dependencies:
   - name: mysql
-    version: 8.6.2
+    version: 9.1.2
     repository: https://charts.bitnami.com/bitnami

--- a/install/installer/third_party/charts/rabbitmq/Chart.yaml
+++ b/install/installer/third_party/charts/rabbitmq/Chart.yaml
@@ -8,5 +8,5 @@ name: rabbitmq
 version: 1.0.0
 dependencies:
   - name: rabbitmq
-    version: 8.24.6
+    version: 10.1.1
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
## Description
We were using a very outdated MinIO, MySQL and RabbitMQ helm chart version. These version have become unavailable since. This PR bumps the helm charts to their latest version.

<img width="780" alt="image" src="https://user-images.githubusercontent.com/3210701/171601820-1b374dee-cf41-4d3d-b745-01be9875bd1c.png">


## How to test
```bash
cd install/installer/third_party/charts/minio
helm dep update
cd ../mysql
helm dep update
cd ../rabbitmq
helm dep update
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Bump MinIO helm chart to 11.6.3
[installer] Bump MySQL helm chart to 9.1.2
[installer] Bump RabbitMQ helm chart to 10.1.1
```
