### PR TITLE
[usage] Implement initial gRPC API 

### DIFF
--- a/components/common-go/baseserver/config.go
+++ b/components/common-go/baseserver/config.go
@@ -15,7 +15,7 @@ type ServicesConfiguration struct {
 
 type ServerConfiguration struct {
 	Address string            `json:"address" yaml:"address"`
-	TLS     *TLSConfiguration `json:"tls" yaml:"tls"`
+	TLS     *TLSConfiguration `json:"tls,omitempty" yaml:"tls,omitempty"`
 }
 
 // GetAddress returns the configured address or an empty string of s is nil

--- a/components/usage/BUILD.yaml
+++ b/components/usage/BUILD.yaml
@@ -7,6 +7,7 @@ packages:
       - "go.sum"
     deps:
       - components/common-go:lib
+      - components/usage-api/go:lib
       - :init-testdb
     env:
       - CGO_ENABLED=0
@@ -19,6 +20,7 @@ packages:
     type: go
     deps:
       - components/common-go:lib
+      - components/usage-api/go:lib
     srcs:
       - "**/*.go"
       - "go.mod"

--- a/components/usage/config.json
+++ b/components/usage/config.json
@@ -1,3 +1,10 @@
 {
-  "controllerSchedule": "1h"
+  "controllerSchedule": "1h",
+  "server": {
+    "services": {
+      "grpc": {
+        "address": ":9001"
+      }
+    }
+  }
 }

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/usage-api v0.0.0-00010101000000-000000000000
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/uuid v1.1.2
 	github.com/prometheus/client_golang v1.12.1
@@ -44,12 +45,14 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
-	google.golang.org/grpc v1.45.0 // indirect
+	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace github.com/gitpod-io/gitpod/usage-api => ../usage-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.23.5 // leeway indirect from components/common-go:lib
 

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -58,8 +58,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
-github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -76,7 +76,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -139,6 +139,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -491,6 +492,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -635,8 +637,8 @@ google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.45.0 h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=
-google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
+google.golang.org/grpc v1.47.0 h1:9n77onPX5F3qfFCqjy9dhn8PbNQsIKeVU04J9G7umt8=
+google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -649,6 +651,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -5,9 +5,6 @@
 package apiv1
 
 import (
-	"context"
-	"fmt"
-
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 )
 
@@ -17,8 +14,4 @@ type UsageService struct {
 
 func NewUsageService() *UsageService {
 	return &UsageService{}
-}
-
-func (u *UsageService) GetUsage(context.Context, *v1.GetUsageRequest) (*v1.GetUsageResponse, error) {
-	return nil, fmt.Errorf("RPC not implemented")
 }

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package apiv1
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
+)
+
+type UsageService struct {
+	v1.UnimplementedUsageServiceServer
+}
+
+func NewUsageService() *UsageService {
+	return &UsageService{}
+}
+
+func (u *UsageService) GetUsage(context.Context, *v1.GetUsageRequest) (*v1.GetUsageResponse, error) {
+	return nil, fmt.Errorf("RPC not implemented")
+}

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -5,8 +5,10 @@ package usage
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/usage/pkg/server"
 	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/gitpod-io/gitpod/usage/pkg/server"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
@@ -18,6 +20,13 @@ import (
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
 		ControllerSchedule: time.Hour.String(),
+		Server: &baseserver.Configuration{
+			Services: baseserver.ServicesConfiguration{
+				GRPC: &baseserver.ServerConfiguration{
+					Address: fmt.Sprintf(":%d", gRPCContainerPort),
+				},
+			},
+		},
 	}
 
 	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -27,8 +27,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
        "server": {
          "services": {
            "grpc": {
-             "address": ":9001",
-             "tls": null
+             "address": ":9001"
            }
          }
        }

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -20,5 +20,19 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 	cfgmap, ok := objs[0].(*corev1.ConfigMap)
 	require.True(t, ok)
 
-	require.JSONEq(t, cfgmap.Data[configJSONFilename], `{"controllerSchedule": "2m", "stripeCredentialsFile": "stripe-secret/apikeys"}`)
+	require.JSONEq(t,
+		`{
+       "controllerSchedule": "2m",
+       "stripeCredentialsFile": "stripe-secret/apikeys",
+       "server": {
+         "services": {
+           "grpc": {
+             "address": ":9001",
+             "tls": null
+           }
+         }
+       }
+     }`,
+		cfgmap.Data[configJSONFilename],
+	)
 }

--- a/install/installer/pkg/components/usage/constants.go
+++ b/install/installer/pkg/components/usage/constants.go
@@ -7,6 +7,8 @@ package usage
 const (
 	Component             = "usage"
 	gRPCContainerPort     = 9001
+	gRPCPortName          = "grpc"
+	gRPCServicePort       = 9001
 	stripeSecretMountPath = "stripe-secret"
 	stripeKeyFilename     = "apikeys"
 	configJSONFilename    = "config.json"

--- a/install/installer/pkg/components/usage/constants.go
+++ b/install/installer/pkg/components/usage/constants.go
@@ -6,6 +6,7 @@ package usage
 
 const (
 	Component             = "usage"
+	gRPCContainerPort     = 9001
 	stripeSecretMountPath = "stripe-secret"
 	stripeKeyFilename     = "apikeys"
 	configJSONFilename    = "config.json"

--- a/install/installer/pkg/components/usage/networkpolicy.go
+++ b/install/installer/pkg/components/usage/networkpolicy.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package usage
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.DefaultLabels(Component)
+
+	return []runtime.Object{
+		&networkingv1.NetworkPolicy{
+			TypeMeta: common.TypeMetaNetworkPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: labels},
+				PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: gRPCContainerPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.ServerComponent,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/usage/objects.go
+++ b/install/installer/pkg/components/usage/objects.go
@@ -23,6 +23,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		configmap,
 		common.DefaultServiceAccount(Component),
 		service,
+		networkpolicy,
 	)(ctx)
 }
 

--- a/install/installer/pkg/components/usage/objects.go
+++ b/install/installer/pkg/components/usage/objects.go
@@ -22,6 +22,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		rolebinding,
 		configmap,
 		common.DefaultServiceAccount(Component),
+		service,
 	)(ctx)
 }
 

--- a/install/installer/pkg/components/usage/objects_test.go
+++ b/install/installer/pkg/components/usage/objects_test.go
@@ -27,7 +27,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 5, "should render expected k8s objects")
+	require.Len(t, objects, 6, "should render expected k8s objects")
 }
 
 func renderContextWithUsageConfig(t *testing.T, usage *experimental.UsageConfig) *common.RenderContext {

--- a/install/installer/pkg/components/usage/objects_test.go
+++ b/install/installer/pkg/components/usage/objects_test.go
@@ -27,7 +27,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 6, "should render expected k8s objects")
+	require.Len(t, objects, 7, "should render expected k8s objects")
 }
 
 func renderContextWithUsageConfig(t *testing.T, usage *experimental.UsageConfig) *common.RenderContext {

--- a/install/installer/pkg/components/usage/service.go
+++ b/install/installer/pkg/components/usage/service.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package usage
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          gRPCPortName,
+			ContainerPort: gRPCContainerPort,
+			ServicePort:   gRPCServicePort,
+		},
+	})(ctx)
+}


### PR DESCRIPTION
## Description
https://github.com/gitpod-io/gitpod/pull/11221 added the `.proto` definitions for a placeholder gRPC API for the `usage` component. 

This PR implements the server side of that placeholder API.

Also updates the installer to deploy config for the `usage` component so that it serves gRPC and adds a k8s service through which it can be accessed.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/10324

## How to test

*  Run the `usage` service locally:
```
cd components/usage
leeway build .:init-testdb
DB_USERNAME=gitpod DB_PORT=23306 DB_PASSWORD=test go run . run
```

* Access the gRPC API (using [evans](https://github.com/ktr0731/evans/releases)):
```
evans -p 9001 -r repl
> package usage.v1
> show services
```

The placeholder API is shown:

<img width="616" alt="image" src="https://user-images.githubusercontent.com/8225907/177953211-bbe9eb3d-59f4-4f05-a852-ee0b1f81070e.png">


## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:

- [x] /werft with-preview

/hold