### PR TITLE
[Installer]: configure endpoint/region of registry S3 backing

### DIFF
--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -113,7 +113,9 @@ func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]strin
 					},
 				},
 				S3Storage: &configv1.S3Storage{
-					Bucket: "some-bucket",
+					Bucket:   "some-bucket",
+					Region:   "some-region",
+					Endpoint: "some-url",
 					Certificate: configv1.ObjectRef{
 						Kind: configv1.ObjectRefSecret,
 						Name: "value",

--- a/install/installer/pkg/components/docker-registry/helm.go
+++ b/install/installer/pkg/components/docker-registry/helm.go
@@ -43,17 +43,22 @@ var Helm = common.CompositeHelmFunc(
 
 		inCluster := pointer.BoolDeref(cfg.Config.ContainerRegistry.InCluster, false)
 		s3Storage := cfg.Config.ContainerRegistry.S3Storage
+		enablePersistence := "true"
 
 		if inCluster && s3Storage != nil {
+			enablePersistence = "false"
 			registryValues = append(registryValues,
-				helm.KeyValue("docker-registry.s3.region", cfg.Config.Metadata.Region),
+				helm.KeyValue("docker-registry.s3.region", s3Storage.Region),
 				helm.KeyValue("docker-registry.s3.bucket", s3Storage.Bucket),
+				helm.KeyValue("docker-registry.s3.regionEndpoint", s3Storage.Endpoint),
 				helm.KeyValue("docker-registry.s3.encrypt", "true"),
 				helm.KeyValue("docker-registry.s3.secure", "true"),
 				helm.KeyValue("docker-registry.storage", "s3"),
 				helm.KeyValue("docker-registry.secrets.s3.secretRef", s3Storage.Certificate.Name),
 			)
 		}
+
+		registryValues = append(registryValues, helm.KeyValue("docker-registry.persistence.enabled", enablePersistence))
 
 		return &common.HelmConfig{
 			Enabled: inCluster,

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -214,6 +214,8 @@ type ContainerRegistryExternal struct {
 
 type S3Storage struct {
 	Bucket      string    `json:"bucket" validate:"required"`
+	Region      string    `json:"region" validate:"required"`
+	Endpoint    string    `json:"endpoint" validate:"required"`
 	Certificate ObjectRef `json:"certificate" validate:"required"`
 }
 

--- a/install/installer/third_party/charts/docker-registry/values.yaml
+++ b/install/installer/third_party/charts/docker-registry/values.yaml
@@ -2,6 +2,4 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-docker-registry:
-  persistence:
-    enabled: true
+docker-registry: {}

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-airgap-openssh.0"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-registry-s3-fork.3"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-airgap-openssh.0"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-registry-s3-fork.3"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -167,6 +167,8 @@ spec:
                 then
                   echo "Gitpod: configuring container registry S3 backend"
 
+                  yq e -i ".containerRegistry.s3storage.region = \"{{repl ConfigOption "reg_incluster_storage_s3_region" }}\"" "${CONFIG_FILE}"
+                  yq e -i ".containerRegistry.s3storage.endpoint = \"{{repl ConfigOption "reg_incluster_storage_s3_endpoint" }}\"" "${CONFIG_FILE}"
                   yq e -i ".containerRegistry.s3storage.bucket = \"{{repl ConfigOption "reg_incluster_storage_s3_bucketname" }}\"" "${CONFIG_FILE}"
                   yq e -i ".containerRegistry.s3storage.certificate.kind = \"secret\"" "${CONFIG_FILE}"
                   yq e -i ".containerRegistry.s3storage.certificate.name = \"container-registry-s3-backend\"" "${CONFIG_FILE}"

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -45,6 +45,22 @@ spec:
             - name: s3
               title: S3
 
+        # S3 help_text
+        - name: reg_incluster_storage_s3_region
+          title: Storage region
+          type: text
+          required: true
+          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          help_text: ID of the region where your storage exists, such as `eu-west-2`.
+
+        - name: reg_incluster_storage_s3_endpoint
+          title: Endpoint
+          type: text
+          required: true
+          value: s3.amazonaws.com
+          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          help_text: The endpoint used to connect to the S3 storage.
+
         - name: reg_incluster_storage_s3_bucketname
           title: S3 bucket name
           type: text


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
There is no way to independently control the bucket configuration for the main S3 bucket and the registry's S3 backing. This introduces the configuration surface in the Installer and implements it in the KOTS installer. The registry persistence is also disabled if the S3 backing is used - this never becomes ready, so causes Helm to timeout.

There is at least one customer blocked by this. If the object storage wasn't configured and the registry S3 was, it also prevented the Helm install job from ever finishing - see [internal discussion](https://gitpod.slack.com/archives/C01KLC56NP7/p1654717329877249).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9800

## How to test
<!-- Provide steps to test this PR -->
Configure S3 backing for registry and the main object storage using the in-cluster option.

I have checked that there's no regression in the in-cluster repo too

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Installer]: configure endpoint/region of registry S3 backing
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
