### PR TITLE
[server] Add API to create and delete blocked repositories

### DIFF
--- a/components/gitpod-db/src/blocked-repository-db.spec.db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.spec.db.ts
@@ -26,6 +26,16 @@ class BlockedRepositoryDBSpec {
     }
 
     @test(timeout(10000))
+    public async canCreateABlockedRepository() {
+        const blockedRepository = await this.blockedRepositoryDb.createBlockedRepository(
+            "github.com/bob/some-repo",
+            true,
+        );
+        expect(blockedRepository.urlRegexp).eq("github.com/bob/some-repo");
+        expect(blockedRepository.blockUser).eq(true);
+    }
+
+    @test(timeout(10000))
     public async checkRepositoryIsBlocked() {
         const typeorm = testContainer.get<TypeORM>(TypeORM);
         const manager = await typeorm.getConnection();

--- a/components/gitpod-db/src/blocked-repository-db.spec.db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.spec.db.ts
@@ -37,13 +37,7 @@ class BlockedRepositoryDBSpec {
 
     @test(timeout(10000))
     public async checkRepositoryIsBlocked() {
-        const typeorm = testContainer.get<TypeORM>(TypeORM);
-        const manager = await typeorm.getConnection();
-        manager.getRepository(DBBlockedRepository).insert({
-            urlRegexp: "github.com/bob/.*",
-            blockUser: true,
-            deleted: false,
-        });
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/.*", true);
 
         const blockedRepository = await this.blockedRepositoryDb.findBlockedRepositoryByURL("github.com/bob/some-repo");
 
@@ -54,13 +48,7 @@ class BlockedRepositoryDBSpec {
 
     @test(timeout(10000))
     public async checkRepositoryIsNotBlocked() {
-        const typeorm = testContainer.get<TypeORM>(TypeORM);
-        const manager = await typeorm.getConnection();
-        manager.getRepository(DBBlockedRepository).insert({
-            urlRegexp: "github.com/bob/.*",
-            blockUser: true,
-            deleted: false,
-        });
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/.*", true);
 
         const blockedRepository = await this.blockedRepositoryDb.findBlockedRepositoryByURL(
             "github.com/alice/some-repo",
@@ -71,20 +59,8 @@ class BlockedRepositoryDBSpec {
 
     @test(timeout(10000))
     public async canFindAllRepositoriesWithoutSearchTerm() {
-        const typeorm = testContainer.get<TypeORM>(TypeORM);
-        const manager = await typeorm.getConnection();
-        manager.getRepository(DBBlockedRepository).insert([
-            {
-                urlRegexp: "github.com/bob/.*",
-                blockUser: true,
-                deleted: false,
-            },
-            {
-                urlRegexp: "github.com/alice/.*",
-                blockUser: true,
-                deleted: false,
-            },
-        ]);
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/.*", true);
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/alice/.*", true);
 
         const blockedRepositories = await this.blockedRepositoryDb.findAllBlockedRepositories(0, 1, "id", "ASC");
 
@@ -93,20 +69,8 @@ class BlockedRepositoryDBSpec {
 
     @test(timeout(10000))
     public async canFindAllRepositoriesWithSearchTerm() {
-        const typeorm = testContainer.get<TypeORM>(TypeORM);
-        const manager = await typeorm.getConnection();
-        manager.getRepository(DBBlockedRepository).insert([
-            {
-                urlRegexp: "github.com/bob/.*",
-                blockUser: true,
-                deleted: false,
-            },
-            {
-                urlRegexp: "github.com/alice/.*",
-                blockUser: true,
-                deleted: false,
-            },
-        ]);
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/.*", true);
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/alice/.*", true);
 
         const blockedRepositories = await this.blockedRepositoryDb.findAllBlockedRepositories(0, 1, "id", "ASC", "bob");
 

--- a/components/gitpod-db/src/blocked-repository-db.spec.db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.spec.db.ts
@@ -36,6 +36,26 @@ class BlockedRepositoryDBSpec {
     }
 
     @test(timeout(10000))
+    public async canDeleteABlockedRepository() {
+        const blockedRepository = await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/*/", true);
+
+        const result = await this.blockedRepositoryDb.deleteBlockedRepository(blockedRepository.id);
+
+        expect(result).eq(true);
+        expect(await this.blockedRepositoryDb.findBlockedRepositoryByURL("github.com/bob/some-repo")).undefined;
+    }
+
+    @test(timeout(10000))
+    public async canNotDeleteABlockedRepositoryWithAnIdThatDoesNotExist() {
+        await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/*/", true);
+
+        const result = await this.blockedRepositoryDb.deleteBlockedRepository(9999);
+
+        expect(result).eq(false);
+        expect(await this.blockedRepositoryDb.findBlockedRepositoryByURL("github.com/bob/some-repo")).not.undefined;
+    }
+
+    @test(timeout(10000))
     public async checkRepositoryIsBlocked() {
         await this.blockedRepositoryDb.createBlockedRepository("github.com/bob/.*", true);
 

--- a/components/gitpod-db/src/blocked-repository-db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.ts
@@ -22,4 +22,6 @@ export interface BlockedRepositoryDB {
     findBlockedRepositoryByURL(contextURL: string): Promise<BlockedRepository | undefined>;
 
     createBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository>;
+
+    deleteBlockedRepository(id: number): Promise<boolean>;
 }

--- a/components/gitpod-db/src/blocked-repository-db.ts
+++ b/components/gitpod-db/src/blocked-repository-db.ts
@@ -20,4 +20,6 @@ export interface BlockedRepositoryDB {
     ): Promise<{ total: number; rows: BlockedRepository[] }>;
 
     findBlockedRepositoryByURL(contextURL: string): Promise<BlockedRepository | undefined>;
+
+    createBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository>;
 }

--- a/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
@@ -23,6 +23,12 @@ export class TypeORMBlockedRepositoryDBImpl implements BlockedRepositoryDB {
         return (await this.getEntityManager()).getRepository<DBBlockedRepository>(DBBlockedRepository);
     }
 
+    public async createBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository> {
+        const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
+
+        return await blockedRepositoryRepo.save({ urlRegexp: urlRegexp, blockUser: blockUser, deleted: false });
+    }
+
     public async findAllBlockedRepositories(
         offset: number,
         limit: number,

--- a/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/blocked-repository-db-impl.ts
@@ -29,6 +29,13 @@ export class TypeORMBlockedRepositoryDBImpl implements BlockedRepositoryDB {
         return await blockedRepositoryRepo.save({ urlRegexp: urlRegexp, blockUser: blockUser, deleted: false });
     }
 
+    public async deleteBlockedRepository(id: number): Promise<boolean> {
+        const blockedRepositoryRepo = await this.getBlockedRepositoryRepo();
+
+        const result = await blockedRepositoryRepo.delete(id);
+        return !!result.affected;
+    }
+
     public async findAllBlockedRepositories(
         offset: number,
         limit: number,

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -21,6 +21,8 @@ export interface AdminServer {
     adminModifyRoleOrPermission(req: AdminModifyRoleOrPermissionRequest): Promise<User>;
     adminModifyPermanentWorkspaceFeatureFlag(req: AdminModifyPermanentWorkspaceFeatureFlagRequest): Promise<User>;
 
+    adminCreateBlockedRepository(urlRegexp: string, blockUser: boolean): Promise<BlockedRepository>;
+    adminDeleteBlockedRepository(id: number): Promise<boolean>;
     adminGetBlockedRepositories(
         req: AdminGetListRequest<BlockedRepository>,
     ): Promise<AdminGetListResult<BlockedRepository>>;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -552,29 +552,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
-    async adminGetBlockedRepositories(
-        ctx: TraceContext,
-        req: AdminGetListRequest<BlockedRepository>,
-    ): Promise<AdminGetListResult<BlockedRepository>> {
-        traceAPIParams(ctx, { req: censor(req, "searchTerm") }); // searchTerm may contain PII
-        await this.requireEELicense(Feature.FeatureAdminDashboard);
-
-        await this.guardAdminAccess("adminGetBlockedRepositories", { req }, Permission.ADMIN_USERS);
-
-        try {
-            const res = await this.blockedRepostoryDB.findAllBlockedRepositories(
-                req.offset,
-                req.limit,
-                req.orderBy,
-                req.orderDir === "asc" ? "ASC" : "DESC",
-                req.searchTerm,
-            );
-            return res;
-        } catch (e) {
-            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
-        }
-    }
-
     async adminGetUser(ctx: TraceContext, userId: string): Promise<User> {
         traceAPIParams(ctx, { userId });
 
@@ -637,6 +614,29 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         try {
             await this.userDeletionService.deleteUser(userId);
+        } catch (e) {
+            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
+        }
+    }
+
+    async adminGetBlockedRepositories(
+        ctx: TraceContext,
+        req: AdminGetListRequest<BlockedRepository>,
+    ): Promise<AdminGetListResult<BlockedRepository>> {
+        traceAPIParams(ctx, { req: censor(req, "searchTerm") }); // searchTerm may contain PII
+        await this.requireEELicense(Feature.FeatureAdminDashboard);
+
+        await this.guardAdminAccess("adminGetBlockedRepositories", { req }, Permission.ADMIN_USERS);
+
+        try {
+            const res = await this.blockedRepostoryDB.findAllBlockedRepositories(
+                req.offset,
+                req.limit,
+                req.orderBy,
+                req.orderDir === "asc" ? "ASC" : "DESC",
+                req.searchTerm,
+            );
+            return res;
         } catch (e) {
             throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
         }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -642,6 +642,36 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
+    async adminCreateBlockedRepository(
+        ctx: TraceContext,
+        urlRegexp: string,
+        blockUser: boolean,
+    ): Promise<BlockedRepository> {
+        traceAPIParams(ctx, { urlRegexp, blockUser });
+        await this.requireEELicense(Feature.FeatureAdminDashboard);
+
+        await this.guardAdminAccess("adminCreateBlockedRepository", { urlRegexp, blockUser }, Permission.ADMIN_USERS);
+
+        try {
+            return await this.blockedRepostoryDB.createBlockedRepository(urlRegexp, blockUser);
+        } catch (e) {
+            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
+        }
+    }
+
+    async adminDeleteBlockedRepository(ctx: TraceContext, id: number): Promise<boolean> {
+        traceAPIParams(ctx, { id });
+        await this.requireEELicense(Feature.FeatureAdminDashboard);
+
+        await this.guardAdminAccess("adminDeleteBlockedRepository", { id }, Permission.ADMIN_USERS);
+
+        try {
+            return await this.blockedRepostoryDB.deleteBlockedRepository(id);
+        } catch (e) {
+            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
+        }
+    }
+
     async adminModifyRoleOrPermission(ctx: TraceContext, req: AdminModifyRoleOrPermissionRequest): Promise<User> {
         traceAPIParams(ctx, { req });
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -159,6 +159,8 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         adminUpdateSettings: { group: "default", points: 1 },
         adminGetTelemetryData: { group: "default", points: 1 },
         adminGetBlockedRepositories: { group: "default", points: 1 },
+        adminCreateBlockedRepository: { group: "default", points: 1 },
+        adminDeleteBlockedRepository: { group: "default", points: 1 },
 
         validateLicense: { group: "default", points: 1 },
         getLicenseInfo: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2577,6 +2577,14 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }
 
+    adminCreateBlockedRepository(ctx: TraceContext, urlRegexp: string, blockUser: boolean): Promise<BlockedRepository> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
+    adminDeleteBlockedRepository(ctx: TraceContext, id: number): Promise<boolean> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
     async adminGetUser(ctx: TraceContext, id: string): Promise<User> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }


### PR DESCRIPTION
## Description
Add `adminCreateBlockedRepository` and `adminDeleteBlockedRepository` APIs to `components/server` to create and delete blocked repositories

This is a step towards using these endpoints to manage blocked repositories in the admin UI.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/11030

## How to test

* Open the developer tools on the admin page for this preview environment.

* Create a blocked repository:
```js
await window._gp.gitpodService.server.adminCreateBlockedRepository("github.com/<your-username>/.*", true)
```

* List blocked repositories: 
```js
await window._gp.gitpodService.server.adminGetBlockedRepositories({offset: 0, limit: 10, orderBy: 'id', orderDir: "desc", searchTerm: "foo"})
```
* (at this point you could try to start a workspace from a repo under your user to see that it really is blocked)

* Delete the blocked repository:
```js
await window._gp.gitpodService.server.adminDeleteBlockedRepository(<id of the blocked repo>)
```

## Release Notes
```release-note
NONE
```

## Documentation


## Werft options:

- [x] /werft with-preview
