### PR TITLE
[server] Reduce gitpod_server_api_calls_duration_seconds precision, add 2 buckets

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -59,7 +59,7 @@ export const apiCallDurationHistogram = new prometheusClient.Histogram({
     name: "gitpod_server_api_calls_duration_seconds",
     help: "Duration of API calls in seconds",
     labelNames: ["method"],
-    buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10],
+    buckets: [0.1, 0.5, 1, 5, 10, 15, 30],
     registers: [prometheusClient.register],
 });
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Because we don't have enough precision where it matters

<img width="1594" alt="Screenshot 2022-07-11 at 13 55 34" src="https://user-images.githubusercontent.com/1419286/178258844-d384dc41-3e5f-442d-90ef-e0a2c4cd6134.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
