### PR TITLE
[content-service] change log message from Warn to Debug

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -99,8 +99,9 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		return src, xerrors.Errorf("git initializer gitClone: %w", err)
 	}
 
+	// this is only needed for prebuilds using PVC, so if it errors out, output only Debug log to prevent log spam
 	if err := ws.AddSafeDirectory(ctx, ws.Location); err != nil {
-		log.WithError(err).Warn("git initializer AddSafeDirectory")
+		log.WithError(err).Debug("git initializer AddSafeDirectory")
 	}
 
 	if ws.Chown {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change log message from Warning to Debug to prevent excessive log entries.
It is fine if that function errors out, that code path is only needed for prebuilds using PVC, but would be excessive to try to pass that information into that function to do `if` statement.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
