### PR TITLE
[supervisor] Make compatible with run-gp

### DIFF
--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -12,6 +12,10 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
 )
 
+var runOpts struct {
+	RunGP bool
+}
+
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "starts the supervisor",
@@ -20,10 +24,11 @@ var runCmd = &cobra.Command{
 		log.Init(ServiceName, Version, true, false)
 		common_grpc.SetupLogging()
 		supervisor.Version = Version
-		supervisor.Run()
+		supervisor.Run(supervisor.WithRunGP(runOpts.RunGP))
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(runCmd)
+	runCmd.Flags().BoolVar(&runOpts.RunGP, "rungp", false, "run supervisor in a run-gp context")
 }


### PR DESCRIPTION
## Description
Makes supervisor compatible with run-gp and cleans up some code.

## How to test
In Gitpod no behaviour should change.

To test this with run-gp:
1. open a workspace on https://github.com/gitpod-io/run-gp
2. run `./hack/update-images.sh cw-run-gp-compat.3`
3. run `./hack/update-assets.sh`
4. run `go run main.go`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
