### PR TITLE
[feature flags] Nudge passing in full User shapes and derive email from it

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -170,7 +170,7 @@ export default function Menu() {
                 "isUsageBasedBillingEnabled",
                 false,
                 {
-                    userId: user?.id,
+                    user,
                     projectId: project?.id,
                     teamId: team?.id,
                     teamName: team?.name,

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -14,6 +14,7 @@ import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
 import { ProjectContext } from "./project-context";
 import { getExperimentsClient } from "./../experiments/client";
+import { UserContext } from "../user-context";
 
 export function getProjectSettingsMenu(project?: Project, team?: Team) {
     const teamOrUserSlug = !!team ? "t/" + team.slug : "projects";
@@ -50,6 +51,7 @@ export function ProjectSettingsPage(props: { project?: Project; children?: React
 }
 
 export default function () {
+    const { user } = useContext(UserContext);
     const { project } = useContext(ProjectContext);
     const location = useLocation();
     const { teams } = useContext(TeamsContext);
@@ -64,10 +66,14 @@ export default function () {
         }
         setProjectSettings({ ...project.settings });
         (async () => {
+            if (!user) {
+                return;
+            }
             const showPersistentVolumeClaim = await getExperimentsClient().getValueAsync(
                 "persistent_volume_claim",
                 false,
                 {
+                    user,
                     projectId: project?.id,
                     teamId: team?.id,
                     teamName: team?.name,

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -54,7 +54,12 @@ export default function Preferences() {
 
     const [isShowWorkspaceClasses, setIsShowWorkspaceClasses] = useState<boolean>(false);
     (async () => {
-        const showWorkspaceClasses = await getExperimentsClient().getValueAsync("workspace_classes", false, {});
+        if (!user) {
+            return;
+        }
+        const showWorkspaceClasses = await getExperimentsClient().getValueAsync("workspace_classes", false, {
+            user,
+        });
         setIsShowWorkspaceClasses(showWorkspaceClasses);
     })();
 

--- a/components/gitpod-protocol/src/experiments/configcat.ts
+++ b/components/gitpod-protocol/src/experiments/configcat.ts
@@ -5,8 +5,9 @@
  */
 
 import { Attributes, Client } from "./types";
-import { User } from "configcat-common/lib/RolloutEvaluator";
+import { User as ConfigCatUser } from "configcat-common/lib/RolloutEvaluator";
 import { IConfigCatClient } from "configcat-common/lib/ConfigCatClient";
+import { User } from "../protocol";
 
 export const PROJECT_ID_ATTRIBUTE = "project_id";
 export const TEAM_ID_ATTRIBUTE = "team_id";
@@ -30,9 +31,9 @@ export class ConfigCatClient implements Client {
     }
 }
 
-export function attributesToUser(attributes: Attributes): User {
-    const userId = attributes.userId || "";
-    const email = attributes.email || "";
+export function attributesToUser(attributes: Attributes): ConfigCatUser {
+    const userId = attributes.user?.id || "";
+    const email = User.is(attributes.user) ? User.getPrimaryEmail(attributes.user) : attributes.user?.email || "";
 
     const custom: { [key: string]: string } = {};
     if (attributes.projectId) {
@@ -49,5 +50,5 @@ export function attributesToUser(attributes: Attributes): User {
         custom[TEAM_IDS_ATTRIBUTE] = attributes.teams.map((t) => t.id).join(",");
     }
 
-    return new User(userId, email, "", custom);
+    return new ConfigCatUser(userId, email, "", custom);
 }

--- a/components/gitpod-protocol/src/experiments/types.ts
+++ b/components/gitpod-protocol/src/experiments/types.ts
@@ -4,6 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { User } from "../protocol";
 import { Team } from "../teams-projects-protocol";
 
 export const Client = Symbol("Client");
@@ -11,8 +12,7 @@ export const Client = Symbol("Client");
 // Attributes define attributes which can be used to segment audiences.
 // Set the attributes which you want to use to group audiences into.
 export interface Attributes {
-    userId?: string;
-    email?: string;
+    user?: User | { id: string; email?: string };
 
     // Currently selected Gitpod Project ID
     projectId?: string;
@@ -23,7 +23,7 @@ export interface Attributes {
     teamName?: string;
 
     // All the Gitpod Teams that the user is a member (or owner) of
-    teams?: Array<Team>;
+    teams?: Team[];
 }
 
 export interface Client {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1946,7 +1946,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             "isUsageBasedBillingEnabled",
             false,
             {
-                userId: user.id,
+                user,
                 teams: teams,
             },
         );

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1576,7 +1576,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 "deprecateOldImageLogsMechanism",
                 false,
                 {
-                    userId: user.id,
+                    user,
                     projectId: workspace.projectId,
                 },
             );


### PR DESCRIPTION

## Description
This will more effective segmentation based on emails and potentially other things, like identity providers (GitHub, GitLab, BitBucket etc.)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
