### PR TITLE
Configure grpc_server histogram metrics with proper buckets

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -259,7 +259,9 @@ func (s *Server) initializeGRPC() error {
 	common_grpc.SetupLogging()
 
 	grpcMetrics := grpc_prometheus.NewServerMetrics()
-	grpcMetrics.EnableHandlingTimeHistogram()
+	grpcMetrics.EnableHandlingTimeHistogram(
+		grpc_prometheus.WithHistogramBuckets([]float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600}),
+	)
 	if err := s.MetricsRegistry().Register(grpcMetrics); err != nil {
 		return fmt.Errorf("failed to register grpc metrics: %w", err)
 	}

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -125,7 +125,9 @@ var runCmd = &cobra.Command{
 		metrics.Registry.MustRegister(ratelimits)
 
 		grpcMetrics := grpc_prometheus.NewServerMetrics()
-		grpcMetrics.EnableHandlingTimeHistogram()
+		grpcMetrics.EnableHandlingTimeHistogram(
+			grpc_prometheus.WithHistogramBuckets([]float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600}),
+		)
 		metrics.Registry.MustRegister(grpcMetrics)
 
 		grpcOpts := common_grpc.ServerOptionsWithInterceptors(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Configure grpc_server histogram metrics with proper buckets - this would make the metrics more accurate, as currently anything that takes more than 10s (default top bucket) would be inaccurate.

For reference the default buckets (11 in total) are:

```
.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10
```

This would also have the side effect of increasing the cardinality slightly, by adding 2 more labels (13 total buckets) for every grpc handler metric.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
