### PR TITLE
Double the Requests Memory from Workspace Resources to increase memory available for Java

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -124,7 +124,7 @@ EOF`)
     private configureWorkspaces(slice: string) {
         exec(`yq w -i ${this.options.installerConfigPath} workspace.runtime.containerdRuntimeDir ${CONTAINERD_RUNTIME_DIR}`, { slice: slice });
         exec(`yq w -i ${this.options.installerConfigPath} workspace.resources.requests.cpu "100m"`, { slice: slice });
-        exec(`yq w -i ${this.options.installerConfigPath} workspace.resources.requests.memory "128Mi"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} workspace.resources.requests.memory "256Mi"`, { slice: slice });
     }
 
     private configureObjectStorage(slice: string) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when we create a workspace from https://github.com/gitpod-io/spring-petclinic on Preview Environment, it will trigger an OutOfMemoryError during the Build Task.

![image](https://user-images.githubusercontent.com/418083/176474789-f3be701f-76d3-4198-8ad5-b1727b604539.png)

This happens because `JAVA_TOOL_OPTIONS` currently is set to `-Xmx134m` due to [this line](https://github.com/gitpod-io/gitpod/blob/6aebb2abf8aae1ea8ada0af39867c8ee6688f5be/.werft/jobs/build/installer/installer.ts#L127) which affects `GITPOD_MEMORY` env var, which in turn is used to set Java's memory [here](https://github.com/gitpod-io/gitpod/blob/65384dbc13544d0a79ca055403e5be7d974d89ad/components/supervisor/pkg/supervisor/supervisor.go#L929-L931).

This PR increases Preview Environments memory to address this issue. By increasing memory to `256Mi`, `JAVA_TOOL_OPTIONS` [becomes](https://www.kylesconverter.com/data-storage/mebibytes-to-bytes) `-Xmx268m`, which is enough to make "gitpod-io/spring-petclinic" to build correctly:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/418083/176487889-009d02b4-14c3-485f-a591-5630fc206c33.png">

<img width="433" alt="image" src="https://user-images.githubusercontent.com/418083/176487950-7b9b60bb-3834-4a61-b754-d0e5a47f5c5f.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
- On the Preview Environment of this PR, start a workspace from `gitpod-io/spring-petclinic` by clicking this URL: https://felladrin-a6a5dd8d00.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/spring-petclinic
- Run on terminal: `export JAVA_TOOL_OPTIONS="-Xmx268m"`
- Then run again the commands from the task:
  - `./mvnw package -DskipTests`
  - `java -jar target/*.jar`
- Confirm if it builds and starts the PetClinic website successfully.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
