### PR TITLE
[kots] Allow multiple docker pull secrets

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -146,22 +146,18 @@ spec:
               then
                 echo "Gitpod: configuring mirrored container registry"
 
-                yq e -i ".containerRegistry.inCluster = false" "${CONFIG_FILE}"
-                yq e -i ".containerRegistry.external.url = \"{{repl LocalRegistryAddress }}\"" "${CONFIG_FILE}"
-                yq e -i ".containerRegistry.external.certificate.kind = \"secret\"" "${CONFIG_FILE}"
-                yq e -i ".containerRegistry.external.certificate.name = \"{{repl ImagePullSecretName }}\"" "${CONFIG_FILE}"
                 yq e -i ".repository = \"{{repl LocalRegistryAddress }}\"" "${CONFIG_FILE}"
                 yq e -i ".imagePullSecrets[0].kind = \"secret\"" "${CONFIG_FILE}"
                 yq e -i ".imagePullSecrets[0].name = \"{{repl ImagePullSecretName }}\"" "${CONFIG_FILE}"
                 yq e -i '.dropImageRepo = true' "${CONFIG_FILE}"
-              elif [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
+              fi
+
+              if [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
               then
                 echo "Gitpod: configuring external container registry"
 
                 yq e -i ".containerRegistry.inCluster = false" "${CONFIG_FILE}"
                 yq e -i ".containerRegistry.external.url = \"{{repl ConfigOption "reg_url" }}\"" "${CONFIG_FILE}"
-                yq e -i ".containerRegistry.external.certificate.kind = \"secret\"" "${CONFIG_FILE}"
-                yq e -i ".containerRegistry.external.certificate.name = \"container-registry\"" "${CONFIG_FILE}"
               else
                 if [ '{{repl ConfigOptionEquals "reg_incluster_storage" "s3" }}' = "true" ];
                 then
@@ -174,6 +170,9 @@ spec:
                   yq e -i ".containerRegistry.s3storage.certificate.name = \"container-registry-s3-backend\"" "${CONFIG_FILE}"
                 fi
               fi
+              # merged-registry-auths will be created below
+              yq e -i ".containerRegistry.external.certificate.kind = \"secret\"" "${CONFIG_FILE}"
+              yq e -i ".containerRegistry.external.certificate.name = \"merged-registry-auths\"" "${CONFIG_FILE}"
 
               if [ '{{repl ConfigOptionNotEquals "store_provider" "incluster" }}' = "true" ];
               then
@@ -272,6 +271,26 @@ spec:
               yq eval-all --inplace \
                 'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
                 "${GITPOD_OBJECTS}/templates/gitpod.yaml"
+
+              # Merge different docker pull secrets into one secret
+              if [ '{{repl HasLocalRegistry }}' = "true" ];
+              then
+                kubectl get secret "{{repl ImagePullSecretName }}" -o=jsonpath="{.data['\.dockerconfigjson']}" | base64 -d | yq -P - > registry-auth-airgap.yaml
+              fi
+              if [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
+              then
+                kubectl get secret "container-registry" -o=jsonpath="{.data['\.dockerconfigjson']}" | base64 -d | yq -P - > registry-auth-external.yaml
+              else
+                yq eval 'select(.kind == "Secret" and .metadata.name == "builtin-registry-auth").data.".dockerconfigjson"' \
+                  "${GITPOD_OBJECTS}/templates/gitpod.yaml" | base64 -d | yq -P - > registry-auth-builtin.yaml
+              fi
+              # merge all files together (https://mikefarah.gitbook.io/yq/operators/reduce#merge-all-yaml-files-together)
+              yq -o=json eval-all '. as $item ireduce ({}; . * $item )' registry-auth-*.yaml > merged-registry-auths.yaml
+              # create secret and update if exists (https://stackoverflow.com/a/45881259/1364435)
+              kubectl create secret generic merged-registry-auths \
+                --save-config --dry-run=client \
+                --from-file=.dockerconfigjson=./merged-registry-auths.yaml \
+                -o yaml > "${GITPOD_OBJECTS}/templates/merged-registry-auths.yaml"
 
               echo "Gitpod: Escape any Golang template values"
               sed -i -r 's/(.*\{\{.*)/{{`\1`}}/' "${GITPOD_OBJECTS}/templates/gitpod.yaml"

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -152,12 +152,31 @@ spec:
                 yq e -i '.dropImageRepo = true' "${CONFIG_FILE}"
               fi
 
+              # Output the local registry secret - this is proxy.replicated.com if user hasn't set their own
+              echo "{{repl LocalRegistryImagePullSecret }}" | base64 -d > /tmp/kotsregistry.json
+
               if [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
               then
                 echo "Gitpod: configuring external container registry"
 
+                # Create a container-registry secret merging the external registry and KOTS registry keys
+                echo '{{repl printf "{\"auths\": {\"%s\": {\"username\": \"%s\", \"password\": %s, \"auth\": \"%s\"}}}" (ConfigOption "reg_server" | default (ConfigOption "reg_url")) (ConfigOption "reg_username") (ConfigOption "reg_password" | toJson) (printf "%s:%s" (ConfigOption "reg_username") (ConfigOption "reg_password") | Base64Encode) }}' \
+                  | yq -o=json '.' - \
+                  > /tmp/gitpodregistry.json
+
+                cat /tmp/kotsregistry.json /tmp/gitpodregistry.json | jq -s '.[0] * .[1]' - - > /tmp/container-registry-secret
+
+                echo "Gitpod: create the container-registry secret"
+                kubectl create secret docker-registry container-registry \
+                  --namespace "{{repl Namespace }}" \
+                  --from-file=.dockerconfigjson=/tmp/container-registry-secret \
+                  -o yaml --dry-run=client | \
+                  kubectl replace --namespace "{{repl Namespace }}" --force -f -
+
                 yq e -i ".containerRegistry.inCluster = false" "${CONFIG_FILE}"
                 yq e -i ".containerRegistry.external.url = \"{{repl ConfigOption "reg_url" }}\"" "${CONFIG_FILE}"
+                yq e -i ".containerRegistry.external.certificate.kind = \"secret\"" "${CONFIG_FILE}"
+                yq e -i ".containerRegistry.external.certificate.name = \"container-registry\"" "${CONFIG_FILE}"
               else
                 if [ '{{repl ConfigOptionEquals "reg_incluster_storage" "s3" }}' = "true" ];
                 then
@@ -170,9 +189,6 @@ spec:
                   yq e -i ".containerRegistry.s3storage.certificate.name = \"container-registry-s3-backend\"" "${CONFIG_FILE}"
                 fi
               fi
-              # merged-registry-auths will be created below
-              yq e -i ".containerRegistry.external.certificate.kind = \"secret\"" "${CONFIG_FILE}"
-              yq e -i ".containerRegistry.external.certificate.name = \"merged-registry-auths\"" "${CONFIG_FILE}"
 
               if [ '{{repl ConfigOptionNotEquals "store_provider" "incluster" }}' = "true" ];
               then
@@ -272,25 +288,22 @@ spec:
                 'del(select(.kind == "StatefulSet" and .metadata.name == "openvsx-proxy").status)' \
                 "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
-              # Merge different docker pull secrets into one secret
-              if [ '{{repl HasLocalRegistry }}' = "true" ];
+              if [ '{{repl ConfigOptionEquals "reg_incluster" "1" }}' = "true" ];
               then
-                kubectl get secret "{{repl ImagePullSecretName }}" -o=jsonpath="{.data['\.dockerconfigjson']}" | base64 -d | yq -P - > registry-auth-airgap.yaml
+                echo "Gitpod: Add the local registry secret to the in-cluster registry secret"
+
+                # Get the in-cluster registry secret
+                yq eval-all '(select(.kind == "Secret" and .metadata.name == "builtin-registry-auth") | .data.".dockerconfigjson")' \
+                  "${GITPOD_OBJECTS}/templates/gitpod.yaml" \
+                  | base64 -d \
+                  > /tmp/gitpodregistry.json
+
+                export REGISTRY_SECRET=$(cat /tmp/kotsregistry.json /tmp/gitpodregistry.json | jq -s '.[0] * .[1]' - - | base64 -w 0)
+
+                echo "Gitpod: update the in-cluster registry secret"
+                yq eval-all --inplace '(select(.kind == "Secret" and .metadata.name == "builtin-registry-auth") | .data.".dockerconfigjson") |= env(REGISTRY_SECRET)' \
+                  "${GITPOD_OBJECTS}/templates/gitpod.yaml"
               fi
-              if [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
-              then
-                kubectl get secret "container-registry" -o=jsonpath="{.data['\.dockerconfigjson']}" | base64 -d | yq -P - > registry-auth-external.yaml
-              else
-                yq eval 'select(.kind == "Secret" and .metadata.name == "builtin-registry-auth").data.".dockerconfigjson"' \
-                  "${GITPOD_OBJECTS}/templates/gitpod.yaml" | base64 -d | yq -P - > registry-auth-builtin.yaml
-              fi
-              # merge all files together (https://mikefarah.gitbook.io/yq/operators/reduce#merge-all-yaml-files-together)
-              yq -o=json eval-all '. as $item ireduce ({}; . * $item )' registry-auth-*.yaml > merged-registry-auths.yaml
-              # create secret and update if exists (https://stackoverflow.com/a/45881259/1364435)
-              kubectl create secret generic merged-registry-auths \
-                --save-config --dry-run=client \
-                --from-file=.dockerconfigjson=./merged-registry-auths.yaml \
-                -o yaml > "${GITPOD_OBJECTS}/templates/merged-registry-auths.yaml"
 
               echo "Gitpod: Escape any Golang template values"
               sed -i -r 's/(.*\{\{.*)/{{`\1`}}/' "${GITPOD_OBJECTS}/templates/gitpod.yaml"

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -28,7 +28,6 @@ spec:
         - name: reg_incluster
           title: Use in-cluster container registry
           type: bool
-          when: '{{repl eq HasLocalRegistry false }}'
           default: "1"
           help_text: You may either use an in-cluster container registry or configure your own external container registry for better performance. This container registry must be accessible from your Kubernetes cluster.
           recommended: false
@@ -85,27 +84,27 @@ spec:
         - name: reg_url
           title: Container registry URL
           type: text
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
           required: true
           help_text: The container registry URL. This will usually be the fully qualified domain of your registry.
 
         - name: reg_server
           title: Container registry server
           type: text
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
           help_text: The container registry server. This is used when [generating your credentials](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line). Depending upon your provider, this may or may not be the same as the registry URL. If not specified, the URL will be used.
 
         - name: reg_username
           title: Container registry username
           type: text
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
           required: true
           help_text: The username for your container registry.
 
         - name: reg_password
           title: Container registry password
           type: password
-          when: '{{repl and (eq HasLocalRegistry false) (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
           required: true
           help_text: The password for your container registry.
 

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -84,27 +84,27 @@ spec:
         - name: reg_url
           title: Container registry URL
           type: text
-          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl ConfigOptionEquals "reg_incluster" "0" }}'
           required: true
           help_text: The container registry URL. This will usually be the fully qualified domain of your registry.
 
         - name: reg_server
           title: Container registry server
           type: text
-          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl ConfigOptionEquals "reg_incluster" "0" }}'
           help_text: The container registry server. This is used when [generating your credentials](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line). Depending upon your provider, this may or may not be the same as the registry URL. If not specified, the URL will be used.
 
         - name: reg_username
           title: Container registry username
           type: text
-          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl ConfigOptionEquals "reg_incluster" "0" }}'
           required: true
           help_text: The username for your container registry.
 
         - name: reg_password
           title: Container registry password
           type: password
-          when: '{{repl (ConfigOptionEquals "reg_incluster" "0") }}'
+          when: '{{repl ConfigOptionEquals "reg_incluster" "0" }}'
           required: true
           help_text: The password for your container registry.
 


### PR DESCRIPTION
## Description
This change allows using a different image registry for Gitpod than the registry that is used to pull the images in an air-gap setup.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10298


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] Allow using a different image registry for Gitpod than the registry that is used to pull the images in an air-gap setup.
```

## Meta
/werft no-preview
/werft publish-to-kots