### PR TITLE
[baseserver] Stop logging healthcheck RPCs Redux

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -268,7 +268,7 @@ func (s *Server) initializeGRPC() error {
 		grpc_logrus.UnaryServerInterceptor(s.Logger(),
 			grpc_logrus.WithDecider(func(fullMethodName string, err error) bool {
 				// Skip gRPC healthcheck logs, they are frequent and pollute our logging infra
-				return fullMethodName != "grpc.health.v1.Health/Check"
+				return fullMethodName != "/grpc.health.v1.Health/Check"
 			}),
 		),
 		grpcMetrics.UnaryServerInterceptor(),


### PR DESCRIPTION
## Description
I noticed that the log of ws-daemon is still full of healthcheck messages. As usual the culprit is a single character :wink: 

## Related Issue(s)
Related to https://github.com/gitpod-io/gitpod/pull/10419

## How to test
Check logs of ws-daemon in preview environment

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```