### PR TITLE
[prebuild] Make prebuild logs view more responsive

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -144,7 +144,7 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                     <WorkspaceLogs classes="h-full w-full" logsEmitter={logsEmitter} errorMessage={error?.message} />
                 </Suspense>
             </div>
-            <div className="h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
+            <div className="w-full bottom-0 h-20 px-6 bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-600 flex space-x-2">
                 {prebuild && <PrebuildStatus prebuild={prebuild} />}
                 <div className="flex-grow" />
                 {props.children}

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -486,7 +486,7 @@ function RunningPrebuildView(props: RunningPrebuildViewProps) {
     return (
         <StartPage title="Prebuild in Progress">
             {/* TODO(gpl) Copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
-            <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+            <div className="h-full mt-6 w-11/12 lg:w-3/5">
                 <PrebuildLogs workspaceId={workspaceId} onIgnorePrebuild={props.onIgnorePrebuild}>
                     <button className="secondary" onClick={() => props.onIgnorePrebuild && props.onIgnorePrebuild()}>
                         Skip Prebuild

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -445,7 +445,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 if (isPrebuild) {
                     return (
                         <StartPage title="Prebuild in Progress">
-                            <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                            <div className="mt-6 w-11/12 lg:w-3/5">
                                 {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
                                 <PrebuildLogs workspaceId={this.props.workspaceId} />
                             </div>
@@ -579,7 +579,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 if (isPrebuild) {
                     return (
                         <StartPage title="Prebuild in Progress">
-                            <div className="mt-6 w-11/12 lg:w-3/5 overflow-hidden">
+                            <div className="mt-6 w-11/12 lg:w-3/5">
                                 {/* TODO(gpl) These classes are copied around in Start-/CreateWorkspace. This should properly go somewhere central. */}
                                 <PrebuildLogs workspaceId={this.props.workspaceId} />
                             </div>


### PR DESCRIPTION
## Description
This makes sure the buttons will always show (and view always scrollable) regardless the screen size.
Tested on workspace start, prebuild detail view, and prebuild prefix trigger.

<img width="500" alt="Screenshot 2022-07-07 at 22 41 04" src="https://user-images.githubusercontent.com/8015191/177867866-64d713bb-1225-4fa0-bc53-a346b6b564de.png">
<img width="518" alt="Screenshot 2022-07-07 at 22 40 09" src="https://user-images.githubusercontent.com/8015191/177867883-21c479b7-45ec-469a-afda-a779371410f8.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11189

## How to test
1. Make a change to a repo with a prebuild
2. Resize the screen to a small size, buttons should always be in view.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make prebuild logs responsive for small viewports
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
