### PR TITLE
[ws-daemon] Fix quota size regex's false positives

### DIFF
--- a/components/ws-daemon/pkg/quota/size.go
+++ b/components/ws-daemon/pkg/quota/size.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	sizeRegexp = regexp.MustCompile(`(\d+)(k|m|g|t)?`)
+	sizeRegexp = regexp.MustCompile(`^(\d+)(k|m|g|t)?$`)
 
 	// ErrInvalidSize is returned by ParseSize if input was not a valid size
 	ErrInvalidSize = errors.New("invalid size")

--- a/components/ws-daemon/pkg/quota/size_test.go
+++ b/components/ws-daemon/pkg/quota/size_test.go
@@ -23,8 +23,8 @@ func TestParseSize(t *testing.T) {
 		{"42m", 42 * quota.Megabyte, nil},
 		{"42g", 42 * quota.Gigabyte, nil},
 		{"42t", 42 * quota.Terabyte, nil},
-		// This test should fail but doesn't because match somehow matches the regexp
-		// {"-42m", 0, quota.ErrInvalidSize},
+		{"-42m", 0, quota.ErrInvalidSize},
+		{"ab-42mcd", 0, quota.ErrInvalidSize},
 		{"abc", 0, quota.ErrInvalidSize},
 		{"99999999999999999999999999999999999999999999999999999999999999999999999999999999", 0, quota.ErrInvalidSize},
 	}


### PR DESCRIPTION
## Description
I found this while browsing the repo

https://github.com/gitpod-io/gitpod/blob/d114f037a1c34df5206bb93fc9fe48481f28bfd7/components/ws-daemon/pkg/quota/size_test.go#L26-L27

`-42m` works because the regex correctly matched on the `42m` part, see https://regexr.com/6o0va

so does this

``` go
{"-42m", 42 * quota.Megabyte, nil},
{"ab-42mcd", 42 * quota.Megabyte, nil},
```

Quick fix is to constrain starting and ending characters, i.e.

``` go
^(\d+)(k|m|g|t)?$
```

## How to test
This test now succeeds 
https://github.com/gitpod-io/gitpod/blob/d114f037a1c34df5206bb93fc9fe48481f28bfd7/components/ws-daemon/pkg/quota/size_test.go#L15

## Release Notes
```release-note
Fixed quota size regex allowing false positives
```
