### PR TITLE
[ws-proxy] Remove the port number from "X-Forwarded-Host" header as it's already defined in "X-Forwarded-Port"

### DIFF
--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -376,10 +376,9 @@ func installWorkspacePortRoutes(r *mux.Router, config *RouteHandlerConfig, infoP
 					r.Header["Sec-WebSocket-"+name] = values
 				}
 			}
-			portString := "443"
 			r.Header.Add("X-Forwarded-Proto", "https")
-			r.Header.Add("X-Forwarded-Host", r.Host+":"+portString)
-			r.Header.Add("X-Forwarded-Port", portString)
+			r.Header.Add("X-Forwarded-Host", r.Host)
+			r.Header.Add("X-Forwarded-Port", "443")
 			proxyPass(
 				config,
 				infoProvider,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove the port number from "X-Forwarded-Host" header as it's already defined in "X-Forwarded-Port".

This is a [suggestion](https://github.com/gitpod-io/gitpod/pull/11110#issuecomment-1179524427) from @ChakshuGautam, and it seems correct to don't have a port there.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/pull/11110

## How to test
<!-- Provide steps to test this PR -->
- Open a workspace on the Preview Environment of this PR.
- Run `curl lama.sh | sh`
- Run `gp preview $(gp url 8080) --external` to open a browser.
- Confirm you see, in the terminal logs of the request, the "X-Forwarded-Host" and "X-Forwarded-Port" headers. The first should have only the host and the second, only the port.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Requests on ws-proxy won't contain the port anymore on the "X-Forwarded-Host" header. It will contain only the host. If you need the port, you can get it from the "X-Forwarded-Port" header.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
