### PR TITLE
[content-service] show error if failed to download backup file

### DIFF
--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -191,7 +191,7 @@ func (bi *fromBackupInitializer) Run(ctx context.Context, mappings []archive.IDM
 
 	hasBackup, err := bi.RemoteStorage.Download(ctx, bi.Location, storage.DefaultBackup, mappings)
 	if !hasBackup {
-		return src, xerrors.Errorf("no backup found")
+		return src, xerrors.Errorf("no backup found: %w", err)
 	}
 	if err != nil {
 		return src, xerrors.Errorf("cannot restore backup: %w", err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Make sure to show if there was an error attempting to download backup, if any.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/10315

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[content-service] make sure to show error if there was one when attempting to download backup
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
