### PR TITLE
Change fluent-bit chart name in KOTS

### DIFF
--- a/install/kots/charts/fluent-bit/Chart.yaml
+++ b/install/kots/charts/fluent-bit/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 description: Gitpod fluent-bit
-name: fluent-bit
+name: gitpod-fluent-bit
 version: 0.20.2
 dependencies:
   - name: fluent-bit

--- a/install/kots/manifests/gitpod-log-collector.yaml
+++ b/install/kots/manifests/gitpod-log-collector.yaml
@@ -4,10 +4,10 @@
 apiVersion: kots.io/v1beta1
 kind: HelmChart
 metadata:
-  name: fluent-bit
+  name: gitpod-fluent-bit
 spec:
   chart:
-    name: fluent-bit
+    name: gitpod-fluent-bit
     chartVersion: 0.20.2
   helmVersion: v3
   useHelmInstall: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, with the latest version of KOTS CLI, we have an issue with the deployment of fluent-bit[ as mentioned here](https://github.com/replicated-collab/replicated-gitpod/issues/27#issuecomment-1165984939). This PR introduced a small workaround for this, changing the name of the `fluent-bit` chart.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create a self-hosted setup using KOTS and you will now see  pod with a changed name `gitpod-fluent-bit-8kpwh`. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
