### PR TITLE
Link to Team Billing docs from dashboard

### DIFF
--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -145,11 +145,11 @@ export default function TeamBilling() {
             subtitle="Manage team billing and plans."
         >
             <TeamUsageBasedBilling />
-            <h3>{!teamPlan ? "Upgrade Team Plan" : "Team Plan"}</h3>
+            <h3>{!teamPlan ? "Select Team Plan" : "Team Plan"}</h3>
             <h2 className="text-gray-500">
                 {!teamPlan ? (
                     <div className="flex space-x-1">
-                        <span>Upgrade team plan to access unlimited workspace hours, and more. Currency:</span>
+                        <span>Currency:</span>
                         <DropDown
                             customClasses="w-32"
                             renderAsLink={true}


### PR DESCRIPTION
## Description
Link to https://www.gitpod.io/docs/team-billing from Team Billing settings.

## Related Issue(s)
Fixes #10741 

## How to test
Look for link in team settings, billing page (as owner).

## Release Notes
```release-note
NONE
```