### PR TITLE
When using the Latest Release of JetBrains IDEs, if the workspace has tasks defined on .gitpod.yml, the IDE will start with one terminal opened for each task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -46,7 +46,7 @@ tasks:
         read -r -p "Press enter to continue Java gradle task"
       fi
       leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew --build-cache build
-      leeway exec --package components/ide/jetbrains/backend-plugin:plugin --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew --build-cache buildPlugin
+      leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew --build-cache buildPlugin
   - name: TypeScript
     before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build

--- a/components/ide/jetbrains/backend-plugin/.gitignore
+++ b/components/ide/jetbrains/backend-plugin/.gitignore
@@ -3,3 +3,4 @@
 .vscode
 bin
 build
+gradle-local.properties

--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: plugin
+  - name: plugin-stable
     type: generic
     deps:
       - components/supervisor-api/java:lib
@@ -8,11 +8,32 @@ packages:
       - "**/*.kt"
       - "build.gradle.kts"
       - "gradle.properties"
+      - "gradle-stable.properties"
       - "gradle/wrapper/*"
       - "gradlew"
       - "settings.gradle.kts"
       - "src/main/resources/*"
+      - "src/main/resources-stable/*"
     config:
       commands:
-        - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "runPluginVerifier"]
-        - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "buildPlugin"]
+        - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "runPluginVerifier"]
+        - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "buildPlugin"]
+  - name: plugin-latest
+    type: generic
+    deps:
+      - components/supervisor-api/java:lib
+      - components/gitpod-protocol/java:lib
+    srcs:
+      - "**/*.kt"
+      - "build.gradle.kts"
+      - "gradle.properties"
+      - "gradle-latest.properties"
+      - "gradle/wrapper/*"
+      - "gradlew"
+      - "settings.gradle.kts"
+      - "src/main/resources/*"
+      - "src/main/resources-latest/*"
+    config:
+      commands:
+        - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "runPluginVerifier"]
+        - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "buildPlugin"]

--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -10,18 +10,36 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     // Java support
     id("java")
-    // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.5.10"
+    // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
+    id("org.jetbrains.kotlin.jvm") version "1.7.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.0"
+    id("org.jetbrains.intellij") version "1.6.0"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
     id("io.gitlab.arturbosch.detekt") version "1.17.1"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    // Gradle Properties Plugin - read more: https://github.com/stevesaliman/gradle-properties-plugin
+    id("net.saliman.properties") version "1.5.2"
 }
 
 group = properties("pluginGroup")
 version = properties("version")
+
+val environmentName = properties("environmentName")
+
+project(":") {
+    kotlin {
+        var excludedPackage = "stable"
+        if (environmentName == excludedPackage) excludedPackage = "latest"
+        sourceSets["main"].kotlin.exclude("io/gitpod/jetbrains/remote/${excludedPackage}/**")
+    }
+
+    sourceSets {
+        main {
+            resources.srcDirs("src/main/resources-${environmentName}")
+        }
+    }
+}
 
 // Configure project's dependencies
 repositories {

--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -1,0 +1,9 @@
+# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# for insight into build numbers and IntelliJ Platform versions.
+pluginSinceBuild=222
+pluginUntilBuild=222.*
+# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
+# See https://jb.gg/intellij-platform-builds-list for available build versions.
+pluginVerifierIdeVersions=2022.2
+# Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+platformVersion=222-EAP-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -1,0 +1,9 @@
+# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# for insight into build numbers and IntelliJ Platform versions.
+pluginSinceBuild=221
+pluginUntilBuild=221.*
+# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
+# See https://jb.gg/intellij-platform-builds-list for available build versions.
+pluginVerifierIdeVersions=2022.1
+# Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+platformVersion=221-EAP-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -1,18 +1,12 @@
 version=0.0.1
+# Supported environments: stable, latest (via https://github.com/stevesaliman/gradle-properties-plugin)
+environmentName=latest
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=io.gitpod.jetbrains
 pluginName=gitpod-remote
-# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-# for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=213
-pluginUntilBuild=221.*
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
-# See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2021.3, 2022.1
-# IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType=IU
-platformVersion=221-EAP-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodTerminalService.kt
@@ -1,0 +1,199 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.client.ClientProjectSession
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.remoteDev.util.onTerminationOrNow
+import com.intellij.util.application
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rdserver.terminal.BackendTerminalManager
+import io.gitpod.jetbrains.remote.GitpodManager
+import io.gitpod.supervisor.api.Status
+import io.gitpod.supervisor.api.StatusServiceGrpc
+import io.gitpod.supervisor.api.TerminalOuterClass
+import io.gitpod.supervisor.api.TerminalServiceGrpc
+import io.grpc.stub.ClientCallStreamObserver
+import io.grpc.stub.ClientResponseObserver
+import org.jetbrains.plugins.terminal.ShellTerminalWidget
+import org.jetbrains.plugins.terminal.TerminalView
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+@Suppress("UnstableApiUsage")
+class GitpodTerminalService(session: ClientProjectSession) : Disposable {
+    private companion object {
+        /** Indicates if this service is already running, because we shouldn't run it more than once. */
+        var isRunning = false
+    }
+
+    private val lifetime = Lifetime.Eternal.createNested()
+    private val terminalView = TerminalView.getInstance(session.project)
+    private val backendTerminalManager = BackendTerminalManager.getInstance(session.project)
+    private val terminalServiceFutureStub = TerminalServiceGrpc.newFutureStub(GitpodManager.supervisorChannel)
+    private val statusServiceStub = StatusServiceGrpc.newStub(GitpodManager.supervisorChannel)
+
+    override fun dispose() {
+        lifetime.terminate()
+    }
+
+    init {
+        run()
+    }
+
+    private fun run() {
+        if (application.isHeadlessEnvironment || isRunning) return
+
+        isRunning = true
+
+        val task = application.executeOnPooledThread {
+            val terminals = getSupervisorTerminalsList()
+            val tasks = getSupervisorTasksList()
+
+            application.invokeLater {
+                createTerminalsAttachedToTasks(terminals, tasks)
+            }
+        }
+
+        lifetime.onTerminationOrNow {
+            task.cancel(true)
+        }
+    }
+
+    private fun createSharedTerminalAndExecuteCommand(title: String, command: String) {
+        val registeredTerminals = terminalView.widgets.toMutableList()
+
+        backendTerminalManager.createNewSharedTerminal(UUID.randomUUID().toString(), title)
+
+        for (widget in terminalView.widgets) {
+            if (!registeredTerminals.contains(widget)) {
+                widget.terminalTitle.change {
+                    applicationTitle = title
+                }
+                (widget as ShellTerminalWidget).executeCommand(command)
+            }
+        }
+    }
+
+    private fun createTerminalsAttachedToTasks(
+        terminals: List<TerminalOuterClass.Terminal>,
+        tasks: List<Status.TaskStatus>
+    ) {
+        if (tasks.isEmpty()) return
+
+        val aliasToTerminalMap: MutableMap<String, TerminalOuterClass.Terminal> = mutableMapOf()
+
+        for (terminal in terminals) {
+            val terminalAlias = terminal.alias
+            aliasToTerminalMap[terminalAlias] = terminal
+        }
+
+        for (task in tasks) {
+            val terminalAlias = task.terminal
+            val terminal = aliasToTerminalMap[terminalAlias]
+
+            if (terminal != null) {
+                createAttachedSharedTerminal(terminal)
+            }
+        }
+    }
+
+    private tailrec fun getSupervisorTasksList(): List<Status.TaskStatus> {
+        var tasksList: List<Status.TaskStatus>? = null
+
+        try {
+            val completableFuture = CompletableFuture<List<Status.TaskStatus>>()
+
+            val taskStatusRequest = Status.TasksStatusRequest.newBuilder().setObserve(true).build()
+
+            val taskStatusResponseObserver = object :
+                ClientResponseObserver<Status.TasksStatusRequest, Status.TasksStatusResponse> {
+                override fun beforeStart(request: ClientCallStreamObserver<Status.TasksStatusRequest>) {
+                    lifetime.onTerminationOrNow {
+                        request.cancel(null, null)
+                    }
+                }
+
+                override fun onNext(response: Status.TasksStatusResponse) {
+                    for (task in response.tasksList) {
+                        if (task.state === Status.TaskState.opening) {
+                            return
+                        }
+                    }
+                    completableFuture.complete(response.tasksList)
+                }
+
+                override fun onCompleted() {}
+
+                override fun onError(throwable: Throwable) {
+                    completableFuture.completeExceptionally(throwable)
+                }
+            }
+
+            statusServiceStub.tasksStatus(taskStatusRequest, taskStatusResponseObserver)
+
+            tasksList = completableFuture.get()
+        } catch (throwable: Throwable) {
+            if (throwable is InterruptedException) {
+                throw throwable
+            }
+
+            thisLogger().error(
+                "Got an error while trying to get tasks list from Supervisor. Trying again in on second.",
+                throwable
+            )
+        }
+
+        return if (tasksList != null) {
+            tasksList
+        } else {
+            TimeUnit.SECONDS.sleep(1)
+            getSupervisorTasksList()
+        }
+    }
+
+    private tailrec fun getSupervisorTerminalsList(): List<TerminalOuterClass.Terminal> {
+        var terminalsList: List<TerminalOuterClass.Terminal>? = null
+
+        try {
+            val listTerminalsRequest = TerminalOuterClass.ListTerminalsRequest.newBuilder().build()
+
+            val listTerminalsResponseFuture = terminalServiceFutureStub.list(listTerminalsRequest)
+
+            lifetime.onTerminationOrNow {
+                listTerminalsResponseFuture.cancel(true)
+            }
+
+            val listTerminalsResponse = listTerminalsResponseFuture.get()
+
+            terminalsList = listTerminalsResponse.terminalsList
+        } catch (throwable: Throwable) {
+            if (throwable is InterruptedException) {
+                throw throwable
+            }
+
+            thisLogger().error(
+                "Got an error while trying to get terminals list from Supervisor. Trying again in on second.",
+                throwable
+            )
+        }
+
+        return if (terminalsList != null) {
+            terminalsList
+        } else {
+            TimeUnit.SECONDS.sleep(1)
+            getSupervisorTerminalsList()
+        }
+    }
+
+    private fun createAttachedSharedTerminal(supervisorTerminal: TerminalOuterClass.Terminal) {
+        createSharedTerminalAndExecuteCommand(
+            supervisorTerminal.title,
+            "gp tasks attach ${supervisorTerminal.alias}"
+        )
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodTerminalService.kt
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.remote
+package io.gitpod.jetbrains.remote.stable
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.runInEdt
@@ -24,7 +24,7 @@ import org.jetbrains.plugins.terminal.TerminalToolWindowFactory
 import org.jetbrains.plugins.terminal.TerminalView
 import java.util.concurrent.CompletableFuture
 
-@Suppress("UnstableApiUsage", "EXPERIMENTAL_IS_NOT_ENABLED", "OPT_IN_IS_NOT_ENABLED")
+@Suppress("UnstableApiUsage", "EXPERIMENTAL_IS_NOT_ENABLED")
 @OptIn(DelicateCoroutinesApi::class)
 class GitpodTerminalService(private val project: Project) : Disposable {
     private val lifetime = Lifetime.Eternal.createNested()

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -1,0 +1,10 @@
+<!--
+ Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodTerminalService" client="guest" preload="true"/>
+    </extensions>
+</idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -1,0 +1,10 @@
+<!--
+ Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodTerminalService" preload="true"/>
+    </extensions>
+</idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -3,8 +3,9 @@
  Licensed under the GNU Affero General Public License (AGPL).
  See License-AGPL.txt in the project root for license information.
 -->
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="/META-INF/extensions.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
-<idea-plugin>
     <id>io.gitpod.jetbrains.remote</id>
     <name>Gitpod Remote</name>
     <vendor>Gitpod</vendor>
@@ -26,7 +27,6 @@
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker" client="guest" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodProjectManager" preload="true"/>
         <gateway.customization.name implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
     </extensions>

--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -18,7 +18,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_intellij.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -40,7 +40,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_intellij.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -62,7 +62,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_goland.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -84,7 +84,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_goland.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -106,7 +106,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_pycharm.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -128,7 +128,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_pycharm.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -150,7 +150,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_phpstorm.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:
@@ -172,7 +172,7 @@ packages:
       - "startup.sh"
       - "supervisor-ide-config_phpstorm.json"
     deps:
-      - components/ide/jetbrains/backend-plugin:plugin
+      - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
       - components/ide/jetbrains/cli:app
     argdeps:

--- a/components/ide/jetbrains/image/leeway.Dockerfile
+++ b/components/ide/jetbrains/image/leeway.Dockerfile
@@ -4,10 +4,11 @@
 
 FROM alpine:3.16 as download
 ARG JETBRAINS_BACKEND_URL
+ARG JETBRAINS_BACKEND_QUALIFIER
 WORKDIR /workdir
 RUN apk add --no-cache --upgrade curl gzip tar unzip
 RUN curl -sSLo backend.tar.gz "$JETBRAINS_BACKEND_URL" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
-COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin/build/distributions/gitpod-remote-0.0.1.zip /workdir
+COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin-${JETBRAINS_BACKEND_QUALIFIER}/build/distributions/gitpod-remote-0.0.1.zip /workdir
 RUN unzip gitpod-remote-0.0.1.zip -d plugins/ && rm gitpod-remote-0.0.1.zip
 # enable shared indexes by default
 RUN printf '\nshared.indexes.download.auto.consent=true' >> "/workdir/bin/idea.properties"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When using the Latest Release of JetBrains IDEs, if the workspace has tasks defined on .gitpod.yml, the IDE will start with one terminal opened for each task, behaving similar to VS Code on Gitpod.

When using the Stable Release the behavior remains the current one: one terminal will be displayed, with a welcome message and invoking `gp tasks attach`.

This separation of versions was required for backward compatibility, as there were breaking changes on the API between IntelliJ 2022.1 and 2022.2. Also, the fix for  [Shared Terminals Losing Reference](https://youtrack.jetbrains.com/issue/CWM-6093) was applied only to v2022.2.

## Known limitations

- It's not possible to resize the terminal (max line width) from Thin Client. Resize happens only if the terminal width is changed on the Backend IDE. [[1](https://youtrack.jetbrains.com/issue/CWM-5410/LINES-env-var-doesnt-update-when-terminal-changes-size)][[2](https://youtrack.jetbrains.com/issue/CWM-5248/Soft-wrap-doesnt-work-in-Terminal)][[3](https://youtrack.jetbrains.com/issue/CWM-5456)][[4](https://youtrack.jetbrains.com/issue/CWM-4314)]
- If we have more than two terminals opened at once, only two of them will be displaying correctly their title in the tab, while the other will be displaying "Local" until the user focuses on them - at this moment the info about the terminal tab is fetched and the tab title is updated.  Seems to be a limitation from the backend. I'm going to file an issue for JetBrains and leave the link here later.
- It's not possible to split shared terminals. This is not on plans to be supported, at this moment.
- When we stop a workspace, restart, and reconnect to it, if there were terminals running, they will show only the last few lines of the history. The number of history lines displayed is currently hardcoded on JetBrains RemoteDev. The only way to see the full history is by looking at the terminals from the Backend IDE.

## To be done in a follow-up PR
- Update the terminal title whenever there's a change on the title running under Supervisor
- Close the IDE Terminal tab if Gitpod Terminal was closed remotely and emit a 'close' signal for Gitpod Terminal if user clicks the "X" button to close the IDE Terminal.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #10579

## How to test
<!-- Provide steps to test this PR -->
- Make sure you're using the latest version from JetBrains Gateway EAP (v222.3048.1 or later). You can download the latest version at https://www.jetbrains.com/remote-development/gateway/ 
- Open, on the Preview Environment of this PR, a new workspace that contains tasks defined on .gitpod.yml.  Suggestion: Gitpod Repository, by clicking this URL: https://felladrin-ed4d29747a.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/gitpod
- As by default the Stable version of the IDE is used, when the workspace starts, you should see the usual terminal with a welcome message:
  ![image](https://user-images.githubusercontent.com/418083/175069435-47cf54e8-27e1-4cbd-bcf9-589506ba8c3c.png)
- Having confirmed that the Stable version of JetBrains IDEs are still using the current implementation of terminals, you can close that workspace.
- Now, open [Preferences on the Preview Environment of this PR](https://felladrin-ed4d29747a.preview.gitpod-dev.com/preferences) and select _IntelliJ_ and mark _Latest Release_ to use the EAP version of the IDE.
  <img width="490" alt="image" src="https://user-images.githubusercontent.com/418083/174128270-d46439a3-1eb5-4075-b38d-4af252f4e765.png">
- Open, on the Preview Environment of this PR, a new workspace, with the same repository as the previous step.
- When opening it, you should see 3 terminals opened (one for each Gitpod Task) and no more terminal displaying a welcome message:
  <img width="725" alt="image" src="https://user-images.githubusercontent.com/418083/175054914-e63ad029-eee1-4fa9-aee9-0d3b2ff3df2d.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
When using the Latest Release of JetBrains IDEs, if the workspace has tasks defined on .gitpod.yml, the IDE will start with one terminal opened for each task, behaving similar to VS Code on Gitpod.
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
