### PR TITLE
[kots]: add monitoring graphs

### DIFF
--- a/install/kots/manifests/kots-app.yaml
+++ b/install/kots/manifests/kots-app.yaml
@@ -27,3 +27,19 @@ spec:
   additionalImages:
     - cr.fluentbit.io/fluent/fluent-bit:1.9.4 # Defined by Fluent Bit Helm chart
     - busybox:1 # Used to pull log files to pull from Fluent Bit, which doesn't container tar binary
+  graphs:
+    # Default Gitpod graphs
+    # @link https://www.gitpod.io/docs/self-hosted/latest/monitoring
+    - title: Running Workspaces
+      queries:
+        - query: 'sum(gitpod_ws_manager_workspace_phase_total{phase="RUNNING"}) by (type)'
+          legend: "Type: {{ type }}"
+        - query: 'sum(gitpod_ws_manager_workspace_activity_total{active="false"})'
+          legend: "Pending workspaces"
+    - title: Workspace Failures per second
+      query: 'sum(rate(gitpod_ws_manager_workspace_stops_total{reason="failed"}[5m])) by (cluster, type) or vector(0)'
+      legend: "{{ type }}"
+    - title: Regular Workspace Startup Time
+      yAxisFormat: s
+      query: 'sum(rate(gitpod_ws_manager_workspace_startup_seconds_bucket{type="REGULAR"}[5m])) by (le)'
+      legend: "{{ le }}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds default monitoring graphs to the [KOTS Graphs](https://docs.replicated.com/reference/custom-resource-application#graphs) section of the app config. This allows users to connect to their own Prometheus instance and for the Gitpod instance to give out simple graphs. The graphs are based upon the published graphs in our [monitoring docs](https://www.gitpod.io/docs/self-hosted/latest/monitoring).

![image](https://user-images.githubusercontent.com/275848/178268601-d2ae1fbb-9980-47b2-8514-70e3ead9d209.png)

**NB** we have limited (documented) control over the Y axis, so we end up with negative time periods by default. My feeling is that this is a convenience inside the KOTS dashboard and that, ultimately, most people will use Grafana over this. However, this should remain as a convenience for those who want a limited monitoring solution over a full-blown Grafana instance.

## How to test
<!-- Provide steps to test this PR -->
Install a Prometheus instance to your cluster and set the 

As a convenience, my [monitoring repo](https://github.com/MrSimonEmms/gitpod-monitoring) is already set up - the URL is `http://monitoring-prometheus-prometheus.gitpod.svc.cluster.local:9090`

```shell
NAMESPACE=gitpod
GITPOD_NAMESPACE=gitpod

helm upgrade \
  --atomic \
  --cleanup-on-fail \
  --create-namespace \
  --install \
  --namespace="${NAMESPACE}" \
  --repo=https://helm.simonemms.com \
  --reset-values \
  --set gitpodNamespace="${GITPOD_NAMESPACE}" \
  --wait \
  monitoring \
  gitpod-monitoring
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add monitoring graphs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
