### PR TITLE
Fix certificate alert to add more debug and use ask handle

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -100,10 +100,11 @@ function waitForCertificateReadiness(werft: Werft, certName: string, slice: stri
             `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs get certificate ${certName} -o yaml`,
             { silent: true },
         ).stdout.trim();
+        const certificateDebug = exec(`cmctl status certificate ${certName}`);
         exec(`kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs delete certificate ${certName}`, {
             slice: slice,
         });
-        reportCertificateError({ certificateName: certName, certifiateYAML: certificateYAML }).catch((error: Error) =>
+        reportCertificateError({ certificateName: certName, certifiateYAML: certificateYAML, certificateDebug: certificateDebug }).catch((error: Error) =>
             console.error("Failed to send message to Slack", error),
         );
         werft.fail(

--- a/.werft/util/slack.ts
+++ b/.werft/util/slack.ts
@@ -51,14 +51,14 @@ export function reportBuildFailureInSlack(context, err: Error): Promise<void> {
     });
 }
 
-export function reportCertificateError(options: { certificateName: string; certifiateYAML: string }): Promise<void> {
+export function reportCertificateError(options: { certificateName: string; certifiateYAML: string, certificateDebug: string }): Promise<void> {
     const data = JSON.stringify({
         blocks: [
             {
                 type: "section",
                 text: {
                     type: "mrkdwn",
-                    text: `A build failed because the certificate ${options.certificateName} never reached the Ready state. @team-platform please investigate using our [Debugging certificate issues guide](https://www.notion.so/gitpod/Debugging-certificate-issues-9453d1c8ac914ce7962557b67f7b49b3) :hug:`,
+                    text: `A build failed because the certificate ${options.certificateName} never reached the Ready state. @ask-platform please investigate using our [Debugging certificate issues guide](https://www.notion.so/gitpod/Debugging-certificate-issues-9453d1c8ac914ce7962557b67f7b49b3) :hug:`,
                 },
             },
             {
@@ -66,6 +66,13 @@ export function reportCertificateError(options: { certificateName: string; certi
                 text: {
                     type: "mrkdwn",
                     text: "```\n" + options.certifiateYAML + "\n```",
+                },
+            },
+            {
+                type: "section",
+                text: {
+                    type: "mrkdwn",
+                    text: "```\n" + options.certificateDebug + "\n```",
                 },
             },
         ],


### PR DESCRIPTION
## Description
Updates the certificate failure alerts to provide more debug and use @ask-platform handle

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
