### PR TITLE
[experiments] Add configcat key for preview-envs

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -71,6 +71,7 @@ export class Installer {
             this.configureSSHGateway(slice)
             this.configurePublicAPIServer(slice)
             this.configureUsage(slice)
+            this.configureConfigCat(slice)
 
             if (this.options.analytics) {
                 this.includeAnalytics(slice)
@@ -195,6 +196,11 @@ EOF`)
 
     private configureUsage(slice: string) {
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.enabled true`, { slice: slice })
+    }
+
+    private configureConfigCat(slice: string) {
+        // This key is not a secret, it is a unique identifier of our ConfigCat application
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.configcatKey "WBLaCPtkjkqKHlHedziE9g/LEAOCNkbuUKiqUZAcVg7dw"`, { slice: slice })
     }
 
     private includeAnalytics(slice: string): void {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Configures ConfigCat in preview env with our non-production configcat environment

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Related to https://github.com/gitpod-io/gitpod/pull/10807

## How to test
<!-- Provide steps to test this PR -->
Preview starts

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
