### PR TITLE
[preview] rename `preview-install` to `local-preview`

### DIFF
--- a/install/preview/BUILD.yaml
+++ b/install/preview/BUILD.yaml
@@ -14,4 +14,4 @@ packages:
     config:
       dockerfile: leeway.Dockerfile
       image:
-        - ${imageRepoBase}/preview-install:${version}
+        - ${imageRepoBase}/local-preview:${version}

--- a/install/preview/README.md
+++ b/install/preview/README.md
@@ -1,4 +1,4 @@
-# Gitpod Preview Installation
+# Gitpod Local Preview
 
 This repo helps users to try out and preview self-hosted Gitpod **locally** without all the things
 needed for a production instance. The aim is to provide an installation mechanism as minimal and
@@ -7,7 +7,7 @@ simple as possible.
 ## Installation
 
 ```bash
-docker run --privileged --name gitpod --rm -it -v /tmp/gitpod:/var/gitpod eu.gcr.io/gitpod-core-dev/build/preview-install:tar-preview-output.2
+docker run --privileged --name gitpod --rm -it -v /tmp/gitpod:/var/gitpod eu.gcr.io/gitpod-core-dev/build/preview-install
 ```
 
 Once the above command starts running and the pods are ready (can be checked by running `docker exec gitpod kubectl get pods`),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the new preview installation method, to be
called `local-preview`. This is part of the recent change
across the documentation https://github.com/gitpod-io/website/pull/2326

The image tag is still `preview-install` in the readme's and other
documentations, but it will be updated once we start publishing
releases with it.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/website/pull/2326

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[preview] rename `preview-install` to `local-preview`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
