### PR TITLE
[supervisor] improve ssh connected behaviors

### DIFF
--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -226,5 +227,23 @@ func configureSSHDefaultDir(cfg *Config) {
 	defer file.Close()
 	if _, err := file.WriteString(fmt.Sprintf("\nif [[ -n $SSH_CONNECTION ]]; then cd \"%s\"; fi\n", cfg.RepoRoot)); err != nil {
 		log.WithError(err).Error("write .bashrc failed")
+	}
+}
+
+func configureSSHMessageOfTheDay() {
+	msg := []byte(`Welcome to Gitpod: Always ready to code. Try the following commands to get started:
+
+	gp tasks list         List all your defined tasks in .gitpod.yml
+	gp tasks attach       Attach your terminal to a workspace task
+
+	gp ports list         Lists workspace ports and their states
+	gp stop               Stop current workspace
+	gp help               To learn about the gp CLI commands
+
+For more information, see the Gitpod documentation: https://gitpod.io/docs
+`)
+
+	if err := ioutil.WriteFile("/etc/motd", msg, 0o644); err != nil {
+		log.WithError(err).Error("write /etc/motd failed")
 	}
 }

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1235,6 +1235,7 @@ func startSSHServer(ctx context.Context, cfg *Config, wg *sync.WaitGroup, childP
 			return
 		}
 		configureSSHDefaultDir(cfg)
+		configureSSHMessageOfTheDay()
 		err = ssh.listenAndServe()
 		if err != nil {
 			log.WithError(err).Error("err starting SSH server")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When we connect to a workspace via SSH, the default folder is `~`, this PR change the default directory to `$GITPOD_REPO_ROOT`, so that user can reach their code folder after conn succeed

After ssh connected, it'll print environment vars in terminal, this PR will remove the log behavior.

After ssh connected, we will print a graceful welcome message for users to tell them useful commands

![image](https://user-images.githubusercontent.com/20944364/174389044-8dc623b5-4dc2-4580-8bfd-bb17d258d97d.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9377

## How to test
<!-- Provide steps to test this PR -->

See if print message as expected after ssh connected

**Test if it works**
- Start a workspace
- Connect via SSH copy-paste to see if default folder is correct

**Test if not change original behavior**
- After tests above
- Open a terminal in browser vscode 
- `cd` into any folder
- Click `Split` button (or `command+\` on MacOS)
- See if the new split terminal goes with same `pwd` with previous terminal


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Change the default directory of ssh connections
Remove env print after connect via ssh
Add graceful welcome message for users after ssh connected
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
