### PR TITLE
Add probe metrics to preview environment

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -79,6 +79,9 @@ export class MonitoringSatelliteInstaller {
             },
             kubescape: {},
             pyrra: {},
+            probe: {
+                targets: ['http://google.com'],
+            },
         }" \
         monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
         find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
This is a follow up to https://github.com/gitpod-io/observability/pull/140. It will add the prober and the configuration to monitor it with Prometheus to our preview-environments

Opening as a draft because the upstream PR needs to be merged first

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2734

## How to test
<!-- Provide steps to test this PR -->
* Run a job with `werft run github -f -s .werft/observability/monitoring-satellite.ts -a withObservabilityBranch="as/prober"`
* Connect to the preview environment with `previewctl install-context`
* Expose Prometheus UI with `kubectl port-forward prometheus-k8s 9090`
* You should be able to query metrics like `probe_success`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
