### PR TITLE
[ws-manager] Increase restore counter only if it's restoring from the Backup/VolumeSnapshot

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -800,22 +800,28 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 		hist.Observe(time.Since(t).Seconds())
 	}
 
+	_, isBackup := initializer.Spec.(*csapi.WorkspaceInitializer_Backup)
+
 	if err != nil {
-		c, cErr := m.manager.metrics.totalRestoreFailureCounterVec.GetMetricWithLabelValues(wsType, wsClass)
-		if cErr != nil {
-			log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace restore failure counter")
-		} else {
-			c.Inc()
+		if isBackup {
+			c, cErr := m.manager.metrics.totalRestoreFailureCounterVec.GetMetricWithLabelValues(wsType, wsClass)
+			if cErr != nil {
+				log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace restore failure counter")
+			} else {
+				c.Inc()
+			}
 		}
 
 		return xerrors.Errorf("cannot initialize workspace: %w", err)
 	}
 
-	c, cErr := m.manager.metrics.totalRestoreSuccessCounterVec.GetMetricWithLabelValues(wsType, wsClass)
-	if cErr != nil {
-		log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace restore success counter")
-	} else {
-		c.Inc()
+	if isBackup {
+		c, cErr := m.manager.metrics.totalRestoreSuccessCounterVec.GetMetricWithLabelValues(wsType, wsClass)
+		if cErr != nil {
+			log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace restore success counter")
+		} else {
+			c.Inc()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Only calculate the restore success/failure counter if it's restoring from the Backup or VolumeSnapshot

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10195

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None