### PR TITLE
previews: Remote-write metrics to core-dev

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -26,6 +26,9 @@ pod:
   - name: gpsh-coredev-license
     secret:
       secretName: gpsh-coredev-license
+  - name: prometheus-remote-write-auth
+    secret:
+      secretName: prometheus-remote-write-auth
   - name: gpsh-harvester-license
     secret:
       secretName: gpsh-harvester-license
@@ -145,6 +148,16 @@ pod:
         secretKeyRef:
           name: npm-auth-token
           key: npm-auth-token.json
+    - name: PROM_REMOTE_WRITE_USER
+      valueFrom:
+        secretKeyRef:
+          name: prometheus-remote-write-auth
+          key: user
+    - name: PROM_REMOTE_WRITE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: prometheus-remote-write-auth
+          key: password
     - name: JB_MARKETPLACE_PUBLISH_TOKEN
       valueFrom:
         secretKeyRef:

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -82,6 +82,17 @@ export class MonitoringSatelliteInstaller {
                     requests: { memory: '200Mi', cpu: '50m' },
                 },
             },
+            remoteWrite: {
+                username: '${process.env.PROM_REMOTE_WRITE_USER}',
+                password: '${process.env.PROM_REMOTE_WRITE_PASSWORD}',
+                urls: ['https://prometheus.gitpod-dev.com/api/v1/write'],
+                writeRelabelConfigs: [{
+                    sourceLabels: ['__name__', 'job'],
+                    separator: ';',
+                    regex: 'probe_.*|rest_client_requests_total.*|up;probe',
+                    action: 'keep',
+                }],
+            },
             kubescape: {},
             pyrra: {},
             probe: {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Configure Prometheus in Preview Environments to remote-write metrics to core-dev, but only the ones needed for our SLIs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2764
Fixes https://github.com/gitpod-io/ops/issues/2766

## How to test
<!-- Provide steps to test this PR -->
Unfortunately, we're still having some network issues between previews and core-dev, but once that is solved we should be able to query metrics from the core-dev Prometheus with the following query:

```
{environment="preview-environment"}
```


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
