### PR TITLE
Minor Stripe API clean-up

### DIFF
--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -36,7 +36,7 @@ export default function TeamUsageBasedBilling() {
             setStripeCustomerId(undefined);
             setIsLoading(true);
             try {
-                const customerId = await getGitpodService().server.getTeamStripeCustomerId(team.id);
+                const customerId = await getGitpodService().server.findStripeCustomerIdForTeam(team.id);
                 setStripeCustomerId(customerId);
             } catch (error) {
                 console.error(error);
@@ -102,7 +102,7 @@ export default function TeamUsageBasedBilling() {
         if (!pollStripeCustomerTimeout) {
             // Refresh Stripe customer in 5 seconds in order to poll for upgrade confirmation
             const timeout = setTimeout(async () => {
-                const customerId = await getGitpodService().server.getTeamStripeCustomerId(team.id);
+                const customerId = await getGitpodService().server.findStripeCustomerIdForTeam(team.id);
                 setStripeCustomerId(customerId);
                 setPollStripeCustomerTimeout(undefined);
             }, 5000);
@@ -164,7 +164,7 @@ function BillingSetupModal(props: { onClose: () => void }) {
     useEffect(() => {
         const { server } = getGitpodService();
         Promise.all([
-            server.getStripePublishableKey().then((v) => () => setStripePromise(loadStripe(v || ""))),
+            server.getStripePublishableKey().then((v) => () => setStripePromise(loadStripe(v))),
             server.getStripeSetupIntentClientSecret().then((v) => () => setStripeSetupIntentClientSecret(v)),
         ]).then((setters) => setters.forEach((s) => s()));
     }, []);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -270,9 +270,9 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     getGithubUpgradeUrls(): Promise<GithubUpgradeURL[]>;
 
-    getStripePublishableKey(): Promise<string | undefined>;
-    getStripeSetupIntentClientSecret(): Promise<string | undefined>;
-    getTeamStripeCustomerId(teamId: string): Promise<string | undefined>;
+    getStripePublishableKey(): Promise<string>;
+    getStripeSetupIntentClientSecret(): Promise<string>;
+    findStripeCustomerIdForTeam(teamId: string): Promise<string | undefined>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
 
     /**

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -198,7 +198,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         tsReassignSlot: { group: "default", points: 1 },
         getStripePublishableKey: { group: "default", points: 1 },
         getStripeSetupIntentClientSecret: { group: "default", points: 1 },
-        getTeamStripeCustomerId: { group: "default", points: 1 },
+        findStripeCustomerIdForTeam: { group: "default", points: 1 },
         subscribeTeamToStripe: { group: "default", points: 1 },
         trackEvent: { group: "default", points: 1 },
         trackLocation: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3033,13 +3033,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getGithubUpgradeUrls(ctx: TraceContext): Promise<GithubUpgradeURL[]> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async getStripePublishableKey(ctx: TraceContext): Promise<string | undefined> {
+    async getStripePublishableKey(ctx: TraceContext): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async getStripeSetupIntentClientSecret(ctx: TraceContext): Promise<string | undefined> {
+    async getStripeSetupIntentClientSecret(ctx: TraceContext): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async getTeamStripeCustomerId(ctx: TraceContext, teamId: string): Promise<string | undefined> {
+    async findStripeCustomerIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
     async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Make `getStripePublishableKey` always return a `string`, or throw an error if there is no key
- Make `getStripeSetupIntentClientSecret` always return a `string`, or throw an error if the SetupIntent doesn't have a client secret
- Rename `getTeamStripeCustomerId` to `findTeamStripeCustomerId` (to clarify that it can be `undefined`)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Should still build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment