### PR TITLE
Allow PRs for JetBrains IDEs updates to be created with a Preview Environment

### DIFF
--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -79,6 +79,13 @@ jobs:
             Update ${{ inputs.productName }} IDE image to version ${{ steps.latest-release.outputs.version }}.
             ```
 
+            ## Werft options:
+            <!--
+            Optional annotations to add to the werft job.
+            * with-preview - whether to create a preview environment for this PR
+            -->
+            - [x] /werft with-preview
+
             _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates-template.yml) template_
           commit-message: "[${{ inputs.productId }}] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
           branch: "jetbrains/${{ inputs.productId }}-${{ steps.latest-release.outputs.version2 }}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allow PRs for JetBrains IDEs updates to be created with a Preview Environment.
We need it to test the IDEs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
#10816

## How to test
<!-- Provide steps to test this PR -->
Not sure if it can be tested without having some IDE update.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
