### PR TITLE
observability: Add GitpodWorkspaceTooLongTerminating alert.

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -141,8 +141,8 @@
             },
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooLongTerminating.md',
-              summary: 'workspace pods are too long in terminating',
-              description: 'workspace pods are too long in terminating',
+              summary: 'workspace pods are terminating for too long',
+              description: 'workspace pods are terminating for too long',
             },
             expr: |||
               sum(time() - kube_pod_deletion_timestamp{namespace="default", pod=~"^ws-.*"}) by (pod) > 24 * 60 * 60

--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -134,6 +134,20 @@
               gitpod_ws_manager_workspace_phase_total{phase="PENDING", type="PREBUILD"} > 20
             |||,
           },
+          {
+            alert: 'GitpodWorkspaceTooLongTerminating',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooLongTerminating.md',
+              summary: 'workspace pods are too long in termintaing',
+              description: 'workspace pods are too long in termintaing',
+            },
+            expr: |||
+              sum(time() - kube_pod_deletion_timestamp{namespace="default", pod=~"^ws-.*"}) by (pod) > 24 * 60 * 60
+            |||,
+          },
         ],
       },
     ],

--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -141,8 +141,8 @@
             },
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooLongTerminating.md',
-              summary: 'workspace pods are too long in termintaing',
-              description: 'workspace pods are too long in termintaing',
+              summary: 'workspace pods are too long in terminating',
+              description: 'workspace pods are too long in terminating',
             },
             expr: |||
               sum(time() - kube_pod_deletion_timestamp{namespace="default", pod=~"^ws-.*"}) by (pod) > 24 * 60 * 60


### PR DESCRIPTION
## Description

Workspaces that have been terminating for more than one day will be detected and acted upon as they affect the backup process for other workspaces on the same node.
[grafana](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22VictoriaMetrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum(time()%20-%20kube_pod_deletion_timestamp%7Bnamespace%3D%5C%22default%5C%22,%20pod%3D~%5C%22%5Ews-.*%5C%22%7D)%20by%20(pod)%20%3E%2024%20*%2060%20*%2060%20%22%7D%5D,%22range%22:%7B%22from%22:%221655276180662%22,%22to%22:%221655845434062%22%7D%7D)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Runbook: https://github.com/gitpod-io/runbooks/pull/355

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
