### PR TITLE
[.gitpod.yml generator] Use 'pnpm' package manager when there is a pnpm-lock.yaml file or the package.json specifies it

### DIFF
--- a/components/server/src/config/config-inferrer.ts
+++ b/components/server/src/config/config-inferrer.ts
@@ -41,9 +41,12 @@ export class ConfigInferrer {
         if (!pckjsonContent) {
             return;
         }
-        let command: "yarn" | "npm" = "npm";
+        let command: "yarn" | "npm" | "pnpm" = "npm";
         if (await ctx.exists("yarn.lock")) {
             command = "yarn";
+        }
+        if (await ctx.exists("pnpm-lock.yaml") || pckjsonContent.packageManager.startsWith("pnpm")) {
+            command = "pnpm";
         }
         this.addCommand(ctx.config, command + " install", "init");
         try {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When auto-generating a `.gitpod.yml`, look for a `pnpm-lock.yaml` file in the root of the repository, or a `packageManager` entry in `package.json` that starts with `"pnpm"`. If it's a match, the wanted package manager is likely `pnpm` (instead of `npm` or `yarn`).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10374

## How to test
<!-- Provide steps to test this PR -->

1. Open a repository using `pnpm` in Gitpod, which does not yet have a committed `.gitpod.yml`
2. The auto-generated `.gitpod.yml` should use `pnpm` (instead of `npm` or `yarn`)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[.gitpod.yml generator] Use 'pnpm' package manager when there is a pnpm-lock.yaml file or the package.json specifies it
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
