### PR TITLE
Auto-forward all workspace open ports when using Latest JetBrains IDEs

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.6.0"
+    id("org.jetbrains.intellij") version "1.8.0"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
     id("io.gitlab.arturbosch.detekt") version "1.17.1"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
@@ -108,7 +108,10 @@ tasks {
     }
 
     test {
-        useJUnitPlatform()
+        // Currently, we need to indicate where are the test classes.
+        // Read more: https://youtrack.jetbrains.com/issue/IDEA-278926/All-inheritors-of-UsefulTestCase-are-invisible-for-Gradle#focus=Comments-27-5561012.0-0
+        isScanForTestClasses = false
+        include("**/*Test.class")
     }
 
     runPluginVerifier {

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodPortsService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodPortsService.kt
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.jetbrains.rd.util.URI
+import org.apache.http.client.utils.URIBuilder
+import java.util.Optional
+import java.util.regex.Pattern
+
+class GitpodPortsService {
+    companion object {
+        /** Host used by forwarded ports on JetBrains Client. */
+        const val FORWARDED_PORT_HOST = "127.0.0.1"
+    }
+    private val hostToClientForwardedPortMap: MutableMap<Int, Int> = mutableMapOf()
+
+    fun isForwarded(hostPort: Int): Boolean = hostToClientForwardedPortMap.containsKey(hostPort)
+
+    private fun getForwardedPort(hostPort: Int): Optional<Int> = Optional.ofNullable(hostToClientForwardedPortMap[hostPort])
+
+    fun setForwardedPort(hostPort: Int, clientPort: Int) {
+        hostToClientForwardedPortMap[hostPort] = clientPort
+    }
+
+    fun removeForwardedPort(hostPort: Int) {
+        hostToClientForwardedPortMap.remove(hostPort)
+    }
+
+    fun getLocalHostUriFromHostPort(hostPort: Int): URI {
+        val optionalForwardedPort = getForwardedPort(hostPort)
+
+        val port = if (optionalForwardedPort.isPresent) {
+            optionalForwardedPort.get()
+        } else {
+            thisLogger().warn(
+                    "gitpod: Tried to get the forwarded port of $hostPort, which was not forwarded. " +
+                    "Returning $hostPort itself."
+            )
+            hostPort
+        }
+
+        return URIBuilder()
+                .setScheme("http")
+                .setHost(FORWARDED_PORT_HOST)
+                .setPort(port)
+                .build()
+    }
+
+    interface LocalHostUriMetadata {
+        val address: String
+        val port: Int
+    }
+
+    fun extractLocalHostUriMetaDataForPortMapping(uri: URI): Optional<LocalHostUriMetadata> {
+        if (uri.scheme != "http" && uri.scheme != "https") return Optional.empty()
+
+        val localhostMatch = Pattern.compile("^(localhost|127(?:\\.[0-9]+){0,2}\\.[0-9]+|0+(?:\\.0+){0,2}\\.0+|\\[(?:0*:)*?:?0*1?])(?::(\\d+))?\$").matcher(uri.authority)
+
+        if (!localhostMatch.find()) return Optional.empty()
+
+        var address = localhostMatch.group(1)
+        if (address.startsWith('[') && address.endsWith(']')) {
+            address = address.substring(1, address.length - 2)
+        }
+
+        var port = 443
+        try {
+            port = localhostMatch.group(2).toInt()
+        } catch (throwable: Throwable){
+            if (uri.scheme == "http") port = 80
+        }
+
+        return Optional.of(object: LocalHostUriMetadata {
+             override val address = address
+             override val port = port
+        })
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortForwardingService.kt
@@ -1,0 +1,129 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.remoteDev.util.onTerminationOrNow
+import com.intellij.util.application
+import com.jetbrains.codeWithMe.model.RdPortType
+import com.jetbrains.rd.platform.util.lifetime
+import com.jetbrains.rd.util.lifetime.LifetimeStatus
+import com.jetbrains.rdserver.portForwarding.ForwardedPortInfo
+import com.jetbrains.rdserver.portForwarding.PortForwardingManager
+import com.jetbrains.rdserver.portForwarding.remoteDev.PortEventsProcessor
+import io.gitpod.jetbrains.remote.GitpodManager
+import io.gitpod.jetbrains.remote.GitpodPortsService
+import io.gitpod.supervisor.api.Status
+import io.gitpod.supervisor.api.StatusServiceGrpc
+import io.grpc.stub.ClientCallStreamObserver
+import io.grpc.stub.ClientResponseObserver
+import io.ktor.utils.io.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+@Suppress("UnstableApiUsage")
+class GitpodPortForwardingService(private val project: Project) {
+    companion object {
+        const val FORWARDED_PORT_LABEL = "gitpod"
+    }
+
+    private val portsService = service<GitpodPortsService>()
+
+    init { start() }
+
+    private fun start() {
+        if (application.isHeadlessEnvironment) return
+
+        observePortsListWhileProjectIsOpen()
+    }
+
+    private fun observePortsListWhileProjectIsOpen() = application.executeOnPooledThread {
+        while (project.lifetime.status == LifetimeStatus.Alive) {
+            try {
+                observePortsList().get()
+            } catch (throwable: Throwable) {
+                when (throwable) {
+                    is InterruptedException, is CancellationException -> break
+                    else -> thisLogger().error(
+                            "gitpod: Got an error while trying to get ports list from Supervisor. " +
+                                    "Going to try again in a second.",
+                            throwable
+                    )
+                }
+            }
+
+            TimeUnit.SECONDS.sleep(1)
+        }
+    }
+
+    private fun observePortsList(): CompletableFuture<Void> {
+        val completableFuture = CompletableFuture<Void>()
+
+        val statusServiceStub = StatusServiceGrpc.newStub(GitpodManager.supervisorChannel)
+
+        val portsStatusRequest = Status.PortsStatusRequest.newBuilder().setObserve(true).build()
+
+        val portsStatusResponseObserver = object :
+                ClientResponseObserver<Status.PortsStatusRequest, Status.PortsStatusResponse> {
+            override fun beforeStart(request: ClientCallStreamObserver<Status.PortsStatusRequest>) {
+                project.lifetime.onTerminationOrNow { request.cancel("gitpod: Project terminated.", null) }
+            }
+            override fun onNext(response: Status.PortsStatusResponse) {
+                application.invokeLater { updateForwardedPortsList(response) }
+            }
+            override fun onCompleted() { completableFuture.complete(null) }
+            override fun onError(throwable: Throwable) { completableFuture.completeExceptionally(throwable) }
+        }
+
+        statusServiceStub.portsStatus(portsStatusRequest, portsStatusResponseObserver)
+
+        return completableFuture
+    }
+
+    private fun updateForwardedPortsList(response: Status.PortsStatusResponse) {
+        val portForwardingManager = PortForwardingManager.getInstance(project)
+        val forwardedPortsList = portForwardingManager.getForwardedPortsWithLabel(FORWARDED_PORT_LABEL)
+
+        for (port in response.portsList) {
+            val hostPort = port.localPort
+            val isServed = port.served
+
+            if (isServed && !forwardedPortsList.containsKey(hostPort)) {
+                val portEventsProcessor = object : PortEventsProcessor {
+                    override fun onPortForwarded(hostPort: Int, clientPort: Int) {
+                        portsService.setForwardedPort(hostPort, clientPort)
+                        thisLogger().info("gitpod: Forwarded port $hostPort to client's port $clientPort.")
+                    }
+
+                    override fun onPortForwardingEnded(hostPort: Int) {
+                        thisLogger().info("gitpod: Finished forwarding port $hostPort.")
+                    }
+
+                    override fun onPortForwardingFailed(hostPort: Int, reason: String) {
+                        thisLogger().error("gitpod: Failed to forward port $hostPort: $reason")
+                    }
+                }
+
+                val portInfo = ForwardedPortInfo(
+                        hostPort,
+                        RdPortType.HTTP,
+                        FORWARDED_PORT_LABEL,
+                        emptyList(),
+                        portEventsProcessor
+                )
+
+                portForwardingManager.forwardPort(portInfo)
+            }
+
+            if (!isServed && forwardedPortsList.containsKey(hostPort)) {
+                portForwardingManager.removePort(hostPort)
+                portsService.removeForwardedPort(hostPort)
+                thisLogger().info("gitpod: Stopped forwarding port $hostPort.")
+            }
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -6,5 +6,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodTerminalService" client="guest" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService" preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
+        <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodPortsService" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker" client="guest" preload="true"/>

--- a/components/ide/jetbrains/backend-plugin/src/test/kotlin/io/gitpod/jetbrains/remote/GitpodPortsServiceTest.kt
+++ b/components/ide/jetbrains/backend-plugin/src/test/kotlin/io/gitpod/jetbrains/remote/GitpodPortsServiceTest.kt
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.gitpod.jetbrains.remote.GitpodPortsService.LocalHostUriMetadata
+import java.net.URI
+
+class GitpodPortsServiceTest : BasePlatformTestCase() {
+    fun testExtractLocalHostUriMetaDataForPortMapping() {
+        val portsService = GitpodPortsService()
+
+        val urlToMetadataMap = mapOf(
+            "https://localhost:80" to object: LocalHostUriMetadata {
+                override val address = "localhost"
+                override val port = 80
+            },
+            "https://localhost" to object: LocalHostUriMetadata {
+                override val address = "localhost"
+                override val port = 443
+            },
+            "http://localhost:12354" to object: LocalHostUriMetadata {
+                override val address = "localhost"
+                override val port = 12354
+            },
+            "https://127.0.0.1:3000" to object: LocalHostUriMetadata {
+                override val address = "127.0.0.1"
+                override val port = 3000
+            },
+            "http://127.0.0.1:5000" to object: LocalHostUriMetadata {
+                override val address = "127.0.0.1"
+                override val port = 5000
+            },
+            "http://[::1]:8080" to object: LocalHostUriMetadata {
+                override val address = "::"
+                override val port = 8080
+            },
+        )
+
+        urlToMetadataMap.forEach { (url, expected) ->
+            val uri = URI.create(url)
+            val actualLocalHostUriMetadataOptional = portsService.extractLocalHostUriMetaDataForPortMapping(uri)
+            val actual = actualLocalHostUriMetadataOptional.get()
+
+            assertEquals(expected.address, actual.address)
+            assertEquals(expected.port, actual.port)
+        }
+
+        val urlsThatShouldReturnEmpty = listOf(
+            "https://localhost:123b",
+            "http://192.168.0.1:4000",
+            "https://example.com?cb=localhost",
+            "https://example.com?cb=http://localhost",
+            "https://example.com?cb=https://localhost:8080",
+            "https://example.com?cb=https://127.0.0.1:8080"
+        )
+
+        urlsThatShouldReturnEmpty.forEach { url ->
+            val uri = URI.create(url)
+            val localHostUriMetaDataForPort = portsService.extractLocalHostUriMetaDataForPortMapping(uri)
+
+            assertTrue(localHostUriMetaDataForPort.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Description

Auto-forward all workspace open ports when using Latest JetBrains IDEs.

Changes included:
- Adds a `GitpodPortsService`, which is used by both _Stable_ and _Latest_ versions of the Backend Plugin.
- Adds a `GitpodPortForwardingService`, which affects only Latest (Unstable) Version of JetBrains IDEs, and controls the auto-forwarding of all ports.
- Adds a `GitpodPortsServiceTest` with a function unit test. It can be tested via IDE UI or command line [[1](https://github.com/gitpod-io/gitpod/pull/11081#discussion_r938863805)].
- Updates `GitpodTerminalService`, as we moved the implementation to forward all ports to `GitpodPortForwardingService`.
- Updates `GitpodClientProjectSessionTracker`, which displays notifications about ports that have just been opened, to have the correct localhost URL if the port is being forwarded. (A few other small changes were made on that file, which were suggestions from IntelliJ to improve the code).
- Updates `GitpodCLIService` to rewrite URLs coming from `gp preview`, when the URL is pointing to localhost, for pointing to the correct forwarded port on the client.
  - For example, a user starts a service on port 3000, which is automatically forwarded from the server to the user machine. But the user had port 3000 already occupied by some other process. What JetBrains IDE does, in this case, is looking for the next free port (3001, for example). So whenever the user runs `gp preview http://127.0.0.1:3000`, it should open `http://127.0.0.1:3001` on the browser.
  - Note: It currently doesn't happen because of [this issue](https://github.com/gitpod-io/gitpod/issues/11849), which will be solved later. So this shouldn't be tested in this PR. But the class is ready for when the issue is fixed.
- Update of gradle-intellij-plugin to v1.8.0, which adds [support for JetBrains Runtime 2022.2 directories layout](https://github.com/JetBrains/gradle-intellij-plugin/issues/1016).

Note: We confirmed with JetBrains that the host used for Forwarded Ports on the client is 127.0.0.1.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #10783

## How to test
<!-- Provide steps to test this PR -->
- Open [Preferences on the Preview Environment of this PR](https://felladrin-d4177edc98.preview.gitpod-dev.com/preferences), select any JetBrains IDE, and mark Latest Release to use the EAP version of the IDE.
- Start any workspace, and once connected, execute any HTTP server from any terminal (can be a terminal used by a Gitpod Task or a new terminal created via the IDE UI). (You can run lama.sh for example: `sh <(curl lama.sh) -p 8080`)
- Click on the "Open Browser" link from the notification and confirm it opens `http://127.0.0.1:<forwarded_service_port>/` on your browser.
  <img width="385" alt="image" src="https://user-images.githubusercontent.com/418083/182841178-d193f58d-c310-4846-b99d-717d1aa8d0c7.png">

Note:
- If the port is already occupied by another process, JetBrains IDE will look for some random open port. (This random port unfortunately isn't displayed anywhere at this moment. It will be solved in a follow-up PR.)
- The links from notifications about open ports should point to localhost only when using the Latest (Unstable) version of the IDE. When using the Stable version, links will point to the remote URL, as usual.
- This PR should be affecting just the toast notification, not the dialog [[1](https://github.com/gitpod-io/gitpod/pull/11081#discussion_r935444156)]. The dialog will be resolved in [another PR](https://github.com/gitpod-io/gitpod/issues/11849).


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user-facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
All open ports from the workspace are automatically forwarded when using Latest JetBrains IDEs.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, there is nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
