### PR TITLE
fix(dashboard): Tab menu visible for urls trailing '/'

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -25,7 +25,7 @@ import { getProjectSettingsMenu } from "./projects/ProjectSettings";
 import { ProjectContext } from "./projects/project-context";
 import { PaymentContext } from "./payment-context";
 import FeedbackFormModal from "./feedback-form/FeedbackModal";
-import { isGitpodIo } from "./utils";
+import { inResource, isGitpodIo } from "./utils";
 import { getExperimentsClient } from "./experiments/client";
 
 interface Entry {
@@ -105,9 +105,9 @@ export default function Menu() {
     }
 
     // Hide most of the top menu when in a full-page form.
-    const isMinimalUI = ["/new", "/teams/new", "/open"].includes(location.pathname);
-    const isWorkspacesUI = ["/workspaces"].includes(location.pathname);
-    const isAdminUI = window.location.pathname.startsWith("/admin");
+    const isMinimalUI = inResource(location.pathname, ["new", "teams/new", "open"]);
+    const isWorkspacesUI = inResource(location.pathname, ["workspaces"]);
+    const isAdminUI = inResource(window.location.pathname, ["admin"]);
 
     const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
     useEffect(() => {

--- a/components/dashboard/src/utils.test.ts
+++ b/components/dashboard/src/utils.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { inResource } from "./utils";
+
+test("inResource", () => {
+
+    // Given root path is a part of resources specified
+    expect(inResource("/app", ["new", "app", "teams"])).toBe(true);
+
+    // Given path is a part of resources specified
+    expect(inResource("/app/testing", ["new", "app", "teams"])).toBe(true);
+
+    // Empty resources
+    expect(inResource("/just/a/path", [])).toBe(false);
+
+    // Both resources starting with '/'
+    expect(inResource("/app", ["/app"])).toBe(true);
+
+    // Both resources ending with '/'
+    expect(inResource("app/", ["app/"])).toBe(true);
+
+    // Both resources containing path with subdirectories
+    expect(inResource("/admin/teams/someTeam/somePerson", ["/admin/teams"])).toBe(true);
+
+});

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -57,3 +57,21 @@ export function isGitpodIo() {
         window.location.hostname.endsWith("gitpod-io-dev.com")
     );
 }
+
+function trimResource(resource: string): string {
+    return resource.split('/').filter(Boolean).join('/');
+}
+
+// Returns 'true' if a 'pathname' is a part of 'resources' provided.
+// `inResource("/app/testing/", ["new", "app", "teams"])` will return true
+// because '/app/testing' is a part of root 'app'
+//
+// 'pathname' arg can be provided via `location.pathname`.
+export function inResource(pathname: string, resources: string[]): boolean {
+    // Removes leading and trailing '/'
+    const trimmedResource = trimResource(pathname)
+
+    // Checks if a path is part of a resource.
+    // E.g. "api/userspace/resource" path is a part of resource "api/userspace"
+    return resources.map(res => trimmedResource.startsWith(trimResource(res))).some(Boolean)
+}


### PR DESCRIPTION
## Description

This bug #10666 was due to this

https://github.com/gitpod-io/gitpod/blob/402894b63b604234899db345fca0a9ce3750cec1/components/dashboard/src/Menu.tsx#L109

failing if `url` contained trailing `'/'`.

Here's a test

``` js
var url = new URL('https://gitpod.io/workspaces/')
>> ["/workspaces"].includes(url.pathname)
<- false
```
So if that was true, it should also happen to 

https://github.com/gitpod-io/gitpod/blob/402894b63b604234899db345fca0a9ce3750cec1/components/dashboard/src/Menu.tsx#L108

which was indeed the case, see https://gitpod.io/new/ (notice trailing '/').

A simple solution would have been to include another element (`"workspaces/")` in the array or discard trailing '/' and check with `includes`. Adding a new element can potentially cause similar problem if we were to forget duplicating for some new path. For the second option, I first thought of regex but it got really unreadable, so instead I chose `split` and `filter`

``` js
url.pathname.split('/').filter(p => p).join('/')
```
This would work but what if we are on a resource but not exactly on base? For example

(Browser console)
``` js
const url1 = new URL('https://gitpod.io/workspaces/testing')
var testingSubpath = url1.pathname.split('/').filter(p => p).join('/')
testingSubpath
"workspaces/testing"
```

``` js
var testing = ["workspaces", "teams/new", "open"]
```
Tab menu shouldn't be displayed in path `workspace/testing` because it is `isWorkspacesUI` (a subdirectory)

``` js
testing.includes(testingSubpath)
false
``` 
A better way would be to test "subpath" against "rootpath"

(Browser console)
``` js
var url1 = new URL("https://gitpod.io/teams/new/testing")
var trimmedPath = url1.pathname.split('/').filter(Boolean).join('/')
trimmedPath
"teams/new/testing"
```
Now if we were to test against 

``` js
var testing = ["workspaces", "teams/new", "open"]
```
we would get an array

``` js
testing.map(r => trimmedPath.startsWith(r))
Array(3) [ false, true, false ]
```
on which we can do an exhaustive search like

``` js
testing.map(r => trimmedPath.startsWith(r)).some(Boolean)
true
```

This would also work for `isAdminUI` check

https://github.com/gitpod-io/gitpod/blob/402894b63b604234899db345fca0a9ce3750cec1/components/dashboard/src/Menu.tsx#L110

(Browser console)
``` js
const url = new URL('https://gitpod.io/admin/testing')
const isAdminUI = url.pathname.startsWith("/admin")
isAdminUI
true
var testing = ["admin"]
var trimmedPath = url.pathname.split('/').filter(Boolean).join('/')
trimmedPath
"admin/testing"
testing.map(r => trimmedPath.startsWith(r)).some(Boolean)
true
```
---
If this subpath check behaviour isn't exactly what we need, we can swap positions and get exact results

``` js
var testing = ["admin"]
testing.map(r => r.startsWith(testingSubpath)).some(Boolean)
false
testing.map(r => testingSubpath.startsWith(r)).some(Boolean)
true
```
## Related Issue(s)
Fixes  #10666

## How to test
Described above

## Release Notes
```release-note
Fixed Tab menu being visible for urls with trailing '/'
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No

- [x] /werft with-preview