### PR TITLE
[usage] Validate workspace instances in reconciler

### DIFF
--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"time"
 )
@@ -23,12 +24,20 @@ func (f ReconcilerFunc) Reconcile() error {
 	return f()
 }
 
+type UsageReconciler struct {
+	conn *gorm.DB
+}
+
 func NewUsageReconciler(conn *gorm.DB) *UsageReconciler {
 	return &UsageReconciler{conn: conn}
 }
 
-type UsageReconciler struct {
-	conn *gorm.DB
+type UsageReconcileStatus struct {
+	StartTime time.Time
+	EndTime   time.Time
+
+	WorkspaceInstances        int
+	InvalidWorkspaceInstances int
 }
 
 func (u *UsageReconciler) Reconcile() error {
@@ -38,16 +47,100 @@ func (u *UsageReconciler) Reconcile() error {
 	startOfCurrentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	startOfNextMonth := startOfCurrentMonth.AddDate(0, 1, 0)
 
-	return u.reconcile(ctx, startOfCurrentMonth, startOfNextMonth)
+	status, err := u.ReconcileTimeRange(ctx, startOfCurrentMonth, startOfNextMonth)
+	if err != nil {
+		return err
+	}
+	log.WithField("usage_reconcile_status", status).Info("Reconcile completed.")
+	return nil
 }
 
-func (u *UsageReconciler) reconcile(ctx context.Context, from, to time.Time) error {
+func (u *UsageReconciler) ReconcileTimeRange(ctx context.Context, from, to time.Time) (*UsageReconcileStatus, error) {
+	log.Infof("Gathering usage data from %s to %s", from, to)
+	status := &UsageReconcileStatus{
+		StartTime: from,
+		EndTime:   to,
+	}
+	instances, invalidInstances, err := u.loadWorkspaceInstances(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load workspace instances: %w", err)
+	}
+	status.WorkspaceInstances = len(instances)
+	status.InvalidWorkspaceInstances = len(invalidInstances)
+
+	if len(invalidInstances) > 0 {
+		log.WithField("invalid_workspace_instances", invalidInstances).Errorf("Detected %d invalid instances. These will be skipped in the current run.", len(invalidInstances))
+	}
+
+	log.WithField("workspace_instances", instances).Debug("Successfully loaded workspace instances.")
+	return status, nil
+}
+
+func (u *UsageReconciler) loadWorkspaceInstances(ctx context.Context, from, to time.Time) ([]db.WorkspaceInstance, []invalidWorkspaceInstance, error) {
 	log.Infof("Gathering usage data from %s to %s", from, to)
 	instances, err := db.ListWorkspaceInstancesInRange(ctx, u.conn, from, to)
 	if err != nil {
-		return fmt.Errorf("failed to list instances: %w", err)
+		return nil, nil, fmt.Errorf("failed to list instances from db: %w", err)
 	}
-
 	log.Infof("Identified %d instances between %s and %s", len(instances), from, to)
-	return nil
+
+	valid, invalid := validateInstances(instances)
+	trimmed := trimStartStopTime(valid, from, to)
+	return trimmed, invalid, nil
+}
+
+type invalidWorkspaceInstance struct {
+	reason              string
+	workspaceInstanceID uuid.UUID
+}
+
+func validateInstances(instances []db.WorkspaceInstance) (valid []db.WorkspaceInstance, invalid []invalidWorkspaceInstance) {
+	for _, i := range instances {
+		// i is a pointer to the current element, we need to assign it to ensure we're copying the value, not the current pointer.
+		instance := i
+
+		// Each instance must have a start time, without it, we do not have a baseline for usage computation.
+		if !instance.CreationTime.IsSet() {
+			invalid = append(invalid, invalidWorkspaceInstance{
+				reason:              "missing creation time",
+				workspaceInstanceID: instance.ID,
+			})
+			continue
+		}
+
+		start := instance.CreationTime.Time()
+
+		// Currently running instances do not have a stopped time set, so we ignore these.
+		if instance.StoppedTime.IsSet() {
+			stop := instance.StoppedTime.Time()
+			if stop.Before(start) {
+				invalid = append(invalid, invalidWorkspaceInstance{
+					reason:              "stop time is before start time",
+					workspaceInstanceID: instance.ID,
+				})
+				continue
+			}
+		}
+
+		valid = append(valid, instance)
+	}
+	return valid, invalid
+}
+
+// trimStartStopTime ensures that start time or stop time of an instance is never outside of specified start or stop time range.
+func trimStartStopTime(instances []db.WorkspaceInstance, maximumStart, minimumStop time.Time) []db.WorkspaceInstance {
+	var updated []db.WorkspaceInstance
+
+	for _, instance := range instances {
+		if instance.StartedTime.Time().Before(maximumStart) {
+			instance.StartedTime = db.NewVarcharTime(maximumStart)
+		}
+
+		if instance.StoppedTime.Time().After(minimumStop) {
+			instance.StoppedTime = db.NewVarcharTime(minimumStop)
+		}
+
+		updated = append(updated, instance)
+	}
+	return updated
 }

--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package controller
+
+import (
+	"context"
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestUsageReconciler_Reconcile(t *testing.T) {
+	conn := db.ConnectForTests(t)
+	workspaceID := "gitpodio-gitpod-gyjr82jkfnd"
+	instanceStatus := []byte(`{"phase": "stopped", "conditions": {"deployed": false, "pullingImages": false, "serviceExists": false}}`)
+	startOfMay := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
+	startOfJune := time.Date(2022, 06, 1, 0, 00, 00, 00, time.UTC)
+	instances := []db.WorkspaceInstance{
+		{
+			ID:           uuid.New(),
+			WorkspaceID:  workspaceID,
+			CreationTime: db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
+			StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+			Status:       instanceStatus,
+		},
+		// No creation time, invalid record
+		{
+			ID:          uuid.New(),
+			WorkspaceID: workspaceID,
+			StoppedTime: db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+			Status:      instanceStatus,
+		},
+	}
+
+	tx := conn.Create(instances)
+	require.NoError(t, tx.Error)
+
+	reconciler := NewUsageReconciler(conn)
+
+	status, err := reconciler.ReconcileTimeRange(context.Background(), startOfMay, startOfJune)
+	require.NoError(t, err)
+	require.Equal(t, &UsageReconcileStatus{
+		StartTime:                 startOfMay,
+		EndTime:                   startOfJune,
+		WorkspaceInstances:        1,
+		InvalidWorkspaceInstances: 1,
+	}, status)
+}

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -57,10 +57,11 @@ func ListWorkspaceInstancesInRange(ctx context.Context, conn *gorm.DB, from, to 
 	var instances []WorkspaceInstance
 	tx := conn.WithContext(ctx).
 		Where(
-			conn.Where("stoppedTime >= ?", from).Or("stoppedTime = ?", ""),
+			conn.Where("stoppedTime >= ?", TimeToISO8601(from)).Or("stoppedTime = ?", ""),
 		).
-		Where("creationTime < ?", to).
-		Where("creationTime != ?", "").
+		Where(
+			conn.Where("creationTime < ?", TimeToISO8601(to)).Or("creationTime = ?", ""),
+		).
 		Find(&instances)
 	if tx.Error != nil {
 		return nil, fmt.Errorf("failed to list workspace instances: %w", tx.Error)

--- a/components/usage/pkg/db/workspace_instance_test.go
+++ b/components/usage/pkg/db/workspace_instance_test.go
@@ -150,6 +150,20 @@ func TestListWorkspaceInstancesInRange(t *testing.T) {
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
 			Status:       status,
 		},
+		// Stopped in May, no creation time, should be retrieved but this is a poor data quality record.
+		{
+			ID:          uuid.New(),
+			WorkspaceID: workspaceID,
+			StoppedTime: db.NewVarcharTime(time.Date(2022, 05, 1, 1, 0, 0, 0, time.UTC)),
+			Status:      status,
+		},
+		// Started in April, no stop time, still running
+		{
+			ID:           uuid.New(),
+			WorkspaceID:  workspaceID,
+			CreationTime: db.NewVarcharTime(time.Date(2022, 04, 31, 23, 00, 00, 00, time.UTC)),
+			Status:       status,
+		},
 	}
 	invalid := []*db.WorkspaceInstance{
 		// Start of June


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Perform sanity checks on retrieved Workspace Instances. Excludes invalid instances and logs the problem with the records.

This is needed because our DB already contains records with instances which have poor data quality.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/10490
* Depends on https://github.com/gitpod-io/gitpod/pull/10456

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE