### PR TITLE
Update project settings preference copy

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -130,7 +130,7 @@ export default function () {
             />
             <CheckBox
                 title={<span>Cancel Prebuilds on Outdated Commits </span>}
-                desc={<span>Cancels all pending and running prebuilds on the branch when a new commit is pushed.</span>}
+                desc={<span>Cancel pending or running prebuilds on the same branch when new commits are pushed.</span>}
                 checked={!projectSettings.keepOutdatedPrebuildsRunning}
                 onChange={toggleCancelOutdatedPrebuilds}
             />


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/10962#discussion_r910117371, this is a minor copy update for the preference option for canceling prebuilds on outdated commits in project settings.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```