### PR TITLE
[usage] Add network policy to allow ingress from server

### DIFF
--- a/install/installer/pkg/components/usage/networkpolicy.go
+++ b/install/installer/pkg/components/usage/networkpolicy.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package usage
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.DefaultLabels(Component)
+
+	return []runtime.Object{
+		&networkingv1.NetworkPolicy{
+			TypeMeta: common.TypeMetaNetworkPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: labels},
+				PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: gRPCContainerPort},
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.ServerComponent,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/usage/objects.go
+++ b/install/installer/pkg/components/usage/objects.go
@@ -23,6 +23,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		configmap,
 		common.DefaultServiceAccount(Component),
 		service,
+		networkpolicy,
 	)(ctx)
 }
 

--- a/install/installer/pkg/components/usage/objects_test.go
+++ b/install/installer/pkg/components/usage/objects_test.go
@@ -27,7 +27,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 6, "should render expected k8s objects")
+	require.Len(t, objects, 7, "should render expected k8s objects")
 }
 
 func renderContextWithUsageConfig(t *testing.T, usage *experimental.UsageConfig) *common.RenderContext {


### PR DESCRIPTION
## Description

Add a network policy for the usage component so that it accepts incoming gRPC connections from `server` (and no other components).

## Related Issue(s)

Part of #9036 

## How to test

1. Open a preview environment and install the kubecontext for this branch:
```
previewctl install-context
```
2. Run an ubuntu pod in the `default` namespace.
```
kubectl run ubuntu -it --image ubuntu -- /bin/sh
```
3. Install a `grpc` client like [evans](https://github.com/ktr0731/evans/releases) or `grpcurl` into the container.

4. Try to connect from the `ubuntu` pod to the `usage` service:
```
./evans --host usage -p 9001 -r repl
```
See that it fails.

5. Label the `ubuntu` pod:
```
kubectl label pod ubuntu component=server
```
6. Try the same `evans` command from inside the ubuntu container.

This time the connection succeeds because the pod is labelled correctly for the network policy to allow ingress.

## Release Notes

```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
