### PR TITLE
Escape column names in INSERT statement

### DIFF
--- a/components/ee/db-sync/src/export.ts
+++ b/components/ee/db-sync/src/export.ts
@@ -139,7 +139,7 @@ export class TableUpdate {
         const updates = this.updateColumns.map((c, i) => `${c}=${updateValues[i]}`).join(", ")
         const updateConditions = this.getUpdateConditions(row);
 
-        let result = [`INSERT${forceInsert ? '' : ' IGNORE'} INTO ${this.table.name} (${(this.table.primaryKeys.concat(this.updateColumns)).join(", ")}) VALUES (${(pkValues.concat(updateValues)).join(", ")});`];
+        let result = [`INSERT${forceInsert ? '' : ' IGNORE'} INTO ${this.table.name} (${(this.table.primaryKeys.concat(this.updateColumns)).map(escapeWithBackticks).join(", ")}) VALUES (${(pkValues.concat(updateValues)).join(", ")});`];
         if(!forceInsert) {
             result.push(`UPDATE ${this.table.name} SET ${updates} WHERE ${updateConditions};`);
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Follow up to https://github.com/gitpod-io/gitpod/pull/11196. We also need the same escaping when running `INSERT`s.
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
