### PR TITLE
[server] Add server API to list blocked repositories

### DIFF
--- a/components/gitpod-db/src/blocked-repository-db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.ts
@@ -9,5 +9,19 @@ import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositor
 export const BlockedRepositoryDB = Symbol("BlockedRepositoryDB");
 
 export interface BlockedRepositoryDB {
+    findAllBlockedRepositories(
+        offset: number,
+        limit: number,
+        orderBy: keyof BlockedRepository,
+        orderDir: "DESC" | "ASC",
+        searchTerm?: string,
+        minCreationDate?: Date,
+        maxCreationDate?: Date,
+    ): Promise<{ total: number; rows: BlockedRepository[] }>;
+
     findBlockedRepositoryByURL(contextURL: string): Promise<BlockedRepository | undefined>;
+
+    createBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository>;
+
+    deleteBlockedRepository(id: number): Promise<boolean>;
 }

--- a/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
@@ -23,6 +23,50 @@ export class TypeORMBlockedRepositoryDBImpl implements BlockedRepositoryDB {
         return (await this.getEntityManager()).getRepository<DBBlockedRepository>(DBBlockedRepository);
     }
 
+    public async createBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository> {
+        const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
+
+        return await blockedRepositoryRepo.save({ urlRegexp: urlRegexp, blockUser: blockUser, deleted: false });
+    }
+
+    public async deleteBlockedRepository(id: number): Promise<boolean> {
+        const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
+
+        const result = await blockedRepositoryRepo.delete(id);
+        return !!result.affected;
+    }
+
+    public async findAllBlockedRepositories(
+        offset: number,
+        limit: number,
+        orderBy: keyof BlockedRepository,
+        orderDir: "DESC" | "ASC",
+        searchTerm?: string,
+        minCreationDate?: Date,
+        maxCreationDate?: Date,
+    ): Promise<{ total: number; rows: BlockedRepository[] }> {
+        const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
+
+        const qBuilder = blockedRepositoryRepo.createQueryBuilder("br").where(`br.deleted = 0`);
+        if (searchTerm) {
+            qBuilder.andWhere(`br.urlRegexp LIKE :searchTerm`, { searchTerm: "%" + searchTerm + "%" });
+        }
+        if (minCreationDate) {
+            qBuilder.andWhere("br.createdAt >= :minCreationDate", {
+                minCreationDate: minCreationDate.toISOString(),
+            });
+        }
+        if (maxCreationDate) {
+            qBuilder.andWhere("br.createdAt < :maxCreationDate", {
+                maxCreationDate: maxCreationDate.toISOString(),
+            });
+        }
+        qBuilder.orderBy("br." + orderBy, orderDir);
+        qBuilder.skip(offset).take(limit).select();
+        const [rows, total] = await qBuilder.getManyAndCount();
+        return { total, rows };
+    }
+
     public async findBlockedRepositoryByURL(contextURL: string): Promise<BlockedRepository | undefined> {
         const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
 

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -5,6 +5,7 @@
  */
 
 import { User, Workspace, NamedWorkspaceFeatureFlag } from "./protocol";
+import { BlockedRepository } from "./blocked-repositories-protocol";
 import { FindPrebuildsParams } from "./gitpod-service";
 import { Project, Team, PrebuildWithStatus, TeamMemberInfo, TeamMemberRole } from "./teams-projects-protocol";
 import { WorkspaceInstance, WorkspaceInstancePhase } from "./workspace-instance";
@@ -19,6 +20,12 @@ export interface AdminServer {
     adminDeleteUser(id: string): Promise<void>;
     adminModifyRoleOrPermission(req: AdminModifyRoleOrPermissionRequest): Promise<User>;
     adminModifyPermanentWorkspaceFeatureFlag(req: AdminModifyPermanentWorkspaceFeatureFlagRequest): Promise<User>;
+
+    adminCreateBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository>;
+    adminDeleteBlockedRepository(id: number): Promise<boolean>;
+    adminGetBlockedRepositories(
+        req: AdminGetListRequest<BlockedRepository>,
+    ): Promise<AdminGetListResult<BlockedRepository>>;
 
     adminGetTeamMembers(teamId: string): Promise<TeamMemberInfo[]>;
     adminGetTeams(req: AdminGetListRequest<Team>): Promise<AdminGetListResult<Team>>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -162,6 +162,9 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         adminGetSettings: { group: "default", points: 1 },
         adminUpdateSettings: { group: "default", points: 1 },
         adminGetTelemetryData: { group: "default", points: 1 },
+        adminGetBlockedRepositories: { group: "default", points: 1 },
+        adminCreateBlockedRepository: { group: "default", points: 1 },
+        adminDeleteBlockedRepository: { group: "default", points: 1 },
 
         validateLicense: { group: "default", points: 1 },
         getLicenseInfo: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -24,6 +24,7 @@ import {
     InstallationAdminDB,
     ProjectDB,
 } from "@gitpod/gitpod-db/lib";
+import { BlockedRepositoryDB } from "@gitpod/gitpod-db/lib/blocked-repository-db";
 import {
     AuthProviderEntry,
     AuthProviderInfo,
@@ -79,6 +80,7 @@ import {
     UserSSHPublicKeyValue,
 } from "@gitpod/gitpod-protocol";
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
+import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
 import {
     AdminBlockUserRequest,
     AdminGetListRequest,
@@ -199,6 +201,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     @inject(ImageBuilderClientProvider) protected imageBuilderClientProvider: ImageBuilderClientProvider;
 
     @inject(UserDB) protected readonly userDB: UserDB;
+    @inject(BlockedRepositoryDB) protected readonly blockedRepostoryDB: BlockedRepositoryDB;
     @inject(TokenProvider) protected readonly tokenProvider: TokenProvider;
     @inject(UserService) protected readonly userService: UserService;
     @inject(UserMessageViewsDB) protected readonly userMessageViewsDB: UserMessageViewsDB;
@@ -2628,6 +2631,21 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     async adminGetUsers(ctx: TraceContext, req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
+    adminGetBlockedRepositories(
+        ctx: TraceContext,
+        req: AdminGetListRequest<BlockedRepository>,
+    ): Promise<AdminGetListResult<BlockedRepository>> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
+    adminCreateBlockedRepository(ctx: TraceContext, urlRegexp: string, blockUser: boolean): Promise<BlockedRepository> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
+    adminDeleteBlockedRepository(ctx: TraceContext, id: number): Promise<boolean> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }
 


### PR DESCRIPTION
## Description

Add `adminGetBlockedRepositories` API to `components/server` to fetch the list of blocked repositories.

This is a step towards using these endpoints to manage blocked repositories in the admin UI.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11030

## How to test

* Follow the first 3 steps on https://github.com/gitpod-io/gitpod/pull/11036 to add some blocked repositories.

* Open the developer tools on the admin page for this preview environment.

* Run:
```js
await window._gp.gitpodService.server.adminGetBlockedRepositories({offset: 0, limit: 10, orderBy: 'id', orderDir: "desc", searchTerm: "foo"})
```

setting `searchTerm` as appropriate (or omitting it entirely).

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options

- [x] /werft with-preview

/hold