### PR TITLE
Remove deprecated function

### DIFF
--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -19,6 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 )
@@ -71,7 +72,7 @@ var credentialHelper = &cobra.Command{
 		if supervisorAddr == "" {
 			supervisorAddr = "localhost:22999"
 		}
-		supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+		supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.WithError(err).Print("error connecting to supervisor")
 			return

--- a/components/gitpod-cli/cmd/env.go
+++ b/components/gitpod-cli/cmd/env.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
@@ -80,7 +81,7 @@ func connectToServer(ctx context.Context) (*connectToServerResult, error) {
 	if supervisorAddr == "" {
 		supervisorAddr = "localhost:22999"
 	}
-	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
 	}

--- a/components/gitpod-cli/cmd/git-token-validator.go
+++ b/components/gitpod-cli/cmd/git-token-validator.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
@@ -52,7 +53,7 @@ var gitTokenValidator = &cobra.Command{
 		if supervisorAddr == "" {
 			supervisorAddr = "localhost:22999"
 		}
-		supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+		supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.WithError(err).Fatal("error connecting to supervisor")
 		}

--- a/components/gitpod-cli/pkg/gitpod/server.go
+++ b/components/gitpod-cli/pkg/gitpod/server.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -29,7 +30,7 @@ func GetWSInfo(ctx context.Context) (*supervisor.WorkspaceInfoResponse, error) {
 	if supervisorAddr == "" {
 		supervisorAddr = "localhost:22999"
 	}
-	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
 	}
@@ -46,7 +47,7 @@ func ConnectToServer(ctx context.Context, wsInfo *supervisor.WorkspaceInfoRespon
 	if supervisorAddr == "" {
 		supervisorAddr = "localhost:22999"
 	}
-	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
 	}

--- a/components/ide/code-desktop/status/main.go
+++ b/components/ide/code-desktop/status/main.go
@@ -16,6 +16,7 @@ import (
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -89,7 +90,7 @@ func GetWSInfo(ctx context.Context) (*supervisor.WorkspaceInfoResponse, error) {
 	if supervisorAddr == "" {
 		supervisorAddr = "localhost:22999"
 	}
-	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+	supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
 	}

--- a/components/ide/code/codehelper/main.go
+++ b/components/ide/code/codehelper/main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -122,7 +123,7 @@ func resolveWorkspaceInfo(ctx context.Context) (*supervisor.ContentStatusRespons
 		if supervisorAddr == "" {
 			supervisorAddr = "localhost:22999"
 		}
-		supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithInsecure())
+		supervisorConn, err := grpc.Dial(supervisorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			err = errors.New("dial supervisor failed: " + err.Error())
 			return

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -86,7 +87,7 @@ func NewOrchestratingBuilder(cfg config.Configuration) (res *Orchestrator, err e
 
 			grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		} else {
-			grpcOpts = append(grpcOpts, grpc.WithInsecure())
+			grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
 		conn, err := grpc.Dial(cfg.WorkspaceManager.Address, grpcOpts...)
 		if err != nil {

--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
@@ -356,7 +357,7 @@ func (b *Bastion) handleUpdate(ur *WorkspaceUpdateRequest) {
 
 		if ws.supervisorClient == nil && ws.supervisorListener != nil {
 			var err error
-			ws.supervisorClient, err = grpc.Dial(ws.supervisorListener.LocalAddr, grpc.WithInsecure())
+			ws.supervisorClient, err = grpc.Dial(ws.supervisorListener.LocalAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				logrus.WithError(err).WithField("workspace", ws.WorkspaceID).Error("error connecting to supervisor")
 			} else {

--- a/components/registry-facade/pkg/registry/registry.go
+++ b/components/registry-facade/pkg/registry/registry.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // BuildStaticLayer builds a layer set from a static layer configuration
@@ -194,7 +195,7 @@ func NewRegistry(cfg config.Config, newResolver ResolverProvider, reg prometheus
 
 			grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		} else {
-			grpcOpts = append(grpcOpts, grpc.WithInsecure())
+			grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
 
 		specprov, err := NewCachingSpecProvider(128, NewRemoteSpecProvider(cfg.RemoteSpecProvider.Addr, grpcOpts))

--- a/components/supervisor/cmd/terminal.go
+++ b/components/supervisor/cmd/terminal.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
@@ -35,7 +36,7 @@ func dialSupervisor() *grpc.ClientConn {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	url := fmt.Sprintf("localhost:%d", cfg.APIEndpointPort)
-	conn, err := grpc.DialContext(ctx, url, grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.DialContext(ctx, url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		log.WithError(err).Fatal("cannot connect to supervisor")
 	}

--- a/components/supervisor/pkg/supervisor/notification.go
+++ b/components/supervisor/pkg/supervisor/notification.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -78,7 +79,7 @@ func (srv *NotificationService) RegisterGRPC(s *grpc.Server) {
 
 // RegisterREST registers a REST service.
 func (srv *NotificationService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint string) error {
-	return api.RegisterNotificationServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithInsecure()})
+	return api.RegisterNotificationServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 }
 
 // Notify sends a notification to the user.

--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -105,7 +106,7 @@ func (s *statusService) RegisterGRPC(srv *grpc.Server) {
 }
 
 func (s *statusService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint string) error {
-	return api.RegisterStatusServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithInsecure()})
+	return api.RegisterStatusServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 }
 
 func (s *statusService) SupervisorStatus(context.Context, *api.SupervisorStatusRequest) (*api.SupervisorStatusResponse, error) {
@@ -284,7 +285,7 @@ func (s RegistrableTokenService) RegisterGRPC(srv *grpc.Server) {
 
 // RegisterREST registers a REST service.
 func (s RegistrableTokenService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint string) error {
-	return api.RegisterTokenServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithInsecure()})
+	return api.RegisterTokenServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 }
 
 // NewInMemoryTokenService produces a new InMemoryTokenService.
@@ -634,7 +635,7 @@ func (is *InfoService) RegisterGRPC(srv *grpc.Server) {
 
 // RegisterREST registers the REST info service.
 func (is *InfoService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint string) error {
-	return api.RegisterInfoServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithInsecure()})
+	return api.RegisterInfoServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 }
 
 // WorkspaceInfo provides information about the workspace.
@@ -829,7 +830,7 @@ func (s *portService) RegisterGRPC(srv *grpc.Server) {
 }
 
 func (s *portService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint string) error {
-	return api.RegisterPortServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithInsecure()})
+	return api.RegisterPortServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 }
 
 // Tunnel opens a new tunnel.

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -67,7 +68,7 @@ func (srv *MuxTerminalService) RegisterGRPC(s *grpc.Server) {
 
 // RegisterREST registers a REST service.
 func (srv *MuxTerminalService) RegisterREST(mux *runtime.ServeMux, grpcEndpoint string) error {
-	return api.RegisterTerminalServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithInsecure()})
+	return api.RegisterTerminalServiceHandlerFromEndpoint(context.Background(), mux, grpcEndpoint, []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())})
 }
 
 // Open opens a new terminal running the shell.

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -955,7 +956,7 @@ func connectToInWorkspaceDaemonService(ctx context.Context) (*inWorkspaceService
 		}
 	}
 
-	conn, err := grpc.DialContext(ctx, "unix://"+socketFN, grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, "unix://"+socketFN, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/components/ws-daemon/cmd/client.go
+++ b/components/ws-daemon/cmd/client.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // clientCmd represents the client command
@@ -31,7 +32,7 @@ func init() {
 }
 
 func getGRPCConnection() (*grpc.ClientConn, error) {
-	secopt := grpc.WithInsecure()
+	secopt := grpc.WithTransportCredentials(insecure.NewCredentials())
 	if clientConfig.cert != "" {
 		creds, err := credentials.NewClientTLSFromFile(clientConfig.cert, "")
 		if err != nil {

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -156,7 +157,7 @@ var runCmd = &cobra.Command{
 		if cfg.ImageBuilderProxy.TargetAddr != "" {
 			// Note: never use block here, because image-builder connects to ws-manager,
 			//       and if we blocked here, ws-manager wouldn't come up, hence we couldn't connect to ws-manager.
-			conn, err := grpc.Dial(cfg.ImageBuilderProxy.TargetAddr, grpc.WithInsecure())
+			conn, err := grpc.Dial(cfg.ImageBuilderProxy.TargetAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				log.WithError(err).Fatal("failed to connect to image builder")
 			}

--- a/components/ws-manager/pkg/manager/integration_test.go
+++ b/components/ws-manager/pkg/manager/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -264,7 +265,7 @@ func connectToMockWsdaemon(ctx context.Context, wsdaemonSrv wsdaemon.WorkspaceCo
 		}
 	}()
 
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }), grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -1313,7 +1314,7 @@ func newWssyncConnectionFactory(managerConfig config.Configuration) (grpcpool.Fa
 
 		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {
-		grpcOpts = append(grpcOpts, grpc.WithInsecure())
+		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 	port := cfg.Port
 

--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,7 +95,7 @@ var runCmd = &cobra.Command{
 
 		var heartbeat sshproxy.Heartbeat
 		if wsm := cfg.WorkspaceManager; wsm != nil {
-			var dialOption grpc.DialOption = grpc.WithInsecure()
+			var dialOption grpc.DialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
 			if wsm.TLS.CA != "" && wsm.TLS.Cert != "" && wsm.TLS.Key != "" {
 				tlsConfig, err := common_grpc.ClientAuthTLSConfig(
 					wsm.TLS.CA, wsm.TLS.Cert, wsm.TLS.Key,

--- a/components/ws-proxy/pkg/sshproxy/server.go
+++ b/components/ws-proxy/pkg/sshproxy/server.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -329,7 +330,7 @@ func (s *Server) TrackSSHConnection(wsInfo *p.WorkspaceInfo, phase string, err e
 }
 
 func (s *Server) GetWorkspaceSSHKey(ctx context.Context, workspaceIP string) (ssh.Signer, error) {
-	supervisorConn, err := grpc.Dial(workspaceIP+":22999", grpc.WithInsecure())
+	supervisorConn, err := grpc.Dial(workspaceIP+":22999", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
 	}

--- a/dev/gpctl/cmd/clusters.go
+++ b/dev/gpctl/cmd/clusters.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -77,7 +78,7 @@ func getClustersClient(ctx context.Context) (*grpc.ClientConn, api.ClusterServic
 		return nil, nil, ctx.Err()
 	}
 
-	secopt := grpc.WithInsecure()
+	secopt := grpc.WithTransportCredentials(insecure.NewCredentials())
 	cert, _ := clustersCmd.Flags().GetString("tls")
 	if cert != "" {
 		creds, err := credentials.NewClientTLSFromFile(cert, "")

--- a/dev/gpctl/cmd/imagebuilds.go
+++ b/dev/gpctl/cmd/imagebuilds.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/gitpod-io/gitpod/gpctl/pkg/util"
@@ -77,7 +78,7 @@ func getImagebuildsClient(ctx context.Context) (*grpc.ClientConn, api.ImageBuild
 		host = fmt.Sprintf("localhost:%d", freePort)
 	}
 
-	secopt := grpc.WithInsecure()
+	secopt := grpc.WithTransportCredentials(insecure.NewCredentials())
 	cert, _ := imagebuildsCmd.Flags().GetString("tls")
 	if cert != "" {
 		creds, err := credentials.NewClientTLSFromFile(cert, "")

--- a/dev/gpctl/cmd/workspaces.go
+++ b/dev/gpctl/cmd/workspaces.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/gitpod-io/gitpod/gpctl/pkg/util"
@@ -42,7 +43,7 @@ func init() {
 
 func getWorkspacesClient(ctx context.Context) (*grpc.ClientConn, api.WorkspaceManagerClient, error) {
 	var addr string
-	secopt := grpc.WithInsecure()
+	secopt := grpc.WithTransportCredentials(insecure.NewCredentials())
 	if host, _ := workspacesCmd.PersistentFlags().GetString("host"); host == "" {
 		cfg, namespace, err := getKubeconfig()
 		if err != nil {

--- a/dev/loadgen/cmd/benchmark.go
+++ b/dev/loadgen/cmd/benchmark.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"sigs.k8s.io/yaml"
 
@@ -102,7 +103,7 @@ var benchmarkCommand = &cobra.Command{
 			})
 			opts = append(opts, grpc.WithTransportCredentials(creds))
 		} else {
-			opts = append(opts, grpc.WithInsecure())
+			opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
 
 		conn, err := grpc.Dial(benchmarkOpts.Host, opts...)

--- a/dev/loadgen/cmd/run.go
+++ b/dev/loadgen/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
@@ -108,7 +109,7 @@ var runCmd = &cobra.Command{
 			})
 			opts = append(opts, grpc.WithTransportCredentials(creds))
 		} else {
-			opts = append(opts, grpc.WithInsecure())
+			opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
 
 		conn, err := grpc.Dial("localhost:8080", opts...)

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -215,7 +216,7 @@ func (c *ComponentAPI) Supervisor(instanceID string) (grpc.ClientConnInterface, 
 	}
 	c.appendCloser(func() error { cancel(); return nil })
 
-	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", localPort), grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", localPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
@@ -712,7 +713,7 @@ func (c *ComponentAPI) BlobService() (csapi.BlobServiceClient, error) {
 		c.contentServiceStatus.Port = localPort
 	}
 
-	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", c.contentServiceStatus.Port), grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", c.contentServiceStatus.Port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
@@ -1011,7 +1012,7 @@ func (c *ComponentAPI) ImageBuilder(opts ...APIImageBuilderOpt) (imgbldr.ImageBu
 			c.imgbldStatus.Port = localPort
 		}
 
-		conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", c.imgbldStatus.Port), grpc.WithInsecure())
+		conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", c.imgbldStatus.Port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return err
 		}
@@ -1060,7 +1061,7 @@ func (c *ComponentAPI) ContentService() (ContentService, error) {
 		c.contentServiceStatus.Port = localPort
 	}
 
-	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", c.contentServiceStatus.Port), grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", c.contentServiceStatus.Port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The function `grpc.WithInsecure()` is deprecated, use `grpc.WithTransportCredentials(insecure.NewCredentials())` instead.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None