### PR TITLE
[usage] Use stripe clients rather than a singleton in the usage controller

### DIFF
--- a/components/usage/cmd/run.go
+++ b/components/usage/cmd/run.go
@@ -47,11 +47,11 @@ func run() *cobra.Command {
 			var billingController controller.BillingController = &controller.NoOpBillingController{}
 
 			if apiKeyFile != "" {
-				err = stripe.Authenticate(apiKeyFile)
+				c, err := stripe.Authenticate(apiKeyFile)
 				if err != nil {
 					log.WithError(err).Fatal("Failed to initialize stripe client.")
 				}
-				billingController = &controller.StripeBillingController{}
+				billingController = controller.NewStripeBillingController(c)
 			}
 
 			ctrl, err := controller.New(schedule, controller.NewUsageReconciler(conn, billingController))

--- a/components/usage/pkg/controller/billing.go
+++ b/components/usage/pkg/controller/billing.go
@@ -11,9 +11,16 @@ type BillingController interface {
 }
 
 type NoOpBillingController struct{}
-type StripeBillingController struct{}
 
 func (b *NoOpBillingController) Reconcile(report []TeamUsage) {}
+
+type StripeBillingController struct {
+	sc *stripe.Client
+}
+
+func NewStripeBillingController(sc *stripe.Client) *StripeBillingController {
+	return &StripeBillingController{sc: sc}
+}
 
 func (b *StripeBillingController) Reconcile(report []TeamUsage) {
 	// Convert the usage report to sum all entries for the same team.
@@ -22,5 +29,5 @@ func (b *StripeBillingController) Reconcile(report []TeamUsage) {
 		summedReport[usageEntry.TeamID] += usageEntry.WorkspaceSeconds
 	}
 
-	stripe.UpdateUsage(summedReport)
+	b.sc.UpdateUsage(summedReport)
 }

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/stripe/stripe-go/v72"
-	"github.com/stripe/stripe-go/v72/customer"
-	"github.com/stripe/stripe-go/v72/usagerecord"
+	"github.com/stripe/stripe-go/v72/client"
 )
+
+type Client struct {
+	sc *client.API
+}
 
 type stripeKeys struct {
 	PublishableKey string `json:"publishableKey"`
@@ -22,25 +25,26 @@ type stripeKeys struct {
 }
 
 // Authenticate authenticates the Stripe client using a provided file containing a Stripe secret key.
-func Authenticate(apiKeyFile string) error {
+func Authenticate(apiKeyFile string) (*Client, error) {
 	bytes, err := os.ReadFile(apiKeyFile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var stripeKeys stripeKeys
 	err = json.Unmarshal(bytes, &stripeKeys)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	stripe.Key = stripeKeys.SecretKey
-	return nil
+	sc := &client.API{}
+	sc.Init(stripeKeys.SecretKey, nil)
+	return &Client{sc: sc}, nil
 }
 
 // UpdateUsage updates teams' Stripe subscriptions with usage data
 // `usageForTeam` is a map from team name to total workspace seconds used within a billing period.
-func UpdateUsage(usageForTeam map[string]int64) error {
+func (c *Client) UpdateUsage(usageForTeam map[string]int64) error {
 	teamIds := make([]string, 0, len(usageForTeam))
 	for k := range usageForTeam {
 		teamIds = append(teamIds, k)
@@ -55,7 +59,7 @@ func UpdateUsage(usageForTeam map[string]int64) error {
 				Expand: []*string{stripe.String("data.subscriptions")},
 			},
 		}
-		iter := customer.Search(params)
+		iter := c.sc.Customers.Search(params)
 		for iter.Next() {
 			customer := iter.Customer()
 			log.Infof("found customer %q for teamId %q", customer.Name, customer.Metadata["teamId"])
@@ -76,7 +80,7 @@ func UpdateUsage(usageForTeam map[string]int64) error {
 
 			subscriptionItemId := subscription.Items.Data[0].ID
 			log.Infof("registering usage against subscriptionItem %q", subscriptionItemId)
-			_, err := usagerecord.New(&stripe.UsageRecordParams{
+			_, err := c.sc.UsageRecords.New(&stripe.UsageRecordParams{
 				SubscriptionItem: stripe.String(subscriptionItemId),
 				Quantity:         stripe.Int64(creditsUsed),
 			})


### PR DESCRIPTION
## Description

Change the usage component's Stripe package to return client instances rather than using a Stripe singleton.

## Related Issue(s)

https://github.com/gitpod-io/gitpod/pull/10754#discussion_r901398982

## How to test

The usual test steps to set up usage based billing and generate a test invoice.

See eg https://github.com/gitpod-io/gitpod/pull/10801

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:
- [x] /werft with-preview
