### PR TITLE
ws-daemon: Soft limit of the xfs at first to ensure that the contents can be restored

### DIFF
--- a/components/ws-daemon/pkg/content/hooks.go
+++ b/components/ws-daemon/pkg/content/hooks.go
@@ -29,6 +29,9 @@ func workspaceLifecycleHooks(cfg Config, kubernetesNamespace string, workspaceEx
 			hookSetupWorkspaceLocation,
 			startIWS, // workspacekit is waiting for starting IWS, so it needs to start as soon as possible.
 			hookSetupRemoteStorage(cfg),
+			// When starting a workspace, use soft limit for the following reason to ensure content is restored
+			// - workspacekit needs to generate some temporary file when starting a workspace
+			// - when extracting tar file, tar command create some symlinks following a original content
 			hookInstallQuota(xfs, false),
 		},
 		session.WorkspaceReady: {
@@ -98,17 +101,24 @@ func hookInstallQuota(xfs *quota.XFS, isHard bool) session.WorkspaceLivecycleHoo
 		if xfs == nil {
 			return nil
 		}
-		size := quota.Size(ws.StorageQuota)
-		if size == 0 {
+
+		if ws.StorageQuota == 0 {
 			return nil
 		}
 
+		size := quota.Size(ws.StorageQuota)
+
+		var (
+			prj int
+			err error
+		)
 		if ws.XFSProjectID != 0 {
 			xfs.RegisterProject(ws.XFSProjectID)
-			return nil
+			prj, err = xfs.SetQuotaWithPrjId(ws.Location, size, ws.XFSProjectID, isHard)
+		} else {
+			prj, err = xfs.SetQuota(ws.Location, size, isHard)
 		}
 
-		prj, err := xfs.SetQuota(ws.Location, size, isHard)
 		if err != nil {
 			log.WithFields(ws.OWI()).WithError(err).Warn("cannot enforce workspace size limit")
 		}

--- a/components/ws-daemon/pkg/quota/xfs.go
+++ b/components/ws-daemon/pkg/quota/xfs.go
@@ -113,6 +113,15 @@ func (xfs *XFS) SetQuota(path string, quota Size, isHard bool) (projectID int, e
 		}
 	}()
 
+	_, err = xfs.SetQuotaWithPrjId(path, quota, prjID, isHard)
+	if err != nil {
+		return 0, err
+	}
+
+	return prjID, nil
+}
+
+func (xfs *XFS) SetQuotaWithPrjId(path string, quota Size, prjID int, isHard bool) (projectID int, err error) {
 	_, err = xfs.exec(xfs.Dir, fmt.Sprintf("project -s -d 1 -p %s %d", path, prjID))
 	if err != nil {
 		return 0, err
@@ -121,7 +130,7 @@ func (xfs *XFS) SetQuota(path string, quota Size, isHard bool) (projectID int, e
 	if isHard {
 		_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bhard=%d %d", quota, prjID))
 	} else {
-		_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bsoft=%d bhard=%d %d", quota, quota, prjID))
+		_, err = xfs.exec(xfs.Dir, fmt.Sprintf("limit -p bsoft=%d %d", quota, prjID))
 	}
 
 	if err != nil {

--- a/components/ws-daemon/pkg/quota/xfs_test.go
+++ b/components/ws-daemon/pkg/quota/xfs_test.go
@@ -116,7 +116,7 @@ func TestSetQuota(t *testing.T) {
 				ProjectIDs: []int{1000},
 				Execs: []string{
 					"project -s -d 1 -p /foo 1000",
-					"limit -p bsoft=102400 bhard=102400 1000",
+					"limit -p bsoft=102400 1000",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix restore failure in some patterns when users run out of space

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10329

## How to test
<!-- Provide steps to test this PR -->

Please refer to the following gists to make sure you do not encounter any errors.
https://gist.github.com/utam0k/7d93ebb513801a597c941f05b030a51e

[The preview env for this branch](https://to-xfs-demo.preview.gitpod-dev.com/) is limited to 30G of storage.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
ws-daemon: Soft limit of the xfs at first to ensure that the contents can be restored
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No