### PR TITLE
Revert "[baseserver] Change default metrics port to 9502 to not clash with kube-rbac-proxy"

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -335,7 +335,7 @@ func (s *Server) GRPCAddress() string { return s.options.config.Services.GRPC.Ge
 
 const (
 	BuiltinDebugPort   = 6060
-	BuiltinMetricsPort = 9502
+	BuiltinMetricsPort = 9500
 	BuiltinHealthPort  = 9501
 )
 


### PR DESCRIPTION
Reverts gitpod-io/gitpod#10109