### PR TITLE
Add a metric of PVC restore duration time

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -273,7 +273,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 			}
 
 			wsType := api.WorkspaceType_name[int32(req.Type)]
-			hist, err := m.metrics.volumeRestoreTimeHistVec.GetMetricWithLabelValues(wsType)
+			hist, err := m.metrics.volumeRestoreTimeHistVec.GetMetricWithLabelValues(wsType, req.Spec.Class)
 			if err != nil {
 				log.WithError(err).WithField("type", wsType).Warn("cannot get volume restore time histogram metric")
 			} else {

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -91,7 +91,7 @@ func newMetrics(m *Manager) *metrics {
 			Name:      "volume_snapshot_seconds",
 			Help:      "time it took to snapshot volume",
 			Buckets:   prometheus.ExponentialBuckets(2, 2, 10),
-		}, []string{"type"}),
+		}, []string{"type", "class"}),
 		volumeRestoreTimeHistVec: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -98,7 +98,7 @@ func newMetrics(m *Manager) *metrics {
 			Name:      "volume_restore_seconds",
 			Help:      "time it took to restore volume",
 			Buckets:   prometheus.ExponentialBuckets(2, 2, 10),
-		}, []string{"type"}),
+		}, []string{"type", "class"}),
 		totalStartsCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,

--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -42,6 +42,7 @@ type metrics struct {
 	initializeTimeHistVec     *prometheus.HistogramVec
 	finalizeTimeHistVec       *prometheus.HistogramVec
 	volumeSnapshotTimeHistVec *prometheus.HistogramVec
+	volumeRestoreTimeHistVec  *prometheus.HistogramVec
 
 	// Counter
 	totalStartsCounterVec         *prometheus.CounterVec
@@ -89,6 +90,13 @@ func newMetrics(m *Manager) *metrics {
 			Subsystem: metricsWorkspaceSubsystem,
 			Name:      "volume_snapshot_seconds",
 			Help:      "time it took to snapshot volume",
+			Buckets:   prometheus.ExponentialBuckets(2, 2, 10),
+		}, []string{"type"}),
+		volumeRestoreTimeHistVec: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkspaceSubsystem,
+			Name:      "volume_restore_seconds",
+			Help:      "time it took to restore volume",
 			Buckets:   prometheus.ExponentialBuckets(2, 2, 10),
 		}, []string{"type"}),
 		totalStartsCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -178,6 +186,7 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 		m.initializeTimeHistVec,
 		m.finalizeTimeHistVec,
 		m.volumeSnapshotTimeHistVec,
+		m.volumeRestoreTimeHistVec,
 		newPhaseTotalVec(m.manager),
 		newWorkspaceActivityVec(m.manager),
 		newTimeoutSettingsVec(m.manager),

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1036,7 +1036,7 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 					return true, nil, err
 				}
 				readyVolumeSnapshot = true
-				hist, err := m.manager.metrics.volumeSnapshotTimeHistVec.GetMetricWithLabelValues(wsType)
+				hist, err := m.manager.metrics.volumeSnapshotTimeHistVec.GetMetricWithLabelValues(wsType, wso.Pod.Labels[workspaceClassLabel])
 				if err != nil {
 					log.WithError(err).WithField("type", wsType).Warn("cannot get volume snapshot time histogram metric")
 				} else {


### PR DESCRIPTION
## Description
Add a metric of PVC restore duration time `gitpod_ws_manager_volume_restore_seconds`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10195

## How to test
<!-- Provide steps to test this PR -->
1. Create a workspace preview.
2. Add GitHub integration.
3. Enable feature flag `persistent_volume_claim`.
4. Launch a workspace.
5. Write some files.
6. Stop a workspace.
7. Port forward the ws-manager `kubectl port-forward <ws-manager-pod> 9500:9500`.
8. Get the metric `curl -XGET localhost:9500/metrics`.
9. Check the metric `gitpod_ws_manager_volume_restore_seconds`, it should match the time that PVC becomes Bound.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[experimental] add a metric to track volume restore time
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None