### PR TITLE
[kots]: change to not install via Helm

### DIFF
--- a/install/kots/manifests/gitpod-log-collector.yaml
+++ b/install/kots/manifests/gitpod-log-collector.yaml
@@ -10,7 +10,7 @@ spec:
     name: fluent-bit
     chartVersion: 0.20.2
   helmVersion: v3
-  useHelmInstall: true
+  useHelmInstall: false
   weight: 10
   values:
     fluent-bit:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A [regression by Replicated](https://github.com/replicated-collab/replicated-gitpod/issues/27) introduced a breaking change to how to deploy KOTS releases that included a Helm chart between v1.72.0 and v1.72.2. The [change](https://github.com/replicatedhq/kots/commit/77690e5cad4a1abe0bb63063129564059777d8f4) only affects manifests that use native Helm but the legacy implementation inside KOTS.

## How to test
<!-- Provide steps to test this PR -->
Install with KOTS v1.72.0 and then with KOTS latest

```sh
# Install KOTS v1.72.0
curl https://kots.io/install/1.72.0 | bash
```

```sh
# Install KOTS latest
curl https://kots.io/install | bash
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: change to not install via Helm
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
