### PR TITLE
[install/infra] Add namespace/context to eks Terraform workspaces

### DIFF
--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -74,7 +74,7 @@ pod:
         sudo chown -R gitpod:gitpod /workspace
         sudo apt update && apt install gettext-base
 
-        export TF_VAR_TEST_ID=$(echo $RANDOM | md5sum | head -c 5; echo)
+        export TF_VAR_TEST_ID="eks-$(date +%s)-$(echo $RANDOM | md5sum | head -c 5; echo)"
 
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
         printf '{{ toJson . }}' > context.json


### PR DESCRIPTION
## Description

At present we generate random 5 character workspace names for our
terraform code. While suitable for machine use, these terse names don't
provide execution context, making it difficult to locate relevant workspaces
and prune old namespaces.

```
$ terraform workspace list|wc -l
298
```

This commit addresses the issue by adding a prefix of the execution
context (EKS) and the current unix epoch to auto-generated terraform
workspace to assist identification of recent CI runs and remove stale
workspaces.

This commit doesn't address this issue in other environments (gke, k3s).
We can address that in a followup commit.

## Related Issue(s)

N/A

## How to test

Run a werft job against this branch and check the terraform workspace list; a new workspace named `eks-<timestamp>-<rand{5}>` should be created.

## Release Notes

N/A

## Documentation

N/A

## Werft options:
