### PR TITLE
Align access level of Workspaces of type "prebuild" with Prebuilds

### DIFF
--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -782,6 +782,43 @@ class TestResourceAccess {
                 teamRole: "owner",
                 expectation: true,
             },
+            // prebuild workspace with repo access
+            {
+                name: "prebuild workspace get owner",
+                resourceKind: "workspace",
+                workspaceType: "prebuild",
+                isOwner: true,
+                teamRole: undefined,
+                repositoryAccess: true,
+                expectation: true,
+            },
+            {
+                name: "prebuild workspace get other",
+                resourceKind: "workspace",
+                workspaceType: "prebuild",
+                isOwner: false,
+                teamRole: undefined,
+                repositoryAccess: true,
+                expectation: true,
+            },
+            {
+                name: "prebuild workspace get team member",
+                resourceKind: "workspace",
+                workspaceType: "prebuild",
+                isOwner: false,
+                teamRole: "member",
+                repositoryAccess: true,
+                expectation: true,
+            },
+            {
+                name: "prebuild workspace get team owner (same as member)",
+                resourceKind: "workspace",
+                workspaceType: "prebuild",
+                isOwner: false,
+                teamRole: "owner",
+                repositoryAccess: true,
+                expectation: true,
+            },
             // regular instance
             {
                 name: "regular workspaceInstance get owner",

--- a/components/server/src/auth/resource-access.ts
+++ b/components/server/src/auth/resource-access.ts
@@ -484,6 +484,13 @@ export class RepositoryResourceGuard implements ResourceAccessGuard {
         // Get Workspace from GuardedResource
         let workspace: Workspace;
         switch (resource.kind) {
+            case "workspace":
+                workspace = resource.subject;
+                if (workspace.type !== "prebuild") {
+                    return false;
+                }
+                // We're only allowed to access prebuild workspaces with the repository guard
+                break;
             case "workspaceLog":
                 workspace = resource.subject;
                 break;


### PR DESCRIPTION
## Description

Align access level of Workspaces of type "prebuild" with Prebuilds

:information_source: It make sense to review this PR per commit:
 - the 1st commit fixes the test setup (and a bug)
 - the 2nd commit is the actual fix for this issue

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11127 

## How to test
 - `cd components/server`
 - `yarn test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
align access level of Workspaces of type "prebuild" with Prebuilds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
