### PR TITLE
[installation-telemetry] Add licenseType to sent telemetry

### DIFF
--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -28,6 +28,7 @@ export interface TelemetryData {
     totalUsers: number;
     totalWorkspaces: number;
     totalInstances: number;
+    licenseType: string;
 }
 
 export namespace InstallationAdmin {

--- a/components/installation-telemetry/cmd/send.go
+++ b/components/installation-telemetry/cmd/send.go
@@ -57,7 +57,8 @@ var sendCmd = &cobra.Command{
 				Set("version", versionId).
 				Set("totalUsers", data.TotalUsers).
 				Set("totalWorkspaces", data.TotalWorkspaces).
-				Set("totalInstances", data.TotalInstances),
+				Set("totalInstances", data.TotalInstances).
+				Set("licenseType", data.LicenseType),
 		}
 
 		client.Enqueue(telemetry)

--- a/components/installation-telemetry/pkg/server/installationAdmin.go
+++ b/components/installation-telemetry/pkg/server/installationAdmin.go
@@ -22,6 +22,7 @@ type Data struct {
 	TotalUsers        int64             `json:"totalUsers"`
 	TotalWorkspaces   int64             `json:"totalWorkspaces"`
 	TotalInstances    int64             `json:"totalInstances"`
+	LicenseType       string            `json:"licenseType"`
 }
 
 type InstallationAdmin struct {

--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -9,12 +9,14 @@ import { injectable, inject } from "inversify";
 import { TelemetryData } from "@gitpod/gitpod-protocol";
 import * as opentracing from "opentracing";
 import { InstallationAdminDB, UserDB, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { LicenseEvaluator } from "@gitpod/licensor/lib";
 
 @injectable()
 export class InstallationAdminTelemetryDataProvider {
     @inject(InstallationAdminDB) protected readonly installationAdminDb: InstallationAdminDB;
     @inject(UserDB) protected readonly userDb: UserDB;
     @inject(WorkspaceDB) protected readonly workspaceDb: WorkspaceDB;
+    @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
 
     async getTelemetryData(): Promise<TelemetryData> {
         const span = opentracing.globalTracer().startSpan("getTelemetryData");
@@ -24,6 +26,7 @@ export class InstallationAdminTelemetryDataProvider {
                 totalUsers: await this.userDb.getUserCount(true),
                 totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
                 totalInstances: await this.workspaceDb.getInstanceCount(),
+                licenseType: this.licenseEvaluator.getLicenseData().type,
             } as TelemetryData;
             return data;
         } finally {


### PR DESCRIPTION
## Description

This pull request adds the Gitpod license type (replicated, gitpod) to installation telemetry.

## Related Issue(s)

Fixes #10508.

## How to test

Installation telemetry should include the `licenseType` field in the dashboard Admin page and the installation telemetry job:

<img width="1046" alt="installation telemetry install type" src="https://user-images.githubusercontent.com/172194/173958483-e901e405-bbe5-49e0-b6db-374a4babb56d.png">


```
❯ kubectl logs installation-telemetry-manual-0001-lwr54 | jq .
{
  "level": "info",
  "message": "installation-telemetry has successfully sent data - exiting",
  "serviceContext": {
    "service": "installation-telemetry",
    "version": "commit-efde5061d789299a2c5273d38d13376083fb4816"
  },
  "severity": "INFO",
  "telemetry": {
    "userId": "822b56b6-6e51-4d74-afbb-900399356a1f",
    "event": "Installation telemetry",
    "timestamp": "0001-01-01T00:00:00Z",
    "properties": {
      "licenseType": "replicated",
      "totalInstances": 0,
      "totalUsers": 1,
      "totalWorkspaces": 0,
      "version": "alt-10508-sh-telem-license-type.1"
    }
  },
  "time": "2022-06-15T23:22:44Z"
}
```

## Release Notes

```release-note
[installation-telemetry] The gitpod license type has been added to telemetry sent upon installation.
```

## Documentation

This change is not user configurable and has no impact upon operations and use; no documentation is necessary.