### PR TITLE
Fix incompatible column type in DBBlockedRepository

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
@@ -5,7 +5,8 @@
  */
 
 import { BlockedRepository } from "@gitpod/gitpod-protocol/src/blocked-repositories-protocol";
-import { Entity, Column, CreateDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+import { Transformer } from "../transformer";
 
 @Entity()
 export class DBBlockedRepository implements BlockedRepository {
@@ -18,10 +19,20 @@ export class DBBlockedRepository implements BlockedRepository {
     @Column()
     blockUser: boolean;
 
-    @CreateDateColumn()
+    @Column({
+        type: "timestamp",
+        precision: 6,
+        default: () => "CURRENT_TIMESTAMP(6)",
+        transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
+    })
     createdAt: string;
 
-    @UpdateDateColumn()
+    @Column({
+        type: "timestamp",
+        precision: 6,
+        default: () => "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)",
+        transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
+    })
     updatedAt: string;
 
     // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.

--- a/components/gitpod-db/src/typeorm/migration/1657105883801-BlockedRepositoryFix.ts
+++ b/components/gitpod-db/src/typeorm/migration/1657105883801-BlockedRepositoryFix.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BlockedRepositoryFix1657105883801 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE d_b_blocked_repository MODIFY createdAt timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE d_b_blocked_repository MODIFY updatedAt timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11146 

## How to test
 - create a new branch + preview environment from `main`
 - open workspace on that branch
 - connect to DB:
   - `kubectl port-forward mysql-0 3306 &`
   - `mysql -u gitpod -h 127.0.0.1 -p`, PW: `jBzVMe2w4Yi7GagadsyB` (not a secret, our default PW)
 - execute both lines of migration from [here](https://github.com/gitpod-io/gitpod/pull/11175/commits/ce8901f551a1481ada0bbbb6abd7dd1c34c8fce5#diff-153bcfe720a7ac18300e0f0215b6997eb1a9e5de7332204d3d55e6a989c07626R12)
 - note how they work without any issues (prod/staging tables are empty as well)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
