### PR TITLE
[prebuild] Fix view when coming from prefix

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -123,17 +123,19 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
     }, [logsEmitter, props.workspaceId, workspaceInstance?.id, workspaceInstance?.status.phase]);
 
     return (
-        <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
+        <div className="rounded-xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col mb-8">
             <div className="h-96 flex">
                 <Suspense fallback={<div />}>
                     <WorkspaceLogs classes="h-full w-full" logsEmitter={logsEmitter} errorMessage={error?.message} />
                 </Suspense>
             </div>
-            <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
-                {prebuild && <PrebuildStatus prebuild={prebuild} />}
-                <div className="flex-grow" />
-                {props.children}
-            </div>
+            {prebuild && (
+                <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
+                    <PrebuildStatus prebuild={prebuild} />
+                    <div className="flex-grow" />
+                    {props.children}
+                </div>
+            )}
         </div>
     );
 }

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -444,10 +444,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             case "running":
                 if (isPrebuild) {
                     return (
-                        <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
-                            {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
-                            <PrebuildLogs workspaceId={this.props.workspaceId} />
-                        </div>
+                        <StartPage title="Prebuild in Progress">
+                            <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                                {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
+                                <PrebuildLogs workspaceId={this.props.workspaceId} />
+                            </div>
+                        </StartPage>
                     );
                 }
                 if (!this.state.desktopIde) {
@@ -576,10 +578,12 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
             case "stopping":
                 if (isPrebuild) {
                     return (
-                        <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
-                            {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
-                            <PrebuildLogs workspaceId={this.props.workspaceId} />
-                        </div>
+                        <StartPage title="Prebuild in Progress">
+                            <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                                {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
+                                <PrebuildLogs workspaceId={this.props.workspaceId} />
+                            </div>
+                        </StartPage>
                     );
                 }
                 phase = StartPhase.Stopping;


### PR DESCRIPTION
## Description
This fixes the broken layout, but doesn't add yet the "Skip Prebuild" button as we intended [in a recent epic](https://github.com/gitpod-io/gitpod/issues/9132). Skipping prebuilds will be covered in [a follow-up issue](https://github.com/gitpod-io/gitpod/issues/11128).

| BEFORE | AFTER |
| - | - |
| <img width="609" alt="Screenshot 2022-07-04 at 15 05 39" src="https://user-images.githubusercontent.com/8015191/177173689-8b6457eb-4c81-4067-92a8-ec699a50d9c1.png"> | <img width="679" alt="Screenshot 2022-07-04 at 18 19 56" src="https://user-images.githubusercontent.com/8015191/177191547-7405e8d6-1e15-41e9-97f2-08fb6e453d7a.png"> |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11079 

## How to test
1. Run a prebuild using `https://laushinka-be81110388.preview.gitpod-dev.com/#prebuild/[YOUR_REPO]`
2. See the fixed view as in the description.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
