### PR TITLE
Re-add core-dev SA secret to preview del job

### DIFF
--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -10,6 +10,9 @@ pod:
             values:
             - "builds"
   volumes:
+  - name: gcp-sa
+    secret:
+      secretName: gcp-sa-gitpod-dev-deployer
   - name: harvester-kubeconfig
     secret:
       secretName: harvester-kubeconfig
@@ -25,6 +28,9 @@ pod:
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:
+    - name: gcp-sa
+      mountPath: /mnt/secrets/gcp-sa
+      readOnly: true
     - name: harvester-kubeconfig
       mountPath: /mnt/secrets/harvester-kubeconfig
     - name: harvester-vm-ssh-keys


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Re-adds the  SA secret used to obtain the core-dev cluster creds. It's required by the delete job to clean-up the certs and LBs.

Currently the job fails:

```
STDERR: ERROR: (gcloud.auth.activate-service-account) Unable to read file [/mnt/secrets/gcp-sa/service-account.json]: [Errno 2] No such file or directory: '/mnt/secrets/gcp-sa/service-account.json'
```

https://werft.gitpod-dev.com/job/gitpod-platform-delete-preview-environments-cron-main.2362


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
