### PR TITLE
[server] Workaround for lagging prebuild permissions

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2250,7 +2250,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             return undefined;
         }
 
-        await this.guardAccess({ kind: "prebuild", subject: pbws, workspace, teamMembers: undefined }, "get");
+        // TODO(gpl) Ideally, we should not need to query the project-team hierarchy here, but decide on a per-prebuild basis.
+        // For that we need to fix Prebuild-access semantics, which is out-of-scope for now.
+        const teamMembers = await this.getTeamMembersByProject(workspace.projectId);
+        await this.guardAccess({ kind: "prebuild", subject: pbws, workspace, teamMembers }, "get");
         const result: PrebuildWithStatus = { info, status: pbws.state };
         if (pbws.error) {
             result.error = pbws.error;
@@ -2273,7 +2276,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             return undefined;
         }
 
-        await this.guardAccess({ kind: "prebuild", subject: pbws, workspace, teamMembers: undefined }, "get");
+        // TODO(gpl) Ideally, we should not need to query the project-team hierarchy here, but decide on a per-prebuild basis.
+        // For that we need to fix Prebuild-access semantics, which is out-of-scope for now.
+        const teamMembers = await this.getTeamMembersByProject(workspace.projectId);
+        await this.guardAccess({ kind: "prebuild", subject: pbws, workspace, teamMembers }, "get");
         return pbws;
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - create a team and project (e.g. on this [test repo](https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins))
 - push a commit, for instance to [this branch](https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins)
 - switch to "Branches", wait for the prebuild to start and click on the Prebuild Details view
 - open a second tab on "Branches", and once the prebuild is there, click "start workspace" right next to it
 - observe that a) streaming of image build logs and b) streaming of prebuild logs works as expected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix prebuild permissions
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
