### PR TITLE
[server] Log hasReadAccess errors

### DIFF
--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -11,6 +11,7 @@ import { GitHubGraphQlEndpoint, GitHubRestApi } from "./api";
 import { RepositoryProvider } from "../repohost/repository-provider";
 import { RepoURL } from "../repohost/repo-url";
 import { Branch, CommitInfo } from "@gitpod/gitpod-protocol/src/protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
 export class GithubRepositoryProvider implements RepositoryProvider {
@@ -211,6 +212,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
             );
             return result.data.repository !== null;
         } catch (err) {
+            log.warn({ userId: user.id }, "hasReadAccess error", err, { owner, repo });
             return false;
         }
     }

--- a/components/server/src/gitlab/gitlab-repository-provider.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.ts
@@ -110,6 +110,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
             }
             return true;
         } catch (err) {
+            log.warn({ userId: user.id }, "hasReadAccess error", err, { owner, repo });
             return false;
         }
     }


### PR DESCRIPTION
## Description

Gain insight into if and why `hasReadAccess` might fail for user registered SCM providers.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #11172 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
