### PR TITLE
ws-manager: Replace backup/restore success with total metric

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -47,9 +47,9 @@ type metrics struct {
 	// Counter
 	totalStartsCounterVec         *prometheus.CounterVec
 	totalStopsCounterVec          *prometheus.CounterVec
-	totalBackupSuccessCounterVec  *prometheus.CounterVec
+	totalBackupCounterVec         *prometheus.CounterVec
 	totalBackupFailureCounterVec  *prometheus.CounterVec
-	totalRestoreSuccessCounterVec *prometheus.CounterVec
+	totalRestoreCounterVec        *prometheus.CounterVec
 	totalRestoreFailureCounterVec *prometheus.CounterVec
 
 	// Gauge
@@ -111,29 +111,29 @@ func newMetrics(m *Manager) *metrics {
 			Name:      "workspace_stops_total",
 			Help:      "total number of workspaces stopped",
 		}, []string{"reason", "type", "class"}),
-		totalBackupSuccessCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
+		totalBackupCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
-			Name:      "workspace_backups_success_total",
-			Help:      "total number of workspace backups success",
+			Name:      "workspace_backups_total",
+			Help:      "total number of workspace backups",
 		}, []string{"type", "class"}),
 		totalBackupFailureCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
 			Name:      "workspace_backups_failure_total",
-			Help:      "total number of workspace backups failure",
+			Help:      "total number of workspace backup failures",
 		}, []string{"type", "class"}),
-		totalRestoreSuccessCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
+		totalRestoreCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
-			Name:      "workspace_restores_success_total",
-			Help:      "total number of workspace restores success",
+			Name:      "workspace_restores_total",
+			Help:      "total number of workspace restores",
 		}, []string{"type", "class"}),
 		totalRestoreFailureCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
 			Name:      "workspace_restores_failure_total",
-			Help:      "total number of workspace restores failure",
+			Help:      "total number of workspace restore failures",
 		}, []string{"type", "class"}),
 		totalOpenPortGauge: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
@@ -193,9 +193,9 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 		newSubscriberQueueLevelVec(m.manager),
 		m.totalStartsCounterVec,
 		m.totalStopsCounterVec,
-		m.totalBackupSuccessCounterVec,
+		m.totalBackupCounterVec,
 		m.totalBackupFailureCounterVec,
-		m.totalRestoreSuccessCounterVec,
+		m.totalRestoreCounterVec,
 		m.totalRestoreFailureCounterVec,
 		m.totalOpenPortGauge,
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Hey Workspace-team!

We noticed that you want to level up your game towards success-criteria-related metrics, and there is momentum in the company to start adopting SLOs to get the right metrics.

We from the platform-team are being a little more proactive regarding implementing SLOs and while trying to get the first example up and running, we noticed that your metrics for workspace backups and workspace restores are a bit out of best practices for SLOs with Prometheus 😬 


When implementing success ratio SLOs, we usually look for metrics that represent "total amount of requests" and "amount of failed requests". So the calculation looks like this: `backup error ratio = amount of backup with errors / total amount of backups`

Would it be fine if we change the current metrics to be more SLO-friendly?

_PS: I also simplified the nested ifs by using `WithLabelValues` instead of `GetMetricWithLabelValues` as well_

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
