### PR TITLE
Fix workspace location when opening in vscode desktop

### DIFF
--- a/components/ide/code-desktop/status/main.go
+++ b/components/ide/code-desktop/status/main.go
@@ -63,10 +63,15 @@ func main() {
 		}
 		queryString := string(b)
 
+		workspaceLocation := wsInfo.GetWorkspaceLocationFile()
+		if workspaceLocation == "" {
+			workspaceLocation = wsInfo.GetWorkspaceLocationFolder()
+		}
+
 		link := url.URL{
 			Scheme:   schema,
 			Host:     "gitpod.gitpod-desktop",
-			Path:     wsInfo.CheckoutLocation,
+			Path:     workspaceLocation,
 			RawQuery: url.QueryEscape(queryString),
 		}
 

--- a/components/ide/jetbrains/image/status/main.go
+++ b/components/ide/jetbrains/image/status/main.go
@@ -68,13 +68,11 @@ func main() {
 		return
 	}
 
-	// wait until content ready
-	contentStatus, wsInfo, err := resolveWorkspaceInfo(context.Background())
-	if err != nil || wsInfo == nil || contentStatus == nil || !contentStatus.Available {
-		log.WithError(err).WithField("wsInfo", wsInfo).WithField("cstate", contentStatus).Error("resolve workspace info failed")
+	wsInfo, err := resolveWorkspaceInfo(context.Background())
+	if err != nil || wsInfo == nil {
+		log.WithError(err).WithField("wsInfo", wsInfo).Error("resolve workspace info failed")
 		return
 	}
-	log.WithField("cost", time.Now().Local().Sub(startTime).Milliseconds()).Info("content available")
 
 	repoRoot := wsInfo.GetCheckoutLocation()
 	gitpodConfig, err := parseGitpodConfig(repoRoot)
@@ -218,8 +216,8 @@ func terminateIDE(backendPort string) error {
 	return nil
 }
 
-func resolveWorkspaceInfo(ctx context.Context) (*supervisor.ContentStatusResponse, *supervisor.WorkspaceInfoResponse, error) {
-	resolve := func(ctx context.Context) (contentStatus *supervisor.ContentStatusResponse, wsInfo *supervisor.WorkspaceInfoResponse, err error) {
+func resolveWorkspaceInfo(ctx context.Context) (*supervisor.WorkspaceInfoResponse, error) {
+	resolve := func(ctx context.Context) (wsInfo *supervisor.WorkspaceInfoResponse, err error) {
 		supervisorAddr := os.Getenv("SUPERVISOR_ADDR")
 		if supervisorAddr == "" {
 			supervisorAddr = "localhost:22999"
@@ -234,22 +232,18 @@ func resolveWorkspaceInfo(ctx context.Context) (*supervisor.ContentStatusRespons
 			err = errors.New("get workspace info failed: " + err.Error())
 			return
 		}
-		contentStatus, err = supervisor.NewStatusServiceClient(supervisorConn).ContentStatus(ctx, &supervisor.ContentStatusRequest{Wait: true})
-		if err != nil {
-			err = errors.New("get content available failed: " + err.Error())
-		}
 		return
 	}
 	// try resolve workspace info 10 times
 	for attempt := 0; attempt < 10; attempt++ {
-		if contentStatus, wsInfo, err := resolve(ctx); err != nil {
+		if wsInfo, err := resolve(ctx); err != nil {
 			log.WithError(err).Error("resolve workspace info failed")
 			time.Sleep(1 * time.Second)
 		} else {
-			return contentStatus, wsInfo, err
+			return wsInfo, err
 		}
 	}
-	return nil, nil, errors.New("failed with attempt 10 times")
+	return nil, errors.New("failed with attempt 10 times")
 }
 
 func run(wsInfo *supervisor.WorkspaceInfoResponse, alias string) {


### PR DESCRIPTION
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11101

## How to test
<!-- Provide steps to test this PR -->
1. Select vscode desktop in dashboard
1. Open https://gitlab.com/bakins-bits/gitpod-setup-for-bitcoin-core-dev in prev env
2. When vscode desktop connects to workspace check the workspace openup with three folders by default - `bitcoin` `btcdeb` `gitpod-setup-for-bitcoin-core-dev`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
