### PR TITLE
Add PVC support to prebuilds

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -341,6 +341,10 @@ func (c *Client) Fetch(ctx context.Context) (err error) {
 	return c.Git(ctx, "fetch", "-p", "-P", "--tags", "-f")
 }
 
+func (c *Client) AddSafeDirectory(ctx context.Context, dir string) (err error) {
+	return c.Git(ctx, "config", "--global", "--add", "safe.directory", dir)
+}
+
 // UpdateRemote performs a git fetch on the upstream remote URI
 func (c *Client) UpdateRemote(ctx context.Context) (err error) {
 	//nolint:staticcheck,ineffassign

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -96,7 +96,11 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 5 * time.Minute
 	if err = backoff.RetryNotify(gitClone, b, onGitCloneFailure); err != nil {
-		return src, xerrors.Errorf("git initializer: %w", err)
+		return src, xerrors.Errorf("git initializer gitClone: %w", err)
+	}
+
+	if err := ws.AddSafeDirectory(ctx, ws.Location); err != nil {
+		log.WithError(err).Warn("git initializer AddSafeDirectory")
 	}
 
 	if ws.Chown {
@@ -115,10 +119,10 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		}
 	}
 	if err := ws.realizeCloneTarget(ctx); err != nil {
-		return src, xerrors.Errorf("git initializer: %w", err)
+		return src, xerrors.Errorf("git initializer clone: %w", err)
 	}
 	if err := ws.UpdateRemote(ctx); err != nil {
-		return src, xerrors.Errorf("git initializer: %w", err)
+		return src, xerrors.Errorf("git initializer updateRemote: %w", err)
 	}
 	if err := ws.UpdateSubmodules(ctx); err != nil {
 		log.WithError(err).Warn("error while updating submodules - continuing")

--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -265,9 +265,10 @@ func newGitInitializer(ctx context.Context, loc string, req *csapi.GitInitialize
 
 func newSnapshotInitializer(loc string, rs storage.DirectDownloader, req *csapi.SnapshotInitializer) (*SnapshotInitializer, error) {
 	return &SnapshotInitializer{
-		Location: loc,
-		Snapshot: req.Snapshot,
-		Storage:  rs,
+		Location:           loc,
+		Snapshot:           req.Snapshot,
+		Storage:            rs,
+		FromVolumeSnapshot: req.FromVolumeSnapshot,
 	}, nil
 }
 

--- a/components/content-service/pkg/layer/provider.go
+++ b/components/content-service/pkg/layer/provider.go
@@ -282,9 +282,27 @@ func (s *Provider) GetContentLayerPVC(ctx context.Context, owner, workspaceID st
 	// At this point we've found neither a full-workspace-backup, nor a legacy backup.
 	// It's time to use the initializer.
 	if gis := initializer.GetSnapshot(); gis != nil {
+		if gis.FromVolumeSnapshot {
+			layer, err = contentDescriptorToLayerPVC([]byte{})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			l = []Layer{*layer}
+			return l, manifest, nil
+		}
 		return s.getSnapshotContentLayer(ctx, gis)
 	}
 	if pis := initializer.GetPrebuild(); pis != nil {
+		if pis.Prebuild.FromVolumeSnapshot {
+			layer, err = contentDescriptorToLayerPVC([]byte{})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			l = []Layer{*layer}
+			return l, manifest, nil
+		}
 		l, manifest, err = s.getPrebuildContentLayer(ctx, pis)
 		if err != nil {
 			log.WithError(err).WithFields(log.OWI(owner, workspaceID, "")).Warn("cannot initialize from prebuild - falling back to Git")
@@ -481,6 +499,7 @@ git config --global --add safe.directory ${GITPOD_REPO_ROOT}
 git status --porcelain=v2 --branch -uall > /.workspace/prestophookdata/git_status.txt
 git log --pretty='%h: %s' --branches --not --remotes > /.workspace/prestophookdata/git_log_1.txt
 git log --pretty=%H -n 1 > /.workspace/prestophookdata/git_log_2.txt
+cp /workspace/.gitpod/prebuild-log* /.workspace/prestophookdata/
 `
 
 // version of this function for persistent volume claim feature

--- a/components/content-service/pkg/logs/logs.go
+++ b/components/content-service/pkg/logs/logs.go
@@ -62,9 +62,16 @@ func ListPrebuildLogFiles(ctx context.Context, location string) (filePaths []str
 		}
 		return logFiles, nil
 	}
-	filePaths, err = listLogFiles(strings.TrimPrefix(TerminalStoreLocation, "/workspace"), prebuildLogFilePrefix)
+	// list log files in `location` first
+	filePaths, err = listLogFiles("", prebuildLogFilePrefix)
 	if err != nil {
 		return nil, err
+	}
+	if len(filePaths) == 0 {
+		filePaths, err = listLogFiles(strings.TrimPrefix(TerminalStoreLocation, "/workspace"), prebuildLogFilePrefix)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(filePaths) == 0 {
 		filePaths, err = listLogFiles(strings.TrimPrefix(legacyTerminalStoreLocation, "/workspace"), legacyPrebuildLogFilePrefix)

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -203,8 +203,10 @@ export class PrebuildManager {
             } else {
                 span.setTag("starting", true);
                 const projectEnvVars = await projectEnvVarsPromise;
+                const usePVC = this.shouldUsePersistentVolumeClaim(project);
                 await this.workspaceStarter.startWorkspace({ span }, workspace, user, [], projectEnvVars, {
                     excludeFeatureFlags: ["full_workspace_backup"],
+                    forcePVC: usePVC,
                 });
             }
 
@@ -272,6 +274,13 @@ export class PrebuildManager {
         const trimRepoUrl = (url: string) => url.replace(/\/$/, "").replace(/\.git$/, "");
         const repoUrl = trimRepoUrl(cloneUrl);
         return this.config.incrementalPrebuilds.repositoryPasslist.some((url) => trimRepoUrl(url) === repoUrl);
+    }
+
+    protected shouldUsePersistentVolumeClaim(project?: Project): boolean {
+        if (project?.settings?.usePersistentVolumeClaim) {
+            return true;
+        }
+        return false;
     }
 
     async fetchConfig(ctx: TraceContext, user: User, context: CommitContext): Promise<WorkspaceConfig> {

--- a/components/server/ee/src/workspace/workspace-starter.ts
+++ b/components/server/ee/src/workspace/workspace-starter.ts
@@ -32,8 +32,9 @@ export class WorkspaceStarterEE extends WorkspaceStarter {
         user: User,
         excludeFeatureFlags: NamedWorkspaceFeatureFlag[],
         ideConfig: IDEConfig,
+        forcePVC: boolean,
     ): Promise<WorkspaceInstance> {
-        const instance = await super.newInstance(ctx, workspace, user, excludeFeatureFlags, ideConfig);
+        const instance = await super.newInstance(ctx, workspace, user, excludeFeatureFlags, ideConfig, forcePVC);
         if (await this.eligibilityService.hasFixedWorkspaceResources(user)) {
             const config: WorkspaceInstanceConfiguration = instance.configuration!;
             const ff = config.featureFlags || [];

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -658,8 +658,12 @@ func (s *WorkspaceService) uploadWorkspaceLogs(ctx context.Context, sess *sessio
 		return xerrors.Errorf("no remote storage configured")
 	}
 
+	logLocation := sess.Location
+	if sess.PersistentVolumeClaim {
+		logLocation = filepath.Join(sess.ServiceLocDaemon, "prestophookdata")
+	}
 	// currently we're only uploading prebuild log files
-	logFiles, err := logs.ListPrebuildLogFiles(ctx, sess.Location)
+	logFiles, err := logs.ListPrebuildLogFiles(ctx, logLocation)
 	if err != nil {
 		return err
 	}

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1081,7 +1081,24 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 				err = m.manager.markWorkspace(context.Background(), workspaceID, addMark(pvcWorkspaceVolumeSnapshotAnnotation, string(b)))
 				if err != nil {
 					log.WithError(err).Error("cannot mark workspace with volume snapshot name - snapshot will be orphaned and backup lost")
+					errMark := m.manager.markWorkspace(ctx, workspaceID, addMark(workspaceExplicitFailAnnotation, xerrors.Errorf("cannot add mark to save snapshot info: %v", err).Error()))
+					if errMark != nil {
+						log.WithError(errMark).Warn("was unable to mark workspace as failed")
+					}
 					return true, nil, err
+				}
+
+				if tpe == api.WorkspaceType_PREBUILD {
+					err = m.manager.markWorkspace(context.Background(), workspaceID, addMark(workspaceSnapshotAnnotation, pvcVolumeSnapshotName))
+					if err != nil {
+						tracing.LogError(span, err)
+						log.WithError(err).Warn("cannot mark headless workspace with snapshot - that's one prebuild lost")
+						errMark := m.manager.markWorkspace(ctx, workspaceID, addMark(workspaceExplicitFailAnnotation, xerrors.Errorf("cannot add mark for prebuild snapshot info: %v", err).Error()))
+						if errMark != nil {
+							log.WithError(errMark).Warn("was unable to mark workspace as failed")
+						}
+						return true, nil, err
+					}
 				}
 
 				markVolumeSnapshotAnnotation = true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds support for PVC to prebuilds.
You can now enable PVC in your project settings, and all prebuilds going forward will use PVC and backup prebuild result into Volume Snapshot. When you open workspace from such prebuild, it will automatically opt in into using PVC feature.
Prebuilds using PVC can only be opened using PVC feature. 
If something is not working or broken, you just disable that option in project setting and trigger a new prebuild to use old method.

Opening workspace from a prebuild that contains a lot of data should be much faster when using PVC. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10260

## How to test
<!-- Provide steps to test this PR -->
1. Open preview environment
2. Add your project. 
3. Go into project settings and enable PVC feature flag.
4. Trigger new prebuild.
5. Open workspace from that prebuild.

For extra points:
Enable incremental prebuilds, and observe that this works correctly with PVC feature enabled as well.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview