### PR TITLE
[usage] Add configmap for usage component to control run frequency

### DIFF
--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package usage
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	schedule := "1h"
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		if ucfg.WebApp != nil && ucfg.WebApp.Usage != nil && ucfg.WebApp.Usage.Schedule != "" {
+			schedule = ucfg.WebApp.Usage.Schedule
+		}
+		return nil
+	})
+
+	return []runtime.Object{
+		&corev1.ConfigMap{
+			TypeMeta: common.TypeMetaConfigmap,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-config", Component),
+				Namespace: ctx.Namespace,
+				Labels:    common.DefaultLabels(Component),
+			},
+			Data: map[string]string{
+				"schedule": schedule,
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package usage
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConfigMap_ContainsSchedule(t *testing.T) {
+	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true, Schedule: "2m"})
+
+	objs, err := configmap(ctx)
+	require.NoError(t, err)
+
+	cfgmap, ok := objs[0].(*corev1.ConfigMap)
+	require.True(t, ok)
+
+	require.Equal(t, cfgmap.Data["schedule"], "2m")
+}

--- a/install/installer/pkg/components/usage/objects.go
+++ b/install/installer/pkg/components/usage/objects.go
@@ -20,6 +20,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return common.CompositeRenderFunc(
 		deployment,
 		rolebinding,
+		configmap,
 		common.DefaultServiceAccount(Component),
 	)(ctx)
 }

--- a/install/installer/pkg/components/usage/objects_test.go
+++ b/install/installer/pkg/components/usage/objects_test.go
@@ -27,16 +27,14 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 4, "should render expected k8s objects")
+	require.Len(t, objects, 5, "should render expected k8s objects")
 }
 
-func renderContextWithUsageEnabled(t *testing.T) *common.RenderContext {
+func renderContextWithUsageConfig(t *testing.T, usage *experimental.UsageConfig) *common.RenderContext {
 	ctx, err := common.NewRenderContext(config.Config{
 		Domain: "test.domain.everything.awesome.is",
 		Experimental: &experimental.Config{
-			WebApp: &experimental.WebAppConfig{
-				Usage: &experimental.UsageConfig{Enabled: true},
-			},
+			WebApp: &experimental.WebAppConfig{Usage: usage},
 		},
 		Database: config.Database{
 			CloudSQL: &config.DatabaseCloudSQL{
@@ -58,4 +56,8 @@ func renderContextWithUsageEnabled(t *testing.T) *common.RenderContext {
 	require.NoError(t, err)
 
 	return ctx
+}
+
+func renderContextWithUsageEnabled(t *testing.T) *common.RenderContext {
+	return renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true})
 }

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -164,7 +164,8 @@ type PublicAPIConfig struct {
 }
 
 type UsageConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled  bool   `json:"enabled"`
+	Schedule string `json:"schedule"`
 }
 
 type IDEConfig struct {


### PR DESCRIPTION
## Description

Make the frequency at which the usage component runs configurable via a configmap.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/10720
Part of #9036 

## How to test

* Open the preview environment.
* Edit the `usage-configmap` (`kubectl edit cm usage-config`) and change the `schedule` to `1m`.
* Kill the usage pod to restart it with the new config (`kubectl delete pod <usage pod>`).
* Tail the logs of the new usage pod, including timestamps (`kubectl logs -f --timestamps=true <usage-pod>`)
* Watch the logs of the usage component and see that it now runs at 1 minute intervals rather than the previous 1 hour.

## Release Notes

```release-note
NONE
```
* [x] /werft run with-payment=true