### PR TITLE
[GP CLI] Allow explicity and automated disabling of output colorization

### DIFF
--- a/components/gitpod-cli/cmd/ports-list.go
+++ b/components/gitpod-cli/cmd/ports-list.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	supervisor_helper "github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor-helper"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -76,9 +77,14 @@ var listPortsCmd = &cobra.Command{
 				}
 			}
 
+			colors := []tablewriter.Colors{}
+			if !noColor && utils.ColorsEnabled() {
+				colors = []tablewriter.Colors{{}, {statusColor}, {}, {}}
+			}
+
 			table.Rich(
 				[]string{fmt.Sprint(port.LocalPort), status, port.Exposed.Url, nameAndDescription},
-				[]tablewriter.Colors{{}, {statusColor}, {}, {}},
+				colors,
 			)
 		}
 
@@ -87,5 +93,6 @@ var listPortsCmd = &cobra.Command{
 }
 
 func init() {
+	listPortsCmd.Flags().BoolVarP(&noColor, "no-color", "", false, "Disable output colorization")
 	portsCmd.AddCommand(listPortsCmd)
 }

--- a/components/gitpod-cli/cmd/root.go
+++ b/components/gitpod-cli/cmd/root.go
@@ -18,6 +18,8 @@ var rootCmd = &cobra.Command{
 	Short: "Command line interface for Gitpod",
 }
 
+var noColor bool
+
 // Execute runs the root command
 func Execute() {
 	entrypoint := strings.TrimPrefix(filepath.Base(os.Args[0]), "gp-")

--- a/components/gitpod-cli/cmd/tasks-list.go
+++ b/components/gitpod-cli/cmd/tasks-list.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	supervisor_helper "github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor-helper"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/spf13/cobra"
 
@@ -48,7 +49,13 @@ var listTasksCmd = &cobra.Command{
 		}
 
 		for _, task := range tasks {
-			table.Rich([]string{task.Terminal, task.Presentation.Name, task.State.String()}, []tablewriter.Colors{{}, {}, {mapStatusToColor[task.State]}})
+			colors := []tablewriter.Colors{}
+
+			if !noColor && utils.ColorsEnabled() {
+				colors = []tablewriter.Colors{{}, {}, {mapStatusToColor[task.State]}}
+			}
+
+			table.Rich([]string{task.Terminal, task.Presentation.Name, task.State.String()}, colors)
 		}
 
 		table.Render()
@@ -56,5 +63,6 @@ var listTasksCmd = &cobra.Command{
 }
 
 func init() {
+	listTasksCmd.Flags().BoolVarP(&noColor, "no-color", "", false, "Disable output colorization")
 	tasksCmd.AddCommand(listTasksCmd)
 }

--- a/components/gitpod-cli/cmd/top.go
+++ b/components/gitpod-cli/cmd/top.go
@@ -21,8 +21,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-var noColor bool
-
 func outputTable(workspaceResources *supervisor.ResourcesStatusResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"CPU (millicores)", "Memory (bytes)"})


### PR DESCRIPTION
## Description
This PR updates the commands of gitpod-cli which use output colorization, making it explicitly disabled when requested by the user (via `--no-color`) or automatically (when stdin/stdout detected or for other community/standard conditions) [[1]](https://github.com/gitpod-io/gitpod/blob/main/components/gitpod-cli/pkg/utils/colors.go).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10633
Related #9930 

## How to test
1. Open the prev env
2. Run `watch gp ports list` and `watch gp tasks list` notice how the output does not display any invalid character and the output is readable (and not colorized).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
We should document this flag/feature: https://github.com/gitpod-io/website/issues/2235
