### PR TITLE
[installation-telemetry] Respect `sendCustomerID` admin setting

### DIFF
--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -27,7 +27,6 @@ export class InstallationAdminTelemetryDataProvider {
                 totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
                 totalInstances: await this.workspaceDb.getInstanceCount(),
                 licenseType: this.licenseEvaluator.getLicenseData().type,
-                customerID: this.licenseEvaluator.getLicenseData().payload.customerID,
             } as TelemetryData;
 
             if (data.installationAdmin.settings.sendCustomerID) {


### PR DESCRIPTION
## Description

An errant `git rebase` accidentally merged in the customer ID into telemetry
data, bypassing a later check in telemetry collection that checked the `sendCustomerID`
field. This commit restores the appropriate check.

## Related Issue(s)

Introduced by #10629 

## How to test

Go to `Admin/Settings`, disable the `Include customer ID in telemetry` option, and refresh the page. The customer ID field should not be present when the checkbox is unticked.

## Release Notes

```release-note
NONE
```

## Documentation

NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
