### PR TITLE
loadgen: fix the error handling when failed to get the ws infomation.

### DIFF
--- a/dev/loadgen/pkg/loadgen/executor.go
+++ b/dev/loadgen/pkg/loadgen/executor.go
@@ -204,12 +204,12 @@ func (w *WsmanExecutor) StopAll(ctx context.Context) error {
 
 	for {
 		resp, err := w.C.GetWorkspaces(ctx, &listReq)
-		if len(resp.Status) == 0 {
-			break
-		}
-
 		if err != nil {
 			log.Warnf("could not get workspaces: %v", err)
+		} else {
+			if len(resp.GetStatus()) == 0 {
+				break
+			}
 		}
 
 		select {

--- a/dev/loadgen/pkg/loadgen/executor.go
+++ b/dev/loadgen/pkg/loadgen/executor.go
@@ -187,6 +187,7 @@ func (w *WsmanExecutor) StopAll(ctx context.Context) error {
 	}
 
 	log.Info("stopping workspaces")
+	start := time.Now()
 	for _, id := range w.workspaces {
 		stopReq := api.StopWorkspaceRequest{
 			Id:     id,
@@ -213,11 +214,15 @@ func (w *WsmanExecutor) StopAll(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("not all workspaces could be stopped")
+			elapsed := time.Since(start)
+			return fmt.Errorf("not all workspaces could be stopped: %s", elapsed)
 		default:
 			time.Sleep(5 * time.Second)
 		}
 	}
+
+	elapsed := time.Since(start)
+	log.Infof("Time taken to stop workspaces: %s", elapsed)
 
 	return nil
 }


### PR DESCRIPTION
## Description
- [loadgen: record the time of stopping workspaces.](https://github.com/gitpod-io/gitpod/commit/33a484a746b58a0ffcb743fc0eaf4c8a3bb08e57)
- [loadgen: fix the error handling when failed to get the ws infomation.](https://github.com/gitpod-io/gitpod/commit/3335c2f6f90c8b187f5d173ca557b0b5fcb1b3db)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NONE

## How to test
<!-- Provide steps to test this PR -->
Run loadgen

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
