### PR TITLE
[werft] Update Stripe product price IDs

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: stripe-config
   namespace: ${NAMESPACE}
 data:
-  config: >
+  config: |
     {
       "usageProductPriceIds": {
-        "EUR": "price_1LD8cQGadRXm50o30QwBU9aY",
-        "USD": "price_1LD8cQGadRXm50o3ftnIiUZL"
+        "EUR": "price_1LFZhJGadRXm50o3v27S1DB1",
+        "USD": "price_1LFZhJGadRXm50o3YEAaspXu"
       }
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The "graduated price with free tier in Stripe" experiment yielded interesting data. However, it doesn't align with our planned team pricing model, so I've adjusted the Stripe product/prices accordingly.

We can re-introduce the graduated price with free tier in Stripe when we implement individual user billing (either as two new Stripe prices under the same product, or as a separate product with 2 prices -- I personally think that having a single product with 4 prices is preferable).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Should still build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
