### PR TITLE
[usage] Automatically cleanup records between test DB connections

### DIFF
--- a/components/usage/pkg/db/project_test.go
+++ b/components/usage/pkg/db/project_test.go
@@ -64,10 +64,5 @@ func insertRawProject(t *testing.T, conn *gorm.DB, obj map[string]interface{}) u
 	tx := conn.Exec(statement, values)
 	require.NoError(t, tx.Error)
 
-	t.Cleanup(func() {
-		tx = conn.Delete(&db.Project{ID: id})
-		require.NoError(t, tx.Error)
-	})
-
 	return id
 }

--- a/components/usage/pkg/db/workspace_instance_test.go
+++ b/components/usage/pkg/db/workspace_instance_test.go
@@ -70,11 +70,6 @@ func insertRawWorkspaceInstance(t *testing.T, conn *gorm.DB, object map[string]i
 	statement := fmt.Sprintf(`INSERT INTO d_b_workspace_instance (%s) VALUES ?;`, strings.Join(columns, ", "))
 	id := uuid.MustParse(insertRawObject(t, conn, columns, statement, object))
 
-	t.Cleanup(func() {
-		tx := conn.Delete(&db.WorkspaceInstance{ID: id})
-		require.NoError(t, tx.Error)
-	})
-
 	return id
 }
 

--- a/components/usage/pkg/db/workspace_test.go
+++ b/components/usage/pkg/db/workspace_test.go
@@ -73,10 +73,6 @@ func insertRawWorkspace(t *testing.T, conn *gorm.DB, rawWorkspace map[string]int
 	) VALUES ?;`, strings.Join(columns, ", "))
 	id := insertRawObject(t, conn, columns, statement, rawWorkspace)
 
-	t.Cleanup(func() {
-		tx := conn.Delete(&db.Workspace{ID: id})
-		require.NoError(t, tx.Error)
-	})
 	return id
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add hooks to test DB connections to clean up records after tests run.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->
* Unit tests (run on CI)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE