### PR TITLE
Add tests for GuardedResources: Workspace, WorkspaceInstance and WorkspaceLog (1/2)

### DIFF
--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -463,16 +463,26 @@ export class RepositoryResourceGuard implements ResourceAccessGuard {
     constructor(protected readonly user: User, protected readonly hostContextProvider: HostContextProvider) {}
 
     async canAccess(resource: GuardedResource, operation: ResourceAccessOp): Promise<boolean> {
-        if (resource.kind !== "workspaceLog" && resource.kind !== "snapshot") {
-            return false;
-        }
-        // only get operations are supported
+        // Only get operations are supported
         if (operation !== "get") {
             return false;
         }
 
+        // Get Workspace from GuardedResource
+        let workspace: Workspace;
+        switch (resource.kind) {
+            case "workspaceLog":
+                workspace = resource.subject;
+                break;
+            case "snapshot":
+                workspace = resource.workspace;
+                break;
+            default:
+                // We do not handle resource kinds here!
+                return false;
+        }
+
         // Check if user has at least read access to the repository
-        const workspace = resource.kind === "snapshot" ? resource.workspace : resource.subject;
         const repos: Repository[] = [];
         if (CommitContext.is(workspace.context)) {
             repos.push(workspace.context.repository);

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1539,7 +1539,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
         traceWI(ctx, { instanceId: instance.id });
         const teamMembers = await this.getTeamMembersByProject(workspace.projectId);
-        await this.guardAccess({ kind: "workspaceInstance", subject: instance, workspace, teamMembers }, "get");
+        await this.guardAccess({ kind: "workspaceLog", subject: workspace, teamMembers }, "get");
 
         // wait for up to 20s for imageBuildLogInfo to appear due to:
         //  - db-sync round-trip times
@@ -1664,7 +1664,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const wsiPromise = this.workspaceDb.trace(ctx).findInstanceById(instanceId);
         const teamMembers = await this.getTeamMembersByProject(ws.projectId);
 
-        await this.guardAccess({ kind: "workspace", subject: ws, teamMembers }, "get");
+        await this.guardAccess({ kind: "workspaceLog", subject: ws, teamMembers }, "get");
 
         const wsi = await wsiPromise;
         if (!wsi) {


### PR DESCRIPTION
## Description

This PR adds tests for workspace-like GuardedResources: `Workspace`, `WorkspaceInstance` and `WorkspaceLog`.
It's a precursor for a follow-up PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: https://github.com/gitpod-io/gitpod/pull/10696

## How to test
 - `cd components/server && yarn test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
