### PR TITLE
[Usage-based] Attribute workspace instances to a Team on start

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -102,4 +102,10 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     workspaceClass?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    attributedTeamId?: string;
 }

--- a/components/gitpod-db/src/typeorm/migration/1654847406624-WorkspaceInstanceAttributedTeam.ts
+++ b/components/gitpod-db/src/typeorm/migration/1654847406624-WorkspaceInstanceAttributedTeam.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_workspace_instance";
+const COLUMN_NAME = "attributedTeamId";
+
+export class WorkspaceInstanceAttributedTeam1654847406624 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} char(36) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} DROP COLUMN ${COLUMN_NAME}, ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -66,6 +66,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
+        attributedTeamId: undefined,
     };
     readonly wsi2: WorkspaceInstance = {
         workspaceId: this.ws.id,
@@ -88,6 +89,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
+        attributedTeamId: undefined,
     };
     readonly ws2: Workspace = {
         id: "2",
@@ -125,6 +127,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
+        attributedTeamId: undefined,
     };
 
     readonly ws3: Workspace = {
@@ -162,6 +165,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
+        attributedTeamId: undefined,
     };
 
     async before() {

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -62,6 +62,13 @@ export interface WorkspaceInstance {
      * resources that are provided to the workspace.
      */
     workspaceClass?: string;
+
+    /**
+     * Identifies the team to which this instance's runtime should be attributed to
+     * (e.g. for usage analytics or billing purposes).
+     * If unset, the usage should be attributed to the workspace's owner (ws.ownerId).
+     */
+    attributedTeamId?: string;
 }
 
 // WorkspaceInstanceStatus describes the current state of a workspace instance

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -633,9 +633,9 @@ export class WorkspaceStarter {
         delete ideConfig.ideOptions.options["code-latest"];
         delete ideConfig.ideOptions.options["code-desktop-insiders"];
 
-        const migratted = migrationIDESettings(user);
-        if (user.additionalData?.ideSettings && migratted) {
-            user.additionalData.ideSettings = migratted;
+        const migrated = migrationIDESettings(user);
+        if (user.additionalData?.ideSettings && migrated) {
+            user.additionalData.ideSettings = migrated;
         }
 
         const ideChoice = user.additionalData?.ideSettings?.defaultIde;
@@ -709,6 +709,8 @@ export class WorkspaceStarter {
             configuration.featureFlags = featureFlags;
         }
 
+        const attributedTeamId = await this.userService.getWorkspaceUsageAttributionTeamId(user, workspace.projectId);
+
         const now = new Date().toISOString();
         const instance: WorkspaceInstance = {
             id: uuidv4(),
@@ -722,6 +724,7 @@ export class WorkspaceStarter {
                 phase: "preparing",
             },
             configuration,
+            attributedTeamId,
         };
         if (WithReferrerContext.is(workspace.context)) {
             this.analytics.track({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When a workspace instance starts, we want to determine and persist which "cost center" that instance's usage should be attributed to:
- If `wsi.attributedTeamId` is set to a specific Team ID, then that Team "owns" the instance's usage
  - This means that the instance's usage time will be reflected in the Team's Usage dashboard, and in their Stripe invoices if usage-based billing is enabled
- If `wsi.attributedTeamId` is not set, then it's the workspace owner (User) who owns the instance's usage
  - This means that we default to user billing or their free credits when no Team is attributed

Reminder: We need to do this on instance start, because the usual attribution links can change over time.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10533

## How to test
<!-- Provide steps to test this PR -->

1. Should build
2. In the DB, `d_b_workspace_instance` should have a `attributedTeamId` column that defaults to empty string (`''`)
3. If you start a workspace **without any Project**:
    - its `attributedTeamId` should be empty (i.e. usage is attributed to you)
4. If you create a Project under your User, and start a workspace for that **User Project**:
    - the `attributedTeamId` should also be empty (i.e. usage still attributed to you)
5. If you create a Project under a Team, and then start a Workspace for that **Team Project**:
    - the `attributedTeamId` should now be set to the Team's ID (i.e. usage is attributed to the team)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
