### PR TITLE
Add cache for ide-proxy static file

### DIFF
--- a/components/ide-proxy/README.md
+++ b/components/ide-proxy/README.md
@@ -1,0 +1,7 @@
+# IDE-proxy
+
+IDE proxy is a simple Caddy application that currently only serve static files e.g. the IDE logo
+
+Attention: All files in the static folder should be immutable, if you need to change them you have to add new files and change the references
+
+For example, to change the IDE logo you must upload a new file and change the `server-ide-config` configmap

--- a/components/ide-proxy/conf/Caddyfile
+++ b/components/ide-proxy/conf/Caddyfile
@@ -26,6 +26,8 @@
 	header @bin_asset {
 		Content-Type application/octet-stream
 		Content-Disposition attachment
+		# static assets configure cache headers
+		Cache-Control "public, max-age=600"
 	}
 
 	@static_path {
@@ -34,6 +36,12 @@
 
 	handle @static_path {
 		try_files {path}
+		# static assets configure cache headers and do not check for changes
+		header {
+			Cache-Control "public, max-age=31536000"
+			# remove Last-Modified header
+			-Last-Modified
+		}
 	}
 
 	handle {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add cache for ide-proxy static file

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Open preview environment, open chrome devtool network, go to preview environment setting -> preference
check devtool, the ide logo should have the header 
```HTTP
Cache-Control: public, max-age=31536000
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
