### PR TITLE
[installer-tests] Fix the k3s installer tests YAML

### DIFF
--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -26,51 +26,49 @@ pod:
     imagePullPolicy: Always
     volumeMounts:
     - name: sh-playground-sa-perm
-      secret:
-        secretName: sh-playground-sa-perm
-    - name: sh-playground-dns-perm
-      secret:
-        secretName: sh-playground-dns-perm
-      env:
-        - name: WERFT_HOST
-          value: "werft.werft.svc.cluster.local:7777"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
-        - name: TF_VAR_sa_creds
-          value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
-        - name: TF_VAR_dns_sa_creds
-          value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
-        - name: WERFT_K8S_NAMESPACE
-          value: "werft"
-        - name: WERFT_K8S_LABEL
-          value: "component=werft"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: USER_TOKEN # this is for the integration tests
-          valueFrom:
-            secretKeyRef:
-              name: integration-test-user
-              key: token
-      command:
-        - bash
-        - -c
-        - |
-          sleep 1
-          set -Eeuo pipefail
+      mountPath: /mnt/secrets/sh-playground-sa-perm
+    - name: sh-playground-dns-perm # this sa is used for the DNS management
+      mountPath: /mnt/secrets/sh-playground-dns-perm
+    env:
+      - name: WERFT_HOST
+        value: "werft.werft.svc.cluster.local:7777"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
+      - name: TF_VAR_sa_creds
+        value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
+      - name: TF_VAR_dns_sa_creds
+        value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
+      - name: WERFT_K8S_NAMESPACE
+        value: "werft"
+      - name: WERFT_K8S_LABEL
+        value: "component=werft"
+      - name: NODENAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: USER_TOKEN # this is for the integration tests
+        valueFrom:
+          secretKeyRef:
+            name: integration-test-user
+            key: token
+    command:
+      - bash
+      - -c
+      - |
+        sleep 1
+        set -Eeuo pipefail
 
-          sudo chown -R gitpod:gitpod /workspace
-          sudo apt update && apt install gettext-base
+        sudo chown -R gitpod:gitpod /workspace
+        sudo apt update && apt install gettext-base
 
-          curl -sLS https://get.k3sup.dev | sh
+        curl -sLS https://get.k3sup.dev | sh
 
-          export TF_VAR_TEST_ID=$(echo $RANDOM | md5sum | head -c 5; echo)
+        export TF_VAR_TEST_ID=$(echo $RANDOM | md5sum | head -c 5; echo)
 
-          (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
-          printf '{{ toJson . }}' > context.json
+        (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
+        printf '{{ toJson . }}' > context.json
 
-          npx ts-node .werft/installer-tests.ts "STANDARD_K3S_TEST"
+        npx ts-node .werft/installer-tests.ts "STANDARD_K3S_TEST"
 # The bit below makes this a cron job
 plugins:
   cron: "15 3 * * *"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The k3s YAML file unfortunately got badly commit conflict resolved. This is a tiny PR that fixes the syntax.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```
werft run github -j .werft/k3s-installer-tests.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
