### PR TITLE
[server] When deleting a team with an active usage-based subscription, also cancel the subscription

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -125,6 +125,10 @@ export class StripeService {
         return result.data[0];
     }
 
+    async cancelSubscription(subscriptionId: string): Promise<void> {
+        await this.getStripe().subscriptions.del(subscriptionId);
+    }
+
     async createSubscriptionForCustomer(customerId: string, currency: Currency): Promise<void> {
         const priceId = this.config?.stripeConfig?.usageProductPriceIds[currency];
         if (!priceId) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- [x] When a team has an active usage-based subscription, but gets deleted --> automatically cancel the usage-based subscription

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Upgrade a team to usage-based billing
2. Notice in the Stripe dashboard your new customer with an active subscription
3. Delete the team
4. In the Stripe dashboard, the above customer should no longer have an active subscription

<img width="300" alt="Screenshot 2022-06-28 at 17 41 00" src="https://user-images.githubusercontent.com/599268/176222201-d87d5af1-6d00-47d0-b455-a8ed3b94a82a.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
