### PR TITLE
[SSH Gateway] remove private key requirement when ownerToken is provide

### DIFF
--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/bombsimon/logrusr/v2"
+	"github.com/gitpod-io/golang-crypto/ssh"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/google/go-cmp v0.5.7
 	github.com/gorilla/handlers v1.5.1
@@ -20,6 +21,7 @@ require (
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.45.0
+	google.golang.org/protobuf v1.28.0
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
@@ -72,7 +74,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -145,6 +145,8 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552 h1:11beloYl4JFQZAj6VfJwZcPtrBqulK5Wzrs624m8qHI=
+github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552/go.mod h1:tJgr4p01k+N5SV9KHeHLPsEYMCEpc0dTSNGPif2ZWac=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/components/ws-proxy/pkg/proxy/proxy.go
+++ b/components/ws-proxy/pkg/proxy/proxy.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gitpod-io/golang-crypto/ssh"
 	"github.com/gorilla/mux"
 	"github.com/klauspost/cpuid/v2"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 )

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitpod-io/golang-crypto/ssh"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 	"golang.org/x/xerrors"
 
 	"github.com/gitpod-io/gitpod/common-go/log"

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gitpod-io/golang-crypto/ssh"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/util"

--- a/components/ws-proxy/pkg/sshproxy/forward.go
+++ b/components/ws-proxy/pkg/sshproxy/forward.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
-	"golang.org/x/crypto/ssh"
+	"github.com/gitpod-io/golang-crypto/ssh"
 	"golang.org/x/net/context"
 )
 

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/gitpod-io/gitpod/content-service v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gitpod-io/gitpod/registry-facade v0.0.0-00010101000000-000000000000 // indirect
+	github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/install/installer/go.sum
+++ b/install/installer/go.sum
@@ -548,6 +548,8 @@ github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552 h1:11beloYl4JFQZAj6VfJwZcPtrBqulK5Wzrs624m8qHI=
+github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552/go.mod h1:tJgr4p01k+N5SV9KHeHLPsEYMCEpc0dTSNGPif2ZWac=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[SSH Gateway] remove private key requirement when ownerToken is provide

At past, we introduce a simple copy/paste command to let users can simply copy it into the terminal to get an ssh connection to the workspace, but there are limitations to the `golang.org/x/crypto/ssh` library, it require user provider a private key in order to skip password prompt, this can be confusing for users and cause an incident for VSCode Desktop can not connect to workspace.

So we move to fork `golang.org/x/crypto/ssh` [repo link](https://github.com/gitpod-io/golang-crypto), and do some change, to make it suits us better.

The first change is cherry-pick some commit from `tailscale` 🙏 , the most important thing is support `NoClientAuthCallback` which let us can verify username in this check, and don't need the user to provide private key. [PR link](https://github.com/gitpod-io/golang-crypto/pull/1)

see [internal discuss](https://gitpod.slack.com/archives/C01KGM9BH54/p1655364943071639)

~~**NOTE: this PR is base on https://github.com/gitpod-io/gitpod/pull/10573 for test, it need rebase to main before merge.**~~

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in preview environment
2. start another workspace or use your local computer (move your private key to another folder)
3. using copy/paste ssh command to connect workspace, it should success
~~4. upload your `public key` in setting -> `SSH Key`~~
~~5. use your `private key` to connect with the workspace~~

~~4 and 5 is check this feature doesn't break https://github.com/gitpod-io/gitpod/pull/10573~~

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[SSH Gateway] remove priavte key requirement when ownerToken is provide
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
