### PR TITLE
[usage] Use workspace class when computing credits used

### DIFF
--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -128,7 +128,10 @@ func (u UsageReport) CreditSummaryForTeams(pricer *WorkspacePricer, maxStopTime 
 		var credits int64
 		for _, instance := range instances {
 			runtime := instance.WorkspaceRuntimeSeconds(maxStopTime)
-			class := "default"
+			class := defaultWorkspaceClass
+			if instance.WorkspaceClass != "" {
+				class = instance.WorkspaceClass
+			}
 			credits += pricer.Credits(class, runtime)
 		}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Takes WorkspaceClass data from the retrieved dataset to determine number of credits this workspace costs


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/10985

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
