### PR TITLE
Introduce SLI for preview environment start

### DIFF
--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -16,7 +16,6 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
     const {
         publishRelease,
         dontTest,
-        withContrib,
         retag,
         version,
         localAppVersion,
@@ -26,6 +25,9 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
     } = jobConfig;
 
     const releaseBranch = jobConfig.repository.ref;
+
+    // We set it to false as default and only set it true if the build succeeds.
+    werft.rootSpan.setAttributes({ "preview.gitpod_built_successfully": false });
 
     werft.phase("build", "build running");
     const imageRepo = publishRelease ? "gcr.io/gitpod-io/self-hosted" : "eu.gcr.io/gitpod-core-dev/build";
@@ -94,6 +96,8 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
     if (jobConfig.publishToKots) {
         publishKots(werft, jobConfig);
     }
+
+    werft.rootSpan.setAttributes({ "preview.gitpod_built_successfully": true });
 }
 
 /**


### PR DESCRIPTION
NOTE: I have added the hold label because the build fails are we seem to have a problems with VMs right now.

## Description
<!-- Describe your changes in detail -->

This PR instruments our build job to include annotations on the root span that we can use as part of our ["Preview environments should start successfully" SLI](https://www.notion.so/gitpod/Preview-Environment-Service-Level-Indicators-SLIs-55b649ad17774f279c142af55ad2fec7#f483f73aa4974ad3b8b6825fa2f251fa).

These annotations are used to created a derived column in Honeycomb that represents our SLI. The structure of the `IF(condition, then-value, else-value)` - see [here](https://docs.honeycomb.io/working-with-your-data/use-advanced-operators/derived-columns/reference/#if) - additionally for SLIs in Honeycomb `true` means the event should count as a success, `false` means it should count as a failure, and `null` means the event isn't part of the SLI.

So in our case, we only count the event if `preview.gitpod_built_successfully` is `true` and the `preview.k3s_successfully_created` attribute exists. We consider it a success if the root span doesn't have an error set and `preview.k3s_successfully_created` is `true`. Otherwise it's a failure.

```
IF(
  AND(
    EQUALS($preview.gitpod_built_successfully, true),
    EXISTS($preview.k3s_successfully_created)
  ),
  AND(
    NOT($error),
    EQUALS($preview.k3s_successfully_created, true)
  ),
  null
)
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2728
Fixes https://github.com/gitpod-io/ops/issues/2729
Fixes https://github.com/gitpod-io/ops/issues/2731

## How to test
<!-- Provide steps to test this PR -->

I started a job off the branch so it loaded my new TS code

```
 werft job run github -f
```

The VM happened to fail as we're overloaded right now, so that's great for testing 😅 See the trace [here](https://ui.honeycomb.io/gitpod/datasets/werft/trace/friXtpnmrq1?fields[]=c_name&fields[]=c_service.name&span=d46e2e9ac9fa9294) and screenshot of it below:
<img width="1453" alt="Screenshot 2022-06-17 at 15 37 12" src="https://user-images.githubusercontent.com/83561/174309412-9cfa7b66-6678-4e39-ae56-1761df4c05b4.png">

Here is a [simple query](https://ui.honeycomb.io/gitpod/datasets/werft/result/FiNjDzu9f1i) showing the count of events grouped by the the SLI - there is a bunch of events that doesn't count as part of the SLI and one failure (no successes because Harvester is overloaded)

<img width="1067" alt="Screenshot 2022-06-17 at 15 48 27" src="https://user-images.githubusercontent.com/83561/174311226-3fc5a9ae-532d-4d9e-a1b6-a790676bb544.png">

Also created an SLO for the fun of it [here](https://ui.honeycomb.io/gitpod/datasets/werft/slo/zRm48xoKMXf/Preview-Start).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A