### PR TITLE
[kots]: move the openssh installation to the container image

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:3.16
 COPY --from=alpine/helm:3.8.0 /usr/bin/helm /usr/bin/helm
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
-RUN apk add --no-cache curl jq yq  \
+RUN apk add --no-cache curl jq openssh-keygen yq  \
     && curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 ENTRYPOINT [ "/app/installer" ]

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:release-2022.04.1.2"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-airgap-openssh.0"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:release-2022.04.1.2"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-airgap-openssh.0"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -211,7 +211,6 @@ spec:
               if [ '{{repl ConfigOptionEquals "ssh_gateway" "1" }}' = "true" ];
               then
                 echo "Gitpod: Generate SSH host key"
-                apk update && apk add --no-cache openssh-keygen # TODO: Move installation of openssh-keygen to installer image
                 ssh-keygen -t rsa -q -N "" -f host.key
                 kubectl create secret generic ssh-gateway-host-key --from-file=host.key -n {{repl Namespace }} || echo "SSH Gateway Host Key secret has not been created. Does it exist already?"
                 yq e -i '.sshGatewayHostKey.kind = "secret"' "${CONFIG_FILE}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The installation of the OpenSSH package meant that airgapped installations are unable to configure SSH access. This moves the installation command to the container image, removing a todo from the initial 🛹 

## How to test
<!-- Provide steps to test this PR -->
Published to `sje/airgap-openssh` channel in Replicated vendor portal.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: move the openssh installation to the container image
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
