### PR TITLE
[usage] Batch lookup Workspaces to fix too many placeholders error

### DIFF
--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.0
+	github.com/stripe/stripe-go/v72 v72.114.0
 	gorm.io/datatypes v1.0.6
 	gorm.io/driver/mysql v1.3.3
 	gorm.io/gorm v1.23.5
@@ -88,7 +89,6 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stripe/stripe-go/v72 v72.114.0 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/components/usage/pkg/db/dbtest/workspace.go
+++ b/components/usage/pkg/db/dbtest/workspace.go
@@ -23,7 +23,7 @@ const (
 func NewWorkspace(t *testing.T, workspace db.Workspace) db.Workspace {
 	t.Helper()
 
-	id := generateWorkspaceID()
+	id := GenerateWorkspaceID()
 	if workspace.ID != "" {
 		id = workspace.ID
 	}
@@ -63,7 +63,7 @@ func NewWorkspace(t *testing.T, workspace db.Workspace) db.Workspace {
 	}
 }
 
-func generateWorkspaceID() string {
+func GenerateWorkspaceID() string {
 	return fmt.Sprintf("gitpodio-gitpod-%s", randSeq(11))
 }
 

--- a/components/usage/pkg/db/workspace_test.go
+++ b/components/usage/pkg/db/workspace_test.go
@@ -126,6 +126,11 @@ func TestListWorkspacesByID(t *testing.T) {
 			QueryIDs: []string{workspaces[0].ID, workspaces[1].ID},
 			Expected: 2,
 		},
+		{
+			Name:     "over 2^16 - 1 IDs requires batching",
+			QueryIDs: append([]string{workspaces[0].ID, workspaces[1].ID}, generateWorkspaceIDs(65535)...),
+			Expected: 2,
+		},
 	} {
 		t.Run(scenario.Name, func(t *testing.T) {
 			results, err := db.ListWorkspacesByID(context.Background(), conn, scenario.QueryIDs)
@@ -134,4 +139,13 @@ func TestListWorkspacesByID(t *testing.T) {
 		})
 
 	}
+}
+
+func generateWorkspaceIDs(count int) []string {
+	var ids []string
+	for i := 0; i < count; i++ {
+		ids = append(ids, dbtest.GenerateWorkspaceID())
+	}
+
+	return ids
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ensures that we do not include more than 2^16 placeholders in a `WHERE field IN (values)` prepared query.
https://bugs.mysql.com/bug.php?id=101630

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10642

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE