### PR TITLE
[usage] Make billing optional in the usage component

### DIFF
--- a/components/usage/pkg/controller/billing.go
+++ b/components/usage/pkg/controller/billing.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package controller
+
+import "github.com/gitpod-io/gitpod/usage/pkg/stripe"
+
+type BillingController interface {
+	Reconcile(report []TeamUsage)
+}
+
+type NoOpBillingController struct{}
+type StripeBillingController struct{}
+
+func (b *NoOpBillingController) Reconcile(report []TeamUsage) {}
+
+func (b *StripeBillingController) Reconcile(report []TeamUsage) {
+	// Convert the usage report to sum all entries for the same team.
+	var summedReport = make(map[string]int64)
+	for _, usageEntry := range report {
+		summedReport[usageEntry.TeamID] += usageEntry.WorkspaceSeconds
+	}
+
+	stripe.UpdateUsage(summedReport)
+}

--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -153,8 +153,9 @@ func TestUsageReconciler_ReconcileTimeRange(t *testing.T) {
 			require.NoError(t, conn.Create(scenario.Instances).Error)
 
 			reconciler := &UsageReconciler{
-				nowFunc: scenario.NowFunc,
-				conn:    conn,
+				billingController: &NoOpBillingController{},
+				nowFunc:           scenario.NowFunc,
+				conn:              conn,
 			}
 			status, err := reconciler.ReconcileTimeRange(context.Background(), startOfMay, startOfJune)
 			require.NoError(t, err)

--- a/install/installer/pkg/components/usage/constants.go
+++ b/install/installer/pkg/components/usage/constants.go
@@ -7,4 +7,5 @@ package usage
 const (
 	Component             = "usage"
 	stripeSecretMountPath = "stripe-secret"
+	stripeKeyFilename     = "apikeys"
 )

--- a/install/installer/pkg/components/usage/deployment.go
+++ b/install/installer/pkg/components/usage/deployment.go
@@ -5,6 +5,7 @@ package usage
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
@@ -21,6 +22,11 @@ import (
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	labels := common.DefaultLabels(Component)
+
+	args := []string{
+		"run",
+		"--schedule=$(RECONCILER_SCHEDULE)",
+	}
 
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -43,6 +49,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				MountPath: stripeSecretMountPath,
 				ReadOnly:  true,
 			})
+
+			args = append(args, fmt.Sprintf("--stripe-secret-path=%s", filepath.Join(stripeSecretMountPath, stripeKeyFilename)))
 		}
 		return nil
 	})
@@ -75,13 +83,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						InitContainers:                []corev1.Container{*common.DatabaseWaiterContainer(ctx)},
 						Volumes:                       volumes,
 						Containers: []corev1.Container{{
-							Name:  Component,
-							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Usage.Version),
-							Args: []string{
-								"run",
-								"--schedule",
-								"$(RECONCILER_SCHEDULE)",
-							},
+							Name:            Component,
+							Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.Usage.Version),
+							Args:            args,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/install/installer/pkg/components/usage/objects_test.go
+++ b/install/installer/pkg/components/usage/objects_test.go
@@ -61,3 +61,14 @@ func renderContextWithUsageConfig(t *testing.T, usage *experimental.UsageConfig)
 func renderContextWithUsageEnabled(t *testing.T) *common.RenderContext {
 	return renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true})
 }
+
+func renderContextWithStripeSecretSet(t *testing.T) *common.RenderContext {
+	ctx := renderContextWithUsageEnabled(t)
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		cfg.WebApp.Server = &experimental.ServerConfig{StripeSecret: "some-stripe-secret"}
+		return nil
+	})
+
+	return ctx
+}


### PR DESCRIPTION
## Description
Make the payment processing part of the usage controller optional. If the secret containing Stripe API keys is configured then enable payments, otherwise disable it.

Usage metering and usage based billing are separate concepts that we will need to enable and disable independently of one another. In Gitpod SaaS we will want both, but for self-hosted installations, users will only care about usage metering.

At some point we will want to have the usage collection and billing integration in separate services but for now, while they both live in the usage component, let's at least be able to toggle billing integration on and off.

## Related Issue(s)
Part of #9036 

## How to test

* Trigger separate Werft builds, one setting `with-payment=true` and the other without.
* Observe that when payment is enabled, the usage component runs with billing integration enabled:
  ```
  {"level":"info","message":"payment integration with Stripe is set to true","serviceContext":{"service":"usage","version":"commit-b5ca1b4eebb51424345134f6847f9d180bd7c44f"},"severity":"INFO","time":"2022-06-20T05:56:38Z"}
  ```
  and when payment is not enabled, observe that it runs with billing integration disabled:
  ```
  {"level":"info","message":"payment integration with Stripe is set to false","serviceContext":{"service":"usage","version":"commit-b5ca1b4eebb51424345134f6847f9d180bd7c44f"},"severity":"INFO","time":"2022-06-20T05:56:38Z"}
  ```

## Release Notes

```release-note
NONE
```

## Documentation

None