### PR TITLE
[usage] Add usageAttributionID to WorkspaceInstance model (in go)

### DIFF
--- a/components/usage/pkg/db/dbtest/workspace_instance.go
+++ b/components/usage/pkg/db/dbtest/workspace_instance.go
@@ -59,9 +59,15 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 		status = instance.Status
 	}
 
+	attributionID := db.NewUserAttributionID(uuid.New().String())
+	if instance.UsageAttributionID != "" {
+		attributionID = instance.UsageAttributionID
+	}
+
 	return db.WorkspaceInstance{
 		ID:                 id,
 		WorkspaceID:        workspaceID,
+		UsageAttributionID: attributionID,
 		Configuration:      nil,
 		Region:             "",
 		ImageBuildInfo:     sql.NullString{},

--- a/components/usage/pkg/db/workspace_instance_test.go
+++ b/components/usage/pkg/db/workspace_instance_test.go
@@ -217,3 +217,25 @@ func TestListWorkspaceInstancesInRange_InBatches(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, len(instances))
 }
+
+func TestAttributionID_Values(t *testing.T) {
+	scenarios := []struct {
+		Input          string
+		ExpectedEntity string
+		ExpectedID     string
+	}{
+		{Input: "team:123", ExpectedEntity: db.AttributionEntity_Team, ExpectedID: "123"},
+		{Input: "user:123", ExpectedEntity: db.AttributionEntity_User, ExpectedID: "123"},
+		{Input: "user:123:invalid", ExpectedEntity: "", ExpectedID: ""},
+		{Input: "invalid:123:", ExpectedEntity: "", ExpectedID: ""},
+		{Input: "", ExpectedEntity: "", ExpectedID: ""},
+	}
+
+	for _, s := range scenarios {
+		t.Run(fmt.Sprintf("attribution in: %s, expecting: %s %s", s.Input, s.ExpectedEntity, s.ExpectedID), func(t *testing.T) {
+			entity, id := db.AttributionID(s.Input).Values()
+			require.Equal(t, s.ExpectedEntity, entity)
+			require.Equal(t, s.ExpectedID, id)
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds model definition to consume usage attribution id

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/10922

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
