### PR TITLE
[usage] Lookup stripe customers for each team in a usage report

### DIFF
--- a/components/usage/.gitignore
+++ b/components/usage/.gitignore
@@ -1,0 +1,1 @@
+apikeys

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stripe/stripe-go/v72 v72.114.0 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -330,6 +330,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stripe/stripe-go/v72 v72.114.0 h1:fF4EEF9p+e8UzRsUYV1woTr8CC8f/51wXJr1MAnnP2M=
+github.com/stripe/stripe-go/v72 v72.114.0/go.mod h1:QwqJQtduHubZht9mek5sds9CtQcKFdsykV9ZepRWwo0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package stripe
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/stripe/stripe-go/v72"
+)
+
+type stripeKeys struct {
+	PublishableKey string `json:"publishableKey"`
+	SecretKey      string `json:"secretKey"`
+}
+
+func Authenticate(apiKeyFile string) error {
+	bytes, err := os.ReadFile(apiKeyFile)
+	if err != nil {
+		return err
+	}
+
+	var stripeKeys stripeKeys
+	err = json.Unmarshal(bytes, &stripeKeys)
+	if err != nil {
+		return err
+	}
+
+	stripe.Key = stripeKeys.SecretKey
+	return nil
+}

--- a/components/usage/pkg/stripe/stripe_test.go
+++ b/components/usage/pkg/stripe/stripe_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package stripe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomerQueriesForTeamIds_SingleQuery(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		TeamIds         []string
+		ExpectedQueries []string
+	}{
+		{
+			Name:            "1 team id",
+			TeamIds:         []string{"abcd-123"},
+			ExpectedQueries: []string{"metadata['teamId']:'abcd-123'"},
+		},
+		{
+			Name:            "2 team ids",
+			TeamIds:         []string{"abcd-123", "abcd-456"},
+			ExpectedQueries: []string{"metadata['teamId']:'abcd-123' OR metadata['teamId']:'abcd-456'"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualQueries := queriesForCustomersWithTeamIds(tc.TeamIds)
+
+			require.Equal(t, tc.ExpectedQueries, actualQueries)
+		})
+	}
+}
+
+func TestCustomerQueriesForTeamIds_MultipleQueries(t *testing.T) {
+	testCases := []struct {
+		Name                    string
+		NumberOfTeamIds         int
+		ExpectedNumberOfQueries int
+	}{
+		{
+			Name:                    "1 team id",
+			NumberOfTeamIds:         1,
+			ExpectedNumberOfQueries: 1,
+		},
+		{
+			Name:                    "10 team ids",
+			NumberOfTeamIds:         10,
+			ExpectedNumberOfQueries: 1,
+		},
+		{
+			Name:                    "11 team ids",
+			NumberOfTeamIds:         11,
+			ExpectedNumberOfQueries: 2,
+		},
+		{
+			Name:                    "1000 team ids",
+			NumberOfTeamIds:         1000,
+			ExpectedNumberOfQueries: 100,
+		},
+	}
+
+	buildTeamIds := func(numberOfTeamIds int) []string {
+		var teamIds []string
+		for i := 0; i < numberOfTeamIds; i++ {
+			teamIds = append(teamIds, fmt.Sprintf("abcd-%d", i))
+		}
+		return teamIds
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			teamIds := buildTeamIds(tc.NumberOfTeamIds)
+			actualQueries := queriesForCustomersWithTeamIds(teamIds)
+
+			require.Equal(t, tc.ExpectedNumberOfQueries, len(actualQueries))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add a `stripe` package to the usage reconciler and use it to find all Stripe `Customers` who have registered usage in the preceding month.

By querying the Stripe API for all teamIds occurring in the usage report, we are able to find a list of Stripe `Customers` who should have their subscriptions updated to register usage.

This PR just finds and logs the `Customers` occurring in the usage report. In a subsequent PR these `Customers` will be updated to register their usage.

## Related Issue(s)
Part of #9036 

## How to test

* Get a kube context for the staging cluster (`gcloud auth login` then `gcloud container clusters get-credentials ...`) - the exact commands can be taken from the GCP console.

* Port forward to the staging database:

```
kubectl port-forward svc/cloudsqlproxy 3306:3306
```

* Get some Stripe test mode API keys from the Stripe dashboard and save them in `components/usage/apikeys`. The file should look like:

```json
{
  "publishableKey": "foo",
  "secretKey": "bar"
}
```

* Run the usage reconciler against the staging database:

```
DB_HOST=localhost DB_USERNAME=gitpod DB_PASSWORD=<> DB_PORT=3306 go run . run --api-key-file ./apikeys
```
(the env vars, including password, can be found in the `server` pod by running):

```
kubectl exec server-849f6f8895-8kct9 -- env | grep DB_
```

After 1 minute the reconciler will run and display output like:

```json
{"level":"info","message":"about to make query \"metadata['teamId']:'0163ce3d-d46d-4c71-9d23-80d5e014959b' OR metadata['teamId']:'2db3d0ae-9fa2-41ed-9781-acfc7e17294b' OR metadata['teamId']:'0d39eefc-d1b7-461d-a4e5-03826b3dd054' OR metadata['teamId']:'0a6486da-b080-4f66-ba86-98f5a03374b5' OR metadata['teamId']:'14f79ba1-6e24-46de-aa80-12f63e58ea5f' OR metadata['teamId']:'7981ba4e-68fe-4d0a-afa1-e21b428bd7d0' OR metadata['teamId']:'af870004-62e5-4b44-9395-cd37abb10e2e' OR metadata['teamId']:'58ba9114-49ee-4538-8550-6f2bace66ac4'\"","serviceContext":{"service":"usage","version":""},"severity":"INFO","time":"2022-06-15T06:36:28Z"}
{"level":"info","message":"found customer \"Test Customer (for invoice generation)\" for teamId \"2db3d0ae-9fa2-41ed-9781-acfc7e17294b\"","serviceContext":{"service":"usage","version":""},"severity":"INFO","time":"2022-06-15T06:36:28Z"}

```

Showing the query that was run against the Stripe API and the 1 customer that was found with a matching teamId.

## Release Notes

```release-note
NONE
```

- [x] /werft with-payment