### PR TITLE
Refactor 'normalizedContextURL' property from Java class 'WorkspaceContext' as Optional

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceContext.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceContext.java
@@ -10,8 +10,8 @@ public class WorkspaceContext {
     private String normalizedContextURL;
     private String ref;
 
-    public String getNormalizedContextURL() {
-        return normalizedContextURL;
+    public Optional<String> getNormalizedContextURL() {
+        return Optional.ofNullable(normalizedContextURL);
     }
 
     public void setNormalizedContextURL(String normalizedContextURL) {

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -124,10 +124,9 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                 }
                             }
                             row {
-                                browserLink(
-                                    workspace.context.normalizedContextURL,
-                                    workspace.context.normalizedContextURL
-                                )
+                                workspace.context.normalizedContextURL.ifPresent {
+                                    browserLink(it, it)
+                                }
                             }
                         }.horizontalAlign(HorizontalAlign.CENTER)
                         row {

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -272,9 +272,12 @@ class GitpodWorkspacesView(
                                     }
                                 ).gap(RightGap.SMALL)
                                 panel {
-                                    row {
+                                    val contextUrlRow = row {
                                         browserLink(info.workspace.id, info.latestInstance.ideUrl)
-                                    }.rowComment("<a href='${info.workspace.context.normalizedContextURL}'>${info.workspace.context.normalizedContextURL}</a>")
+                                    }
+                                    info.workspace.context.normalizedContextURL.ifPresent {
+                                        contextUrlRow.rowComment("<a href='${it}'>${it}</a>")
+                                    }
                                 }
                                 label("").resizableColumn().horizontalAlign(HorizontalAlign.FILL)
                                 panel {
@@ -283,11 +286,7 @@ class GitpodWorkspacesView(
                                         it.totalUncommitedFiles + it.totalUntrackedFiles + it.totalUnpushedCommits
                                     } ?: 0
                                     row {
-                                        if (info.workspace.context.ref.isPresent()) {
-                                            label(info.workspace.context.ref.get())
-                                        } else {
-                                            label("(detached)")
-                                        }
+                                        info.workspace.context.ref.ifPresentOrElse({ label(it) },{ label("(detached)") })
                                     }.rowComment(
                                         when {
                                             changes == 1 -> "<b>$changes Change</b>"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactor 'normalizedContextURL' property from Java class 'WorkspaceContext' as Optional, because it can come null from the server, as you can see on the _interface WorkspaceContext_ from `components/gitpod-protocol/src/protocol.ts`.

https://github.com/gitpod-io/gitpod/blob/40158aceb4c956f097b22253c040afa71d565c66/components/gitpod-protocol/src/protocol.ts#L885

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Issue raised by @mustard-mh in https://github.com/gitpod-io/gitpod/pull/10377#pullrequestreview-990366026

## How to test
<!-- Provide steps to test this PR -->
I haven't seen a case where the 'normalizedContextURL' of a workspace was null. And don't know if we can simulate it, but following the same `How to test` from https://github.com/gitpod-io/gitpod/pull/10377 should show it's working as expected. The difference is that we should use the [gateway-plugin build generated by this PR](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/183936) instead.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user-facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- [x] /werft --no-preview=true