### PR TITLE
[dashboard] Don't get users stuck on "aborted"/"timeout" prebuilds

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -68,6 +68,16 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                         onPrebuildUpdate(update: PrebuildWithStatus) {
                             if (update.info && update.info.buildWorkspaceId === props.workspaceId) {
                                 setPrebuild(update);
+
+                                // In case the Prebuild got "aborted" or "time(d)out" we want to user to proceed anyway
+                                if (
+                                    props.onIgnorePrebuild &&
+                                    (update.status === "aborted" || update.status === "timeout")
+                                ) {
+                                    props.onIgnorePrebuild();
+                                }
+                                // TODO(gpl) We likely want to move the "happy path" logic (for status "available")
+                                // here as well at some point. For that to work we need a "registerPrebuildUpdate(prebuildId)" API
                             }
                         },
                     }),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix the start-workspace flow for when a prebuild got auto-cancelled
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
