### PR TITLE
[workspacekit] fix mount when use ubuntu docker image

### DIFF
--- a/components/workspacekit/pkg/readarg/readarg.go
+++ b/components/workspacekit/pkg/readarg/readarg.go
@@ -38,6 +38,9 @@ func OpenMem(pid uint32) (*os.File, error) {
 }
 
 func ReadString(memFile *os.File, offset int64) (string, error) {
+	if offset == 0 {
+		return "", nil
+	}
 	var buffer = make([]byte, 4096) // PATH_MAX
 
 	_, err := unix.Pread(int(memFile.Fd()), buffer, offset)
@@ -58,6 +61,9 @@ func ReadString(memFile *os.File, offset int64) (string, error) {
 }
 
 func ReadBytes(memFile *os.File, offset int64, len int) ([]byte, error) {
+	if offset == 0 && len == 0 {
+		return nil, nil
+	}
 	var buffer = make([]byte, len)
 
 	// pread() will always return the size of the buffer


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fix some edge case when workspace run mount, in ubuntu base system, if you run `mount --make-rshared /` the filesystem is NULL point, so if you want read string from NULL it will failed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11299 

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace
2. run `docker run -it --rm --privileged ubuntu` start a container
3. run `mount --make-rshared /` in container

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
