### PR TITLE
[github action] Fix a bug which can cover build image

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -37,19 +37,16 @@ jobs:
         with:
           distribution: zulu
           java-version: "11"
-      - name: Leeway build
+      - name: Setup Google Cloud
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.projectId }}
-        env:
-          LEEWAY_REMOTE_CACHE_BUCKET: gitpod-core-leeway-cache-branch
-      - run: |
+      - name: Leeway build
+        run: |
           gcloud auth configure-docker --quiet
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
-          data=$(curl -sSL "https://data.services.jetbrains.com/products?code=${{ inputs.productCode }}&fields=distributions%2Clink%2Cname%2Creleases&_=$(date +%s)000")
-          link=$(echo "$data" | jq -r '.[0].releases[0].downloads.linux.link')
           cd components/ide/jetbrains/image
-          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DjetbrainsBackendQualifier=latest -D${{ inputs.productId }}DownloadUrl=$link .:${{ inputs.productId }}
+          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build .:${{ inputs.productId }}-latest
       - name: Slack Notification
         if: always()
         uses: rtCamp/action-slack-notify@v2

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -9,7 +9,6 @@ defaultArgs:
   localAppVersion: unknown
   codeCommit: d02dcf1b9ecd032e10a4792f57fcfe5e777aa221
   codeQuality: stable
-  jetbrainsBackendQualifier: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.1.2.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2022.1.2.tar.gz"

--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -24,7 +24,6 @@ packages:
     argdeps:
       - imageRepoBase
       - intellijDownloadUrl
-      - jetbrainsBackendQualifier
     config:
       dockerfile: leeway.Dockerfile
       metadata:
@@ -32,9 +31,8 @@ packages:
       buildArgs:
         JETBRAINS_BACKEND_URL: ${intellijDownloadUrl}
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
-        JETBRAINS_BACKEND_QUALIFIER: ${jetbrainsBackendQualifier}
+        JETBRAINS_BACKEND_QUALIFIER: stable
       image:
-        - ${imageRepoBase}/ide/intellij:${version}
         - ${imageRepoBase}/ide/intellij:commit-${__git_commit}
   - name: intellij-latest
     type: docker
@@ -56,7 +54,7 @@ packages:
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
-        - ${imageRepoBase}/ide/intellij:${version}-latest
+        - ${imageRepoBase}/ide/intellij:${version}
         - ${imageRepoBase}/ide/intellij:commit-${__git_commit}-latest
   - name: goland
     type: docker
@@ -70,7 +68,6 @@ packages:
     argdeps:
       - imageRepoBase
       - golandDownloadUrl
-      - jetbrainsBackendQualifier
     config:
       dockerfile: leeway.Dockerfile
       metadata:
@@ -78,9 +75,8 @@ packages:
       buildArgs:
         JETBRAINS_BACKEND_URL: ${golandDownloadUrl}
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_goland.json
-        JETBRAINS_BACKEND_QUALIFIER: ${jetbrainsBackendQualifier}
+        JETBRAINS_BACKEND_QUALIFIER: stable
       image:
-        - ${imageRepoBase}/ide/goland:${version}
         - ${imageRepoBase}/ide/goland:commit-${__git_commit}
   - name: goland-latest
     type: docker
@@ -102,7 +98,7 @@ packages:
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_goland.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
-        - ${imageRepoBase}/ide/goland:${version}-latest
+        - ${imageRepoBase}/ide/goland:${version}
         - ${imageRepoBase}/ide/goland:commit-${__git_commit}-latest
   - name: pycharm
     type: docker
@@ -116,7 +112,6 @@ packages:
     argdeps:
       - imageRepoBase
       - pycharmDownloadUrl
-      - jetbrainsBackendQualifier
     config:
       dockerfile: leeway.Dockerfile
       metadata:
@@ -124,9 +119,8 @@ packages:
       buildArgs:
         JETBRAINS_BACKEND_URL: ${pycharmDownloadUrl}
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_pycharm.json
-        JETBRAINS_BACKEND_QUALIFIER: ${jetbrainsBackendQualifier}
+        JETBRAINS_BACKEND_QUALIFIER: stable
       image:
-        - ${imageRepoBase}/ide/pycharm:${version}
         - ${imageRepoBase}/ide/pycharm:commit-${__git_commit}
   - name: pycharm-latest
     type: docker
@@ -148,7 +142,7 @@ packages:
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_pycharm.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
-        - ${imageRepoBase}/ide/pycharm:${version}-latest
+        - ${imageRepoBase}/ide/pycharm:${version}
         - ${imageRepoBase}/ide/pycharm:commit-${__git_commit}-latest
   - name: phpstorm
     type: docker
@@ -162,7 +156,6 @@ packages:
     argdeps:
       - imageRepoBase
       - phpstormDownloadUrl
-      - jetbrainsBackendQualifier
     config:
       dockerfile: leeway.Dockerfile
       metadata:
@@ -170,9 +163,8 @@ packages:
       buildArgs:
         JETBRAINS_BACKEND_URL: ${phpstormDownloadUrl}
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_phpstorm.json
-        JETBRAINS_BACKEND_QUALIFIER: ${jetbrainsBackendQualifier}
+        JETBRAINS_BACKEND_QUALIFIER: stable
       image:
-        - ${imageRepoBase}/ide/phpstorm:${version}
         - ${imageRepoBase}/ide/phpstorm:commit-${__git_commit}
   - name: phpstorm-latest
     type: docker
@@ -194,5 +186,5 @@ packages:
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_phpstorm.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
-        - ${imageRepoBase}/ide/phpstorm:${version}-latest
+        - ${imageRepoBase}/ide/phpstorm:${version}
         - ${imageRepoBase}/ide/phpstorm:commit-${__git_commit}-latest


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fix a problem which can cover build image
This is because leeway always upload image using commit-{commitID} https://github.com/gitpod-io/gitpod/blob/2e55f9cffa9582f60809f96389fafab068d92d81/components/ide/jetbrains/image/BUILD.yaml#L38
At before, we only checkout main branch and run `leeway` command, it will cause cover image build with same tag

~~This PR add a commit before run `leeway`, so it never effect main branch~~
This PR using suffix `-latest` as build target, so it never affect stable branch

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
