### PR TITLE
[experiments] Configure ConfigCat SDK through installer

### DIFF
--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -77,6 +77,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		common.WebappTracingEnv(ctx),
 		common.AnalyticsEnv(&ctx.Config),
 		common.MessageBusEnv(&ctx.Config),
+		configcatEnv(ctx),
 		[]corev1.EnvVar{
 			{
 				Name:  "CONFIG_PATH",
@@ -397,4 +398,25 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 	}, nil
+}
+
+func configcatEnv(ctx *common.RenderContext) []corev1.EnvVar {
+	var sdkKey string
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.ConfigcatKey != "" {
+			sdkKey = cfg.WebApp.ConfigcatKey
+		}
+		return nil
+	})
+
+	if sdkKey == "" {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "CONFIGCAT_SDK_KEY",
+			Value: sdkKey,
+		},
+	}
 }

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -103,6 +103,7 @@ type WebAppConfig struct {
 	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
 	DisableMigration       bool                   `json:"disableMigration"`
 	Usage                  *UsageConfig           `json:"usage,omitempty"`
+	ConfigcatKey           string                 `json:"configcatKey"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In https://github.com/gitpod-io/gitpod/pull/10807, we are adding support for configuring configcat through an ENV variable to target various ConfigCat environments.

The SDK Key is **NOT A SECRET**, it is a unique identifier of app just like Google Analytics has a unique identifier.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to #10807 

## How to test
<!-- Provide steps to test this PR -->
Run installer with config:
```
experimental:
	webApp:
		configcatKey: "config-cat-key-here"
```
Observe it's in the resulting yaml

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE
