### PR TITLE
[kots]: add firewall check for the pull registry

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -44,6 +44,32 @@ spec:
           - '{{repl ConfigOption "store_s3_access_key_id" }}' # S3_ACCESS_KEY_ID
           - '{{repl ConfigOption "store_s3_secret_access_key" }}' # S3_SECRET_ACCESS_KEY
           - '{{repl ConfigOption "store_s3_bucket" }}' # S3_BUCKET_NAME
+    - run:
+        # Check that the pull registry is accessible from the cluster
+        collectorName: ping-registry
+        image: alpine/curl
+        name: ping-registry
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            CONNECTION="error"
+
+            if [ '{{repl HasLocalRegistry }}' = "true" ];
+            then
+              # Don't test for airgapped
+              CONNECTION="ok"
+            else
+              URL="https://eu.gcr.io/v2/"
+              echo "ping ${URL}"
+              if curl --silent --max-time 5 "${URL}" > /dev/null;
+              then
+                CONNECTION="ok"
+              fi
+            fi
+
+            echo "connection: ${CONNECTION}"
   analyzers:
     - clusterVersion:
         outcomes:
@@ -206,3 +232,13 @@ spec:
               message: Object storage connection is valid
           - fail:
               message: Object storage connection is invalid. Please check your settings and that the resource is accessible from your cluster
+    - textAnalyze:
+        checkName: Pull registry is accessible from cluster
+        fileName: ping-registry/ping-registry.log
+        regexGroups: 'connection: (?P<Connection>\w+)'
+        outcomes:
+          - pass:
+              when: "Connection == ok"
+              message: Registry is accessible
+          - fail:
+              message: Registry is inaccessible. Please check your network and firewall settings

--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -35,6 +35,31 @@ spec:
           - '{{repl ConfigOption "store_s3_access_key_id" }}' # S3_ACCESS_KEY_ID
           - '{{repl ConfigOption "store_s3_secret_access_key" }}' # S3_SECRET_ACCESS_KEY
           - '{{repl ConfigOption "store_s3_bucket" }}' # S3_BUCKET_NAME
+    - run:
+        collectorName: ping-registry
+        image: alpine/curl
+        name: ping-registry
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            CONNECTION="error"
+
+            if [ '{{repl HasLocalRegistry }}' = "true" ];
+            then
+              # Don't test for airgapped
+              CONNECTION="ok"
+            else
+              URL="https://eu.gcr.io/v2/"
+              echo "ping ${URL}"
+              if curl --silent --max-time 5 "${URL}" > /dev/null;
+              then
+                CONNECTION="ok"
+              fi
+            fi
+
+            echo "connection: ${CONNECTION}"
     - clusterInfo: {}
     - clusterResources: {}
     - logs:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a simple check to ensure that a network connection can be made to the pull registry. The command `curl https://eu.gcr.io/v2/` does actually (correctly) return an unauthorized error as the check is that it can make an HTTP connection in the timeout. However, it still exits with a code 0.

If it fails to connect within the timeout, it will exit with a non-zero error code.

In airgapped, it runs against the pull repository.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10244

## How to test
<!-- Provide steps to test this PR -->
Install in a non-airgapped and airgapped environment

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add firewall check for the pull registry
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
