### PR TITLE
Add blobserve router under ide-proxy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 #
 /.github/CODEOWNERS
 
-/components/blobserve @gitpod-io/engineering-workspace
+/components/blobserve @gitpod-io/engineering-ide
 /components/common-go @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp
 /components/content-service-api @csweichel @geropl @corneliusludmann
 /components/content-service @gitpod-io/engineering-workspace

--- a/components/blobserve/pkg/blobserve/blobserve.go
+++ b/components/blobserve/pkg/blobserve/blobserve.go
@@ -215,7 +215,7 @@ func (reg *Server) serve(w http.ResponseWriter, req *http.Request) {
 
 	// The blobFor operation's context must be independent of this request. Even if we do not
 	// serve this request in time, we might want to serve another from the same ref in the future.
-	blob, hash, err := reg.refstore.BlobFor(context.Background(), ref, req.Header.Get("X-BlobServe-ReadOnly") == "true")
+	blob, hash, err := reg.refstore.BlobFor(context.Background(), ref, false)
 	if err == errdefs.ErrNotFound {
 		http.Error(w, fmt.Sprintf("image %s not found: %q", html.EscapeString(ref), err), http.StatusNotFound)
 		return

--- a/components/ide-proxy/conf/Caddyfile
+++ b/components/ide-proxy/conf/Caddyfile
@@ -3,8 +3,40 @@
 	admin off
 }
 
+(compression) {
+	encode zstd gzip
+}
+
+(upstream_headers) {
+	header_up X-Real-IP {http.request.remote.host}
+}
+
+(upstream_connection) {
+	lb_try_duration 1s
+}
+
 :80 {
 	header -Server
+
+	@blobserve path /blobserve/*
+	handle @blobserve {
+		import compression
+
+		uri strip_prefix /blobserve
+		uri replace /__files__/ / 1
+
+		header {
+			Access-Control-Allow-Origin *
+			Access-Control-Allow-Methods "GET, OPTIONS"
+		}
+
+		reverse_proxy blobserve.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:4000 {
+			import upstream_headers
+			import upstream_connection
+
+			flush_interval -1
+		}
+	}
 
 	root * /www
 	file_server {

--- a/install/installer/pkg/components/blobserve/networkpolicy.go
+++ b/install/installer/pkg/components/blobserve/networkpolicy.go
@@ -6,6 +6,7 @@ package blobserve
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	ideproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ide-proxy"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
 	wsproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ws-proxy"
 
@@ -38,8 +39,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 						"component": proxy.Component,
 					}},
 				}, {
+					// TODO: (pd) delete this after all workspace cluster deployed
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": wsproxy.Component,
+					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": ideproxy.Component,
 					}},
 				}},
 			}},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR is 1st part of move blobserve behind ide proxy https://github.com/gitpod-io/gitpod/issues/7986

This PR contain follow things
1. remove blobserve `read only mode` see comment for detail https://github.com/gitpod-io/gitpod/issues/7986#issuecomment-1149498029, simple not execute, didn't remove logic, in case we need add this back
2. change blobserve owner to team IDE
3. add cache policy, if header is not contain `X-BlobServe-InlineVars` and HTTP method is not `GET`, set cache max-age to 31536000, otherwise is `no-cache`
4. add `HEAD` method for warm-up cache


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate #7986

## How to test
<!-- Provide steps to test this PR -->

### You can simple test this PR https://github.com/gitpod-io/gitpod/pull/10514, it contains the effect of the change in this PR

1. open a workspace, see workspace can open, this does not affect what was there before
2. check the following URL, it should be work, and check the response header, `Cache-Control` should be set `public, max-age=31536000`
```
https://ide.pd-move-blob.preview.gitpod-dev.com/blobserve/eu.gcr.io/gitpod-core-dev/build/ide/code:commit-80d9b1ebfd826fd0db25320ba94d762b51887ada/__files__/index.html

https://ide.pd-move-blob.preview.gitpod-dev.com/blobserve/eu.gcr.io/gitpod-core-dev/build/ide/code:commit-80d9b1ebfd826fd0db25320ba94d762b51887ada/index.html

https://ide.pd-move-blob.preview.gitpod-dev.com/blobserve/eu.gcr.io/gitpod-core-dev/build/ide/code:commit-80d9b1ebfd826fd0db25320ba94d762b51887ada
```
3. check `X-BlobServe-InlineVars` works, diff response body with remove `X-BlobServe-InlineVars` header, the difference should like https://www.diffchecker.com/iBzZcjRj ,this is because https://github.com/gitpod-io/gitpod/blob/86b2b9e01257bd5bd94327256047f7e8f353cc8f/install/installer/pkg/components/blobserve/configmap.go#L74-L89
```bash
# using the following command test  and check the response header, `Cache-Control` should be set `no-cache` 
curl -v "https://ide.pd-move-blob-2.preview.gitpod-dev.com/blobserve/eu.gcr.io/gitpod-core-dev/build/ide/code:commit-80d9b1ebfd826fd0db25320ba94d762b51887ada/index.html" \
     -H 'X-BlobServe-InlineVars: {"ide": "_____IDE__URL____STRING___", "supervisor": "____SUPERVISOR____URL"}'

```
4. try `curl  -v --head "https://ide.pd-move-blob-2.preview.gitpod-dev.com/blobserve/eu.gcr.io/gitpod-core-dev/build/ide/code:commit-80d9b1ebfd826fd0db25320ba94d762b51887ada/index.html"`, it should not response body, only HTTP status

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
