### PR TITLE
[usage] Ensure controller ticks are not concurrent

### DIFF
--- a/components/usage/pkg/controller/controller.go
+++ b/components/usage/pkg/controller/controller.go
@@ -26,23 +26,38 @@ type Controller struct {
 
 	scheduler *cron.Cron
 
+	jobs        chan struct{}
 	runningJobs sync.WaitGroup
 }
 
 func (c *Controller) Start() error {
 	log.Info("Starting usage controller.")
+	// Using channel of size 1 ensures we don't queue up overly many runs when there is already 1 queued up.
+	c.jobs = make(chan struct{}, 1)
+
+	go func() {
+		// Here, we guarantee we're only ever executing 1 job at a time - in other words we always wait for the previous job to finish.
+		for range c.jobs {
+			c.runningJobs.Add(1)
+			defer c.runningJobs.Done()
+
+			err := c.reconciler.Reconcile()
+			if err != nil {
+				log.WithError(err).Errorf("Reconciliation run failed.")
+			} else {
+				log.Info("Completed usage reconciliation run without errors.")
+			}
+		}
+	}()
 
 	err := c.scheduler.AddFunc(fmt.Sprintf("@every %s", c.schedule.String()), cron.FuncJob(func() {
 		log.Info("Starting usage reconciliation.")
 
-		c.runningJobs.Add(1)
-		defer c.runningJobs.Done()
-
-		err := c.reconciler.Reconcile()
-		if err != nil {
-			log.WithError(err).Errorf("Reconciliation run failed.")
-		} else {
-			log.Info("Completed usage reconciliation run without errors.")
+		select {
+		case c.jobs <- struct{}{}:
+			log.Info("Triggered next reconciliation.")
+		default:
+			log.Info("Previous reconciliation loop is still running, skipping.")
 		}
 	}))
 	if err != nil {
@@ -60,7 +75,10 @@ func (c *Controller) Stop() {
 	// Stop any new jobs from running
 	c.scheduler.Stop()
 
+	close(c.jobs)
+
 	log.Info("Awaiting existing reconciliation runs to complete..")
 	// Wait for existing jobs to finish
 	c.runningJobs.Wait()
+
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ensures that a single instance of the usage component does not invoke multiple usage controller ticks concurrently. This is done by consuming from a channel which only ever executes linearly. Additionally, we skip buffering runs when we've exceeded 1 item queued already - prevents build up.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
