### PR TITLE
Update spacing in project settings

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -150,8 +150,7 @@ export default function () {
                 disabled={isLoading}
                 onChange={toggleIncrementalPrebuilds}
             />
-            <br></br>
-            <h3>Persistent Volume Claim</h3>
+            <h3 className="mt-12">Persistent Volume Claim</h3>
             <CheckBox
                 title={
                     <span>


### PR DESCRIPTION
Replace line break elements with proper spacing in project settings between sections following our spacing scale.

## Description
Following up from https://github.com/gitpod-io/gitpod/pull/10539, this is a minor spacing update in projects settings, following our spacing scale and guidelines, and also avoid any confusion around the grouping[[1](https://en.wikipedia.org/wiki/Principles_of_grouping)] of these two sections.

Other potential updates could include:
1. Rephrasing the title and description of this feature so that it's easier to understand what this is about.
2. Using the BETA label as we do across the product.

See also [relevant discussion](https://gitpod.slack.com/archives/C02F19UUW6S/p1655477531703569) (internal). Cc @sagor999 @loujaybee 

## How to test
1. Go to projects settings for a project.
3. Notice the spacing between _Incremental Prebuilds_ and _Persistent Volume Claim_. The spacing should follow the ones used in **[/preferences](https://gitpod.io/preferences)** under user settings.

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="878" alt="project-settings-before" src="https://user-images.githubusercontent.com/120486/176006170-192f9f5f-ecf6-4ebe-8e19-d81ca384000c.png"> | <img width="878" alt="project-settings-after" src="https://user-images.githubusercontent.com/120486/176006176-eace79a1-7ef3-4f43-9146-d044829bc16c.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```