### PR TITLE
Update docs link in user menu

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -451,11 +451,11 @@ export default function Menu() {
                                     },
                                     {
                                         title: "Docs",
-                                        link: "https://www.gitpod.io/docs/",
+                                        href: "https://www.gitpod.io/docs/",
                                     },
                                     {
                                         title: "Help",
-                                        href: "https://www.gitpod.io/support",
+                                        href: "https://www.gitpod.io/support/",
                                         separator: true,
                                     },
                                     {


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/10309, this will fix a broken link in user menu.

## How to test

Open user menu and click on _Docs_. 💣 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```