### PR TITLE
[supervisor] enabled SSH debug log by default

### DIFF
--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -100,10 +100,7 @@ func (s *sshServer) handleConn(ctx context.Context, conn net.Conn) {
 		"-oUseDNS no", // Disable DNS lookups.
 		"-oSubsystem sftp internal-sftp",
 		"-oStrictModes no", // don't care for home directory and file permissions
-	}
-
-	if os.Getenv("SUPERVISOR_DEBUG_ENABLE") != "" {
-		args = append(args, "-oLogLevel DEBUG")
+		"-oLogLevel DEBUG", // enabled DEBUG mode by default
 	}
 
 	socketFD, err := conn.(*net.TCPConn).File()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[supervisor] enabled SSH debug log by default, it write to workspace standard log

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace in preview environment
2. connect via ssh
3. use `kubectl logs ws-${instanceId}` see log, it should contain ssh debug log, but in ssh client, it didn't print environment variable

![image](https://user-images.githubusercontent.com/20944364/175325907-d7746a1e-c331-4c55-8faa-f92876eb0787.png)
![image](https://user-images.githubusercontent.com/20944364/175326474-4bcebb7c-0b7a-4b56-91c4-9258a854dfa9.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
