### PR TITLE
Infer config with go mod download instead of go get

### DIFF
--- a/components/server/src/config/config-inferrer.spec.ts
+++ b/components/server/src/config/config-inferrer.spec.ts
@@ -171,7 +171,7 @@ describe("config inferrer", () => {
                 {
                     tasks: [
                         {
-                            init: "go get && go build ./... && go test ./...",
+                            init: "go mod download && go build ./... && go test ./...",
                             command: "go run",
                         },
                     ],

--- a/components/server/src/config/config-inferrer.ts
+++ b/components/server/src/config/config-inferrer.ts
@@ -143,7 +143,7 @@ export class ConfigInferrer {
 
     protected async checkGo(ctx: Context) {
         if (await ctx.exists("go.mod")) {
-            this.addCommand(ctx.config, "go get", "init");
+            this.addCommand(ctx.config, "go mod download", "init");
             this.addCommand(ctx.config, "go build ./...", "init");
             this.addCommand(ctx.config, "go test ./...", "init");
             this.addCommand(ctx.config, "go run", "command");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`go get` doesn't work for most Go projects nowadays in my experience, I always replace it with `go mod download`.
https://go.dev/ref/mod#go-mod-download

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
```sh
cd components/server && npm run test
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
infer config with go mod download instead of go get
```


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
