### PR TITLE
Temporarily use a fixed version of JetBrains Gateway SDK

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -14,7 +14,7 @@ pluginVerifierIdeVersions=2022.1, 2022.2
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType=GW
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=222-NIGHTLY-CUSTOM-SNAPSHOT
+platformVersion=222.3244.1-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Temporarily use a fixed version of JetBrains Gateway SDK, to solve Werft not being able to build the gateway plugin  on main branch [[1](https://werft.gitpod-dev.com/job/gitpod-build-main.3765)].

It's currently failing with the message
```
> Task :compileKotlin FAILED
e: /tmp/build/components-ide-jetbrains-gateway-plugin--publish.0b3644e51dba5594b271ae6e6c3ef871e0b47c39/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt: (231, 41): Type mismatch: inferred type is RemoteCredentialsHolder but HostTunnelConnector was expected
```

Later I'll create another PR fixing the code to make it work again with the latest version of Gateway SDK.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
Check if Werft build succeeds for this PR: https://werft.gitpod-dev.com/job/gitpod-build-felladrin-temporarily-use-a-fixed-version-ofa.0

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
