### PR TITLE
Update prebuild status description alignment

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -366,7 +366,7 @@ export function PrebuildStatus(props: { prebuild: PrebuildWithStatus }) {
                 </div>
             </div>
             <div className="flex space-x-1 items-center text-gray-400">
-                <span>{getPrebuildStatusDescription(prebuild)}</span>
+                <span className="text-left">{getPrebuildStatusDescription(prebuild)}</span>
             </div>
         </div>
     );


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/10696, this will fix text alignment for the prebuild status description text.

Cc @geropl based on a [recent discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1656682927568149?thread_ts=1656675972.139439&cid=C02EN94AEPL) (internal).

## How to test
<!-- Provide steps to test this PR -->

## Screenshots 

| BEFORE | AFTER |
|-|-|
| <img width="898" alt="logs-before" src="https://user-images.githubusercontent.com/120486/176916314-16b65cb9-aeb4-42b5-9c8b-4f691c8da8e0.png"> | <img width="898" alt="logs-after" src="https://user-images.githubusercontent.com/120486/176916319-cb93bc7f-7b0f-4bd9-a817-df2b085ca157.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
