### PR TITLE
[installer] allow to specify agent smith config

### DIFF
--- a/install/installer/pkg/components/agent-smith/configmap.go
+++ b/install/installer/pkg/components/agent-smith/configmap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/agent-smith/pkg/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,10 +30,13 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 	}
 
-	if ctx.Config.Experimental.AgentSmith != nil {
-		ascfg.Config = *ctx.Config.Experimental.AgentSmith
-		ascfg.Config.KubernetesNamespace = ctx.Namespace
-	}
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.AgentSmith != nil {
+			ascfg.Config = *cfg.AgentSmith
+			ascfg.Config.KubernetesNamespace = ctx.Namespace
+		}
+		return nil
+	})
 
 	fc, err := common.ToJSONString(ascfg)
 	if err != nil {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -11,17 +11,19 @@
 package experimental
 
 import (
+	agentSmith "github.com/gitpod-io/gitpod/agent-smith/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Config contains all experimental configuration.
 type Config struct {
-	Workspace *WorkspaceConfig `json:"workspace,omitempty"`
-	WebApp    *WebAppConfig    `json:"webapp,omitempty"`
-	IDE       *IDEConfig       `json:"ide,omitempty"`
-	Common    *CommonConfig    `json:"common,omitempty"`
-	Telemetry *TelemetryConfig `json:"telemetry,omitempty"`
+	Workspace  *WorkspaceConfig   `json:"workspace,omitempty"`
+	WebApp     *WebAppConfig      `json:"webapp,omitempty"`
+	IDE        *IDEConfig         `json:"ide,omitempty"`
+	Common     *CommonConfig      `json:"common,omitempty"`
+	Telemetry  *TelemetryConfig   `json:"telemetry,omitempty"`
+	AgentSmith *agentSmith.Config `json:"agentSmith,omitempty"`
 }
 
 type TelemetryConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allows to specify agent smith config via installer yaml, as currently we overwrite configmap instead when deploying in SaaS.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/10418

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
