### PR TITLE
[ws-proxy] Add X-Forwarded-Port header

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -377,8 +377,10 @@ func installWorkspacePortRoutes(r *mux.Router, config *RouteHandlerConfig, infoP
 					r.Header["Sec-WebSocket-"+name] = values
 				}
 			}
+			portString := "443"
 			r.Header.Add("X-Forwarded-Proto", "https")
-			r.Header.Add("X-Forwarded-Host", r.Host+":443")
+			r.Header.Add("X-Forwarded-Host", r.Host+":"+portString)
+			r.Header.Add("X-Forwarded-Port", portString)
 			proxyPass(
 				config,
 				infoProvider,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add X-Forwarded-Port header, as it's required by some software, like [FusionAuth](https://fusionauth.io/).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- This issue was reported by `(M) Chakshu` on Discord [[1](https://discord.com/channels/816244985187008514/989421509615448104)].
- https://github.com/FusionAuth/fusionauth-issues/issues/470

## How to test
<!-- Provide steps to test this PR -->
- [Open a workspace on the Preview Environment of this PR](https://felladrin-6876f11602.preview.gitpod-dev.com/#https://github.com/gitpod-io/empty).
- Run `curl lama.sh | sh`
- Run `gp preview $(gp url 8080) --external` to open a browser.
- Confirm you see, in the terminal logs of the request, the `X-Forwarded-Port` header. It should be the same port displayed at the end of `X-Forwarded-Host` header.
  ![image](https://user-images.githubusercontent.com/418083/177140806-40e216ea-b99b-4f7c-bb4e-81efa70c659f.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Requests on ws-proxy now contain also the `X-Forwarded-Port` header.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
