### PR TITLE
[dashboard] Show assigned node for workspace

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -144,6 +144,11 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                             {workspace.stoppedTime ? moment(workspace.stoppedTime).fromNow() : "---"}
                         </Property>
                     </div>
+                    <div className="flex w-full mt-12">
+                        <Property name="Node">
+                            <div className="overflow-scroll">{workspace.status.nodeName ?? "not assigned"}</div>
+                        </Property>
+                    </div>
                     <div className="flex w-full mt-6">{[0, 1, 2].map(adminLink)}</div>
                     <div className="flex w-full mt-6">{[3, 4, 5].map(adminLink)}</div>
                 </div>


### PR DESCRIPTION
## Description
Sometimes it is useful to know the node a workspace was scheduled on. This adds the node name to the admin dashboard.

![ShowNode](https://user-images.githubusercontent.com/24721048/177984354-f5ccac6e-0bd9-434e-b1cc-9998be58bf89.png)


## Related Issue(s)
n.a.

## How to test
- Start a workspace in preview environment and check the workspace in admin

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
