### PR TITLE
[ws-proxy] use target host for foreign resource

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -343,7 +343,6 @@ func installBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvi
 		image, path := segments[0], segments[1]
 
 		req.URL.Path = path
-		req.Header.Add("X-BlobServe-ReadOnly", "true")
 
 		var dst url.URL
 		dst.Scheme = cfg.BlobServer.Scheme

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -350,7 +350,7 @@ func installBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvi
 		dst.Path = cfg.BlobServer.PathPrefix + "/" + strings.TrimPrefix(image, "/")
 		return &dst, nil
 	}
-	r.NewRoute().Handler(proxyPass(config, infoProvider, targetResolver, withLongTermCaching()))
+	r.NewRoute().Handler(proxyPass(config, infoProvider, targetResolver, withLongTermCaching(), withUseTargetHost()))
 }
 
 // installWorkspacePortRoutes configures routing for exposed ports.

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -138,11 +138,6 @@ func startTestTarget(t *testing.T, host, name string, checkedHost bool) *testTar
 				format += "host: %s\n"
 				args = append(args, r.Host)
 			}
-			readonly := r.Header.Get("X-BlobServe-ReadOnly")
-			if readonly != "" {
-				format += "readOnly: %s\n"
-				args = append(args, readonly)
-			}
 			inlineVars := r.Header.Get("X-BlobServe-InlineVars")
 			if inlineVars != "" {
 				format += "inlineVars: %s\n"

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -335,6 +335,24 @@ func TestRoutes(t *testing.T) {
 			},
 		},
 		{
+			Desc:   "blobserve foreign resource",
+			Config: &config,
+			Request: modifyRequest(httptest.NewRequest("GET", "https://v--sr1o1nu24nqdf809l0u27jk5t7"+wsHostSuffix+"/image/__files__/test.html", nil),
+				addHostHeader,
+				addHeader("Sec-Fetch-Mode", "navigate"),
+			),
+			Expectation: Expectation{
+				Status: http.StatusOK,
+				Header: http.Header{
+					"Cache-Control":  {"public, max-age=31536000"},
+					"Content-Length": {"54"},
+					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
+				},
+				Body: "blobserve hit: /image/test.html\nhost: localhost:20003\n",
+			},
+		},
+		{
 			Desc:   "CORS preflight",
 			Config: &config,
 			Request: modifyRequest(httptest.NewRequest("GET", workspaces[0].URL+"somewhere/in/the/ide", nil),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
use target host for foreign resource, in preview environment and self-hosted instance, the traffic through `proxy` -> `ide-proxy` -> `blobserve`, the `proxy` need correct hostname so they can forward to correct components

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open workspace
2. use `gp preview https://www.google.com`
3. check simple web browser works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
