### PR TITLE
[install/tests] Delete gitpod namespace before infrastructure removal

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -243,7 +243,7 @@ kots-upgrade:
 	@echo "Upgrade gitpod KOTS app to latest"
 	kubectl kots upstream upgrade --kubeconfig=${KUBECONFIG} gitpod -n gitpod --deploy
 
-cleanup: check-env-cloud destroy-$(cloud)
+cleanup: check-env-cloud destroy-gitpod destroy-$(cloud)
 
 select-workspace:
 	terraform workspace select $(TF_VAR_TEST_ID)
@@ -253,6 +253,15 @@ destroy-gcp: select-workspace
 	ls ${KUBECONFIG} && terraform destroy -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
 	terraform destroy -target=module.k3s -var kubeconfig=${KUBECONFIG} --auto-approve
 	terraform destroy -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
+
+# Delete the Gitpod namespace and all associated resources.
+#
+# The sleep following deletion adds a bit of padding so that external resources (such
+# as AWS ELBs generated from LoadBalancer type services) can terminate.
+destroy-gitpod:
+	[[ -f ${KUBECONFIG} ]] \
+		&& kubectl --kubeconfig=${KUBECONFIG} delete namespace/gitpod --now --timeout 60s \
+		|| true
 
 destroy-aws: select-workspace
 	terraform destroy -target=module.aws-add-dns-record -var kubeconfig=${KUBECONFIG} --auto-approve


### PR DESCRIPTION
EKS clusters implement `LoadBalancer` type services with ELBs; when an
EKS cluster is destroyed via terraform these ELBs are not automatically
deleted. The continued presence of these ELBs will remain attached to
the associated subnets and prevent the subnets and VPC from being
destroyed.

This commit resolves the issue by explicitly deleting the `gitpod`
namespace (and pausing to allow the ELBs to be removed) before
continuing.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)

This issue is related to #11092 and may partially resolve that issue; more testing is needed.

## How to test

```
werft job run github \
  gitpod-io/gitpod:alt/fix-int-test/delete-gitpod-ns \
  -s .werft/installer-tests.ts \
  -j .werft/eks-installer-tests.yaml \
  -a debug=true -a
```

## Release Notes

```release-note
NONE
```

## Documentation

N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
