### PR TITLE
[server] Allow team members (non-owners) to read the team's usage-based subscription ID

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1907,7 +1907,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
         const user = this.checkAndBlockUser("findStripeSubscriptionIdForTeam");
         await this.ensureIsUsageBasedFeatureFlagEnabled(user);
-        await this.guardTeamOperation(teamId, "update");
+        await this.guardTeamOperation(teamId, "get");
         try {
             const customer = await this.stripeService.findCustomerByTeamId(teamId);
             if (!customer?.id) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**Problem**: When a user chooses a billing-enabled team to attribute their usage to, the UI needs to know which team has an active usage-based subscription (teams without an active subscription cannot accept usage attribution).

**Symptoms**:
| Infinite spinner in user billing settings | Console error |
| --- | --- |
| <img width="400" alt="Screenshot 2022-06-28 at 4 49 21 PM" src="https://user-images.githubusercontent.com/599268/176197673-86997f08-ef45-4440-9c79-dd26f48cdea0.png"> | <code>Error: operation not permitted: missing update permission on team</code> |

**Solution**: Allow team members to read their team's active subscription ID if it exists. This fixes the UI, and allows selecting a valid "billing account".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Join a team with usage-based billing, but where you're not an owner (e.g. by [joining this team](https://jx-team-me0c514059aa.preview.gitpod-dev.com/teams/join?inviteId=ecaba5db-0f1b-4f40-8070-c5fc19c79d90))
2. Try to select that team as a "billing account" in your user settings

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
