### PR TITLE
[usage] List workspaces for each workspace instance in usage period

### DIFF
--- a/components/usage/pkg/db/dbtest/workspace.go
+++ b/components/usage/pkg/db/dbtest/workspace.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
+	"testing"
+)
+
+func NewWorkspace(t *testing.T, id string) db.Workspace {
+	t.Helper()
+
+	return db.Workspace{
+		ID:         id,
+		OwnerID:    uuid.New(),
+		Type:       "prebuild",
+		ContextURL: "https://github.com/gitpod-io/gitpod",
+		Context:    []byte(`{"title":"[usage] List workspaces for each workspace instance in usage period","repository":{"cloneUrl":"https://github.com/gitpod-io/gitpod.git","host":"github.com","name":"gitpod","owner":"gitpod-io","private":false},"ref":"mp/usage-list-workspaces","refType":"branch","revision":"586f22ecaeeb3b4796fd92f9ae1ca3512ca1e330","nr":10495,"base":{"repository":{"cloneUrl":"https://github.com/gitpod-io/gitpod.git","host":"github.com","name":"gitpod","owner":"gitpod-io","private":false},"ref":"mp/usage-validate-instances","refType":"branch"},"normalizedContextURL":"https://github.com/gitpod-io/gitpod/pull/10495","checkoutLocation":"gitpod"}`),
+		Config:     []byte(`{"image":"eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-me-image.1","workspaceLocation":"gitpod/gitpod-ws.code-workspace","checkoutLocation":"gitpod","ports":[{"port":1337,"onOpen":"open-preview"},{"port":3000,"onOpen":"ignore"},{"port":3001,"onOpen":"ignore"},{"port":3306,"onOpen":"ignore"},{"port":4000,"onOpen":"ignore"},{"port":5900,"onOpen":"ignore"},{"port":6080,"onOpen":"ignore"},{"port":7777,"onOpen":"ignore"},{"port":9229,"onOpen":"ignore"},{"port":9999,"onOpen":"ignore"},{"port":13001,"onOpen":"ignore"},{"port":13444}],"tasks":[{"name":"Install Preview Environment kube-context","command":"(cd dev/preview/previewctl && go install .)\npreviewctl install-context\nexit\n"},{"name":"Add Harvester kubeconfig","command":"./dev/preview/util/download-and-merge-harvester-kubeconfig.sh\nexit 0\n"},{"name":"Java","command":"if [ -z \"$RUN_GRADLE_TASK\" ]; then\n  read -r -p \"Press enter to continue Java gradle task\"\nfi\nleeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew --build-cache build\nleeway exec --package components/ide/jetbrains/backend-plugin:plugin --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew --build-cache buildPlugin\n"},{"name":"TypeScript","before":"scripts/branch-namespace.sh","init":"yarn --network-timeout 100000 && yarn build"},{"name":"Go","before":"pre-commit install --install-hooks","init":"leeway exec --filter-type go -v -- go mod verify","openMode":"split-right"}],"vscode":{"extensions":["bradlc.vscode-tailwindcss","EditorConfig.EditorConfig","golang.go","hashicorp.terraform","ms-azuretools.vscode-docker","ms-kubernetes-tools.vscode-kubernetes-tools","stkb.rewrap","zxh404.vscode-proto3","matthewpi.caddyfile-support","heptio.jsonnet","timonwong.shellcheck","vscjava.vscode-java-pack","fwcd.kotlin","dbaeumer.vscode-eslint","esbenp.prettier-vscode"]},"jetbrains":{"goland":{"prebuilds":{"version":"stable"}}},"_origin":"repo","_featureFlags":[]}`),
+	}
+}

--- a/components/usage/pkg/db/workspace.go
+++ b/components/usage/pkg/db/workspace.go
@@ -5,15 +5,19 @@
 package db
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
+	"github.com/google/uuid"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 	"time"
 )
 
 // Workspace represents the underlying DB object
 type Workspace struct {
 	ID          string         `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
-	OwnerID     string         `gorm:"column:ownerId;type:char;size:36;" json:"ownerId"`
+	OwnerID     uuid.UUID      `gorm:"column:ownerId;type:char;size:36;" json:"ownerId"`
 	ProjectID   sql.NullString `gorm:"column:projectId;type:char;size:36;" json:"projectId"`
 	Description string         `gorm:"column:description;type:varchar;size:255;" json:"description"`
 	Type        string         `gorm:"column:type;type:char;size:16;default:regular;" json:"type"`
@@ -45,4 +49,18 @@ type Workspace struct {
 
 func (d *Workspace) TableName() string {
 	return "d_b_workspace"
+}
+
+func ListWorkspacesByID(ctx context.Context, conn *gorm.DB, ids []string) ([]Workspace, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var workspaces []Workspace
+	tx := conn.WithContext(ctx).Where(ids).Find(&workspaces)
+	if tx.Error != nil {
+		return nil, fmt.Errorf("failed to list workspaces by id: %w", tx.Error)
+	}
+
+	return workspaces, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We first compute all workspace instances in a given period, for each WorkspaceID, we fetch the underlying Workspace from DB to have the necessary information to proceed to determining the owner (cost center)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE