### PR TITLE
Fix JetBrains Gateway Plugin to work on v222.2889.2

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.remote.RemoteCredentialsHolder
 import com.intellij.ssh.AskAboutHostKey
 import com.intellij.ssh.OpenSshLikeHostKeyVerifier
@@ -301,7 +302,11 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
         credentials.port = 22
         credentials.userName = userName
         credentials.password = password
-        credentials.connectionBuilder().withSshConnectionConfig {
+        credentials.connectionBuilder(
+            null,
+            ProgressManager.getGlobalProgressIndicator(),
+            false
+        ).withSshConnectionConfig {
             val hostKeyVerifier = it.hostKeyVerifier
             if (hostKeyVerifier is OpenSshLikeHostKeyVerifier) {
                 val acceptHostKey = acceptHostKey(ideUrl, hostKeys)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add parameters to ConnectionBuilder constructor, as on the next Gateway release it won't run without them.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
Note: This can only be tested by Gitpod Team, with access to the non-released version of JetBrains Gateway.
- Download JetBrains Gateway v222.2889.2 for Mac and install it.
- Install the Gitpod's gateway-plugin from the JetBrains Gateway home screen.
  <img width="381" alt="image" src="https://user-images.githubusercontent.com/418083/172421307-691641b6-df70-41c3-9033-9e81f8569a9c.png">
- Connect to any workspace and confirm you're getting the following error when clicking 'Connect' button from the Gateway workspaces list.
  <img width="712" alt="image" src="https://user-images.githubusercontent.com/418083/172419528-489ee722-197d-4257-9d80-f0c063178ac3.png">
- Uninstall the gateway-plugin.
- Download the gateway-plugin build from this PR from [here](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/182624) and install it on the Gateway.
- Connect to the same workspace and confirm if now you don't get any error while connecting.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix JetBrains Gateway Plugin to work on v222.2889.2
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft --no-preview=true