### PR TITLE
Change disk bus from scsi to virtio to gain performance

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -73,7 +73,7 @@ spec:
             - name: system
               bootOrder: 1
               disk:
-                bus: scsi
+                bus: virtio
             - name: cloudinitdisk
               disk:
                 bus: virtio


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, the Harvester VM uses `scsi`, we change to `virtio` to gain the performance.
Check the VM image supports the `virtio` by
```shell
$ lsmod | grep virtio_blk
```

Related slack discussion https://gitpod.slack.com/archives/C01KGM9EBD4/p1655444499062949

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Check the VM is bootable.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None