### PR TITLE
previews: Replace remote-write address

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -82,7 +82,7 @@ export class MonitoringSatelliteInstaller {
             remoteWrite: {
                 username: '${process.env.PROM_REMOTE_WRITE_USER}',
                 password: '${process.env.PROM_REMOTE_WRITE_PASSWORD}',
-                urls: ['https://prometheus.gitpod-dev.com/api/v1/write'],
+                urls: ['https://victoriametrics.gitpod.io/api/v1/write'],
                 writeRelabelConfigs: [{
                     sourceLabels: ['__name__', 'job'],
                     separator: ';',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As a follow-up to https://github.com/gitpod-io/ops/pull/3006, this PR changes the remote-write address used by preview-environments

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
