### PR TITLE
Update feedback issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback_issue.yml
+++ b/.github/ISSUE_TEMPLATE/feedback_issue.yml
@@ -1,15 +1,15 @@
 name: Feedback Issue
-description: Open a feedback issue to gather feedback, suggestions, and experiences from users.
+description: Feedback issues are used to gather feedback, suggestions, and experiences from users while iterating on a specific product feature.
 title: "Feedback Issue: "
 labels: ["feedback-issue"]
 body:
 - type: markdown
   attributes:
-    value: Before raising a feedback issue, please search for [existing feedback issues](https://github.com/gitpod-io/gitpod/issues?q=is%3Aopen+is%3Aissue+label%3Afeedback-issue) to avoid creating duplicates.
+    value: Before raising a feedback issue, please search for [existing feedback issues](https://github.com/gitpod-io/gitpod/issues?q=is%3Aopen+is%3Aissue+label%3Afeedback-issue) to avoid creating duplicates. If you are looking to [report a bug](https://github.com/gitpod-io/gitpod/issues/new?assignees=&labels=type%3A+bug&template=bug_report.yml) or [suggest a feature request](https://github.com/gitpod-io/gitpod/issues/new?assignees=&labels=&template=feature_request.md&title=) choose a different issue template.
 - type: textarea
   id: objective
   attributes:
     label: Objective
-    description: Include the objective of this issue and any relevant features 
+    description: Include the objective of this issue and any relevant features
   validations:
     required: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The goal of the feedback issue template is to make it easier and provide a skeleton for opening feedback issues for specific features as done in the past, see relevant pull request in https://github.com/gitpod-io/gitpod/pull/10593.

See also [relevant discussion](https://gitpod.slack.com/archives/C01KLC5750D/p1652903673228329) (internal). Cc @atduarte 

There were a few issues (see list below) opened recently using this template that actually aimed at providing general feedback instead. This caused new issues having the **~feedback-issue** label or the **Feedback Issue:** title prefix while containing general feedback.

This will update the description of the template to clarify the goal of this template.

- https://github.com/gitpod-io/gitpod/issues/11062
- https://github.com/gitpod-io/gitpod/issues/11063
- https://github.com/gitpod-io/gitpod/issues/10817
- https://github.com/gitpod-io/gitpod/issues/11227
- ...

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
