### PR TITLE
Add persistent volume claim to prebuild settings

### DIFF
--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -63,6 +63,9 @@ export default function ProjectDetail(props: { project: Project; owner: string |
                     <Property name="Incremental Prebuilds">
                         {props.project.settings?.useIncrementalPrebuilds ? "Yes" : "No"}
                     </Property>
+                    <Property name="Persistent Volume Claim">
+                        {props.project.settings?.usePersistentVolumeClaim ? "Yes" : "No"}
+                    </Property>
                     <Property name="Marked Deleted">{props.project.markedDeleted ? "Yes" : "No"}</Property>
                 </div>
             </div>

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -14,6 +14,7 @@ export interface ProjectConfig {
 
 export interface ProjectSettings {
     useIncrementalPrebuilds?: boolean;
+    usePersistentVolumeClaim?: boolean;
 }
 
 export interface Project {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds setting to prebuilds to enable support for persistent volume claims.
Made sure to add a warning to let users know to not enable this setting, but I am open for a better alternative\text or if there is way to gate this feature to gitpod only for now.

This is how it would look:
![Screenshot from 2022-06-08 16-41-29](https://user-images.githubusercontent.com/18602811/172735569-d8d3cfc8-857f-40d8-88c8-fb9483d93aed.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related: https://github.com/gitpod-io/gitpod/issues/10260

## How to test
<!-- Provide steps to test this PR -->
Launch preview env, add your project to it and navigate to settings.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
