### PR TITLE
Add `gp timeout show` command

### DIFF
--- a/components/gitpod-cli/cmd/timeout-show.go
+++ b/components/gitpod-cli/cmd/timeout-show.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/spf13/cobra"
+)
+
+// showTimeoutCommand shows the workspace timeout
+var showTimeoutCommand = &cobra.Command{
+	Use:   "show",
+	Short: "Show the current workspace timeout",
+	Run: func(_ *cobra.Command, _ []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			fail(err.Error())
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:getWorkspaceTimeout",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+
+		res, err := client.GetWorkspaceTimeout(ctx, wsInfo.WorkspaceId)
+		if err != nil {
+			fail(err.Error())
+		}
+
+		// Try to use `DurationRaw` but fall back to `Duration` in case of
+		// old server component versions that don't expose it.
+		if res.DurationRaw != "" {
+			fmt.Println(res.DurationRaw)
+		} else {
+			fmt.Println(res.Duration)
+		}
+	},
+}
+
+func init() {
+	timeoutCmd.AddCommand(showTimeoutCommand)
+}

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1707,8 +1707,9 @@ type StartWorkspaceOptions struct {
 
 // GetWorkspaceTimeoutResult is the GetWorkspaceTimeoutResult message type
 type GetWorkspaceTimeoutResult struct {
-	CanChange bool   `json:"canChange,omitempty"`
-	Duration  string `json:"duration,omitempty"`
+	CanChange   bool   `json:"canChange,omitempty"`
+	DurationRaw string `json:"durationRaw,omitempty"`
+	Duration    string `json:"duration,omitempty"`
 }
 
 // WorkspaceInstancePort is the WorkspaceInstancePort message type


### PR DESCRIPTION
## Description
Add a `gp timeout show` command to the `gp` CLI to go along with the recently added `gp timeout extend` command (see https://github.com/gitpod-io/gitpod/pull/10619).

- [x] ~~Need to hold until PR https://github.com/gitpod-io/gitpod/pull/10896 deployed~~
- [x] Maybe want to follow up @filiptronicek 's suggestion https://github.com/gitpod-io/gitpod/pull/10782#issuecomment-1162703143 


## Related Issue(s)


## How to test

1. Create a workspace in preview environment
2. Run `gp timeout show`
3. Output should be (value depends on user's plan):
  ```
  60m
  ```
4. Extend the workspace timeout with `gp timeout extend`. 
5. Rerun `gp timeout show`. Output should be:
  ```
  180m
  ```
6. Open another workspace, and extend its timeout `gp timeout extend`
7. Back to first one, `gp timeout show` should back to original one

## Release Notes

```release-note
Add command `gp timeout show` to show the timeout of current workspace
```

## Documentation

We'll need to add something to https://github.com/gitpod-io/website/pull/2218 either before or after it's merged.

## Werft options:

- [x] /werft with-preview
