### PR TITLE
[Usage-based] Use different Stripe prices for individuals (with free tier) vs teams (no free tier)

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -4,10 +4,18 @@ metadata:
   name: stripe-config
   namespace: ${NAMESPACE}
 data:
-  config: >
+  config: |
     {
       "usageProductPriceIds": {
         "EUR": "price_1LD8cQGadRXm50o30QwBU9aY",
         "USD": "price_1LD8cQGadRXm50o3ftnIiUZL"
+      },
+      "teamPriceIds": {
+        "EUR": "price_1LFIvhGadRXm50o3MZHXKowI",
+        "USD": "price_1LFIvhGadRXm50o3Z19aHMfh"
+      },
+      "individualPriceIds": {
+        "EUR": "price_1LFIvhGadRXm50o38QZxADDr",
+        "USD": "price_1LFIvhGadRXm50o3fd2RMWoP"
       }
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use different Stripe prices for individuals (with free tier) vs teams (no free tier):
- [x] Update the Stripe product price IDs in Werft
- [ ] Use the correct price IDs when subscribing individuals vs teams

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment