### PR TITLE
[gp-cli] add command to extend workspace timeout

### DIFF
--- a/components/gitpod-cli/cmd/timeout-extend.go
+++ b/components/gitpod-cli/cmd/timeout-extend.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/spf13/cobra"
+)
+
+// extendTimeoutCmd extend timeout of current workspace
+var extendTimeoutCmd = &cobra.Command{
+	Use:   "extend",
+	Short: "Extend timeout of current workspace",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			fail(err.Error())
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:setWorkspaceTimeout",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+		var tmp serverapi.WorkspaceTimeoutDuration = serverapi.WorkspaceTimeoutDuration180m
+		if _, err := client.SetWorkspaceTimeout(ctx, wsInfo.WorkspaceId, &tmp); err != nil {
+			if err, ok := err.(*jsonrpc2.Error); ok && err.Code == serverapi.PLAN_PROFESSIONAL_REQUIRED {
+				fail("Cannot extend workspace timeout for current plan, please upgrade your plan")
+			}
+			fail(err.Error())
+		}
+	},
+}
+
+func init() {
+	timeoutCmd.AddCommand(extendTimeoutCmd)
+}

--- a/components/gitpod-cli/cmd/timeout.go
+++ b/components/gitpod-cli/cmd/timeout.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// timeoutCmd commands collection
+var timeoutCmd = &cobra.Command{
+	Use:   "timeout",
+	Short: "A collection of commands for workspace timeout",
+}
+
+func init() {
+	rootCmd.AddCommand(timeoutCmd)
+}

--- a/components/gitpod-protocol/go/error.go
+++ b/components/gitpod-protocol/go/error.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package protocol
+
+const (
+
+	// 400 Unauthorized
+	BAD_REQUEST = 400
+
+	// 401 Unauthorized
+	NOT_AUTHENTICATED = 401
+
+	// 402 Payment Required
+	NOT_ENOUGH_CREDIT = 402
+
+	// 403 Forbidden
+	PERMISSION_DENIED = 403
+
+	// 404 Not Found
+	NOT_FOUND = 404
+
+	// 409 Conflict (e.g. already existing)
+	CONFLICT = 409
+
+	// 410 No User
+	SETUP_REQUIRED = 410
+
+	// 429 Too Many Requests
+	TOO_MANY_REQUESTS = 429
+
+	// 430 Repository not whitelisted (custom status code)
+	REPOSITORY_NOT_WHITELISTED = 430
+
+	// 460 Context Parse Error (custom status code)
+	CONTEXT_PARSE_ERROR = 460
+
+	// 461 Invalid gitpod yml
+	INVALID_GITPOD_YML = 461
+
+	// 450 Payment error
+	PAYMENT_ERROR = 450
+
+	// 470 User Blocked (custom status code)
+	USER_BLOCKED = 470
+
+	// 471 User Deleted (custom status code)
+	USER_DELETED = 471
+
+	// 472 Terms Acceptance Required (custom status code)
+	USER_TERMS_ACCEPTANCE_REQUIRED = 472
+
+	// 480 Plan does not allow private repos
+	PLAN_DOES_NOT_ALLOW_PRIVATE_REPOS = 480
+
+	// 481 Professional plan is required for this operation
+	PLAN_PROFESSIONAL_REQUIRED = 481
+
+	// 485 Plan is only allowed for students
+	PLAN_ONLY_ALLOWED_FOR_STUDENTS = 485
+
+	// 490 Too Many Running Workspace
+	TOO_MANY_RUNNING_WORKSPACES = 490
+
+	// 500 Internal Server Error
+	INTERNAL_SERVER_ERROR = 500
+
+	// 501 EE Feature
+	EE_FEATURE = 501
+
+	// 555 EE License Required
+	EE_LICENSE_REQUIRED = 555
+
+	// 601 SaaS Feature
+	SAAS_FEATURE = 601
+
+	// 610 Invalid Team Subscription Quantity
+	TEAM_SUBSCRIPTION_INVALID_QUANTITY = 610
+
+	// 620 Team Subscription Assignment Failed
+	TEAM_SUBSCRIPTION_ASSIGNMENT_FAILED = 620
+
+	// 630 Snapshot Error
+	SNAPSHOT_ERROR = 630
+
+	// 640 Headless logs are not available (yet)
+	HEADLESS_LOG_NOT_YET_AVAILABLE = 640
+)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Support configure workspace timeout with gp-cli

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10525

## How to test
<!-- Provide steps to test this PR -->
### unlimited plan
- Open in gitpod.io with current PR
- Exec `cd components/gitpod-cli`
- Exec `go run main.go timeout extend` to see if current workspace timeout extended, how to check see image below

### free plan
- Open a workspace in preview env
- Run `gp timeout extend` should reply error that plan of prev env not allow timeout extend

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add command `gp timeout extend` to extend timeout of current workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
https://github.com/gitpod-io/website/pull/2218