### PR TITLE
[db-sync] Escape column name in UPDATE statement

### DIFF
--- a/components/ee/db-sync/src/export.ts
+++ b/components/ee/db-sync/src/export.ts
@@ -136,7 +136,7 @@ export class TableUpdate {
 
         const pkValues = this.table.primaryKeys.map(c => escape(row[c], true));
         const updateValues = this.updateColumns.map(c => escape(row[c], true));
-        const updates = this.updateColumns.map((c, i) => `${c}=${updateValues[i]}`).join(", ")
+        const updates = this.updateColumns.map((c, i) => `${escapeWithBackticks(c)}=${updateValues[i]}`).join(", ")
         const updateConditions = this.getUpdateConditions(row);
 
         let result = [`INSERT${forceInsert ? '' : ' IGNORE'} INTO ${this.table.name} (${(this.table.primaryKeys.concat(this.updateColumns)).map(escapeWithBackticks).join(", ")}) VALUES (${(pkValues.concat(updateValues)).join(", ")});`];
@@ -147,7 +147,7 @@ export class TableUpdate {
     }
 
     protected getUpdateConditions(row: any): string {
-        return this.table.primaryKeys.map(pk => `${pk}=${escape(row[pk])}`).concat([`${this.table.timeColumn}<=${escape(row[this.table.timeColumn])}`]).join(" AND ");
+        return this.table.primaryKeys.map(pk => `${escapeWithBackticks(pk)}=${escape(row[pk])}`).concat([`${this.table.timeColumn}<=${escape(row[this.table.timeColumn])}`]).join(" AND ");
     }
 
 }


### PR DESCRIPTION
## Description

Escape column names in backquotes when `db-sync` generates `UPDATE` statements.

This ensures that `db-sync` is able to generate these statements for tables having SQL keywords as column names.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11265

## How to test

Take the `db-sync` image built on this branch and hot-patch the `db-sync` image running in staging. See that `db-sync` runs without error in staging.

## Release Notes

```release-note
NONE
```
