### PR TITLE
[code] Update stable to 1.68

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-80d9b1ebfd826fd0db25320ba94d762b51887ada" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-c6a1de9dcfea97e31f7bb133dafe6b72cb55562d" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates stable VS Code version to 1.68.0.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #10487 

## How to test
Switch to stable in the preview environment and in the about dialog confirm you are running 1.68

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
