### PR TITLE
Make it possible to skip cache

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -29,6 +29,7 @@ export interface JobConfig {
     previewEnvironment: PreviewEnvironmentConfig,
     repository: Repository
     observability: Observability
+    noCache: boolean;
 }
 
 export interface PreviewEnvironmentConfig {
@@ -92,6 +93,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         ref: context.Repository.ref,
         branch: context.Repository.ref,
     }
+    const noCache = "no-cache" in buildConfig
     const refsPrefix = "refs/heads/";
     if (repository.branch.startsWith(refsPrefix)) {
         repository.branch = repository.branch.substring(refsPrefix.length);
@@ -137,6 +139,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         withPayment,
         withVM,
         workspaceFeatureFlags,
+        noCache
     }
 
     werft.log("job config", JSON.stringify(jobConfig));


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

As part of https://github.com/gitpod-io/gitpod/pull/10509 and the revert of it here https://github.com/gitpod-io/gitpod/pull/10522 it would have been nice to be able to trigger a full rebuild to validate changes. E.g. this we could add instructions like

> If you're changing the dev image then run a build from your branch (by default we use the job spec from main due to job protection) and rebuild all components like so: `werft job run github -a no-cache=true -a updateGitHubStatus=gitpod-io/gitpod`

### Alternatives

This is still a very manual way to solve the issue and people might forget to run the job manually when changing the build job spec or the CI image.

- Could we have Leeway invalidate the build cache if the dev image changes?
- Could we have Werft not use job protection if the job was changed and the owner is a Gitpod employee?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

From a workspace on this branch:

```
werft job run github -a no-cache=true -a updateGitHubStatus=gitpod-io/gitpod
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A