### PR TITLE
[loadgen] Wait before workspace termination

### DIFF
--- a/dev/loadgen/README.md
+++ b/dev/loadgen/README.md
@@ -13,7 +13,7 @@ You can find a short explanation of this tool in this [loom video](https://www.l
 `gpctl clusters get-tls-config`
 - Port-forward ws-manager
 `kubectl port-forward deployment/ws-manager 12001:8080`
-- Now you can start the benchmark with loadgen. If you want to keep the workspaces around after testing, add --interactive. Loadgen will then ask you before taking any destructive action.
+- Now you can start the benchmark with loadgen. If you want to keep the workspaces around after testing, add --interactive. Loadgen will then ask you before taking any destructive action. If you do not specify `--interative` loadgen will wait 2 minutes before workspaces are deleted.
 `loadgen benchmark [config-file] --host localhost:12001 --tls ./wsman-tls --interactive`
 
 In order to configure the benchmark, you can use the configuration file


### PR DESCRIPTION
## Description
Wait 2 minutes before workspaces are terminated after loadgen benchmark has been performed. If you do not want to wait you can send SIGINT and loadgen will start cleaning up immediately.

## Related Issue(s)
n.a.

## How to test
See loadgen README for information on how to perform a load test. Start the loadtest without --interactive. After workspaces are running, you have 2 minutes before the workspaces are stopped.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```