### PR TITLE
[ws-daemon] Increase process priority

### DIFF
--- a/components/ws-daemon/cmd/run.go
+++ b/components/ws-daemon/cmd/run.go
@@ -7,8 +7,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
+	"os"
+	"syscall"
 	"time"
+
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
@@ -82,6 +85,11 @@ var runCmd = &cobra.Command{
 		})
 		if err != nil {
 			log.WithError(err).Fatal("Cannot start watch of configuration file.")
+		}
+
+		err = syscall.Setpriority(syscall.PRIO_PROCESS, os.Getpid(), -19)
+		if err != nil {
+			log.WithError(err).Error("cannot change ws-daemon priority")
 		}
 
 		err = srv.ListenAndServe()


### PR DESCRIPTION
## Description

Increase ws-daemond process priority to improve responsiveness when the node CPU and/or I/O utilization is high

## How to test
- Check `ws-daemond` process nice level running  `ps ax -o pid,ni,cmd` is `-19`

## Release Notes
```release-note
NONE
```

## Werft options:
- [X] /werft with-preview


Note: we cannot do the same thing with `registry-facade` because it does not run as privileged :( 