### PR TITLE
[dashboard] Move inactive workspaces out of sight

### DIFF
--- a/components/dashboard/src/components/Arrow.tsx
+++ b/components/dashboard/src/components/Arrow.tsx
@@ -10,7 +10,7 @@ function Arrow(props: { up: boolean; customBorderClasses?: string }) {
             className={
                 "mx-2 " +
                 (props.customBorderClasses ||
-                    "border-gray-400 dark:border-gray-600 group-hover:border-gray-600 dark:group-hover:border-gray-400")
+                    "border-gray-400 dark:border-gray-500 group-hover:border-gray-600 dark:group-hover:border-gray-400")
             }
             style={{
                 marginTop: 2,

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -18,6 +18,8 @@ import { User } from "@gitpod/gitpod-protocol";
 import { useLocation } from "react-router";
 import { StartWorkspaceModalContext, StartWorkspaceModalKeyBinding } from "./start-workspace-modal-context";
 import SelectIDEModal from "../settings/SelectIDEModal";
+import Arrow from "../components/Arrow";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 export interface WorkspacesProps {}
 
@@ -25,6 +27,8 @@ export interface WorkspacesState {
     workspaces: WorkspaceInfo[];
     isTemplateModelOpen: boolean;
     repos: WhitelistedRepository[];
+    showInactive: boolean;
+    deleteModalVisible: boolean;
 }
 
 export default function () {
@@ -35,6 +39,8 @@ export default function () {
     const [activeWorkspaces, setActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [inactiveWorkspaces, setInactiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [workspaceModel, setWorkspaceModel] = useState<WorkspaceModel>();
+    const [showInactive, setShowInactive] = useState<boolean>();
+    const [deleteModalVisible, setDeleteModalVisible] = useState<boolean>();
     const { setIsStartWorkspaceModalVisible } = useContext(StartWorkspaceModalContext);
 
     useEffect(() => {
@@ -49,6 +55,18 @@ export default function () {
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
+
+            <ConfirmationModal
+                title="Delete Inactive Workspaces"
+                areYouSureText="You are about to permanently delete your inactive workspaces."
+                buttonText="Delete Inactive Workspaces"
+                visible={!!deleteModalVisible}
+                onClose={() => setDeleteModalVisible(false)}
+                onConfirm={() => {
+                    inactiveWorkspaces.forEach((ws) => workspaceModel?.deleteWorkspace(ws.workspace.id));
+                    setDeleteModalVisible(false);
+                }}
+            ></ConfirmationModal>
 
             {isOnboardingUser && <SelectIDEModal location={"workspace_list"} />}
 
@@ -128,27 +146,58 @@ export default function () {
                             })}
                             {activeWorkspaces.length > 0 && <div className="py-6"></div>}
                             {inactiveWorkspaces.length > 0 && (
-                                <div className="p-3 text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl text-sm text-center">
-                                    Unpinned workspaces that have been inactive for more than 14 days will be
-                                    automatically deleted.{" "}
-                                    <a
-                                        className="gp-link"
-                                        href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
+                                <div className="pt-14">
+                                    <div className="border-t border-gray-200 dark:border-gray-800"></div>
+                                    <div
+                                        onClick={() => setShowInactive(!showInactive)}
+                                        className="flex cursor-pointer py-6"
                                     >
-                                        Learn more
-                                    </a>
+                                        <div className="flex flex-col">
+                                            <h2 className="">Inactive Workspaces</h2>
+                                        </div>
+                                        <div>
+                                            <Arrow
+                                                up={!!showInactive}
+                                                customBorderClasses="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+                                            />
+                                        </div>
+                                    </div>
+                                    {showInactive ? (
+                                        <>
+                                            <div className="flex flex-row p-3 text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl">
+                                                <div className="text-sm flex-auto py-3">
+                                                    Unpinned workspaces that have been inactive for more than 14 days
+                                                    will be automatically deleted.{" "}
+                                                    <a
+                                                        className="gp-link"
+                                                        href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
+                                                    >
+                                                        Learn more
+                                                    </a>
+                                                </div>
+                                                <button
+                                                    onClick={() => setDeleteModalVisible(true)}
+                                                    className="ml-2 danger secondary w-64 p-2"
+                                                >
+                                                    Delete Inactive Workspaces
+                                                </button>
+                                            </div>
+                                            {inactiveWorkspaces.map((e) => {
+                                                return (
+                                                    <WorkspaceEntry
+                                                        key={e.workspace.id}
+                                                        desc={e}
+                                                        model={workspaceModel}
+                                                        stopWorkspace={(wsId) =>
+                                                            getGitpodService().server.stopWorkspace(wsId)
+                                                        }
+                                                    />
+                                                );
+                                            })}
+                                        </>
+                                    ) : null}
                                 </div>
                             )}
-                            {inactiveWorkspaces.map((e) => {
-                                return (
-                                    <WorkspaceEntry
-                                        key={e.workspace.id}
-                                        desc={e}
-                                        model={workspaceModel}
-                                        stopWorkspace={(wsId) => getGitpodService().server.stopWorkspace(wsId)}
-                                    />
-                                );
-                            })}
                         </ItemsList>
                     </>
                 ) : (

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -58,7 +58,7 @@ export default function () {
 
             <ConfirmationModal
                 title="Delete Inactive Workspaces"
-                areYouSureText="You are about to permanently delete your inactive workspaces."
+                areYouSureText="Are you sure you want to delete all inactive workspaces?"
                 buttonText="Delete Inactive Workspaces"
                 visible={!!deleteModalVisible}
                 onClose={() => setDeleteModalVisible(false)}
@@ -146,42 +146,49 @@ export default function () {
                             })}
                             {activeWorkspaces.length > 0 && <div className="py-6"></div>}
                             {inactiveWorkspaces.length > 0 && (
-                                <div className="pt-14">
-                                    <div className="border-t border-gray-200 dark:border-gray-800"></div>
+                                <div>
                                     <div
                                         onClick={() => setShowInactive(!showInactive)}
-                                        className="flex cursor-pointer py-6"
+                                        className="flex cursor-pointer py-6 px-6 flex-row text-gray-400 bg-gray-50  hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 rounded-xl mb-2"
                                     >
-                                        <div className="flex flex-col">
-                                            <h2 className="">Inactive Workspaces</h2>
+                                        <div className="pr-2">
+                                            <Arrow up={!!showInactive} />
                                         </div>
-                                        <div>
-                                            <Arrow
-                                                up={!!showInactive}
-                                                customBorderClasses="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
-                                            />
+                                        <div className="flex flex-grow flex-col ">
+                                            <div className="font-medium text-gray-500 dark:text-gray-200 truncate">
+                                                <span>Inactive Workspaces&nbsp;</span>
+                                                <span className="text-gray-400 dark:text-gray-400 bg-gray-200 dark:bg-gray-600 rounded-xl px-2 py-0.5 text-xs">
+                                                    {inactiveWorkspaces.length}
+                                                </span>
+                                            </div>
+                                            <div className="text-sm flex-auto">
+                                                Unpinned workspaces that have been inactive for more than 14 days will
+                                                be automatically deleted.{" "}
+                                                <a
+                                                    className="gp-link"
+                                                    href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
+                                                    onClick={(evt) => evt.stopPropagation()}
+                                                >
+                                                    Learn more
+                                                </a>
+                                            </div>
+                                        </div>
+                                        <div className="self-center">
+                                            {showInactive ? (
+                                                <button
+                                                    onClick={(evt) => {
+                                                        setDeleteModalVisible(true);
+                                                        evt.stopPropagation();
+                                                    }}
+                                                    className="secondary danger"
+                                                >
+                                                    Delete Inactive Workspaces
+                                                </button>
+                                            ) : null}
                                         </div>
                                     </div>
                                     {showInactive ? (
                                         <>
-                                            <div className="flex flex-row p-3 text-gray-400 bg-gray-50 dark:bg-gray-800 rounded-xl">
-                                                <div className="text-sm flex-auto py-3">
-                                                    Unpinned workspaces that have been inactive for more than 14 days
-                                                    will be automatically deleted.{" "}
-                                                    <a
-                                                        className="gp-link"
-                                                        href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
-                                                    >
-                                                        Learn more
-                                                    </a>
-                                                </div>
-                                                <button
-                                                    onClick={() => setDeleteModalVisible(true)}
-                                                    className="ml-2 danger secondary w-64 p-2"
-                                                >
-                                                    Delete Inactive Workspaces
-                                                </button>
-                                            </div>
                                             {inactiveWorkspaces.map((e) => {
                                                 return (
                                                     <WorkspaceEntry

--- a/components/dashboard/src/workspaces/workspace-model.ts
+++ b/components/dashboard/src/workspaces/workspace-model.ts
@@ -11,6 +11,7 @@ import {
     WorkspaceInfo,
     WorkspaceInstance,
 } from "@gitpod/gitpod-protocol";
+import { hoursBefore, isDateSmallerOrEqual } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 import { getGitpodService } from "../service/service";
 
 export class WorkspaceModel implements Disposable, Partial<GitpodClient> {
@@ -145,8 +146,12 @@ export class WorkspaceModel implements Disposable, Partial<GitpodClient> {
     }
 
     protected isActive(info: WorkspaceInfo): boolean {
+        const lastSessionStart = WorkspaceInfo.lastActiveISODate(info);
+        const twentyfourHoursAgo = hoursBefore(new Date().toISOString(), 24);
         return (
-            (info.workspace.pinned || (!!info.latestInstance && info.latestInstance.status?.phase !== "stopped")) &&
+            (info.workspace.pinned ||
+                (!!info.latestInstance && info.latestInstance.status?.phase !== "stopped") ||
+                isDateSmallerOrEqual(twentyfourHoursAgo, lastSessionStart)) &&
             !info.workspace.softDeleted
         );
     }

--- a/components/gitpod-protocol/src/util/timeutil.ts
+++ b/components/gitpod-protocol/src/util/timeutil.ts
@@ -47,6 +47,12 @@ export const orderAsc = (d1: string, d2: string): number => liftDate(d1, d2, (d1
 export const liftDate1 = <T>(d1: string, f: (d1: Date) => T): T => f(new Date(d1));
 export const liftDate = <T>(d1: string, d2: string, f: (d1: Date, d2: Date) => T): T => f(new Date(d1), new Date(d2));
 
+export function hoursBefore(date: string, hours: number): string {
+    const result = new Date(date);
+    result.setHours(result.getHours() - hours);
+    return result.toISOString();
+}
+
 export function hoursLater(date: string, hours: number): string {
     const result = new Date(date);
     result.setHours(result.getHours() + hours);


### PR DESCRIPTION
## Description
Many users are manually deleting workspaces, keeping their workspaces list clean. 
Users should feel less urge to manually clean up and cleaning up should be simpler.

This PR, makes the inactive workspaces section on the /workspaces list collapsable (collapsed by default) to give a cleaner impression. When expanded there is a button to delete them.

- [ ] TODO: Keep workspaces of the last 12 hours active

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #1053
Fixes #4233

## How to test
Use the preview env and start a few workspaces, stop them. Check the workspaces list.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added action to delete all inactive workspaces
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

<img width="1639" alt="Screenshot 2022-06-03 at 12 02 12" src="https://user-images.githubusercontent.com/372735/171835416-33c5c1c5-1333-49a1-9fa4-cc539b1cf693.png">
<img width="1639" alt="Screenshot 2022-06-03 at 12 02 18" src="https://user-images.githubusercontent.com/372735/171835414-9056a4f9-06cb-4475-9755-38e75c611119.png">
<img width="1639" alt="Screenshot 2022-06-03 at 12 02 24" src="https://user-images.githubusercontent.com/372735/171835406-f23289e7-4abf-402c-ae68-a2889daa9b07.png">

