### PR TITLE
refactor(dashboard/new-project): persist selected provider host

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -62,7 +62,7 @@ export default function NewProject() {
             const authProvider = authProviders.find((p) => p.host === storedSelectedProviderHost);
 
             // if the stored provider exists and is in one of the user's identities, use it
-            if (authProvider && user.identities.some((idt) => idt.authProviderId === authProvider.authProviderId)) {
+            if (storedSelectedProviderHost && authProvider && user.identities.some((idt) => idt.authProviderId === authProvider.authProviderId)) {
                 return setSelectedProviderHost(authProvider.host);
             }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Persist the selected provider locally for better UX.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #8524

## How to test
<!-- Provide steps to test this PR -->
1. Open dashboard
2. Navigate to projects
3. Click "New Project"
4. Change the selected provider
5. Refresh
6. Repeat 4 and 5 and optionally check local storage to see the host changing

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
persist selected provider when creating a new project
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A