### PR TITLE
[server] Make Stripe usage-based product price IDs configurable

### DIFF
--- a/.werft/jobs/build/helm/values.payment.yaml
+++ b/.werft/jobs/build/helm/values.payment.yaml
@@ -6,22 +6,16 @@ components:
       - name: chargebee-config
         mountPath: "/chargebee"
         readOnly: true
-      - name: stripe-secret
-        mountPath: "/stripe-secret"
-        readOnly: true
       - name: stripe-config
-        mountPath: "/stripe-config"
+        mountPath: "/stripe"
         readOnly: true
     volumes:
     - name: chargebee-config
       secret:
         secretName: chargebee-config
-    - name: stripe-secret
+    - name: stripe-config
       secret:
         secretName: stripe-api-keys
-    - name: stripe-config
-      configMap:
-        name: stripe-config
 
   paymentEndpoint:
     disabled: false

--- a/.werft/jobs/build/helm/values.payment.yaml
+++ b/.werft/jobs/build/helm/values.payment.yaml
@@ -6,16 +6,22 @@ components:
       - name: chargebee-config
         mountPath: "/chargebee"
         readOnly: true
+      - name: stripe-secret
+        mountPath: "/stripe-secret"
+        readOnly: true
       - name: stripe-config
-        mountPath: "/stripe"
+        mountPath: "/stripe-config"
         readOnly: true
     volumes:
     - name: chargebee-config
       secret:
         secretName: chargebee-config
-    - name: stripe-config
+    - name: stripe-secret
       secret:
         secretName: stripe-api-keys
+    - name: stripe-config
+      configMap:
+        name: stripe-config
 
   paymentEndpoint:
     disabled: false

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -84,6 +84,7 @@ export class Installer {
 
                 // let installer know that there is a stripe config
                 exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.stripeSecret stripe-api-keys`, { slice: slice });
+                exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.server.stripeConfig stripe-config`, { slice: slice });
             }
 
         } catch (err) {

--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -7,7 +7,7 @@ data:
   config: >
     {
       "usageProductPriceIds": {
-        "EUR": "price_1LAE0AGadRXm50o3xjegX0Kd",
-        "USD": "price_1LAE0AGadRXm50o3rKoktPiJ"
+        "EUR": "price_1LAyjSGadRXm50o3MO7CNyVU",
+        "USD": "price_1LAyjSGadRXm50o3tkwZe1N2"
       }
     }

--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stripe-config
+  namespace: ${NAMESPACE}
+data:
+  config: >
+    {
+      "usageProductPriceIds": {
+        "EUR": "price_1LAE0AGadRXm50o3xjegX0Kd",
+        "USD": "price_1LAE0AGadRXm50o3rKoktPiJ"
+      }
+    }

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -116,16 +116,15 @@ export class StripeService {
     }
 
     async createSubscriptionForCustomer(customerId: string, currency: Currency): Promise<void> {
-        // FIXME(janx): Use configmap.
-        const prices = {
-            EUR: "price_1LAE0AGadRXm50o3xjegX0Kd",
-            USD: "price_1LAE0AGadRXm50o3rKoktPiJ",
-        };
+        const priceId = this.config?.stripeConfig?.usageProductPriceIds[currency];
+        if (!priceId) {
+            throw new Error(`No Stripe Price ID configured for currency '${currency}'`);
+        }
         const startOfNextMonth = new Date(new Date().toISOString().slice(0, 7) + "-01"); // First day of this month (YYYY-MM-01)
         startOfNextMonth.setMonth(startOfNextMonth.getMonth() + 1); // Add one month
         await this.getStripe().subscriptions.create({
             customer: customerId,
-            items: [{ price: prices[currency] }],
+            items: [{ price: priceId }],
             billing_cycle_anchor: Math.round(startOfNextMonth.getTime() / 1000),
         });
     }

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -99,6 +99,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	stripeConfig := ""
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			stripeConfig = cfg.WebApp.Server.StripeConfig
+		}
+		return nil
+	})
+
 	disableWsGarbageCollection := false
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
@@ -216,9 +224,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ImageBuilderAddr:             "image-builder-mk3:8080",
 		CodeSync:                     CodeSync{},
 		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
-		EnablePayment:                chargebeeSecret != "" || stripeSecret != "",
+		EnablePayment:                chargebeeSecret != "" || stripeSecret != "" || stripeConfig != "",
 		ChargebeeProviderOptionsFile: fmt.Sprintf("%s/providerOptions", chargebeeMountPath),
-		StripeSecretsFile:            fmt.Sprintf("%s/apikeys", stripeMountPath),
+		StripeSecretsFile:            fmt.Sprintf("%s/apikeys", stripeSecretMountPath),
+		StripeConfigFile:             fmt.Sprintf("%s/config", stripeConfigMountPath),
 		InsecureNoDomain:             false,
 		PrebuildLimiter: map[string]int{
 			// default limit for all cloneURLs

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -15,7 +15,8 @@ const (
 	authProviderFilePath  = "/gitpod/auth-providers"
 	licenseFilePath       = "/gitpod/license"
 	chargebeeMountPath    = "/chargebee"
-	stripeMountPath       = "/stripe"
+	stripeSecretMountPath = "/stripe-secret"
+	stripeConfigMountPath = "/stripe-config"
 	githubAppCertSecret   = "github-app-cert-secret"
 	PrometheusPort        = 9500
 	PrometheusPortName    = "metrics"

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -204,7 +204,30 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      "stripe-secret",
-				MountPath: stripeMountPath,
+				MountPath: stripeSecretMountPath,
+				ReadOnly:  true,
+			})
+		}
+		return nil
+	})
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.StripeConfig != "" {
+			stripeConfig := cfg.WebApp.Server.StripeConfig
+
+			volumes = append(volumes,
+				corev1.Volume{
+					Name: "stripe-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: stripeConfig},
+						},
+					},
+				})
+
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      "stripe-config",
+				MountPath: stripeConfigMountPath,
 				ReadOnly:  true,
 			})
 		}

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -33,6 +33,7 @@ type ConfigSerialized struct {
 	VSXRegistryUrl                    string   `json:"vsxRegistryUrl"`
 	ChargebeeProviderOptionsFile      string   `json:"chargebeeProviderOptionsFile"`
 	StripeSecretsFile                 string   `json:"stripeSecretsFile"`
+	StripeConfigFile                  string   `json:"stripeConfigFile"`
 	EnablePayment                     bool     `json:"enablePayment"`
 
 	WorkspaceHeartbeat         WorkspaceHeartbeat         `json:"workspaceHeartbeat"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -140,6 +140,7 @@ type ServerConfig struct {
 	GithubApp                         *GithubApp          `json:"githubApp"`
 	ChargebeeSecret                   string              `json:"chargebeeSecret"`
 	StripeSecret                      string              `json:"stripeSecret"`
+	StripeConfig                      string              `json:"stripeConfig"`
 	DisableDynamicAuthProviderLogin   bool                `json:"disableDynamicAuthProviderLogin"`
 	EnableLocalApp                    *bool               `json:"enableLocalApp"`
 	RunDbDeleter                      *bool               `json:"runDbDeleter"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make Stripe usage-based product price IDs configurable.

Companion ops PR: https://github.com/gitpod-io/ops/pull/2819 (internal)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10655

## How to test
<!-- Provide steps to test this PR -->

1. Trigger a custom Werft build (using the config from this PR)
    - E.g. like so: `kubectx dev` then `werft job run github -j .werft/build.yaml -a with-clean-slate-deployment=true`
2. Then, same test flow as in https://github.com/gitpod-io/gitpod/pull/10630

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-payment=true