### PR TITLE
obserbility: Add a alert for AutoscaleFailure.

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -34,6 +34,20 @@
             },
             expr: '((sum(cluster_autoscaler_nodes_count) by (cluster)) - (sum(cluster_autoscaler_nodes_count offset 10m) by (cluster))) > 15',
           },
+          {
+            alert: 'AutoscaleFailure',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscaleFailure.md',
+              summary: "Automatic scale-up failed for some reason.",
+              description: 'Automatic scale-up failed for some reason.',
+            },
+            expr: |||
+              increase(cluster_autoscaler_failed_scale_ups_total[1m]) != 0
+            |||,
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
alert when we cannot scale-up

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11051
https://github.com/gitpod-io/runbooks/pull/363

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
no

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
