### PR TITLE
Refactor workspace instance `attributedTeamId` to an explicit, not-team-specific `usageAttributionId`

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -107,5 +107,5 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
         default: "",
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
-    attributedTeamId?: string;
+    usageAttributionId?: string;
 }

--- a/components/gitpod-db/src/typeorm/migration/1655988518555-WorkspaceInstanceUsageAttributionId.ts
+++ b/components/gitpod-db/src/typeorm/migration/1655988518555-WorkspaceInstanceUsageAttributionId.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists, indexExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_workspace_instance";
+const COLUMN_NAME = "usageAttributionId";
+const INDEX_NAME = "ind_usageAttributionId";
+
+export class WorkspaceInstanceUsageAttributionId1655988518555 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} varchar(60) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+        if (!(await indexExists(queryRunner, TABLE_NAME, INDEX_NAME))) {
+            await queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE_NAME} (${COLUMN_NAME})`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} DROP COLUMN ${COLUMN_NAME}, ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+}

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -66,7 +66,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
-        attributedTeamId: undefined,
+        usageAttributionId: undefined,
     };
     readonly wsi2: WorkspaceInstance = {
         workspaceId: this.ws.id,
@@ -89,7 +89,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
-        attributedTeamId: undefined,
+        usageAttributionId: undefined,
     };
     readonly ws2: Workspace = {
         id: "2",
@@ -127,7 +127,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
-        attributedTeamId: undefined,
+        usageAttributionId: undefined,
     };
 
     readonly ws3: Workspace = {
@@ -165,7 +165,7 @@ class WorkspaceDBSpec {
             ideImage: "unknown",
         },
         deleted: false,
-        attributedTeamId: undefined,
+        usageAttributionId: undefined,
     };
 
     async before() {

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -64,11 +64,10 @@ export interface WorkspaceInstance {
     workspaceClass?: string;
 
     /**
-     * Identifies the team to which this instance's runtime should be attributed to
+     * Identifies the team or user to which this instance's runtime should be attributed to
      * (e.g. for usage analytics or billing purposes).
-     * If unset, the usage should be attributed to the workspace's owner (ws.ownerId).
      */
-    attributedTeamId?: string;
+    usageAttributionId?: string;
 }
 
 // WorkspaceInstanceStatus describes the current state of a workspace instance

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -207,25 +207,24 @@ export class UserService {
     }
 
     /**
-     * Identifies the team to which a workspace instance's running time should be attributed to
+     * Identifies the team or user to which a workspace instance's running time should be attributed to
      * (e.g. for usage analytics or billing purposes).
-     * If no specific team is identified, the usage will be attributed to the user instead (default).
      *
      * @param user
      * @param projectId
      */
-    async getWorkspaceUsageAttributionTeamId(user: User, projectId?: string): Promise<string | undefined> {
+    async getWorkspaceUsageAttributionId(user: User, projectId?: string): Promise<string | undefined> {
         if (!projectId) {
             // No project -- attribute to the user.
-            return undefined;
+            return `user:${user.id}`;
         }
         const project = await this.projectDb.findProjectById(projectId);
         if (!project?.teamId) {
             // The project doesn't exist, or it isn't owned by a team -- attribute to the user.
-            return undefined;
+            return `user:${user.id}`;
         }
         // Attribute workspace usage to the team that currently owns this project.
-        return project.teamId;
+        return `team:${project.teamId}`;
     }
 
     /**

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -722,7 +722,7 @@ export class WorkspaceStarter {
             configuration.featureFlags = featureFlags;
         }
 
-        const attributedTeamId = await this.userService.getWorkspaceUsageAttributionTeamId(user, workspace.projectId);
+        const usageAttributionId = await this.userService.getWorkspaceUsageAttributionId(user, workspace.projectId);
 
         const now = new Date().toISOString();
         const instance: WorkspaceInstance = {
@@ -737,7 +737,7 @@ export class WorkspaceStarter {
                 phase: "preparing",
             },
             configuration,
-            attributedTeamId,
+            usageAttributionId,
         };
         if (WithReferrerContext.is(workspace.context)) {
             this.analytics.track({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Refactor workspace instance `attributedTeamId` to an explicit, not-team-specific `usageAttributionId`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10822

## How to test
<!-- Provide steps to test this PR -->

1. Should build
2. Workspace instances should always get a `usageAttributionId`
    - If the workspace is for a project that's owned by a Team, the attribution ID should look like `team:1234`
    - If the workspace is for a user project, or for no project at all, the attribution ID should look like `user:1234`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
