### PR TITLE
fix: Refactored server methods to return a 404 error instead of undefined when something cannot be found

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -276,7 +276,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     getStripePublishableKey(): Promise<string>;
     getStripeSetupIntentClientSecret(): Promise<string>;
-    findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
+    findStripeSubscriptionIdForTeam(teamId: string): Promise<string>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string, currency: Currency): Promise<void>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1924,21 +1924,21 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
-    async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
+    async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string> {
         const user = this.checkAndBlockUser("findStripeSubscriptionIdForTeam");
         await this.ensureIsUsageBasedFeatureFlagEnabled(user);
         await this.guardTeamOperation(teamId, "get");
         try {
             const customer = await this.stripeService.findCustomerByTeamId(teamId);
             if (!customer?.id) {
-                return undefined;
+                throw new ResponseError(ErrorCodes.NOT_FOUND, "Not found");
             }
             const subscription = await this.stripeService.findUncancelledSubscriptionByCustomer(customer.id);
             return subscription?.id;
         } catch (error) {
             log.error(`Failed to get Stripe Subscription ID for team '${teamId}'`, error);
             throw new ResponseError(
-                ErrorCodes.INTERNAL_SERVER_ERROR,
+                ErrorCodes.NOT_FOUND,
                 `Failed to get Stripe Subscription ID for team '${teamId}'`,
             );
         }


### PR DESCRIPTION
…ined when something cannot be found

## Description
<!-- Describe your changes in detail -->
Refactored server methods to return a 404 error instead of undefined when something cannot be found

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10892


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
