### PR TITLE
Preview environments: Add extra external_labels to Prometheus

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -161,6 +161,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
             clusterName: deploymentConfig.namespace,
             nodeExporterPort: 9100,
             previewDomain: deploymentConfig.domain,
+            previewName: previewNameFromBranchName(jobConfig.repository.branch),
             stackdriverServiceAccount: STACKDRIVER_SERVICEACCOUNT,
             withVM: withVM,
             werft: werft

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -9,6 +9,7 @@ type MonitoringSatelliteInstallerOptions = {
     clusterName: string;
     nodeExporterPort: number;
     branch: string;
+    previewName: string;
     previewDomain: string;
     stackdriverServiceAccount: any;
     withVM: boolean;
@@ -30,6 +31,7 @@ export class MonitoringSatelliteInstaller {
             stackdriverServiceAccount,
             withVM,
             previewDomain,
+            previewName,
             nodeExporterPort,
         } = this.options;
 
@@ -57,7 +59,7 @@ export class MonitoringSatelliteInstaller {
         let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
         --ext-code config="{
             namespace: '${satelliteNamespace}',
-            clusterName: '${satelliteNamespace}',
+            clusterName: '${previewName}',
             tracing: {
                 honeycombAPIKey: '${process.env.HONEYCOMB_API_KEY}',
                 honeycombDataset: 'preview-environments',
@@ -73,6 +75,9 @@ export class MonitoringSatelliteInstaller {
                 privateKey: '${stackdriverServiceAccount.private_key}',
             },
             prometheus: {
+                externalLabels: {
+                    environment: 'preview-environments',
+                },
                 resources: {
                     requests: { memory: '200Mi', cpu: '50m' },
                 },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add extra external_labels for preview environments. External labels are labels that are added to all metrics when Prometheus performs remote-write to a Long Term Storage. More context on why we need them can be seen in the issue https://github.com/gitpod-io/ops/issues/2770

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2771

## How to test
<!-- Provide steps to test this PR -->
* Start a new werft job with `werft run github -f -s .werft/jobs/build/deploy-to-preview-environment.ts -s .werft/observability/monitoring-satellite.ts`
* Install the preview environment context with `previewctl install-context`
* Describe the prometheus object with `kubectl describe prometheus k8s`
* You should see the external labels configured:

![image](https://user-images.githubusercontent.com/24193764/173669321-7a5072f1-8278-40a8-8a5f-e5f1bdf9e3e9.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
