### PR TITLE
[preview] run the telemetry job right after gitpod is ready

### DIFF
--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -136,6 +136,18 @@ yq eval-all -i 'del(.spec.template.spec.initContainers[0])' /var/lib/rancher/k3s
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/manifests/gitpod.yaml; done
 rm -rf /var/lib/rancher/k3s/server/manifests/gitpod
 
+# waits for gitpod pods to be ready, and manually runs the `gitpod-telemetry` cronjob
+run_telemetry(){
+  # wait for the k3s cluster to be ready and Gitpod workloads are added
+  sleep 100
+  # indefinitely wait for Gitpod pods to be ready
+  kubectl wait --timeout=-1s --for=condition=ready pod -l app=gitpod,component!=migrations
+  # manually tun the cronjob
+  kubectl create job gitpod-telemetry-init --from=cronjob/gitpod-telemetry
+}
+
+run_telemetry 2>&1 &
+
 /bin/k3s server --disable traefik \
   --node-label gitpod.io/workload_meta=true \
   --node-label gitpod.io/workload_ide=true \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the `entry-point.sh` to run a parallel step
that waits for the gitpod pods to be ready, and manually executes
the cronjob once its necessary.

This is necessary as our telemetry `cronjobs` are only ran
daily in the midnight, and we can't expect this schedule to work
for local previews as they are short lived.

example data that we get:

```
client.Track(&analytics.Track{
  UserId: "334c379a-afee-4882-ba44-fbd7dfc0a8b0",
  Event: "Installation telemetry",
  Properties: map[string]interface{}{
    "customerID": "",
    "platform": "local-preview",
    "totalInstances": 0,
    "totalUsers": 0,
    "totalWorkspaces": 0,
    "version": "tar-preview-tel-init.4",
  },
})
```


Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11113

## How to test
<!-- Provide steps to test this PR -->
Check if there is a new job called `gitpod-telemetry-init` is created once
gitpod pods are ready.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[preview] run the telemetry job right after a Gitpod install is ready
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
