### PR TITLE
[db-sync] Add alert for crashlooping

### DIFF
--- a/operations/observability/mixins/meta/rules/components/db-sync/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/db-sync/alerts.libsonnet
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'gitpod-component-meta-db-sync-alerts',
+        rules: [
+          {
+            alert: 'DBSyncCrashLooping',
+            expr: 'sum(increase(kube_pod_container_status_restarts_total{container=~"db-sync.*"}[30m])) > 5',
+            'for': '30m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/DBSyncCrashLooping.md',
+              summary: 'DB Sync is crashlooping and has restarted more than 5 times in the last 30 minutes',
+              description: 'DB Sync ensures US and EU databases are in sync. It has been crash-looping which indicates it is not able to synchronize DBs. Prolonged failure will lead to data out sync.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds alert for db-sync crash-looping. This happened on Thursday 2022-07-07 and was not detected automatically.

<img width="1606" alt="Screenshot 2022-07-08 at 15 21 20" src="https://user-images.githubusercontent.com/1419286/178000094-035d00c6-5ac1-4f74-a02f-698a7d3f480f.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
