### PR TITLE
[usage] Expose metrics for reconciles started and duration

### DIFF
--- a/components/usage/cmd/run.go
+++ b/components/usage/cmd/run.go
@@ -83,6 +83,8 @@ func run() *cobra.Command {
 				log.WithError(err).Fatal("Failed to initialize server.")
 			}
 
+			controller.RegisterMetrics(srv.MetricsRegistry())
+
 			err = srv.ListenAndServe()
 			if err != nil {
 				log.WithError(err).Fatal("Failed to listen and serve.")

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -47,9 +47,14 @@ type UsageReconcileStatus struct {
 	InvalidWorkspaceInstances int
 }
 
-func (u *UsageReconciler) Reconcile() error {
+func (u *UsageReconciler) Reconcile() (err error) {
 	ctx := context.Background()
 	now := time.Now().UTC()
+
+	reportUsageReconcileStarted()
+	defer func() {
+		reportUsageReconcileFinished(time.Since(now), err)
+	}()
 
 	startOfCurrentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	startOfNextMonth := startOfCurrentMonth.AddDate(0, 1, 0)

--- a/components/usage/pkg/controller/reporter.go
+++ b/components/usage/pkg/controller/reporter.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+const (
+	namespace = "gitpod"
+	subsystem = "usage"
+)
+
+var (
+	reconcileStartedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "reconcile_started_total",
+		Help:      "Number of usage reconciliation runs started",
+	}, []string{})
+
+	reconcileStartedDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "reconcile_completed_duration_seconds",
+		Help:      "Histogram of reconcile duration",
+	}, []string{"outcome"})
+)
+
+func RegisterMetrics(reg *prometheus.Registry) error {
+	err := reg.Register(reconcileStartedTotal)
+	if err != nil {
+		return err
+	}
+
+	err = reg.Register(reconcileStartedDurationSeconds)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func reportUsageReconcileStarted() {
+	reconcileStartedTotal.WithLabelValues().Inc()
+}
+
+func reportUsageReconcileFinished(duration time.Duration, err error) {
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	reconcileStartedDurationSeconds.WithLabelValues(outcome).Observe(duration.Seconds())
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
So that we can setup dashboards and alerts on these

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
