### PR TITLE
Team Subscription UI fixes

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -190,7 +190,9 @@ export default function UserDetail(p: { user: User }) {
                             >
                                 {accountStatement?.subscriptions
                                     ? accountStatement.subscriptions
-                                          .filter((s) => Subscription.isActive(s, new Date().toISOString()))
+                                          .filter(
+                                              (s) => !s.deleted && Subscription.isActive(s, new Date().toISOString()),
+                                          )
                                           .map((s) => Plans.getById(s.planId)?.name)
                                           .join(", ")
                                     : "---"}

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -185,11 +185,10 @@ function AllTeams() {
         return types;
     };
 
-    const getSlotsForSub = (sub: TeamSubscription) => {
+    const getSlotsForSub = (ts: TeamSubscription) => {
         const result: Slot[] = [];
-        const plan = getPlan(sub);
         slots.forEach((s) => {
-            if (s.teamSubscription.planId === plan.chargebeeId) {
+            if (s.teamSubscription.id === ts.id) {
                 result.push(s);
             }
         });

--- a/components/gitpod-db/src/typeorm/team-subscription-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-subscription-db-impl.ts
@@ -74,7 +74,8 @@ export class TeamSubscriptionDBImpl implements TeamSubscriptionDB {
             .createQueryBuilder("ts")
             .where("ts.userId = :userId", { userId: userId })
             .andWhere("ts.startDate <= :date", { date: date })
-            .andWhere('ts.endDate = "" OR ts.endDate > :date', { date: date });
+            .andWhere('ts.endDate = "" OR ts.endDate > :date', { date: date })
+            .andWhere("ts.deleted = FALSE");
         return query.getMany();
     }
 


### PR DESCRIPTION
## Description
This PR fixes two issues:
 1. "Teams" UI no longer displays slots from multiple Team Subscriptions, but used the id to match them correctly
 2. Do not forward "deleted" Team Subscriptions from the DB.
 3. User Details: filter out deleted subscriptions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11203 

## How to test
Not sure how to test: I'd argue we should thoroughly review the diff and judge based on that.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
two fixes the old Team Subscription UI
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
