### PR TITLE
Update overview.json

### DIFF
--- a/operations/observability/mixins/platform/dashboards/preview-environments/overview.json
+++ b/operations/observability/mixins/platform/dashboards/preview-environments/overview.json
@@ -60,7 +60,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1655818317025,
+  "iteration": 1656107717942,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -337,7 +337,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum_over_time((probe_success{environment=\"preview-environments\", job=\"probe\"} == 1)[5m]) \r\n/\r\ncount_over_time(up{environment=\"preview-environments\", job=\"probe\"}[5m])",
+          "expr": "sum(probe_success{environment=\"preview-environments\", job=\"probe\"} == 1)\r\n/\r\ncount(up{environment=\"preview-environments\", job=\"probe\"})",
           "format": "time_series",
           "instant": false,
           "legendFormat": "Probe success rate",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix the SLI 2's query.

`sum_over_time` and `count_over_time` do not aggregate timeseries, giving us one result per preview environment. This PR updates the query to use `sum` and `count`, which aggregates metrics from all previews into a single one.


Before:
![image](https://user-images.githubusercontent.com/24193764/175698463-5eff3117-bcc7-405c-8d64-f56b4a8a6eee.png)


After:
![image](https://user-images.githubusercontent.com/24193764/175698443-2d0574b0-e2ef-46a5-9603-564a72b9679f.png)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
