### PR TITLE
[jb] add track for sent closed heartbeat

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/services/HeartbeatService.kt
@@ -24,8 +24,8 @@ class HeartbeatService : Disposable {
         val info = manager.pendingInfo.await()
         val intervalInSeconds = 30
         var current = ControllerStatus(
-            connected = false,
-            secondsSinceLastActivity = 0
+                connected = false,
+                secondsSinceLastActivity = 0
         )
         while (isActive) {
             try {
@@ -41,6 +41,11 @@ class HeartbeatService : Disposable {
 
                 if (wasClosed != null) {
                     manager.client.server.sendHeartBeat(SendHeartBeatOptions(info.instanceId, wasClosed)).await()
+                    if (wasClosed) {
+                        manager.trackEvent("ide_close_signal", mapOf(
+                                "clientKind" to "jetbrains"
+                        ))
+                    }
                 }
             } catch (t: Throwable) {
                 thisLogger().error("gitpod: failed to check activity:", t)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add track for sent closed heartbeat

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace with IntelliJ
2. open and the close the client
3. monitor in segment, it should send a `ide_close_signal` event
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe