### PR TITLE
[installer]: promote proxy service type from experimental

### DIFF
--- a/install/installer/cmd/render.go
+++ b/install/installer/cmd/render.go
@@ -149,6 +149,11 @@ func renderKubernetesObjects(cfgVersion string, cfg *configv1.Config) ([]string,
 			fmt.Fprintln(os.Stderr, "configuration is invalid")
 			os.Exit(1)
 		}
+
+		// Warnings are printed to stderr
+		for _, r := range res.Warnings {
+			fmt.Fprintf(os.Stderr, "%s\n", r)
+		}
 	}
 
 	ctx, err := common.NewRenderContext(*cfg, *versionMF, renderOpts.Namespace)

--- a/install/installer/pkg/components/proxy/service.go
+++ b/install/installer/pkg/components/proxy/service.go
@@ -81,10 +81,10 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 		service.Spec.Type = serviceType
 		if serviceType == corev1.ServiceTypeLoadBalancer {
 			service.Spec.LoadBalancerIP = loadBalancerIP
-		}
 
-		service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", ctx.Config.Domain, ctx.Config.Domain, ctx.Config.Domain)
-		service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
+			service.Annotations["external-dns.alpha.kubernetes.io/hostname"] = fmt.Sprintf("%s,*.%s,*.ws.%s", ctx.Config.Domain, ctx.Config.Domain, ctx.Config.Domain)
+			service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
+		}
 
 		for k, v := range annotations {
 			service.Annotations[k] = v

--- a/install/installer/pkg/config/loader.go
+++ b/install/installer/pkg/config/loader.go
@@ -47,6 +47,10 @@ type ConfigVersion interface {
 
 	// ClusterValidation introduces configuration specific cluster validation checks
 	ClusterValidation(cfg interface{}) cluster.ValidationChecks
+
+	// CheckDeprecated checks for deprecated config params.
+	// Returns key/value pair of deprecated params/values and any error messages (used for conflicting params)
+	CheckDeprecated(cfg interface{}) (map[string]interface{}, []string)
 }
 
 // AddVersion adds a new version.

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -76,6 +76,27 @@ func (v version) Defaults(in interface{}) error {
 func (v version) CheckDeprecated(rawCfg interface{}) (map[string]interface{}, []string) {
 	warnings := make(map[string]interface{}, 0)
 	conflicts := make([]string, 0)
+	cfg := rawCfg.(*Config)
+
+	if cfg.Experimental != nil && cfg.Experimental.WebApp != nil && cfg.Experimental.WebApp.ProxyConfig != nil && cfg.Experimental.WebApp.ProxyConfig.ServiceType != nil {
+		warnings["experimental.webapp.proxy.serviceType"] = *cfg.Experimental.WebApp.ProxyConfig.ServiceType
+
+		if cfg.Components != nil && cfg.Components.Proxy != nil && cfg.Components.Proxy.Service != nil && cfg.Components.Proxy.Service.ServiceType != nil {
+			conflicts = append(conflicts, "Cannot set proxy service type in both components and experimental")
+		} else {
+			// Promote the experimental value to the components
+			if cfg.Components == nil {
+				cfg.Components = &Components{}
+			}
+			if cfg.Components.Proxy == nil {
+				cfg.Components.Proxy = &ProxyComponent{}
+			}
+			if cfg.Components.Proxy.Service == nil {
+				cfg.Components.Proxy.Service = &ComponentTypeService{}
+			}
+			cfg.Components.Proxy.Service.ServiceType = cfg.Experimental.WebApp.ProxyConfig.ServiceType
+		}
+	}
 
 	return warnings, conflicts
 }
@@ -119,6 +140,8 @@ type Config struct {
 	DropImageRepo *bool `json:"dropImageRepo,omitempty"`
 
 	Customization *[]Customization `json:"customization,omitempty"`
+
+	Components *Components `json:"components,omitempty"`
 
 	Experimental *experimental.Config `json:"experimental,omitempty"`
 }
@@ -346,4 +369,16 @@ type Customization struct {
 
 type CustomizationSpec struct {
 	Env []corev1.EnvVar `json:"env"`
+}
+
+type Components struct {
+	Proxy *ProxyComponent `json:"proxy,omitempty"`
+}
+
+type ProxyComponent struct {
+	Service *ComponentTypeService `json:"service,omitempty"`
+}
+
+type ComponentTypeService struct {
+	ServiceType *corev1.ServiceType `json:"serviceType,omitempty" validate:"omitempty,service_config_type"`
 }

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -73,6 +73,13 @@ func (v version) Defaults(in interface{}) error {
 	return nil
 }
 
+func (v version) CheckDeprecated(rawCfg interface{}) (map[string]interface{}, []string) {
+	warnings := make(map[string]interface{}, 0)
+	conflicts := make([]string, 0)
+
+	return warnings, conflicts
+}
+
 // Config defines the v1 version structure of the gitpod config file
 type Config struct {
 	// Installation type to run - for most users, this will be Full

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -164,9 +164,11 @@ type BlockedRepository struct {
 }
 
 type ProxyConfig struct {
-	StaticIP           string              `json:"staticIP"`
-	ServiceAnnotations map[string]string   `json:"serviceAnnotations"`
-	ServiceType        *corev1.ServiceType `json:"serviceType,omitempty" validate:"omitempty,service_config_type"`
+	StaticIP           string            `json:"staticIP"`
+	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
+
+	// @deprecated use components.proxy.service.serviceType instead
+	ServiceType *corev1.ServiceType `json:"serviceType,omitempty" validate:"omitempty,service_config_type"`
 }
 
 type PublicAPIConfig struct {

--- a/install/installer/pkg/config/validation.go
+++ b/install/installer/pkg/config/validation.go
@@ -33,6 +33,14 @@ func Validate(version ConfigVersion, cfg interface{}) (r *ValidationResult, err 
 	}
 
 	var res ValidationResult
+
+	warnings, conflicts := version.CheckDeprecated(cfg)
+
+	for k, v := range warnings {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("Deprecated config parameter: %s=%v", k, v))
+	}
+	res.Fatal = append(res.Fatal, conflicts...)
+
 	err = validate.Struct(cfg)
 	if err != nil {
 		validationErrors := err.(validator.ValidationErrors)

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:tar-preview-telemetry.25"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-clusterip.8"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:tar-preview-telemetry.25"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-clusterip.8"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -263,6 +263,15 @@ spec:
 
               if [ '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}' = "true" ];
               then
+                echo "Gitpod: Applying advanced configuration"
+
+                if [ '{{repl ConfigOptionNotEquals "component_proxy_service_serviceType" "" }}' = "true" ];
+                then
+                  # Empty string defaults to LoadBalancer. This maintains backwards compatibility with the deprecated experimental value
+                  echo "Gitpod: Applying Proxy service type"
+                  yq e -i ".components.proxy.service.serviceType = \"{{repl ConfigOption "component_proxy_service_serviceType" }}\"" "${CONFIG_FILE}"
+                fi
+
                 if [ '{{repl ConfigOptionNotEquals "customization_patch" "" }}' = "true" ];
                 then
                   CUSTOMIZATION='{{repl ConfigOptionData "customization_patch" | Base64Encode }}'
@@ -271,6 +280,8 @@ spec:
                   # Apply the customization property - if something else is set, this will be ignored
                   yq e -i ".customization = $(echo "${CUSTOMIZATION}" | base64 -d | yq e -o json '.customization' - | jq -rc) // []" "${CONFIG_FILE}"
                 fi
+              else
+                echo "Gitpod: No advanced configuration applied"
               fi
 
               echo "Gitpod: Update platform telemetry value"

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -370,14 +370,14 @@ spec:
             Add the domain only (eg, `gitpod.io`). Separate multiple domains with spaces.
 
     - name: advanced
-      title: Additional Options
-      description: Here are additional options that you should only make use of in coordination with us or when you know what you are doing.
+      title: Advanced Options
+      description: Here are advanced options that you should only make use of in coordination with us or when you know what you are doing.
       items:
         - name: advanced_mode_enabled
-          title: Enable additional options
+          title: Enable advanced options
           type: bool
           default: "0"
-          help_text: Enables additional customization options. Enable only when you know what you are doing!
+          help_text: Enables advanced customization options. Enable only when you know what you are doing!
 
         - name: customization_patch
           title: Gitpod customization patch (YAML file)

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -400,3 +400,24 @@ spec:
           required: false
           when: '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}'
           help_text: A file with Gitpod config that will be used to patch the generated Gitpod config. Usually provided by Gitpod as a way to tailor your installation.
+
+    - name: components
+      title: Components
+      description: Customize your component configuration
+      when: '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}'
+      items:
+        - name: component_proxy_service_serviceType
+          title: Proxy service type
+          default: ""
+          help_text: |
+            Select the [Service Type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+            for the Proxy service. If using anything other than "Load Balancer", you are responsible for configuring your network to route
+            traffic through to the `proxy` service.
+          type: select_one
+          items:
+            - name: ""
+              title: Load balancer
+            - name: ClusterIP
+              title: Cluster IP
+            - name: NodePort
+              title: Node port


### PR DESCRIPTION
> Anyone relying upon this config in the `experimental` section should move to the `components`. See description for new format

## Description
<!-- Describe your changes in detail -->
Deprecated the proxy's service type in `experimental` and promotes it to the primary configuration. Implements the configuration as per #10983.

Includes the KOTS config section in a separate "Components" group - the reasoning behind this is that there may be additional component-specific configuration in the future. This should make it easier to manage/visualise. This is only displayed if the "enable additional options" is enabled.

Adds the ability to deprecate config parameters.

I've also renamed "additional options" to "advanced options"

![image](https://user-images.githubusercontent.com/275848/176465296-8a3dc674-3860-47a4-ad45-1b8a6afc11f2.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11008
Fixes #11009
Fixes #11025
Fixes #11033 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: promote proxy service type from experimental
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
