### PR TITLE
[usage] Add db model for TeamMembership

### DIFF
--- a/components/usage/pkg/db/conn.go
+++ b/components/usage/pkg/db/conn.go
@@ -82,6 +82,7 @@ func ConnectForTests(t *testing.T) *gorm.DB {
 			&Workspace{},
 			&Project{},
 			&Team{},
+			&TeamMembership{},
 		} {
 			// See https://gorm.io/docs/delete.html#Block-Global-Delete
 			tx := conn.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(model)

--- a/components/usage/pkg/db/team_membership.go
+++ b/components/usage/pkg/db/team_membership.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+type TeamMembership struct {
+	ID uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
+
+	TeamID         uuid.UUID          `gorm:"column:teamId;type:char;size:36;" json:"teamId"`
+	UserID         uuid.UUID          `gorm:"column:userId;type:char;size:36;" json:"userId"`
+	Role           TeamMembershipRole `gorm:"column:role;type:varchar;size:255;" json:"role"`
+	SubscriptionID uuid.UUID          `gorm:"column:subscriptionId;type:char;size:36;" json:"subscriptionId"`
+
+	CreationTime VarcharTime `gorm:"column:creationTime;type:varchar;size:255;" json:"creationTime"`
+	// Read-only (-> property).
+	LastModified time.Time `gorm:"->:column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
+
+	// deleted column is reserved for use by db-sync
+	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
+}
+
+// TableName sets the insert table name for this struct type
+func (d *TeamMembership) TableName() string {
+	return "d_b_team_membership"
+}
+
+type TeamMembershipRole string
+
+const (
+	TeamMembershipRole_Owner  = TeamMembershipRole("owner")
+	TeamMembershipRole_Member = TeamMembershipRole("member")
+)

--- a/components/usage/pkg/db/team_membership_test.go
+++ b/components/usage/pkg/db/team_membership_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTeamMembership_WriteRead(t *testing.T) {
+	conn := db.ConnectForTests(t)
+
+	membership := &db.TeamMembership{
+		ID:             uuid.New(),
+		TeamID:         uuid.New(),
+		UserID:         uuid.New(),
+		Role:           db.TeamMembershipRole_Member,
+		SubscriptionID: uuid.New(),
+	}
+
+	tx := conn.Create(membership)
+	require.NoError(t, tx.Error)
+
+	read := &db.TeamMembership{ID: membership.ID}
+	tx = conn.First(read)
+	require.NoError(t, tx.Error)
+	require.Equal(t, membership, read)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add DB model for TeamMembership. This is needed to be able to establish who is being charged for a workspace (and their membership determines if the team, or not)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE