### PR TITLE
[usage] Add WorkspaceClass field to WorkspaceInstance model (in go)

### DIFF
--- a/components/usage/pkg/db/dbtest/workspace_instance.go
+++ b/components/usage/pkg/db/dbtest/workspace_instance.go
@@ -66,10 +66,16 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 		attributionID = instance.UsageAttributionID
 	}
 
+	workspaceClass := db.WorkspaceClass_Default
+	if instance.WorkspaceClass != "" {
+		workspaceClass = instance.WorkspaceClass
+	}
+
 	return db.WorkspaceInstance{
 		ID:                 id,
 		WorkspaceID:        workspaceID,
 		UsageAttributionID: attributionID,
+		WorkspaceClass:     workspaceClass,
 		Configuration:      nil,
 		Region:             "",
 		ImageBuildInfo:     sql.NullString{},

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -25,6 +25,7 @@ type WorkspaceInstance struct {
 	WorkspaceBaseImage string         `gorm:"column:workspaceBaseImage;type:varchar;size:255;" json:"workspaceBaseImage"`
 	WorkspaceImage     string         `gorm:"column:workspaceImage;type:varchar;size:255;" json:"workspaceImage"`
 	UsageAttributionID AttributionID  `gorm:"column:usageAttributionId;type:varchar;size:60;" json:"usageAttributionId"`
+	WorkspaceClass     string         `gorm:"column:workspaceClass;type:varchar;size:255;" json:"workspaceClass"`
 
 	CreationTime VarcharTime `gorm:"column:creationTime;type:varchar;size:255;" json:"creationTime"`
 	StartedTime  VarcharTime `gorm:"column:startedTime;type:varchar;size:255;" json:"startedTime"`
@@ -120,3 +121,7 @@ func (a AttributionID) Values() (entity string, identifier string) {
 
 	return tokens[0], tokens[1]
 }
+
+const (
+	WorkspaceClass_Default = "default"
+)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Originally implemented in TS in https://github.com/gitpod-io/gitpod/pull/10454

Adds the field definition into the Go model, such that it can be used for computing usage by WorkspaceClass

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/10985

## How to test
<!-- Provide steps to test this PR -->
Unit tests work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
