### PR TITLE
Allow custom annotations for k8s resources

### DIFF
--- a/install/installer/pkg/common/display.go
+++ b/install/installer/pkg/common/display.go
@@ -99,9 +99,10 @@ func GenerateInstallationConfigMap(ctx *RenderContext, objects []RuntimeObject) 
 	cfgMap := corev1.ConfigMap{
 		TypeMeta: TypeMetaConfigmap,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      component,
-			Namespace: ctx.Namespace,
-			Labels:    DefaultLabels(component),
+			Name:        component,
+			Namespace:   ctx.Namespace,
+			Labels:      CustomOverrideLabel(ctx, component, TypeMetaConfigmap),
+			Annotations: CustomOverrideAnnotation(ctx, component, TypeMetaConfigmap),
 		},
 	}
 

--- a/install/installer/pkg/common/objects.go
+++ b/install/installer/pkg/common/objects.go
@@ -28,9 +28,10 @@ func DefaultServiceAccount(component string) RenderFunc {
 			&corev1.ServiceAccount{
 				TypeMeta: TypeMetaServiceAccount,
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      component,
-					Namespace: cfg.Namespace,
-					Labels:    DefaultLabels(component),
+					Name:        component,
+					Namespace:   cfg.Namespace,
+					Labels:      CustomOverrideLabel(cfg, component, TypeMetaServiceAccount),
+					Annotations: CustomOverrideAnnotation(cfg, component, TypeMetaServiceAccount),
 				},
 				AutomountServiceAccountToken: pointer.Bool(true),
 				ImagePullSecrets:             pullSecrets,
@@ -80,6 +81,18 @@ func GenerateService(component string, ports []ServicePort, mod ...func(spec *co
 			// Apply any custom modifications to the spec
 			m(service)
 		}
+
+		// Apply any custom overrides - perform after the custom modifications so they can overridden
+
+		// Annotations
+		service.ObjectMeta.Annotations = CustomOverrideAnnotation(cfg, component, TypeMetaService, func() map[string]string {
+			return service.ObjectMeta.Annotations
+		})
+
+		// Labels
+		service.ObjectMeta.Labels = CustomOverrideLabel(cfg, component, TypeMetaService, func() map[string]string {
+			return service.ObjectMeta.Labels
+		})
 
 		return []runtime.Object{service}, nil
 	}

--- a/install/installer/pkg/common/overrides.go
+++ b/install/installer/pkg/common/overrides.go
@@ -4,16 +4,63 @@
 package common
 
 import (
+	"sort"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// CustomOverrideAnnotation override the annotations based upon rules that the config defines
 func CustomOverrideAnnotation(ctx *RenderContext, component string, typeMeta metav1.TypeMeta, existingAnnotations ...func() map[string]string) map[string]string {
-	annotations := make(map[string]string, 0)
+	// Get the metadata kind in lowercase
+	kind := strings.ToLower(typeMeta.Kind)
 
+	annotations := make(map[string]string)
+
+	// Start with any existing annotations
 	for _, e := range existingAnnotations {
 		for k, v := range e() {
 			annotations[k] = v
+		}
+	}
+
+	if ctx.Config.Components != nil && ctx.Config.Components.Annotations != nil {
+		annotationKeys := make([]string, 0, len(*ctx.Config.Components.Annotations))
+		for k := range *ctx.Config.Components.Annotations {
+			annotationKeys = append(annotationKeys, k)
+		}
+		// Ensure that "*" comes first
+		sort.Strings(annotationKeys)
+
+		for _, annotationKindKey := range annotationKeys {
+			annotationKindData := (*ctx.Config.Components.Annotations)[annotationKindKey]
+
+			if annotationKindKey == "*" || annotationKindKey == kind {
+				// The key here matches this resource's "kind"
+				componentKeys := make([]string, 0, len(annotationKindData))
+				for k := range annotationKindData {
+					componentKeys = append(componentKeys, k)
+				}
+				// Ensure that "*" comes first
+				sort.Strings(componentKeys)
+
+				for _, componentName := range componentKeys {
+					annotationMap := annotationKindData[componentName]
+					if componentName == "*" || componentName == component {
+						// The key here match this resource's "name" - we can now look to add these to the annotation map
+						for k, v := range annotationMap {
+							if v == "" {
+								// Delete the key/value pair
+								delete(annotations, k)
+							} else {
+								// Add the key/value
+								annotations[k] = v
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/install/installer/pkg/common/overrides.go
+++ b/install/installer/pkg/common/overrides.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CustomOverrideAnnotation(ctx *RenderContext, component string, typeMeta metav1.TypeMeta, existingAnnotations ...func() map[string]string) map[string]string {
+	annotations := make(map[string]string, 0)
+
+	for _, e := range existingAnnotations {
+		for k, v := range e() {
+			annotations[k] = v
+		}
+	}
+
+	return annotations
+}
+
+func CustomOverrideEnvvar(ctx *RenderContext, component string, existingEnvvars []corev1.EnvVar) []corev1.EnvVar {
+	return existingEnvvars
+}
+
+func CustomOverrideLabel(ctx *RenderContext, component string, typeMeta metav1.TypeMeta, existingLabels ...func() map[string]string) map[string]string {
+	labels := DefaultLabels(component)
+
+	for _, e := range existingLabels {
+		for k, v := range e() {
+			labels[k] = v
+		}
+	}
+
+	return labels
+}

--- a/install/installer/pkg/common/overrides_test.go
+++ b/install/installer/pkg/common/overrides_test.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package common_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestComponentAnnotation(t *testing.T) {
+	testCases := []struct {
+		Annotations         config.CustomOverride
+		Name                string
+		Component           string
+		TypeMeta            metav1.TypeMeta
+		ExistingAnnotations []func() map[string]string
+		Expect              map[string]string
+	}{
+		{
+			Annotations: nil,
+			Name:        "no annotations",
+			Component:   "component",
+			TypeMeta:    common.TypeMetaDeployment,
+			Expect:      map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{},
+			Name:        "empty annotations",
+			Component:   "component",
+			TypeMeta:    common.TypeMetaDeployment,
+			Expect:      map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				strings.ToLower(common.TypeMetaDeployment.Kind): {},
+			},
+			Name:      "empty kind annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect:    map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				strings.ToLower(common.TypeMetaDeployment.Kind): {
+					"component": {},
+				},
+			},
+			Name:      "empty component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect:    map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				strings.ToLower(common.TypeMetaBatchCronJob.Kind): {
+					"component": {
+						"hello": "world",
+					},
+				},
+			},
+			Name:      "ignore different kind annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect:    map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				strings.ToLower(common.TypeMetaDeployment.Kind): {
+					"component2": {
+						"hello": "world",
+					},
+				},
+			},
+			Name:      "ignore same kind different name annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect:    map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				strings.ToLower(common.TypeMetaDeployment.Kind): {
+					"component": {
+						"hello": "world",
+					},
+				},
+			},
+			Name:      "single component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"hello": "world",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				strings.ToLower(common.TypeMetaDeployment.Kind): {
+					"component": {
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			Name:      "multiple component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {},
+			},
+			Name:      "empty wildcard kind annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect:    map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"component": {},
+				},
+			},
+			Name:      "empty wildcard kind component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect:    map[string]string{},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"component": {
+						"hello": "world",
+					},
+				},
+			},
+			Name:      "single wildcard kind named component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"hello": "world",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"component": {
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			Name:      "multiple wildcard kind named component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"*": {
+						"hello": "world",
+					},
+				},
+			},
+			Name:      "single wildcard component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"hello": "world",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"*": {
+						"key1": "value1",
+					},
+					"component": {
+						"key2": "value2",
+					},
+				},
+			},
+			Name:      "single wildcard component annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"*": {
+						"key1": "value1",
+					},
+					"component": {
+						"key2": "value2",
+					},
+				},
+				strings.ToLower(common.TypeMetaDeployment.Kind): {
+					"*": {
+						"key3": "value3",
+					},
+					"component": {
+						"key4": "value4",
+					},
+				},
+			},
+			Name:      "wildcard and named annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+				"key4": "value4",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"*": {
+						"key1":     "value1",
+						"override": "override1",
+					},
+					"component": {
+						"key2":     "value2",
+						"override": "override2",
+					},
+				},
+				strings.ToLower(common.TypeMetaDeployment.Kind): {
+					"component": {
+						"key4":     "value4",
+						"override": "override4",
+					},
+					"*": {
+						"key3":     "value3",
+						"override": "override3",
+					},
+				},
+			},
+			Name:      "wildcard and named annotations",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			Expect: map[string]string{
+				"key1":     "value1",
+				"key2":     "value2",
+				"key3":     "value3",
+				"key4":     "value4",
+				"override": "override4",
+			},
+		},
+		{
+			Annotations: config.CustomOverride{
+				"*": {
+					"*": {
+						"override": "override",
+						"delete":   "",
+					},
+				},
+			},
+			Name:      "existing annotations overriden",
+			Component: "component",
+			TypeMeta:  common.TypeMetaDeployment,
+			ExistingAnnotations: []func() map[string]string{
+				func() map[string]string {
+					return map[string]string{
+						"delete":     "original",
+						"nooverride": "original",
+						"override":   "original",
+					}
+				},
+			},
+			Expect: map[string]string{
+				"nooverride": "original",
+				"override":   "override",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ctx, err := common.NewRenderContext(config.Config{
+				Components: &config.Components{
+					Annotations: &testCase.Annotations,
+				},
+			}, versions.Manifest{}, "test_namespace")
+			require.NoError(t, err)
+
+			result := common.CustomOverrideAnnotation(ctx, testCase.Component, testCase.TypeMeta, testCase.ExistingAnnotations...)
+
+			if !reflect.DeepEqual(testCase.Expect, result) {
+				t.Errorf("expected %v but got %v", testCase.Expect, result)
+			}
+		})
+	}
+}

--- a/install/installer/pkg/components/agent-smith/configmap.go
+++ b/install/installer/pkg/components/agent-smith/configmap.go
@@ -49,9 +49,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/components/agent-smith/daemonset.go
+++ b/install/installer/pkg/components/agent-smith/daemonset.go
@@ -17,7 +17,7 @@ import (
 )
 
 func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDaemonset)
 
 	configHash, err := common.ObjectHash(configmap(ctx))
 	if err != nil {
@@ -30,16 +30,19 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Name:      Component,
 			Namespace: ctx.Namespace,
 			Labels:    labels,
-			Annotations: map[string]string{
-				common.AnnotationConfigChecksum: configHash,
-			},
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDaemonset, func() map[string]string {
+				return map[string]string{
+					common.AnnotationConfigChecksum: configHash,
+				}
+			}),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   Component,
-					Labels: labels,
+					Name:        Component,
+					Labels:      labels,
+					Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDaemonset),
 				},
 				Spec: corev1.PodSpec{
 					Affinity:                      common.NodeAffinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
@@ -64,7 +67,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:      "config",
 							MountPath: "/config",
 						}},
-						Env: common.MergeEnv(
+						Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
 							common.WorkspaceTracingEnv(ctx),
 							[]corev1.EnvVar{{
@@ -73,7 +76,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 									FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 								},
 							}},
-						),
+						)),
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: pointer.Bool(true),
 							ProcMount:  func() *corev1.ProcMountType { r := corev1.DefaultProcMount; return &r }(),

--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -113,9 +113,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -20,7 +20,7 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	volumeName := "pull-secret"
 	var secretName string
@@ -54,9 +54,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -67,9 +68,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
-						Annotations: map[string]string{
-							common.AnnotationConfigChecksum: configHash,
-						},
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+							return map[string]string{
+								common.AnnotationConfigChecksum: configHash,
+							}
+						}),
 					},
 					Spec: corev1.PodSpec{
 						Affinity:           common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
@@ -110,10 +113,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Privileged: pointer.Bool(false),
 								RunAsUser:  pointer.Int64(1000),
 							},
-							Env: common.MergeEnv(
+							Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
 								common.WorkspaceTracingEnv(ctx),
-							),
+							)),
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      "config",
 								MountPath: "/mnt/config",

--- a/install/installer/pkg/components/content-service/configmap.go
+++ b/install/installer/pkg/components/content-service/configmap.go
@@ -6,6 +6,7 @@ package content_service
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 
 	"github.com/gitpod-io/gitpod/content-service/api/config"
@@ -32,9 +33,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{&corev1.ConfigMap{
 		TypeMeta: common.TypeMetaConfigmap,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    common.DefaultLabels(Component),
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 		},
 		Data: map[string]string{
 			"config.json": string(fc),

--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -17,7 +17,7 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	configHash, err := common.ObjectHash(configmap(ctx))
 	if err != nil {
@@ -65,14 +65,14 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Privileged: pointer.Bool(false),
 				RunAsUser:  pointer.Int64(1000),
 			},
-			Env: common.MergeEnv(
+			Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
 				common.WorkspaceTracingEnv(ctx),
 				[]corev1.EnvVar{{
 					Name:  "GRPC_GO_RETRY",
 					Value: "on",
 				}},
-			),
+			)),
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "config",
 				MountPath: "/config",
@@ -90,9 +90,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&v1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: v1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -103,9 +104,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
-						Annotations: map[string]string{
-							common.AnnotationConfigChecksum: configHash,
-						},
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+							return map[string]string{
+								common.AnnotationConfigChecksum: configHash,
+							}
+						}),
 					},
 					Spec: podSpec,
 				},

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -18,15 +18,16 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -34,9 +35,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      Component,
-						Namespace: ctx.Namespace,
-						Labels:    labels,
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 					},
 					Spec: corev1.PodSpec{
 						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
@@ -62,9 +64,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 							},
-							Env: common.MergeEnv(
+							Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-							),
+							)),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/install/installer/pkg/components/database/cloudsql/deployment.go
+++ b/install/installer/pkg/components/database/cloudsql/deployment.go
@@ -6,6 +6,7 @@ package cloudsql
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,15 +18,16 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-cloud-sql-proxy", Component),
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        fmt.Sprintf("%s-cloud-sql-proxy", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Strategy: appsv1.DeploymentStrategy{
@@ -39,9 +41,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Replicas: common.Replicas(ctx, Component),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      Component,
-						Namespace: ctx.Namespace,
-						Labels:    labels,
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 					},
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
@@ -84,6 +87,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								MountPath: "/credentials",
 								Name:      "gcloud-sql-token",
 							}},
+							Env: common.CustomOverrideEnvvar(ctx, Component, []corev1.EnvVar{}),
 						}},
 					},
 				},

--- a/install/installer/pkg/components/database/incluster/configmap.go
+++ b/install/installer/pkg/components/database/incluster/configmap.go
@@ -51,9 +51,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      SQLInitScripts,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        SQLInitScripts,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"init.sql":      initScriptData,

--- a/install/installer/pkg/components/database/incluster/service.go
+++ b/install/installer/pkg/components/database/incluster/service.go
@@ -15,14 +15,15 @@ import (
 // service this doesn't use the common.GenerateService function
 // because it's more complex than this caters for
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaService)
 
 	return []runtime.Object{&corev1.Service{
 		TypeMeta: common.TypeMetaService,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    labels,
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      labels,
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaService),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{

--- a/install/installer/pkg/components/database/init/configmap.go
+++ b/install/installer/pkg/components/database/init/configmap.go
@@ -47,9 +47,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      sqlInitScripts,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        sqlInitScripts,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"init.sql": initScriptData,

--- a/install/installer/pkg/components/database/init/job.go
+++ b/install/installer/pkg/components/database/init/job.go
@@ -25,9 +25,10 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	objectMeta := metav1.ObjectMeta{
-		Name:      fmt.Sprintf("%s-session", Component),
-		Namespace: ctx.Namespace,
-		Labels:    common.DefaultLabels(Component),
+		Name:        fmt.Sprintf("%s-session", Component),
+		Namespace:   ctx.Namespace,
+		Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaBatchJob),
+		Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaBatchJob),
 	}
 
 	return []runtime.Object{&batchv1.Job{

--- a/install/installer/pkg/components/ide-proxy/deployment.go
+++ b/install/installer/pkg/components/ide-proxy/deployment.go
@@ -18,15 +18,16 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -34,9 +35,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      Component,
-						Namespace: ctx.Namespace,
-						Labels:    labels,
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 					},
 					Spec: corev1.PodSpec{
 						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
@@ -62,9 +64,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 							},
-							Env: common.MergeEnv(
+							Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-							),
+							)),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/install/installer/pkg/components/image-builder-mk3/configmap.go
+++ b/install/installer/pkg/components/image-builder-mk3/configmap.go
@@ -81,9 +81,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"image-builder.json": string(fc),

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -34,7 +34,7 @@ func pullSecretName(ctx *common.RenderContext) (string, error) {
 }
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	var hashObj []runtime.Object
 	if objs, err := configmap(ctx); err != nil {
@@ -112,9 +112,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{&appsv1.Deployment{
 		TypeMeta: common.TypeMetaDeployment,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    labels,
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      labels,
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -125,9 +126,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Name:      Component,
 					Namespace: ctx.Namespace,
 					Labels:    labels,
-					Annotations: map[string]string{
-						common.AnnotationConfigChecksum: configHash,
-					},
+					Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+						return map[string]string{
+							common.AnnotationConfigChecksum: configHash,
+						}
+					}),
 				},
 				Spec: corev1.PodSpec{
 					Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
@@ -149,10 +152,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							"--config",
 							"/config/image-builder.json",
 						},
-						Env: common.MergeEnv(
+						Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
 							common.WorkspaceTracingEnv(ctx),
-						),
+						)),
 						Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),

--- a/install/installer/pkg/components/migrations/job.go
+++ b/install/installer/pkg/components/migrations/job.go
@@ -20,9 +20,10 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	objectMeta := metav1.ObjectMeta{
-		Name:      Component,
-		Namespace: ctx.Namespace,
-		Labels:    common.DefaultLabels(Component),
+		Name:        Component,
+		Namespace:   ctx.Namespace,
+		Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaBatchJob),
+		Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaBatchJob),
 	}
 
 	return []runtime.Object{&batchv1.Job{
@@ -43,9 +44,9 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:            Component,
 						Image:           ctx.ImageName(ctx.Config.Repository, "db-migrations", ctx.VersionManifest.Components.DBMigrations.Version),
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Env: common.MergeEnv(
+						Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 							common.DatabaseEnv(&ctx.Config),
-						),
+						)),
 						Command: []string{
 							"sh",
 							"-c",

--- a/install/installer/pkg/components/openvsx-proxy/configmap.go
+++ b/install/installer/pkg/components/openvsx-proxy/configmap.go
@@ -48,9 +48,10 @@ maxmemory-policy allkeys-lfu
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: data,
 		},

--- a/install/installer/pkg/components/proxy/configmap.go
+++ b/install/installer/pkg/components/proxy/configmap.go
@@ -159,9 +159,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: data,
 		},

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -22,7 +22,7 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	var hashObj []runtime.Object
 	if objs, err := configmap(ctx); err != nil {
@@ -123,9 +123,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -136,9 +137,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
-						Annotations: map[string]string{
-							common.AnnotationConfigChecksum: configHash,
-						},
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+							return map[string]string{
+								common.AnnotationConfigChecksum: configHash,
+							}
+						}),
 					},
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
@@ -241,13 +244,13 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								FailureThreshold:    3,
 							},
 							VolumeMounts: volumeMounts,
-							Env: common.MergeEnv(
+							Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
 								[]corev1.EnvVar{{
 									Name:  "PROXY_DOMAIN",
 									Value: ctx.Config.Domain,
 								}},
-							),
+							)),
 						}},
 					},
 				},

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -6,6 +6,7 @@ package public_api_server
 
 import (
 	"fmt"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/public-api/config"
 
@@ -40,9 +41,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				configJSONFilename: string(fc),

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -5,13 +5,14 @@ package public_api_server
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/public-api/config"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestConfigMap(t *testing.T) {
@@ -39,9 +40,10 @@ func TestConfigMap(t *testing.T) {
 	require.Equal(t, &corev1.ConfigMap{
 		TypeMeta: common.TypeMetaConfigmap,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    common.DefaultLabels(Component),
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 		},
 		Data: map[string]string{
 			"config.json": string(expectedJSON),

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -31,7 +31,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
@@ -39,9 +39,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Name:      Component,
 				Namespace: ctx.Namespace,
 				Labels:    labels,
-				Annotations: map[string]string{
-					common.AnnotationConfigChecksum: configHash,
-				},
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+					return map[string]string{
+						common.AnnotationConfigChecksum: configHash,
+					}
+				}),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -49,9 +51,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      Component,
-						Namespace: ctx.Namespace,
-						Labels:    labels,
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 					},
 					Spec: corev1.PodSpec{
 						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
@@ -85,9 +88,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: pointer.Bool(false),
 								},
-								Env: common.MergeEnv(
+								Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 									common.DefaultEnv(&ctx.Config),
-								),
+								)),
 								LivenessProbe: &corev1.Probe{
 									ProbeHandler: corev1.ProbeHandler{
 										HTTPGet: &corev1.HTTPGetAction{

--- a/install/installer/pkg/components/registry-facade/configmap.go
+++ b/install/installer/pkg/components/registry-facade/configmap.go
@@ -101,9 +101,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -23,7 +23,7 @@ import (
 )
 
 func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDaemonset)
 
 	var hashObj []runtime.Object
 	if objs, err := configmap(ctx); err != nil {
@@ -187,9 +187,10 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{&appsv1.DaemonSet{
 		TypeMeta: common.TypeMetaDaemonset,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    labels,
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      labels,
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDaemonset),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -197,9 +198,11 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   Component,
 					Labels: labels,
-					Annotations: map[string]string{
-						common.AnnotationConfigChecksum: configHash,
-					},
+					Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDaemonset, func() map[string]string {
+						return map[string]string{
+							common.AnnotationConfigChecksum: configHash,
+						}
+					}),
 				},
 				Spec: corev1.PodSpec{
 					PriorityClassName:             common.SystemNodeCritical,
@@ -230,7 +233,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Privileged: pointer.Bool(false),
 							RunAsUser:  pointer.Int64(1000),
 						},
-						Env: common.MergeEnv(
+						Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
 							common.WorkspaceTracingEnv(ctx),
 							[]corev1.EnvVar{
@@ -248,7 +251,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							},
 							envvars,
-						),
+						)),
 						VolumeMounts: append(
 							[]corev1.VolumeMount{
 								{

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -244,9 +244,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -26,7 +26,7 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	var hashObj []runtime.Object
 	if objs, err := configmap(ctx); err != nil {
@@ -281,9 +281,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -294,9 +295,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
-						Annotations: map[string]string{
-							common.AnnotationConfigChecksum: configHash,
-						},
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+							return map[string]string{
+								common.AnnotationConfigChecksum: configHash,
+							}
+						}),
 					},
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
@@ -369,7 +372,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							},
 							// todo(sje): do we need to cater for serverContainer.env from values.yaml?
-							Env: env,
+							Env: common.CustomOverrideEnvvar(ctx, Component, env),
 							// todo(sje): do we need to cater for serverContainer.volumeMounts from values.yaml?
 							VolumeMounts: append(
 								[]corev1.VolumeMount{

--- a/install/installer/pkg/components/server/ide/configmap.go
+++ b/install/installer/pkg/components/server/ide/configmap.go
@@ -146,9 +146,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-ide-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-ide-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -26,9 +26,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"schedule": schedule,

--- a/install/installer/pkg/components/usage/deployment.go
+++ b/install/installer/pkg/components/usage/deployment.go
@@ -20,7 +20,7 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -51,9 +51,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -61,9 +62,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      Component,
-						Namespace: ctx.Namespace,
-						Labels:    labels,
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 					},
 					Spec: corev1.PodSpec{
 						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
@@ -93,7 +95,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),
 							},
-							Env: common.MergeEnv(
+							Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
 								common.DatabaseEnv(&ctx.Config),
 								[]corev1.EnvVar{{
@@ -105,7 +107,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 										},
 									},
 								}},
-							),
+							)),
 							VolumeMounts: volumeMounts,
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -145,9 +145,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{&corev1.ConfigMap{
 		TypeMeta: common.TypeMetaConfigmap,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    common.DefaultLabels(Component),
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 		},
 		Data: map[string]string{
 			"config.json": string(fc),

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -22,7 +22,7 @@ import (
 
 func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := ctx.Config
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDaemonset)
 
 	configHash, err := common.ObjectHash(configmap(ctx))
 	if err != nil {
@@ -201,7 +201,7 @@ fi
 					HostPort:      ServicePort,
 					ContainerPort: ServicePort,
 				}},
-				Env: common.MergeEnv(
+				Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 					common.DefaultEnv(&cfg),
 					common.WorkspaceTracingEnv(ctx),
 					[]corev1.EnvVar{{
@@ -212,7 +212,7 @@ fi
 							},
 						},
 					}},
-				),
+				)),
 				Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("1m"),
 					"memory": resource.MustParse("1Mi"),
@@ -351,19 +351,22 @@ fi
 	return []runtime.Object{&appsv1.DaemonSet{
 		TypeMeta: common.TypeMetaDaemonset,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      Component,
-			Namespace: ctx.Namespace,
-			Labels:    labels,
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      labels,
+			Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDaemonset),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
-					Annotations: map[string]string{
-						"seccomp.security.alpha.kubernetes.io/shiftfs-module-loader": "unconfined",
-						common.AnnotationConfigChecksum:                              configHash,
-					},
+					Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDaemonset, func() map[string]string {
+						return map[string]string{
+							"seccomp.security.alpha.kubernetes.io/shiftfs-module-loader": "unconfined",
+							common.AnnotationConfigChecksum:                              configHash,
+						}
+					}),
 				},
 				Spec: podSpec,
 			},

--- a/install/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/install/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -44,9 +44,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-config", Component),
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        fmt.Sprintf("%s-config", Component),
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"ws-manager-bridge.json": string(fc),

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -20,7 +20,7 @@ import (
 )
 
 func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
-	labels := common.DefaultLabels(Component)
+	labels := common.CustomOverrideLabel(ctx, Component, common.TypeMetaDeployment)
 
 	var hashObj []runtime.Object
 	if objs, err := configmap(ctx); err != nil {
@@ -66,9 +66,10 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    labels,
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -79,9 +80,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Name:      Component,
 						Namespace: ctx.Namespace,
 						Labels:    labels,
-						Annotations: map[string]string{
-							common.AnnotationConfigChecksum: configHash,
-						},
+						Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+							return map[string]string{
+								common.AnnotationConfigChecksum: configHash,
+							}
+						}),
 					},
 					Spec: corev1.PodSpec{
 						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
@@ -121,7 +124,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Privileged: pointer.Bool(false),
 								RunAsUser:  pointer.Int64(31001),
 							},
-							Env: common.MergeEnv(
+							Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
 								common.WorkspaceTracingEnv(ctx),
 								common.AnalyticsEnv(&ctx.Config),
@@ -131,7 +134,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 									Name:  "WSMAN_BRIDGE_CONFIGPATH",
 									Value: "/config/ws-manager-bridge.json",
 								}},
-							),
+							)),
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 9500,

--- a/install/installer/pkg/components/ws-manager/configmap.go
+++ b/install/installer/pkg/components/ws-manager/configmap.go
@@ -207,9 +207,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -52,11 +52,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: pointer.Bool(false),
 			},
-			Env: common.MergeEnv(
+			Env: common.CustomOverrideEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
 				common.WorkspaceTracingEnv(ctx),
 				[]corev1.EnvVar{{Name: "GRPC_GO_RETRY", Value: "on"}},
-			),
+			)),
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      VolumeConfig,

--- a/install/installer/pkg/components/ws-proxy/configmap.go
+++ b/install/installer/pkg/components/ws-proxy/configmap.go
@@ -89,9 +89,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomOverrideLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomOverrideAnnotation(ctx, Component, common.TypeMetaConfigmap),
 			},
 			Data: map[string]string{
 				"config.json": string(fc),

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -110,6 +110,8 @@ type Config struct {
 
 	DropImageRepo *bool `json:"dropImageRepo,omitempty"`
 
+	Components *Components `json:"components,omitempty"`
+
 	Experimental *experimental.Config `json:"experimental,omitempty"`
 }
 
@@ -326,3 +328,13 @@ type OAuth struct {
 	ClientSecret string `json:"clientSecret" validate:"required"`
 	CallBackUrl  string `json:"callBackUrl" validate:"required"`
 }
+
+type Components struct {
+	Annotations *CustomOverride `json:"annotations,omitempty"`
+}
+
+type CustomOverride map[string]CustomOverrideKind
+
+type CustomOverrideKind map[string]ComponentKeyValue
+
+type ComponentKeyValue map[string]string


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Configure custom annotations for kubernetes resources

To be merged after #10857

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10826

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow custom annotations for k8s resources
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
