### PR TITLE
[observability] Add `nodepool` variable to Overview dashboards

### DIFF
--- a/operations/observability/mixins/README.md
+++ b/operations/observability/mixins/README.md
@@ -295,22 +295,11 @@ This `jsonnetfile.json` lists all dependencies that we use, which includes this 
 
 ### How do I review dashboards before merging PRs?
 
-There are a couple of options to trigger a werft job that will deploy a preview environment with Prometheus+Grafana with your changes:
+Now with Harvester VM's being default, Monitoring-satellite should be deployed automatically in your preview environments.
 
-#### Pull request description
+But if you want to use Gitpod helm charts to deploy a preview, add the observability annotation to the pull request
+description
 
-By adding werft annotations to Pull Request descriptions, you make sure that all following job will have those annotations set.
-
-The following combination of annotations can be used to deploy monitoring satellite
-* Use harvester previews. Monitoring-satellite is deployed on those previews by default
-```
-/werft with-vm=true
-# Just in case your PR requires extra configuration on Prometheus side (and you have a new branch on https://github.com/gitpod-io/observability with such changes)
-# You can add the line below
-/werft withObservabilityBranch=<my-branch>
-```
-
-* Use Gitpod helm charts to deploy a preview, and add the observability annotation
 ```
 /werft with-helm=true with-observability=true
 # Just in case your PR requires extra configuration on Prometheus side (and you have a new branch on https://github.com/gitpod-io/observability with such changes)
@@ -318,15 +307,8 @@ The following combination of annotations can be used to deploy monitoring satell
 /werft withObservabilityBranch=<my-branch>
 ```
 
-#### Github comment
-
 If you want to run **one** particular job with different annotations, you can add them to a particular Github comment
 
-```
-/werft run with-vm=true
-/werft run withObservabilityBranch=<my-branch>
-```
-or
 ```
 /werft run with-helm=true with-observability=true
 /werft run withObservabilityBranch=<my-branch>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With the advent of different types of node pools i.e `xl` and
`standard` now, All metric labels are duplicated twice with no
information on what relates to which nodepool.

This PR fixes that by adding a global `nodepool` variable that
can be used to filter down metrics

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
