### PR TITLE
[ws-manager] log errors as warnings during exponential backoff

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -301,11 +301,11 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 			safePod, _ := log.RedactJSON(m)
 
 			if k8serr.IsAlreadyExists(err) {
-				clog.WithError(err).WithField("req", req).WithField("pod", safePod).Warn("was unable to start workspace which already exists")
+				clog.WithError(err).WithField("req", req).WithField("pod", string(safePod)).Warn("was unable to start workspace which already exists")
 				return false, status.Error(codes.AlreadyExists, "workspace instance already exists")
 			}
 
-			clog.WithError(err).WithField("req", req).WithField("pod", safePod).Error("was unable to start workspace")
+			clog.WithError(err).WithField("req", req).WithField("pod", string(safePod)).Warn("was unable to start workspace")
 			return false, err
 		}
 
@@ -331,7 +331,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 		if err != nil {
 			jsonPod, _ := json.Marshal(pod)
 			safePod, _ := log.RedactJSON(jsonPod)
-			clog.WithError(err).WithField("req", req).WithField("pod", string(safePod)).Error("was unable to reach ready state")
+			clog.WithError(err).WithField("req", req).WithField("pod", string(safePod)).Warn("was unable to reach ready state")
 			retryErr = err
 
 			var tempPod corev1.Pod
@@ -348,7 +348,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 						// pod doesn't exist, so we are safe to proceed with retry
 						return false, nil
 					}
-					clog.WithError(getErr).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Error("was unable to get pod")
+					clog.WithError(getErr).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Warn("was unable to get pod")
 					// pod get call failed so we error out
 					return false, retryErr
 				}
@@ -360,7 +360,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 						// pod doesn't exist, so we are safe to proceed with retry
 						return false, nil
 					}
-					clog.WithError(updateErr).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Error("was unable to remove finalizer")
+					clog.WithError(updateErr).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Warn("was unable to remove finalizer")
 					continue
 				}
 				finalizerRemoved = true
@@ -372,7 +372,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 
 			deleteErr := m.Clientset.Delete(rmCtx, &tempPod)
 			if deleteErr != nil && !k8serr.IsNotFound(deleteErr) {
-				clog.WithError(deleteErr).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Error("was unable to delete pod")
+				clog.WithError(deleteErr).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Warn("was unable to delete pod")
 				// failed to delete pod, so not going to be able to create a new pod, so bail out
 				return false, retryErr
 			}
@@ -388,6 +388,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	}
 
 	if err != nil {
+		clog.WithError(err).WithField("pod.Namespace", pod.Namespace).WithField("pod.Name", pod.Name).Error("was unable to start workspace after backoff")
 		return nil, xerrors.Errorf("cannot create workspace pod: %w", err)
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If we have an error after backoff, log it as an error, otherwise log errors during backoff as a warning.

The errors we encounter while doing exponential backoff should be treated as warnings, because they don't necessarily require action. This way, the error at the end (signifying we could not start a workspace) becomes more valuable.

For example, during a traffic shift, these were showing as errors, but that was false (we were waiting for nodes to scale-up).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
1. Go to the [preview environment](https://kylos101-b4ce73b066e.preview.gitpod-dev.com/workspaces)
2. Before you start a workspace in the preview environment, `kubectl cordon` the node (_this is already done_), so a workspace pod cannot be scheduled
3. Try starting a workspace 
4. Observe via `kubectl logs deployment/ws-manager ` that you see the warnings during backoff, the error at the end (after backoff), and that pod we log is a string representation of the pod object, rather than a byte array.

```
# errors being shown as warnings during back off
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"context deadline exceeded","instanceId":"28f4512d-0357-4594-8ef8-3988fb50942c","level":"warning","message":"was unable to start workspace","pod":"{\"metadata\":{\"annotations\":...

# the final error indicating backoff bumped into an error
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"context deadline exceeded","instanceId":"28f4512d-0357-4594-8ef8-3988fb50942c","level":"error","message":"was unable to start workspace after backoff","pod.Name":"ws-28f4512d-0357-4594-8ef8-3988fb50942c","pod.Namespace":"default",
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
