### PR TITLE
[db] fix adminGetWorkspaces/findAllWorkspaceAndInstances

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -1048,7 +1048,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
             .createQueryBuilder("ws")
             // We need to put the subquery into the join condition (ON) here to be able to reference `ws.id` which is
             // not possible in a subquery on JOIN (e.g. 'LEFT JOIN (SELECT ... WHERE i.workspaceId = ws.id)')
-            .leftJoinAndMapOne(
+            .innerJoinAndMapOne(
                 "ws.instance",
                 DBWorkspaceInstance,
                 "wsi",


### PR DESCRIPTION
## Description
This PR fixes a SQL query bug in the admin dashboard, which causes to  return an empty page instead the list of a user's workspaces. 

## How to test
Verify that workspaces are shown as expected in the admin panel.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix a SQL query bug on admin panel.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
