### PR TITLE
[ws-manager] change log from debug to error

### DIFF
--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -521,7 +521,7 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 		return nil
 	}
 
-	log.WithFields(wsk8s.GetOWIFromObject(&pod.ObjectMeta)).WithField("pod", pod).Debug("cannot determine workspace phase")
+	log.WithFields(wsk8s.GetOWIFromObject(&pod.ObjectMeta)).WithField("pod", pod).Error("cannot determine workspace phase")
 	result.Phase = api.WorkspacePhase_UNKNOWN
 	result.Message = "cannot determine workspace phase. We should never get here."
 	return nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Not sure why that log entry was set to Debug, when it should have been an Error.
Would have allowed to figure out why our status handling not catching OOM Error.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/10506

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
