### PR TITLE
[kots] Add --use-experimental-config to installer render call

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -264,7 +264,7 @@ spec:
               EOF
 
               echo "Gitpod: render Kubernetes manifests"
-              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} > "${GITPOD_OBJECTS}/templates/gitpod.yaml"
+              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} --use-experimental-config > "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
               # Workaround for #8532 and #8529
               echo "Gitpod: Remove the StatefulSet status object for OpenVSX Proxy"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, in the KOTS installer job, the Gitpod Installer render call is without `--use-experimental-config`. This limits what we can do with the Gitpod config patch file. This pull requests add this flag.

Use case: We want to try if some configs that currently exist as experimental only will solve customer issues. If yes, we will move these configs out of experimental. To be able to test these configs first, the experimental flag is needed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## werft
/werft no-preview
/werft publish-to-kots