### PR TITLE
Clean up unused `attributedTeamId` column from workspace instances post-deployment

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1655992230337-DropDeprecatedAttributedTeamId.ts
+++ b/components/gitpod-db/src/typeorm/migration/1655992230337-DropDeprecatedAttributedTeamId.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_workspace_instance";
+const COLUMN_NAME = "attributedTeamId";
+
+export class DropDeprecatedAttributedTeamId1655992230337 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} DROP COLUMN ${COLUMN_NAME}, ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} char(36) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Once we've merged and successfully deployed https://github.com/gitpod-io/gitpod/pull/10868, we should merge this Pull Request to clean up the left-over `attributedTeamId` column.

Optionally, we may also want to "save" the historical attribution data from that older column and back-fill the newer column with it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up to https://github.com/gitpod-io/gitpod/pull/10868

## How to test
<!-- Provide steps to test this PR -->

1. Should build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
