### PR TITLE
[usage] Simplify Workspace record creation for tests

### DIFF
--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -19,7 +19,7 @@ func TestUsageReconciler_Reconcile(t *testing.T) {
 	instanceStatus := []byte(`{"phase": "stopped", "conditions": {"deployed": false, "pullingImages": false, "serviceExists": false}}`)
 	startOfMay := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
 	startOfJune := time.Date(2022, 06, 1, 0, 00, 00, 00, time.UTC)
-	workspace := dbtest.NewWorkspace(t, "gitpodio-gitpod-gyjr82jkfnd")
+	workspace := dbtest.NewWorkspace(t, db.Workspace{ID: "gitpodio-gitpod-gyjr82jkfnd"})
 	instances := []db.WorkspaceInstance{
 		// Ran throughout the reconcile period
 		{

--- a/components/usage/pkg/db/dbtest/workspace.go
+++ b/components/usage/pkg/db/dbtest/workspace.go
@@ -5,20 +5,74 @@
 package dbtest
 
 import (
+	"fmt"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/google/uuid"
+	"math/rand"
 	"testing"
 )
 
-func NewWorkspace(t *testing.T, id string) db.Workspace {
+const (
+	WorkspaceContext = `{"title":"[usage] List workspaces for each workspace instance in usage period","repository":{"cloneUrl":"https://github.com/gitpod-io/gitpod.git","host":"github.com","name":"gitpod","owner":"gitpod-io","private":false},"ref":"mp/usage-list-workspaces","refType":"branch","revision":"586f22ecaeeb3b4796fd92f9ae1ca3512ca1e330","nr":10495,"base":{"repository":{"cloneUrl":"https://github.com/gitpod-io/gitpod.git","host":"github.com","name":"gitpod","owner":"gitpod-io","private":false},"ref":"mp/usage-validate-instances","refType":"branch"},"normalizedContextURL":"https://github.com/gitpod-io/gitpod/pull/10495","checkoutLocation":"gitpod"}`
+	WorkspaceConfig  = `{"image":"eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-me-image.1","workspaceLocation":"gitpod/gitpod-ws.code-workspace","checkoutLocation":"gitpod","ports":[{"port":1337,"onOpen":"open-preview"},{"port":3000,"onOpen":"ignore"},{"port":3001,"onOpen":"ignore"},{"port":3306,"onOpen":"ignore"},{"port":4000,"onOpen":"ignore"},{"port":5900,"onOpen":"ignore"},{"port":6080,"onOpen":"ignore"},{"port":7777,"onOpen":"ignore"},{"port":9229,"onOpen":"ignore"},{"port":9999,"onOpen":"ignore"},{"port":13001,"onOpen":"ignore"},{"port":13444}],"tasks":[{"name":"Install Preview Environment kube-context","command":"(cd dev/preview/previewctl && go install .)\npreviewctl install-context\nexit\n"},{"name":"Add Harvester kubeconfig","command":"./dev/preview/util/download-and-merge-harvester-kubeconfig.sh\nexit 0\n"},{"name":"Java","command":"if [ -z \"$RUN_GRADLE_TASK\" ]; then\n  read -r -p \"Press enter to continue Java gradle task\"\nfi\nleeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew --build-cache build\nleeway exec --package components/ide/jetbrains/backend-plugin:plugin --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew --build-cache buildPlugin\n"},{"name":"TypeScript","before":"scripts/branch-namespace.sh","init":"yarn --network-timeout 100000 && yarn build"},{"name":"Go","before":"pre-commit install --install-hooks","init":"leeway exec --filter-type go -v -- go mod verify","openMode":"split-right"}],"vscode":{"extensions":["bradlc.vscode-tailwindcss","EditorConfig.EditorConfig","golang.go","hashicorp.terraform","ms-azuretools.vscode-docker","ms-kubernetes-tools.vscode-kubernetes-tools","stkb.rewrap","zxh404.vscode-proto3","matthewpi.caddyfile-support","heptio.jsonnet","timonwong.shellcheck","vscjava.vscode-java-pack","fwcd.kotlin","dbaeumer.vscode-eslint","esbenp.prettier-vscode"]},"jetbrains":{"goland":{"prebuilds":{"version":"stable"}}},"_origin":"repo","_featureFlags":[]}`
+)
+
+// NewWorkspace creates a new stub workspace with default values, unless these are set on the workspace argument
+// Records are not stored, use `db.Create(dbtest.NewWorkspace(t, db.Workspace{})) to store it.
+// Only used for tests. Additional default properties may be added in the future.
+func NewWorkspace(t *testing.T, workspace db.Workspace) db.Workspace {
 	t.Helper()
+
+	id := generateWorkspaceID()
+	if workspace.ID != "" {
+		id = workspace.ID
+	}
+
+	ownerID := uuid.New()
+	if workspace.OwnerID.ID() != 0 { // empty value
+		ownerID = workspace.OwnerID
+	}
+
+	workspaceType := db.WorkspaceType_Regular
+	if workspace.Type != "" {
+		workspaceType = workspace.Type
+	}
+
+	contextURL := "https://github.com/gitpod-io/gitpod"
+	if workspace.ContextURL != "" {
+		contextURL = workspace.ContextURL
+	}
+
+	context := []byte(WorkspaceContext)
+	if workspace.Context.String() != "" {
+		context = workspace.Context
+	}
+
+	config := []byte(WorkspaceConfig)
+	if workspace.Config.String() != "" {
+		config = workspace.Config
+	}
 
 	return db.Workspace{
 		ID:         id,
-		OwnerID:    uuid.New(),
-		Type:       "prebuild",
-		ContextURL: "https://github.com/gitpod-io/gitpod",
-		Context:    []byte(`{"title":"[usage] List workspaces for each workspace instance in usage period","repository":{"cloneUrl":"https://github.com/gitpod-io/gitpod.git","host":"github.com","name":"gitpod","owner":"gitpod-io","private":false},"ref":"mp/usage-list-workspaces","refType":"branch","revision":"586f22ecaeeb3b4796fd92f9ae1ca3512ca1e330","nr":10495,"base":{"repository":{"cloneUrl":"https://github.com/gitpod-io/gitpod.git","host":"github.com","name":"gitpod","owner":"gitpod-io","private":false},"ref":"mp/usage-validate-instances","refType":"branch"},"normalizedContextURL":"https://github.com/gitpod-io/gitpod/pull/10495","checkoutLocation":"gitpod"}`),
-		Config:     []byte(`{"image":"eu.gcr.io/gitpod-core-dev/dev/dev-environment:me-me-image.1","workspaceLocation":"gitpod/gitpod-ws.code-workspace","checkoutLocation":"gitpod","ports":[{"port":1337,"onOpen":"open-preview"},{"port":3000,"onOpen":"ignore"},{"port":3001,"onOpen":"ignore"},{"port":3306,"onOpen":"ignore"},{"port":4000,"onOpen":"ignore"},{"port":5900,"onOpen":"ignore"},{"port":6080,"onOpen":"ignore"},{"port":7777,"onOpen":"ignore"},{"port":9229,"onOpen":"ignore"},{"port":9999,"onOpen":"ignore"},{"port":13001,"onOpen":"ignore"},{"port":13444}],"tasks":[{"name":"Install Preview Environment kube-context","command":"(cd dev/preview/previewctl && go install .)\npreviewctl install-context\nexit\n"},{"name":"Add Harvester kubeconfig","command":"./dev/preview/util/download-and-merge-harvester-kubeconfig.sh\nexit 0\n"},{"name":"Java","command":"if [ -z \"$RUN_GRADLE_TASK\" ]; then\n  read -r -p \"Press enter to continue Java gradle task\"\nfi\nleeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew --build-cache build\nleeway exec --package components/ide/jetbrains/backend-plugin:plugin --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew --build-cache buildPlugin\n"},{"name":"TypeScript","before":"scripts/branch-namespace.sh","init":"yarn --network-timeout 100000 && yarn build"},{"name":"Go","before":"pre-commit install --install-hooks","init":"leeway exec --filter-type go -v -- go mod verify","openMode":"split-right"}],"vscode":{"extensions":["bradlc.vscode-tailwindcss","EditorConfig.EditorConfig","golang.go","hashicorp.terraform","ms-azuretools.vscode-docker","ms-kubernetes-tools.vscode-kubernetes-tools","stkb.rewrap","zxh404.vscode-proto3","matthewpi.caddyfile-support","heptio.jsonnet","timonwong.shellcheck","vscjava.vscode-java-pack","fwcd.kotlin","dbaeumer.vscode-eslint","esbenp.prettier-vscode"]},"jetbrains":{"goland":{"prebuilds":{"version":"stable"}}},"_origin":"repo","_featureFlags":[]}`),
+		OwnerID:    ownerID,
+		Type:       workspaceType,
+		ContextURL: contextURL,
+		Context:    context,
+		Config:     config,
 	}
+}
+
+func generateWorkspaceID() string {
+	return fmt.Sprintf("gitpodio-gitpod-%s", randSeq(11))
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }

--- a/components/usage/pkg/db/workspace.go
+++ b/components/usage/pkg/db/workspace.go
@@ -20,7 +20,7 @@ type Workspace struct {
 	OwnerID     uuid.UUID      `gorm:"column:ownerId;type:char;size:36;" json:"ownerId"`
 	ProjectID   sql.NullString `gorm:"column:projectId;type:char;size:36;" json:"projectId"`
 	Description string         `gorm:"column:description;type:varchar;size:255;" json:"description"`
-	Type        string         `gorm:"column:type;type:char;size:16;default:regular;" json:"type"`
+	Type        WorkspaceType  `gorm:"column:type;type:char;size:16;default:regular;" json:"type"`
 	CloneURL    string         `gorm:"column:cloneURL;type:varchar;size:255;" json:"cloneURL"`
 
 	ContextURL            string         `gorm:"column:contextURL;type:text;size:65535;" json:"contextURL"`
@@ -50,6 +50,14 @@ type Workspace struct {
 func (d *Workspace) TableName() string {
 	return "d_b_workspace"
 }
+
+type WorkspaceType string
+
+const (
+	WorkspaceType_Prebuild WorkspaceType = "prebuild"
+	WorkspaceType_Probe    WorkspaceType = "probe"
+	WorkspaceType_Regular  WorkspaceType = "regular"
+)
 
 func ListWorkspacesByID(ctx context.Context, conn *gorm.DB, ids []string) ([]Workspace, error) {
 	if len(ids) == 0 {

--- a/components/usage/pkg/db/workspace_test.go
+++ b/components/usage/pkg/db/workspace_test.go
@@ -90,8 +90,8 @@ func TestListWorkspacesByID(t *testing.T) {
 	conn := db.ConnectForTests(t)
 
 	workspaces := []db.Workspace{
-		dbtest.NewWorkspace(t, "gitpodio-gitpod-aaaaaaaaaaa"),
-		dbtest.NewWorkspace(t, "gitpodio-gitpod-bbbbbbbbbbb"),
+		dbtest.NewWorkspace(t, db.Workspace{ID: "gitpodio-gitpod-aaaaaaaaaaa"}),
+		dbtest.NewWorkspace(t, db.Workspace{ID: "gitpodio-gitpod-bbbbbbbbbbb"}),
 	}
 	tx := conn.Create(workspaces)
 	require.NoError(t, tx.Error)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a helper to construct Workspace records with default values, for tests. Helpers for other objects may be added in the future, and this current one may be extended (does not handle all fields) as need arises.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE