### PR TITLE
Use `xterm-256color` when creating terminal

### DIFF
--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -99,7 +99,7 @@ func (srv *MuxTerminalService) OpenWithOptions(ctx context.Context, req *api.Ope
 	if cmd.Dir == "" {
 		cmd.Dir = srv.DefaultWorkdir
 	}
-	cmd.Env = append(srv.Env, "TERM=xterm-color")
+	cmd.Env = append(srv.Env, "TERM=xterm-256color")
 	for key, value := range req.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%v=%v", key, value))
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use `xterm-256color` when creating pty terminal

## How to test
<!-- Provide steps to test this PR -->
1. Run `echo $TERM` in a  task terminal it should output `xterm-256color`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
