### PR TITLE
[db-sync] Escape column names

### DIFF
--- a/components/ee/db-sync/src/export.ts
+++ b/components/ee/db-sync/src/export.ts
@@ -72,7 +72,8 @@ export class TableUpdate {
         if (timeConditions.length > 0) {
             condition = `WHERE ${timeConditions.join(" AND ")}`;
         }
-        const dataQuery = `SELECT ${this.columns.join(", ")} FROM ${this.table.name} ${condition}`;
+
+        const dataQuery = `SELECT ${this.columns.map(escapeWithBackticks).join(", ")} FROM \`${this.table.name}\` ${condition}`;
         const deletionsAndUpdates = await new Promise<string[][]>((resolve, reject) => {
             const updates: string[] = [];
             const deletions: string[] = [];
@@ -180,4 +181,8 @@ export class TableUpdateProvider {
         return { deletions, updates };
     }
 
+}
+
+function escapeWithBackticks(val: string): string {
+    return "`" + val + "`"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When DB sync runs on on 
```
"SELECT id, userId, name, key, fingerprint, deleted, _lastModified, creationTime, lastUsedTime FROM d_b_user_ssh_public_key WHERE _lastModified >= '2022-07-07 08:24:39.562'"
```
It fails with 
```
 "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'key, fingerprint, deleted, _lastModified, creationTime, lastUsedTime FROM d_b_us' at line 1"
```
This is because of `name` and `key` are keywords in SQL. This fixes it.

Also, we shouldn't string roll an ORM model... :/

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
