### PR TITLE
[ws-proxy] use ide-proxy to serve blobserve

### DIFF
--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -120,8 +120,9 @@ func (c *GitpodInstallation) Validate() error {
 
 // BlobServerConfig configures where to serve the IDE from.
 type BlobServerConfig struct {
-	Scheme string `json:"scheme"`
-	Host   string `json:"host"`
+	Scheme     string `json:"scheme"`
+	Host       string `json:"host"`
+	PathPrefix string `json:"pathPrefix"`
 }
 
 // Validate validates the configuration to catch issues during startup and not at runtime.

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -224,11 +224,11 @@ func TestRoutes(t *testing.T) {
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
 					"Location": {
-						"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/favicon.ico",
+						"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__/favicon.ico",
 					},
 					"Vary": {"Accept-Encoding"},
 				},
-				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/favicon.ico\">See Other</a>.\n\n",
+				Body: "<a href=\"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__/favicon.ico\">See Other</a>.\n\n",
 			},
 		},
 		{
@@ -241,10 +241,10 @@ func TestRoutes(t *testing.T) {
 				Status: http.StatusSeeOther,
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
-					"Location":     {"https://blobserve.ws.test-domain.com/gitpod-io/ide:latest/__files__/"},
+					"Location":     {"https://ide.test-domain.com/blobserve/gitpod-io/ide:latest/__files__/"},
 					"Vary":         {"Accept-Encoding"},
 				},
-				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/ide:latest/__files__/\">See Other</a>.\n\n",
+				Body: "<a href=\"https://ide.test-domain.com/blobserve/gitpod-io/ide:latest/__files__/\">See Other</a>.\n\n",
 			},
 		},
 		{
@@ -257,11 +257,11 @@ func TestRoutes(t *testing.T) {
 			Expectation: Expectation{
 				Status: http.StatusOK,
 				Header: http.Header{
-					"Content-Length": {"218"},
+					"Content-Length": {"220"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
 					"Vary":           {"Accept-Encoding"},
 				},
-				Body: "blobserve hit: /gitpod-io/ide:latest/\ninlineVars: {\"ide\":\"https://blobserve.ws.test-domain.com/gitpod-io/ide:latest/__files__\",\"supervisor\":\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__\"}\n",
+				Body: "blobserve hit: /gitpod-io/ide:latest/\ninlineVars: {\"ide\":\"https://ide.test-domain.com/blobserve/gitpod-io/ide:latest/__files__\",\"supervisor\":\"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__\"}\n",
 			},
 		},
 		{
@@ -274,11 +274,11 @@ func TestRoutes(t *testing.T) {
 			Expectation: Expectation{
 				Status: http.StatusOK,
 				Header: http.Header{
-					"Content-Length": {"218"},
+					"Content-Length": {"220"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
 					"Vary":           {"Accept-Encoding"},
 				},
-				Body: "blobserve hit: /gitpod-io/ide:latest/\ninlineVars: {\"ide\":\"https://blobserve.ws.test-domain.com/gitpod-io/ide:latest/__files__\",\"supervisor\":\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__\"}\n",
+				Body: "blobserve hit: /gitpod-io/ide:latest/\ninlineVars: {\"ide\":\"https://ide.test-domain.com/blobserve/gitpod-io/ide:latest/__files__\",\"supervisor\":\"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__\"}\n",
 			},
 		},
 		{
@@ -467,10 +467,10 @@ func TestRoutes(t *testing.T) {
 				Status: http.StatusSeeOther,
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
-					"Location":     {"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js"},
+					"Location":     {"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__/main.js"},
 					"Vary":         {"Accept-Encoding"},
 				},
-				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js\">See Other</a>.\n\n",
+				Body: "<a href=\"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__/main.js\">See Other</a>.\n\n",
 			},
 		},
 		{
@@ -493,10 +493,10 @@ func TestRoutes(t *testing.T) {
 				Status: http.StatusSeeOther,
 				Header: http.Header{
 					"Content-Type": {"text/html; charset=utf-8"},
-					"Location":     {"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js"},
+					"Location":     {"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__/main.js"},
 					"Vary":         {"Accept-Encoding"},
 				},
-				Body: "<a href=\"https://blobserve.ws.test-domain.com/gitpod-io/supervisor:latest/__files__/main.js\">See Other</a>.\n\n",
+				Body: "<a href=\"https://ide.test-domain.com/blobserve/gitpod-io/supervisor:latest/__files__/main.js\">See Other</a>.\n\n",
 			},
 		},
 		{

--- a/install/installer/pkg/components/ws-proxy/configmap.go
+++ b/install/installer/pkg/components/ws-proxy/configmap.go
@@ -44,8 +44,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				MaxIdleConnsPerHost: 100,
 			},
 			BlobServer: &proxy.BlobServerConfig{
-				Scheme: "http",
-				Host:   fmt.Sprintf("blobserve.%s.svc.cluster.local:%d", ctx.Namespace, common.BlobServeServicePort),
+				Scheme:     "https",
+				Host:       fmt.Sprintf("ide.%s", ctx.Config.Domain),
+				PathPrefix: "/blobserve",
 			},
 			GitpodInstallation: &proxy.GitpodInstallation{
 				Scheme:                   "https",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR is 2st part of move blobserve behind ide proxy https://github.com/gitpod-io/gitpod/issues/7986

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate #7986

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace in preview environment, [quick link](https://pd-move-blob-2.preview.gitpod-dev.com/#https://github.com/gitpod-io/template-sveltejs), check everything is works, include `simple webview` and `vim extension`
2. open chrome dev-tool, check non file from `blobserve.ws.pd-move-blob2.preview.gitpod-dev.com`, every blob file should be serve by `ide.pd-move-blob2.preview.gitpod-dev.com/blobserve`
![image](https://user-images.githubusercontent.com/8299500/172549674-2a639b0a-ca9a-46c9-b773-3d67c3516a92.png)

4. in this preview environment, I manual remove network ingress policy for `ws-proxy` to `blobserve`, now it's only allow `ide-proxy` access. ignore `proxy` component, I am not sure why it need

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: blobserve
  namespace: default
  labels:
    app: gitpod
    component: blobserve
spec:
  podSelector:
    matchLabels:
      app: gitpod
      component: blobserve
  ingress:
    - ports:
        - protocol: TCP
          port: 32224
      from:
        - podSelector:
            matchLabels:
              component: proxy
        # - podSelector:
        #     matchLabels:
        #       component: ws-proxy
        - podSelector:
            matchLabels:
              component: ide-proxy
  policyTypes:
    - Ingress

```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
use `ide.gitpod.io/blobserve` to serve blobfile
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
