### PR TITLE
[server] Use image-builder from workspace cluster (feature flag: "movedImageBuilder")

### DIFF
--- a/components/gitpod-protocol/src/experiments/configcat-server.ts
+++ b/components/gitpod-protocol/src/experiments/configcat-server.ts
@@ -28,6 +28,7 @@ export function getExperimentsClientForBackend(): Client {
     }
 
     const configCatClient = configcat.createClient(sdkKey, {
+        pollIntervalSeconds: 3 * 60, // 3 minutes
         logger: configcat.createConsoleLogger(LogLevel.Error),
         maxInitWaitTimeSeconds: 0,
     });

--- a/components/gitpod-protocol/src/experiments/configcat.ts
+++ b/components/gitpod-protocol/src/experiments/configcat.ts
@@ -9,6 +9,7 @@ import { User as ConfigCatUser } from "configcat-common/lib/RolloutEvaluator";
 import { IConfigCatClient } from "configcat-common/lib/ConfigCatClient";
 import { User } from "../protocol";
 
+export const USER_ID_ATTRIBUTE = "user_id";
 export const PROJECT_ID_ATTRIBUTE = "project_id";
 export const TEAM_ID_ATTRIBUTE = "team_id";
 export const TEAM_IDS_ATTRIBUTE = "team_ids";
@@ -36,6 +37,9 @@ export function attributesToUser(attributes: Attributes): ConfigCatUser {
     const email = User.is(attributes.user) ? User.getPrimaryEmail(attributes.user) : attributes.user?.email || "";
 
     const custom: { [key: string]: string } = {};
+    if (userId) {
+        custom[USER_ID_ATTRIBUTE] = userId;
+    }
     if (attributes.projectId) {
         custom[PROJECT_ID_ATTRIBUTE] = attributes.projectId;
     }

--- a/components/gitpod-protocol/src/experiments/types.ts
+++ b/components/gitpod-protocol/src/experiments/types.ts
@@ -12,17 +12,18 @@ export const Client = Symbol("Client");
 // Attributes define attributes which can be used to segment audiences.
 // Set the attributes which you want to use to group audiences into.
 export interface Attributes {
+    // user.id is mapped to ConfigCat's "identifier" + "custom.user_id"
     user?: User | { id: string; email?: string };
 
-    // Currently selected Gitpod Project ID
+    // Currently selected Gitpod Project ID (mapped to "custom.project_id")
     projectId?: string;
 
-    // Currently selected Gitpod Team ID
+    // Currently selected Gitpod Team ID (mapped to "custom.team_id")
     teamId?: string;
-    // Currently selected Gitpod Team Name
+    // Currently selected Gitpod Team Name (mapped to "custom.team_name")
     teamName?: string;
 
-    // All the Gitpod Teams that the user is a member (or owner) of
+    // All the Gitpod Teams that the user is a member (or owner) of (mapped to "custom.team_names" and "custom.team_ids")
     teams?: Team[];
 }
 

--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -28,13 +28,13 @@ import {
 import { injectable, inject, optional } from "inversify";
 import * as grpc from "@grpc/grpc-js";
 import { TextDecoder } from "util";
-import { ImageBuildLogInfo } from "@gitpod/gitpod-protocol";
+import { ImageBuildLogInfo, User, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 
 export const ImageBuilderClientProvider = Symbol("ImageBuilderClientProvider");
 
 // ImageBuilderClientProvider caches image builder connections
 export interface ImageBuilderClientProvider {
-    getDefault(): PromisifiedImageBuilderClient;
+    getClient(user: User, workspace: Workspace, instance?: WorkspaceInstance): Promise<PromisifiedImageBuilderClient>;
 }
 
 function withTracing(ctx: TraceContext) {
@@ -92,6 +92,22 @@ export class CachingImageBuilderClientProvider implements ImageBuilderClientProv
 
         this.connectionCache = connection;
         return connection;
+    }
+
+    async getClient(user: User, workspace: Workspace, instance?: WorkspaceInstance) {
+        return this.getDefault();
+    }
+
+    promisify(c: ImageBuilderClient): PromisifiedImageBuilderClient {
+        let interceptors: grpc.Interceptor[] = [];
+        if (this.clientCallMetrics) {
+            interceptors = [createClientCallMetricsInterceptor(this.clientCallMetrics)];
+        }
+
+        return new PromisifiedImageBuilderClient(
+            new ImageBuilderClient(this.clientConfig.address, grpc.credentials.createInsecure()),
+            interceptors,
+        );
     }
 }
 

--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -5,14 +5,27 @@
  */
 
 import { ImageBuilderClient } from "./imgbuilder_grpc_pb";
-import { TraceContext } from '@gitpod/gitpod-protocol/lib/util/tracing';
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/content-service/lib/client-call-metrics";
-import * as opentracing from 'opentracing';
+import {
+    createClientCallMetricsInterceptor,
+    IClientCallMetrics,
+} from "@gitpod/content-service/lib/client-call-metrics";
+import * as opentracing from "opentracing";
 import { Metadata } from "@grpc/grpc-js";
-import { BuildRequest, BuildResponse, BuildStatus, LogsRequest, LogsResponse, ResolveWorkspaceImageResponse, ResolveWorkspaceImageRequest, ResolveBaseImageRequest, ResolveBaseImageResponse } from "./imgbuilder_pb";
-import { injectable, inject, optional } from 'inversify';
+import {
+    BuildRequest,
+    BuildResponse,
+    BuildStatus,
+    LogsRequest,
+    LogsResponse,
+    ResolveWorkspaceImageResponse,
+    ResolveWorkspaceImageRequest,
+    ResolveBaseImageRequest,
+    ResolveBaseImageResponse,
+} from "./imgbuilder_pb";
+import { injectable, inject, optional } from "inversify";
 import * as grpc from "@grpc/grpc-js";
 import { TextDecoder } from "util";
 import { ImageBuildLogInfo } from "@gitpod/gitpod-protocol";
@@ -21,7 +34,7 @@ export const ImageBuilderClientProvider = Symbol("ImageBuilderClientProvider");
 
 // ImageBuilderClientProvider caches image builder connections
 export interface ImageBuilderClientProvider {
-    getDefault(): PromisifiedImageBuilderClient
+    getDefault(): PromisifiedImageBuilderClient;
 }
 
 function withTracing(ctx: TraceContext) {
@@ -29,13 +42,15 @@ function withTracing(ctx: TraceContext) {
     if (ctx.span) {
         const carrier: { [key: string]: string } = {};
         opentracing.globalTracer().inject(ctx.span, opentracing.FORMAT_HTTP_HEADERS, carrier);
-        Object.keys(carrier).filter(p => carrier.hasOwnProperty(p)).forEach(p => metadata.set(p, carrier[p]));
+        Object.keys(carrier)
+            .filter((p) => carrier.hasOwnProperty(p))
+            .forEach((p) => metadata.set(p, carrier[p]));
     }
     return metadata;
 }
 
 export const ImageBuilderClientConfig = Symbol("ImageBuilderClientConfig");
-export const ImageBuilderClientCallMetrics = Symbol('ImageBuilderCallMetrics')
+export const ImageBuilderClientCallMetrics = Symbol("ImageBuilderCallMetrics");
 
 // ImageBuilderClientConfig configures the access to an image builder
 export interface ImageBuilderClientConfig {
@@ -46,7 +61,8 @@ export interface ImageBuilderClientConfig {
 export class CachingImageBuilderClientProvider implements ImageBuilderClientProvider {
     @inject(ImageBuilderClientConfig) protected readonly clientConfig: ImageBuilderClientConfig;
 
-    @inject(ImageBuilderClientCallMetrics) @optional()
+    @inject(ImageBuilderClientCallMetrics)
+    @optional()
     protected readonly clientCallMetrics: IClientCallMetrics;
 
     // gRPC connections can be used concurrently, even across services.
@@ -56,13 +72,13 @@ export class CachingImageBuilderClientProvider implements ImageBuilderClientProv
     getDefault() {
         let interceptors: grpc.Interceptor[] = [];
         if (this.clientCallMetrics) {
-            interceptors = [ createClientCallMetricsInterceptor(this.clientCallMetrics) ];
+            interceptors = [createClientCallMetricsInterceptor(this.clientCallMetrics)];
         }
 
         const createClient = () => {
             return new PromisifiedImageBuilderClient(
                 new ImageBuilderClient(this.clientConfig.address, grpc.credentials.createInsecure()),
-                interceptors
+                interceptors,
             );
         };
         let connection = this.connectionCache;
@@ -77,7 +93,6 @@ export class CachingImageBuilderClientProvider implements ImageBuilderClientProv
         this.connectionCache = connection;
         return connection;
     }
-
 }
 
 // StagedBuildResponse captures the multi-stage nature (starting, running, done) of image builds.
@@ -91,12 +106,15 @@ export interface StagedBuildResponse {
 }
 
 export class PromisifiedImageBuilderClient {
-
-    constructor(public readonly client: ImageBuilderClient, protected readonly interceptor: grpc.Interceptor[]) { }
+    constructor(public readonly client: ImageBuilderClient, protected readonly interceptor: grpc.Interceptor[]) {}
 
     public isConnectionAlive() {
         const cs = this.client.getChannel().getConnectivityState(false);
-        return cs == grpc.connectivityState.CONNECTING || cs == grpc.connectivityState.IDLE || cs == grpc.connectivityState.READY;
+        return (
+            cs == grpc.connectivityState.CONNECTING ||
+            cs == grpc.connectivityState.IDLE ||
+            cs == grpc.connectivityState.READY
+        );
     }
 
     public resolveBaseImage(ctx: TraceContext, request: ResolveBaseImageRequest): Promise<ResolveBaseImageResponse> {
@@ -114,24 +132,36 @@ export class PromisifiedImageBuilderClient {
         });
     }
 
-    public resolveWorkspaceImage(ctx: TraceContext, request: ResolveWorkspaceImageRequest): Promise<ResolveWorkspaceImageResponse> {
+    public resolveWorkspaceImage(
+        ctx: TraceContext,
+        request: ResolveWorkspaceImageRequest,
+    ): Promise<ResolveWorkspaceImageResponse> {
         return new Promise<ResolveWorkspaceImageResponse>((resolve, reject) => {
             const span = TraceContext.startSpan(`/image-builder/resolveWorkspaceImage`, ctx);
-            this.client.resolveWorkspaceImage(request, withTracing({ span }), this.getDefaultUnaryOptions(), (err, resp) => {
-                span.finish();
-                if (err) {
-                    TraceContext.setError({ span }, err);
-                    reject(err);
-                } else {
-                    resolve(resp);
-                }
-            });
+            this.client.resolveWorkspaceImage(
+                request,
+                withTracing({ span }),
+                this.getDefaultUnaryOptions(),
+                (err, resp) => {
+                    span.finish();
+                    if (err) {
+                        TraceContext.setError({ span }, err);
+                        reject(err);
+                    } else {
+                        resolve(resp);
+                    }
+                },
+            );
         });
     }
 
     // build returns a nested promise. The outer one resolves/rejects with the build start,
     // the inner one resolves/rejects when the build is done.
-    public build(ctx: TraceContext, request: BuildRequest, logInfoDeferred: Deferred<ImageBuildLogInfo> = new Deferred<ImageBuildLogInfo>()): Promise<StagedBuildResponse> {
+    public build(
+        ctx: TraceContext,
+        request: BuildRequest,
+        logInfoDeferred: Deferred<ImageBuildLogInfo> = new Deferred<ImageBuildLogInfo>(),
+    ): Promise<StagedBuildResponse> {
         const span = TraceContext.startSpan(`/image-builder/build`, ctx);
 
         const buildResult = new Deferred<BuildResponse>();
@@ -143,12 +173,12 @@ export class PromisifiedImageBuilderClient {
             actuallyNeedsBuild: true,
             ref: "unknown",
             baseRef: "unknown",
-        }
+        };
 
         try {
             const stream = this.client.build(request, withTracing({ span }));
-            stream.on('error', err => {
-                log.debug("stream err", err)
+            stream.on("error", (err) => {
+                log.debug("stream err", err);
 
                 if (!result.isResolved) {
                     result.reject(err);
@@ -160,8 +190,8 @@ export class PromisifiedImageBuilderClient {
                 TraceContext.setError({ span }, err);
                 span.finish();
             });
-            stream.on('data', (resp: BuildResponse) => {
-                log.debug("stream resp", resp)
+            stream.on("data", (resp: BuildResponse) => {
+                log.debug("stream resp", resp);
 
                 if (!resultResp.ref || resultResp.ref === "unknown") {
                     resultResp.ref = resp.getRef();
@@ -172,7 +202,7 @@ export class PromisifiedImageBuilderClient {
 
                 if (resp.hasInfo()) {
                     // assumes that log info stays stable for instance lifetime
-                    const info = resp.getInfo()
+                    const info = resp.getInfo();
                     if (info && info.hasLogInfo() && !logInfoDeferred.isResolved) {
                         const logInfo = info.getLogInfo()!;
                         const headers: { [key: string]: string } = {};
@@ -189,7 +219,10 @@ export class PromisifiedImageBuilderClient {
                 if (resp.getStatus() == BuildStatus.RUNNING) {
                     resultResp.actuallyNeedsBuild = true;
                     result.resolve(resultResp);
-                } else if (resp.getStatus() == BuildStatus.DONE_FAILURE || resp.getStatus() == BuildStatus.DONE_SUCCESS) {
+                } else if (
+                    resp.getStatus() == BuildStatus.DONE_FAILURE ||
+                    resp.getStatus() == BuildStatus.DONE_SUCCESS
+                ) {
                     if (!result.isResolved) {
                         resultResp.actuallyNeedsBuild = false;
                         result.resolve(resultResp);
@@ -204,8 +237,8 @@ export class PromisifiedImageBuilderClient {
                     span.finish();
                 }
             });
-            stream.on('end', () => {
-                log.debug("stream end")
+            stream.on("end", () => {
+                log.debug("stream end");
 
                 const err = new Error("stream ended before the build did");
                 let spanFinished = (result.isResolved && !resultResp.actuallyNeedsBuild) || buildResult.isResolved;
@@ -232,26 +265,26 @@ export class PromisifiedImageBuilderClient {
     }
 
     // logs subscribes to build logs. This function returns when there are no more logs to provide
-    public logs(ctx: TraceContext, request: LogsRequest, cb: (data: string) => 'continue' | 'stop'): Promise<void> {
+    public logs(ctx: TraceContext, request: LogsRequest, cb: (data: string) => "continue" | "stop"): Promise<void> {
         const span = TraceContext.startSpan(`/image-builder/logs`, ctx);
 
         const stream = this.client.logs(request, withTracing({ span }));
         return new Promise<void>((resolve, reject) => {
-            stream.on('end', () => {
+            stream.on("end", () => {
                 span.finish();
-                resolve()
-            })
-            stream.on('error', err => {
+                resolve();
+            });
+            stream.on("error", (err) => {
                 TraceContext.setError({ span }, err);
                 span.finish();
-                reject(err)
+                reject(err);
             });
-            stream.on('data', (resp: LogsResponse) => {
-                if (cb(new TextDecoder("utf-8").decode(resp.getContent_asU8())) === 'stop') {
-                    stream.cancel()
+            stream.on("data", (resp: LogsResponse) => {
+                if (cb(new TextDecoder("utf-8").decode(resp.getContent_asU8())) === "stop") {
+                    stream.cancel();
                 }
             });
-        })
+        });
     }
 
     public dispose() {
@@ -261,7 +294,6 @@ export class PromisifiedImageBuilderClient {
     protected getDefaultUnaryOptions(): Partial<grpc.CallOptions> {
         return {
             interceptors: this.interceptor,
-        }
+        };
     }
-
 }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -99,6 +99,7 @@ import { ReferrerPrefixParser } from "./workspace/referrer-prefix-context-parser
 import { InstallationAdminTelemetryDataProvider } from "./installation-admin/telemetry-data-provider";
 import { IDEService } from "./ide-service";
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
+import { WorkspaceClusterImagebuilderClientProvider } from "./workspace/workspace-cluster-imagebuilder-client-provider";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -162,6 +163,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
         return { address: config.imageBuilderAddr };
     });
     bind(CachingImageBuilderClientProvider).toSelf().inSingletonScope();
+    bind(WorkspaceClusterImagebuilderClientProvider).toSelf().inSingletonScope(); // during the transition period, we have two kinds of image builder client providers
     bind(ImageBuilderClientProvider).toService(CachingImageBuilderClientProvider);
     bind(ImageBuilderClientCallMetrics).toService(IClientCallMetrics);
 

--- a/components/server/src/workspace/image-source-provider.ts
+++ b/components/server/src/workspace/image-source-provider.ts
@@ -5,7 +5,6 @@
  */
 
 import { injectable, inject } from "inversify";
-import { ImageBuilderClientProvider } from "@gitpod/image-builder/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import {
@@ -23,7 +22,6 @@ import { createHash } from "crypto";
 
 @injectable()
 export class ImageSourceProvider {
-    @inject(ImageBuilderClientProvider) protected readonly imagebuilderClientProvider: ImageBuilderClientProvider;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
 
     public async getImageSource(

--- a/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
+++ b/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messaging/client-call-metrics";
+import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import {
+    ImageBuilderClient,
+    ImageBuilderClientCallMetrics,
+    ImageBuilderClientProvider,
+    PromisifiedImageBuilderClient,
+} from "@gitpod/image-builder/lib";
+import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+import {
+    WorkspaceManagerClientProviderCompositeSource,
+    WorkspaceManagerClientProviderSource,
+} from "@gitpod/ws-manager/lib/client-provider-source";
+import { ExtendedUser } from "@gitpod/ws-manager/lib/constraints";
+import { inject, injectable, optional } from "inversify";
+
+@injectable()
+export class WorkspaceClusterImagebuilderClientProvider implements ImageBuilderClientProvider {
+    @inject(WorkspaceManagerClientProviderCompositeSource)
+    protected readonly source: WorkspaceManagerClientProviderSource;
+    @inject(WorkspaceManagerClientProvider) protected readonly clientProvider: WorkspaceManagerClientProvider;
+    @inject(ImageBuilderClientCallMetrics) @optional() protected readonly clientCallMetrics: IClientCallMetrics;
+
+    // gRPC connections can be used concurrently, even across services.
+    // Thus it makes sense to cache them rather than create a new connection for each request.
+    protected readonly connectionCache = new Map<string, ImageBuilderClient>();
+
+    async getClient(
+        user: ExtendedUser,
+        workspace: Workspace,
+        instance: WorkspaceInstance,
+    ): Promise<PromisifiedImageBuilderClient> {
+        const clusters = await this.clientProvider.getStartClusterSets(user, workspace, instance);
+        for await (let cluster of clusters) {
+            const info = await this.source.getWorkspaceCluster(cluster.installation);
+            if (!info) {
+                continue;
+            }
+
+            var client = this.connectionCache.get(info.name);
+            if (!client) {
+                client = this.clientProvider.createConnection(ImageBuilderClient, info, defaultGRPCOptions);
+                this.connectionCache.set(info.name, client);
+            }
+            return new PromisifiedImageBuilderClient(client, []);
+        }
+
+        throw new Error("no image-builder available");
+    }
+}

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -4,26 +4,33 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/content-service/lib/client-call-metrics";
+import {
+    createClientCallMetricsInterceptor,
+    IClientCallMetrics,
+} from "@gitpod/content-service/lib/client-call-metrics";
 import { Disposable, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
-import { defaultGRPCOptions } from '@gitpod/gitpod-protocol/lib/util/grpc';
-import { log } from '@gitpod/gitpod-protocol/lib/util/logging';
-import { WorkspaceClusterWoTLS, WorkspaceManagerConnectionInfo } from '@gitpod/gitpod-protocol/lib/workspace-cluster';
+import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { WorkspaceClusterWoTLS, WorkspaceManagerConnectionInfo } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import * as grpc from "@grpc/grpc-js";
-import { inject, injectable, optional } from 'inversify';
-import { WorkspaceManagerClientProviderCompositeSource, WorkspaceManagerClientProviderSource } from "./client-provider-source";
+import { inject, injectable, optional } from "inversify";
+import {
+    WorkspaceManagerClientProviderCompositeSource,
+    WorkspaceManagerClientProviderSource,
+} from "./client-provider-source";
 import { ExtendedUser, workspaceClusterSetsAuthorized } from "./constraints";
-import { WorkspaceManagerClient } from './core_grpc_pb';
+import { WorkspaceManagerClient } from "./core_grpc_pb";
 import { linearBackoffStrategy, PromisifiedWorkspaceManagerClient } from "./promisified-client";
 
-export const IWorkspaceManagerClientCallMetrics = Symbol('IWorkspaceManagerClientCallMetrics')
+export const IWorkspaceManagerClientCallMetrics = Symbol("IWorkspaceManagerClientCallMetrics");
 
 @injectable()
 export class WorkspaceManagerClientProvider implements Disposable {
     @inject(WorkspaceManagerClientProviderCompositeSource)
     protected readonly source: WorkspaceManagerClientProviderSource;
 
-    @inject(IWorkspaceManagerClientCallMetrics) @optional()
+    @inject(IWorkspaceManagerClientCallMetrics)
+    @optional()
     protected readonly clientCallMetrics: IClientCallMetrics;
 
     // gRPC connections maintain their connectivity themselves, i.e. they reconnect when neccesary.
@@ -41,17 +48,23 @@ export class WorkspaceManagerClientProvider implements Disposable {
      * @param instance the instance we want to start
      * @returns a set of workspace clusters we can start the workspace in
      */
-    public async getStartClusterSets(user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): Promise<IWorkspaceClusterStartSet> {
+    public async getStartClusterSets(
+        user: ExtendedUser,
+        workspace: Workspace,
+        instance: WorkspaceInstance,
+    ): Promise<IWorkspaceClusterStartSet> {
         const allClusters = await this.source.getAllWorkspaceClusters();
-        const availableClusters = allClusters.filter(c => c.score > 0 && c.state === "available");
+        const availableClusters = allClusters.filter((c) => c.score > 0 && c.state === "available");
 
-        const sets = workspaceClusterSetsAuthorized.map(constraints => {
-            const r = constraints.constraint(availableClusters, user, workspace, instance);
-            if (!r) {
-                return;
-            }
-            return new ClusterSet(this, r);
-        }).filter(s => s !== undefined) as ClusterSet[];
+        const sets = workspaceClusterSetsAuthorized
+            .map((constraints) => {
+                const r = constraints.constraint(availableClusters, user, workspace, instance);
+                if (!r) {
+                    return;
+                }
+                return new ClusterSet(this, r);
+            })
+            .filter((s) => s !== undefined) as ClusterSet[];
 
         return {
             [Symbol.asyncIterator]: (): AsyncIterator<ClusterClientEntry> => {
@@ -59,7 +72,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
                     next: async (): Promise<IteratorResult<ClusterClientEntry>> => {
                         while (true) {
                             if (sets.length === 0) {
-                                return {done: true, value: undefined};
+                                return { done: true, value: undefined };
                             }
 
                             let res = await sets[0].next();
@@ -70,10 +83,10 @@ export class WorkspaceManagerClientProvider implements Disposable {
 
                             return res;
                         }
-                    }
-                }
-            }
-        }
+                    },
+                };
+            },
+        };
     }
 
     /**
@@ -105,11 +118,16 @@ export class WorkspaceManagerClientProvider implements Disposable {
 
         let interceptor: grpc.Interceptor[] = [];
         if (this.clientCallMetrics) {
-            interceptor = [ createClientCallMetricsInterceptor(this.clientCallMetrics) ];
+            interceptor = [createClientCallMetricsInterceptor(this.clientCallMetrics)];
         }
 
         const stopSignal = { stop: false };
-        return new PromisifiedWorkspaceManagerClient(client, linearBackoffStrategy(30, 1000, stopSignal), interceptor, stopSignal);
+        return new PromisifiedWorkspaceManagerClient(
+            client,
+            linearBackoffStrategy(30, 1000, stopSignal),
+            interceptor,
+            stopSignal,
+        );
     }
 
     /**
@@ -133,33 +151,39 @@ export class WorkspaceManagerClientProvider implements Disposable {
 
         const options: Partial<grpc.ClientOptions> = {
             ...grpcOptions,
-            'grpc.ssl_target_name_override': "ws-manager",  // this makes sure we can call ws-manager with a URL different to "ws-manager"
+            "grpc.ssl_target_name_override": "ws-manager", // this makes sure we can call ws-manager with a URL different to "ws-manager"
         };
         return new WorkspaceManagerClient(info.url, credentials, options);
     }
 
     public dispose() {
-        Array.from(this.connectionCache.values()).map(c => c.close());
+        Array.from(this.connectionCache.values()).map((c) => c.close());
     }
 }
 
 export interface IWorkspaceClusterStartSet extends AsyncIterable<ClusterClientEntry> {}
 
-export interface ClusterClientEntry { manager: PromisifiedWorkspaceManagerClient, installation: string }
+export interface ClusterClientEntry {
+    manager: PromisifiedWorkspaceManagerClient;
+    installation: string;
+}
 
 /**
  * ClusterSet is an iterator
  */
 class ClusterSet implements AsyncIterator<ClusterClientEntry> {
     protected usedCluster: string[] = [];
-    constructor(protected readonly provider: WorkspaceManagerClientProvider, protected readonly cluster: WorkspaceClusterWoTLS[]) {}
+    constructor(
+        protected readonly provider: WorkspaceManagerClientProvider,
+        protected readonly cluster: WorkspaceClusterWoTLS[],
+    ) {}
 
     public async next(): Promise<IteratorResult<ClusterClientEntry>> {
-        const available = this.cluster.filter(c => !this.usedCluster.includes(c.name));
+        const available = this.cluster.filter((c) => !this.usedCluster.includes(c.name));
         const chosenCluster = chooseCluster(available);
         if (!chosenCluster) {
             // empty set
-            return {done: true, value: undefined };
+            return { done: true, value: undefined };
         }
         this.usedCluster.push(chosenCluster.name);
 
@@ -172,7 +196,7 @@ class ClusterSet implements AsyncIterator<ClusterClientEntry> {
             value: {
                 manager: client,
                 installation: chosenCluster.name,
-            }
+            },
         };
     }
 }
@@ -184,7 +208,7 @@ class ClusterSet implements AsyncIterator<ClusterClientEntry> {
  */
 function chooseCluster(availableCluster: WorkspaceClusterWoTLS[]): WorkspaceClusterWoTLS {
     const scoreFunc = (c: WorkspaceClusterWoTLS): number => {
-        let score = c.score;    // here is the point where we may want to implement non-static approaches
+        let score = c.score; // here is the point where we may want to implement non-static approaches
 
         // clamp to maxScore
         if (score > c.maxScore) {
@@ -193,14 +217,12 @@ function chooseCluster(availableCluster: WorkspaceClusterWoTLS[]): WorkspaceClus
         return score;
     };
 
-    const scoreSum = availableCluster
-        .map(scoreFunc)
-        .reduce((sum, cScore) => cScore + sum, 0);
-    const pNormalized = availableCluster.map(c => scoreFunc(c) / scoreSum);
+    const scoreSum = availableCluster.map(scoreFunc).reduce((sum, cScore) => cScore + sum, 0);
+    const pNormalized = availableCluster.map((c) => scoreFunc(c) / scoreSum);
     const p = Math.random();
     let pSummed = 0;
     for (let i = 0; i < availableCluster.length; i++) {
-        pSummed += pNormalized[i]
+        pSummed += pNormalized[i];
         if (p <= pSummed) {
             return availableCluster[i];
         }

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -105,14 +105,14 @@ export class WorkspaceManagerClientProvider implements Disposable {
         let client = this.connectionCache.get(name);
         if (!client) {
             const info = await getConnectionInfo();
-            client = this.createClient(info, grpcOptions);
+            client = this.createConnection(WorkspaceManagerClient, info, grpcOptions);
             this.connectionCache.set(name, client);
         } else if (client.getChannel().getConnectivityState(true) != grpc.connectivityState.READY) {
             client.close();
 
             console.warn(`Lost connection to workspace manager \"${name}\" - attempting to reestablish`);
             const info = await getConnectionInfo();
-            client = this.createClient(info, grpcOptions);
+            client = this.createConnection(WorkspaceManagerClient, info, grpcOptions);
             this.connectionCache.set(name, client);
         }
 
@@ -137,7 +137,16 @@ export class WorkspaceManagerClientProvider implements Disposable {
         return this.source.getAllWorkspaceClusters();
     }
 
-    public createClient(info: WorkspaceManagerConnectionInfo, grpcOptions?: object): WorkspaceManagerClient {
+    public createConnection<T extends grpc.Client>(
+        creator: { new (address: string, credentials: grpc.ChannelCredentials, options?: grpc.ClientOptions): T },
+        info: WorkspaceManagerConnectionInfo,
+        grpcOptions?: object,
+    ): T {
+        const options: Partial<grpc.ClientOptions> = {
+            ...grpcOptions,
+            "grpc.ssl_target_name_override": "ws-manager", // this makes sure we can call ws-manager with a URL different to "ws-manager"
+        };
+
         let credentials: grpc.ChannelCredentials;
         if (info.tls) {
             const rootCerts = Buffer.from(info.tls.ca, "base64");
@@ -149,11 +158,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
             credentials = grpc.credentials.createInsecure();
         }
 
-        const options: Partial<grpc.ClientOptions> = {
-            ...grpcOptions,
-            "grpc.ssl_target_name_override": "ws-manager", // this makes sure we can call ws-manager with a URL different to "ws-manager"
-        };
-        return new WorkspaceManagerClient(info.url, credentials, options);
+        return new creator(info.url, credentials, options);
     }
 
     public dispose() {

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -34,7 +34,7 @@ import {
     UpdateResponse,
     AdmissionConstraint as GRPCAdmissionConstraint,
 } from "@gitpod/ws-manager-bridge-api/lib";
-import { GetWorkspacesRequest } from "@gitpod/ws-manager/lib";
+import { GetWorkspacesRequest, WorkspaceManagerClient } from "@gitpod/ws-manager/lib";
 import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import {
     WorkspaceManagerClientProviderCompositeSource,
@@ -161,7 +161,7 @@ export class ClusterService implements IClusterServiceServer {
                 } else {
                     // try to connect to validate the config. Throws an exception if it fails.
                     await new Promise<void>((resolve, reject) => {
-                        const c = this.clientProvider.createClient(newCluster);
+                        const c = this.clientProvider.createConnection(WorkspaceManagerClient, newCluster);
                         c.getWorkspaces(new GetWorkspacesRequest(), (err: any) => {
                             if (err) {
                                 reject(

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -10,7 +10,12 @@ import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-pr
 import { inject, injectable } from "inversify";
 import { Configuration } from "./config";
 import { Client } from "@gitpod/gitpod-protocol/lib/experiments/types";
-import { DescribeClusterRequest, DescribeClusterResponse, WorkspaceClass } from "@gitpod/ws-manager/lib";
+import {
+    DescribeClusterRequest,
+    DescribeClusterResponse,
+    WorkspaceClass,
+    WorkspaceManagerClient,
+} from "@gitpod/ws-manager/lib";
 import { AdmissionConstraintHasClass } from "@gitpod/gitpod-protocol/src/workspace-cluster";
 import { GRPCError } from "./rpc";
 import * as grpc from "@grpc/grpc-js";
@@ -75,7 +80,7 @@ export async function getSupportedWorkspaceClasses(
             ? await (
                   await clientProvider.get(cluster.name, grpcOptions)
               ).client
-            : clientProvider.createClient(cluster, grpcOptions);
+            : clientProvider.createConnection(WorkspaceManagerClient, cluster, grpcOptions);
 
         client.describeCluster(new DescribeClusterRequest(), (err: any, resp: DescribeClusterResponse) => {
             if (err) {


### PR DESCRIPTION
## Description

This is part II of a translation from [Chris' PR](https://github.com/gitpod-io/gitpod/pull/9337). To be able to move forward with this, it got split into two:
 1. The deprecation of the old log retrieval mechanism in [this PR](https://github.com/gitpod-io/gitpod/pull/11026) (feature flag: "deprecateOldImageLogsMechanism")
 2. Make `server` talk to `ws-manager` for image builds (this PR) (feature flag: "movedImageBuilder")
 
The idea is to get both merged, and be able to test and iterate independently.

/cc @kylos101 

**Note 1**: All formatting should be in commit 1, so it's sufficient to review commit 2 alone.

**Note 2**: Commit 3 + 4 do not strictly belong into this PR but I left them here because they ease testing. :lotus_position: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9248

Context: #9337

## How to test
 - [preview env](https://gpl-imgbldr.preview.gitpod-dev.com/workspaces): create a team with a name containing `imgbldr` and project (e.g. on this [test repo](https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins)) (the `imgbldr` triggers feature flags  `movedImageBuilder` and `deprecateOldImageLogsMechanism`, cmp. [here](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853))
 - push a commit, for instance to [this branch](https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins)
 - [open a workspace on that branch](https://gpl-imgbldr.preview.gitpod-dev.com/#https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-2mins)
 - observe that workspace start and the streaming of image build logs works as expected
 - check `server` logs for the line `image-builder in workspace cluster` to validate you actually used the new mechanism

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
