### PR TITLE
[installer]: order the custom envvars

### DIFF
--- a/install/installer/pkg/common/customize_test.go
+++ b/install/installer/pkg/common/customize_test.go
@@ -5,7 +5,6 @@ package common_test
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -390,7 +389,6 @@ func TestCustomizeEnvvar(t *testing.T) {
 		ExistingEnnvars []corev1.EnvVar
 		Expect          []corev1.EnvVar
 	}{
-
 		{
 			Name:          "no customization",
 			Customization: nil,
@@ -489,6 +487,10 @@ func TestCustomizeEnvvar(t *testing.T) {
 			},
 			ExistingEnnvars: []corev1.EnvVar{
 				{
+					Name:  "key4",
+					Value: "value",
+				},
+				{
 					Name:  "key3",
 					Value: "original",
 				},
@@ -497,15 +499,19 @@ func TestCustomizeEnvvar(t *testing.T) {
 			Component: "component",
 			Expect: []corev1.EnvVar{
 				{
+					Name:  "key4",
+					Value: "value",
+				},
+				{
+					Name:  "key3",
+					Value: "original",
+				},
+				{
 					Name:  "key1",
 					Value: "override",
 				},
 				{
 					Name:  "key2",
-					Value: "original",
-				},
-				{
-					Name:  "key3",
 					Value: "original",
 				},
 			},
@@ -520,13 +526,6 @@ func TestCustomizeEnvvar(t *testing.T) {
 			require.NoError(t, err)
 
 			result := common.CustomizeEnvvar(ctx, testCase.Component, testCase.ExistingEnnvars)
-
-			sort.Slice(result, func(a, b int) bool {
-				return result[a].Name < result[b].Name
-			})
-			sort.Slice(testCase.Expect, func(a, b int) bool {
-				return result[a].Name < result[b].Name
-			})
 
 			if !reflect.DeepEqual(testCase.Expect, result) {
 				t.Errorf("expected %v but got %v", testCase.Expect, result)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changes how the customize envvars orders it's output. It keeps the existing envvars in the order that's given and the customized envvars are ordered in terms of first one received. This is to avoid unnecessary deploys in a GitOps setup.

Overrides the "fix failing test" commit in #10836 by @Furisto - it achieves the same effect, but does so in the application code rather than the test

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11000

## How to test
<!-- Provide steps to test this PR -->
The unit tests provides the test coverage. @mads-hartmann should check that the order is as expected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: order the custom envvars
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
