### PR TITLE
[installer]: allow docker-registry customization

### DIFF
--- a/install/installer/pkg/components/docker-registry/helm.go
+++ b/install/installer/pkg/components/docker-registry/helm.go
@@ -41,6 +41,12 @@ var Helm = common.CompositeHelmFunc(
 			}
 		}
 
+		// Append the custom parameters
+		registryValues = helm.CustomizeAnnotation(registryValues, "docker-registry.podAnnotations", cfg, Component, common.TypeMetaDeployment)
+		registryValues = helm.CustomizeLabel(registryValues, "docker-registry.podLabels", cfg, Component, common.TypeMetaDeployment)
+		registryValues = helm.CustomizeAnnotation(registryValues, "docker-registry.service.annotations", cfg, Component, common.TypeMetaService)
+		registryValues = helm.CustomizeEnvvar(registryValues, "docker-registry.extraEnvVars", cfg, Component)
+
 		inCluster := pointer.BoolDeref(cfg.Config.ContainerRegistry.InCluster, false)
 		s3Storage := cfg.Config.ContainerRegistry.S3Storage
 		enablePersistence := "true"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Configure customization in the Helm container registry. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10966
Fixes #10967

## How to test
<!-- Provide steps to test this PR -->
Add a customization YAML such as below:

```yaml
customization:
  - apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: docker-registry # Important - the component name is "docker-registry"
      annotations:
        hello: world
      labels:
        hello2: world2
    spec:
      env:
        - name: hello3
          value: world3
```



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: allow docker-registry customization
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
