### PR TITLE
[jb]: monitor low memory notifications

### DIFF
--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -49,4 +49,6 @@ export GIT_EDITOR="$EDITOR --wait"
 export GP_PREVIEW_BROWSER="$IDEA_CLI_DEV_PATH preview"
 export GP_EXTERNAL_BROWSER="$IDEA_CLI_DEV_PATH preview"
 
+export JETBRAINS_GITPOD_BACKEND_KIND=intellij
+
 $TEST_BACKEND_DIR/bin/remote-dev-server.sh run $TEST_DIR

--- a/operations/observability/mixins/IDE/dashboards.libsonnet
+++ b/operations/observability/mixins/IDE/dashboards.libsonnet
@@ -10,6 +10,7 @@
     // 'my-new-dashboard.json': (import 'dashboards/components/new-component.json'),
     'gitpod-component-openvsx-proxy.json': (import 'dashboards/components/openvsx-proxy.json'),
     'gitpod-component-ssh-gateway.json': (import 'dashboards/components/ssh-gateway.json'),
+    'gitpod-component-jb.json': (import 'dashboards/components/jb.json'),
 
   },
 }

--- a/operations/observability/mixins/IDE/dashboards/components/jb.json
+++ b/operations/observability/mixins/IDE/dashboards/components/jb.json
@@ -1,0 +1,232 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 63,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "notification/second",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(gitpod_jb_backend_low_memory_after_gc_total[5m]))",
+          "legendFormat": "rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total low memory after GC",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "notification/second",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum(rate(gitpod_jb_backend_low_memory_after_gc_total[5m])) by (pod))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top low memory after GC",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "JetBrains Overview",
+  "uid": "oamBLUC7k",
+  "version": 8,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

As for now we monitor JVM used and max memory. It is not enough though to detect perf degradation, since GC can kick off and release memory. It turned out though that JB backend already monitors performance degradation internally and notifies a user about it with low memory notification after GC. This PR adds a counter of low memory notifications. Steady increase of such notifications means performance degradation for a user.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Monitoring for https://github.com/gitpod-io/gitpod/issues/8704

## How to test
<!-- Provide steps to test this PR -->

### Reproducing low memory notifications
- Configure prev envs with IntelliJ IDEA: https://ak-jb-gc-pause.preview.gitpod-dev.com/preferences
- Start a workspace in prev envs with low max heap to emulate low memory usage: https://ak-jb-gc-pause.preview.gitpod-dev.com/#INTELLIJ_VMOPTIONS=-Xmx384m/https://github.com/eclipse/xtext-core
- Connect with IntelliJ and confirm loading gradle project.
<img width="514" alt="Screenshot 2022-06-16 at 14 13 23" src="https://user-images.githubusercontent.com/3082655/174067316-d04934ea-04e9-4104-8f0b-2b649b2a023b.png">

- Double Shift → Find and open `LanguageServerImpl.java` file
- Find some method and start typing to get auto triggered completions:
    - for local symbols like parameters
    - for global symbols like IllegalStateExceptions
- Now try to trigger completions manually via Ctrl+Space.
- Repeat 2 steps above till you get low memory notifications. It usually happens after indexing of JDK is done, IntellIJ is trying to index gradle project itself and serve completions already. After you seen it do above a bit more to trigger more notifications. You won't see them on UI new but backend will count them.
<img width="486" alt="Screenshot 2022-06-16 at 14 15 11" src="https://user-images.githubusercontent.com/3082655/174067651-10dedc24-c2ea-4f84-9c8e-8c2fa8cc5fc8.png">

### Monitoring
- Start a dev workspace [https://gitpod.io#https://github.com/gitpod-io/gitpod/pull/10558](https://gitpod.io#https://github.com/gitpod-io/gitpod/pull/10558)
- Run `./dev/preview/portforward-monitoring-satellite.sh -c harvester` to port forward prometheus API endpoint.
- Run `gp preview $(gp url 3000)/d/oamBLUC7k/jetbrains-overview?orgId=1 --external` to open JetBrains Overview dashboard.
- You can see rate of low memory after GC notifications in the last 5 minutes as well as top 10 pods.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
