### PR TITLE
[prebuilds] prebuild detail view in create workspace

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -106,16 +106,18 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
     }, [props.workspaceId, workspaceInstance?.status.phase]);
 
     return (
-        <>
-            <Suspense fallback={<div />}>
-                <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={error?.message} />
-            </Suspense>
-            <div className="h-20 px-6 border-gray-200 dark:border-gray-600 flex space-x-2">
+        <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
+            <div className="h-96 flex">
+                <Suspense fallback={<div />}>
+                    <WorkspaceLogs classes="h-full w-full" logsEmitter={logsEmitter} errorMessage={error?.message} />
+                </Suspense>
+            </div>
+            <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
                 {prebuild && <PrebuildStatus prebuild={prebuild} />}
                 <div className="flex-grow" />
                 {props.children}
             </div>
-        </>
+        </div>
     );
 }
 

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -13,7 +13,6 @@ import PrebuildLogs from "../components/PrebuildLogs";
 import Spinner from "../icons/Spinner.svg";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
-import { PrebuildStatus } from "./Prebuilds";
 import { shortCommitMessage } from "./render-utils";
 
 export default function () {
@@ -157,12 +156,7 @@ export default function () {
             <Header title={renderTitle()} subtitle={renderSubtitle()} />
             <div className="app-container mt-8">
                 <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
-                    <div className="h-96 flex">
-                        <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId} />
-                    </div>
-                    <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
-                        {prebuild && <PrebuildStatus prebuild={prebuild} />}
-                        <div className="flex-grow" />
+                    <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId}>
                         {["aborted", "timeout", "failed"].includes(prebuild?.status || "") || !!prebuild?.error ? (
                             <button
                                 className="flex items-center space-x-2"
@@ -195,7 +189,7 @@ export default function () {
                         ) : (
                             <button disabled={true}>New Workspace ({prebuild?.info.branch})</button>
                         )}
-                    </div>
+                    </PrebuildLogs>
                 </div>
             </div>
         </>

--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -155,42 +155,40 @@ export default function () {
         <>
             <Header title={renderTitle()} subtitle={renderSubtitle()} />
             <div className="app-container mt-8">
-                <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
-                    <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId}>
-                        {["aborted", "timeout", "failed"].includes(prebuild?.status || "") || !!prebuild?.error ? (
-                            <button
-                                className="flex items-center space-x-2"
-                                disabled={isRerunningPrebuild}
-                                onClick={rerunPrebuild}
-                            >
-                                {isRerunningPrebuild && (
-                                    <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
-                                )}
-                                <span>Rerun Prebuild ({prebuild?.info.branch})</span>
-                            </button>
-                        ) : ["building", "queued"].includes(prebuild?.status || "") ? (
-                            <button
-                                className="danger flex items-center space-x-2"
-                                disabled={isCancellingPrebuild}
-                                onClick={cancelPrebuild}
-                            >
-                                {isCancellingPrebuild && (
-                                    <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
-                                )}
-                                <span>Cancel Prebuild</span>
-                            </button>
-                        ) : prebuild?.status === "available" ? (
-                            <a
-                                className="my-auto"
-                                href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}
-                            >
-                                <button>New Workspace ({prebuild?.info.branch})</button>
-                            </a>
-                        ) : (
-                            <button disabled={true}>New Workspace ({prebuild?.info.branch})</button>
-                        )}
-                    </PrebuildLogs>
-                </div>
+                <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId}>
+                    {["aborted", "timeout", "failed"].includes(prebuild?.status || "") || !!prebuild?.error ? (
+                        <button
+                            className="flex items-center space-x-2"
+                            disabled={isRerunningPrebuild}
+                            onClick={rerunPrebuild}
+                        >
+                            {isRerunningPrebuild && (
+                                <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
+                            )}
+                            <span>Rerun Prebuild ({prebuild?.info.branch})</span>
+                        </button>
+                    ) : ["building", "queued"].includes(prebuild?.status || "") ? (
+                        <button
+                            className="danger flex items-center space-x-2"
+                            disabled={isCancellingPrebuild}
+                            onClick={cancelPrebuild}
+                        >
+                            {isCancellingPrebuild && (
+                                <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
+                            )}
+                            <span>Cancel Prebuild</span>
+                        </button>
+                    ) : prebuild?.status === "available" ? (
+                        <a
+                            className="my-auto"
+                            href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}
+                        >
+                            <button>New Workspace ({prebuild?.info.branch})</button>
+                        </a>
+                    ) : (
+                        <button disabled={true}>New Workspace ({prebuild?.info.branch})</button>
+                    )}
+                </PrebuildLogs>
             </div>
         </>
     );

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -5,7 +5,7 @@
  */
 
 import EventEmitter from "events";
-import React, { useEffect, Suspense, useContext, useState } from "react";
+import React, { useEffect, useContext, useState } from "react";
 import {
     CreateWorkspaceMode,
     WorkspaceCreationResult,
@@ -21,12 +21,10 @@ import StartWorkspace, { parseProps } from "./StartWorkspace";
 import { openAuthorizeWindow } from "../provider-utils";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { SelectAccountModal } from "../settings/SelectAccountModal";
-import { watchHeadlessLogs } from "../components/PrebuildLogs";
+import PrebuildLogs, { watchHeadlessLogs } from "../components/PrebuildLogs";
 import CodeText from "../components/CodeText";
 import FeedbackComponent from "../feedback-form/FeedbackComponent";
 import { isGitpodIo } from "../utils";
-
-const WorkspaceLogs = React.lazy(() => import("../components/WorkspaceLogs"));
 
 export interface CreateWorkspaceProps {
     contextUrl: string;
@@ -490,17 +488,11 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
 
     return (
         <StartPage title="Prebuild in Progress">
-            <Suspense fallback={<div />}>
-                <WorkspaceLogs logsEmitter={logsEmitter} />
-            </Suspense>
-            <button
-                className="mt-6 secondary"
-                onClick={() => {
-                    props.onIgnorePrebuild();
-                }}
-            >
-                Don't Wait for Prebuild
-            </button>
+            <PrebuildLogs workspaceId={props.runningPrebuild.workspaceID} onIgnorePrebuild={props.onIgnorePrebuild}>
+                <button className="secondary" onClick={() => props.onIgnorePrebuild && props.onIgnorePrebuild()}>
+                    Skip Prebuild
+                </button>
+            </PrebuildLogs>
         </StartPage>
     );
 }

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -488,11 +488,14 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
 
     return (
         <StartPage title="Prebuild in Progress">
-            <PrebuildLogs workspaceId={props.runningPrebuild.workspaceID} onIgnorePrebuild={props.onIgnorePrebuild}>
-                <button className="secondary" onClick={() => props.onIgnorePrebuild && props.onIgnorePrebuild()}>
-                    Skip Prebuild
-                </button>
-            </PrebuildLogs>
+            {/* TODO(gpl) Copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
+            <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                <PrebuildLogs workspaceId={props.runningPrebuild.workspaceID} onIgnorePrebuild={props.onIgnorePrebuild}>
+                    <button className="secondary" onClick={() => props.onIgnorePrebuild && props.onIgnorePrebuild()}>
+                        Skip Prebuild
+                    </button>
+                </PrebuildLogs>
+            </div>
         </StartPage>
     );
 }

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -443,7 +443,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             // or as a headless workspace.
             case "running":
                 if (isPrebuild) {
-                    return <PrebuildLogs workspaceId={this.props.workspaceId} />;
+                    return (
+                        <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                            {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
+                            <PrebuildLogs workspaceId={this.props.workspaceId} />
+                        </div>
+                    );
                 }
                 if (!this.state.desktopIde) {
                     phase = StartPhase.Running;
@@ -570,7 +575,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             // Stopping means that the workspace is currently shutting down. It could go to stopped every moment.
             case "stopping":
                 if (isPrebuild) {
-                    return <PrebuildLogs workspaceId={this.props.workspaceId} />;
+                    return (
+                        <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                            {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
+                            <PrebuildLogs workspaceId={this.props.workspaceId} />
+                        </div>
+                    );
                 }
                 phase = StartPhase.Stopping;
                 statusMessage = (

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -24,6 +24,7 @@ import {
     GuessGitTokenScopesParams,
     GuessedGitTokenScopes,
     ProjectEnvVar,
+    PrebuiltWorkspace,
 } from "./protocol";
 import {
     Team,
@@ -172,6 +173,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getUserProjects(): Promise<Project[]>;
     getProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
     findPrebuilds(params: FindPrebuildsParams): Promise<PrebuildWithStatus[]>;
+    findPrebuildByWorkspaceID(workspaceId: string): Promise<PrebuiltWorkspace | undefined>;
+    getPrebuild(prebuildId: string): Promise<PrebuildWithStatus | undefined>;
     triggerPrebuild(projectId: string, branchName: string | null): Promise<StartPrebuildResult>;
     cancelPrebuild(projectId: string, prebuildId: string): Promise<void>;
     fetchProjectRepositoryConfiguration(projectId: string): Promise<string | undefined>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -110,6 +110,8 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         getUserProjects: { group: "default", points: 1 },
         deleteProject: { group: "default", points: 1 },
         findPrebuilds: { group: "default", points: 1 },
+        getPrebuild: { group: "default", points: 1 },
+        findPrebuildByWorkspaceID: { group: "default", points: 1 },
         getProjectOverview: { group: "default", points: 1 },
         triggerPrebuild: { group: "default", points: 1 },
         cancelPrebuild: { group: "default", points: 1 },


### PR DESCRIPTION
## Description
This PR gives a perceived consistency between the create workspace page and the prebuild detail view.  

<img width="705" alt="Screenshot 2022-06-22 at 00 36 13" src="https://user-images.githubusercontent.com/8015191/174908440-3d54d3f6-698e-4d5e-9b91-b4fe6bb21ebb.png">


## Related Issue(s)
Fixes #9132

## How to test
1. Make a commit to a project with a prebuild.
2. Go to the project page's Branches tab. Once the prebuild is shown as "Running", start a new workspace.
3. See the logs running and the prebuild status showing below.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Prebuild status is shown under the logs when starting a workspace.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- [x] /werft with-preview
- [x] /werft with-clean-slate-deployment