### PR TITLE
[ws-daemon] Fix extraction of process arguments

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go
@@ -132,6 +132,10 @@ func extractCommand(p *process.Process) []string {
 		return []string{}
 	}
 
+	if len(cmdLine) == 0 {
+		return []string{}
+	}
+
 	cmd := cmdLine[0]
 	if cmd == "/bin/bash" || cmd == "sh" {
 		return cmdLine[1:]


### PR DESCRIPTION

## Related Issue(s)
```
goroutine 155927 [running]:
github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup.extractCommand(0x22f7190?)
	github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go:135 +0xd0
github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup.determineProcessType(0x22f7190?)
	github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go:104 +0x25
github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup.(*ProcessPriorityV2).Apply.func1()
	github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go:83 +0x8ca
created by github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup.(*ProcessPriorityV2).Apply
	github.com/gitpod-io/gitpod/ws-daemon/pkg/cgroup/plugin_process_priority_v2.go:52 +0x18c
``` 

## Release Notes
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
