### PR TITLE
Use `omitempty` struct tag in baseserver config

### DIFF
--- a/components/common-go/baseserver/config.go
+++ b/components/common-go/baseserver/config.go
@@ -15,7 +15,7 @@ type ServicesConfiguration struct {
 
 type ServerConfiguration struct {
 	Address string            `json:"address" yaml:"address"`
-	TLS     *TLSConfiguration `json:"tls" yaml:"tls"`
+	TLS     *TLSConfiguration `json:"tls,omitempty" yaml:"tls,omitempty"`
 }
 
 // GetAddress returns the configured address or an empty string of s is nil

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -27,8 +27,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
        "server": {
          "services": {
            "grpc": {
-             "address": ":9001",
-             "tls": null
+             "address": ":9001"
            }
          }
        }


### PR DESCRIPTION
## Description

Add an `omitempty` struct tag to the `TLS` field in the baseserver config. This makes it slightly easier to write tests against.


## Related Issue(s)

See [this comment](https://github.com/gitpod-io/gitpod/pull/11224#discussion_r916627199) on https://github.com/gitpod-io/gitpod/pull/11224

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/hold