### PR TITLE
Hot fix release for `local-preview`

### DIFF
--- a/components/installation-telemetry/cmd/send.go
+++ b/components/installation-telemetry/cmd/send.go
@@ -45,6 +45,11 @@ var sendCmd = &cobra.Command{
 			return fmt.Errorf("GITPOD_INSTALLATION_VERSION envvar not set")
 		}
 
+		platform := os.Getenv("GITPOD_INSTALLATION_PLATFORM")
+		if platform == "" {
+			return fmt.Errorf("GITPOD_INSTALLATION_PLATFORM envvar not set")
+		}
+
 		client, err := analytics.NewWithConfig(segmentIOToken, analytics.Config{})
 		defer func() {
 			err = client.Close()
@@ -54,7 +59,8 @@ var sendCmd = &cobra.Command{
 			Set("version", versionId).
 			Set("totalUsers", data.TotalUsers).
 			Set("totalWorkspaces", data.TotalWorkspaces).
-			Set("totalInstances", data.TotalInstances)
+			Set("totalInstances", data.TotalInstances).
+			Set("platform", platform)
 
 		if data.InstallationAdmin.Settings.SendCustomerID {
 			properties.Set("customerID", data.CustomerID)

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -25,7 +25,8 @@
         { "path": "dev/gpctl" },
         { "path": "dev/loadgen" },
         { "path": "dev/poolkeeper" },
-        { "path": "install/installer" }
+        { "path": "install/installer" },
+        { "path": "install/preview" }
     ],
     "settings": {
         "typescript.tsdk": "gitpod/node_modules/typescript/lib",

--- a/install/installer/pkg/components/gitpod/cronjob.go
+++ b/install/installer/pkg/components/gitpod/cronjob.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,14 @@ func cronjob(ctx *common.RenderContext) ([]runtime.Object, error) {
 	if ctx.Config.Kind == config.InstallationWorkspace {
 		return []runtime.Object{}, nil
 	}
+
+	platformTelemetryData := "unknown"
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.Telemetry != nil && cfg.Telemetry.Data.Platform != "" {
+			platformTelemetryData = cfg.Telemetry.Data.Platform
+		}
+		return nil
+	})
 
 	installationTelemetryComponent := fmt.Sprintf("%s-telemetry", Component)
 
@@ -62,6 +71,10 @@ func cronjob(ctx *common.RenderContext) ([]runtime.Object, error) {
 											{
 												Name:  "GITPOD_INSTALLATION_VERSION",
 												Value: ctx.VersionManifest.Version,
+											},
+											{
+												Name:  "GITPOD_INSTALLATION_PLATFORM",
+												Value: platformTelemetryData,
 											},
 											{
 												Name:  "SERVER_URL",

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -21,6 +21,13 @@ type Config struct {
 	WebApp    *WebAppConfig    `json:"webapp,omitempty"`
 	IDE       *IDEConfig       `json:"ide,omitempty"`
 	Common    *CommonConfig    `json:"common,omitempty"`
+	Telemetry *TelemetryConfig `json:"telemetry,omitempty"`
+}
+
+type TelemetryConfig struct {
+	Data struct {
+		Platform string `json:"platform"`
+	} `json:"data"`
 }
 
 type CommonConfig struct {

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -273,6 +273,9 @@ spec:
                 fi
               fi
 
+              echo "Gitpod: Update platform telemetry value"
+              yq eval-all --inplace '.experimental.telemetry.data.platform = "{{repl Distribution }}"' "${CONFIG_FILE}"
+
               echo "Gitpod: Patch Gitpod config"
               base64 -d "${CONFIG_PATCH_FILE}" > /tmp/patch.yaml
               config_patch=$(cat /tmp/patch.yaml)

--- a/install/preview/BUILD.yaml
+++ b/install/preview/BUILD.yaml
@@ -14,4 +14,4 @@ packages:
     config:
       dockerfile: leeway.Dockerfile
       image:
-        - ${imageRepoBase}/preview-install:${version}
+        - ${imageRepoBase}/local-preview:${version}

--- a/install/preview/README.md
+++ b/install/preview/README.md
@@ -1,4 +1,4 @@
-# Gitpod Preview Installation
+# Gitpod Local Preview
 
 This repo helps users to try out and preview self-hosted Gitpod **locally** without all the things
 needed for a production instance. The aim is to provide an installation mechanism as minimal and
@@ -7,7 +7,7 @@ simple as possible.
 ## Installation
 
 ```bash
-docker run --privileged --name gitpod --rm -it -v /tmp/gitpod:/var/gitpod eu.gcr.io/gitpod-core-dev/build/preview-install:tar-preview-output.2
+docker run --privileged --name gitpod --rm -it -v /tmp/gitpod:/var/gitpod eu.gcr.io/gitpod-core-dev/build/preview-install
 ```
 
 Once the above command starts running and the pods are ready (can be checked by running `docker exec gitpod kubectl get pods`),

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -136,6 +136,18 @@ yq eval-all -i 'del(.spec.template.spec.initContainers[0])' /var/lib/rancher/k3s
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/manifests/gitpod.yaml; done
 rm -rf /var/lib/rancher/k3s/server/manifests/gitpod
 
+# waits for gitpod pods to be ready, and manually runs the `gitpod-telemetry` cronjob
+run_telemetry(){
+  # wait for the k3s cluster to be ready and Gitpod workloads are added
+  sleep 100
+  # indefinitely wait for Gitpod pods to be ready
+  kubectl wait --timeout=-1s --for=condition=ready pod -l app=gitpod,component!=migrations
+  # manually tun the cronjob
+  kubectl create job gitpod-telemetry-init --from=cronjob/gitpod-telemetry
+}
+
+run_telemetry 2>&1 &
+
 /bin/k3s server --disable traefik \
   --node-label gitpod.io/workload_meta=true \
   --node-label gitpod.io/workload_ide=true \

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -105,9 +105,10 @@ yq e -i '.customCACert.kind = "secret"' config.yaml
 yq e -i '.observability.logLevel = "debug"' config.yaml
 yq e -i '.workspace.runtime.containerdSocket = "/run/k3s/containerd/containerd.sock"' config.yaml
 yq e -i '.workspace.runtime.containerdRuntimeDir = "/var/lib/rancher/k3s/agent/containerd/io.containerd.runtime.v2.task/k8s.io/"' config.yaml
+yq e -i '.experimental.telemetry.data.platform = "local-preview"' config.yaml
 
 echo "extracting images to download ahead..."
-/gitpod-installer render --config config.yaml | grep 'image:' | sed 's/ *//g' | sed 's/image://g' | sed 's/\"//g' | sed 's/^-//g' | sort | uniq > /gitpod-images.txt
+/gitpod-installer render --use-experimental-config --config config.yaml | grep 'image:' | sed 's/ *//g' | sed 's/image://g' | sed 's/\"//g' | sed 's/^-//g' | sort | uniq > /gitpod-images.txt
 echo "downloading images..."
 while read -r image "$(cat /gitpod-images.txt)"; do
    # shellcheck disable=SC2154
@@ -116,7 +117,7 @@ done
 
 ctr images pull "docker.io/gitpod/workspace-full:latest" >/dev/null &
 
-/gitpod-installer render --config config.yaml --output-split-files /var/lib/rancher/k3s/server/manifests/gitpod
+/gitpod-installer render --use-experimental-config --config config.yaml --output-split-files /var/lib/rancher/k3s/server/manifests/gitpod
 
 # store files in `gitpod.debug` for debugging purposes
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/gitpod.debug; done


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Even though `local-preview` builds along side the `self-hosted` release, It requires
a faster release cycles atleast in the initial stages and hence hotfixes. This is one such
release, which constitutes
- Renaming of `preview-install` to `local-preview`
- Adding new `platform` telemetry field to distinguish general installs from this,
  and which runs right away.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11114 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
