### PR TITLE
[ws-proxy] not use target host when serve workspace port route

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -221,7 +221,7 @@ func (ir *ideRoutes) HandleSupervisorFrontendRoute(route *mux.Route) {
 				return image
 			},
 		}
-	}))
+	}, withUseTargetHost()))
 }
 
 func resolveSupervisorURL(cfg *Config, info *WorkspaceInfo, req *http.Request) (*url.URL, error) {
@@ -319,7 +319,7 @@ func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 				return image
 			},
 		}
-	}, withHTTPErrorHandler(workspaceIDEPass)))
+	}, withHTTPErrorHandler(workspaceIDEPass), withUseTargetHost()))
 }
 
 const imagePathSeparator = "/__files__"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ws-proxy] not use target host when serve workspace port route
At this PR https://github.com/gitpod-io/gitpod/pull/10514  

We use targetHost in order to allow `blobserve` behind `ide-proxy` to process requests properly, but this creates a problem that causes users to receive the wrong host when they use `https://{port}-workspaceUrl`, which is `internal-pod-ip: port`, this PR fixes that bug

|  In gen 51   | in preview environment  |
|  ----  | ----  |
| ![image](https://user-images.githubusercontent.com/8299500/176864422-9de9f827-3835-47d9-bad0-5f2291983bf9.png)  | ![image](https://user-images.githubusercontent.com/8299500/176868722-2f2b7440-5bf5-4c38-b728-2dd31e99c5fb.png) |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11070

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace
2. run `curl lama.sh | sh`
3. use `gp preview $(gp url 8080) --external` to open a browser, you can see the log of `Host` header, it should be workspace port url

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-proxy] not use target host when serve workspace port route
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
