### PR TITLE
Always keep preview envs on db activity

### DIFF
--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -375,6 +375,11 @@ async function determineStalePreviewEnvironments(options: {previews: PreviewEnvi
     werft.done(SLICES.CHECKING_FOR_DB_ACTIVITY)
 
     const previewsToDelete = previews.filter((preview: PreviewEnvironment) => {
+        if (!previewNamespacesWithNoDBActivity.has(preview.namespace)){
+            werft.log(SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS, `Considering ${preview.name} (${preview.namespace}) active due to recent DB activity`)
+            return false
+        }
+
         if (!previewNamespaceBasedOnBranches.has(preview.namespace)) {
             werft.log(SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS, `Considering ${preview.name} (${preview.namespace}) stale due to missing branch`)
             return true


### PR DESCRIPTION
## Description
Always keep preview environments when there is DB activity. This addresses an edge case where forks that have a running preview env would get delete due to not having a "real" branch in the repo.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9891#issuecomment-1148318363

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
