### PR TITLE
[db][protocol] Implement a CostCenter entity to attribute workspace usage to

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -67,6 +67,8 @@ import { TypeORMBlockedRepositoryDBImpl } from "./typeorm/blocked-repository-db-
 import { BlockedRepositoryDB } from "./blocked-repository-db";
 import { WebhookEventDB } from "./webhook-event-db";
 import { WebhookEventDBImpl } from "./typeorm/webhook-event-db-impl";
+import { CostCenterDB } from "./cost-center-db";
+import { CostCenterDBImpl } from "./typeorm/cost-center-db-impl";
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -143,6 +145,9 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
     bind(ProjectDB).toService(ProjectDBImpl);
     bind(WebhookEventDBImpl).toSelf().inSingletonScope();
     bind(WebhookEventDB).toService(WebhookEventDBImpl);
+
+    bind(CostCenterDBImpl).toSelf().inSingletonScope();
+    bind(CostCenterDB).toService(CostCenterDBImpl);
 
     // com concerns
     bind(AccountingDB).to(TypeORMAccountingDBImpl).inSingletonScope();

--- a/components/gitpod-db/src/cost-center-db.ts
+++ b/components/gitpod-db/src/cost-center-db.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { CostCenter } from "@gitpod/gitpod-protocol";
+
+export const CostCenterDB = Symbol("CostCenterDB");
+export interface CostCenterDB {
+    storeEntry(ts: CostCenter): Promise<void>;
+    findById(id: string): Promise<CostCenter | undefined>;
+}

--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -39,3 +39,4 @@ export * from "./project-db";
 export * from "./team-db";
 export * from "./installation-admin-db";
 export * from "./webhook-event-db";
+export * from "./cost-center-db";

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -280,6 +280,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             deletionColumn: "deleted",
             timeColumn: "_lastModified",
         },
+        {
+            name: "d_b_cost_center",
+            primaryKeys: ["id"],
+            deletionColumn: "deleted",
+            timeColumn: "_lastModified",
+        },
     ];
 
     public getSortedTables(): TableDescription[] {

--- a/components/gitpod-db/src/typeorm/cost-center-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/cost-center-db-impl.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { injectable, inject } from "inversify";
+import { Repository } from "typeorm";
+
+import { CostCenter } from "@gitpod/gitpod-protocol";
+
+import { CostCenterDB } from "../cost-center-db";
+import { DBCostCenter } from "./entity/db-cost-center";
+import { TypeORM } from "./typeorm";
+
+@injectable()
+export class CostCenterDBImpl implements CostCenterDB {
+    @inject(TypeORM) protected readonly typeORM: TypeORM;
+
+    protected async getEntityManager() {
+        return (await this.typeORM.getConnection()).manager;
+    }
+
+    protected async getRepo(): Promise<Repository<DBCostCenter>> {
+        return (await this.getEntityManager()).getRepository(DBCostCenter);
+    }
+
+    async storeEntry(ts: CostCenter): Promise<void> {
+        const repo = await this.getRepo();
+        await repo.save(ts);
+    }
+
+    async findById(id: string): Promise<CostCenter | undefined> {
+        const repo = await this.getRepo();
+        return repo.findOne(id);
+    }
+}

--- a/components/gitpod-db/src/typeorm/entity/db-cost-center.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-cost-center.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { Entity, Column, PrimaryColumn } from "typeorm";
+import { CostCenter } from "@gitpod/gitpod-protocol";
+
+@Entity()
+// on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
+export class DBCostCenter implements CostCenter {
+    @PrimaryColumn()
+    id: string;
+
+    @Column()
+    spendingLimit: number;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
+}

--- a/components/gitpod-db/src/typeorm/migration/1658241900000-CostCenter.ts
+++ b/components/gitpod-db/src/typeorm/migration/1658241900000-CostCenter.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CostCenter1658241900000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TABLE IF NOT EXISTS `d_b_cost_center` (`id` char(255) NOT NULL, `spendingLimit` int(11) NOT NULL DEFAULT '0', `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1481,3 +1481,11 @@ export interface Terms {
     readonly content: string;
     readonly formElements?: object;
 }
+
+export interface CostCenter {
+    readonly id: string;
+    /**
+     * Unit: credits
+     */
+    spendingLimit: number;
+}

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -16,7 +16,7 @@ import {
     WORKSPACE_TIMEOUT_EXTENDED,
     WORKSPACE_TIMEOUT_EXTENDED_ALT,
 } from "@gitpod/gitpod-protocol";
-import { ProjectDB, TermsAcceptanceDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { CostCenterDB, ProjectDB, TermsAcceptanceDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";
@@ -65,6 +65,7 @@ export class UserService {
     @inject(TermsAcceptanceDB) protected readonly termsAcceptanceDb: TermsAcceptanceDB;
     @inject(TermsProvider) protected readonly termsProvider: TermsProvider;
     @inject(ProjectDB) protected readonly projectDb: ProjectDB;
+    @inject(CostCenterDB) protected readonly costCenterDb: CostCenterDB;
 
     /**
      * Takes strings in the form of <authHost>/<authName> and returns the matching User


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implement a CostCenter entity to attribute workspace usage to.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10757

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
