### PR TITLE
Listen on instance updates of a running prebuild

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -276,17 +276,21 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         //           to clients who might not otherwise have access to that information.
         this.disposables.push(
             this.localMessageBroker.listenForWorkspaceInstanceUpdates(this.user.id, (ctx, instance) =>
-                TraceContext.withSpan(
-                    "forwardInstanceUpdateToClient",
-                    (ctx) => {
-                        traceClientMetadata(ctx, this.clientMetadata);
-                        TraceContext.setJsonRPCMetadata(ctx, "onInstanceUpdate");
-
-                        this.client?.onInstanceUpdate(this.censorInstance(instance));
-                    },
-                    ctx,
-                ),
+                this.forwardInstanceUpdateToClient(ctx, instance),
             ),
+        );
+    }
+
+    protected forwardInstanceUpdateToClient(ctx: TraceContext, instance: WorkspaceInstance) {
+        TraceContext.withSpan(
+            "forwardInstanceUpdateToClient",
+            (ctx) => {
+                traceClientMetadata(ctx, this.clientMetadata);
+                TraceContext.setJsonRPCMetadata(ctx, "onInstanceUpdate");
+
+                this.client?.onInstanceUpdate(this.censorInstance(instance));
+            },
+            ctx,
         );
     }
 


### PR DESCRIPTION
... even if you are not the workspace owner.

Follow up to https://github.com/gitpod-io/gitpod/pull/10357

### How to test
* clone https://gitlab.com/alex736/gitpod-large-image into your account
* create a project for it using the preview environment from this PR
* push a change which modifies a) the Dockerfile and/or b) the init script in the .gitpod.yml file
* quickly switch to the project's page and start a workspace when you see the prebuild being started
* now you should see the "Prebuild in Progress" page
* depending on the time "configured" in the Dockerfile of the repo (modification a) you should eventually see the transition to the following workspace creation pages

Fixes https://github.com/gitpod-io/gitpod/issues/8195

```release-notes
NONE
```