### PR TITLE
[usage] Use attribution ID to reduce DB queries for usage report

### DIFF
--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -45,12 +45,6 @@ type UsageReconcileStatus struct {
 
 	WorkspaceInstances        int
 	InvalidWorkspaceInstances int
-
-	Workspaces int
-
-	Teams int
-
-	Report []TeamUsage
 }
 
 func (u *UsageReconciler) Reconcile() error {
@@ -60,7 +54,7 @@ func (u *UsageReconciler) Reconcile() error {
 	startOfCurrentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	startOfNextMonth := startOfCurrentMonth.AddDate(0, 1, 0)
 
-	status, err := u.ReconcileTimeRange(ctx, startOfCurrentMonth, startOfNextMonth)
+	status, report, err := u.ReconcileTimeRange(ctx, startOfCurrentMonth, startOfNextMonth)
 	if err != nil {
 		return err
 	}
@@ -75,7 +69,7 @@ func (u *UsageReconciler) Reconcile() error {
 	defer f.Close()
 
 	enc := json.NewEncoder(f)
-	err = enc.Encode(status.Report)
+	err = enc.Encode(report)
 	if err != nil {
 		return fmt.Errorf("failed to marshal report to JSON: %w", err)
 	}
@@ -89,7 +83,7 @@ func (u *UsageReconciler) Reconcile() error {
 	return nil
 }
 
-func (u *UsageReconciler) ReconcileTimeRange(ctx context.Context, from, to time.Time) (*UsageReconcileStatus, error) {
+func (u *UsageReconciler) ReconcileTimeRange(ctx context.Context, from, to time.Time) (*UsageReconcileStatus, UsageReport, error) {
 	now := u.nowFunc().UTC()
 	log.Infof("Gathering usage data from %s to %s", from, to)
 	status := &UsageReconcileStatus{
@@ -98,7 +92,7 @@ func (u *UsageReconciler) ReconcileTimeRange(ctx context.Context, from, to time.
 	}
 	instances, invalidInstances, err := u.loadWorkspaceInstances(ctx, from, to)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load workspace instances: %w", err)
+		return nil, nil, fmt.Errorf("failed to load workspace instances: %w", err)
 	}
 	status.WorkspaceInstances = len(instances)
 	status.InvalidWorkspaceInstances = len(invalidInstances)
@@ -108,129 +102,38 @@ func (u *UsageReconciler) ReconcileTimeRange(ctx context.Context, from, to time.
 	}
 	log.WithField("workspace_instances", instances).Debug("Successfully loaded workspace instances.")
 
-	workspaces, err := u.loadWorkspaces(ctx, instances)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load workspaces for workspace instances in time range: %w", err)
-	}
-	status.Workspaces = len(workspaces)
+	instancesByAttributionID := groupInstancesByAttributionID(instances)
 
-	// match workspaces to teams
-	teams, err := u.loadTeamsForWorkspaces(ctx, workspaces)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load teams for workspaces: %w", err)
-	}
-	status.Teams = len(teams)
+	u.billingController.Reconcile(ctx, now, instancesByAttributionID)
 
-	report, err := generateUsageReport(teams, now)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate usage report: %w", err)
-	}
-	status.Report = report
-
-	u.billingController.Reconcile(status.Report)
-
-	return status, nil
+	return status, instancesByAttributionID, nil
 }
 
-func generateUsageReport(teams []teamWithWorkspaces, maxStopTime time.Time) ([]TeamUsage, error) {
-	var report []TeamUsage
-	for _, team := range teams {
-		var teamTotalRuntime int64
-		for _, workspace := range team.Workspaces {
-			for _, instance := range workspace.Instances {
-				teamTotalRuntime += instance.WorkspaceRuntimeSeconds(maxStopTime)
-			}
+type UsageReport map[db.AttributionID][]db.WorkspaceInstance
+
+func (u UsageReport) RuntimeSummaryForTeams(maxStopTime time.Time) map[string]int64 {
+	attributedUsage := map[string]int64{}
+
+	for attribution, instances := range u {
+		entity, id := attribution.Values()
+		if entity != db.AttributionEntity_Team {
+			continue
 		}
 
-		report = append(report, TeamUsage{
-			TeamID:           team.TeamID.String(),
-			WorkspaceSeconds: teamTotalRuntime,
-		})
+		var runtime uint64
+		for _, instance := range instances {
+			runtime += instance.WorkspaceRuntimeSeconds(maxStopTime)
+		}
+
+		attributedUsage[id] = int64(runtime)
 	}
-	return report, nil
+
+	return attributedUsage
 }
 
-type teamWithWorkspaces struct {
-	TeamID     uuid.UUID
-	Workspaces []workspaceWithInstances
-}
-
-func (u *UsageReconciler) loadTeamsForWorkspaces(ctx context.Context, workspaces []workspaceWithInstances) ([]teamWithWorkspaces, error) {
-	// find owner IDs of these workspaces
-	var ownerIDs []uuid.UUID
-	for _, workspace := range workspaces {
-		ownerIDs = append(ownerIDs, workspace.Workspace.OwnerID)
-	}
-
-	// Retrieve memberships. This gives a link between an Owner and a Team they belong to.
-	memberships, err := db.ListTeamMembershipsForUserIDs(ctx, u.conn, ownerIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list team memberships: %w", err)
-	}
-
-	membershipsByUserID := map[uuid.UUID]db.TeamMembership{}
-	for _, membership := range memberships {
-		// User can belong to multiple teams. For now, we're choosing the membership at random.
-		membershipsByUserID[membership.UserID] = membership
-	}
-
-	// Convert workspaces into a lookup so that we can index into them by Owner ID, needed for joining Teams with Workspaces
-	workspacesByOwnerID := map[uuid.UUID][]workspaceWithInstances{}
-	for _, workspace := range workspaces {
-		workspacesByOwnerID[workspace.Workspace.OwnerID] = append(workspacesByOwnerID[workspace.Workspace.OwnerID], workspace)
-	}
-
-	// Finally, join the datasets
-	// Because we iterate over memberships, and not workspaces, we're in effect ignoring Workspaces which are not in a team.
-	// This is intended as we focus on Team usage for now.
-	var teamsWithWorkspaces []teamWithWorkspaces
-	for userID, membership := range membershipsByUserID {
-		teamsWithWorkspaces = append(teamsWithWorkspaces, teamWithWorkspaces{
-			TeamID:     membership.TeamID,
-			Workspaces: workspacesByOwnerID[userID],
-		})
-	}
-
-	return teamsWithWorkspaces, nil
-}
-
-type workspaceWithInstances struct {
-	Workspace db.Workspace
-	Instances []db.WorkspaceInstance
-}
-
-func (u *UsageReconciler) loadWorkspaces(ctx context.Context, instances []db.WorkspaceInstance) ([]workspaceWithInstances, error) {
-	var workspaceIDs []string
-	for _, instance := range instances {
-		workspaceIDs = append(workspaceIDs, instance.WorkspaceID)
-	}
-
-	workspaces, err := db.ListWorkspacesByID(ctx, u.conn, toSet(workspaceIDs))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find workspaces for provided workspace instances: %w", err)
-	}
-
-	workspacesByID := map[string]db.Workspace{}
-	for _, workspace := range workspaces {
-		workspacesByID[workspace.ID] = workspace
-	}
-
-	// We need to also add the instances to corresponding records, a single workspace can have multiple instances
-	instancesByWorkspaceID := map[string][]db.WorkspaceInstance{}
-	for _, instance := range instances {
-		instancesByWorkspaceID[instance.WorkspaceID] = append(instancesByWorkspaceID[instance.WorkspaceID], instance)
-	}
-
-	// Flatten results into a list
-	var workspacesWithInstances []workspaceWithInstances
-	for workspaceID, workspace := range workspacesByID {
-		workspacesWithInstances = append(workspacesWithInstances, workspaceWithInstances{
-			Workspace: workspace,
-			Instances: instancesByWorkspaceID[workspaceID],
-		})
-	}
-
-	return workspacesWithInstances, nil
+type invalidWorkspaceInstance struct {
+	reason              string
+	workspaceInstanceID uuid.UUID
 }
 
 func (u *UsageReconciler) loadWorkspaceInstances(ctx context.Context, from, to time.Time) ([]db.WorkspaceInstance, []invalidWorkspaceInstance, error) {
@@ -244,11 +147,6 @@ func (u *UsageReconciler) loadWorkspaceInstances(ctx context.Context, from, to t
 	valid, invalid := validateInstances(instances)
 	trimmed := trimStartStopTime(valid, from, to)
 	return trimmed, invalid, nil
-}
-
-type invalidWorkspaceInstance struct {
-	reason              string
-	workspaceInstanceID uuid.UUID
 }
 
 func validateInstances(instances []db.WorkspaceInstance) (valid []db.WorkspaceInstance, invalid []invalidWorkspaceInstance) {
@@ -302,20 +200,15 @@ func trimStartStopTime(instances []db.WorkspaceInstance, maximumStart, minimumSt
 	return updated
 }
 
-func toSet(items []string) []string {
-	m := map[string]struct{}{}
-	for _, i := range items {
-		m[i] = struct{}{}
+func groupInstancesByAttributionID(instances []db.WorkspaceInstance) map[db.AttributionID][]db.WorkspaceInstance {
+	result := map[db.AttributionID][]db.WorkspaceInstance{}
+	for _, instance := range instances {
+		if _, ok := result[instance.UsageAttributionID]; !ok {
+			result[instance.UsageAttributionID] = []db.WorkspaceInstance{}
+		}
+
+		result[instance.UsageAttributionID] = append(result[instance.UsageAttributionID], instance)
 	}
 
-	var result []string
-	for s := range m {
-		result = append(result, s)
-	}
 	return result
-}
-
-type TeamUsage struct {
-	TeamID           string `json:"team_id"`
-	WorkspaceSeconds int64  `json:"workspace_seconds"`
 }

--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -15,153 +15,58 @@ import (
 )
 
 func TestUsageReconciler_ReconcileTimeRange(t *testing.T) {
-	type Scenario struct {
-		Name    string
-		NowFunc func() time.Time
-
-		Memberships []db.TeamMembership
-		Workspaces  []db.Workspace
-		Instances   []db.WorkspaceInstance
-
-		Expected *UsageReconcileStatus
-	}
-
 	startOfMay := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
 	startOfJune := time.Date(2022, 06, 1, 0, 00, 00, 00, time.UTC)
 
-	scenarios := []Scenario{
-		(func() Scenario {
-			teamID := uuid.New()
-			userID := uuid.New()
-			scenarioRunTime := time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)
+	teamID := uuid.New()
+	scenarioRunTime := time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)
 
-			membership := db.TeamMembership{
-				ID:     uuid.New(),
-				TeamID: teamID,
-				UserID: userID,
-				Role:   db.TeamMembershipRole_Member,
-			}
-			workspace := dbtest.NewWorkspace(t, db.Workspace{
-				ID:      "gitpodio-gitpod-gyjr82jkfna",
-				OwnerID: userID,
-			})
-			instances := []db.WorkspaceInstance{
-				// Ran throughout the reconcile period
-				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-					ID:           uuid.New(),
-					WorkspaceID:  workspace.ID,
-					CreationTime: db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
-					StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
-					StoppedTime:  db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-				}),
-				// Still running
-				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-					ID:           uuid.New(),
-					WorkspaceID:  workspace.ID,
-					CreationTime: db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
-					StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
-				}),
-				// No creation time, invalid record
-				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-					ID:          uuid.New(),
-					WorkspaceID: workspace.ID,
-					StartedTime: db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-					StoppedTime: db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-				}),
-			}
-
-			expectedRuntime := instances[0].WorkspaceRuntimeSeconds(scenarioRunTime) + instances[1].WorkspaceRuntimeSeconds(scenarioRunTime)
-
-			return Scenario{
-				Name:        "one team with one workspace",
-				Memberships: []db.TeamMembership{membership},
-				Workspaces:  []db.Workspace{workspace},
-				Instances:   instances,
-				NowFunc:     func() time.Time { return scenarioRunTime },
-				Expected: &UsageReconcileStatus{
-					StartTime:                 startOfMay,
-					EndTime:                   startOfJune,
-					WorkspaceInstances:        2,
-					InvalidWorkspaceInstances: 1,
-					Workspaces:                1,
-					Teams:                     1,
-					Report: []TeamUsage{
-						{
-							TeamID:           teamID.String(),
-							WorkspaceSeconds: expectedRuntime,
-						},
-					},
-				},
-			}
-		})(),
-		(func() Scenario {
-			runTime := time.Date(2022, 05, 31, 23, 59, 59, 999999, time.UTC)
-			teamID, userID := uuid.New(), uuid.New()
-			workspaceID := "gitpodio-gitpod-gyjr82jkfnd"
-			var instances []db.WorkspaceInstance
-			for i := 0; i < 100; i++ {
-				instances = append(instances, dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-					ID:           uuid.New(),
-					WorkspaceID:  workspaceID,
-					CreationTime: db.NewVarcharTime(time.Date(2022, 05, 01, 00, 00, 00, 00, time.UTC)),
-					StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 01, 00, 00, 00, 00, time.UTC)),
-					StoppedTime:  db.NewVarcharTime(time.Date(2022, 05, 31, 23, 59, 59, 999999, time.UTC)),
-				}))
-			}
-
-			return Scenario{
-				Name:    "many long running instances do not overflow number of seconds in usage",
-				NowFunc: func() time.Time { return runTime },
-				Memberships: []db.TeamMembership{
-					{
-						ID:     uuid.New(),
-						TeamID: teamID,
-						UserID: userID,
-						Role:   db.TeamMembershipRole_Member,
-					},
-				},
-				Workspaces: []db.Workspace{
-					dbtest.NewWorkspace(t, db.Workspace{
-						ID:      workspaceID,
-						OwnerID: userID,
-					}),
-				},
-				Instances: instances,
-				Expected: &UsageReconcileStatus{
-					StartTime:                 startOfMay,
-					EndTime:                   startOfJune,
-					WorkspaceInstances:        100,
-					InvalidWorkspaceInstances: 0,
-					Workspaces:                1,
-					Teams:                     1,
-					Report: []TeamUsage{
-						{
-							TeamID:           teamID.String(),
-							WorkspaceSeconds: instances[0].WorkspaceRuntimeSeconds(runTime) * 100,
-						},
-					},
-				},
-			}
-		})(),
+	instances := []db.WorkspaceInstance{
+		// Ran throughout the reconcile period
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
+			ID:                 uuid.New(),
+			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
+			CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
+			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+		}),
+		// Still running
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
+			ID:                 uuid.New(),
+			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
+			CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
+		}),
+		// No creation time, invalid record
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
+			ID:                 uuid.New(),
+			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+		}),
 	}
 
-	for _, scenario := range scenarios {
-		t.Run(scenario.Name, func(t *testing.T) {
-			conn := dbtest.ConnectForTests(t)
-			require.NoError(t, conn.Create(scenario.Memberships).Error)
-			dbtest.CreateWorkspaces(t, conn, scenario.Workspaces...)
-			dbtest.CreateWorkspaceInstances(t, conn, scenario.Instances...)
+	expectedRuntime := instances[0].WorkspaceRuntimeSeconds(scenarioRunTime) + instances[1].WorkspaceRuntimeSeconds(scenarioRunTime)
 
-			reconciler := &UsageReconciler{
-				billingController: &NoOpBillingController{},
-				nowFunc:           scenario.NowFunc,
-				conn:              conn,
-			}
-			status, err := reconciler.ReconcileTimeRange(context.Background(), startOfMay, startOfJune)
-			require.NoError(t, err)
+	conn := dbtest.ConnectForTests(t)
+	dbtest.CreateWorkspaceInstances(t, conn, instances...)
 
-			require.Equal(t, scenario.Expected, status)
-		})
-
+	reconciler := &UsageReconciler{
+		billingController: &NoOpBillingController{},
+		nowFunc:           func() time.Time { return scenarioRunTime },
+		conn:              conn,
 	}
+	status, report, err := reconciler.ReconcileTimeRange(context.Background(), startOfMay, startOfJune)
+	require.NoError(t, err)
+
+	require.Len(t, report, 1)
+	require.Equal(t, &UsageReconcileStatus{
+		StartTime:                 startOfMay,
+		EndTime:                   startOfJune,
+		WorkspaceInstances:        2,
+		InvalidWorkspaceInstances: 1,
+	}, status)
+	require.Equal(t, map[string]int64{
+		teamID.String(): int64(expectedRuntime),
+	}, report.RuntimeSummaryForTeams(scenarioRunTime))
 }

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -46,7 +46,7 @@ type WorkspaceInstance struct {
 
 // WorkspaceRuntimeSeconds computes how long this WorkspaceInstance has been running.
 // If the instance is still running (no stop time set), maxStopTime is used to to compute the duration - this is an upper bound on stop
-func (i *WorkspaceInstance) WorkspaceRuntimeSeconds(maxStopTime time.Time) int64 {
+func (i *WorkspaceInstance) WorkspaceRuntimeSeconds(maxStopTime time.Time) uint64 {
 	start := i.CreationTime.Time()
 	stop := maxStopTime
 
@@ -56,7 +56,7 @@ func (i *WorkspaceInstance) WorkspaceRuntimeSeconds(maxStopTime time.Time) int64
 		}
 	}
 
-	return int64(stop.Sub(start).Round(time.Second).Seconds())
+	return uint64(stop.Sub(start).Round(time.Second).Seconds())
 }
 
 // TableName sets the insert table name for this struct type
@@ -79,6 +79,7 @@ func ListWorkspaceInstancesInRange(ctx context.Context, conn *gorm.DB, from, to 
 		).
 		Where("creationTime < ?", TimeToISO8601(to)).
 		Where("startedTime != ?", "").
+		Where("usageAttributionId != ?", "").
 		FindInBatches(&instancesInBatch, 1000, func(_ *gorm.DB, _ int) error {
 			instances = append(instances, instancesInBatch...)
 			return nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Updates usage controller flow to do the following:

1. Find all Workspace Instances (with time bounds) which have an `usageAttributionId` set.
2. Groups these (in-code) by Attribution ID to create the report

We can't use SQL level group-by because it can only be used with summary functions (like count). The secondary reason is that the Billing controller (which runs after the usage controller) needs to given the full list of WorkspaceInstances to exclude any WorkspaceInstances which it may have already billed for (in another invoice, for example). For this, it has to get the raw data-set and can't receive an aggregation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/10922

## How to test
<!-- Provide steps to test this PR -->
Unit tests
Can be run against staging by port forwarding

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
