### PR TITLE
[kots]: apply customization file to Installer

### DIFF
--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-azure-minio-gateway.0"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-kots-customization.1"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-azure-minio-gateway.0"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-kots-customization.1"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -259,6 +259,18 @@ spec:
                   echo "Gitpod: Adding domain \"${domain}\" to blockNewUsers config"
                   yq e -i ".blockNewUsers.passlist += \"${domain}\"" "${CONFIG_FILE}"
                 done
+              fi
+
+              if [ '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}' = "true" ];
+              then
+                if [ '{{repl ConfigOptionNotEquals "customization_patch" "" }}' = "true" ];
+                then
+                  CUSTOMIZATION='{{repl ConfigOptionData "customization_patch" | Base64Encode }}'
+                  echo "Gitpod: Applying customization patch ${CUSTOMIZATION}"
+
+                  # Apply the customization property - if something else is set, this will be ignored
+                  yq e -i ".customization = $(echo "${CUSTOMIZATION}" | base64 -d | yq e -o json '.customization' - | jq -rc) // []" "${CONFIG_FILE}"
+                fi
               fi
 
               echo "Gitpod: Patch Gitpod config"

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -379,6 +379,21 @@ spec:
           default: "0"
           help_text: Enables additional customization options. Enable only when you know what you are doing!
 
+        - name: customization_patch
+          title: Gitpod customization patch (YAML file)
+          type: file
+          required: false
+          when: '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}'
+          help_text: |
+            A file configured to override annotations, labels and environment variables in components. See our
+            [advanced documentation](https://www.gitpod.io/docs/self-hosted/latest/advanced/customization) for
+            more details and the format.
+
+            Labels are an immutable property in Kubernetes, so you may need to uninstall your Gitpod instance
+            before applying - run `helm uninstall -n {{repl Namespace }} gitpod`.
+
+            **WARNING** this should not be run if using in-cluster database and/or object storage.
+
         - name: config_patch
           title: Gitpod config patch (YAML file)
           type: file


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds the config section to the KOTS dashboard for the customization file

**NB** this must be applied to a cluster which does not have Gitpod installed. If you have it installed, you must run `helm un -n gitpod gitpod` beforehand if you intend to change any labels with your customization file. This is because Kubernetes cannot change the labels of a deployment/daemonset/statefulset. As this is for a specific set of enterprise customers who have engaged us for support, this should be an acceptable compromise for the time being.

This may be fixed in a future PR.

This is not an issue if changing annotations

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10910

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS to a cluster, using this YAML as your customization file

```yaml
customization:
  - apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: server
      annotations:
        hello: world
```

When you next run it, `kubectl get pods -n gitpod -l component=server -o jsonpath="{.items[0].metadata.annotations}"` should have the annotation `hello=word`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: apply customization file to Installer
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
