### PR TITLE
[analytics] add error field to feedback event

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -9,6 +9,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import Cookies from "js-cookie";
 import { v4 } from "uuid";
 import { Experiment } from "./experiments";
+import { StartWorkspaceError } from "./start/StartPage";
 
 export type Event =
     | "invite_url_requested"
@@ -40,6 +41,8 @@ export interface TrackFeedback {
     feedback: string;
     href: string;
     path: string;
+    error_object?: StartWorkspaceError;
+    error_message?: string;
 }
 interface TrackDashboardClick {
     dnt?: boolean;

--- a/components/dashboard/src/components/ErrorMessage.tsx
+++ b/components/dashboard/src/components/ErrorMessage.tsx
@@ -22,6 +22,7 @@ function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string 
                     initialSize={24}
                     isError={true}
                     isModal={false}
+                    error_message={props.message}
                 />
             )}
         </>

--- a/components/dashboard/src/feedback-form/FeedbackComponent.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackComponent.tsx
@@ -10,6 +10,7 @@ import happy from "../images/feedback/happy-emoji.svg";
 import meh from "../images/feedback/meh-emoji.svg";
 import crying from "../images/feedback/crying-emoji.svg";
 import { trackEvent } from "../Analytics";
+import { StartWorkspaceError } from "../start/StartPage";
 
 function FeedbackComponent(props: {
     onClose?: () => void;
@@ -17,6 +18,8 @@ function FeedbackComponent(props: {
     isError: boolean;
     message?: string;
     initialSize?: number;
+    error_object?: StartWorkspaceError;
+    error_message?: string;
 }) {
     const [text, setText] = useState<string>("");
     const [selectedEmoji, setSelectedEmoji] = useState<number | undefined>();
@@ -35,6 +38,8 @@ function FeedbackComponent(props: {
                 feedback: text,
                 href: window.location.href,
                 path: window.location.pathname,
+                error_object: props.error_object || undefined,
+                error_message: props.error_message,
             };
             trackEvent("feedback_submitted", feedbackObj);
         }

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -515,6 +515,8 @@ function RepositoryNotFoundView(p: { error: StartWorkspaceError }) {
                     message={"Was this error message helpful?"}
                     isError={true}
                     initialSize={24}
+                    error_object={p.error}
+                    error_message={p.error.message}
                 />
             )}
         </StartPage>


### PR DESCRIPTION
## Description
_[@jldec updated Aug 17, 2022]_  
The intent of this PR was to add the rendered error message along with the feedback tracking event, however, the object used in this implementation does not actually include the rendered error message, because that is derived in JSX.

| With error | Without error |
| - | - |
| <img width="430" alt="Screenshot 2022-06-03 at 14 18 12" src="https://user-images.githubusercontent.com/8015191/171863181-1131683c-5ce3-4c1d-9913-1f792115bc45.png"> | <img width="430" alt="Screenshot 2022-06-03 at 15 26 14" src="https://user-images.githubusercontent.com/8015191/171863303-af51c1c1-5374-457b-8cdb-341e8dd25dd4.png"> |

## Related Issue(s)

<!-- List the issue(s) this PR solves -->
Fixes #10402 

## How to test
1. Trigger an error when creating a workspace (steps [here](https://github.com/gitpod-io/gitpod/pull/10071#issue-1238938630)).
2. Visit [Segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and filter for `feedback_submitted`.
3. See the `error_rendered` body.
4. Send a non-error feedback and see no `error_rendered` field on Segment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe