### PR TITLE
[installer]: set minio azure image to last supported version

### DIFF
--- a/install/installer/pkg/components/minio/azure/constants.go
+++ b/install/installer/pkg/components/minio/azure/constants.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package azure
+
+const (
+	ImageTag = "2022.4.29-debian-10-r0" // Last tag with Azure gateway support @link https://github.com/bitnami/charts/issues/10258
+)

--- a/install/installer/pkg/components/minio/azure/minio.go
+++ b/install/installer/pkg/components/minio/azure/minio.go
@@ -6,6 +6,7 @@ package azure
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/helm"
 	"github.com/gitpod-io/gitpod/installer/third_party/charts"
@@ -21,6 +22,7 @@ var Helm = func(apiPort int32, consolePort int32, commonHelmValues []string) com
 					Values: append(
 						[]string{
 							helm.KeyValue("minio.gateway.enabled", "true"),
+							helm.KeyValue("minio.image.tag", ImageTag),
 							helm.KeyValue("minio.gateway.auth.azure.accessKey", cfg.Values.StorageAccessKey), // Azure value actually taken from secret - used for console/API access
 							helm.KeyValue("minio.gateway.auth.azure.secretKey", cfg.Values.StorageSecretKey), // Ditto
 							helm.KeyValue("minio.gateway.auth.azure.storageAccountNameExistingSecret", cfg.Config.ObjectStorage.Azure.Credentials.Name),

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-registry-s3-fork.3"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-azure-minio-gateway.0"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-registry-s3-fork.3"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-azure-minio-gateway.0"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Azure support has been removed from the latest version of Minio gateway. If Azure is selected as the object store, this uses the last supported version of Minio gateway with Azure support.

This also means that the Azure gateway won't receive any updates. I think this is an acceptable compromise on the basis that the gateway and the object storage endpoints are separate binaries/codebases anyway. This will need a better fix in time (probably adding Azure as a native storage option in the `content-service`) as there will undoubtedly be divergences between the Helm chart and image. However, this will solve the problem in the short-term.

Proof that it's uploading to the blob store

![image](https://user-images.githubusercontent.com/275848/174311851-88ab3463-4a82-42c2-a7c2-f70f405affe6.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10697

## How to test
<!-- Provide steps to test this PR -->
Deploy with an Azure object store

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: set minio azure image to last supported version
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
