### PR TITLE
Disable 5 second delay before returning feature flag value

### DIFF
--- a/components/dashboard/src/experiments/configcat.ts
+++ b/components/dashboard/src/experiments/configcat.ts
@@ -23,6 +23,7 @@ export function newProductionConfigCatClient(): Client {
     // clientKey is an identifier of our ConfigCat application. It is not a secret.
     const clientKey = "WBLaCPtkjkqKHlHedziE9g/TwAe6YyftEGPnGxVRXd0Ig";
     const client = configcat.createClient(clientKey, {
+        maxInitWaitTimeSeconds: 0,
         logger: configcat.createConsoleLogger(2),
     });
 
@@ -35,6 +36,7 @@ export function newNonProductionConfigCatClient(): Client {
     // clientKey is an identifier of our ConfigCat application. It is not a secret.
     const clientKey = "WBLaCPtkjkqKHlHedziE9g/LEAOCNkbuUKiqUZAcVg7dw";
     const client = configcat.createClient(clientKey, {
+        maxInitWaitTimeSeconds: 0,
         pollIntervalSeconds: 60 * 3, // 3 minutes
         logger: configcat.createConsoleLogger(3),
     });

--- a/components/server/src/experiments.ts
+++ b/components/server/src/experiments.ts
@@ -14,6 +14,7 @@ export function getExperimentsClient(): IConfigCatClient {
     if (client === undefined) {
         client = configcat.createClient("WBLaCPtkjkqKHlHedziE9g/LEAOCNkbuUKiqUZAcVg7dw", {
             // <-- This is the actual SDK Key for your Test environment
+            maxInitWaitTimeSeconds: 0,
             logger: logger,
         });
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

While debugging with @easyCZ why getting feature flag values was sometimes so slow, we found that by default, our experiments client waits for 5 seconds before returning the initial value (see [all options](https://configcat.com/docs/sdk-reference/js/#auto-polling-default)):

<img width="824" alt="Screenshot 2022-06-24 at 12 57 35" src="https://user-images.githubusercontent.com/599268/175521540-4d944167-d64a-4208-b552-2f33bda16fc0.png">

Disabling this delay makes getting feature flag values instantaneous. 🪄 ⚡

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10786

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod"
2. Go to Team Billing
3. The Usage-Based UI should be instantly visible, even if you reload the page

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
