### PR TITLE
Improve  "GitpodWorkspaceTooManyRegularNotActive" alert

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -77,14 +77,14 @@
             labels: {
               severity: 'critical',
             },
-            'for': '15m',
+            'for': '10m',
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceTooManyRegularNotActive.md',
               summary: 'too many running but inactive workspaces',
               description: 'too many running but inactive workspaces',
             },
             expr: |||
-              gitpod_workspace_regular_not_active_percentage > 0.15 AND sum(gitpod_ws_manager_workspace_activity_total) > 100
+              gitpod_workspace_regular_not_active_percentage > 0.10
             |||,
           },
           {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Around the time Build one first reported this issue (see [internal](https://gitpod.slack.com/archives/C03145ZD98D/p1657005586660919)) at around 9:15 AM European central Time 7:15 UCT the
 `gitpod_workspace_regular_not_active_percentage` was quite high around 0.9 as can be seen from the picture (it got it's peak at 7AM which was still 0.135). So we definitely do need to reduce the `0.15` value we specify in the prom rule. I propose we set this to `0.10`

![grafana png(1)](https://user-images.githubusercontent.com/2624550/178071622-e24082f9-724f-4907-8c09-079164ad23f2.jpg)

Now the second thing is, even at this hour, our total active workspaces were much lower, and out alert to go off we have set a limit of `100`. This needs to be reduced too. I propose we eliminate this condition to get alerted if the percentage of inactive workspaces get high enough.
 
![grafana-2](https://user-images.githubusercontent.com/2624550/178072272-038dd73c-b327-4851-ae1b-137b5eae416d.jpg)

According to the trend I see, the inactivity period would be very easily detectable if we reduce our interval to `10m`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11241 

## How to test
<!-- Provide steps to test this PR -->
The best way to test this would be to try this metric on grafana

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
