### PR TITLE
[ws-manager] Only extract secrets when FF is set

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -969,30 +969,6 @@ func (m *Manager) newStartWorkspaceContext(ctx context.Context, req *api.StartWo
 		}
 	}
 
-	var (
-		secrets    = make(map[string]string)
-		secretsLen int
-	)
-	for _, env := range req.Spec.Envvars {
-		if env.Secret != nil {
-			continue
-		}
-		if !isProtectedEnvVar(env.Name) {
-			continue
-		}
-
-		name := fmt.Sprintf("%x", sha256.Sum256([]byte(env.Name)))
-		secrets[name] = env.Value
-		secretsLen += len(env.Value)
-	}
-	for k, v := range csapi.ExtractSecretsFromInitializer(req.Spec.Initializer) {
-		secrets[k] = v
-		secretsLen += len(v)
-	}
-	if secretsLen > maxSecretsLength {
-		return nil, xerrors.Errorf("secrets exceed maximum permitted length (%d > %d bytes): please reduce the numer or length of environment variables", secretsLen, maxSecretsLength)
-	}
-
 	return &startWorkspaceContext{
 		Labels:         labels,
 		CLIAPIKey:      cliAPIKey,
@@ -1004,7 +980,6 @@ func (m *Manager) newStartWorkspaceContext(ctx context.Context, req *api.StartWo
 		Headless:       headless,
 		Class:          class,
 		VolumeSnapshot: volumeSnapshot,
-		Secrets:        secrets,
 	}, nil
 }
 

--- a/components/ws-manager/pkg/manager/manager_test.go
+++ b/components/ws-manager/pkg/manager/manager_test.go
@@ -23,7 +23,8 @@ import (
 
 func TestValidateStartWorkspaceRequest(t *testing.T) {
 	type fixture struct {
-		Req *api.StartWorkspaceRequest `json:"request"`
+		Req      *api.StartWorkspaceRequest `json:"request"`
+		BloatEnv bool                       `json:"bloatEnv"`
 	}
 	type gold struct {
 		Error string `json:"error,omitempty"`
@@ -39,6 +40,13 @@ func TestValidateStartWorkspaceRequest(t *testing.T) {
 			if fixture.Req == nil {
 				t.Errorf("request is nil")
 				return nil
+			}
+
+			if fixture.BloatEnv {
+				fixture.Req.Spec.Envvars = append(fixture.Req.Spec.Envvars, &api.EnvironmentVariable{
+					Name:  "BLOAT",
+					Value: string(make([]byte, 2*maxSecretsLength)),
+				})
 			}
 
 			err := validateStartWorkspaceRequest(fixture.Req)

--- a/components/ws-manager/pkg/manager/testdata/validateStartReq_invalidType.golden
+++ b/components/ws-manager/pkg/manager/testdata/validateStartReq_invalidType.golden
@@ -1,3 +1,3 @@
 {
-    "error": "invalid request: workspace_image: cannot be blank; workspace_location: cannot be blank."
+    "error": "invalid request: type: value 200 is out of range."
 }

--- a/components/ws-manager/pkg/manager/testdata/validateStartReq_invalidType.json
+++ b/components/ws-manager/pkg/manager/testdata/validateStartReq_invalidType.json
@@ -7,14 +7,14 @@
             "owner": "tester",
             "metaId": "foobar"
         },
-        "servicePrefix": "foobarservice",
+        "service_prefix": "foobarservice",
         "spec": {
             "ideImage": {
                 "webRef": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion"
             },
-            "workspaceImage": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
-            "checkoutLocation": "/",
-            "workspaceLocation": "/",
+            "workspace_image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+            "checkout_location": "/",
+            "workspace_location": "/",
             "initializer": {
                 "snapshot": {
                     "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"

--- a/components/ws-manager/pkg/manager/testdata/validateStartReq_oversizedSecret.golden
+++ b/components/ws-manager/pkg/manager/testdata/validateStartReq_oversizedSecret.golden
@@ -1,0 +1,3 @@
+{
+    "error": "secrets exceed maximum permitted length (1610612739 \u003e 805306368 bytes): please reduce the numer or length of environment variables"
+}

--- a/components/ws-manager/pkg/manager/testdata/validateStartReq_oversizedSecret.json
+++ b/components/ws-manager/pkg/manager/testdata/validateStartReq_oversizedSecret.json
@@ -1,0 +1,39 @@
+{
+    "bloatEnv": true,
+    "request": {
+        "id": "foobar",
+        "type": 0,
+        "metadata": {
+            "owner": "tester",
+            "metaId": "foobar"
+        },
+        "servicePrefix": "foobarservice",
+        "spec": {
+            "ideImage": {
+                "webRef": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion"
+            },
+            "workspace_image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+            "workspace_location": "/",
+            "initializer": {
+                "snapshot": {
+                    "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"
+                }
+            },
+            "ports": [
+                {
+                    "port": 8080
+                }
+            ],
+            "envvars": [
+                {
+                    "name": "foo",
+                    "value": "bar"
+                }
+            ],
+            "git": {
+                "username": "usernameGoesHere",
+                "email": "some@user.com"
+            }
+        }
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/validateStartReq_valid.golden
+++ b/components/ws-manager/pkg/manager/testdata/validateStartReq_valid.golden
@@ -1,3 +1,1 @@
-{
-    "error": "invalid request: workspace_image: cannot be blank; workspace_location: cannot be blank."
-}
+{}

--- a/components/ws-manager/pkg/manager/testdata/validateStartReq_valid.json
+++ b/components/ws-manager/pkg/manager/testdata/validateStartReq_valid.json
@@ -7,13 +7,13 @@
             "owner": "tester",
             "metaId": "foobar"
         },
-        "servicePrefix": "foobarservice",
+        "service_prefix": "foobarservice",
         "spec": {
             "ideImage": {
                 "webRef": "eu.gcr.io/gitpod-core-dev/buid/theia-ide:someversion"
             },
-            "workspaceImage": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
-            "workspaceLocation": "/",
+            "workspace_image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+            "workspace_location": "/",
             "initializer": {
                 "snapshot": {
                     "snapshot": "workspaces/cryptic-id-goes-herg/fd62804b-4cab-11e9-843a-4e645373048e.tar@gitpod-dev-user-christesting"


### PR DESCRIPTION
## Description
Otherwise content init fails for private repositories.

## How to test
1. open a workspace on a private repo
2. enable the protected_secrets FF and open a workspace on a private repo

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
