### PR TITLE
[gpctl] add command to get last heartbeat time of workspace

### DIFF
--- a/dev/gpctl/cmd/workspaces-last-heartbeat.go
+++ b/dev/gpctl/cmd/workspaces-last-heartbeat.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/ws-manager/api"
+)
+
+// workspacesLastHeartbeatCmd get workspace last heartbeat time
+var workspacesLastHeartbeatCmd = &cobra.Command{
+	Use:   "last-heartbeat <instanceID>",
+	Short: "get workspace last heartbeat time",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		conn, client, err := getWorkspacesClient(ctx)
+		if err != nil {
+			log.WithError(err).Fatal("cannot connect")
+		}
+		defer conn.Close()
+
+		instanceID := args[0]
+
+		resp, err := client.DescribeWorkspace(ctx, &api.DescribeWorkspaceRequest{
+			Id: instanceID,
+		})
+		if err != nil {
+			log.WithError(err).Fatal("error during RPC call")
+		}
+
+		fmt.Println(resp.LastActivity)
+	},
+}
+
+func init() {
+	workspacesCmd.AddCommand(workspacesLastHeartbeatCmd)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open a workspace in prev env
- Open this gitpod with this PR
- Get workspace instance id that you created
```
# from k8s
kubectl get pods | grep ws-

# from workspace terminal
env | grep INSTANCE_ID
```
- Exec `gpctl workspaces last-heartbeat <instance_id>` in gitpod repo workspace

Should output like
```
gitpod /workspace/gitpod/dev/gpctl (main) $ go run main.go workspaces last-heartbeat 3191e531-2c7c-42e5-8f28-57ab47fd33f9
2022-07-08T09:21:09.103544311Z
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
