### PR TITLE
[Analytics] Remove PII from deleted Users

### DIFF
--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -92,6 +92,16 @@ export class UserDeletionService {
                 deleted_at: new Date().toISOString(),
             },
         });
+        this.analytics.identify({
+            userId: user.id,
+            traits: {
+                github_slug: "deleted-user",
+                gitlab_slug: "deleted-user",
+                bitbucket_slug: "deleted-user",
+                email: "deleted-user",
+                full_name: "deleted-user",
+            },
+        });
     }
 
     protected async stopWorkspaces(user: User) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ensures there is no remaining PII of deleted users in third party apps by sending an identify call with `deleted-user` values for all properties that contain PII.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

1. Open a preview environment, sign up, and then delete the account
3. Go to the [debugger of Staging Untrusted](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and ensure that an `identify` call that accompanies the deletion track call is sent

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe