### PR TITLE
feature(supervisor): installation of dotfiles via Makefile

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -485,6 +485,7 @@ func installDotfiles(ctx context.Context, cfg *Config, tokenService *InMemoryTok
 			"install",
 			"bootstrap.sh",
 			"bootstrap",
+			"Makefile",
 			"script/bootstrap",
 			"setup.sh",
 			"setup",


### PR DESCRIPTION
## Description

I and many folks use a `Makefile` as a standard interface to dotfiles. This pull-request adds support for `Makefile`s

## How to test

* Change was directly applied using GitHub editor and is pending test
* Start instance, configure dotfiles repo with `Makefile` - does it work?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
feature: installation of dotfiles via Makefile
```

## Documentation

Will require https://www.gitpod.io/docs/config-dotfiles to be updated once this ships.

