### PR TITLE
[usage] Workspace Pricer uses config

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -239,7 +239,9 @@ EOF`);
     }
 
     private configureUsage(slice: string) {
-        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.enabled true`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.enabled true`, { slice: slice })
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.creditsPerMinuteByWorkspaceClass['default'] 0.1666666667`, { slice: slice })
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.creditsPerMinuteByWorkspaceClass['gitpodio-internal-xl'] 0.3333333333`, { slice: slice })
     }
 
     private configureConfigCat(slice: string) {

--- a/components/usage/config.json
+++ b/components/usage/config.json
@@ -1,5 +1,9 @@
 {
   "controllerSchedule": "1h",
+  "creditsPerMinuteByWorkspaceClass": {
+    "default": 0.1666666667,
+    "gitpodio-internal-xl": 0.3333333333
+  },
   "server": {
     "services": {
       "grpc": {

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -29,11 +29,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 	}
 
-	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
-		if ucfg != nil && ucfg.WebApp != nil && ucfg.WebApp.Usage != nil && ucfg.WebApp.Usage.Schedule != "" {
-			cfg.ControllerSchedule = ucfg.WebApp.Usage.Schedule
+	expConfig := getExperimentalConfig(ctx)
+	if expConfig != nil {
+		if expConfig.Schedule != "" {
+			cfg.ControllerSchedule = expConfig.Schedule
 		}
 
+		cfg.CreditsPerMinuteByWorkspaceClass = expConfig.CreditsPerMinuteByWorkspaceClass
+	}
+
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
 		_, _, path, ok := getStripeConfig(ucfg)
 		if !ok {
 			return nil

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -189,8 +189,9 @@ type PublicAPIConfig struct {
 }
 
 type UsageConfig struct {
-	Enabled  bool   `json:"enabled"`
-	Schedule string `json:"schedule"`
+	Enabled                          bool               `json:"enabled"`
+	Schedule                         string             `json:"schedule"`
+	CreditsPerMinuteByWorkspaceClass map[string]float64 `json:"creditsPerMinuteByWorkspaceClass"`
 }
 
 type IDEConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Provide config to usage component about how to price each workspace class

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Run the build directly, as it changes werft config `werft run github -j .werft/build.yaml -f`
2. Check the pod started
3. Check pod logs and validate you're seeing 
```
{"config":{"controllerSchedule":"1h0m0s","creditsPerMinuteByWorkspaceClass":{"default":0.1666666667,"gitpodio-internal-xl":0.3333333333},"server":{"services":{"grpc":{"address":":9001"}}}},"level":"info","message":"Starting usage component.","serviceContext":{"service":"usage","version":"commit-5201aba69e22b07e3d75e0181e19f7711ed987e3"},"severity":"INFO","time":"2022-07-11T08:53:29Z"}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
