### PR TITLE
Configure workspace classes from dashboard

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -10,7 +10,12 @@ import Cookies from "js-cookie";
 import { v4 } from "uuid";
 import { Experiment } from "./experiments";
 
-export type Event = "invite_url_requested" | "organisation_authorised" | "dotfile_repo_changed" | "feedback_submitted";
+export type Event =
+    | "invite_url_requested"
+    | "organisation_authorised"
+    | "dotfile_repo_changed"
+    | "feedback_submitted"
+    | "workspace_class_changed";
 type InternalEvent = Event | "path_changed" | "dashboard_clicked";
 
 export type EventProperties = TrackOrgAuthorised | TrackInviteUrlRequested | TrackDotfileRepo | TrackFeedback;

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -14,8 +14,10 @@ import getSettingsMenu from "./settings-menu";
 import { trackEvent } from "../Analytics";
 import { PaymentContext } from "../payment-context";
 import SelectIDE from "./SelectIDE";
+import { WorkspaceClasses } from "@gitpod/gitpod-protocol";
 
 type Theme = "light" | "dark" | "system";
+// type WorkspaceClass = "standard" | "XL";
 
 export default function Preferences() {
     const { user } = useContext(UserContext);
@@ -47,6 +49,26 @@ export default function Preferences() {
                 previous: prevDotfileRepo,
                 current: value,
             });
+        }
+    };
+
+    const [workspaceClass, setWorkspaceClass] = useState<string>(
+        user?.additionalData?.workspaceClasses?.regular || "standard",
+    );
+    const actuallySetWorkspaceClass = async (value: string) => {
+        const additionalData = user?.additionalData || {};
+        const prevWorkspaceClass = additionalData?.workspaceClasses?.regular || "standard";
+        const workspaceClasses = (additionalData?.workspaceClasses || {}) as WorkspaceClasses;
+        workspaceClasses.regular = value;
+        workspaceClasses.prebuild = value;
+        additionalData.workspaceClasses = workspaceClasses;
+        if (value !== prevWorkspaceClass) {
+            await getGitpodService().server.updateLoggedInUser({ additionalData });
+            trackEvent("workspace_class_changed", {
+                previous: prevWorkspaceClass,
+                current: value,
+            });
+            setWorkspaceClass(value);
         }
     };
 
@@ -115,9 +137,7 @@ export default function Preferences() {
                     </SelectableCardSolid>
                 </div>
 
-                <h3 className="mt-12">
-                    Dotfiles{" "}
-                </h3>
+                <h3 className="mt-12">Dotfiles </h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Customize workspaces using dotfiles.</p>
                 <div className="mt-4 max-w-xl">
                     <h4>Repository URL</h4>
@@ -140,6 +160,48 @@ export default function Preferences() {
                             clone and install your dotfiles for every new workspace.
                         </p>
                     </div>
+                </div>
+
+                <h3 className="mt-12">Workspaces</h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">
+                    Choose the workspace machine type for your workspaces.
+                </p>
+                <div className="mt-4 space-x-3 flex">
+                    <SelectableCardSolid
+                        className="w-36 h-32"
+                        title="Standard"
+                        selected={workspaceClass === "standard"}
+                        onClick={() => actuallySetWorkspaceClass("standard")}
+                    >
+                        <div className="flex-grow flex items-end p-1">
+                            <svg width="112" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path
+                                    d="M0 8a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM0 32a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM0 56a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM40 6a6 6 0 0 1 6-6h60a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H46a6 6 0 0 1-6-6V6Z"
+                                    fill="#D6D3D1"
+                                />
+                            </svg>
+                        </div>
+                    </SelectableCardSolid>
+                    <SelectableCardSolid
+                        className="w-36 h-32"
+                        title="XL"
+                        selected={workspaceClass === "XL"}
+                        onClick={() => actuallySetWorkspaceClass("XL")}
+                    >
+                        <div className="flex-grow flex items-end p-1">
+                            <svg width="112" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path
+                                    d="M0 8a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM40 6a6 6 0 0 1 6-6h60a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H46a6 6 0 0 1-6-6V6Z"
+                                    fill="#D9D9D9"
+                                />
+                                <path
+                                    d="M84 0h22a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H68L84 0ZM0 32a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8Z"
+                                    fill="#78716C"
+                                />
+                                <path d="M0 56a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8Z" fill="#D9D9D9" />
+                            </svg>
+                        </div>
+                    </SelectableCardSolid>
                 </div>
             </PageWithSubMenu>
         </div>

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -18,7 +18,6 @@ import { getExperimentsClient } from "../experiments/client";
 import SelectWorkspaceClass from "./selectClass";
 
 type Theme = "light" | "dark" | "system";
-// type WorkspaceClass = "standard" | "XL";
 
 export default function Preferences() {
     const { user } = useContext(UserContext);
@@ -56,7 +55,6 @@ export default function Preferences() {
     const [isShowWorkspaceClasses, setIsShowWorkspaceClasses] = useState<boolean>(false);
     (async () => {
         const showWorkspaceClasses = await getExperimentsClient().getValueAsync("workspace_classes", false, {});
-        console.log("is enabled", showWorkspaceClasses);
         setIsShowWorkspaceClasses(showWorkspaceClasses);
     })();
 

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -14,7 +14,8 @@ import getSettingsMenu from "./settings-menu";
 import { trackEvent } from "../Analytics";
 import { PaymentContext } from "../payment-context";
 import SelectIDE from "./SelectIDE";
-import { WorkspaceClasses } from "@gitpod/gitpod-protocol";
+import { getExperimentsClient } from "../experiments/client";
+import SelectWorkspaceClass from "./selectClass";
 
 type Theme = "light" | "dark" | "system";
 // type WorkspaceClass = "standard" | "XL";
@@ -52,25 +53,12 @@ export default function Preferences() {
         }
     };
 
-    const [workspaceClass, setWorkspaceClass] = useState<string>(
-        user?.additionalData?.workspaceClasses?.regular || "standard",
-    );
-    const actuallySetWorkspaceClass = async (value: string) => {
-        const additionalData = user?.additionalData || {};
-        const prevWorkspaceClass = additionalData?.workspaceClasses?.regular || "standard";
-        const workspaceClasses = (additionalData?.workspaceClasses || {}) as WorkspaceClasses;
-        workspaceClasses.regular = value;
-        workspaceClasses.prebuild = value;
-        additionalData.workspaceClasses = workspaceClasses;
-        if (value !== prevWorkspaceClass) {
-            await getGitpodService().server.updateLoggedInUser({ additionalData });
-            trackEvent("workspace_class_changed", {
-                previous: prevWorkspaceClass,
-                current: value,
-            });
-            setWorkspaceClass(value);
-        }
-    };
+    const [isShowWorkspaceClasses, setIsShowWorkspaceClasses] = useState<boolean>(false);
+    (async () => {
+        const showWorkspaceClasses = await getExperimentsClient().getValueAsync("workspace_classes", false, {});
+        console.log("is enabled", showWorkspaceClasses);
+        setIsShowWorkspaceClasses(showWorkspaceClasses);
+    })();
 
     return (
         <div>
@@ -161,48 +149,7 @@ export default function Preferences() {
                         </p>
                     </div>
                 </div>
-
-                <h3 className="mt-12">Workspaces</h3>
-                <p className="text-base text-gray-500 dark:text-gray-400">
-                    Choose the workspace machine type for your workspaces.
-                </p>
-                <div className="mt-4 space-x-3 flex">
-                    <SelectableCardSolid
-                        className="w-36 h-32"
-                        title="Standard"
-                        selected={workspaceClass === "standard"}
-                        onClick={() => actuallySetWorkspaceClass("standard")}
-                    >
-                        <div className="flex-grow flex items-end p-1">
-                            <svg width="112" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path
-                                    d="M0 8a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM0 32a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM0 56a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM40 6a6 6 0 0 1 6-6h60a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H46a6 6 0 0 1-6-6V6Z"
-                                    fill="#D6D3D1"
-                                />
-                            </svg>
-                        </div>
-                    </SelectableCardSolid>
-                    <SelectableCardSolid
-                        className="w-36 h-32"
-                        title="XL"
-                        selected={workspaceClass === "XL"}
-                        onClick={() => actuallySetWorkspaceClass("XL")}
-                    >
-                        <div className="flex-grow flex items-end p-1">
-                            <svg width="112" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path
-                                    d="M0 8a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM40 6a6 6 0 0 1 6-6h60a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H46a6 6 0 0 1-6-6V6Z"
-                                    fill="#D9D9D9"
-                                />
-                                <path
-                                    d="M84 0h22a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H68L84 0ZM0 32a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8Z"
-                                    fill="#78716C"
-                                />
-                                <path d="M0 56a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8Z" fill="#D9D9D9" />
-                            </svg>
-                        </div>
-                    </SelectableCardSolid>
-                </div>
+                <SelectWorkspaceClass enabled={isShowWorkspaceClasses} />
             </PageWithSubMenu>
         </div>
     );

--- a/components/dashboard/src/settings/selectClass.tsx
+++ b/components/dashboard/src/settings/selectClass.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext, useState } from "react";
+import SelectableCardSolid from "../components/SelectableCardSolid";
+import { getGitpodService } from "../service/service";
+import { UserContext } from "../user-context";
+import { trackEvent } from "../Analytics";
+import { WorkspaceClasses } from "@gitpod/gitpod-protocol";
+
+interface SelectWorkspaceClassProps {
+    enabled: boolean;
+}
+
+export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
+    const { user } = useContext(UserContext);
+
+    const [workspaceClass, setWorkspaceClass] = useState<string>(
+        user?.additionalData?.workspaceClasses?.regular || "standard",
+    );
+    const actuallySetWorkspaceClass = async (value: string) => {
+        const additionalData = user?.additionalData || {};
+        const prevWorkspaceClass = additionalData?.workspaceClasses?.regular || "standard";
+        const workspaceClasses = (additionalData?.workspaceClasses || {}) as WorkspaceClasses;
+        workspaceClasses.regular = value;
+        workspaceClasses.prebuild = value;
+        additionalData.workspaceClasses = workspaceClasses;
+        if (value !== prevWorkspaceClass) {
+            await getGitpodService().server.updateLoggedInUser({ additionalData });
+            trackEvent("workspace_class_changed", {
+                previous: prevWorkspaceClass,
+                current: value,
+            });
+            setWorkspaceClass(value);
+        }
+    };
+
+    if (!props.enabled) {
+        return <div></div>;
+    } else {
+        return (
+            <div>
+                <h3 className="mt-12">Workspaces</h3>
+                <p className="text-base text-gray-500 dark:text-gray-400">
+                    Choose the workspace machine type for your workspaces.
+                </p>
+                <div className="mt-4 space-x-3 flex">
+                    <SelectableCardSolid
+                        className="w-36 h-32"
+                        title="Standard"
+                        selected={workspaceClass === "standard"}
+                        onClick={() => actuallySetWorkspaceClass("standard")}
+                    >
+                        <div className="flex-grow flex items-end p-1">
+                            <svg width="112" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path
+                                    d="M0 8a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM0 32a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM0 56a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM40 6a6 6 0 0 1 6-6h60a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H46a6 6 0 0 1-6-6V6Z"
+                                    fill="#D6D3D1"
+                                />
+                            </svg>
+                        </div>
+                    </SelectableCardSolid>
+                    <SelectableCardSolid
+                        className="w-36 h-32"
+                        title="XL"
+                        selected={workspaceClass === "XL"}
+                        onClick={() => actuallySetWorkspaceClass("XL")}
+                    >
+                        <div className="flex-grow flex items-end p-1">
+                            <svg width="112" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path
+                                    d="M0 8a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8ZM40 6a6 6 0 0 1 6-6h60a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H46a6 6 0 0 1-6-6V6Z"
+                                    fill="#D9D9D9"
+                                />
+                                <path
+                                    d="M84 0h22a6 6 0 0 1 6 6v28a6 6 0 0 1-6 6H68L84 0ZM0 32a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8Z"
+                                    fill="#78716C"
+                                />
+                                <path d="M0 56a8 8 0 0 1 8-8h16a8 8 0 1 1 0 16H8a8 8 0 0 1-8-8Z" fill="#D9D9D9" />
+                            </svg>
+                        </div>
+                    </SelectableCardSolid>
+                </div>
+            </div>
+        );
+    }
+}

--- a/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
+++ b/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
@@ -77,7 +77,11 @@ const end = new Date(Date.UTC(2000, 2, 1)).toISOString();
                 emailNotificationSettings: {
                     allowsChangelogMail: true,
                     allowsDevXMail: true
-                }
+                },
+                workspaceClasses: {
+                    regular: "default",
+                    prebuild: "default,"
+                },
             }
         });
         await this.workspaceDb.store({

--- a/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
+++ b/components/ee/payment-endpoint/src/accounting/account-service.spec.db.ts
@@ -78,10 +78,6 @@ const end = new Date(Date.UTC(2000, 2, 1)).toISOString();
                     allowsChangelogMail: true,
                     allowsDevXMail: true
                 },
-                workspaceClasses: {
-                    regular: "default",
-                    prebuild: "default,"
-                },
             }
         });
         await this.workspaceDb.store({

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -116,6 +116,10 @@ export class TypeORMUserDBImpl implements UserDB {
                     allowsDevXMail: true,
                     allowsOnboardingMail: true,
                 },
+                workspaceClasses: {
+                    regular: "default",
+                    prebuild: "default",
+                },
             },
         };
         await this.storeUser(user);

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -116,10 +116,6 @@ export class TypeORMUserDBImpl implements UserDB {
                     allowsDevXMail: true,
                     allowsOnboardingMail: true,
                 },
-                workspaceClasses: {
-                    regular: "default",
-                    prebuild: "default",
-                },
             },
         };
         await this.storeUser(user);

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -157,6 +157,8 @@ export interface AdditionalUserData {
     dotfileRepo?: string;
     // Identifies an explicit team or user ID to which all the user's workspace usage should be attributed to (e.g. for billing purposes)
     usageAttributionId?: string;
+    // preferred workspace classes
+    workspaceClasses?: WorkspaceClasses;
     // additional user profile data
     profile?: ProfileDetails;
 }
@@ -185,6 +187,11 @@ export type IDESettings = {
     defaultDesktopIde?: string;
     useLatestVersion?: boolean;
 };
+
+export interface WorkspaceClasses {
+    regular: string;
+    prebuild: string;
+}
 
 export interface UserPlatform {
     uid: string;


### PR DESCRIPTION
## Description
Add dialog for selecting workspace classes to preferences. Note that the current icons and class names are placeholders. This PR is purely for setting up the logic in the frontend.

![Classes_Dialog](https://user-images.githubusercontent.com/24721048/176918654-b954c004-d5cd-48e8-8c34-d6c9c49277bc.png)


## Related Issue(s)
Fixes #https://github.com/gitpod-io/gitpod/issues/10843

## How to test
- Open dashboard and go to Settings -> Preferences
- Set your workspace  class
- Switch to another submenu and switch back -> your changes should have been persisted
- In the user table, additionalData should have a workspaceClasses entry

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
