### PR TITLE
[jb] enable vmoptions config in .gitpod.yml

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -287,6 +287,10 @@
                                     "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
                                 }
                             }
+                        },
+                        "vmoptions": {
+                            "type": "string",
+                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
                         }
                     }
                 },
@@ -317,6 +321,10 @@
                                     "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
                                 }
                             }
+                        },
+                        "vmoptions": {
+                            "type": "string",
+                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
                         }
                     }
                 },
@@ -347,6 +355,10 @@
                                     "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
                                 }
                             }
+                        },
+                        "vmoptions": {
+                            "type": "string",
+                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
                         }
                     }
                 },
@@ -377,6 +389,10 @@
                                     "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
                                 }
                             }
+                        },
+                        "vmoptions": {
+                            "type": "string",
+                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
                         }
                     }
                 }

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -175,6 +175,9 @@ type JetBrainsProduct struct {
 
 	// Enable warming up of JetBrains product in prebuilds
 	Prebuilds *JetBrainsPrebuilds `yaml:"prebuilds,omitempty"`
+
+	// JVM Options for IDE backend server, separated by space
+	VMOptions string `yaml:"vmoptions,omitempty"`
 }
 
 // Enable warming up of JetBrains product in prebuilds

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -640,6 +640,7 @@ export interface JetBrainsConfig {
 }
 export interface JetBrainsProductConfig {
     prebuilds?: JetBrainsPrebuilds;
+    vmoptions?: string;
 }
 export interface JetBrainsPrebuilds {
     version?: "stable" | "latest" | "both";

--- a/components/ide/jetbrains/image/status/BUILD.yaml
+++ b/components/ide/jetbrains/image/status/BUILD.yaml
@@ -2,6 +2,7 @@ packages:
   - name: app
     type: go
     srcs:
+      - "testdata/**"
       - "**/*.go"
       - "go.mod"
       - "go.sum"

--- a/components/ide/jetbrains/image/status/go.mod
+++ b/components/ide/jetbrains/image/status/go.mod
@@ -5,13 +5,17 @@ go 1.18
 require (
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/google/go-cmp v0.5.7
+	github.com/stretchr/testify v1.7.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 require (

--- a/components/ide/jetbrains/image/status/go.sum
+++ b/components/ide/jetbrains/image/status/go.sum
@@ -428,6 +428,7 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/components/ide/jetbrains/image/status/main_test.go
+++ b/components/ide/jetbrains/image/status/main_test.go
@@ -11,6 +11,7 @@ import (
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetProductConfig(t *testing.T) {
@@ -24,6 +25,14 @@ func TestGetProductConfig(t *testing.T) {
 	if diff := cmp.Diff(expectation, actual); diff != "" {
 		t.Errorf("unexpected output (-want +got):\n%s", diff)
 	}
+}
+
+func TestParseGitpodConfig(t *testing.T) {
+	gitpodConfig, _ := parseGitpodConfig("testdata")
+	assert.Equal(t, 1, len(gitpodConfig.JetBrains.IntelliJ.Plugins))
+	assert.Equal(t, "both", gitpodConfig.JetBrains.IntelliJ.Prebuilds.Version)
+	assert.Equal(t, "-Xmx3g", gitpodConfig.JetBrains.IntelliJ.VMOptions)
+	assert.Equal(t, "-Xmx4096m -XX:MaxRAMPercentage=75", gitpodConfig.JetBrains.GoLand.VMOptions)
 }
 
 func TestUpdateVMOptions(t *testing.T) {
@@ -49,7 +58,7 @@ func TestUpdateVMOptions(t *testing.T) {
 		lessFunc := func(a, b string) bool { return a < b }
 
 		t.Run(test.Desc, func(t *testing.T) {
-			actual := updateVMOptions(test.Alias, test.Src)
+			actual := updateVMOptions(nil, test.Alias, test.Src)
 			if diff := cmp.Diff(strings.Fields(test.Expectation), strings.Fields(actual), cmpopts.SortSlices(lessFunc)); diff != "" {
 				t.Errorf("unexpected output (-want +got):\n%s", diff)
 			}
@@ -58,7 +67,7 @@ func TestUpdateVMOptions(t *testing.T) {
 		t.Run("updateVMOptions multiple time should be stable", func(t *testing.T) {
 			actual := test.Src
 			for i := 0; i < 5; i++ {
-				actual = updateVMOptions(test.Alias, actual)
+				actual = updateVMOptions(nil, test.Alias, actual)
 				if diff := cmp.Diff(strings.Fields(test.Expectation), strings.Fields(actual), cmpopts.SortSlices(lessFunc)); diff != "" {
 					t.Errorf("unexpected output (-want +got):\n%s", diff)
 				}

--- a/components/ide/jetbrains/image/status/testdata/.gitpod.yml
+++ b/components/ide/jetbrains/image/status/testdata/.gitpod.yml
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+# see https://github.com/gitpod-io/spring-petclinic/blob/master/.gitpod.yml
+tasks:
+  - init: ./mvnw package -DskipTests
+    command: java -jar target/*.jar
+    name: Run PetClinic app
+
+# exposed ports
+ports:
+  - port: 8080
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - redhat.java
+    - vscjava.vscode-java-debug
+    - vscjava.vscode-java-test
+    - pivotal.vscode-spring-boot
+
+jetbrains:
+  intellij:
+    plugins:
+      - com.haulmont.jpab
+    prebuilds:
+      version: both
+    vmoptions: "-Xmx3g"
+  goland:
+    vmoptions: "-Xmx4096m -XX:MaxRAMPercentage=75"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add `vmoptions` in gitpod schema (`.gitpod.yml`).

```yaml
jetbrains:
  intellij:
    vmoptions: "-Xmx4g"
  goland:
    vmoptions: "-Xmx3g"
```

- This is a follow-up PR with https://github.com/gitpod-io/gitpod/pull/10175
- Schema description text is borrowed from https://www.jetbrains.com/help/idea/remote-development-a.html#rd_add_vm_options
- VMOptions specified by project level `.gitpod.yml` have higher priority than user's environment variables. Suppose we have a workspace with:
    - project level `.gitpod.yml`: `jetbrains.intellij.vmoptions = "-Xmx4g"`
    - Gitpod user preferences `INTELLIJ_VMOPTIONS` EnvVar set to `-Xmx3g -Didea.is.internal=true` 
    - the final effective VMOptions will be `-Didea.is.internal=true -Xmx4g`


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Remedy for https://github.com/gitpod-io/gitpod/issues/8704

## How to test
<!-- Provide steps to test this PR -->

> Build & test `status` from a Gitpod workspace

- Start Gitpod workspace from this PR: https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/10768
- **Modify project's `.gitpod.yml` and insert a `jetbrains.intellij.vmoptions` field with value `"-Xmx4g"`**
- Launch a new Terminal and build the `status` binary: `cd /workspace/gitpod/components/ide/jetbrains/image/status && go build`. Replace the `status` binary: `rm /ide-desktop/status; cp status /ide-desktop/status`
- Kill the `status` process: `ps aux | grep status; kill -9 <pid>`
- (`supervisor` restart `status` immediately) Check JetBrains IDE server VMOptions: `jps -mlv | grep intellij | grep -i xmx`

Expected result:

- IDE Server should be running with `-Xmx4g`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note

- Allow customize VMOptions for JetBrains backend server, by setting "vmoptions" in .gitpod.yml

```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
