### PR TITLE
[server] Increase startWorkspace rate limit 1 → 3 starts per user per 10 seconds

### DIFF
--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -39,7 +39,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
             durationsSec: 60,
         },
         startWorkspace: {
-            points: 1, // 1 workspace start per user per 10s
+            points: 3, // 3 workspace starts per user per 10s
             durationsSec: 10,
         },
         createWorkspace: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Increase startWorkspace rate limit 1 → 3 starts per user per 10 seconds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

This makes getting stuck in this screen less frequent:

<img width="600" alt="Screenshot 2022-06-22 at 18 00 30" src="https://user-images.githubusercontent.com/599268/175081240-5855b9d9-db08-4e7c-856b-3ce3978face7.png">

## How to test
<!-- Provide steps to test this PR -->

1. Start many parallel workspaces
2. They should come up fast (without getting stuck in `Preparing` for some seconds while priting rate-limit messages in the console)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
