### PR TITLE
[server] Return raw duration from `getWorkspaceTimeout`

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1707,8 +1707,9 @@ type StartWorkspaceOptions struct {
 
 // GetWorkspaceTimeoutResult is the GetWorkspaceTimeoutResult message type
 type GetWorkspaceTimeoutResult struct {
-	CanChange bool   `json:"canChange,omitempty"`
-	Duration  string `json:"duration,omitempty"`
+	CanChange   bool   `json:"canChange,omitempty"`
+	DurationRaw string `json:"durationRaw,omitempty"`
+	Duration    string `json:"duration,omitempty"`
 }
 
 // WorkspaceInstancePort is the WorkspaceInstancePort message type

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -380,6 +380,7 @@ export interface SetWorkspaceTimeoutResult {
 
 export interface GetWorkspaceTimeoutResult {
     duration: WorkspaceTimeoutDuration;
+    durationRaw: string;
     canChange: boolean;
 }
 


### PR DESCRIPTION
## Description

Add a new `rawDuration` field to the object returned by `getWorkspaceTimeout`. This represents the workspace timeout as a string in the format `30m`, `60m`, `180m`. The existing `duration` field translates these times into `short` or `extended`.

This is necessary for the new `gp timeout show` command (https://github.com/gitpod-io/gitpod/pull/10782) to present the workspace timeout in a format that makes the most sense to the user.

## Related Issue(s)

https://github.com/gitpod-io/gitpod/pull/10782

## How to test

1. Open the preview environment and start a workspace.
3. In the browser console on the workspaces list run:
  ```js
  await window._gp.gitpodService.server.getWorkspaceTimeout()
  ```

Observe the new `rawDuration` field in the response object:
```json
{
  "duration": "short", 
  "durationRaw": "30m"
  "canChange": true,
}
```

## Release Notes

```release-note
NONE
```

## Documentation
None

## Werft options

- [x] /werft with-preview
