### PR TITLE
Update platform version from 'gateway-plugin' to target JetBrains Gateway v2022.2-Nightly

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -11,8 +11,8 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     // Java support
     id("java")
-    // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.5.10"
+    // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
+    id("org.jetbrains.kotlin.jvm") version "1.7.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "1.6.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
@@ -135,6 +135,11 @@ tasks {
             }
         }
         channels.set(listOf(pluginChannel))
+    }
+
+    // TODO: Remove the following three lines to reenable 'buildSearchableOptions' task if it's working fine next time we update 'platformVersion' on 'gradle.properties'.
+    buildSearchableOptions {
+        isEnabled = false
     }
 
     register("buildFromLeeway") {

--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -6,13 +6,15 @@ pluginName=gitpod-gateway
 pluginVersion=0.0.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=221
+pluginSinceBuild=222.3048.1
 pluginUntilBuild=222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2022.1, 2022.2
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType=GW
-platformVersion=222.2270.16-CUSTOM-SNAPSHOT
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+platformVersion=222-NIGHTLY-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update platform version from 'gateway-plugin' to the [nightly](https://www.jetbrains.com/intellij-repository/snapshots) (_com.jetbrains.gateway: 222-NIGHTLY-CUSTOM-SNAPSHOT_), to make use of the latest API.

Also, update the minimum version of the plugin to 222.3048.1, so it can only be installed on new gateway versions (2022.2+) downloaded from https://www.jetbrains.com/remote-development/gateway/ after June 16 2022.
Gateway 2022.1 (221) will is not going to receive new features.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up for #10505

## How to test
<!-- Provide steps to test this PR -->
- Download JetBrains Gateway from https://www.jetbrains.com/remote-development/gateway/ - The download button of this page actually downloads EAP Version. (At the moment of writing, the latest EAP version is 222.3048.1)
- Download the gateway-plugin version built on this PR from https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev: get the most recent one containing the title "Gitpod Gateway 0.0.1-felladrin-update-gw-platform"
- Install it (using the "Install plugin from disk" option) on JetBrains Gateway EAP
- Restart the Gateway
- Confirm if the extension is running fine (create a new workspace, connect to a running workspace, change Gitpod Host setting)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user-facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft --no-preview=true --clean-slate-deployment=true