### PR TITLE
Use new stripe secret in preview environments

### DIFF
--- a/.werft/jobs/build/helm/values.payment.yaml
+++ b/.werft/jobs/build/helm/values.payment.yaml
@@ -15,7 +15,7 @@ components:
         secretName: chargebee-config
     - name: stripe-config
       secret:
-        secretName: stripe-config
+        secretName: stripe-api-keys
 
   paymentEndpoint:
     disabled: false

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -81,8 +81,9 @@ export class Installer {
             if (this.options.withPayment) {
                 // let installer know that there is a chargbee config
                 exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.chargebeeSecret chargebee-config`, { slice: slice });
+
                 // let installer know that there is a stripe config
-                exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.stripeSecret stripe-config`, { slice: slice });
+                exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.stripeSecret stripe-api-keys`, { slice: slice });
             }
 
         } catch (err) {

--- a/.werft/jobs/build/payment/stripe-config-secret.yaml
+++ b/.werft/jobs/build/payment/stripe-config-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  settings: eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfNTFLeHVyN0dhZFJYbTUwbzNJNXJKQTNvbnkxdGNmdTNkM0NOd3BUWFR6QURkWTJISmlvRk1XTGdTa2M1d2h0UkZRam85UG5kM3pYYUdlcktQcXRmN0REQ3kwMFhBb01kbjZhIiwic2VjcmV0S2V5Ijoic2tfdGVzdF81MUt4dXI3R2FkUlhtNTBvM0NtVFJWc1Q2Q0xqd0VlSlhsWWtmdjZHajREQm42aVlVeDJQWUlUNDhjVlI5dlNUS0s1b2hwQTVCdWdycU5NUU9WVzN0NVJIODAwS011T3lEZ1QifQo=
-kind: Secret
-metadata:
-  name: stripe-config
-  namespace: ${NAMESPACE}
-type: Opaque

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -17,10 +17,10 @@ export class StripeService {
 
     protected getStripe(): Stripe {
         if (!this._stripe) {
-            if (!this.config.stripeSettings?.secretKey) {
+            if (!this.config.stripeSecrets?.secretKey) {
                 throw new Error("Stripe is not properly configured");
             }
-            this._stripe = new Stripe(this.config.stripeSettings.secretKey, { apiVersion: "2020-08-27" });
+            this._stripe = new Stripe(this.config.stripeSecrets.secretKey, { apiVersion: "2020-08-27" });
         }
         return this._stripe;
     }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1851,7 +1851,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     async getStripePublishableKey(ctx: TraceContext): Promise<string> {
         const user = this.checkAndBlockUser("getStripePublishableKey");
         await this.ensureIsUsageBasedFeatureFlagEnabled(user);
-        const publishableKey = this.config.stripeSettings?.publishableKey;
+        const publishableKey = this.config.stripeSecrets?.publishableKey;
         if (!publishableKey) {
             throw new ResponseError(
                 ErrorCodes.INTERNAL_SERVER_ERROR,

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -20,12 +20,12 @@ import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 export const Config = Symbol("Config");
 export type Config = Omit<
     ConfigSerialized,
-    "blockedRepositories" | "hostUrl" | "chargebeeProviderOptionsFile" | "stripeSettingsFile" | "licenseFile"
+    "blockedRepositories" | "hostUrl" | "chargebeeProviderOptionsFile" | "stripeSecretsFile" | "licenseFile"
 > & {
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
     chargebeeProviderOptions?: ChargebeeProviderOptions;
-    stripeSettings?: { publishableKey: string; secretKey: string };
+    stripeSecrets?: { publishableKey: string; secretKey: string };
     builtinAuthProvidersConfigured: boolean;
     blockedRepositories: { urlRegExp: RegExp; blockUser: boolean }[];
     inactivityPeriodForRepos?: number;
@@ -151,7 +151,7 @@ export interface ConfigSerialized {
      * Payment related options
      */
     chargebeeProviderOptionsFile?: string;
-    stripeSettingsFile?: string;
+    stripeSecretsFile?: string;
     enablePayment?: boolean;
 
     /**
@@ -215,12 +215,14 @@ export namespace ConfigFile {
         const chargebeeProviderOptions = readOptionsFromFile(
             filePathTelepresenceAware(config.chargebeeProviderOptionsFile || ""),
         );
-        let stripeSettings: { publishableKey: string; secretKey: string } | undefined;
-        if (config.enablePayment && config.stripeSettingsFile) {
+        let stripeSecrets: { publishableKey: string; secretKey: string } | undefined;
+        if (config.enablePayment && config.stripeSecretsFile) {
             try {
-                stripeSettings = JSON.parse(fs.readFileSync(filePathTelepresenceAware(config.stripeSettingsFile), "utf-8"));
+                stripeSecrets = JSON.parse(
+                    fs.readFileSync(filePathTelepresenceAware(config.stripeSecretsFile), "utf-8"),
+                );
             } catch (error) {
-                console.error("Could not load Stripe settings", error);
+                console.error("Could not load Stripe secrets", error);
             }
         }
         let license = config.license;
@@ -249,7 +251,7 @@ export namespace ConfigFile {
             authProviderConfigs,
             builtinAuthProvidersConfigured,
             chargebeeProviderOptions,
-            stripeSettings,
+            stripeSecrets,
             license,
             workspaceGarbageCollection: {
                 ...config.workspaceGarbageCollection,

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -218,7 +218,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
 		EnablePayment:                chargebeeSecret != "" || stripeSecret != "",
 		ChargebeeProviderOptionsFile: fmt.Sprintf("%s/providerOptions", chargebeeMountPath),
-		StripeSettingsFile:           fmt.Sprintf("%s/settings", stripeMountPath),
+		StripeSecretsFile:            fmt.Sprintf("%s/apikeys", stripeMountPath),
 		InsecureNoDomain:             false,
 		PrebuildLimiter: map[string]int{
 			// default limit for all cloneURLs

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -194,7 +194,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 			volumes = append(volumes,
 				corev1.Volume{
-					Name: "stripe-config",
+					Name: "stripe-secret",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: stripeSecret,
@@ -203,7 +203,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				})
 
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      "stripe-config",
+				Name:      "stripe-secret",
 				MountPath: stripeMountPath,
 				ReadOnly:  true,
 			})

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -33,6 +33,7 @@ type ConfigSerialized struct {
 	VSXRegistryUrl                    string   `json:"vsxRegistryUrl"`
 	ChargebeeProviderOptionsFile      string   `json:"chargebeeProviderOptionsFile"`
 	StripeSettingsFile                string   `json:"stripeSettingsFile"`
+	StripeSecretsFile                 string   `json:"stripeSecretsFile"`
 	EnablePayment                     bool     `json:"enablePayment"`
 
 	WorkspaceHeartbeat         WorkspaceHeartbeat         `json:"workspaceHeartbeat"`

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -32,7 +32,6 @@ type ConfigSerialized struct {
 	ImageBuilderAddr                  string   `json:"imageBuilderAddr"`
 	VSXRegistryUrl                    string   `json:"vsxRegistryUrl"`
 	ChargebeeProviderOptionsFile      string   `json:"chargebeeProviderOptionsFile"`
-	StripeSettingsFile                string   `json:"stripeSettingsFile"`
 	StripeSecretsFile                 string   `json:"stripeSecretsFile"`
 	EnablePayment                     bool     `json:"enablePayment"`
 


### PR DESCRIPTION
## Description

Following on from #10552 which added the `stripe-api-keys` secret to preview environment clusters, this PR makes the `server` component use the secret and removes the old `stripe-config` secret from the repo.

## Related Issue(s)

Part of #9036 and https://github.com/gitpod-io/ops/issues/2554

## How to test

Manually trigger a werft job for this branch [(Notion doc)](https://www.notion.so/gitpod/Manually-triggering-a-Werft-job-4aaf0cacbfc54f21991be700746637c3#840790f17f7143009bf0164bcd0720c1), setting `with-payment=true`.

Check that `server` is in a running state in the preview environment cluster and that it has successfully mounted the `stripe-api-keys` secret:

```
> kubectl describe pod <server pod>
```

## Release Notes

```release-note
NONE
```
