### PR TITLE
chore(dashboard): adjust prebuild table col width

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -190,7 +190,7 @@ export default function (props: { project?: Project; isAdminDashboard?: boolean 
                 </div>
                 <ItemsList className="mt-2">
                     <Item header={true}>
-                        <ItemField className="my-auto w-5/12">
+                        <ItemField className="my-auto md:w-3/12 xl:w-4/12">
                             <span>Prebuild</span>
                         </ItemField>
                         <ItemField className="my-auto w-5/12">
@@ -216,7 +216,7 @@ export default function (props: { project?: Project; isAdminDashboard?: boolean 
                             >
                                 <Item key={`prebuild-${p.info.id}`}>
                                     <ItemField
-                                        className={`flex items-center my-auto w-5/12 ${
+                                        className={`flex items-center my-auto md:w-3/12 xl:w-4/12 ${
                                             props.isAdminDashboard ? "pointer-events-none" : ""
                                         }`}
                                     >


### PR DESCRIPTION
## Description
The Prebuilds page not always align correctly the columns, e.g. see screeenshot below:

<img width="1702" alt="Screenshot 2022-06-09 at 11 21 36 copy" src="https://user-images.githubusercontent.com/2318450/172898598-f3f371ac-fed9-439b-adc2-a18bc7408afa.png">

I think this small CSS change could improve already some scenarios.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
1. Start the dashboard for gitpod.io

(I would also suggest Prev Env, but there are no prebuilds there)

| Before | After |
|--------|-------|
|     <img width="1702" alt="Screenshot 2022-06-09 at 11 21 36" src="https://user-images.githubusercontent.com/2318450/172899230-1ad3474f-867d-48ff-980a-0a299e5d93a3.png">   |   <img width="1725" alt="Screenshot 2022-06-09 at 11 21 03" src="https://user-images.githubusercontent.com/2318450/172899216-dff2ad65-5f18-4d17-8ea1-e8dd09a10e91.png">    |


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
