### PR TITLE
Implement Stripe portal to allow usage-based customers to manage their billing details

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -274,6 +274,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripeSetupIntentClientSecret(): Promise<string>;
     findStripeCustomerIdForTeam(teamId: string): Promise<string | undefined>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
+    getStripePortalUrlForTeam(teamId: string): Promise<string>;
 
     /**
      * Analytics

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -101,4 +101,16 @@ export class StripeService {
         });
         return customer;
     }
+
+    async getPortalUrlForTeam(team: Team): Promise<string> {
+        const customer = await this.findCustomerByTeamId(team.id);
+        if (!customer) {
+            throw new Error(`No Stripe Customer ID found for team '${team.id}'`);
+        }
+        const session = await this.getStripe().billingPortal.sessions.create({
+            customer: customer.id,
+            return_url: this.config.hostUrl.with(() => ({ pathname: `/t/${team.slug}/billing` })).toString(),
+        });
+        return session.url;
+    }
 }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1906,6 +1906,23 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
+    async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
+        const user = this.checkAndBlockUser("getStripePortalUrlForTeam");
+        await this.ensureIsUsageBasedFeatureFlagEnabled(user);
+        await this.guardTeamOperation(teamId, "update");
+        const team = await this.teamDB.findTeamById(teamId);
+        try {
+            const url = await this.stripeService.getPortalUrlForTeam(team!);
+            return url;
+        } catch (error) {
+            log.error(`Failed to get Stripe portal URL for team '${teamId}'`, error);
+            throw new ResponseError(
+                ErrorCodes.INTERNAL_SERVER_ERROR,
+                `Failed to get Stripe portal URL for team '${teamId}'`,
+            );
+        }
+    }
+
     // (SaaS) – admin
     async adminGetAccountStatement(ctx: TraceContext, userId: string): Promise<AccountStatement> {
         traceAPIParams(ctx, { userId });

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -200,6 +200,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         getStripeSetupIntentClientSecret: { group: "default", points: 1 },
         findStripeCustomerIdForTeam: { group: "default", points: 1 },
         subscribeTeamToStripe: { group: "default", points: 1 },
+        getStripePortalUrlForTeam: { group: "default", points: 1 },
         trackEvent: { group: "default", points: 1 },
         trackLocation: { group: "default", points: 1 },
         identifyUser: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3045,6 +3045,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     //
     //#endregion
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- [x] Implement Stripe portal to allow usage-based customers to manage their subscription.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/10327

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod", or "Gitpod1", "Gitpod2" ...
2. Navigate to Team Settings > Team Billing
3. Wait for the Usage-Based Billing UI to appear
4. Upgrade to Usage-Based Billing by adding a credit card (e.g. 4242 4242 4242 4242, 4/24, 424)
5. Once upgraded, clicking on `Manage Billing` should open the Stripe Portal
6. (The Stripe Portal also has a link that takes you back to Gitpod)

| Click on Manage Billing | View Stripe Portal |
| --- | --- |
| <img width="1436" alt="Screenshot 2022-06-10 at 08 29 13" src="https://user-images.githubusercontent.com/599268/173004670-1dfe4cd5-9457-4a7d-b5b7-631d8cfcf5cc.png"> | <img width="1437" alt="Screenshot 2022-06-10 at 08 29 30" src="https://user-images.githubusercontent.com/599268/173004672-ba6df7bc-b46e-4bdf-99cb-704d37313acf.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment