### PR TITLE
installation-telemetry: add customer ID

### DIFF
--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -59,8 +59,27 @@ export default function Settings() {
                     checked={adminSettings?.sendTelemetry ?? false}
                     onChange={(evt) =>
                         actuallySetTelemetryPrefs({
+                            ...adminSettings,
                             sendTelemetry: evt.target.checked,
-                        })
+                        } as InstallationAdminSettings)
+                    }
+                />
+                <CheckBox
+                    title="Include customer ID in telemetry"
+                    desc={
+                        <span>
+                            An optional customer ID can be included with telemetry to provide better customer support.{" "}
+                            <a className="gp-link" href="https://www.gitpod.io/privacy">
+                                Read our Privacy Policy
+                            </a>
+                        </span>
+                    }
+                    checked={adminSettings?.sendCustomerID ?? false}
+                    onChange={(evt) =>
+                        actuallySetTelemetryPrefs({
+                            ...adminSettings,
+                            sendCustomerID: evt.target.checked,
+                        } as InstallationAdminSettings)
                     }
                 />
                 <InfoBox>

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -45,15 +45,21 @@ export default function Settings() {
                 subtitle="Configure settings for your Gitpod cluster."
             >
                 <h3>Usage Statistics</h3>
+                <p className="text-base text-gray-500 pb-4 max-w-2xl">
+                    We collect usage telemetry to gain insights on how you use your Gitpod instance, so we can provide a
+                    better overall experience.
+                </p>
+                <p>
+                    <a className="gp-link" href="https://www.gitpod.io/privacy">
+                        Read our Privacy Policy
+                    </a>
+                </p>
                 <CheckBox
-                    title="Enable Service Ping"
+                    title="Enable usage telemetry"
                     desc={
                         <span>
-                            The following usage data is sent to provide insights on how you use your Gitpod instance, so
-                            we can provide a better overall experience.{" "}
-                            <a className="gp-link" href="https://www.gitpod.io/privacy">
-                                Read our Privacy Policy
-                            </a>
+                            Enable usage telemetry on your Gitpod instance. A preview of your telemetry is available
+                            below.
                         </span>
                     }
                     checked={adminSettings?.sendTelemetry ?? false}
@@ -68,10 +74,7 @@ export default function Settings() {
                     title="Include customer ID in telemetry"
                     desc={
                         <span>
-                            An optional customer ID can be included with telemetry to provide better customer support.{" "}
-                            <a className="gp-link" href="https://www.gitpod.io/privacy">
-                                Read our Privacy Policy
-                            </a>
+                            Include an optional customer ID in usage telemetry to provide individualized support.
                         </span>
                     }
                     checked={adminSettings?.sendCustomerID ?? false}
@@ -82,6 +85,7 @@ export default function Settings() {
                         } as InstallationAdminSettings)
                     }
                 />
+                <h3 className="mt-4">Telemetry preview</h3>
                 <InfoBox>
                     <pre>{JSON.stringify(telemetryData, null, 2)}</pre>
                 </InfoBox>

--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 
 const InstallationAdminSettingsPrototype = {
     sendTelemetry: true,
+    sendCustomerID: true,
 };
 
 export type InstallationAdminSettings = typeof InstallationAdminSettingsPrototype;

--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -29,6 +29,7 @@ export interface TelemetryData {
     totalWorkspaces: number;
     totalInstances: number;
     licenseType: string;
+    customerID?: string;
 }
 
 export namespace InstallationAdmin {

--- a/components/installation-telemetry/cmd/send.go
+++ b/components/installation-telemetry/cmd/send.go
@@ -50,15 +50,20 @@ var sendCmd = &cobra.Command{
 			err = client.Close()
 		}()
 
+		properties := analytics.NewProperties().
+			Set("version", versionId).
+			Set("totalUsers", data.TotalUsers).
+			Set("totalWorkspaces", data.TotalWorkspaces).
+			Set("totalInstances", data.TotalInstances)
+
+		if data.InstallationAdmin.Settings.SendCustomerID {
+			properties.Set("customerID", data.CustomerID)
+		}
+
 		telemetry := analytics.Track{
-			UserId: data.InstallationAdmin.ID,
-			Event:  "Installation telemetry",
-			Properties: analytics.NewProperties().
-				Set("version", versionId).
-				Set("totalUsers", data.TotalUsers).
-				Set("totalWorkspaces", data.TotalWorkspaces).
-				Set("totalInstances", data.TotalInstances).
-				Set("licenseType", data.LicenseType),
+			UserId:     data.InstallationAdmin.ID,
+			Event:      "Installation telemetry",
+			Properties: properties,
 		}
 
 		client.Enqueue(telemetry)

--- a/components/installation-telemetry/pkg/server/installationAdmin.go
+++ b/components/installation-telemetry/pkg/server/installationAdmin.go
@@ -14,7 +14,8 @@ import (
 )
 
 type InstallationAdminSettings struct {
-	SendTelemetry bool `json:"sendTelemetry"`
+	SendTelemetry  bool `json:"sendTelemetry"`
+	SendCustomerID bool `json:"sendCustomerID"`
 }
 
 type Data struct {

--- a/components/installation-telemetry/pkg/server/installationAdmin.go
+++ b/components/installation-telemetry/pkg/server/installationAdmin.go
@@ -23,6 +23,7 @@ type Data struct {
 	TotalWorkspaces   int64             `json:"totalWorkspaces"`
 	TotalInstances    int64             `json:"totalInstances"`
 	LicenseType       string            `json:"licenseType"`
+	CustomerID        string            `json:"customerID,omitempty"`
 }
 
 type InstallationAdmin struct {

--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -53,6 +53,9 @@ type LicensePayload struct {
 
 	// Seats == 0 means there's no seat limit
 	Seats int `json:"seats"`
+
+	// CustomerID is used to identify installations in installation analytics
+	CustomerID string `json:"customerID"`
 }
 
 type licensePayload struct {

--- a/components/licensor/ee/pkg/licensor/replicated.go
+++ b/components/licensor/ee/pkg/licensor/replicated.go
@@ -118,6 +118,9 @@ func newReplicatedEvaluator(client *http.Client) (res *Evaluator) {
 
 		case "seats":
 			lic.Seats = int(i.Value.(float64))
+
+		case "customerId":
+			lic.CustomerID = i.Value.(string)
 		}
 	}
 

--- a/components/licensor/typescript/ee/src/api.ts
+++ b/components/licensor/typescript/ee/src/api.ts
@@ -29,6 +29,7 @@ export interface LicensePayload {
     level: LicenseLevel
     validUntil: string
     seats: number
+    customerID: string
 }
 
 export enum LicenseSubscriptionLevel {

--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -29,6 +29,11 @@ export class InstallationAdminTelemetryDataProvider {
                 licenseType: this.licenseEvaluator.getLicenseData().type,
                 customerID: this.licenseEvaluator.getLicenseData().payload.customerID,
             } as TelemetryData;
+
+            if (data.installationAdmin.settings.sendCustomerID) {
+                data.customerID = this.licenseEvaluator.getLicenseData().payload.customerID;
+            }
+
             return data;
         } finally {
             span.finish();

--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -27,6 +27,7 @@ export class InstallationAdminTelemetryDataProvider {
                 totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
                 totalInstances: await this.workspaceDb.getInstanceCount(),
                 licenseType: this.licenseEvaluator.getLicenseData().type,
+                customerID: this.licenseEvaluator.getLicenseData().payload.customerID,
             } as TelemetryData;
             return data;
         } finally {


### PR DESCRIPTION
## Description

This pull request exposes the GitPod Customer ID field in installation telemetry.

## Related Issue(s)

This issue resolves #10183.

## How to test

<!-- Provide steps to test this PR -->

The `customerID` field will be available in the Gitpod Admin/Settings page, displayed in the installation-telemetry job output, and will be present in the segment.io telemetry.

<details>
<summary>Telemetry Disabled</summary>

**Dashboard: Admin/Settings:**

<img width="1062" alt="Dashboard: Admin/Settings, telemetry disabled" src="https://user-images.githubusercontent.com/172194/175568372-a17cadbd-9027-4b88-8654-6d212272e208.png">

**Installation telemetry job:**

```json
 {
  "level": "info",
  "message": "installation-telemetry is not permitted to send - exiting",
  "serviceContext": {
    "service": "installation-telemetry",
    "version": "commit-2b1c7e10da04762651d753db7b1fb1b9954b3e70"
  },
  "severity": "INFO",
  "time": "2022-06-24T15:28:09Z"
}
```

</details>

<details>
<summary>Telemetry enabled, Customer ID disabled</summary>

**Dashboard: Admin/Settings:**

<img width="1062" alt="Screen Shot 2022-06-24 at 8 35 23 AM" src="https://user-images.githubusercontent.com/172194/175569113-34e7fece-2341-4b6e-9083-b553f902cf9c.png">

**Installation Telemetry job:**

```json
{
  "level": "info",
  "message": "installation-telemetry has successfully sent data - exiting",
  "serviceContext": {
    "service": "installation-telemetry",
    "version": "commit-2b1c7e10da04762651d753db7b1fb1b9954b3e70"
  },
  "severity": "INFO",
  "telemetry": {
    "userId": "cfcc2cfa-9ac6-482f-879e-f327c260c533",
    "event": "Installation telemetry",
    "timestamp": "0001-01-01T00:00:00Z",
    "properties": {
      "totalInstances": 0,
      "totalUsers": 1,
      "totalWorkspaces": 0,
      "version": "gitpod-custom-alt-10183-sh-telem-license.30"
    }
  },
  "time": "2022-06-24T15:36:05Z"
}
```

</details>

<details>
<summary>Telemetry enabled, Customer ID enabled, empty customer ID</summary>

**Dashboard: Admin/Settings:**
<img width="1062" alt="Screen Shot 2022-06-24 at 8 38 03 AM" src="https://user-images.githubusercontent.com/172194/175569568-4dc461cd-f7fc-4259-9618-62f6edd06858.png">

**Installation Telemetry job:**

```json
{
  "level": "info",
  "message": "installation-telemetry has successfully sent data - exiting",
  "serviceContext": {
    "service": "installation-telemetry",
    "version": "commit-2b1c7e10da04762651d753db7b1fb1b9954b3e70"
  },
  "severity": "INFO",
  "telemetry": {
    "userId": "cfcc2cfa-9ac6-482f-879e-f327c260c533",
    "event": "Installation telemetry",
    "timestamp": "0001-01-01T00:00:00Z",
    "properties": {
      "customerID": "",
      "totalInstances": 0,
      "totalUsers": 1,
      "totalWorkspaces": 0,
      "version": "gitpod-custom-alt-10183-sh-telem-license.30"
    }
  },
  "time": "2022-06-24T15:39:50Z"
}
```

</details>

<details>
<summary>Installation telemetry enabled, customer ID enabled, customer ID set</summary>

**Dashboard: Settings/Admin:**

<img width="1062" alt="Screen Shot 2022-06-24 at 8 47 52 AM" src="https://user-images.githubusercontent.com/172194/175571732-b9a9f28a-b1ce-4252-a273-9dccb27acae3.png">

**Installation telemetry job:**

```json
{
  "level": "info",
  "message": "installation-telemetry has successfully sent data - exiting",
  "serviceContext": {
    "service": "installation-telemetry",
    "version": "commit-2b1c7e10da04762651d753db7b1fb1b9954b3e70"
  },
  "severity": "INFO",
  "telemetry": {
    "userId": "cfcc2cfa-9ac6-482f-879e-f327c260c533",
    "event": "Installation telemetry",
    "timestamp": "0001-01-01T00:00:00Z",
    "properties": {
      "customerID": "Tessier Ashpool S.A.",
      "totalInstances": 0,
      "totalUsers": 1,
      "totalWorkspaces": 0,
      "version": "gitpod-custom-alt-10183-sh-telem-license.30"
    }
  },
  "time": "2022-06-24T15:48:56Z"
}
```

</details>


## Release Notes

```release-note
[self-hosted] Installation telemetry optionally includes the Gitpod customer ID
```

## Documentation

This change is user facing, and when enabled adds information that removes the pseudononymous guarantees in our documentation. We'll amend that in a separate pull request against the website.