### PR TITLE
Simplify configuration of KubeRBACProxyContainerWithConfig and remove collision

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -364,7 +364,7 @@ func newBuiltinServices(server *Server) *builtinServices {
 			Handler: server.healthEndpoint(),
 		},
 		Metrics: &http.Server{
-			Addr:    fmt.Sprintf(":%d", BuiltinMetricsPort),
+			Addr:    fmt.Sprintf("127.0.0.1:%d", BuiltinMetricsPort),
 			Handler: server.metricsEndpoint(),
 		},
 	}

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
@@ -303,21 +304,20 @@ func MessageBusWaiterContainer(ctx *RenderContext) *corev1.Container {
 }
 
 func KubeRBACProxyContainer(ctx *RenderContext) *corev1.Container {
-	return KubeRBACProxyContainerWithConfig(ctx, 9500, "http://127.0.0.1:9500/")
+	return KubeRBACProxyContainerWithConfig(ctx)
 }
 
-func KubeRBACProxyContainerWithConfig(ctx *RenderContext, listenPort int32, upstream string) *corev1.Container {
+func KubeRBACProxyContainerWithConfig(ctx *RenderContext) *corev1.Container {
 	return &corev1.Container{
 		Name:  "kube-rbac-proxy",
 		Image: ctx.ImageName(ThirdPartyContainerRepo(ctx.Config.Repository, KubeRBACProxyRepo), KubeRBACProxyImage, KubeRBACProxyTag),
 		Args: []string{
-			"--v=5",
 			"--logtostderr",
-			fmt.Sprintf("--insecure-listen-address=[$(IP)]:%d", listenPort),
-			fmt.Sprintf("--upstream=%s", upstream),
+			fmt.Sprintf("--insecure-listen-address=[$(IP)]:%d", baseserver.BuiltinMetricsPort),
+			fmt.Sprintf("--upstream=http://127.0.0.1:%d/", baseserver.BuiltinMetricsPort),
 		},
 		Ports: []corev1.ContainerPort{
-			{Name: "metrics", ContainerPort: listenPort},
+			{Name: "metrics", ContainerPort: baseserver.BuiltinMetricsPort},
 		},
 		Env: []corev1.EnvVar{
 			{

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -5,12 +5,13 @@ package common_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestKubeRBACProxyContainer_DefaultPorts(t *testing.T) {
@@ -19,7 +20,6 @@ func TestKubeRBACProxyContainer_DefaultPorts(t *testing.T) {
 
 	container := common.KubeRBACProxyContainer(ctx)
 	require.Equal(t, []string{
-		"--v=5",
 		"--logtostderr",
 		"--insecure-listen-address=[$(IP)]:9500",
 		"--upstream=http://127.0.0.1:9500/",
@@ -33,13 +33,12 @@ func TestKubeRBACProxyContainerWithConfig(t *testing.T) {
 	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test_namespace")
 	require.NoError(t, err)
 
-	listenPort := int32(9000)
-	container := common.KubeRBACProxyContainerWithConfig(ctx, listenPort, "http://127.0.0.1:9500/metrics")
+	listenPort := int32(9500)
+	container := common.KubeRBACProxyContainerWithConfig(ctx)
 	require.Equal(t, []string{
-		"--v=5",
 		"--logtostderr",
 		fmt.Sprintf("--insecure-listen-address=[$(IP)]:%d", listenPort),
-		"--upstream=http://127.0.0.1:9500/metrics",
+		"--upstream=http://127.0.0.1:9500/",
 	}, container.Args)
 	require.Equal(t, []corev1.ContainerPort{
 		{Name: "metrics", ContainerPort: listenPort},

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -5,6 +5,7 @@ package public_api_server
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
@@ -120,7 +121,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 									},
 								},
 							},
-							*common.KubeRBACProxyContainerWithConfig(ctx, 9500, fmt.Sprintf("http://127.0.0.1:%d/", baseserver.BuiltinMetricsPort)),
+							*common.KubeRBACProxyContainerWithConfig(ctx),
 						},
 						Volumes: []corev1.Volume{
 							{

--- a/install/installer/pkg/components/usage/deployment.go
+++ b/install/installer/pkg/components/usage/deployment.go
@@ -4,8 +4,6 @@
 package usage
 
 import (
-	"fmt"
-
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -93,7 +91,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								TimeoutSeconds:   1,
 							},
 						},
-							*common.KubeRBACProxyContainerWithConfig(ctx, 9500, fmt.Sprintf("http://127.0.0.1:%d/", baseserver.BuiltinMetricsPort)),
+							*common.KubeRBACProxyContainerWithConfig(ctx),
 						},
 					},
 				},

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -5,8 +5,6 @@
 package wsmanager
 
 import (
-	"fmt"
-	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
@@ -79,7 +77,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
-			*common.KubeRBACProxyContainerWithConfig(ctx, 9500, fmt.Sprintf("http://127.0.0.1:%d/", baseserver.BuiltinMetricsPort)),
+			*common.KubeRBACProxyContainerWithConfig(ctx),
 		},
 		Volumes: []corev1.Volume{
 			{


### PR DESCRIPTION
## Description

Gitpod components listen for metrics on localhost port 9500. Simplify KubeRBACProxyContainerWithConfig and remove any chance to brake that definition.

## How to test
- All components should start without issues
- Prometheus metrics should listen on `127.0.0.1:9500`
 
## Release Notes
```release-note
Simplify configuration of KubeRBACProxyContainerWithConfig and remove collision
```

Requires https://github.com/gitpod-io/gitpod/pull/10442