### PR TITLE
Remove critical alert GitpodWsDaemonExcessiveGC > 60s (but keep the non-critical warning for now)

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
@@ -29,26 +29,12 @@
               severity: 'warning',
             },
             annotations: {
-              runbook_url: '',
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonExcessiveGC.md',
               summary: 'Ws-daemon is doing excessive garbage collection.',
               description: 'Ws-daemon has excessive garbage collection time. Collecting garbage for more than 1 second.',
             },
             expr: |||
               go_gc_duration_seconds{job="ws-daemon", quantile="1"} > 1
-            |||,
-          },
-          {
-            alert: 'GitpodWsDaemonExcessiveGC',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonExcessiveGC.md',
-              summary: 'Ws-daemon is doing excessive garbage collection.',
-              description: 'Ws-daemon has excessive garbage collection time. Collecting garbage for more than 1 minute.',
-            },
-            expr: |||
-              go_gc_duration_seconds{job="ws-daemon", quantile="1"} > 60
             |||,
           },
         ],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove critical alert GitpodWsDaemonExcessiveGC > 60s (but keep the non-critical warning at > 1s for now).

Context: [Slack message](https://gitpod.slack.com/archives/C03KBGEGU9F/p1655329529371319?thread_ts=1655310895.380789&cid=C03KBGEGU9F) (internal)

> For tomorrow, I recommend:
> 1. Removing [this critical alert](https://github.com/gitpod-io/gitpod/blob/fe6e39e3a34dd48ea5c52717a3939ab3f7e4d87f/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet#L41) entirely

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes some PagerDuty noise

## How to test
<!-- Provide steps to test this PR -->

1. Merge this PR
2. Observe that the on-call person no longer gets PagerDuty alerts when ws-daemon GC takes longer than a minute

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
