### PR TITLE
[jb] check maxHeapSize of IDE server and guide users to set vmoptions in .gitpod.yml

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -111,6 +111,10 @@ tasks {
         useJUnitPlatform()
     }
 
+    runIde {
+        jvmArgs = listOf("-Xmx2096m")
+    }
+
     runPluginVerifier {
         ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
     }

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -10,7 +10,7 @@ platformType=IU
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=Git4Idea, org.jetbrains.plugins.terminal, com.jetbrains.codeWithMe
+platformPlugins=Git4Idea, org.jetbrains.plugins.terminal, com.jetbrains.codeWithMe, org.jetbrains.plugins.yaml
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodStartupActivity.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodStartupActivity.kt
@@ -1,0 +1,129 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.diagnostic.VMOptions
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.actions.OpenFileAction
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.util.BuildNumber
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiManager
+import com.intellij.util.application
+import io.gitpod.jetbrains.remote.utils.GitpodConfig
+import io.gitpod.jetbrains.remote.utils.GitpodConfig.YamlKey.jetbrains
+import io.gitpod.jetbrains.remote.utils.GitpodConfig.YamlKey.vmOptions
+import io.gitpod.jetbrains.remote.utils.GitpodConfig.defaultXmxOption
+import io.gitpod.jetbrains.remote.utils.GitpodConfig.gitpodYamlFile
+import io.gitpod.jetbrains.remote.utils.GitpodConfig.gitpodYamlReferenceLink
+import org.jetbrains.yaml.YAMLFileType
+import org.jetbrains.yaml.YAMLUtil
+import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLKeyValue
+import java.nio.file.Paths
+
+class GitpodStartupActivity : StartupActivity.Background {
+
+    override fun runActivity(project: Project) {
+        application.invokeLater { checkMemoryOption(project) }
+    }
+
+    private fun checkMemoryOption(project: Project) {
+        val productCode = BuildNumber.currentVersion().productCode
+        val productName = GitpodConfig.getJetBrainsProductName(productCode) ?: return
+        // it's ok for .gitpod.yml to not exist
+        var vmOptions = emptyList<String>()
+        getGitpodYamlVirtualFile(project)?.let {
+            val vmOptionsKeyValue = getGitpodYamlVMOptionsPsiElement(project, it, productName)
+            vmOptions = vmOptionsKeyValue?.valueText?.split("\\s".toRegex()) ?: emptyList()
+        }
+        // if there is no -Xmx option from .gitpod.yml, compare runtime maxHeapSize with default value
+        var xmxVmOptions = vmOptions.filter { it.startsWith("-Xmx") }
+        if (xmxVmOptions.isEmpty()) {
+            xmxVmOptions = listOf(defaultXmxOption)
+        }
+        // the rightmost -Xmx option is the one to take effect (after deduplication)
+        val finalXmx = xmxVmOptions.last()
+        // shift right 20 (xmxInBytes >> 20) to convert to MiB
+        val finalXmxValueInMiB = VMOptions.parseMemoryOption(finalXmx.substringAfter("-Xmx")).shr(20)
+        val runtimeXmxValueInMiB = Runtime.getRuntime().maxMemory().shr(20)
+        if (finalXmxValueInMiB != runtimeXmxValueInMiB) {
+            showEditVMOptionsNotification(project, runtimeXmxValueInMiB, finalXmxValueInMiB, productName)
+        }
+    }
+
+    private fun getGitpodYamlVirtualFile(project: Project): VirtualFile? {
+        val basePath = project.basePath ?: return null
+        return VfsUtil.findFile(Paths.get(basePath, gitpodYamlFile), true)
+    }
+
+    private fun getGitpodYamlVMOptionsPsiElement(
+        project: Project,
+        virtualFile: VirtualFile,
+        productName: String
+    ): YAMLKeyValue? {
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile) as? YAMLFile ?: return null
+        return YAMLUtil.getQualifiedKeyInFile(psiFile, jetbrains, productName, vmOptions)
+    }
+
+    private fun showEditVMOptionsNotification(project: Project, runtimeXmxMiB: Long, configXmxMiB: Long, productName: String) {
+        val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("Gitpod Notifications")
+        val title = "Gitpod memory settings"
+        val message = """
+            |Current maxHeapSize <code>-Xmx${runtimeXmxMiB}m</code> is not matched to configured <code>-Xmx${configXmxMiB}m</code>.<br/>
+            |Set vmoptions in .gitpod.yml
+        """.trimMargin()
+        val notification = notificationGroup.createNotification(title, message, NotificationType.WARNING)
+        // edit or create .gitpod.yaml
+        val virtualFile = getGitpodYamlVirtualFile(project)
+        val primaryAction = if (virtualFile != null) {
+            editGitpodYamlAction(project, virtualFile, productName)
+        } else {
+            createGitpodYamlAction(project, productName, runtimeXmxMiB)
+        }
+        notification.addAction(primaryAction)
+        // show gitpod.yml reference
+        val helpAction = NotificationAction.createSimple("More info") {
+            BrowserUtil.browse(gitpodYamlReferenceLink)
+        }
+        notification.addAction(helpAction)
+        notification.notify(project)
+    }
+
+    private fun editGitpodYamlAction(project: Project, gitpodYaml: VirtualFile, productName: String): NotificationAction {
+        return NotificationAction.createSimple("Edit .gitpod.yml") {
+            OpenFileAction.openFile(gitpodYaml, project)
+            val vmOptionsKeyValue = getGitpodYamlVMOptionsPsiElement(project, gitpodYaml, productName)
+            // navigate caret to "vmoptions" if exist
+            vmOptionsKeyValue?.navigate(true)
+        }
+    }
+
+    private fun createGitpodYamlAction(project: Project, productName: String, runtimeXmxMiB: Long): NotificationAction {
+        return NotificationAction.createSimple("Create .gitpod.yml") {
+            application.runWriteAction {
+                val psiFile = PsiFileFactory.getInstance(project).createFileFromText(
+                    gitpodYamlFile,
+                    YAMLFileType.YML,
+                    GitpodConfig.YamlTemplate.buildVMOptions(productName, runtimeXmxMiB)
+                )
+                project.basePath?.let { basePath ->
+                    LocalFileSystem.getInstance().findFileByPath(basePath)?.let { dir ->
+                        PsiManager.getInstance(project).findDirectory(dir)?.add(psiFile)
+                        // refresh VFS and open created .gitpod.yml in editor
+                        getGitpodYamlVirtualFile(project)?.let { OpenFileAction.openFile(it, project) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/utils/GitpodConfig.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/utils/GitpodConfig.kt
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.utils
+
+/**
+ * Constants and util functions for Gitpod config spec
+ */
+object GitpodConfig {
+
+    const val gitpodYamlFile = ".gitpod.yml"
+    const val defaultXmxOption = "-Xmx2048m"
+    const val gitpodYamlReferenceLink = "https://www.gitpod.io/docs/references/gitpod-yml#jetbrainsproductvmoptions"
+
+    object YamlKey {
+        const val jetbrains = "jetbrains"
+        const val vmOptions = "vmoptions"
+    }
+
+    object YamlTemplate {
+
+        fun buildVMOptions(productName: String, xmxValueMiB: Long): String {
+            return """
+             |jetbrains:
+             |  $productName:
+             |    vmoptions: "-Xmx${xmxValueMiB}m"
+             """.trimMargin()
+        }
+    }
+
+    /**
+     * map JetBrains IDE productCode to YAML key for .gitpod.yml
+     */
+    fun getJetBrainsProductName(productCode: String): String? {
+        return when (productCode) {
+            "IC" -> "intellij"
+            "IU" -> "intellij"
+            "PS" -> "phpstorm"
+            "PY" -> "pycharm"
+            "GO" -> "goland"
+            else -> null
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -19,9 +19,11 @@
         <plugin id="Git4Idea"/>
         <plugin id="org.jetbrains.plugins.terminal"/>
         <plugin id="com.jetbrains.codeWithMe"/>
+        <plugin id="org.jetbrains.plugins.yaml"/>
     </dependencies>
 
     <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="io.gitpod.jetbrains.remote.GitpodStartupActivity"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService" preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Quote https://github.com/gitpod-io/gitpod/issues/10924

> An idea is to detect a user change to the actual max heap size in the backend plugin and suggest a user to put in .gitpod.yml to persist. So the flow would be like:
>
> - a user starts using with default Xmx
> - experience perf issues and follow notifications to upgrade Xmx of the running instance
> - after JB backend restart there will be a warning on .gitpod.yml that Xmx of the running instance was changed, but it should be applied to .gitpod.yml to be persistent
>
> Also check out https://github.com/gitpod-io/gitpod/pull/10768 for more background info

This PR implements Xmx config checks in JetBrains `gitpod-remote` plugin:
- Register a background activity (GitpodStartupActivity) for handling postStart events
- Add YAML plugin dependency for parsing & navigating PSI elements in `.gitpod.yml`
- Show warning notification when the runtime Xmx is different from the configured Xmx
  - Add edit/create-if-missing `.gitpod.yml` actions, and navigate caret to `vmoptions` YAML key if exists
  - Add help action for browsing gitpod.yml references
- Set `jvmArgs` for the `runIde` task (only affect local sandbox IDE instance with the developed plugin), which can be modified for local testing purpose


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolve #10924

## How to test
<!-- Provide steps to test this PR -->

Test locally:

- Run `runIde` task from IntelliJ plugin, and modify `jvmArgs = listOf("-Xmx4g")` to simulate the user's change to the -Xmx of JetBrains IDE server inside a Gitpod workspace. When sandbox IDE instance is started, a warning Notification should popup, indicating current runtime maxHeapSize is different with default/configured vmoptions from `.gitpod.yml`. Click on "Edit .gitpod.yml" would open the file in the editor
  - <img width="480" alt="edit .gitpod.yml action" src="https://user-images.githubusercontent.com/3115235/176419790-ad93f932-2f7f-4560-b5b3-da073d4e281c.png">

- If there is no `.gitpod.yml` in the project root, the notification popup would suggest the user to create a `.gitpod.yml` with generated content (with the current runtime Xmx configured)
  -  <img width="480" alt="create .gitpod.yml action" src="https://user-images.githubusercontent.com/3115235/176421788-169fbd81-99ce-4898-be9e-8e08ff2d5ada.png">
  - <img width="480" alt=".gitpod.yml created" src="https://user-images.githubusercontent.com/3115235/176421800-ba2b20ba-1575-4d99-b0cc-ea4ebed469a1.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- Detect user changes to the max heap size of IDE server when using JetBrains Gateway, and suggest a user to put in .gitpod.yml to persist.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
