### PR TITLE
[kots]: add node CPU/memory check tests to workspace node only

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -193,18 +193,80 @@ spec:
           - pass:
               message: Cert-manager is installed and available.
     - nodeResources:
-        checkName: CPU Cores per node
+        checkName: CPU Cores per workload_workspace_services node
+        filters:
+          selector:
+            matchLabel:
+              gitpod.io/workload_workspace_services: "true"
         outcomes:
           - fail:
               when: "min(cpuCapacity) < 2"
-              message: The cluster must contain at least 2 cores
+              message: The nodes must contain at least 2 cores
           - warn:
               when: "min(cpuCapacity) < 4"
-              message: The cluster must contain at least 4 cores
+              message: The nodes must contain at least 4 cores
           - pass:
-              message: There are at least 4 cores in the cluster
+              message: There are at least 4 cores in the nodes
     - nodeResources:
-        checkName: Memory per node
+        checkName: CPU Cores per workload_workspace_regular node
+        filters:
+          selector:
+            matchLabel:
+              gitpod.io/workload_workspace_regular: "true"
+        outcomes:
+          - fail:
+              when: "min(cpuCapacity) < 2"
+              message: The nodes must contain at least 2 cores
+          - warn:
+              when: "min(cpuCapacity) < 4"
+              message: The nodes must contain at least 4 cores
+          - pass:
+              message: There are at least 4 cores in the nodes
+    - nodeResources:
+        checkName: CPU Cores per workload_workspace_headless node
+        filters:
+          selector:
+            matchLabel:
+              gitpod.io/workload_workspace_headless: "true"
+        outcomes:
+          - fail:
+              when: "min(cpuCapacity) < 2"
+              message: The nodes must contain at least 2 cores
+          - warn:
+              when: "min(cpuCapacity) < 4"
+              message: The nodes must contain at least 4 cores
+          - pass:
+              message: There are at least 4 cores in the nodes
+    - nodeResources:
+        checkName: Memory per workload_workspace_services node
+        filters:
+          selector:
+            matchLabel:
+              gitpod.io/workload_workspace_services: "true"
+        outcomes:
+          - fail:
+              when: "min(memoryCapacity) < 16G"
+              message: Each node must have at least 16GB of memory
+          - pass:
+              message: Each node has at least 16GB of memory
+    - nodeResources:
+        checkName: Memory per workload_workspace_regular node
+        filters:
+          selector:
+            matchLabel:
+              gitpod.io/workload_workspace_regular: "true"
+        outcomes:
+          - fail:
+              when: "min(memoryCapacity) < 16G"
+              message: Each node must have at least 16GB of memory
+          - pass:
+              message: Each node has at least 16GB of memory
+    - nodeResources:
+        checkName: Memory per workload_workspace_headless node
+        filters:
+          selector:
+            matchLabel:
+              gitpod.io/workload_workspace_headless: "true"
         outcomes:
           - fail:
               when: "min(memoryCapacity) < 16G"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Applies tests on the CPU/memory to the workspace nodes only. Our [requirements](https://www.gitpod.io/docs/self-hosted/latest/cluster-set-up) only stipulate the performance of these nodes, not all the nodes in the cluster.

This also changes the wording for the CPU tests to change "cluster" to "node" (a remnant of when we had the tests on a cluster basis).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9307

## How to test
<!-- Provide steps to test this PR -->
Run the preflight checks

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add node CPU/memory check tests to workspace node only
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
