### PR TITLE
[usage] Encode gitpodio-internal-xl in pricing

### DIFF
--- a/components/usage/pkg/controller/billing.go
+++ b/components/usage/pkg/controller/billing.go
@@ -39,12 +39,16 @@ func (b *StripeBillingController) Reconcile(ctx context.Context, now time.Time, 
 
 const (
 	defaultWorkspaceClass = "default"
+	gitpodInternalXL      = "gitpodio-internal-xl"
 )
 
 var (
 	DefaultWorkspacePricer, _ = NewWorkspacePricer(map[string]float64{
-		// 1 credit = 6 minutes
-		"default": float64(1) / float64(6),
+		// SaaS, 10 credits per hour, 1 credit = 6 minutes
+		defaultWorkspaceClass: float64(1) / float64(6),
+
+		// SaaS, 20 credits per hour, 1 credit = 3 minutes
+		gitpodInternalXL: float64(1) / float64(3),
 	})
 )
 

--- a/components/usage/pkg/controller/billing_test.go
+++ b/components/usage/pkg/controller/billing_test.go
@@ -60,3 +60,65 @@ func TestWorkspacePricer_Default(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspacePricer_InternalGitpodIO_XL(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		Seconds         int64
+		ExpectedCredits int64
+	}{
+		{
+			Name:            "0 seconds",
+			Seconds:         0,
+			ExpectedCredits: 0,
+		},
+		{
+			Name:            "1 second",
+			Seconds:         1,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "60 seconds",
+			Seconds:         60,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "90 seconds",
+			Seconds:         90,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "3 minutes",
+			Seconds:         180,
+			ExpectedCredits: 1,
+		},
+		{
+			Name:            "3 minutes 1 second",
+			Seconds:         181,
+			ExpectedCredits: 2,
+		},
+		{
+			Name:            "6 minutes",
+			Seconds:         360,
+			ExpectedCredits: 2,
+		},
+		{
+			Name:            "6 minutes and 1 second",
+			Seconds:         361,
+			ExpectedCredits: 3,
+		},
+		{
+			Name:            "1 hour",
+			Seconds:         3600,
+			ExpectedCredits: 20,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualCredits := DefaultWorkspacePricer.Credits(gitpodInternalXL, tc.Seconds)
+
+			require.Equal(t, tc.ExpectedCredits, actualCredits)
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For now, hard-codes the SaaS XL class in the code. Subsequent PR (once https://github.com/gitpod-io/gitpod/pull/11028 lands) will move this into config. Doing it in code now gives us data earlier.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
