### PR TITLE
[installer]: set a stable password for messagebus

### DIFF
--- a/install/installer/pkg/common/render.go
+++ b/install/installer/pkg/common/render.go
@@ -158,10 +158,7 @@ func (r *RenderContext) generateValues() error {
 		return nil
 	})
 	if messageBusPassword == "" {
-		messageBusPassword, err = RandomString(20)
-		if err != nil {
-			return err
-		}
+		messageBusPassword = "uq4KxOLtrA-QsDTfuwQ-"
 	}
 	r.Values.MessageBusPassword = messageBusPassword
 

--- a/install/installer/pkg/components/rabbitmq/secret.go
+++ b/install/installer/pkg/components/rabbitmq/secret.go
@@ -6,6 +6,7 @@ package rabbitmq
 
 import (
 	_ "embed"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,10 +23,7 @@ var clientCert []byte
 var clientPem []byte
 
 func secrets(ctx *common.RenderContext) ([]runtime.Object, error) {
-	cookieString, err := common.RandomString(20)
-	if err != nil {
-		return nil, err
-	}
+	cookieString := "ZX3m37WDZvdH8zy03ZVZ"
 
 	return []runtime.Object{&corev1.Secret{
 		TypeMeta: common.TypeMetaSecret,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This sets both the `rabbitmq.auth.password` value and the `messagebus-erlang-cookie` secret with static values. This has the benefit of not reloading the message bus every time a redeployment happens - this makes deployments faster and existing workspaces don't lose connections.

The initial ticket only mentions the cookie secret, but discovered that the [password is hardcoded in the experimental section](https://github.com/gitpod-io/ops/search?q=staticMessagebusPassword) - this doesn't change the functionality of `experiments.common.staticMessagebusPassword` so the Ops repo will still work as expected.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10459

## How to test
<!-- Provide steps to test this PR -->
Deploy the application

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: set a stable password for messagebus
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
