### PR TITLE
[usage] Refactor server start into a function, specify config

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/usage/pkg/controller"
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/gitpod-io/gitpod/usage/pkg/stripe"
+	"net"
+	"os"
+	"time"
+)
+
+type Config struct {
+	// ControllerSchedule determines how frequently to run the Usage/Billing controller
+	ControllerSchedule time.Duration `json:"controllerSchedule,omitempty"`
+
+	StripeCredentialsFile string `json:"stripeCredentialsFile,omitempty"`
+
+	Server *baseserver.Configuration `json:"server,omitempty"`
+}
+
+func Start(cfg Config) error {
+	log.WithField("config", cfg).Info("Starting usage component.")
+
+	conn, err := db.Connect(db.ConnectionParams{
+		User:     os.Getenv("DB_USERNAME"),
+		Password: os.Getenv("DB_PASSWORD"),
+		Host:     net.JoinHostPort(os.Getenv("DB_HOST"), os.Getenv("DB_PORT")),
+		Database: "gitpod",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to establish database connection: %w", err)
+	}
+
+	var billingController controller.BillingController = &controller.NoOpBillingController{}
+
+	if cfg.StripeCredentialsFile != "" {
+		config, err := stripe.ReadConfigFromFile(cfg.StripeCredentialsFile)
+		if err != nil {
+			return fmt.Errorf("failed to load stripe credentials: %w", err)
+		}
+
+		c, err := stripe.New(config)
+		if err != nil {
+			return fmt.Errorf("failed to initialize stripe client: %w", err)
+		}
+		billingController = controller.NewStripeBillingController(c, controller.DefaultWorkspacePricer)
+	}
+
+	ctrl, err := controller.New(cfg.ControllerSchedule, controller.NewUsageReconciler(conn, billingController))
+	if err != nil {
+		return fmt.Errorf("failed to initialize usage controller: %w", err)
+	}
+
+	err = ctrl.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start usage controller: %w", err)
+	}
+	defer ctrl.Stop()
+
+	var serverOpts []baseserver.Option
+	if cfg.Server != nil {
+		serverOpts = append(serverOpts, baseserver.WithConfig(cfg.Server))
+	}
+	srv, err := baseserver.New("usage", serverOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to initialize usage server: %w", err)
+	}
+
+	err = controller.RegisterMetrics(srv.MetricsRegistry())
+	if err != nil {
+		return fmt.Errorf("failed to register controller metrics: %w", err)
+	}
+
+	err = srv.ListenAndServe()
+	if err != nil {
+		return fmt.Errorf("failed to listen and server: %w", err)
+	}
+
+	return nil
+}

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -5,7 +5,9 @@
 package stripe
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -20,6 +22,21 @@ type Client struct {
 type ClientConfig struct {
 	PublishableKey string `json:"publishableKey"`
 	SecretKey      string `json:"secretKey"`
+}
+
+func ReadConfigFromFile(path string) (ClientConfig, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return ClientConfig{}, fmt.Errorf("failed to read stripe client config: %w", err)
+	}
+
+	var config ClientConfig
+	err = json.Unmarshal(bytes, &config)
+	if err != nil {
+		return ClientConfig{}, fmt.Errorf("failed to unmarshal Stripe Client config: %w", err)
+	}
+
+	return config, nil
 }
 
 // New authenticates a Stripe client using the provided config


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactors `usage` server startup into a function to allow for an integration tests to be created, this also cleans up the commands a bit.

This is the first part of https://github.com/gitpod-io/gitpod/issues/10753, subsequent PR will specify a file with the configuration rather than pass config as command line arguments.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/10753
* Follow-up https://github.com/gitpod-io/gitpod/pull/11028

## How to test
<!-- Provide steps to test this PR -->
Component starts in preview
Unit tests still work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
