### PR TITLE
[installer] Move blobserve out workspace clusters

### DIFF
--- a/install/installer/pkg/components/components-webapp/components.go
+++ b/install/installer/pkg/components/components-webapp/components.go
@@ -6,6 +6,7 @@ package componentswebapp
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/blobserve"
 	contentservice "github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/dashboard"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/database"
@@ -22,6 +23,7 @@ import (
 )
 
 var Objects = common.CompositeRenderFunc(
+	blobserve.Objects,
 	contentservice.Objects,
 	dashboard.Objects,
 	database.Objects,

--- a/install/installer/pkg/components/components-workspace/components.go
+++ b/install/installer/pkg/components/components-workspace/components.go
@@ -7,7 +7,6 @@ package componentsworkspace
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	agentsmith "github.com/gitpod-io/gitpod/installer/pkg/components/agent-smith"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/blobserve"
 	imagebuildermk3 "github.com/gitpod-io/gitpod/installer/pkg/components/image-builder-mk3"
 	registryfacade "github.com/gitpod-io/gitpod/installer/pkg/components/registry-facade"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
@@ -18,7 +17,6 @@ import (
 
 var Objects = common.CompositeRenderFunc(
 	agentsmith.Objects,
-	blobserve.Objects,
 	registryfacade.Objects,
 	workspace.Objects,
 	wsdaemon.Objects,


### PR DESCRIPTION
## Description

Blobserve is served through the IDE proxy now

## Release Notes
```release-note
NONE
```

/hold