### PR TITLE
bump werft cli version in dev image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -71,7 +71,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -21,7 +21,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/ide-integration-tests-startup-jetbrains.yaml
+++ b/.werft/ide-integration-tests-startup-jetbrains.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-integration-tests-startup-vscode.yaml
+++ b/.werft/ide-integration-tests-startup-vscode.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/.werft/ide-run-integration-tests.yaml
+++ b/.werft/ide-run-integration-tests.yaml
@@ -25,7 +25,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -27,7 +27,7 @@ pod:
       secretName: harvester-vm-ssh-keys
   containers:
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
     emptyDir: {}
   initContainers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
       secretName: gcp-sa-gitpod-dev-deployer
   containers:
   - name: wipe-devstaging
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -12,7 +12,7 @@ pod:
     emptyDir: {}
   containers:
   - name: gcloud
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go183.2.1
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-upgrade-werft-cli.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -66,7 +66,7 @@ RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/dazzle/releases/downl
 # werft CLI
 ENV WERFT_K8S_NAMESPACE=werft
 ENV WERFT_DIAL_MODE=kubernetes
-RUN cd /usr/bin && curl -fsSL https://github.com/csweichel/werft/releases/download/v0.3.0/werft-client-linux-amd64.tar.gz | tar xz && mv werft-client-linux-amd64 werft
+RUN cd /usr/bin && curl -fsSL https://github.com/csweichel/werft/releases/download/v0.3.3/werft-client-linux-amd64.tar.gz | tar xz && mv werft-client-linux-amd64 werft
 
 # yq - jq for YAML files
 # Note: we rely on version 3.x.x in various places, 4.x breaks this!


### PR DESCRIPTION
## Description
Upgrade werft to the latest, allowing for TLS connections

## Related Issue(s)
[Fixes #](https://github.com/gitpod-io/ops/issues/2083)

## Release Notes
- werft CLI in dev image upgraded to 0.3.3
