### PR TITLE
[Usage-based] When payment is enabled, attribute all workspace instance usage to an explicitly selected "billing account"

### DIFF
--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -4,14 +4,48 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { useContext } from "react";
+import { Team } from "@gitpod/gitpod-protocol";
+import { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import getSettingsMenu from "./settings-menu";
+import { ReactComponent as Spinner } from "../icons/Spinner.svg";
+import DropDown from "../components/DropDown";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { PaymentContext } from "../payment-context";
-import getSettingsMenu from "./settings-menu";
+import { getGitpodService } from "../service/service";
+import { TeamsContext } from "../teams/teams-context";
+import { UserContext } from "../user-context";
 
 export default function Billing() {
+    const { user } = useContext(UserContext);
     const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
+    const { teams } = useContext(TeamsContext);
+    const [teamsWithBillingEnabled, setTeamsWithBillingEnabled] = useState<Team[] | undefined>();
+
+    useEffect(() => {
+        if (!teams) {
+            setTeamsWithBillingEnabled(undefined);
+            return;
+        }
+        const teamsWithBilling: Team[] = [];
+        Promise.all(
+            teams.map(async (t) => {
+                const subscriptionId = await getGitpodService().server.findStripeSubscriptionIdForTeam(t.id);
+                if (subscriptionId) {
+                    teamsWithBilling.push(t);
+                }
+            }),
+        ).then(() => setTeamsWithBillingEnabled(teamsWithBilling));
+    }, [teams]);
+
+    const setUsageAttributionTeam = async (team?: Team) => {
+        if (!user) {
+            return;
+        }
+        const additionalData = user.additionalData || {};
+        additionalData.usageAttributionId = team ? `team:${team.id}` : `user:${user.id}`;
+        await getGitpodService().server.updateLoggedInUser({ additionalData });
+    };
 
     return (
         <PageWithSubMenu
@@ -21,13 +55,45 @@ export default function Billing() {
         >
             <h3>Usage-Based Billing</h3>
             <h2 className="text-gray-500">Manage usage-based billing, spending limit, and payment method.</h2>
-            <p className="mt-8">
-                Hint:{" "}
-                <Link className="gp-link" to="/teams/new">
-                    Create a team
-                </Link>{" "}
-                to set up usage-based billing.
-            </p>
+            <div className="mt-8">
+                <h3>Billing Account</h3>
+                {teamsWithBillingEnabled === undefined && <Spinner className="m-2 h-5 w-5 animate-spin" />}
+                {teamsWithBillingEnabled && teamsWithBillingEnabled.length === 0 && (
+                    <div className="flex space-x-2">
+                        <span>
+                            <Link className="gp-link" to="/teams/new">
+                                Create a team
+                            </Link>{" "}
+                            to set up usage-based billing.
+                        </span>
+                    </div>
+                )}
+                {teamsWithBillingEnabled && teamsWithBillingEnabled.length > 0 && (
+                    <div className="flex space-x-2">
+                        <span>Bill all my usage to:</span>
+                        <DropDown
+                            activeEntry={
+                                teamsWithBillingEnabled.find(
+                                    (t) => `team:${t.id}` === user?.additionalData?.usageAttributionId,
+                                )?.name
+                            }
+                            customClasses="w-32"
+                            renderAsLink={true}
+                            entries={[
+                                {
+                                    title: "(myself)",
+                                    onClick: () => setUsageAttributionTeam(undefined),
+                                },
+                            ].concat(
+                                teamsWithBillingEnabled.map((t) => ({
+                                    title: t.name,
+                                    onClick: () => setUsageAttributionTeam(t),
+                                })),
+                            )}
+                        />
+                    </div>
+                )}
+            </div>
         </PageWithSubMenu>
     );
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -150,9 +150,10 @@ export interface AdditionalUserData {
     oauthClientsApproved?: { [key: string]: string };
     // to remember GH Orgs the user installed/updated the GH App for
     knownGitHubOrgs?: string[];
-
     // Git clone URL pointing to the user's dotfile repo
     dotfileRepo?: string;
+    // Identifies an explicit team or user ID to which all the user's workspace usage should be attributed to (e.g. for billing purposes)
+    usageAttributionId?: string;
 }
 
 export interface EmailNotificationSettings {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When payment is enabled, attribute all workspace instance usage to an explicitly selected "billing account".

TODO:

- [x] In the user's Billing settings, show all the teams that have usage-based billing enabled in a dropdown
- [x] Persist a user's selected "billing account"
- [x] When computing the `usageAttributionId` of a workspace instance, attribute based on the workspace owner's selected "billing account"

Follow-ups:
- Auto-select "billing account" when there is no ambiguity (e.g. when a team upgrades to usage-based billing, also update all its users' `usageAttributionId` where it makes sense)
- Auto-revert to user account when the team subscription is cancelled, or when the user leaves the team

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10901

## How to test
<!-- Provide steps to test this PR -->

1. Open a workspace with no project
2. Create a project under your user (this automatically triggers a prebuild, so no need to also start a workspace)
3. Create a Team A, with a Project A under it
4. Create a Team B, with a Project B under it
5. Verify attribution*:
  a. Workspace with no project --> your user
  b. Workspace with user project --> your user
  c. Workspace with Team A project --> your user
  d. Workspace with Team B project --> your user
6. Now, enable usage-based billing for Team A, by adding a credit card for it (e.g 4242 4242 4242 4242, 4/24, 424)
7. Next, in your user's Settings, go to the "Billing" page, and select "Team A" as a billing account (note: "Team B" should not be available, since it doesn't have usage-based billing enabled)
8. Open a new workspace with no project
9. Open a new workspace for your user project
10. Open a new workspace for Project A
11. Open a new workspace for Project B
12. Verify attribution*:
  a. Workspace with no project --> team A
  b. Workspace with user project --> team A
  c. Workspace with Team A project --> team A
  d. Workspace with Team B project --> team A

*To verify attribution, open this PR in Gitpod, then run:

```
kubectl port-forward mysql-0 3306 &
mysql -h 127.0.0.1 -pjBzVMe2w4Yi7GagadsyB gitpod
mysql> select workspaceId, usageAttributionId, creationTime from d_b_workspace_instance order by creationTime;
```

Example output:

```
+-----------------------------------+-------------------------------------------+--------------------------+
| workspaceId                       | usageAttributionId                        | creationTime             |
+-----------------------------------+-------------------------------------------+--------------------------+
| autofixdev-autofix-vyof8v6yj9i    | user:a7dcf253-f05e-4dcf-9a47-cf8fccc74717 | 2022-06-24T13:13:34.254Z |
| jankeromnes-metachess-g7xzjycgnqj | team:8eba990a-4f1c-4233-b80f-c45330f81dd6 | 2022-06-24T13:14:41.517Z |
| jankeromnes-metaboard-9uzkqymxtz0 | team:8eba990a-4f1c-4233-b80f-c45330f81dd6 | 2022-06-24T13:15:04.492Z |
| jankeromnes-metachess-zwbh1q0jis4 | user:a7dcf253-f05e-4dcf-9a47-cf8fccc74717 | 2022-06-24T13:15:38.521Z |
+-----------------------------------+-------------------------------------------+--------------------------+
```

You can also verify every user's `usageAttributionId` preference like so:

```
mysql> select name, additionalData->"$.usageAttributionId" from d_b_user;
+--------------------------+---------------------------------------------+
| name                     | additionalData->"$.usageAttributionId"      |
+--------------------------+---------------------------------------------+
| jankeromnes              | "team:8eba990a-4f1c-4233-b80f-c45330f81dd6" |
| agent-smith              | NULL                                        |
| builtin-workspace-prober | NULL                                        |
+--------------------------+---------------------------------------------+
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
