### PR TITLE
[ws-manager] retry the finalizer loop when the ws-daemon is unavailable

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1247,15 +1247,15 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 		GitStatus:      gitStatus,
 	}
 	if backupError != nil {
-		c, cErr := m.manager.metrics.totalBackupFailureCounterVec.GetMetricWithLabelValues(wsType, wso.Pod.Labels[workspaceClassLabel])
-		if cErr != nil {
-			log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace backup failure metric")
-		} else {
-			c.Inc()
-		}
-
 		if dataloss {
 			disposalStatus.BackupFailure = backupError.Error()
+
+			c, cErr := m.manager.metrics.totalBackupFailureCounterVec.GetMetricWithLabelValues(wsType, wso.Pod.Labels[workspaceClassLabel])
+			if cErr != nil {
+				log.WithError(cErr).WithField("type", wsType).Warn("cannot get counter for workspace backup failure metric")
+			} else {
+				c.Inc()
+			}
 		} else {
 			// internal errors make no difference to the user experience. The backup still worked, we just messed up some
 			// state management or cleanup. No need to worry the user.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If the workspace is closing, the ws-manager asks the ws-daemon to backup and upload the content.
However, the ws-daemon _probably_ unavailable intermittent because the ws-daemon is being restarted.
In this case, we give the finalizer loop retry every 5 seconds and the maximum retry period is 120 seconds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-manager] retry the finalizer loop when the ws-daemon is unavailable
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
