### PR TITLE
[local-preview] Differentiate btw Gitpod `starting` and `running`

### DIFF
--- a/install/preview/prettylog/main.go
+++ b/install/preview/prettylog/main.go
@@ -23,7 +23,7 @@ var msgs = []struct {
 	{Msg: "preparing system", Success: "extracting images to download ahead"},
 	{Msg: "downloading images", Success: "--output-split-files"},
 	{Msg: "preparing Gitpod preview installation", Success: "rm -rf /var/lib/rancher/k3s/server/manifests/gitpod"},
-	{Msg: "starting k3s", Success: "ws-proxy"},
+	{Msg: "starting Gitpod", Success: "gitpod-telemetry-init"},
 	{Msg: "Gitpod is running"},
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, It takes a while before Gitpod is ready even though
the status says `Gitpod is running` as its not checking for
readyness.

This PR updates the output to separate btw `starting` and `running`.
`Gitpod is running` message is showed only when we see that
the `gitpod-telemetry-init` job has run which happens when
all pods are ready.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11259

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[local-preview] Differentiate btw Gitpod `starting` and `running`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
