### PR TITLE
[billing] Create Stripe invoices for teams based on their usage

### DIFF
--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -132,18 +132,13 @@ func (u *UsageReconciler) ReconcileTimeRange(ctx context.Context, from, to time.
 }
 
 func submitUsageReport(report []TeamUsage) {
-	var teamIdSet = make(map[string]bool)
-
-	// Convert the usage report into a set of teamIds occurring in the report
+	// Convert the usage report to sum all entries for the same team.
+	var summedReport = make(map[string]int64)
 	for _, usageEntry := range report {
-		teamIdSet[usageEntry.TeamID] = true
-	}
-	teamIds := make([]string, 0, len(teamIdSet))
-	for k := range teamIdSet {
-		teamIds = append(teamIds, k)
+		summedReport[usageEntry.TeamID] += usageEntry.WorkspaceSeconds
 	}
 
-	stripe.FindCustomersForTeamIds(teamIds)
+	stripe.UpdateUsage(summedReport)
 }
 
 func generateUsageReport(teams []teamWithWorkspaces, maxStopTime time.Time) ([]TeamUsage, error) {

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -20,6 +20,7 @@ type stripeKeys struct {
 	SecretKey      string `json:"secretKey"`
 }
 
+// Authenticate authenticates the Stripe client using a provided file containing a Stripe secret key.
 func Authenticate(apiKeyFile string) error {
 	bytes, err := os.ReadFile(apiKeyFile)
 	if err != nil {

--- a/components/usage/pkg/stripe/stripe_test.go
+++ b/components/usage/pkg/stripe/stripe_test.go
@@ -83,3 +83,50 @@ func TestCustomerQueriesForTeamIds_MultipleQueries(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspaceSecondsToCreditsCalcuation(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		Seconds         int64
+		ExpectedCredits int64
+	}{
+		{
+			Name:            "0 seconds",
+			Seconds:         0,
+			ExpectedCredits: 0,
+		},
+		{
+			Name:            "1 second",
+			Seconds:         1,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "60 seconds",
+			Seconds:         60,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "61 seconds",
+			Seconds:         61,
+			ExpectedCredits: 2,
+		},
+		{
+			Name:            "90 seconds",
+			Seconds:         90,
+			ExpectedCredits: 2,
+		},
+		{
+			Name:            "1 hour",
+			Seconds:         3600,
+			ExpectedCredits: 60,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualCredits := workspaceSecondsToCredits(tc.Seconds)
+
+			require.Equal(t, tc.ExpectedCredits, actualCredits)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Update teams' Stripe subscriptions with their usage credits during a given billing period.

Each time the usage reconciler runs, update Stripe invoices with usage credits for each team.

An example invoice: 

<img width="1513" alt="image" src="https://user-images.githubusercontent.com/8225907/174241667-31316712-556f-43a4-9c06-5c5239b3374e.png">

(exact dollar amounts per credit are still TBD, the value is a placeholder).

## Related Issue(s)
Part of #9036 

## How to test
1. Open a preview environment for this PR.
2. Create a team called 'Gitpod n', where `n` is the lowest number not yet used.
3. Enable usage based billing for the new team.
4. Start a workspace.
5. Update the `usage` component to make it run more frequently:
  * `kubectl edit deploy/usage`
  * Edit the `usage` container's `args` field to look like:
    ```yaml
     - args:
       - run
       - --schedule
       - 1m
    ```
6. Wait until the usage reconciler runs (tail its logs).
6. Visit the Stripe dashboard and find the Stripe customer that corresponds to the team you created.
7. Click on the Customer's subscription.
8. Check the 'Upcoming invoice' section and see that the customer has used Gitpod credits.

Every time the reconciler runs, the invoice should be updated with another credit (assuming the above interval of `1m` for the reconciler).

## Release Notes

```release-note
NONE
```

* [x] /werft with-payment=true