### PR TITLE
Reliably fetch logs for imagebuild and prebuild itself

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -7,7 +7,6 @@
 import EventEmitter from "events";
 import React, { Suspense, useEffect, useState } from "react";
 import {
-    Workspace,
     WorkspaceInstance,
     DisposableCollection,
     WorkspaceImageBuild,
@@ -21,13 +20,13 @@ import { PrebuildStatus } from "../projects/Prebuilds";
 const WorkspaceLogs = React.lazy(() => import("./WorkspaceLogs"));
 
 export interface PrebuildLogsProps {
+    // The workspace ID of the "prebuild" workspace
     workspaceId: string | undefined;
     onIgnorePrebuild?: () => void;
     children?: React.ReactNode;
 }
 
 export default function PrebuildLogs(props: PrebuildLogsProps) {
-    const [workspace, setWorkspace] = useState<Workspace | undefined>();
     const [workspaceInstance, setWorkspaceInstance] = useState<WorkspaceInstance | undefined>();
     const [error, setError] = useState<Error | undefined>();
     const [logsEmitter] = useState(new EventEmitter());
@@ -44,7 +43,6 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                 const info = await getGitpodService().server.getWorkspace(props.workspaceId);
                 const pbws = await getGitpodService().server.findPrebuildByWorkspaceID(props.workspaceId);
                 if (info.latestInstance) {
-                    setWorkspace(info.workspace);
                     setWorkspaceInstance(info.latestInstance);
                 }
                 if (pbws) {
@@ -74,36 +72,45 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                         },
                     }),
                 );
-                if (info.latestInstance) {
-                    disposables.push(
-                        watchHeadlessLogs(
-                            info.latestInstance.id,
-                            (chunk) => {
-                                logsEmitter.emit("logs", chunk);
-                            },
-                            async () => workspaceInstance?.status.phase === "stopped",
-                        ),
-                    );
-                }
             } catch (err) {
                 console.error(err);
                 setError(err);
             }
         })();
-        return function cleanUp() {
+        return function cleanup() {
             disposables.dispose();
         };
-    }, [props.workspaceId]);
+    }, [logsEmitter, props.workspaceId]);
 
     useEffect(() => {
-        switch (workspaceInstance?.status.phase) {
-            // Building means we're building the Docker image for the workspace so the workspace hasn't started yet.
-            case "building":
-            case "stopped":
-                getGitpodService().server.watchWorkspaceImageBuildLogs(workspace!.id);
-                break;
+        const workspaceId = props.workspaceId;
+        if (!workspaceId || !workspaceInstance?.status.phase) {
+            return;
         }
-    }, [props.workspaceId, workspaceInstance?.status.phase]);
+
+        const disposables = new DisposableCollection();
+        switch (workspaceInstance.status.phase) {
+            // "building" means we're building the Docker image for the prebuild's workspace so the workspace hasn't started yet.
+            case "building":
+                // Try to grab image build logs
+                disposables.push(retryWatchWorkspaceImageBuildLogs(workspaceId));
+                break;
+            // When we're "running" we want to switch to the logs from the actual prebuild workspace, instead
+            case "running":
+                disposables.push(
+                    watchHeadlessLogs(
+                        workspaceInstance.id,
+                        (chunk) => {
+                            logsEmitter.emit("logs", chunk);
+                        },
+                        async () => workspaceInstance?.status.phase === "stopped",
+                    ),
+                );
+        }
+        return function cleanup() {
+            disposables.dispose();
+        };
+    }, [logsEmitter, props.workspaceId, workspaceInstance?.id, workspaceInstance?.status.phase]);
 
     return (
         <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
@@ -121,7 +128,39 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
     );
 }
 
-export function watchHeadlessLogs(
+function retryWatchWorkspaceImageBuildLogs(workspaceId: string): Disposable {
+    let abortImageLogs = false;
+    (async () => {
+        // Linear backoff + abort for re-trying fetching of imagebuild logs
+        const initialDelaySeconds = 1;
+        const backoffFactor = 1.2;
+        const maxBackoffSeconds = 5;
+        let delayInSeconds = initialDelaySeconds;
+
+        while (true) {
+            delayInSeconds = Math.min(delayInSeconds * backoffFactor, maxBackoffSeconds);
+
+            console.debug("re-trying image build logs");
+            // eslint-disable-next-line
+            await new Promise((resolve) => {
+                setTimeout(resolve, delayInSeconds * 1000);
+            });
+            if (abortImageLogs) {
+                return;
+            }
+            try {
+                await getGitpodService().server.watchWorkspaceImageBuildLogs(workspaceId);
+            } catch (err) {
+                console.error("watchWorkspaceImageBuildLogs", err);
+            }
+        }
+    })();
+    return Disposable.create(() => {
+        abortImageLogs = true;
+    });
+}
+
+function watchHeadlessLogs(
     instanceId: string,
     onLog: (chunk: string) => void,
     checkIsDone: () => Promise<boolean>,

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -4,13 +4,13 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import EventEmitter from "events";
 import React, { useEffect, useContext, useState } from "react";
 import {
     CreateWorkspaceMode,
     WorkspaceCreationResult,
     RunningWorkspacePrebuildStarting,
     ContextURL,
+    DisposableCollection,
 } from "@gitpod/gitpod-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import Modal from "../components/Modal";
@@ -21,7 +21,7 @@ import StartWorkspace, { parseProps } from "./StartWorkspace";
 import { openAuthorizeWindow } from "../provider-utils";
 import { SelectAccountPayload } from "@gitpod/gitpod-protocol/lib/auth";
 import { SelectAccountModal } from "../settings/SelectAccountModal";
-import PrebuildLogs, { watchHeadlessLogs } from "../components/PrebuildLogs";
+import PrebuildLogs from "../components/PrebuildLogs";
 import CodeText from "../components/CodeText";
 import FeedbackComponent from "../feedback-form/FeedbackComponent";
 import { isGitpodIo } from "../utils";
@@ -459,19 +459,15 @@ interface RunningPrebuildViewProps {
 }
 
 function RunningPrebuildView(props: RunningPrebuildViewProps) {
-    const [logsEmitter] = useState(new EventEmitter());
+    const workspaceId = props.runningPrebuild.workspaceID;
 
     useEffect(() => {
-        const disposables = watchHeadlessLogs(
-            props.runningPrebuild.instanceID,
-            (chunk) => logsEmitter.emit("logs", chunk),
-            async () => false,
-        );
+        const disposables = new DisposableCollection();
 
         disposables.push(
             getGitpodService().registerClient({
                 onInstanceUpdate: (update) => {
-                    if (update.workspaceId !== props.runningPrebuild.workspaceID) {
+                    if (update.workspaceId !== workspaceId) {
                         return;
                     }
                     if (update.status.phase === "stopped") {
@@ -484,13 +480,14 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
         return function cleanup() {
             disposables.dispose();
         };
-    }, []);
+        // eslint-disable-next-line
+    }, [workspaceId]);
 
     return (
         <StartPage title="Prebuild in Progress">
             {/* TODO(gpl) Copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
             <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
-                <PrebuildLogs workspaceId={props.runningPrebuild.workspaceID} onIgnorePrebuild={props.onIgnorePrebuild}>
+                <PrebuildLogs workspaceId={workspaceId} onIgnorePrebuild={props.onIgnorePrebuild}>
                     <button className="secondary" onClick={() => props.onIgnorePrebuild && props.onIgnorePrebuild()}>
                         Skip Prebuild
                     </button>

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1605,7 +1605,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 aborted,
             );
         } catch (err) {
-            log.error(logCtx, "cannot watch imagebuild logs for workspaceId", err);
+            // This error is most likely a temporary one (too early). We defer to the client whether they want to keep on trying or not.
+            log.debug(logCtx, "cannot watch imagebuild logs for workspaceId", err);
             throw new ResponseError(
                 ErrorCodes.HEADLESS_LOG_NOT_YET_AVAILABLE,
                 "cannot watch imagebuild logs for workspaceId",

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1027,7 +1027,12 @@ export class WorkspaceStarter {
                         .catch((err) => log.error("error writing image build log info to the DB", err));
                 })
                 .catch((err) =>
-                    log.warn("image build: never received log info", err, {
+                    // TODO (gpl) This error happens quite often, but looks like it's mostly triggered by user errors:
+                    // The image build fails (e.g. bc the base image cannot be pulled) so fast that we never received the log meta info.
+                    // We switch this to "debug" for now. Going forward, we should:
+                    //  1. turn this into a metric to feat the "image build reliability" SLI
+                    //  2. fix the image-builder implementation
+                    log.debug("image build: never received log info", err, {
                         instanceId: instance.id,
                         workspaceId: instance.workspaceId,
                     }),


### PR DESCRIPTION
## Description

This PR deprecates an older mechanism to stream image build logs. Removing that revealed that it was shadowing reliabilty problems, so those got fixed in the frontend as well. :see_no_evil: 

I hid the changes behind a feature flag to safely test the effects in staging + prod (different ingress infrastructure).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11024

## How to test
 - create a team and project (e.g. on this [test repo](https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins))
 - push a commit, for instance to [this branch](https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins)
 - switch to "Branches", wait for the prebuild to start and click on the Prebuild Details view
 - open a second tab on "Branches", and once the prebuild is there, click "start workspace" right next to it
 - observe that a) streaming of image build logs and b) streaming of prebuild logs works as expected
 - go to ConfigCat, and add a filter for your project to include the projectId and set the flag `deprecateOldImageLogsMechanism` to true
 - repeat tests above :point_up: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve reliability of log streaming for image builds and prebuilds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
