### PR TITLE
Add workspace class to workspace environment variables

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -730,6 +730,7 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 	result = append(result, corev1.EnvVar{Name: "GITPOD_HOST", Value: m.Config.GitpodHostURL})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_URL", Value: startContext.WorkspaceURL})
 	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_CLUSTER_HOST", Value: m.Config.WorkspaceClusterHost})
+	result = append(result, corev1.EnvVar{Name: "GITPOD_WORKSPACE_CLASS", Value: startContext.Request.Spec.Class})
 	result = append(result, corev1.EnvVar{Name: "THEIA_SUPERVISOR_ENDPOINT", Value: fmt.Sprintf(":%d", startContext.SupervisorPort)})
 	// TODO(ak) remove THEIA_WEBVIEW_EXTERNAL_ENDPOINT and THEIA_MINI_BROWSER_HOST_PATTERN when Theia is removed
 	result = append(result, corev1.EnvVar{Name: "THEIA_WEBVIEW_EXTERNAL_ENDPOINT", Value: "webview-{{hostname}}"})

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
@@ -111,6 +111,10 @@
                             "value": "test-foobarservice-gitpod.io"
                         },
                         {
+                            "name": "GITPOD_WORKSPACE_CLASS",
+                            "value": "gitpodio-internal-foobar"
+                        },
+                        {
                             "name": "THEIA_SUPERVISOR_ENDPOINT",
                             "value": ":22999"
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
@@ -111,6 +111,10 @@
                             "value": "test-foobarservice-gitpod.io"
                         },
                         {
+                            "name": "GITPOD_WORKSPACE_CLASS",
+                            "value": "gitpodio-internal-not-found"
+                        },
+                        {
                             "name": "THEIA_SUPERVISOR_ENDPOINT",
                             "value": ":22999"
                         },


### PR DESCRIPTION
## Description
Now that XL clusters are gone, customers have asked for a way to identify the workspace class of the workspace. This adds an environment variable for easy identification.

## Related Issue(s)
https://gitpod.slack.com/archives/C02SF4A050W/p1654765497210679

## How to test
Open workspace in preview environment and look for GITPOD_WORKSPACE_CLASS environment variable.

## Release Notes
```release-note
Add GITPOD_WORKSPACE_CLASS environment variable to workspaces to allow easier identification of the workspace class
```