### PR TITLE
call prestophook.sh from ring1 directly

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -572,15 +572,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			// not needed, since it is using dedicated disk
 			pod.Spec.Containers[0].VolumeMounts[0].MountPropagation = nil
 
-			// add prestop hook to capture git status
-			pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
-				PreStop: &corev1.LifecycleHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"/bin/sh", "-c", "/.supervisor/workspacekit lift /.supervisor/prestophook.sh"},
-					},
-				},
-			}
-
 			// pavel: 133332 is the Gitpod UID (33333) shifted by 99999. The shift happens inside the workspace container due to the user namespace use.
 			// We set this magical ID to make sure that gitpod user inside the workspace can write into /workspace folder mounted by PVC
 			gitpodGUID := int64(133332)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When adding support for prebuilds to work with PVC, noticed that pod's lifecycle hook does not execute for prebuilds, because when they are done, they transition into completed state. 
So this PR changes how prestophook.sh is executed and allows prebuilds to execute it as well now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/pull/10689

## How to test
<!-- Provide steps to test this PR -->
1. Open preview environment
2. Open workspace. Edit file. Close workspace. Notice pending changes in workspace dashboard.
3. Now enable persistent_volume_claim feature from admin dashboard for your user.
4. Do step 2 again.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
