### PR TITLE
Keep preview environment context in sync

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -34,7 +34,7 @@ tasks:
   - name: Install Preview Environment kube-context
     command: |
       (cd dev/preview/previewctl && go install .)
-      previewctl install-context
+      previewctl install-context --watch
       exit
   - name: Add Harvester kubeconfig
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,6 +30,9 @@ ports:
     onOpen: ignore
   # Dev Theia
   - port: 13444
+  # Used when using port-forwarding to SSH to preview environment VMs
+  - port: 8022
+    onOpen: ignore
 tasks:
   - name: Install Preview Environment kube-context
     command: |

--- a/dev/preview/previewctl/cmd/install_context.go
+++ b/dev/preview/previewctl/cmd/install_context.go
@@ -19,25 +19,53 @@ var (
 
 func installContextCmd(logger *logrus.Logger) *cobra.Command {
 
+	// Used to ensure that we only install contexts
+	var lastSuccessfulPreviewEnvironment *preview.Preview = nil
+
+	install := func(timeout time.Duration) error {
+		p, err := preview.New("", logger)
+
+		if err != nil {
+			return err
+		}
+
+		if lastSuccessfulPreviewEnvironment != nil && lastSuccessfulPreviewEnvironment.Same(p) {
+			logger.Infof("The preview envrionment hasn't changed")
+			return nil
+		}
+
+		err = p.InstallContext(true, timeout)
+		if err == nil {
+			lastSuccessfulPreviewEnvironment = p
+		}
+		return err
+	}
+
 	cmd := &cobra.Command{
 		Use:   "install-context",
 		Short: "Installs the kubectl context of a preview environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := preview.New(branch, logger)
-			if err != nil {
-				return err
-			}
 
-			err = p.InstallContext(watch, timeout)
-			if err != nil {
-				logger.WithFields(logrus.Fields{"err": err}).Fatal("Failed to install context.")
+			if watch {
+				for range time.Tick(15 * time.Second) {
+					// We're using a short timeout here to handle the scenario where someone switches
+					// to a branch that doens't have a preview envrionment. In that case the default
+					// timeout would mean that we would block for 10 minutes, potentially missing
+					// if the user changes to a new branch that does that a preview.
+					err := install(30 * time.Second)
+					if err != nil {
+						logger.WithFields(logrus.Fields{"err": err}).Info("Failed to install context. Trying again soon.")
+					}
+				}
+			} else {
+				return install(timeout)
 			}
 
 			return nil
 		},
 	}
 
-	cmd.Flags().BoolVar(&watch, "watch", false, "If wait is enabled, previewctl will keep trying to install the kube-context every 30 seconds.")
-	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 10*time.Minute, "Timeout for the watch flag.")
+	cmd.Flags().BoolVar(&watch, "watch", false, "If watch is enabled, previewctl will keep trying to install the kube-context every 15 seconds.")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 10*time.Minute, "Timeout before considering the installation failed")
 	return cmd
 }

--- a/dev/preview/previewctl/pkg/preview/preview.go
+++ b/dev/preview/previewctl/pkg/preview/preview.go
@@ -73,7 +73,7 @@ func (p *Preview) InstallContext(wait bool, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	p.logger.WithFields(logrus.Fields{"branch": p.branch, "timeout": timeout}).Infof("Installing context")
+	p.logger.WithFields(logrus.Fields{"timeout": timeout}).Infof("Installing context")
 
 	// we use this channel to signal when we've found an event in wait functions, so we know when we're done
 	doneCh := make(chan struct{})

--- a/dev/preview/previewctl/pkg/preview/preview.go
+++ b/dev/preview/previewctl/pkg/preview/preview.go
@@ -9,12 +9,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/gitpod-io/gitpod/previewctl/pkg/k8s"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/gitpod-io/gitpod/previewctl/pkg/k8s"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,6 +33,8 @@ type Preview struct {
 	kubeClient *k8s.Config
 
 	logger *logrus.Entry
+
+	vmiCreationTime *metav1.Time
 }
 
 func New(branch string, logger *logrus.Logger) (*Preview, error) {
@@ -55,17 +60,20 @@ func New(branch string, logger *logrus.Logger) (*Preview, error) {
 	}
 
 	return &Preview{
-		branch:     branch,
-		namespace:  fmt.Sprintf("preview-%s", GetName(branch)),
-		name:       GetName(branch),
-		kubeClient: harvesterConfig,
-		logger:     logEntry,
+		branch:          branch,
+		namespace:       fmt.Sprintf("preview-%s", GetName(branch)),
+		name:            GetName(branch),
+		kubeClient:      harvesterConfig,
+		logger:          logEntry,
+		vmiCreationTime: nil,
 	}, nil
 }
 
-func (p *Preview) InstallContext(watch bool, timeout time.Duration) error {
+func (p *Preview) InstallContext(wait bool, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
+	p.logger.WithFields(logrus.Fields{"branch": p.branch, "timeout": timeout}).Infof("Installing context")
 
 	// we use this channel to signal when we've found an event in wait functions, so we know when we're done
 	doneCh := make(chan struct{})
@@ -75,9 +83,9 @@ func (p *Preview) InstallContext(watch bool, timeout time.Duration) error {
 	err := p.kubeClient.GetVMStatus(ctx, p.name, p.namespace)
 	if err != nil && !errors.Is(err, k8s.ErrVmNotReady) {
 		return err
-	} else if errors.Is(err, k8s.ErrVmNotReady) && !watch {
+	} else if errors.Is(err, k8s.ErrVmNotReady) && !wait {
 		return err
-	} else if errors.Is(err, k8s.ErrVmNotReady) && watch {
+	} else if errors.Is(err, k8s.ErrVmNotReady) && wait {
 		err = p.kubeClient.WaitVMReady(ctx, p.name, p.namespace, doneCh)
 		if err != nil {
 			return err
@@ -87,16 +95,16 @@ func (p *Preview) InstallContext(watch bool, timeout time.Duration) error {
 	err = p.kubeClient.GetProxyVMServiceStatus(ctx, p.namespace)
 	if err != nil && !errors.Is(err, k8s.ErrSvcNotReady) {
 		return err
-	} else if errors.Is(err, k8s.ErrSvcNotReady) && !watch {
+	} else if errors.Is(err, k8s.ErrSvcNotReady) && !wait {
 		return err
-	} else if errors.Is(err, k8s.ErrSvcNotReady) && watch {
+	} else if errors.Is(err, k8s.ErrSvcNotReady) && wait {
 		err = p.kubeClient.WaitProxySvcReady(ctx, p.namespace, doneCh)
 		if err != nil {
 			return err
 		}
 	}
 
-	if watch {
+	if wait {
 		for {
 			select {
 			case <-ctx.Done():
@@ -105,6 +113,7 @@ func (p *Preview) InstallContext(watch bool, timeout time.Duration) error {
 				p.logger.Infof("waiting for context install to succeed")
 				err = installContext(p.branch)
 				if err == nil {
+					p.logger.Infof("Successfully installed context")
 					return nil
 				}
 			}
@@ -112,6 +121,36 @@ func (p *Preview) InstallContext(watch bool, timeout time.Duration) error {
 	}
 
 	return installContext(p.branch)
+}
+
+// Same compares two preview envrionments
+//
+// Preview environments are considered the same if they are based on the same underlying
+// branch and the VM hasn't changed.
+//
+func (p *Preview) Same(newPreview *Preview) bool {
+	sameBranch := p.branch == newPreview.branch
+	if !sameBranch {
+		return false
+	}
+
+	ensureVMICreationTime(p)
+	ensureVMICreationTime(newPreview)
+
+	return p.vmiCreationTime.Equal(newPreview.vmiCreationTime)
+}
+
+func ensureVMICreationTime(p *Preview) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if p.vmiCreationTime == nil {
+		creationTime, err := p.kubeClient.GetVMICreationTimestamp(ctx, p.name, p.namespace)
+		p.vmiCreationTime = creationTime
+		if err != nil {
+			p.logger.WithFields(logrus.Fields{"err": err}).Infof("Failed to get creation time")
+		}
+	}
 }
 
 func installContext(branch string) error {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR implements the `--watch` option and uses it in `.gitpod.yaml`. I considered the following requirements:

- It should deal with users changing branches
- It should deal with users using "with-clean-slate-deployment"; that is, it should re-install the kubectx if the underlying VM is recreated.

### Implementation

This changes the behaviour of "--watch" so that it runs forever and polls the current branch and VM periodically to see if a new preview environment context should be installed.

### Alternative implementation

If we wanted to avoid polling could've created a channel for changes to the preview environment. For changes to the VM we could (I think) have used an Informer. Branch changes would be a bit more tricky though but might be achievable using a git hook that sends a signal to the process. Or if the current branch is stored in the filesystem we might be able to be notified on changes to that file. 

I went with polling as that seemed like a smaller 🛹 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11108

## How to test
<!-- Provide steps to test this PR -->

```
# Run manually during development (or start a workspace off this branch as gitpod.yaml runs --watch
go run main.go install-context --watch

# To test switching branches:
# In another terminal
# change between a few different branches. See that it installs the context
git checkout main
# wait
kubectx
git checkout - 
# wait
kubectx

# To test re-creating the VM
werft run github -a with-clean-slate-deployment=true

```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
N/A