### PR TITLE
[usage] Handle empty value varchar time, use ISO8601

### DIFF
--- a/components/usage/pkg/db/types_test.go
+++ b/components/usage/pkg/db/types_test.go
@@ -6,6 +6,7 @@ package db
 
 import (
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 	"testing"
 	"time"
 )
@@ -75,5 +76,83 @@ func TestVarcharTime_Scan(t *testing.T) {
 				Error: err != nil,
 			})
 		})
+	}
+}
+
+func TestVarcharTime_Value_ISO8601(t *testing.T) {
+	for _, scenario := range []struct {
+		Time     VarcharTime
+		Expected string
+	}{
+		{
+			Time:     NewVarcharTime(time.Date(2019, 05, 10, 9, 54, 28, 185000000, time.UTC)),
+			Expected: "2019-05-10T09:54:28.185Z",
+		},
+		{
+			Time:     VarcharTime{},
+			Expected: "",
+		},
+	} {
+		wireFormat, err := scenario.Time.Value()
+		require.NoError(t, err)
+		require.Equal(t, scenario.Expected, wireFormat)
+	}
+}
+
+func TestVarcharTime_String_ISO8601(t *testing.T) {
+	for _, scenario := range []struct {
+		Time     VarcharTime
+		Expected string
+	}{
+		{
+			Time:     NewVarcharTime(time.Date(2019, 05, 10, 9, 54, 28, 185000000, time.UTC)),
+			Expected: "2019-05-10T09:54:28.185Z",
+		},
+		{
+			Time:     VarcharTime{},
+			Expected: "",
+		},
+	} {
+		require.Equal(t, scenario.Expected, scenario.Time.String())
+	}
+}
+
+func TestVarcharTime_SerializeAndDeserialize(t *testing.T) {
+	// Custom table to be able to exercise serialization easily, independent of other models
+	type VarcharModel struct {
+		ID   int         `gorm:"primaryKey"`
+		Time VarcharTime `gorm:"column:time;type:varchar(255);"`
+	}
+
+	conn := ConnectForTests(t)
+	require.NoError(t, conn.AutoMigrate(&VarcharModel{}))
+
+	conn.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&VarcharModel{})
+
+	for _, scenario := range []struct {
+		Description string
+		Input       VarcharModel
+		Expected    VarcharModel
+	}{
+		{
+			Description: "empty value for VarcharTime",
+			Input: VarcharModel{
+				ID:   1,
+				Time: VarcharTime{},
+			},
+			Expected: VarcharModel{
+				ID:   1,
+				Time: VarcharTime{},
+			},
+		},
+	} {
+		tx := conn.Create(scenario.Input)
+		require.NoError(t, tx.Error)
+
+		var read VarcharModel
+		tx = conn.First(&read, scenario.Input.ID)
+		require.NoError(t, tx.Error)
+
+		require.Equal(t, scenario.Expected, read)
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Hardens handling of Varchar Time records in the DB. Here, we ensure that empty value of VarChar is equivalent to the empty string and therefore not a valid Timestamp, but a valid value to store in the DB.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Follow-up from conversation in https://github.com/gitpod-io/gitpod/pull/10293#discussion_r885595480

## How to test
<!-- Provide steps to test this PR -->
Unit tests (run by CI)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE