### PR TITLE
Add tests for external dependencies in GCP

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -209,7 +209,7 @@ function callMakeTargets(phase: string, description: string, makeTarget: string)
 function randomize(resource: string, platform: string): string {
     // in the follow-up PR we will add `${platform}-${resource}` as an option here to
     // test against resource dependencies(storage, db, registry) for each cloud platform
-    const options = ["incluster"];
+    const options = [`${platform}-${resource}`, "incluster"];
     return options[Math.floor(Math.random() * options.length)];
 }
 

--- a/install/infra/terraform/gke/main.tf
+++ b/install/infra/terraform/gke/main.tf
@@ -152,6 +152,29 @@ resource "google_container_node_pool" "workspaces" {
   }
 }
 
+resource "google_sql_database_instance" "gitpod" {
+  name = "sql-${var.name}"
+  database_version = "MYSQL_5_7"
+  region = "${var.region}"
+  settings {
+      tier = "db-n1-standard-2"
+  }
+  deletion_protection = false
+}
+
+resource "google_sql_database" "database" {
+    name = "gitpod"
+    instance = "${google_sql_database_instance.gitpod.name}"
+    charset = "utf8"
+    collation = "utf8_general_ci"
+}
+
+resource "google_sql_user" "users" {
+    name = "gitpod"
+    instance = "${google_sql_database_instance.gitpod.name}"
+    password = "gitpod"
+}
+
 module "gke_auth" {
   depends_on = [google_container_node_pool.workspaces]
 

--- a/install/infra/terraform/k3s/main.tf
+++ b/install/infra/terraform/k3s/main.tf
@@ -171,6 +171,28 @@ resource "google_dns_record_set" "gitpod-dns-3" {
   rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
 }
 
+resource "google_sql_database_instance" "gitpod" {
+  name = "sql-${var.name}"
+  database_version = "MYSQL_5_7"
+  region = "${var.gcp_region}"
+  settings {
+      tier = "db-n1-standard-2"
+  }
+  deletion_protection = false
+}
+
+resource "google_sql_database" "database" {
+    name = "gitpod"
+    instance = "${google_sql_database_instance.gitpod.name}"
+    charset = "utf8"
+    collation = "utf8_general_ci"
+}
+
+resource "google_sql_user" "users" {
+    name = "gitpod"
+    instance = "${google_sql_database_instance.gitpod.name}"
+    password = "gitpod"
+}
 
 data "local_file" "kubeconfig" {
   depends_on = [null_resource.k3sup_install]

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -60,9 +60,34 @@ KOTS_KONFIG := "./manifests/kots-config.yaml"
 get-base-config:
 	envsubst < ${KOTS_KONFIG} > tmp_config.yml
 
+get-config-incluster:
+	@echo "Nothing to do"
+
+get-config-gcp-storage: config-file = "./manifests/kots-config-gcp-storage.yaml"
+get-config-gcp-storage:
+	export BASE64_GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | base64 -w 0) && \
+	envsubst '$${BASE64_GCP_KEY}' < ${config-file} > tmp_2_config.yml
+	yq m -i tmp_config.yml tmp_2_config.yml
+
+get-config-gcp-registry: config-file = "./manifests/kots-config-gcp-registry.yaml"
+get-config-gcp-registry:
+	export GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | base64 -w 0) && \
+	envsubst '$${GCP_KEY}' < ${config-file} > tmp_4_config.yml
+	yq m -i tmp_config.yml tmp_4_config.yml
+
+get-config-gcp-db: config-file = "./manifests/kots-config-gcp-db.yaml"
+get-config-gcp-db:
+	export BASE64_GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | base64 -w 0) && \
+	envsubst '$${BASE64_GCP_KEY}' < ${config-file} > tmp_4_config.yml
+	envsubst '$${TF_VAR_TEST_ID}' < tmp_4_config.yml > tmp_5_config.yml
+	yq m -i tmp_config.yml tmp_5_config.yml
+
+storage ?= incluster
+registry ?= incluster
+db ?= incluster
 .PHONY:
 ## generate-kots-config: Generate the kots config based on test config
-generate-kots-config: get-base-config
+generate-kots-config: get-base-config get-config-${storage} get-config-${registry} get-config-${db}
 
 license_community_beta := "../licenses/Community (Beta).yaml"
 license_community_stable := "../licenses/Community.yaml"

--- a/install/tests/manifests/kots-config-gcp-db.yaml
+++ b/install/tests/manifests/kots-config-gcp-db.yaml
@@ -1,0 +1,22 @@
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+spec:
+  values:
+      db_incluster:
+        value: "0"
+        data: "db_incluster"
+      db_cloudsql_enabled:
+        value: "1"
+        data: "db_cloudsql_enabled"
+      db_cloudsql_instance:
+        value: sh-automated-tests:europe-west1:sql-${TF_VAR_TEST_ID}
+        data: "db_cloudsql_instance"
+      db_gcp_credentials:
+        value: "${BASE64_GCP_KEY}"
+        data: "db_cloudsql_credentials"
+      db_gcp_username:
+        value: gitpod
+        data: "db_username"
+      db_password:
+        value: gitpod
+        data: "db_password"

--- a/install/tests/manifests/kots-config-gcp-registry.yaml
+++ b/install/tests/manifests/kots-config-gcp-registry.yaml
@@ -1,0 +1,19 @@
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+spec:
+  values:
+      reg_incluster:
+        value: "0"
+        data: "reg_incluster"
+      reg_url:
+        value: "gcr.io/sh-automated-tests"
+        data: "reg_url"
+      reg_server:
+        value: "gcr.io"
+        data: "reg_server"
+      reg_username:
+        value: "_json_key"
+        data: "reg_username"
+      reg_password:
+        value: "${GCP_KEY}"
+        data: "reg_password"

--- a/install/tests/manifests/kots-config-gcp-storage.yaml
+++ b/install/tests/manifests/kots-config-gcp-storage.yaml
@@ -1,0 +1,16 @@
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+spec:
+  values:
+      store_provider:
+        value: gcp
+        data: "store_provider"
+      store_region:
+        value: "europe-west1"
+        data: "store_region"
+      store_gcp_project:
+        value: "sh-automated-tests"
+        data: "store_gcp_project"
+      store_gcp_credentials:
+        value: "${BASE64_GCP_KEY}"
+        data: "store_gcp_credentials"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds the external dependencies test for GCP cloud platform. These dependencies include `cloudsql` as external database, `GCR` as external registry, and `cloud storage` as external storage. These dependencies are randomly selected for each test providing us a overall testing of every combination over a course of days. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can run the following command to test one of the available combinations:
```
werft run github -j .werft/gke-installer-tests.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
