### PR TITLE
[usage] Fix flaky test for ListWorkspacesByID

### DIFF
--- a/components/usage/pkg/db/workspace_test.go
+++ b/components/usage/pkg/db/workspace_test.go
@@ -87,14 +87,10 @@ func stringToVarchar(t *testing.T, s string) db.VarcharTime {
 }
 
 func TestListWorkspacesByID(t *testing.T) {
-	conn := db.ConnectForTests(t)
-
 	workspaces := []db.Workspace{
-		dbtest.NewWorkspace(t, db.Workspace{ID: "gitpodio-gitpod-aaaaaaaaaaa"}),
-		dbtest.NewWorkspace(t, db.Workspace{ID: "gitpodio-gitpod-bbbbbbbbbbb"}),
+		dbtest.NewWorkspace(t, db.Workspace{}),
+		dbtest.NewWorkspace(t, db.Workspace{}),
 	}
-	tx := conn.Create(workspaces)
-	require.NoError(t, tx.Error)
 
 	for _, scenario := range []struct {
 		Name     string
@@ -133,6 +129,11 @@ func TestListWorkspacesByID(t *testing.T) {
 		},
 	} {
 		t.Run(scenario.Name, func(t *testing.T) {
+			conn := db.ConnectForTests(t)
+
+			tx := conn.Create(workspaces)
+			require.NoError(t, tx.Error)
+
 			results, err := db.ListWorkspacesByID(context.Background(), conn, scenario.QueryIDs)
 			require.NoError(t, err)
 			require.Len(t, results, scenario.Expected)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Sometimes (~15/100 from my repeated runs), the DB cleanup hook post tests would conflict with the data creation and would cause the tests to fail due to the exact missing IDs. Generating new random IDs hasn't failed in my test runs.


## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE 

