### PR TITLE
[image-builder] Support Multiple Pull-Secrets

### DIFF
--- a/components/image-builder-api/go/config/config.go
+++ b/components/image-builder-api/go/config/config.go
@@ -65,13 +65,8 @@ func (c *TLSConfig) ServerOption() (grpc.ServerOption, error) {
 type Configuration struct {
 	WorkspaceManager WorkspaceManagerConfig `json:"wsman"`
 
-	// PullSecret names a Kubernetes secret which contains a `.dockerconfigjson` entry
-	// carrying the Docker authentication credentials to interact with the baseImageRepository
-	// and workspaceImageRepository.
-	PullSecret string `json:"pullSecret,omitempty"`
-
-	// PullSecretFile points to a mount of the .dockerconfigjson file of the PullSecret.
-	PullSecretFile string `json:"pullSecretFile,omitempty"`
+	// PullSecrets configrues the secrets available to the image-builder
+	PullSecrets []PullSecret `json:"pullSecrets,omitempty"`
 
 	// BaseImageRepository configures repository where we'll push base images to.
 	BaseImageRepository string `json:"baseImageRepository"`
@@ -82,6 +77,16 @@ type Configuration struct {
 
 	// BuilderImage is an image ref to the workspace builder image
 	BuilderImage string `json:"builderImage"`
+}
+
+type PullSecret struct {
+	// Name refers to a Kubernetes secret which contains a `.dockerconfigjson` entry
+	// carrying the Docker authentication credentials to interact with the baseImageRepository
+	// and workspaceImageRepository.
+	Name string `json:"name,omitempty"`
+
+	// MountPath points to a mount of the .dockerconfigjson file of the PullSecret.
+	MountPath string `json:"mountPath,omitempty"`
 }
 
 type TLS struct {

--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -24,6 +24,26 @@ type RegistryAuthenticator interface {
 	Authenticate(registry string) (auth *Authentication, err error)
 }
 
+type CompositeRegistryAuthenticator []RegistryAuthenticator
+
+func (cra CompositeRegistryAuthenticator) Authenticate(registry string) (auth *Authentication, err error) {
+	for _, c := range cra {
+		res, err := c.Authenticate(registry)
+		if err != nil {
+			return nil, err
+		}
+		if res.Username == "" && res.Password == "" && res.RegistryToken == "" {
+			continue
+		}
+
+		if res != nil {
+			return res, nil
+		}
+	}
+
+	return &Authentication{}, nil
+}
+
 // NewDockerConfigFileAuth reads a docker config file to provide authentication
 func NewDockerConfigFileAuth(fn string) (*DockerConfigFileAuth, error) {
 	fp, err := os.OpenFile(fn, os.O_RDONLY, 0600)

--- a/install/installer/pkg/components/image-builder-mk3/configmap.go
+++ b/install/installer/pkg/components/image-builder-mk3/configmap.go
@@ -32,7 +32,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, fmt.Errorf("%s: invalid container registry config", Component)
 	}
 
-	secretName, err := pullSecretName(ctx)
+	pss, err := pullSecrets(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +46,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				PrivateKey:  "/wsman-certs/tls.key",
 			},
 		},
-		PullSecret:               secretName,
-		PullSecretFile:           PullSecretFile,
+		PullSecrets:              pss,
 		BaseImageRepository:      fmt.Sprintf("%s/base-images", registryName),
 		BuilderImage:             ctx.ImageName(ctx.Config.Repository, BuilderImage, ctx.VersionManifest.Components.ImageBuilderMk3.BuilderImage.Version),
 		WorkspaceImageRepository: fmt.Sprintf("%s/workspace-images", registryName),

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -65,6 +65,8 @@ type WorkspaceConfig struct {
 	} `json:"registryFacade"`
 
 	WorkspaceClasses map[string]WorkspaceClass `json:"classes,omitempty"`
+
+	ImageBuilderPullSecrets []string `json:"imagesPullSecrets,omitempty"`
 }
 
 type PersistentVolumeClaim struct {


### PR DESCRIPTION
## Description
This PR adds support for multiple pull-secrets in image-builder.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10396

## How to test
- run an image build in a preview environment
- configure a separate registry, add a pull secret for it, and try to build an image from that

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
