### PR TITLE
Allow teams to cancel and renew their usage-based subscription in Stripe

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -273,7 +273,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     getStripePublishableKey(): Promise<string>;
     getStripeSetupIntentClientSecret(): Promise<string>;
-    findStripeCustomerIdForTeam(teamId: string): Promise<string | undefined>;
+    findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string, currency: Currency): Promise<void>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
 

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -115,6 +115,16 @@ export class StripeService {
         return session.url;
     }
 
+    async findUncancelledSubscriptionByCustomer(customerId: string): Promise<Stripe.Subscription | undefined> {
+        const result = await this.getStripe().subscriptions.list({
+            customer: customerId,
+        });
+        if (result.data.length > 1) {
+            throw new Error(`Stripe customer '${customerId}') has more than one subscription!`);
+        }
+        return result.data[0];
+    }
+
     async createSubscriptionForCustomer(customerId: string, currency: Currency): Promise<void> {
         const priceId = this.config?.stripeConfig?.usageProductPriceIds[currency];
         if (!priceId) {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -198,7 +198,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         tsReassignSlot: { group: "default", points: 1 },
         getStripePublishableKey: { group: "default", points: 1 },
         getStripeSetupIntentClientSecret: { group: "default", points: 1 },
-        findStripeCustomerIdForTeam: { group: "default", points: 1 },
+        findStripeSubscriptionIdForTeam: { group: "default", points: 1 },
         subscribeTeamToStripe: { group: "default", points: 1 },
         getStripePortalUrlForTeam: { group: "default", points: 1 },
         trackEvent: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3048,7 +3048,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getStripeSetupIntentClientSecret(ctx: TraceContext): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async findStripeCustomerIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
+    async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
     async subscribeTeamToStripe(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Allow teams to cancel and renew their usage-based subscription in Stripe.

**Before**:
- We show subscription status based on whether the Stripe customer exists
- If the Stripe customer has a payment issue, or cancels their subscription, they are "stuck" in "Active Billing" status (but without a subscription and no way to renew it)

**After**:
- We show subscription status based on whether a valid Stripe subscription exists
- If the Stripe customer has a payment issue, or cancels their subscription, the UI goes back to the "Inactive Billing" (allowing an existing customer to create a new subscription)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
