### PR TITLE
[prebuilds] add metrics for prebuilds 10383

### DIFF
--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -30,7 +30,7 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { HostContextProvider } from "../../../src/auth/host-context-provider";
 import { UserDB } from "@gitpod/gitpod-db/lib";
 import { UserCounter } from "../user/user-counter";
-
+import { increasePrebuildsStartedCounter } from "../../../src/prometheus-metrics";
 @injectable()
 export class WorkspaceFactoryEE extends WorkspaceFactory {
     @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
@@ -176,6 +176,10 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                 branch,
                 statusVersion: 0,
             });
+
+            if (pws) {
+                increasePrebuildsStartedCounter();
+            }
 
             log.debug(
                 { userId: user.id, workspaceId: ws.id },

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -151,3 +151,13 @@ const instanceStartsFailedTotal = new prometheusClient.Counter({
 export function increaseFailedInstanceStartCounter(reason: "clusterSelectionFailed" | "startOnClusterFailed") {
     instanceStartsFailedTotal.inc({ reason });
 }
+
+const prebuildsStartedTotal = new prometheusClient.Counter({
+    name: "gitpod_prebuilds_started_total",
+    help: "Counter of total prebuilds started.",
+    registers: [prometheusClient.register],
+});
+
+export function increasePrebuildsStartedCounter() {
+    prebuildsStartedTotal.inc();
+}

--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -18,6 +18,7 @@ export class PrometheusMetricsExporter {
     protected readonly clusterCordoned: prom.Gauge<string>;
     protected readonly statusUpdatesTotal: prom.Counter<string>;
     protected readonly stalePrebuildEventsTotal: prom.Counter<string>;
+    protected readonly prebuildsCompletedTotal: prom.Counter<string>;
 
     protected readonly workspaceInstanceUpdateStartedTotal: prom.Counter<string>;
     protected readonly workspaceInstanceUpdateCompletedSeconds: prom.Histogram<string>;
@@ -72,6 +73,12 @@ export class PrometheusMetricsExporter {
             // and outcomes by read-only replicas.
             labelNames: ["db_write", "workspace_cluster", "workspace_instance_type", "outcome"],
             buckets: prom.exponentialBuckets(2, 2, 8),
+        });
+
+        this.prebuildsCompletedTotal = new prom.Counter({
+            name: "gitpod_prebuilds_completed_total",
+            help: "Counter of total prebuilds ended.",
+            labelNames: ["state"],
         });
     }
 
@@ -141,5 +148,9 @@ export class PrometheusMetricsExporter {
         this.workspaceInstanceUpdateCompletedSeconds
             .labels(String(dbWrite), workspaceCluster, WorkspaceType[type], outcome)
             .observe(durationSeconds);
+    }
+
+    increasePrebuildsCompletedCounter(state: string) {
+        this.prebuildsCompletedTotal.inc({ state });
     }
 }


### PR DESCRIPTION
## Description
Provides counter metrics for prebuilds with states as labels.
- gitpod_prebuilds_started_total ("queued")
- gitpod_prebuilds_completed_total ("available", "failed", "timeout", "aborted" )

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10383 

## How to test
1. Trigger prebuilds
2. Check that those prebuilds show up on this Prometheus query page[[1](https://9090-gitpodio-gitpod-wbcbfz9sl3s.ws-eu46.gitpod.io/graph?g0.expr=gitpod_prebuilds_total&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h)]

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft run with-observability