### PR TITLE
[Analytics] move "project_created" call to projects-service.ts and add project ID

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2222,21 +2222,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             await this.guardTeamOperation(params.teamId, "get");
         }
 
-        const project = this.projectsService.createProject(params, user);
-        this.analytics.track({
-            userId: user.id,
-            event: "project_created",
-            properties: {
-                name: params.name,
-                clone_url: params.cloneUrl,
-                account: params.account,
-                provider: params.provider,
-                owner_type: !!params.teamId ? "team" : "user",
-                owner_id: !!params.teamId ? params.teamId : params.userId,
-                app_installation_id: params.appInstallationId,
-            },
-        });
-        return project;
+        return this.projectsService.createProject(params, user);
     }
 
     public async deleteProject(ctx: TraceContext, projectId: string): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Moves the tracking call for `project_created` to `projects-service.ts` in order to have access and use the project's ID.

## How to test
<!-- Provide steps to test this PR -->

1. Open a preview environment, sign up, and create a project
2. Go to the [debugger of Staging Untrusted](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) and ensure that a `project_created` call was fired and that it contains the project's ID as one of its properties

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe
