### PR TITLE
[code] make 1.68.2 stable

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-c2b136bc2a5931878cd08b80ea41a4b6e8648c0d" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-5cff80fdce975a70553712505e3eebf73bfdf5fa" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates stable VS Code version to 1.68.2.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to https://github.com/gitpod-io/gitpod/issues/10828

## How to test
Switch to stable in the preview environment and in the about dialog confirm you are running 1.68.2

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
