### PR TITLE
[server] Read blocked repositories from database

### DIFF
--- a/components/gitpod-db/src/blocked-repository-db.spec.db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.spec.db.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+const expect = chai.expect;
+import { suite, test, timeout } from "mocha-typescript";
+
+import { testContainer } from "./test-container";
+import { TypeORMBlockedRepositoryDBImpl } from "./typeorm/blocked-repository-db-impl";
+import { TypeORM } from "./typeorm/typeorm";
+import { DBBlockedRepository } from "./typeorm/entity/db-blocked-repository";
+
+@suite
+class BlockedRepositoryDBSpec {
+    blockedRepositoryDb = testContainer.get<TypeORMBlockedRepositoryDBImpl>(TypeORMBlockedRepositoryDBImpl);
+
+    async before() {
+        await this.wipeRepo();
+    }
+
+    async after() {
+        await this.wipeRepo();
+    }
+
+    @test(timeout(10000))
+    public async checkRepositoryIsBlocked() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        manager.getRepository(DBBlockedRepository).insert({
+            urlRegexp: "github.com/bob/.*",
+            blockUser: true,
+            deleted: false,
+        });
+
+        const blockedRepository = await this.blockedRepositoryDb.isRepositoryBlocked("github.com/bob/some-repo");
+
+        expect(blockedRepository).not.undefined;
+        expect(blockedRepository?.urlRegexp).to.eq("github.com/bob/.*");
+        expect(blockedRepository?.blockUser).to.eq(true);
+    }
+
+    @test(timeout(10000))
+    public async checkRepositoryIsNotBlocked() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        manager.getRepository(DBBlockedRepository).insert({
+            urlRegexp: "github.com/bob/.*",
+            blockUser: true,
+            deleted: false,
+        });
+
+        const blockedRepository = await this.blockedRepositoryDb.isRepositoryBlocked("github.com/alice/some-repo");
+
+        expect(blockedRepository).undefined;
+    }
+
+    async wipeRepo() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        await manager.getRepository(DBBlockedRepository).delete({});
+    }
+}
+
+module.exports = new BlockedRepositoryDBSpec();

--- a/components/gitpod-db/src/blocked-repository-db.spec.db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.spec.db.ts
@@ -35,7 +35,7 @@ class BlockedRepositoryDBSpec {
             deleted: false,
         });
 
-        const blockedRepository = await this.blockedRepositoryDb.isRepositoryBlocked("github.com/bob/some-repo");
+        const blockedRepository = await this.blockedRepositoryDb.findBlockedRepositoryByURL("github.com/bob/some-repo");
 
         expect(blockedRepository).not.undefined;
         expect(blockedRepository?.urlRegexp).to.eq("github.com/bob/.*");
@@ -52,7 +52,9 @@ class BlockedRepositoryDBSpec {
             deleted: false,
         });
 
-        const blockedRepository = await this.blockedRepositoryDb.isRepositoryBlocked("github.com/alice/some-repo");
+        const blockedRepository = await this.blockedRepositoryDb.findBlockedRepositoryByURL(
+            "github.com/alice/some-repo",
+        );
 
         expect(blockedRepository).undefined;
     }

--- a/components/gitpod-db/src/blocked-repository-db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
+
+export const BlockedRepositoryDB = Symbol("BlockedRepositoryDB");
+
+export interface BlockedRepositoryDB {
+    isRepositoryBlocked(contextURL: string): Promise<BlockedRepository | undefined>;
+}

--- a/components/gitpod-db/src/blocked-repository-db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.ts
@@ -9,5 +9,5 @@ import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositor
 export const BlockedRepositoryDB = Symbol("BlockedRepositoryDB");
 
 export interface BlockedRepositoryDB {
-    isRepositoryBlocked(contextURL: string): Promise<BlockedRepository | undefined>;
+    findBlockedRepositoryByURL(contextURL: string): Promise<BlockedRepository | undefined>;
 }

--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -63,6 +63,8 @@ import { TypeORMInstallationAdminImpl } from "./typeorm/installation-admin-db-im
 import { InstallationAdminDB } from "./installation-admin-db";
 import { TeamSubscription2DB } from "./team-subscription-2-db";
 import { TeamSubscription2DBImpl } from "./typeorm/team-subscription-2-db-impl";
+import { TypeORMBlockedRepositoryDBImpl } from "./typeorm/blocked-repository-db-impl";
+import { BlockedRepositoryDB } from "./blocked-repository-db";
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -70,6 +72,9 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
     bind(TypeORM).toSelf().inSingletonScope();
     bind(DBWithTracing).toSelf().inSingletonScope();
     bind(TransactionalWorkspaceDbImpl).toSelf().inSingletonScope();
+
+    bind(TypeORMBlockedRepositoryDBImpl).toSelf().inSingletonScope();
+    bind(BlockedRepositoryDB).toService(TypeORMBlockedRepositoryDBImpl);
 
     bind(TypeORMUserDBImpl).toSelf().inSingletonScope();
     bind(UserDB).toService(TypeORMUserDBImpl);

--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -48,6 +48,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
     readonly name = "gitpod";
     protected readonly tables: TableDescription[] = [
         {
+            name: "d_b_blocked_repository",
+            primaryKeys: ["id"],
+            timeColumn: "updatedAt",
+            deletionColumn: "deleted",
+        },
+        {
             name: "d_b_account_entry",
             primaryKeys: ["uid"],
             timeColumn: "_lastModified",

--- a/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable } from "inversify";
+import { EntityManager, Repository } from "typeorm";
+import { TypeORM } from "./typeorm";
+import { DBBlockedRepository } from "./entity/db-blocked-repository";
+import { BlockedRepositoryDB } from "../blocked-repository-db";
+import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
+
+@injectable()
+export class TypeORMBlockedRepositoryDBImpl implements BlockedRepositoryDB {
+    @inject(TypeORM) protected readonly typeorm: TypeORM;
+
+    protected async getEntityManager(): Promise<EntityManager> {
+        return (await this.typeorm.getConnection()).manager;
+    }
+
+    async getBlockedRepositoryRepo(): Promise<Repository<DBBlockedRepository>> {
+        return (await this.getEntityManager()).getRepository<DBBlockedRepository>(DBBlockedRepository);
+    }
+
+    public async isRepositoryBlocked(contextURL: string): Promise<BlockedRepository | undefined> {
+        const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
+
+        const query = blockedRepositoryRepo
+            .createQueryBuilder("br")
+            .where(":pattern REGEXP br.urlRegexp", { pattern: contextURL });
+
+        return query.getOne();
+    }
+}

--- a/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
@@ -23,7 +23,7 @@ export class TypeORMBlockedRepositoryDBImpl implements BlockedRepositoryDB {
         return (await this.getEntityManager()).getRepository<DBBlockedRepository>(DBBlockedRepository);
     }
 
-    public async isRepositoryBlocked(contextURL: string): Promise<BlockedRepository | undefined> {
+    public async findBlockedRepositoryByURL(contextURL: string): Promise<BlockedRepository | undefined> {
         const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
 
         const query = blockedRepositoryRepo

--- a/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
@@ -27,8 +27,6 @@ export class DBBlockedRepository implements BlockedRepository {
     @DeleteDateColumn()
     deletedAt: string;
 
-    // TODO: not sure if we need this?
-    // TODO: should have a default value of false?
     // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;

--- a/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
+import { Entity, Column, CreateDateColumn, DeleteDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class DBBlockedRepository implements BlockedRepository {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column("varchar")
+    urlRegexp: string;
+
+    @Column()
+    blockUser: boolean;
+
+    @CreateDateColumn()
+    createdAt: string;
+
+    @UpdateDateColumn()
+    updatedAt: string;
+
+    @DeleteDateColumn()
+    deletedAt: string;
+
+    // TODO: not sure if we need this?
+    // TODO: should have a default value of false?
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
+}

--- a/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
-import { Entity, Column, CreateDateColumn, DeleteDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, Column, CreateDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class DBBlockedRepository implements BlockedRepository {
@@ -23,9 +23,6 @@ export class DBBlockedRepository implements BlockedRepository {
 
     @UpdateDateColumn()
     updatedAt: string;
-
-    @DeleteDateColumn()
-    deletedAt: string;
 
     // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
     @Column()

--- a/components/gitpod-db/src/typeorm/migration/1656408949484-AddBlockedRepositoryTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1656408949484-AddBlockedRepositoryTable.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddBlockedRepositoryTable1656408949484 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE \`d_b_blocked_repository\` (\`id\` int NOT NULL AUTO_INCREMENT, \`urlRegexp\` varchar(255) NOT NULL, \`blockUser\` tinyint NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updatedAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`deletedAt\` datetime(6) NULL, \`deleted\` tinyint NOT NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE \`d_b_blocked_repository\``);
+    }
+}

--- a/components/gitpod-db/src/typeorm/migration/1656408949484-AddBlockedRepositoryTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1656408949484-AddBlockedRepositoryTable.ts
@@ -9,7 +9,7 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class AddBlockedRepositoryTable1656408949484 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `CREATE TABLE \`d_b_blocked_repository\` (\`id\` int NOT NULL AUTO_INCREMENT, \`urlRegexp\` varchar(255) NOT NULL, \`blockUser\` tinyint NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updatedAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`deletedAt\` datetime(6) NULL, \`deleted\` tinyint NOT NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+            `CREATE TABLE \`d_b_blocked_repository\` (\`id\` int NOT NULL AUTO_INCREMENT, \`urlRegexp\` varchar(255) NOT NULL, \`blockUser\` tinyint NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updatedAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`deleted\` tinyint NOT NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
         );
     }
 

--- a/components/gitpod-protocol/src/blocked-repositories-protocol.ts
+++ b/components/gitpod-protocol/src/blocked-repositories-protocol.ts
@@ -10,5 +10,4 @@ export interface BlockedRepository {
     blockUser: boolean;
     createdAt: string;
     updatedAt: string;
-    deletedAt: string;
 }

--- a/components/gitpod-protocol/src/blocked-repositories-protocol.ts
+++ b/components/gitpod-protocol/src/blocked-repositories-protocol.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+// TODO: Maybe this should be in protocol.ts?
+export interface BlockedRepository {
+    id: number;
+    urlRegexp: string;
+    blockUser: boolean;
+    createdAt: string;
+    updatedAt: string;
+    deletedAt: string;
+}

--- a/components/gitpod-protocol/src/blocked-repositories-protocol.ts
+++ b/components/gitpod-protocol/src/blocked-repositories-protocol.ts
@@ -4,7 +4,6 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-// TODO: Maybe this should be in protocol.ts?
 export interface BlockedRepository {
     id: number;
     urlRegexp: string;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -385,7 +385,7 @@ export class WorkspaceStarter {
     }
 
     protected async checkBlockedRepositoryInDB(user: User, contextURL: string) {
-        const blockedRepository = await this.blockedRepositoryDB.isRepositoryBlocked(contextURL);
+        const blockedRepository = await this.blockedRepositoryDB.findBlockedRepositoryByURL(contextURL);
         if (!blockedRepository) return;
 
         if (blockedRepository.blockUser) {


### PR DESCRIPTION
## Description

Add a `d_b_blocked_repository` table to the application database and use it at workspace startup to check whether a workspace should be blocked. Also checks if the user should be blocked for attempting to start such a workspace and blocks the user as necessary.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/11030

## How to test

* Get a kube context for the preview environment for this branch:

  ```bash
  previewctl install-context
  ```

* Port forward to the database (username and password is in the `server` environment):

  ```bash
  kubectl port-forward svc/mysql 3306:3306
  ```

* Using `mysql` client or `mycli` (needs `brew install mycli` first) add an entry to the `d_b_blocked_repository` table.

  ```sql
  insert into d_b_blocked_repository (`urlRegexp`, `blockUser`, `deleted`) values ("github.com/<your github username>", true, false)
  ```

* Attempt to start a workspace from a github repository under your user.

* Observe that the workspace fails to start.

* Try to open another workspace and see that you are now blocked.

* Unblock yourself  by updating your entry in the `d_b_users` table:

  ```sql
  update d_b_user set blocked = 0 where id=<id field value for the row for your username>'
  ```

* Experiment by inserting/deleting other combinations of `urlRegexp` and `blockUser` in the `d_b_blocked_repository` table.


<insert image>

## Release Notes

```release-note
NONE
```

## Werft options

- [x] /werft with-preview
