### PR TITLE
observability: Ring the phone only when a data loss occurs with GitpodWsDaemonCrashLooping

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
@@ -12,7 +12,7 @@
           {
             alert: 'GitpodWsDaemonCrashLooping',
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonCrashLooping.md',
@@ -21,6 +21,20 @@
             },
             expr: |||
               increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m]) > 0
+            |||,
+          },
+          {
+            alert: 'BackupFailureBecauseOfGitpodWsDaemonCrash',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonCrashLooping.md',
+              summary: 'Increase the number of backup failure because of ws-daemon is crashlooping.',
+              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.',
+            },
+            expr: |||
+              sum(increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m])) > 0 AND sum(increase(gitpod_ws_manager_workspace_backups_failure_total{type="REGULAR"}[10m])) > 0
             |||,
           },
           {


### PR DESCRIPTION
## Description
This PR reduces the number of calls to 6 in the last week.
[grafana](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22VictoriaMetrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22increase(kube_pod_container_status_restarts_total%7Bcontainer%3D%5C%22ws-daemon%5C%22,%7D%5B10m%5D)%20%3E%200%20%22,%22hide%22:true%7D,%7B%22refId%22:%22B%22,%22expr%22:%22increase(gitpod_ws_manager_workspace_backups_failure_total%7Btype%3D%5C%22REGULAR%5C%22%7D%5B10m%5D)%20!%3D%200%22,%22hide%22:true%7D,%7B%22refId%22:%22C%22,%22expr%22:%22sum(increase(kube_pod_container_status_restarts_total%7Bcontainer%3D%5C%22ws-daemon%5C%22%7D%5B10m%5D))%20%3E%200%20AND%20sum(increase(gitpod_ws_manager_workspace_backups_failure_total%7Btype%3D%5C%22REGULAR%5C%22%7D%5B10m%5D))%20%3E%200%22,%22hide%22:false%7D%5D,%22range%22:%7B%22from%22:%221655375855282%22,%22to%22:%221655962807900%22%7D%7D)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
