### PR TITLE
[gp-cli] Add alias for forward and await in ports

### DIFF
--- a/components/gitpod-cli/cmd/ports-await.go
+++ b/components/gitpod-cli/cmd/ports-await.go
@@ -16,7 +16,7 @@ import (
 )
 
 var awaitPortCmd = &cobra.Command{
-	Use:   "await-port <port>",
+	Use:   "await <port>",
 	Short: "Waits for a process to listen on a port",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -54,6 +54,18 @@ var awaitPortCmd = &cobra.Command{
 	},
 }
 
+var awaitPortCmdAlias = &cobra.Command{
+	Hidden:     true,
+	Deprecated: "please use `ports await` instead.",
+	Use:        "await-port <port>",
+	Short:      awaitPortCmd.Short,
+	Long:       awaitPortCmd.Long,
+	Args:       awaitPortCmd.Args,
+	Run:        awaitPortCmd.Run,
+}
+
 func init() {
-	rootCmd.AddCommand(awaitPortCmd)
+	portsCmd.AddCommand(awaitPortCmd)
+
+	rootCmd.AddCommand(awaitPortCmdAlias)
 }

--- a/components/gitpod-cli/cmd/ports-expose.go
+++ b/components/gitpod-cli/cmd/ports-expose.go
@@ -20,8 +20,8 @@ import (
 
 var rewriteHostHeader bool
 
-var portFwdCmd = &cobra.Command{
-	Use:   "forward-port <local-port> [target-port]",
+var portExposeCmd = &cobra.Command{
+	Use:   "expose <local-port> [target-port]",
 	Short: "Makes a port available on 0.0.0.0 so that it can be exposed to the internet",
 	Long:  ``,
 	Args:  cobra.RangeArgs(1, 2),
@@ -71,7 +71,20 @@ var portFwdCmd = &cobra.Command{
 	},
 }
 
+var portExposeCmdAlias = &cobra.Command{
+	Hidden:     true,
+	Deprecated: "please use `ports expose` instead.",
+	Use:        "forward-port <local-port> [target-port]",
+	Short:      portExposeCmd.Short,
+	Long:       portExposeCmd.Long,
+	Args:       portExposeCmd.Args,
+	Run:        portExposeCmd.Run,
+}
+
 func init() {
-	rootCmd.AddCommand(portFwdCmd)
-	portFwdCmd.Flags().BoolVarP(&rewriteHostHeader, "rewrite-host-header", "r", false, "rewrites the host header of passing HTTP requests to localhost")
+	portsCmd.AddCommand(portExposeCmd)
+	portExposeCmd.Flags().BoolVarP(&rewriteHostHeader, "rewrite-host-header", "r", false, "rewrites the host header of passing HTTP requests to localhost")
+
+	rootCmd.AddCommand(portExposeCmdAlias)
+	portExposeCmdAlias.Flags().BoolVarP(&rewriteHostHeader, "rewrite-host-header", "r", false, "rewrites the host header of passing HTTP requests to localhost")
 }


### PR DESCRIPTION
## Description
This PR aliases `forward-port` and `await-port` command to `ports` namespace as `ports forward`, `ports await`

## Related Issue(s)
Closes  #10449

## How to test

Both commands should be similar except for their `Usage` message

`forward-port`
``` sh
❯ gp forward-port --help
Makes a port available on 0.0.0.0 so that it can be exposed to the internet

Usage:
  gp forward-port <local-port> [target-port] [flags]

Flags:
  -h, --help                  help for forward-port
  -r, --rewrite-host-header   rewrites the host header of passing HTTP requests to localhost
```
``` sh
❯ gp ports forward --help
Makes a port available on 0.0.0.0 so that it can be exposed to the internet

Usage:
  gp ports forward <local-port> [target-port] [flags]

Flags:
  -h, --help                  help for forward
  -r, --rewrite-host-header   rewrites the host header of passing HTTP requests to localhost
```
`await-port`
``` sh
❯ gp await-port --help
Waits for a process to listen on a port

Usage:
  gp await-port <port> [flags]

Flags:
  -h, --help   help for await-port
```
``` sh
❯ gp ports await --help
Waits for a process to listen on a port

Usage:
  gp ports await <port> [flags]

Flags:
  -h, --help   help for await
```

## Release Notes
```release-note
Added alias for forward and await in ports CLI namespace
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes

- [x] Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E

- [x] Paste the link to the docs issue below this comment


https://github.com/gitpod-io/website/issues/2173#issue-1260679472