### PR TITLE
remove certificate kubectl wait assert

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -77,7 +77,7 @@ export async function installCertificate(werft, params: InstallCertificateParams
 function waitForCertificateReadiness(werft: Werft, certName: string, slice: string) {
     const timeout = "600s"
     werft.log(slice, "Waiting for certificate readiness")
-    const rc = exec(`kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} wait --for=condition=Ready --timeout=${timeout} -n certs certificate ${certName}`).code
+    const rc = exec(`kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} wait --for=condition=Ready --timeout=${timeout} -n certs certificate ${certName}`, {dontCheckRc: true}).code
 
     if (rc != 0) {
         werft.log(slice, "The certificate never became Ready. We are deleting the certificate so that the next job can create a new one")


### PR DESCRIPTION
## Description
Removes an assertion from the wait exec for certificate failures

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10823

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
