### PR TITLE
[usage] Add listing of memberships by UserID

### DIFF
--- a/components/usage/pkg/db/team_membership.go
+++ b/components/usage/pkg/db/team_membership.go
@@ -5,7 +5,10 @@
 package db
 
 import (
+	"context"
+	"fmt"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 	"time"
 )
 
@@ -36,3 +39,19 @@ const (
 	TeamMembershipRole_Owner  = TeamMembershipRole("owner")
 	TeamMembershipRole_Member = TeamMembershipRole("member")
 )
+
+func ListTeamMembershipsForUserIDs(ctx context.Context, conn *gorm.DB, userIDs []uuid.UUID) ([]TeamMembership, error) {
+	if len(userIDs) == 0 {
+		return nil, nil
+	}
+
+	var memberships []TeamMembership
+	tx := conn.WithContext(ctx).
+		Where("userId IN ?", userIDs).
+		Find(&memberships)
+	if tx.Error != nil {
+		return nil, fmt.Errorf("failed to list team memberships for user IDs: %w", tx.Error)
+	}
+
+	return memberships, nil
+}

--- a/components/usage/pkg/db/team_membership_test.go
+++ b/components/usage/pkg/db/team_membership_test.go
@@ -5,6 +5,7 @@
 package db_test
 
 import (
+	"context"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -29,4 +30,71 @@ func TestTeamMembership_WriteRead(t *testing.T) {
 	tx = conn.First(read)
 	require.NoError(t, tx.Error)
 	require.Equal(t, membership, read)
+}
+
+func TestListTeamMembershipsForUserIDs(t *testing.T) {
+	conn := db.ConnectForTests(t)
+	userWithTwoTeams := uuid.New()
+	memberships := []db.TeamMembership{
+		{
+			ID:     uuid.New(),
+			TeamID: uuid.New(),
+			UserID: uuid.New(),
+			Role:   db.TeamMembershipRole_Member,
+		},
+		{
+			ID:     uuid.New(),
+			TeamID: uuid.New(),
+			UserID: userWithTwoTeams,
+			Role:   db.TeamMembershipRole_Member,
+		},
+		{
+			ID:     uuid.New(),
+			TeamID: uuid.New(),
+			UserID: userWithTwoTeams,
+			Role:   db.TeamMembershipRole_Member,
+		},
+	}
+
+	tx := conn.Create(&memberships)
+	require.NoError(t, tx.Error)
+
+	for _, scenario := range []struct {
+		Name     string
+		UserIDs  []uuid.UUID
+		Expected int
+	}{
+		{
+			Name:     "no user ids return empty",
+			UserIDs:  nil,
+			Expected: 0,
+		},
+		{
+			Name:     "no matching user IDs returns empty",
+			UserIDs:  []uuid.UUID{uuid.New()},
+			Expected: 0,
+		},
+		{
+			Name:     "one matching, and one not returns only one record",
+			UserIDs:  []uuid.UUID{memberships[0].UserID, uuid.New()},
+			Expected: 1,
+		},
+		{
+			Name:     "all matching returns all records (with duplicate userID in query)",
+			UserIDs:  []uuid.UUID{memberships[0].UserID, memberships[1].UserID, memberships[2].UserID},
+			Expected: 3,
+		},
+		{
+			Name:     "one ID with multiple memberships returns all membership for the ID",
+			UserIDs:  []uuid.UUID{userWithTwoTeams},
+			Expected: 2,
+		},
+	} {
+		t.Run(scenario.Name, func(t *testing.T) {
+			retrieved, err := db.ListTeamMembershipsForUserIDs(context.Background(), conn, scenario.UserIDs)
+			require.NoError(t, err)
+
+			require.Len(t, retrieved, scenario.Expected)
+		})
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds implementation of listing memberships by User ID, needed to attribute workspace instances to a team.
This is used in sub-sequent [PR](https://github.com/gitpod-io/gitpod/pull/10534/files)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE