### PR TITLE
Opt-in preview environments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Description
+<!-- Describe your changes in detail -->
+
+## Related Issue(s)
+<!-- List the issue(s) this PR solves -->
+Fixes #
+
+## How to test
+<!-- Provide steps to test this PR -->
+
+## Release Notes
+<!--
+  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
+  Each line becomes a separate entry.
+  Format: [!<optional for breaking>] <description>
+  Example: !basic auth is no longer supported
+  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
+-->
+```release-note
+```
+
+## Documentation
+<!--
+Does this PR require updates to the documentation at www.gitpod.io/docs?
+* Yes
+  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
+  * 2. Paste the link to the docs issue below this comment
+* No
+  * Are you sure? If so, nothing to do here.
+-->
+
+## Werft options:
+<!--
+Optional annotations to add to the werft job.
+
+* with-preview - whether to create a preview environment for this PR
+-->
+- [ ] /werft with-preview

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -54,9 +54,9 @@ async function run(context: any) {
     await typecheckWerftJobs(werft)
     await buildAndPublish(werft, config)
 
-    if (config.noPreview) {
+    if (!config.withPreview || config.publishRelease) {
         werft.phase("deploy", "not deploying");
-        console.log("no-preview or publish-release is set");
+        console.log("running without preview environment or publish-release is set");
         return
     }
 

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -12,7 +12,7 @@ export interface JobConfig {
     installEELicense: boolean
     localAppVersion: string
     mainBuild: boolean;
-    noPreview: boolean;
+    withPreview: boolean;
     publishRelease: boolean;
     publishToJBMarketplace: string
     publishToNpm: string
@@ -73,7 +73,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     // ['with-contrib', 'publish-to-npm', 'publish-to-jb-marketplace', 'with-clean-slate-deployment']
     const dynamicCPULimits = "dynamic-cpu-limits" in buildConfig && !mainBuild;
     const withContrib = "with-contrib" in buildConfig || mainBuild;
-    const noPreview = ("no-preview" in buildConfig && buildConfig["no-preview"] !== "false") || publishRelease;
+    const withPreview = "with-preview" in buildConfig && !mainBuild;
     const storage = buildConfig["storage"] || "";
     const withIntegrationTests = "with-integration-tests" in buildConfig && !mainBuild;
     const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
@@ -120,7 +120,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         installEELicense,
         localAppVersion,
         mainBuild,
-        noPreview,
+        withPreview,
         observability,
         previewEnvironment,
         publishRelease,

--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -20,7 +20,7 @@ export async function validateChanges(werft: Werft, config: JobConfig) {
 // more for the ".<BUILD NUMBER>" ending. That leaves us 45 characters for the branch name.
 // See Werft source https://github.com/csweichel/werft/blob/057cfae0fd7bb1a7b05f89d1b162348378d74e71/pkg/werft/service.go#L376
 async function branchNameCheck(werft: Werft, config: JobConfig) {
-    if (!config.noPreview) {
+    if (config.withPreview) {
         const maxBranchNameLength = 45;
         werft.log("check-branchname", `Checking if branch name is shorter than ${maxBranchNameLength} characters.`)
 

--- a/dev/changelog/pullrequest.go
+++ b/dev/changelog/pullrequest.go
@@ -133,6 +133,6 @@ func init() {
 	prFlags.StringVarP(&prOpts.HeadBranch, "head", "H", "main", "the head branch for pull requests")
 	prFlags.StringVarP(&prOpts.BaseBranch, "base", "b", "main", "the base branch for pull requests")
 	prFlags.StringVarP(&prOpts.Title, "title", "T", "[changelog] updated changelog", "the title of the PR")
-	prFlags.StringVarP(&prOpts.Body, "body", "B", "Updated the changelog from recent PR descriptions\n\n```release-note\nNONE\n```\n/werft no-preview\n/werft no-test", "the body of the PR")
+	prFlags.StringVarP(&prOpts.Body, "body", "B", "Updated the changelog from recent PR descriptions\n\n```release-note\nNONE\n```\n/werft no-test", "the body of the PR")
 	rootCommand.AddCommand(pullRequestCommand)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Preview environments become optional with a toggle switch in the PR template.



The org-wide PR template is at:
https://github.com/gitpod-io/.github/blob/main/.github/pull_request_template.md

But we only care about modifying the template for this repository - therefore I've added it here and made the change.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9899

## How to test
<!-- Provide steps to test this PR -->
Job without `with-preview` set: https://werft.gitpod-dev.com/job/gitpod-custom-aa-opt-in-prevs.1/logs
Job with `with-preview` set: https://werft.gitpod-dev.com/job/gitpod-custom-aa-opt-in-prevs.2/logs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview