### PR TITLE
[server] abort running prebuilds on same branch

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -221,7 +221,10 @@ export default function (props: { project?: Project; isAdminDashboard?: boolean 
                                         }`}
                                     >
                                         <div>
-                                            <div className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1">
+                                            <div
+                                                className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1"
+                                                title={getPrebuildStatusDescription(p)}
+                                            >
                                                 <div className="inline-block align-text-bottom mr-2 w-4 h-4">
                                                     {prebuildStatusIcon(p)}
                                                 </div>
@@ -329,38 +332,25 @@ export function prebuildStatusIcon(prebuild?: PrebuildWithStatus) {
     }
 }
 
-function PrebuildStatusDescription(props: { prebuild: PrebuildWithStatus }) {
-    switch (props.prebuild.status) {
+function getPrebuildStatusDescription(prebuild: PrebuildWithStatus): string {
+    switch (prebuild.status) {
         case "queued":
-            return <span>Prebuild is queued and will be processed when there is execution capacity.</span>;
+            return `Prebuild is queued and will be processed when there is execution capacity.`;
         case "building":
-            return <span>Prebuild is currently in progress.</span>;
+            return `Prebuild is currently in progress.`;
         case "aborted":
-            return (
-                <span>
-                    Prebuild has been cancelled. Either a user cancelled it, or the prebuild rate limit has been
-                    exceeded. {props.prebuild.error}
-                </span>
-            );
+            return `Prebuild has been cancelled. Either a newer commit was pushed to the same branch, a user cancelled it manually, or the prebuild rate limit has been exceeded.`;
         case "failed":
-            return <span>Prebuild failed for system reasons. Please contact support. {props.prebuild.error}</span>;
+            return `Prebuild failed for system reasons. Please contact support. ${prebuild.error}`;
         case "timeout":
-            return (
-                <span>
-                    Prebuild timed out. Either the image, or the prebuild tasks took too long. {props.prebuild.error}
-                </span>
-            );
+            return `Prebuild timed out. Either the image, or the prebuild tasks took too long. ${prebuild.error}`;
         case "available":
-            if (props.prebuild?.error) {
-                return (
-                    <span>
-                        The tasks executed in the prebuild returned a non-zero exit code. {props.prebuild.error}
-                    </span>
-                );
+            if (prebuild.error) {
+                return `The tasks executed in the prebuild returned a non-zero exit code. ${prebuild.error}`;
             }
-            return <span>Prebuild completed successfully.</span>;
+            return `Prebuild completed successfully.`;
         default:
-            return <span>Unknown prebuild status.</span>;
+            return `Unknown prebuild status.`;
     }
 }
 
@@ -376,7 +366,7 @@ export function PrebuildStatus(props: { prebuild: PrebuildWithStatus }) {
                 </div>
             </div>
             <div className="flex space-x-1 items-center text-gray-400">
-                <PrebuildStatusDescription prebuild={prebuild} />
+                <span>{getPrebuildStatusDescription(prebuild)}</span>
             </div>
         </div>
     );

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -18,6 +18,7 @@ import {
     WorkspaceAndOwner,
     WorkspacePortsAuthData,
     WorkspaceOwnerAndSoftDeleted,
+    PrebuildWithWorkspaceAndInstances,
 } from "../workspace-db";
 import {
     Workspace,
@@ -814,6 +815,38 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
                 "pws.buildWorkspaceId = ws.id and ws.contentDeletedTime = ''",
             )
             .getOne();
+    }
+
+    public async findActivePrebuiltWorkspacesByBranch(
+        projectId: string,
+        branch: string,
+    ): Promise<PrebuildWithWorkspaceAndInstances[]> {
+        if (!branch) {
+            return [];
+        }
+        const repo = await this.getPrebuiltWorkspaceRepo();
+        const result = await repo
+            .createQueryBuilder("pws")
+            .where(
+                "(pws.state = 'queued' OR pws.state = 'building') AND pws.projectId = :projectId AND pws.branch = :branch",
+                { projectId, branch },
+            )
+            .orderBy("pws.creationTime", "DESC")
+            .innerJoinAndMapOne(
+                "pws.workspace",
+                DBWorkspace,
+                "ws",
+                "pws.buildWorkspaceId = ws.id and ws.contentDeletedTime = ''",
+            )
+            .innerJoinAndMapMany("pws.instances", DBWorkspaceInstance, "wsi", "pws.buildWorkspaceId = wsi.workspaceId")
+            .getMany();
+        return result.map((r) => {
+            return {
+                prebuild: r,
+                workspace: (<any>r).workspace,
+                instances: (<any>r).instances,
+            };
+        });
     }
 
     public async findPrebuildByWorkspaceID(wsid: string): Promise<PrebuiltWorkspace | undefined> {

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -63,6 +63,12 @@ export interface PrebuildWithWorkspace {
     workspace: Workspace;
 }
 
+export interface PrebuildWithWorkspaceAndInstances {
+    prebuild: PrebuiltWorkspace;
+    workspace: Workspace;
+    instances: WorkspaceInstance[];
+}
+
 export type WorkspaceAndOwner = Pick<Workspace, "id" | "ownerId">;
 export type WorkspaceOwnerAndSoftDeleted = Pick<Workspace, "id" | "ownerId" | "softDeleted">;
 
@@ -170,6 +176,10 @@ export interface WorkspaceDB {
 
     storePrebuiltWorkspace(pws: PrebuiltWorkspace): Promise<PrebuiltWorkspace>;
     findPrebuiltWorkspaceByCommit(cloneURL: string, commit: string): Promise<PrebuiltWorkspace | undefined>;
+    findActivePrebuiltWorkspacesByBranch(
+        projectId: string,
+        branch: string,
+    ): Promise<PrebuildWithWorkspaceAndInstances[]>;
     findPrebuildsWithWorkpace(cloneURL: string): Promise<PrebuildWithWorkspace[]>;
     findPrebuildByWorkspaceID(wsid: string): Promise<PrebuiltWorkspace | undefined>;
     findPrebuildByID(pwsid: string): Promise<PrebuiltWorkspace | undefined>;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -15,6 +15,7 @@ export interface ProjectConfig {
 export interface ProjectSettings {
     useIncrementalPrebuilds?: boolean;
     usePersistentVolumeClaim?: boolean;
+    keepOutdatedPrebuildsRunning?: boolean;
 }
 
 export interface Project {

--- a/components/server/ee/src/prebuilds/gitlab-app.ts
+++ b/components/server/ee/src/prebuilds/gitlab-app.ts
@@ -155,6 +155,8 @@ export class GitLabApp {
             );
 
             return ws;
+        } catch (e) {
+            log.error("error processing GitLab webhook", e, body);
         } finally {
             span.finish();
         }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -591,7 +591,12 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         (await Promise.all(workspaces.map((workspace) => workspaceDb.findRunningInstance(workspace.id))))
             .filter(isDefined)
             .forEach((instance) =>
-                this.internalStopWorkspaceInstance(ctx, instance.id, instance.region, StopWorkspacePolicy.IMMEDIATELY),
+                this.workspaceStarter.stopWorkspaceInstance(
+                    ctx,
+                    instance.id,
+                    instance.region,
+                    StopWorkspacePolicy.IMMEDIATELY,
+                ),
             );
 
         // For some reason, returning the result of `this.userDB.storeUser(target)` does not work. The response never arrives the caller.

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -87,6 +87,8 @@ import {
     WorkspaceMetadata,
     WorkspaceType,
     VolumeSnapshotInfo,
+    StopWorkspacePolicy,
+    StopWorkspaceRequest,
 } from "@gitpod/ws-manager/lib/core_pb";
 import * as crypto from "crypto";
 import { inject, injectable } from "inversify";
@@ -347,6 +349,20 @@ export class WorkspaceStarter {
         } finally {
             span.finish();
         }
+    }
+
+    public async stopWorkspaceInstance(
+        ctx: TraceContext,
+        instanceId: string,
+        instanceRegion: string,
+        policy?: StopWorkspacePolicy,
+    ): Promise<void> {
+        const req = new StopWorkspaceRequest();
+        req.setId(instanceId);
+        req.setPolicy(policy || StopWorkspacePolicy.NORMALLY);
+
+        const client = await this.clientProvider.get(instanceRegion);
+        await client.stopWorkspace(ctx, req);
     }
 
     protected async checkBlockedRepository(user: User, contextURL: string) {


### PR DESCRIPTION
## Description
Cancels all running and queued prebuilds for the same branch when a new commit is pushed. 
Adds a project setting to opt-out of this behavior.

<img width="1391" alt="Screenshot 2022-06-28 at 12 54 36" src="https://user-images.githubusercontent.com/372735/176162248-c5365cbf-3267-4f01-b0e1-b4a8e2a46ee5.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #6569

## How to test
- Add a project with a long prebuild task
- push multipüle times to the same branch
- see how the previous prebuilds get cancelled.
- push to a different branch and verify that running prebuilds on the other branch are not getting cancelled.
- disable the project setting and verify that the cancellation doesn't happen


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Outdated prebuilds (i.e. new commits are pushed on a branch) are automatically canceled. This behavior can be disabled in the project's settings.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
