### PR TITLE
Add feedback issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback_issue.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_issue.yml
@@ -1,0 +1,15 @@
+name: Feedback Issue
+description: Open a feedback issue to gather feedback, suggestions, and experiences from users.
+title: "Feedback Issue: "
+labels: ["feedback-issue"]
+body:
+- type: markdown
+  attributes:
+    value: Before raising a feedback issue, please search for [existing feedback issues](https://github.com/gitpod-io/gitpod/issues?q=is%3Aopen+is%3Aissue+label%3Afeedback-issue) to avoid creating duplicates.
+- type: textarea
+  id: objective
+  attributes:
+    label: Objective
+    description: Include the objective of this issue and any relevant features 
+  validations:
+    required: true


### PR DESCRIPTION
## Description

This will add a feedback issue template to help us be more intentional about creating feedback issues.

See [relevant discussion](https://gitpod.slack.com/archives/C01KLC5750D/p1652903673228329) (internal) as well as example feedback issues (https://github.com/gitpod-io/gitpod/issues/5712, https://github.com/gitpod-io/gitpod/issues/6576, https://github.com/gitpod-io/gitpod/issues/7603, etc).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```