### PR TITLE
feat: Clean out terminal buffer before running tasks commands

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -378,9 +378,10 @@ func getHistfileCommand(task *task, commands []*string, contentSource csapi.Work
 		return ""
 	}
 
-	// the space at beginning of the HISTFILE command prevents the HISTFILE command itself from appearing in
+	// the printf command clears out the terminal buffer
+	// the space at beginning of the printf command prevents our injected commands itself from appearing in
 	// the bash history.
-	return " HISTFILE=" + histfile + " history -r"
+	return " printf '\\e[3J\033c\\e[3J'" + " && " + "HISTFILE=" + histfile + " history -r"
 }
 
 func getCommands(task *task, isHeadless bool, contentSource csapi.WorkspaceInitSource, storeLocation string) []*string {

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -378,10 +378,10 @@ func getHistfileCommand(task *task, commands []*string, contentSource csapi.Work
 		return ""
 	}
 
-	// the printf command clears out the terminal buffer
+	// the printf command clears out the excess terminal scrollback buffer
 	// the space at beginning of the printf command prevents our injected commands itself from appearing in
 	// the bash history.
-	return " printf '\\e[3J\033c\\e[3J'" + " && " + "HISTFILE=" + histfile + " history -r"
+	return " printf '\033[3J\033c\033[3J'" + " && " + "HISTFILE=" + histfile + " history -r"
 }
 
 func getCommands(task *task, isHeadless bool, contentSource csapi.WorkspaceInitSource, storeLocation string) []*string {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It gets kinda confusing to look at what's happening on a `tasks` terminal as gitpod spawns a bunch of vscode terminals with task shell commands.

For comparison, please open [this](https://gitpod.io/#https://github.com/gitpod-io/template-flutter/tree/test-demo) and [this](https://gitpod.io/#https://github.com/gitpod-io/template-flutter) to see. (I've been manually including the `printf` command to clean out my task terminals on `template-flutter` repo to make it intuitive and less confusing)

This change will run ` printf '\e[3J\033c\e[3J'`([ref](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences)) before task shell commands and thus cleaning out the terminal entirely.

| Previously  | Now |
| ------------- | ------------- |
| <img width="1093" alt="Screenshot 2022-06-08 at 1 20 53 AM" src="https://user-images.githubusercontent.com/39482679/172464761-cf643203-cb0b-44e9-b7ca-8e1452bf18bf.png">|<img width="1105" alt="Screenshot 2022-06-08 at 1 19 25 AM" src="https://user-images.githubusercontent.com/39482679/172464546-f49b961c-e9e3-4e19-a21e-3b6058629c70.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
See description 🙏 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
feat: Clean the excess scrollback buffer of task terminals
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
