### PR TITLE
improve seccomp notify

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -523,7 +523,7 @@ var ring1Cmd = &cobra.Command{
 				WorkspaceId: wsid,
 			}
 
-			stp, errchan := seccomp.Handle(scmpfd, handler)
+			stp, errchan := seccomp.Handle(scmpfd, handler, wsid)
 			defer close(stp)
 			go func() {
 				t := time.NewTicker(10 * time.Millisecond)

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -526,7 +526,7 @@ var ring1Cmd = &cobra.Command{
 			stp, errchan := seccomp.Handle(scmpfd, handler, wsid)
 			defer close(stp)
 			go func() {
-				t := time.NewTicker(10 * time.Millisecond)
+				t := time.NewTicker(100 * time.Microsecond)
 				defer t.Stop()
 				for {
 					// We use the ticker to rate-limit the errors from the syscall handler.

--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/workspacekit
 
 go 1.18
 
-replace github.com/seccomp/libseccomp-golang => github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1
+replace github.com/seccomp/libseccomp-golang => github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220701021458-9bf1c833815b
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000

--- a/components/workspacekit/go.sum
+++ b/components/workspacekit/go.sum
@@ -95,6 +95,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1 h1:Z97P8/nLkIJf7uKQ1hjz3MdIfZyX3t8zWspNFj3Ox5M=
 github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220203100026-45179215fdb1/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220701021458-9bf1c833815b h1:DENOL02oc3uC9wOZlFBGOPxCtxf1zPwiYdGxEkfJ3+4=
+github.com/gitpod-io/libseccomp-golang v0.9.2-0.20220701021458-9bf1c833815b/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -106,7 +106,9 @@ func LoadFilter() (libseccomp.ScmpFd, error) {
 
 // Handle actually listens on the seccomp notif FD and handles incoming requests.
 // This function returns when the notif FD is closed.
-func Handle(fd libseccomp.ScmpFd, handler SyscallHandler) (stop chan<- struct{}, errchan <-chan error) {
+func Handle(fd libseccomp.ScmpFd, handler SyscallHandler, wsid string) (stop chan<- struct{}, errchan <-chan error) {
+	log := log.WithField("workspaceId", wsid)
+
 	ec := make(chan error)
 	stp := make(chan struct{})
 

--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -197,10 +197,10 @@ type BindEvent struct {
 // Mount handles mount syscalls
 func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
 	log := log.WithFields(map[string]interface{}{
-		"syscall":     "mount",
-		"worksapceId": h.WorkspaceId,
-		"pid":         req.Pid,
-		"id":          req.ID,
+		"syscall":          "mount",
+		log.WorkspaceField: h.WorkspaceId,
+		"pid":              req.Pid,
+		"id":               req.ID,
 	})
 
 	memFile, err := readarg.OpenMem(req.Pid)
@@ -303,10 +303,10 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 func (h *InWorkspaceHandler) Umount(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
 	nme, _ := req.Data.Syscall.GetName()
 	log := log.WithFields(map[string]interface{}{
-		"syscall":     nme,
-		"workspaceId": h.WorkspaceId,
-		"pid":         req.Pid,
-		"id":          req.ID,
+		"syscall":          nme,
+		log.WorkspaceField: h.WorkspaceId,
+		"pid":              req.Pid,
+		"id":               req.ID,
 	})
 
 	memFile, err := readarg.OpenMem(req.Pid)
@@ -383,10 +383,10 @@ func (h *InWorkspaceHandler) Umount(req *libseccomp.ScmpNotifReq) (val uint64, e
 
 func (h *InWorkspaceHandler) Bind(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
 	log := log.WithFields(map[string]interface{}{
-		"syscall":     "bind",
-		"workspaceId": h.WorkspaceId,
-		"pid":         req.Pid,
-		"id":          req.ID,
+		"syscall":          "bind",
+		log.WorkspaceField: h.WorkspaceId,
+		"pid":              req.Pid,
+		"id":               req.ID,
 	})
 	// We want the syscall to succeed, no matter what we do in this handler.
 	// The Kernel will execute the syscall for us.
@@ -429,10 +429,10 @@ func (h *InWorkspaceHandler) Bind(req *libseccomp.ScmpNotifReq) (val uint64, err
 
 func (h *InWorkspaceHandler) Chown(req *libseccomp.ScmpNotifReq) (val uint64, errno int32, flags uint32) {
 	log := log.WithFields(map[string]interface{}{
-		"syscall":     "chown",
-		"workspaceId": h.WorkspaceId,
-		"pid":         req.Pid,
-		"id":          req.ID,
+		"syscall":          "chown",
+		log.WorkspaceField: h.WorkspaceId,
+		"pid":              req.Pid,
+		"id":               req.ID,
 	})
 
 	memFile, err := readarg.OpenMem(req.Pid)

--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/moby/sys/mountinfo"
@@ -117,6 +118,11 @@ func Handle(fd libseccomp.ScmpFd, handler SyscallHandler, wsid string) (stop cha
 		for {
 			req, err := libseccomp.NotifReceive(fd)
 			if err != nil {
+				if err == syscall.ENOENT {
+					log.WithError(err).Warn("failed to get notification beucase it has already been not valid anymore(the kernel sets that)")
+					continue
+				}
+
 				log.WithError(err).Error("failed to get notification")
 				ec <- err
 				if err == unix.ECANCELED {

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -863,7 +863,14 @@ func nsinsider(instanceID string, targetPid int, mod func(*exec.Cmd), opts ...ns
 	err = cmd.Run()
 	log.FromBuffer(&cmdOut, log.WithFields(log.OWI("", "", instanceID)))
 	if err != nil {
-		out, err := cmd.CombinedOutput()
+		out, oErr := cmd.CombinedOutput()
+		if oErr != nil {
+			return xerrors.Errorf("run nsinsider (%v) \n%v\n output error: %v",
+				cmd.Args,
+				err,
+				oErr,
+			)
+		}
 		return xerrors.Errorf("run nsinsider (%v) failed: %q\n%v",
 			cmd.Args,
 			string(out),

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -107,8 +107,8 @@ RUN curl -fsSL -o /usr/bin/toxiproxy https://github.com/Shopify/toxiproxy/releas
 ### libseccomp > 2.5.2
 RUN install-packages gperf \
     && cd $(mktemp -d) \
-    && curl -fsSL https://github.com/seccomp/libseccomp/releases/download/v2.5.2/libseccomp-2.5.2.tar.gz | tar xz \
-    && cd libseccomp-2.5.2 && ./configure && make && make install
+    && curl -fsSL https://github.com/seccomp/libseccomp/releases/download/v2.5.4/libseccomp-2.5.4.tar.gz | tar xz \
+    && cd libseccomp-2.5.4 && ./configure && make && make install
 
 ### Cypress deps
 RUN install-packages \


### PR DESCRIPTION
## Description

- improve logging
- upgrade libseccomp-golang https://github.com/gitpod-io/libseccomp-golang/pull/2
- Addition of parallel processing of shisumu koru

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9247

Precisely up to the reduction. For some reason seccomp notify is cancelled by the linux kernel. Neither docker-compose nor runc can handle it.
We mitigate it a bit by processing it as quickly as possible.
More detail
https://github.com/seccomp/libseccomp-golang/commit/3879420cc921efb4f1a2d75bea84e6158ef21a78

## How to test

open this repository and works fine
https://github.com/appwrite/integration-for-gitpod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve system call handling
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
