### PR TITLE
Retrieve supported workspace classes  from workspace cluster

### DIFF
--- a/components/gitpod-protocol/src/experiments/types.ts
+++ b/components/gitpod-protocol/src/experiments/types.ts
@@ -6,6 +6,8 @@
 
 import { Team } from "../teams-projects-protocol";
 
+export const Client = Symbol("Client");
+
 // Attributes define attributes which can be used to segment audiences.
 // Set the attributes which you want to use to group audiences into.
 export interface Attributes {

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -57,11 +57,13 @@ export type AdmissionConstraint =
     | AdmissionConstraintFeaturePreview
     | AdmissionConstraintHasPermission
     | AdmissionConstraintHasUserLevel
-    | AdmissionConstraintHasMoreResources;
+    | AdmissionConstraintHasMoreResources
+    | AdmissionConstraintHasClass;
 export type AdmissionConstraintFeaturePreview = { type: "has-feature-preview" };
 export type AdmissionConstraintHasPermission = { type: "has-permission"; permission: PermissionName };
 export type AdmissionConstraintHasUserLevel = { type: "has-user-level"; level: string };
 export type AdmissionConstraintHasMoreResources = { type: "has-more-resources" };
+export type AdmissionConstraintHasClass = { type: "has-class"; id: string; displayName: string };
 
 export namespace AdmissionConstraint {
     export function is(o: any): o is AdmissionConstraint {

--- a/components/ws-manager-bridge/debug.sh
+++ b/components/ws-manager-bridge/debug.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+source /workspace/gitpod/scripts/ws-deploy.sh deployment ws-manager-bridge

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { WorkspaceCluster, WorkspaceClusterDB } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+import { inject, injectable } from "inversify";
+import { Configuration } from "./config";
+import { Client } from "@gitpod/gitpod-protocol/lib/experiments/types";
+import { DescribeClusterRequest, DescribeClusterResponse, WorkspaceClass } from "@gitpod/ws-manager/lib";
+import { AdmissionConstraintHasClass } from "@gitpod/gitpod-protocol/src/workspace-cluster";
+import { GRPCError } from "./rpc";
+import * as grpc from "@grpc/grpc-js";
+import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";
+
+@injectable()
+export class ClusterSyncService {
+    @inject(Configuration)
+    protected readonly config: Configuration;
+
+    @inject(WorkspaceClusterDB)
+    protected readonly clusterDB: WorkspaceClusterDB;
+
+    @inject(WorkspaceManagerClientProvider)
+    protected readonly clientProvider: WorkspaceManagerClientProvider;
+
+    @inject(Client)
+    protected readonly featureClient: Client;
+
+    protected timer: NodeJS.Timer;
+
+    public start() {
+        this.timer = setInterval(() => this.reconcile(), this.config.clusterSyncIntervalSeconds * 1000);
+    }
+
+    private async reconcile() {
+        const enabled = await this.featureClient.getValueAsync("workspace_classes_backend", false, {});
+        if (!enabled) {
+            return;
+        }
+
+        log.debug("reconciling workspace classes...");
+        let allClusters = await this.clusterDB.findFiltered({});
+        for (const cluster of allClusters) {
+            try {
+                let supportedClasses = await getSupportedWorkspaceClasses(this.clientProvider, cluster, true);
+                let existingOtherConstraints = cluster.admissionConstraints?.filter((c) => c.type !== "has-class");
+                cluster.admissionConstraints = existingOtherConstraints?.concat(supportedClasses);
+                await this.clusterDB.save(cluster);
+            } catch (err) {
+                log.error("failed to reconcile workspace classes for cluster", err, { cluster: cluster.name });
+            }
+        }
+        log.debug("done reconciling workspace classes");
+    }
+
+    public stop() {
+        clearInterval(this.timer);
+    }
+}
+
+export async function getSupportedWorkspaceClasses(
+    clientProvider: WorkspaceManagerClientProvider,
+    cluster: WorkspaceCluster,
+    useCache: boolean,
+) {
+    let constraints = await new Promise<AdmissionConstraintHasClass[]>(async (resolve, reject) => {
+        const grpcOptions: grpc.ClientOptions = {
+            ...defaultGRPCOptions,
+        };
+        let client = useCache
+            ? await (
+                  await clientProvider.get(cluster.name, grpcOptions)
+              ).client
+            : clientProvider.createClient(cluster, grpcOptions);
+
+        client.describeCluster(new DescribeClusterRequest(), (err: any, resp: DescribeClusterResponse) => {
+            if (err) {
+                reject(new GRPCError(grpc.status.FAILED_PRECONDITION, `cannot reach ${cluster.url}: ${err.message}`));
+            } else {
+                let classes = resp.getWorkspaceclassesList().map((cl) => mapWorkspaceClass(cl));
+                resolve(classes);
+            }
+        });
+    });
+
+    return constraints;
+}
+
+function mapWorkspaceClass(c: WorkspaceClass): AdmissionConstraintHasClass {
+    return <AdmissionConstraintHasClass>{ type: "has-class", id: c.getId(), displayName: c.getDisplayname() };
+}

--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -35,4 +35,7 @@ export interface Configuration {
 
     // emulatePreparingIntervalSeconds configures how often we check for Workspaces in phase "preparing" for clusters we do not govern
     emulatePreparingIntervalSeconds: number;
+
+    // clusterSyncIntervalSeconds configures how often we sync workspace cluster information
+    clusterSyncIntervalSeconds: number;
 }

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -35,6 +35,9 @@ import { PreparingUpdateEmulator, PreparingUpdateEmulatorFactory } from "./prepa
 import { PrebuildStateMapper } from "./prebuild-state-mapper";
 import { PrebuildUpdater, PrebuildUpdaterNoOp } from "./prebuild-updater";
 import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
+import { Client } from "@gitpod/gitpod-protocol/lib/experiments/types";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { ClusterSyncService } from "./cluster-sync-service";
 
 export const containerModule = new ContainerModule((bind) => {
     bind(MessagebusConfiguration).toSelf().inSingletonScope();
@@ -57,6 +60,7 @@ export const containerModule = new ContainerModule((bind) => {
 
     bind(ClusterServiceServer).toSelf().inSingletonScope();
     bind(ClusterService).toSelf().inRequestScope();
+    bind(ClusterSyncService).toSelf().inSingletonScope();
 
     bind(TracingManager).toSelf().inSingletonScope();
 
@@ -85,4 +89,6 @@ export const containerModule = new ContainerModule((bind) => {
     bind(PrebuildUpdater).to(PrebuildUpdaterNoOp).inSingletonScope();
 
     bind(DebugApp).toSelf().inSingletonScope();
+
+    bind(Client).toDynamicValue(getExperimentsClientForBackend).inSingletonScope();
 });

--- a/components/ws-manager-bridge/src/main.ts
+++ b/components/ws-manager-bridge/src/main.ts
@@ -14,6 +14,7 @@ import { TypeORM } from "@gitpod/gitpod-db/lib/typeorm/typeorm";
 import { TracingManager } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { ClusterServiceServer } from "./cluster-service-server";
 import { BridgeController } from "./bridge-controller";
+import { ClusterSyncService } from "./cluster-sync-service";
 
 log.enableJSONLogging("ws-manager-bridge", undefined, LogrusLogLevel.getFromEnv());
 
@@ -47,6 +48,9 @@ export const start = async (container: Container) => {
 
         const clusterServiceServer = container.get<ClusterServiceServer>(ClusterServiceServer);
         await clusterServiceServer.start();
+
+        const clusterSyncService = container.get<ClusterSyncService>(ClusterSyncService);
+        clusterSyncService.start();
 
         process.on("SIGTERM", async () => {
             log.info("SIGTERM received, stopping");

--- a/components/ws-manager-bridge/src/rpc.ts
+++ b/components/ws-manager-bridge/src/rpc.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as grpc from "@grpc/grpc-js";
+import { ServiceError as grpcServiceError } from "@grpc/grpc-js";
+
+export class GRPCError extends Error implements Partial<grpcServiceError> {
+    public name = "ServiceError";
+
+    details: string;
+
+    constructor(public readonly status: grpc.status, err: any) {
+        super(GRPCError.errToMessage(err));
+
+        this.details = this.message;
+    }
+
+    static errToMessage(err: any): string | undefined {
+        if (typeof err === "string") {
+            return err;
+        } else if (typeof err === "object") {
+            return err.message;
+        }
+    }
+
+    static isGRPCError(obj: any): obj is GRPCError {
+        return obj !== undefined && typeof obj === "object" && "status" in obj;
+    }
+}

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -263,6 +263,27 @@ func DatabaseEnv(cfg *config.Config) (res []corev1.EnvVar) {
 	return envvars
 }
 
+func ConfigcatEnv(ctx *RenderContext) []corev1.EnvVar {
+	var sdkKey string
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.ConfigcatKey != "" {
+			sdkKey = cfg.WebApp.ConfigcatKey
+		}
+		return nil
+	})
+
+	if sdkKey == "" {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "CONFIGCAT_SDK_KEY",
+			Value: sdkKey,
+		},
+	}
+}
+
 func DatabaseWaiterContainer(ctx *RenderContext) *corev1.Container {
 	return &corev1.Container{
 		Name:  "database-waiter",

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -77,7 +77,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		common.WebappTracingEnv(ctx),
 		common.AnalyticsEnv(&ctx.Config),
 		common.MessageBusEnv(&ctx.Config),
-		configcatEnv(ctx),
+		common.ConfigcatEnv(ctx),
 		[]corev1.EnvVar{
 			{
 				Name:  "CONFIG_PATH",
@@ -401,25 +401,4 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 	}, nil
-}
-
-func configcatEnv(ctx *common.RenderContext) []corev1.EnvVar {
-	var sdkKey string
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.ConfigcatKey != "" {
-			sdkKey = cfg.WebApp.ConfigcatKey
-		}
-		return nil
-	})
-
-	if sdkKey == "" {
-		return nil
-	}
-
-	return []corev1.EnvVar{
-		{
-			Name:  "CONFIGCAT_SDK_KEY",
-			Value: sdkKey,
-		},
-	}
 }

--- a/install/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/install/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -31,6 +31,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		EmulatePreparingIntervalSeconds: 10,
 		StaticBridges:                   WSManagerList(ctx),
+		ClusterSyncIntervalSeconds:      60,
 	}
 
 	fc, err := common.ToJSONString(wsmbcfg)

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -130,6 +130,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								common.AnalyticsEnv(&ctx.Config),
 								common.MessageBusEnv(&ctx.Config),
 								common.DatabaseEnv(&ctx.Config),
+								common.ConfigcatEnv(ctx),
 								[]corev1.EnvVar{{
 									Name:  "WSMAN_BRIDGE_CONFIGPATH",
 									Value: "/config/ws-manager-bridge.json",

--- a/install/installer/pkg/components/ws-manager-bridge/types.go
+++ b/install/installer/pkg/components/ws-manager-bridge/types.go
@@ -14,6 +14,7 @@ type Configuration struct {
 	ControllerMaxDisconnectSeconds      int32              `json:"controllerMaxDisconnectSeconds"`
 	EmulatePreparingIntervalSeconds     int32              `json:"emulatePreparingIntervalSeconds"`
 	Timeouts                            Timeouts           `json:"timeouts"`
+	ClusterSyncIntervalSeconds          int32              `json:"clusterSyncIntervalSeconds"`
 }
 
 type ClusterService struct {


### PR DESCRIPTION
## Description
**Note:** This is a stacked PR that depends on https://github.com/gitpod-io/gitpod/pull/10982

During registration of a workspace cluster the workspace classes that are supported by this cluster will be fetched from the DescribeCluster endpoint of ws-manager. They are also fetched in a configurable interval (currently 60 seconds) so that updates to the supported classes are propagated to the meta side. 

I have added a feature flag, so that this change can be deployed even if the new endpoint from https://github.com/gitpod-io/gitpod/pull/10982 has not been deployed to workspace clusters yet.

## Related Issue(s)
Partially fixes #https://github.com/gitpod-io/gitpod/issues/10842

## How to test
- Currently the feature flag (workspace_classes_backend) is active, so with debug logs activated (gpctl debug logs ws-manager-bridge) you should see messages like `reconciling workspace classes...`in the log output. After disabling the flag and restarting ws-manager-bridge you should not see any messages.

- Registration of a workspace cluster can be done with `gpctl clusters register --name ws-cluster1 --hint-cordoned --hint-govern --tls-path ./wsman-tls/ --url 34.77.51.162:8081 --kubeconfig ./meta-cluster`. After that in the admissionConstraints column of d_b_workspace_cluster you should see an entry similar to this:

```
[
   {
      "type":"has-class",
      "id":"default",
      "displayName":"default"
   },
   {
      "type":"has-class",
      "id":"gitpodio-internal-xl",
      "displayName":"XL"
   }
]
```

You can create a workspace cluster with workspace preview. I already have created a VM which you can use for registration. Contact me for the credentials.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
