### PR TITLE
[usage] Fix querying workspace instances to use startedTime existence to filter

### DIFF
--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -28,7 +28,6 @@ func TestUsageReconciler_ReconcileTimeRange(t *testing.T) {
 
 	startOfMay := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
 	startOfJune := time.Date(2022, 06, 1, 0, 00, 00, 00, time.UTC)
-	instanceStatus := []byte(`{"phase": "stopped", "conditions": {"deployed": false, "pullingImages": false, "serviceExists": false}}`)
 
 	scenarios := []Scenario{
 		(func() Scenario {
@@ -48,33 +47,33 @@ func TestUsageReconciler_ReconcileTimeRange(t *testing.T) {
 			})
 			instances := []db.WorkspaceInstance{
 				// Ran throughout the reconcile period
-				{
+				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 					ID:           uuid.New(),
 					WorkspaceID:  workspace.ID,
 					CreationTime: db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
+					StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
 					StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-					Status:       instanceStatus,
-				},
+				}),
 				// Still running
-				{
+				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 					ID:           uuid.New(),
 					WorkspaceID:  workspace.ID,
 					CreationTime: db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
-					Status:       instanceStatus,
-				},
+					StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
+				}),
 				// No creation time, invalid record
-				{
+				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 					ID:          uuid.New(),
 					WorkspaceID: workspace.ID,
+					StartedTime: db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
 					StoppedTime: db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-					Status:      instanceStatus,
-				},
+				}),
 			}
 
 			expectedRuntime := instances[0].WorkspaceRuntimeSeconds(scenarioRunTime) + instances[1].WorkspaceRuntimeSeconds(scenarioRunTime)
 
 			return Scenario{
-				Name:        "oen team with one workspace",
+				Name:        "one team with one workspace",
 				Memberships: []db.TeamMembership{membership},
 				Workspaces:  []db.Workspace{workspace},
 				Instances:   instances,
@@ -101,13 +100,13 @@ func TestUsageReconciler_ReconcileTimeRange(t *testing.T) {
 			workspaceID := "gitpodio-gitpod-gyjr82jkfnd"
 			var instances []db.WorkspaceInstance
 			for i := 0; i < 100; i++ {
-				instances = append(instances, db.WorkspaceInstance{
+				instances = append(instances, dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 					ID:           uuid.New(),
 					WorkspaceID:  workspaceID,
 					CreationTime: db.NewVarcharTime(time.Date(2022, 05, 01, 00, 00, 00, 00, time.UTC)),
+					StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 01, 00, 00, 00, 00, time.UTC)),
 					StoppedTime:  db.NewVarcharTime(time.Date(2022, 05, 31, 23, 59, 59, 999999, time.UTC)),
-					Status:       instanceStatus,
-				})
+				}))
 			}
 
 			return Scenario{

--- a/components/usage/pkg/db/dbtest/workspace_instance.go
+++ b/components/usage/pkg/db/dbtest/workspace_instance.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"database/sql"
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
+	"testing"
+	"time"
+)
+
+var (
+	workspaceInstanceStatus = `{"phase": "stopped", "conditions": {"deployed": false, "pullingImages": false, "serviceExists": false}}`
+)
+
+func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.WorkspaceInstance {
+	t.Helper()
+
+	id := uuid.New()
+	if instance.ID.ID() != 0 { // empty value
+		id = instance.ID
+	}
+
+	workspaceID := generateWorkspaceID()
+	if instance.WorkspaceID != "" {
+		workspaceID = instance.WorkspaceID
+	}
+
+	creationTime := db.VarcharTime{}
+	if instance.CreationTime.IsSet() {
+		creationTime = instance.CreationTime
+	}
+
+	startedTime := db.VarcharTime{}
+	if instance.StartedTime.IsSet() {
+		startedTime = instance.StartedTime
+	}
+
+	deployedTime := db.VarcharTime{}
+	if instance.DeployedTime.IsSet() {
+		deployedTime = instance.DeployedTime
+	}
+
+	stoppedTime := db.VarcharTime{}
+	if instance.StoppedTime.IsSet() {
+		stoppedTime = instance.StoppedTime
+	}
+
+	stoppingTime := db.VarcharTime{}
+	if instance.StoppingTime.IsSet() {
+		stoppingTime = instance.StoppingTime
+	}
+
+	status := []byte(workspaceInstanceStatus)
+	if instance.Status.String() != "" {
+		status = instance.Status
+	}
+
+	return db.WorkspaceInstance{
+		ID:                 id,
+		WorkspaceID:        workspaceID,
+		Configuration:      nil,
+		Region:             "",
+		ImageBuildInfo:     sql.NullString{},
+		IdeURL:             "",
+		WorkspaceBaseImage: "",
+		WorkspaceImage:     "",
+		CreationTime:       creationTime,
+		StartedTime:        startedTime,
+		DeployedTime:       deployedTime,
+		StoppedTime:        stoppedTime,
+		LastModified:       time.Time{},
+		StoppingTime:       stoppingTime,
+		LastHeartbeat:      "",
+		StatusOld:          sql.NullString{},
+		Status:             status,
+		Phase:              sql.NullString{},
+		PhasePersisted:     "",
+	}
+}

--- a/components/usage/pkg/db/workspace_instance_test.go
+++ b/components/usage/pkg/db/workspace_instance_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -100,88 +101,86 @@ func TestListWorkspaceInstancesInRange(t *testing.T) {
 	conn := db.ConnectForTests(t)
 
 	workspaceID := "gitpodio-gitpod-gyjr82jkfnd"
-	status := []byte(`{"phase": "stopped", "conditions": {"deployed": false, "pullingImages": false, "serviceExists": false}}`)
-	valid := []*db.WorkspaceInstance{
+	valid := []db.WorkspaceInstance{
 		// In the middle of May
-		{
-			ID:           uuid.New(),
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 05, 15, 12, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 15, 12, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 05, 15, 13, 00, 00, 00, time.UTC)),
-			Status:       status,
-		},
+		}),
 		// Start of May
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 05, 1, 1, 00, 00, 00, time.UTC)),
-			Status:       status,
-		},
+		}),
 		// End of May
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 05, 31, 23, 59, 59, 999999, time.UTC)),
-			Status:       status,
-		},
+		}),
 		// Started in April, but continued into May
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 04, 30, 23, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 04, 30, 23, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 05, 1, 0, 0, 0, 0, time.UTC)),
-			Status:       status,
-		},
+		}),
 		// Started in May, but continued into June
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			Status:       status,
-		},
+		}),
 		// Started in April, but continued into June (ran for all of May)
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 04, 31, 23, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 04, 31, 23, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			Status:       status,
-		},
+		}),
 		// Stopped in May, no creation time, should be retrieved but this is a poor data quality record.
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:          uuid.New(),
 			WorkspaceID: workspaceID,
+			StartedTime: db.NewVarcharTime(time.Date(2022, 05, 1, 1, 0, 0, 0, time.UTC)),
 			StoppedTime: db.NewVarcharTime(time.Date(2022, 05, 1, 1, 0, 0, 0, time.UTC)),
-			Status:      status,
-		},
+		}),
 		// Started in April, no stop time, still running
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 04, 31, 23, 00, 00, 00, time.UTC)),
-			Status:       status,
-		},
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 04, 31, 23, 00, 00, 00, time.UTC)),
+		}),
 	}
-	invalid := []*db.WorkspaceInstance{
+	invalid := []db.WorkspaceInstance{
 		// Start of June
-		{
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:           uuid.New(),
 			WorkspaceID:  workspaceID,
 			CreationTime: db.NewVarcharTime(time.Date(2022, 06, 1, 00, 00, 00, 00, time.UTC)),
+			StartedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 00, 00, 00, 00, time.UTC)),
 			StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			Status:       status,
-		},
+		}),
 	}
 
-	var all []*db.WorkspaceInstance
+	var all []db.WorkspaceInstance
 	all = append(all, valid...)
 	all = append(all, invalid...)
 
 	for _, instance := range all {
-		tx := conn.Create(instance)
+		tx := conn.Create(&instance)
 		require.NoError(t, tx.Error)
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The underlying query used `creationTime` to validate the record should be included but in https://github.com/gitpod-io/gitpod/issues/10642#issuecomment-1154861661 it was pointed out that should not be the case, and `startedTime` should be used instead.

The rest of the changes are to tests, and streamlining test object creation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10642

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
