### PR TITLE
[ws-manager] Watch VolumeSnapshot object and notify to the Pod finalizer loop

### DIFF
--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -200,6 +200,16 @@ var runCmd = &cobra.Command{
 			log.WithError(err).Fatal(err, "unable to create controller", "controller", "Pod")
 		}
 
+		err = (&manager.VolumeSnapshotReconciler{
+			Monitor: monitor,
+			Client:  mgr.GetClient(),
+			Log:     ctrl.Log.WithName("controllers").WithName("VolumeSnapshot"),
+			Scheme:  mgr.GetScheme(),
+		}).SetupWithManager(mgr)
+		if err != nil {
+			log.WithError(err).Fatal(err, "unable to create controller", "controller", "VolumeSnapshot")
+		}
+
 		if cfg.PProf.Addr != "" {
 			go pprof.Serve(cfg.PProf.Addr)
 		}

--- a/components/ws-manager/pkg/manager/volume_snapshot_controller.go
+++ b/components/ws-manager/pkg/manager/volume_snapshot_controller.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package manager
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// VolumeSnapshotReconciler reconciles a VolumeSnapshot object
+type VolumeSnapshotReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+
+	Monitor *Monitor
+}
+
+// Reconcile performs a reconciliation of a volume snapshot
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
+func (r *VolumeSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var vs volumesnapshotv1.VolumeSnapshot
+	err := r.Client.Get(context.Background(), req.NamespacedName, &vs)
+	if errors.IsNotFound(err) {
+		// volume snapshot is gone - that's ok
+		return reconcile.Result{}, nil
+	}
+
+	r.Monitor.eventpool.Add(vs.Name, watch.Event{
+		Type:   watch.Modified,
+		Object: &vs,
+	})
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VolumeSnapshotReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&volumesnapshotv1.VolumeSnapshot{}).
+		Complete(r)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add volume_snapshot_controller to watch the VolumeSnapshot object, and once the VolumeSnapshot object is ready, notify the Pod in the finalizer loop that the VolumeSnapshot is ready.
This improves the volume snapshot metric `gitpod_ws_manager_volume_snapshot_seconds` more accurately when the workspace stops.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10334

## How to test
<!-- Provide steps to test this PR -->
1. Enable PVC feature flag
2. Watch the time that the VolumeSnapshot object becomes ready `kubectl get vs -w`
3. Open a workspace, write some data into it, close the workspace
4. Port forward ws-manager 9500 to localhost `kubectl port-forward <ws-manager-pod> 9500:9500`
5. Get the metrics `curl -XGET 'localhost:9500/metrics' | grep gitpod_ws_manager_volume_snapshot_seconds`, and check if the time matches step 2.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
