### PR TITLE
Add text panel with link to Preview Start SLO

### DIFF
--- a/operations/observability/mixins/platform/dashboards/preview-environments/overview.json
+++ b/operations/observability/mixins/platform/dashboards/preview-environments/overview.json
@@ -54,7 +54,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1654680320363,
+  "iteration": 1655713296033,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -132,12 +132,33 @@
       "type": "gauge"
     },
     {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 0,
+        "y": 8
+      },
+      "id": 86,
+      "options": {
+        "content": "We have an SLO for preview starts in Honeycomb. You can see the SLO [here](https://ui.honeycomb.io/gitpod/datasets/werft/slo/zRm48xoKMXf/Preview-Start). Alternatively you can use [this query](https://ui.honeycomb.io/gitpod/datasets/werft/result/a64cNk4sArf) to dig into succesful and failed SLI events. The definition of the SLO can be found [here](https://www.notion.so/gitpod/Preview-Environment-Service-Level-Indicators-SLIs-55b649ad17774f279c142af55ad2fec7#f483f73aa4974ad3b8b6825fa2f251fa).",
+        "mode": "markdown"
+      },
+      "pluginVersion": "8.5.5",
+      "title": "Preview Start SLO",
+      "type": "text"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 12
       },
       "id": 70,
       "panels": [],
@@ -182,7 +203,7 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 9
+        "y": 13
       },
       "id": 68,
       "options": {
@@ -224,7 +245,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 23
       },
       "id": 65,
       "panels": [
@@ -344,7 +365,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 24
       },
       "id": 52,
       "panels": [


### PR DESCRIPTION
## Description
This adds a simple text panel to our [Preview Environments dashboard](https://grafana.gitpod.io/d/preview-environments/preview-environments?orgId=1) which links to our new SLO for Preview Starts in Honeycomb as well as a simple query and the description of the SLO (the RFC).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2768

## How to test
<!-- Provide steps to test this PR -->

In the Grafana for my preview environment I manually imported the dashboard by copy-pasting the JSON in the repo. It loaded it just fine, see below:

<img width="1446" alt="Screenshot 2022-06-20 at 10 48 06" src="https://user-images.githubusercontent.com/83561/174563121-d7735601-dc21-4d10-b5da-f13e02eeab9b.png">

I was expecting it to create the Preview Environment dashboard automatically, but did didn't. Should it have @ArthurSens?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A