### PR TITLE
Implement skateboard Usage view with dummy data

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -68,6 +68,7 @@ const JoinTeam = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/Jo
 const Members = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/Members"));
 const TeamSettings = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/TeamSettings"));
 const TeamBilling = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/TeamBilling"));
+const TeamUsage = React.lazy(() => import(/* webpackPrefetch: true */ "./teams/TeamUsage"));
 const NewProject = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/NewProject"));
 const ConfigureProject = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ConfigureProject"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Projects"));
@@ -439,6 +440,9 @@ function App() {
                                     }
                                     if (maybeProject === "billing") {
                                         return <TeamBilling />;
+                                    }
+                                    if (maybeProject === "usage") {
+                                        return <TeamUsage />;
                                     }
                                     if (resourceOrPrebuild === "prebuilds") {
                                         return <Prebuilds />;

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -64,6 +64,7 @@ export default function Menu() {
                 "members",
                 "settings",
                 "billing",
+                "usage",
                 // admin sub-pages
                 "users",
                 "workspaces",
@@ -220,7 +221,7 @@ export default function Menu() {
                 teamSettingsList.push({
                     title: "Settings",
                     link: `/t/${team.slug}/settings`,
-                    alternatives: getTeamSettingsMenu({ team, showPaymentUI }).flatMap((e) => e.link),
+                    alternatives: getTeamSettingsMenu({ team, showPaymentUI, showUsageBasedUI }).flatMap((e) => e.link),
                 });
             }
 

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -31,7 +31,7 @@ export default function TeamBilling() {
     const team = getCurrentTeam(location, teams);
     const [members, setMembers] = useState<TeamMemberInfo[]>([]);
     const [teamSubscription, setTeamSubscription] = useState<TeamSubscription2 | undefined>();
-    const { showPaymentUI, currency, setCurrency } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI, currency, setCurrency } = useContext(PaymentContext);
     const [pendingTeamPlan, setPendingTeamPlan] = useState<PendingPlan | undefined>();
     const [pollTeamSubscriptionTimeout, setPollTeamSubscriptionTimeout] = useState<NodeJS.Timeout | undefined>();
 
@@ -140,7 +140,7 @@ export default function TeamBilling() {
 
     return (
         <PageWithSubMenu
-            subMenu={getTeamSettingsMenu({ team, showPaymentUI })}
+            subMenu={getTeamSettingsMenu({ team, showPaymentUI, showUsageBasedUI })}
             title="Billing"
             subtitle="Manage team billing and plans."
         >

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -15,8 +15,8 @@ import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
 
-export function getTeamSettingsMenu(params: { team?: Team; showPaymentUI?: boolean }) {
-    const { team, showPaymentUI } = params;
+export function getTeamSettingsMenu(params: { team?: Team; showPaymentUI?: boolean; showUsageBasedUI?: boolean }) {
+    const { team, showPaymentUI, showUsageBasedUI } = params;
     return [
         {
             title: "General",
@@ -27,6 +27,14 @@ export function getTeamSettingsMenu(params: { team?: Team; showPaymentUI?: boole
                   {
                       title: "Billing",
                       link: [`/t/${team?.slug}/billing`],
+                  },
+              ]
+            : []),
+        ...(showUsageBasedUI
+            ? [
+                  {
+                      title: "Usage",
+                      link: [`/t/${team?.slug}/usage`],
                   },
               ]
             : []),
@@ -41,7 +49,7 @@ export default function TeamSettings() {
     const { user } = useContext(UserContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
 
     const close = () => setModal(false);
 
@@ -68,7 +76,7 @@ export default function TeamSettings() {
     return (
         <>
             <PageWithSubMenu
-                subMenu={getTeamSettingsMenu({ team, showPaymentUI })}
+                subMenu={getTeamSettingsMenu({ team, showPaymentUI, showUsageBasedUI })}
                 title="Settings"
                 subtitle="Manage general team settings."
             >

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext, useEffect, useState } from "react";
+import { Redirect, useLocation } from "react-router";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { getCurrentTeam, TeamsContext } from "./teams-context";
+import { getTeamSettingsMenu } from "./TeamSettings";
+import { PaymentContext } from "../payment-context";
+import { getGitpodService } from "../service/service";
+import { BillableSession, BillableWorkspaceType } from "@gitpod/gitpod-protocol/lib/usage";
+import { Item, ItemField, ItemsList } from "../components/ItemsList";
+import moment from "moment";
+import Property from "../admin/Property";
+import Arrow from "../components/Arrow";
+
+function TeamUsage() {
+    const { teams } = useContext(TeamsContext);
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
+    const location = useLocation();
+    const team = getCurrentTeam(location, teams);
+    const [billedUsage, setBilledUsage] = useState<BillableSession[]>([]);
+
+    useEffect(() => {
+        if (!team) {
+            return;
+        }
+        (async () => {
+            const billedUsageResult = await getGitpodService().server.getBilledUsage("some-attribution-id");
+            setBilledUsage(billedUsageResult);
+        })();
+    }, [team]);
+
+    if (!showUsageBasedUI) {
+        return <Redirect to="/" />;
+    }
+
+    const getType = (type: BillableWorkspaceType) => {
+        if (type === "regular") {
+            return "Workspace";
+        }
+        return "Prebuild";
+    };
+
+    const getHours = (endTime: number, startTime: number) => {
+        return (endTime - startTime) / (1000 * 60 * 60) + "hrs";
+    };
+
+    return (
+        <PageWithSubMenu
+            subMenu={getTeamSettingsMenu({ team, showPaymentUI, showUsageBasedUI })}
+            title="Usage"
+            subtitle="Manage team usage."
+        >
+            <div className="flex flex-col w-full">
+                <div className="flex w-full mt-6 mb-6">
+                    <Property name="Last 30 days">Jun 1 - June 30</Property>
+                    <Property name="Workspaces">4,200 Min</Property>
+                    <Property name="Prebuilds">12,334 Min</Property>
+                </div>
+            </div>
+            <ItemsList className="mt-2 text-gray-500">
+                <Item header={false} className="grid grid-cols-6 bg-gray-100">
+                    <ItemField className="my-auto">
+                        <span>Type</span>
+                    </ItemField>
+                    <ItemField className="my-auto">
+                        <span>Class</span>
+                    </ItemField>
+                    <ItemField className="my-auto">
+                        <span>Amount</span>
+                    </ItemField>
+                    <ItemField className="my-auto">
+                        <span>Credits</span>
+                    </ItemField>
+                    <ItemField className="my-auto" />
+                </Item>
+                {billedUsage.map((usage) => (
+                    <div
+                        key={usage.instanceId}
+                        className="flex p-3 grid grid-cols-6 justify-between transition ease-in-out rounded-xl focus:bg-gitpod-kumquat-light"
+                    >
+                        <div className="my-auto">
+                            <span className={usage.workspaceType === "prebuild" ? "text-orange-400" : "text-green-500"}>
+                                {getType(usage.workspaceType)}
+                            </span>
+                        </div>
+                        <div className="my-auto">
+                            <span className="text-gray-400">{usage.workspaceClass}</span>
+                        </div>
+                        <div className="my-auto">
+                            <span className="text-gray-700">{getHours(usage.endTime, usage.startTime)}</span>
+                        </div>
+                        <div className="my-auto">
+                            <span className="text-gray-700">{usage.credits}</span>
+                        </div>
+                        <div className="my-auto">
+                            <span className="text-gray-400">
+                                {moment(new Date(usage.startTime).toDateString()).fromNow()}
+                            </span>
+                        </div>
+                        <div className="pr-2">
+                            <Arrow up={false} />
+                        </div>
+                    </div>
+                ))}
+            </ItemsList>
+        </PageWithSubMenu>
+    );
+}
+
+export default TeamUsage;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -60,6 +60,7 @@ import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from "./
 import { IDEServer } from "./ide-protocol";
 import { InstallationAdminSettings, TelemetryData } from "./installation-admin-protocol";
 import { Currency } from "./plans";
+import { BillableSession } from "./usage";
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -287,6 +288,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string, currency: Currency): Promise<void>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
+
+    getBilledUsage(attributionId: string): Promise<BillableSession[]>;
 
     /**
      * Analytics

--- a/components/gitpod-protocol/src/usage.ts
+++ b/components/gitpod-protocol/src/usage.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { WorkspaceType } from "./protocol";
+
+export interface BillableSession {
+    // The id of the one paying the bill
+    attributionId: string;
+
+    // Relevant for workspace type. When prebuild, shows "prebuild"
+    userId?: string;
+    teamId?: string;
+
+    instanceId: string;
+
+    workspaceId: string;
+
+    workspaceType: BillableWorkspaceType;
+
+    // "standard" or "XL"
+    workspaceClass: string;
+
+    // When the workspace started
+    startTime: number;
+
+    // When the workspace ended
+    endTime: number;
+
+    // The credits used for this session
+    credits: number;
+
+    // TODO - maybe
+    projectId?: string;
+}
+
+export type BillableWorkspaceType = Omit<WorkspaceType, "probe">;
+
+export const billableSessionDummyData: BillableSession[] = [
+    {
+        attributionId: "some-attribution-id",
+        userId: "prebuild",
+        teamId: "prebuild",
+        instanceId: "some-instance-id",
+        workspaceId: "some-workspace-id",
+        workspaceType: "prebuild",
+        workspaceClass: "XL",
+        startTime: Date.now() + -3 * 24 * 3600 * 1000, // 3 days ago
+        endTime: Date.now(),
+        credits: 320,
+        projectId: "project-123",
+    },
+    {
+        attributionId: "some-attribution-id2",
+        userId: "some-user",
+        teamId: "some-team",
+        instanceId: "some-instance-id2",
+        workspaceId: "some-workspace-id2",
+        workspaceType: "regular",
+        workspaceClass: "standard",
+        startTime: Date.now() + -5 * 24 * 3600 * 1000,
+        endTime: Date.now(),
+        credits: 130,
+        projectId: "project-123",
+    },
+    {
+        attributionId: "some-attribution-id3",
+        userId: "some-other-user",
+        teamId: "some-other-team",
+        instanceId: "some-instance-id3",
+        workspaceId: "some-workspace-id3",
+        workspaceType: "regular",
+        workspaceClass: "XL",
+        startTime: Date.now() + -5 * 24 * 3600 * 1000,
+        endTime: Date.now() + -4 * 24 * 3600 * 1000,
+        credits: 150,
+        projectId: "project-134",
+    },
+    {
+        attributionId: "some-attribution-id4",
+        userId: "some-other-user2",
+        teamId: "some-other-team2",
+        instanceId: "some-instance-id4",
+        workspaceId: "some-workspace-id4",
+        workspaceType: "regular",
+        workspaceClass: "standard",
+        startTime: Date.now() + -10 * 24 * 3600 * 1000,
+        endTime: Date.now() + -9 * 24 * 3600 * 1000,
+        credits: 330,
+        projectId: "project-137",
+    },
+    {
+        attributionId: "some-attribution-id5",
+        userId: "some-other-user3",
+        teamId: "some-other-team3",
+        instanceId: "some-instance-id5",
+        workspaceId: "some-workspace-id5",
+        workspaceType: "regular",
+        workspaceClass: "XL",
+        startTime: Date.now() + -2 * 24 * 3600 * 1000,
+        endTime: Date.now(),
+        credits: 222,
+        projectId: "project-138",
+    },
+    {
+        attributionId: "some-attribution-id6",
+        userId: "some-other-user4",
+        teamId: "some-other-team4",
+        instanceId: "some-instance-id6",
+        workspaceId: "some-workspace-id3",
+        workspaceType: "regular",
+        workspaceClass: "XL",
+        startTime: Date.now() + -7 * 24 * 3600 * 1000,
+        endTime: Date.now() + -6 * 24 * 3600 * 1000,
+        credits: 300,
+        projectId: "project-134",
+    },
+    {
+        attributionId: "some-attribution-id8",
+        userId: "some-other-user5",
+        teamId: "some-other-team5",
+        instanceId: "some-instance-id8",
+        workspaceId: "some-workspace-id3",
+        workspaceType: "regular",
+        workspaceClass: "standard",
+        startTime: Date.now() + -1 * 24 * 3600 * 1000,
+        endTime: Date.now(),
+        credits: 100,
+        projectId: "project-567",
+    },
+    {
+        attributionId: "some-attribution-id7",
+        userId: "prebuild",
+        teamId: "some-other-team7",
+        instanceId: "some-instance-id7",
+        workspaceId: "some-workspace-id7",
+        workspaceType: "prebuild",
+        workspaceClass: "XL",
+        startTime: Date.now() + -1 * 24 * 3600 * 1000,
+        endTime: Date.now(),
+        credits: 200,
+        projectId: "project-345",
+    },
+];

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -70,6 +70,7 @@ import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositor
 import { EligibilityService } from "../user/eligibility-service";
 import { AccountStatementProvider } from "../user/account-statement-provider";
 import { GithubUpgradeURL, PlanCoupon } from "@gitpod/gitpod-protocol/lib/payment-protocol";
+import { BillableSession, billableSessionDummyData } from "@gitpod/gitpod-protocol/lib/usage";
 import {
     AssigneeIdentityIdentifier,
     TeamSubscription,
@@ -2054,6 +2055,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 `Failed to get Stripe portal URL for team '${teamId}'`,
             );
         }
+    }
+
+    async getBilledUsage(ctx: TraceContext, attributionId: string): Promise<BillableSession[]> {
+        return billableSessionDummyData;
     }
 
     // (SaaS) – admin

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -210,6 +210,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         findStripeSubscriptionIdForTeam: { group: "default", points: 1 },
         subscribeTeamToStripe: { group: "default", points: 1 },
         getStripePortalUrlForTeam: { group: "default", points: 1 },
+        getBilledUsage: { group: "default", points: 1 },
         trackEvent: { group: "default", points: 1 },
         trackLocation: { group: "default", points: 1 },
         identifyUser: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -167,6 +167,7 @@ import { LicenseEvaluator } from "@gitpod/licensor/lib";
 import { Feature } from "@gitpod/licensor/lib/api";
 import { Currency } from "@gitpod/gitpod-protocol/lib/plans";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { BillableSession } from "@gitpod/gitpod-protocol/lib/usage";
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi); // userId is already taken care of in WebsocketConnectionManager
@@ -3182,6 +3183,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+
+    async getBilledUsage(ctx: TraceContext, attributionId: string): Promise<BillableSession[]> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
+
     //
     //#endregion
 }


### PR DESCRIPTION
## Description
Skateboard of table of billable sessions with dummy data behind a feature flag.
We didn't have a design for this skateboard table (which will be updated according to the actual design), so the view here was my decision based on a combination of [this](https://gitpod.slack.com/archives/C01KPEPQYE6/p1657289918794709?thread_ts=1657137000.465299&cid=C01KPEPQYE6) and what dummy data we agreed on.

<img width="711" alt="Screenshot 2022-07-10 at 21 37 51" src="https://user-images.githubusercontent.com/8015191/178159557-310f54ac-44bc-44c3-9c5f-878faf0e4020.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11257 
I didn't list #10328 because this is only a skateboard of it - so I added this PR as a task under it.

## How to test
1. Join team "Gitpod" with this [link](https://laushinka-7c7be98297.preview.gitpod-dev.com/teams/join?inviteId=d0842f9c-4a3a-48d0-b234-9453fd3afd80).
2. Create any team.
3. Go to the team's Settings.
4. Click on "Usage".

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Users can see their billable sessions.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
