### PR TITLE
[installer] Update kube-rbac-proxy to v0.12.0

### DIFF
--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -24,7 +24,7 @@ const (
 	InClusterMessageQueueTLS    = "messagebus-certificates-secret-core"
 	KubeRBACProxyRepo           = "quay.io"
 	KubeRBACProxyImage          = "brancz/kube-rbac-proxy"
-	KubeRBACProxyTag            = "v0.11.0"
+	KubeRBACProxyTag            = "v0.12.0"
 	MinioServiceAPIPort         = 9000
 	MonitoringChart             = "monitoring"
 	ProxyComponent              = "proxy"


### PR DESCRIPTION
## Description

Changes https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.12.0

## How to test
- Pods should start without issues
- Gathering of metrics should not fail

## Release Notes
```release-note
[installer] Update kube-rbac-proxy to v0.12.0
```
