### PR TITLE
previewctl: Add SSH command

### DIFF
--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -26,6 +26,7 @@ func RootCmd(logger *logrus.Logger) *cobra.Command {
 		installContextCmd(logger),
 		getNameCmd(logger),
 		listPreviewsCmd(logger),
+		SSHPreviewCmd(logger),
 	)
 	return cmd
 }

--- a/dev/preview/previewctl/cmd/ssh_vm.go
+++ b/dev/preview/previewctl/cmd/ssh_vm.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func SSHPreviewCmd(logger *logrus.Logger) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "ssh",
+		Short: "SSH into a preview's Virtual Machine.",
+		Run: func(cmd *cobra.Command, args []string) {
+			p := preview.New(branch, logger)
+
+			err := p.SSHPreview()
+			if err != nil {
+				logger.WithFields(logrus.Fields{"err": err}).Fatal("Failed to SSH preview's VM.")
+			}
+		},
+	}
+
+	return cmd
+}

--- a/dev/preview/previewctl/pkg/preview/preview.go
+++ b/dev/preview/previewctl/pkg/preview/preview.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -76,6 +77,18 @@ func (p *Preview) InstallContext(watch bool) error {
 
 func installContext(branch string) error {
 	return exec.Command("bash", "/workspace/gitpod/dev/preview/install-k3s-kubeconfig.sh", "-b", branch).Run()
+}
+
+func (p *Preview) SSHPreview() error {
+	sshCommand := exec.Command("bash", "/workspace/gitpod/dev/preview/ssh-vm.sh", "-b", p.Branch)
+
+	// We need to bind standard output files to the command
+	// otherwise 'previewctl' will exit as soon as the script is run.
+	sshCommand.Stderr = os.Stderr
+	sshCommand.Stdin = os.Stdin
+	sshCommand.Stdout = os.Stdout
+
+	return sshCommand.Run()
 }
 
 func (p *Preview) GetPreviewName() string {

--- a/dev/preview/ssh-vm.sh
+++ b/dev/preview/ssh-vm.sh
@@ -9,28 +9,31 @@ THIS_DIR="$(dirname "$0")"
 
 source "$THIS_DIR/util/preview-name-from-branch.sh"
 
-if [[ -z "${VM_NAME:-}" ]]; then
-    VM_NAME="$(preview-name-from-branch)"
-fi
-
-NAMESPACE="preview-${VM_NAME}"
 PRIVATE_KEY=$HOME/.ssh/vm_id_rsa
 PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub
 PORT=8022
 USER="ubuntu"
 COMMAND=""
+BRANCH=""
 
-while getopts c:n:p:u:v: flag
+while getopts c:n:p:u:b: flag
 do
     case "${flag}" in
         c) COMMAND="${OPTARG}";;
         n) NAMESPACE="${OPTARG}";;
         p) PORT="${OPTARG}";;
         u) USER="${OPTARG}";;
-        v) VM_NAME="${OPTARG}";;
+        b) BRANCH="${2}";;
         *) ;;
     esac
 done
+
+if [[ "${BRANCH}" == "" ]]; then
+    VM_NAME="$(preview-name-from-branch)"
+else
+    VM_NAME="$(preview-name-from-branch "$BRANCH")"
+fi
+NAMESPACE="preview-${VM_NAME}"
 
 
 function log {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Add the command `previewctl ssh`, which will SSH into the related preview's Virtual Machine.

It can also be used to SSH into VM unrelated to the branch, by passing the `--branch` flag

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
We don't have a issue for this one, but we agreed to work on this in our team's sync

## How to test
<!-- Provide steps to test this PR -->
Open a preview from this PR and run:
* `previewctl ssh`
* `previewctl ssh --branch main`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
