### PR TITLE
Mount Stripe API keys into the usage component

### DIFF
--- a/install/installer/pkg/components/usage/constants.go
+++ b/install/installer/pkg/components/usage/constants.go
@@ -5,5 +5,6 @@
 package usage
 
 const (
-	Component = "usage"
+	Component             = "usage"
+	stripeSecretMountPath = "stripe-secret"
 )


### PR DESCRIPTION
## Description

Mount the Stripe API keys into the `usage` component so that they are available to report usage data to the Stripe API.

These are the same API keys that are mounted into the `server` component (#10563)

## Related Issue(s)
Part of #9036 

## How to test

Manually trigger a werft job for this branch [(Notion doc)](https://www.notion.so/gitpod/Manually-triggering-a-Werft-job-4aaf0cacbfc54f21991be700746637c3#840790f17f7143009bf0164bcd0720c1), setting with-payment=true.

In the preview environment for the branch, verify that the usage pod has a `/stripe-secrets` mount containing Stripe API keys.

## Release Notes

```release-note
NONE
```

- [x] /werft with-payment=true