### PR TITLE
[Self-Hosted] Changed preflight memory check error amount and reworded

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -165,13 +165,10 @@ spec:
         checkName: Memory per node
         outcomes:
           - fail:
-              when: "min(memoryCapacity) < 8G"
-              message: The cluster must have least 8GB of memory
-          - warn:
               when: "min(memoryCapacity) < 16G"
-              message: The cluster must have least 16GB of memory
+              message: Each node must have at least 16GB of memory
           - pass:
-              message: There is at least 16GB of memory in the cluster
+              message: Each node has at least 16GB of memory
     - storageClass:
         checkName: Check for default storage class
         outcomes:


### PR DESCRIPTION
## Description
Changed the node memory preflight check:
1. Changed it so that it errors on 16gb
2. Reworded it to be about per node memory, not per cluster memory

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10726 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```