### PR TITLE
[Usage-based] Update credit prices, calculation, and Stripe product IDs

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -7,7 +7,7 @@ data:
   config: >
     {
       "usageProductPriceIds": {
-        "EUR": "price_1LAyjSGadRXm50o3MO7CNyVU",
-        "USD": "price_1LAyjSGadRXm50o3tkwZe1N2"
+        "EUR": "price_1LD8cQGadRXm50o30QwBU9aY",
+        "USD": "price_1LD8cQGadRXm50o3ftnIiUZL"
       }
     }

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -7,6 +7,7 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -111,6 +112,7 @@ func queriesForCustomersWithTeamIds(teamIds []string) []string {
 }
 
 // workspaceSecondsToCredits converts seconds (of workspace usage) into Stripe credits.
+// (1 credit = 6 minutes, rounded up)
 func workspaceSecondsToCredits(seconds int64) int64 {
-	return (seconds + 59) / 60
+	return int64(math.Ceil(float64(seconds) / (60 * 6)))
 }

--- a/components/usage/pkg/stripe/stripe_test.go
+++ b/components/usage/pkg/stripe/stripe_test.go
@@ -106,19 +106,24 @@ func TestWorkspaceSecondsToCreditsCalcuation(t *testing.T) {
 			ExpectedCredits: 1,
 		},
 		{
-			Name:            "61 seconds",
-			Seconds:         61,
-			ExpectedCredits: 2,
-		},
-		{
 			Name:            "90 seconds",
 			Seconds:         90,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "6 minutes",
+			Seconds:         360,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "6 minutes and 1 second",
+			Seconds:         361,
 			ExpectedCredits: 2,
 		},
 		{
 			Name:            "1 hour",
 			Seconds:         3600,
-			ExpectedCredits: 60,
+			ExpectedCredits: 10,
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Update credit prices, calculation, and Stripe product IDs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Trigger a custom Werft build (using the config from this PR)
    - E.g. like so: `kubectx dev` then `werft job run github -j .werft/build.yaml`
1. Once built, in the preview, create a team called "Gitpod" (or any team name containing the word "Gitpod")
2. Go to Team Settings > Team Billing
3. Wait for the Usage-Based UI to show up
4. Subscribe to Usage-Based Billing by entering a credit card (e.g. 4242 4242 4242 4242, 4/24, 424)
5. Wait for the Stripe subscription to be created
6. Once you can, click on "Manage Billing"
    - Your subscription should be linked to a product called `Gitpod Usage (with latest prices)`
7. Start a workspace
8. Wait for one hour (or manually trigger a `usage` report*)
9. Go to the Stripe dashboard > Customers > (your created test customer) > click on the Subscription
10. The "Upcoming invoice" should show some credits (with the first 50 credits being free)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment