### PR TITLE
Add `--schedule` flag to `usage run` command

### DIFF
--- a/components/usage/cmd/run.go
+++ b/components/usage/cmd/run.go
@@ -24,6 +24,7 @@ func run() *cobra.Command {
 	var (
 		verbose    bool
 		apiKeyFile string
+		schedule   time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -48,7 +49,7 @@ func run() *cobra.Command {
 				log.WithError(err).Fatal("Failed to initialize stripe client.")
 			}
 
-			ctrl, err := controller.New(1*time.Minute, controller.NewUsageReconciler(conn))
+			ctrl, err := controller.New(schedule, controller.NewUsageReconciler(conn))
 			if err != nil {
 				log.WithError(err).Fatal("Failed to initialize usage controller.")
 			}
@@ -72,6 +73,7 @@ func run() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Toggle verbose logging (debug level)")
+	cmd.Flags().DurationVar(&schedule, "schedule", 1*time.Hour, "The schedule on which the reconciler should run")
 	cmd.Flags().StringVar(&apiKeyFile, "api-key-file", "/stripe-secret/apikeys", "Location of the stripe credentials file on disk")
 
 	return cmd


### PR DESCRIPTION
## Description

⚠️ This is based on https://github.com/gitpod-io/gitpod/pull/10674. Review and merge that one first ⚠️ 

Add a `--schedule` flag to the `usage run` command to allow setting the schedule on which the reconciler runs.

The main motivation here is to make local development easier (don't have to wait 1 min after invoking the command to get a reconciliation run), but we'll probably want to set this in-cluster via a configmap later on.

## Related Issue(s)
Part of #9036 

## How to test

```bash
DB_HOST=localhost DB_USERNAME=gitpod DB_PASSWORD=foo DB_PORT=3306 go run . run --api-key-file ./apikeys --schedule 5s
```

Reconciliation now runs after 5 seconds. Without the flag, reconciliation runs after 1m.

## Release Notes

```release-note
NONE
```