### PR TITLE
Fix registry facade not being able to start up in preview environment

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -96,6 +96,7 @@ function copyCachedSecret(werft: Werft, params: InstallCertificateParams, slice:
     | yq d - 'metadata.uid' \
     | yq d - 'metadata.resourceVersion' \
     | yq d - 'metadata.creationTimestamp' \
+    | yq d - 'metadata.ownerReferences' \
     | sed 's/${params.certName}/${params.certSecretName}/g' \
     | kubectl --kubeconfig ${params.destinationKubeconfig} apply --namespace=${params.destinationNamespace} -f -`
 


### PR DESCRIPTION
## Description
Remove ownerReferences as they still reference the old secret name, which makes Kubernetes accept the creation of the secret, but then it vanishes without a trace. Registry-facade then tries to mount the non existing secret.

```
 ownerReferences:
  - apiVersion: cert-manager.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Certificate
    name: harvester-fo-ws-class-env
    uid: 1ab08d7c-78f2-43ae-ad3a-fc0a67d06bde
```

## Related Issue(s)
n.a.

## How to test
Preview environment should get into ready state

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```