### PR TITLE
Delete preview env harvester certs

### DIFF
--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -412,7 +412,7 @@ async function removePreviewEnvironment(previewEnvironment: PreviewEnvironment) 
 }
 
 async function removeCertificate(preview: string, kubectlConfig: string, slice: string) {
-    return exec(`kubectl --kubeconfig ${kubectlConfig} -n certs delete --ignore-not-found=true cert ${preview}`, {slice: slice, async: true})
+    return exec(`kubectl --kubeconfig ${kubectlConfig} -n certs delete --ignore-not-found=true cert harvester-${preview} ${preview}`, {slice: slice, async: true})
 }
 
 async function cleanLoadbalancer() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Harvester certs have the following format: `harvester-PREVIEW_ENV_NAME`, therefore they were never getting cleaned up. This should make sure that also those certs gets deleted properly. I'll do a manual clean-up of the ones that exist but have no corresponding preview environment..

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2483

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
