### PR TITLE
[previews] Expose observability components through stable DNS

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -268,6 +268,9 @@ EOF`)
         exec(`kubectl --kubeconfig ${this.options.kubeconfigPath} apply -f k8s.yaml`, { silent: true });
 
         exec(`werft log result -d "dev installation" -c github-check-preview-env url https://${this.options.domain}/workspaces`);
+        exec(`werft log result -d "Prometheus" -c github-check-preview-env url https://prometheus.${this.options.domain}`);
+        exec(`werft log result -d "Grafana" -c github-check-preview-env url https://grafana.${this.options.domain}`);
+        exec(`werft log result -d "Pyrra" -c github-check-preview-env url https://pyrra.${this.options.domain}`);
         this.options.werft.done(slice)
     }
 

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -3,7 +3,7 @@ import { exec } from '../../util/shell';
 import { Werft } from "../../util/werft";
 import * as VM from '../../vm/vm'
 import { CORE_DEV_KUBECONFIG_PATH, GCLOUD_SERVICE_ACCOUNT_PATH, HARVESTER_KUBECONFIG_PATH } from "./const";
-import { issueMetaCerts } from './deploy-to-preview-environment';
+import { issueCerts } from './deploy-to-preview-environment';
 import { JobConfig } from './job-config';
 import * as Manifests from '../../vm/manifests';
 
@@ -66,7 +66,7 @@ async function issueCertificate(werft: Werft, config: JobConfig) {
     const domain = config.withVM ? `${config.previewEnvironment.destname}.preview.gitpod-dev.com` : `${config.previewEnvironment.destname}.staging.gitpod-dev.com`;
 
     werft.log(prepareSlices.ISSUE_CERTIFICATES, prepareSlices.ISSUE_CERTIFICATES)
-    await issueMetaCerts(werft, certName, "certs", domain, config.withVM, prepareSlices.ISSUE_CERTIFICATES)
+    await issueCerts(werft, certName, "certs", domain, config.withVM, prepareSlices.ISSUE_CERTIFICATES)
     werft.done(prepareSlices.ISSUE_CERTIFICATES)
 }
 

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -163,10 +163,10 @@ export class MonitoringSatelliteInstaller {
         werft.log(sliceName, "Post-processing manifests so it works on Harvester");
         exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.type 'NodePort'`);
         exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.type 'NodePort'`);
+        exec(`yq w -i observability/monitoring-satellite/manifests/pyrra/apiService.yaml spec.type 'NodePort'`);
 
-        exec(
-            `yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`,
-        );
         exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.ports[0].nodePort 32000`);
+        exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`);
+        exec(`yq w -i observability/monitoring-satellite/manifests/grafana/apiService.yaml spec.ports[0].nodePort 32002`);
     }
 }

--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -79,7 +79,9 @@ class HarvesterPreviewEnvironment {
             deleteDNSRecord('A', `prometheus-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
             deleteDNSRecord('TXT', `prometheus-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
             deleteDNSRecord('A', `grafana-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
-            deleteDNSRecord('TXT', `grafana-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID)
+            deleteDNSRecord('TXT', `grafana-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
+            deleteDNSRecord('A', `pyrra-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
+            deleteDNSRecord('TXT', `pyrra-${this.name}.preview.gitpod-dev.com`, 'gitpod-core-dev', 'preview-gitpod-dev-com', sliceID),
         ])
     }
 
@@ -181,6 +183,8 @@ class CoreDevPreviewEnvironment {
             deleteDNSRecord('TXT', `prometheus-${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID),
             deleteDNSRecord('A', `grafana-${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID),
             deleteDNSRecord('TXT', `grafana-${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID),
+            deleteDNSRecord('A', `pyrra-${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID),
+            deleteDNSRecord('TXT', `pyrra-${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID),
             deleteDNSRecord('TXT', `_acme-challenge.${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID),
             deleteDNSRecord('TXT', `_acme-challenge.ws-dev.${this.name}.staging.gitpod-dev.com`, 'gitpod-dev', 'gitpod-dev-com', sliceID)
         ])

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -10,9 +10,7 @@ export class IssueCertificateParams {
     gcpSaPath: string
     dnsZoneDomain: string
     domain: string
-    ip: string
     additionalSubdomains: string[]
-    bucketPrefixTail: string
     certName: string
     certNamespace: string
     withVM: boolean

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -168,6 +168,18 @@ spec:
       protocol: TCP
       port: 443
       targetPort: 4430
+    - name: grafana
+      protocol: TCP
+      port: 3000
+      targetPort: 32000
+    - name: prometheus
+      protocol: TCP
+      port: 9090
+      targetPort: 32001
+    - name: pyrra
+      protocol: TCP
+      port: 9099
+      targetPort: 32002
   selector:
     gitpod.io/lbName: ${name}
   type: LoadBalancer
@@ -216,6 +228,9 @@ spec:
             - svc/proxy
             - '4430:443'
             - '2200:22'
+            - '32000:3000'  # Grafana
+            - '32001:9090'  # Prometheus
+            - '32002:9099'  # Pyrra
           resources: {}
           volumeMounts:
             - name: kubeconfig


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The developer experience when working with metrics is not great and leads to metrics breaking in production every now and then.

This PR improves the DevX a little bit by facilitating access to the Observability components through stable domain names.

## TODO before merging

This PR only implements the routing to Harvester/Core-dev ingresses, we still need to configure the ingresses to route traffic to the correct components/previews


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/881

## How to test
<!-- Provide steps to test this PR -->
Access werft results

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
