### PR TITLE
Add feature flag for blocked repositories UI

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -48,6 +48,7 @@ import { parseProps } from "./start/StartWorkspace";
 import SelectIDEModal from "./settings/SelectIDEModal";
 import { StartPage, StartPhase } from "./start/StartPage";
 import { isGitpodIo } from "./utils";
+import { BlockedRepositorySettings } from "./admin/BlockedRepositorySettings";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "./workspaces/Workspaces"));
@@ -364,6 +365,7 @@ function App() {
                     <AdminRoute path="/admin/teams" component={TeamsSearch} />
                     <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
                     <AdminRoute path="/admin/projects" component={ProjectsSearch} />
+                    <AdminRoute path="/admin/blocked-repositories" component={BlockedRepositorySettings} />
                     <AdminRoute path="/admin/license" component={License} />
                     <AdminRoute path="/admin/settings" component={AdminSettings} />
 

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -15,7 +15,7 @@ import { getGitpodService, gitpodHostUrl } from "./service/service";
 import { UserContext } from "./user-context";
 import { TeamsContext, getCurrentTeam } from "./teams/teams-context";
 import getSettingsMenu from "./settings/settings-menu";
-import { adminMenu } from "./admin/admin-menu";
+import { getAdminMenu } from "./admin/admin-menu";
 import ContextMenu from "./components/ContextMenu";
 import Separator from "./components/Separator";
 import PillMenuItem from "./components/PillMenuItem";
@@ -26,6 +26,7 @@ import { ProjectContext } from "./projects/project-context";
 import { PaymentContext } from "./payment-context";
 import FeedbackFormModal from "./feedback-form/FeedbackModal";
 import { inResource, isGitpodIo } from "./utils";
+import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
 import { getExperimentsClient } from "./experiments/client";
 
 interface Entry {
@@ -48,6 +49,7 @@ export default function Menu() {
         setIsStudent,
         setIsChargebeeCustomer,
     } = useContext(PaymentContext);
+    const { isBlockedRepositoriesUIEnabled } = useContext(FeatureFlagContext);
     const { project, setProject } = useContext(ProjectContext);
     const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
@@ -246,7 +248,7 @@ export default function Menu() {
                   {
                       title: "Admin",
                       link: "/admin",
-                      alternatives: adminMenu.flatMap((e) => e.link),
+                      alternatives: getAdminMenu(isBlockedRepositoriesUIEnabled).flatMap((e) => e.link),
                   },
               ]
             : []),

--- a/components/dashboard/src/admin/BlockedRepositorySettings.tsx
+++ b/components/dashboard/src/admin/BlockedRepositorySettings.tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
+
+export function BlockedRepositorySettings() {
+    return (
+        <PageWithAdminSubMenu title="Blocked Repositories" subtitle="Search and manage all blocked repositories.">
+            <div></div>
+        </PageWithAdminSubMenu>
+    );
+}

--- a/components/dashboard/src/admin/License.tsx
+++ b/components/dashboard/src/admin/License.tsx
@@ -4,9 +4,6 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import { adminMenu } from "./admin-menu";
-
 import { LicenseContext } from "../license-context";
 import { ReactElement, useContext, useEffect } from "react";
 import { getGitpodService } from "../service/service";
@@ -20,6 +17,7 @@ import { ReactComponent as LinkSvg } from "../images/external-link.svg";
 import SolidCard from "../components/SolidCard";
 import Card from "../components/Card";
 import { isGitpodIo } from "../utils";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 export default function License() {
     const { license, setLicense } = useContext(LicenseContext);
@@ -44,11 +42,7 @@ export default function License() {
 
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={adminMenu}
-                title="License"
-                subtitle="License associated with your Gitpod installation"
-            >
+            <PageWithAdminSubMenu title="License" subtitle="License associated with your Gitpod installation">
                 <div className="flex flex-row space-x-4">
                     <Card className="w-72 h-64">
                         <span>
@@ -91,7 +85,7 @@ export default function License() {
                         </span>
                     </SolidCard>
                 </div>
-            </PageWithSubMenu>
+            </PageWithAdminSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/admin/PageWithAdminSubMenu.tsx
+++ b/components/dashboard/src/admin/PageWithAdminSubMenu.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext } from "react";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { getAdminMenu } from "./admin-menu";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+
+export interface PageWithAdminSubMenuProps {
+    title: string;
+    subtitle: string;
+    children: React.ReactNode;
+}
+
+export function PageWithAdminSubMenu({ title, subtitle, children }: PageWithAdminSubMenuProps) {
+    const { isBlockedRepositoriesUIEnabled } = useContext(FeatureFlagContext);
+
+    return (
+        <PageWithSubMenu subMenu={getAdminMenu(isBlockedRepositoriesUIEnabled)} title={title} subtitle={subtitle}>
+            {children}
+        </PageWithSubMenu>
+    );
+}

--- a/components/dashboard/src/admin/ProjectsSearch.tsx
+++ b/components/dashboard/src/admin/ProjectsSearch.tsx
@@ -9,17 +9,16 @@ import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 
-import { adminMenu } from "./admin-menu";
 import ProjectDetail from "./ProjectDetail";
 import { getGitpodService } from "../service/service";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { AdminGetListResult, Project } from "@gitpod/gitpod-protocol";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 export default function ProjectsSearchPage() {
     return (
-        <PageWithSubMenu subMenu={adminMenu} title="Projects" subtitle="Search and manage all projects.">
+        <PageWithAdminSubMenu title="Projects" subtitle="Search and manage all projects.">
             <ProjectsSearch />
-        </PageWithSubMenu>
+        </PageWithAdminSubMenu>
     );
 }
 

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -8,12 +8,11 @@ import { useContext } from "react";
 import { TelemetryData, InstallationAdminSettings } from "@gitpod/gitpod-protocol";
 import { AdminContext } from "../admin-context";
 import CheckBox from "../components/CheckBox";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import { adminMenu } from "./admin-menu";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
 import { isGitpodIo } from "../utils";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 export default function Settings() {
     const { adminSettings, setAdminSettings } = useContext(AdminContext);
@@ -39,11 +38,7 @@ export default function Settings() {
 
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={adminMenu}
-                title="Settings"
-                subtitle="Configure settings for your Gitpod cluster."
-            >
+            <PageWithAdminSubMenu title="Settings" subtitle="Configure settings for your Gitpod cluster.">
                 <h3>Usage Statistics</h3>
                 <p className="text-base text-gray-500 pb-4 max-w-2xl">
                     We collect usage telemetry to gain insights on how you use your Gitpod instance, so we can provide a
@@ -89,7 +84,7 @@ export default function Settings() {
                 <InfoBox>
                     <pre>{JSON.stringify(telemetryData, null, 2)}</pre>
                 </InfoBox>
-            </PageWithSubMenu>
+            </PageWithAdminSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/admin/TeamsSearch.tsx
+++ b/components/dashboard/src/admin/TeamsSearch.tsx
@@ -8,19 +8,18 @@ import moment from "moment";
 import { useState, useEffect } from "react";
 
 import TeamDetail from "./TeamDetail";
-import { adminMenu } from "./admin-menu";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import { getGitpodService } from "../service/service";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { AdminGetListResult, Team } from "@gitpod/gitpod-protocol";
 import Label from "./Label";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 export default function TeamsSearchPage() {
     return (
-        <PageWithSubMenu subMenu={adminMenu} title="Teams" subtitle="Search and manage teams.">
+        <PageWithAdminSubMenu title="Teams" subtitle="Search and manage teams.">
             <TeamsSearch />
-        </PageWithSubMenu>
+        </PageWithAdminSubMenu>
     );
 }
 

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -18,11 +18,10 @@ import moment from "moment";
 import { useEffect, useRef, useState } from "react";
 import CheckBox from "../components/CheckBox";
 import Modal from "../components/Modal";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import { adminMenu } from "./admin-menu";
 import { WorkspaceSearch } from "./WorkspacesSearch";
 import Property from "./Property";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 export default function UserDetail(p: { user: User }) {
     const [activity, setActivity] = useState(false);
@@ -117,7 +116,7 @@ export default function UserDetail(p: { user: User }) {
 
     return (
         <>
-            <PageWithSubMenu subMenu={adminMenu} title="Users" subtitle="Search and manage all users.">
+            <PageWithAdminSubMenu title="Users" subtitle="Search and manage all users.">
                 <div className="flex">
                     <div className="flex-1">
                         <div className="flex">
@@ -246,7 +245,7 @@ export default function UserDetail(p: { user: User }) {
                     </div>
                 </div>
                 <WorkspaceSearch user={user} />
-            </PageWithSubMenu>
+            </PageWithAdminSubMenu>
             <Modal
                 visible={editFeatureFlags}
                 onClose={() => setEditFeatureFlags(false)}

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -9,9 +9,8 @@ import moment from "moment";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import { adminMenu } from "./admin-menu";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 import UserDetail from "./UserDetail";
 
 export default function UserSearch() {
@@ -58,7 +57,7 @@ export default function UserSearch() {
         }
     };
     return (
-        <PageWithSubMenu subMenu={adminMenu} title="Users" subtitle="Search and manage all users.">
+        <PageWithAdminSubMenu title="Users" subtitle="Search and manage all users.">
             <div className="pt-8 flex">
                 <div className="flex justify-between w-full">
                     <div className="flex">
@@ -104,7 +103,7 @@ export default function UserSearch() {
                         <UserEntry user={u} />
                     ))}
             </div>
-        </PageWithSubMenu>
+        </PageWithAdminSubMenu>
     );
 }
 

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -19,12 +19,11 @@ import moment from "moment";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
 import { getProject, WorkspaceStatusIndicator } from "../workspaces/WorkspaceEntry";
-import { adminMenu } from "./admin-menu";
 import WorkspaceDetail from "./WorkspaceDetail";
 import info from "../images/info.svg";
+import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 interface Props {
     user?: User;
@@ -32,9 +31,9 @@ interface Props {
 
 export default function WorkspaceSearchPage() {
     return (
-        <PageWithSubMenu subMenu={adminMenu} title="Workspaces" subtitle="Search and manage all workspaces.">
+        <PageWithAdminSubMenu title="Workspaces" subtitle="Search and manage all workspaces.">
             <WorkspaceSearch />
-        </PageWithSubMenu>
+        </PageWithAdminSubMenu>
     );
 }
 

--- a/components/dashboard/src/admin/admin-menu.ts
+++ b/components/dashboard/src/admin/admin-menu.ts
@@ -4,29 +4,39 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-export const adminMenu = [
-    {
-        title: "Users",
-        link: ["/admin/users", "/admin"],
-    },
-    {
-        title: "Workspaces",
-        link: ["/admin/workspaces"],
-    },
-    {
-        title: "Projects",
-        link: ["/admin/projects"],
-    },
-    {
-        title: "Teams",
-        link: ["/admin/teams"],
-    },
-    {
-        title: "License",
-        link: ["/admin/license"],
-    },
-    {
-        title: "Settings",
-        link: ["/admin/settings"],
-    },
-];
+export function getAdminMenu(isBlockedRepositoriesUIEnabled: boolean) {
+    return [
+        {
+            title: "Users",
+            link: ["/admin/users", "/admin"],
+        },
+        {
+            title: "Workspaces",
+            link: ["/admin/workspaces"],
+        },
+        {
+            title: "Projects",
+            link: ["/admin/projects"],
+        },
+        {
+            title: "Teams",
+            link: ["/admin/teams"],
+        },
+        ...(isBlockedRepositoriesUIEnabled
+            ? [
+                  {
+                      title: "Blocked Repositories",
+                      link: ["/admin/blocked-repositories"],
+                  },
+              ]
+            : []),
+        {
+            title: "License",
+            link: ["/admin/license"],
+        },
+        {
+            title: "Settings",
+            link: ["/admin/settings"],
+        },
+    ];
+}

--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -25,7 +25,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
             <Header title={p.title} subtitle={p.subtitle} />
             <div className="app-container flex pt-9">
                 <div>
-                    <ul className="flex flex-col text tracking-wide text-gray-500 pt-4 lg:pt-0 w-48 space-y-2">
+                    <ul className="flex flex-col text tracking-wide text-gray-500 pt-4 lg:pt-0 w-52 space-y-2">
                         {p.subMenu.map((e) => {
                             let classes = "flex block py-2 px-4 rounded-md";
                             if (e.link.some((l) => l === location.pathname)) {

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { getExperimentsClient } from "../experiments/client";
+import { UserContext } from "../user-context";
+
+const FeatureFlagContext = createContext<{
+    isBlockedRepositoriesUIEnabled: boolean;
+    setIsBlockedRepositoriesUIEnabled: React.Dispatch<boolean>;
+}>({
+    isBlockedRepositoriesUIEnabled: false,
+    setIsBlockedRepositoriesUIEnabled: () => {},
+});
+
+const FeatureFlagContextProvider: React.FC = ({ children }) => {
+    const [isBlockedRepositoriesUIEnabled, setIsBlockedRepositoriesUIEnabled] = useState(false);
+    const { user } = useContext(UserContext);
+
+    useEffect(() => {
+        (async () => {
+            const isBlockedRepositoriesUIEnabled = await getExperimentsClient().getValueAsync(
+                "isblockedrepositoriesuienabled",
+                false,
+                { user },
+            );
+            setIsBlockedRepositoriesUIEnabled(isBlockedRepositoriesUIEnabled);
+        })();
+    }, [user]);
+
+    return (
+        <FeatureFlagContext.Provider
+            value={{
+                isBlockedRepositoriesUIEnabled,
+                setIsBlockedRepositoriesUIEnabled,
+            }}
+        >
+            {children}
+        </FeatureFlagContext.Provider>
+    );
+};
+
+export { FeatureFlagContext, FeatureFlagContextProvider };

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -14,6 +14,7 @@ import { LicenseContextProvider } from "./license-context";
 import { TeamsContextProvider } from "./teams/teams-context";
 import { ProjectContextProvider } from "./projects/project-context";
 import { ThemeContextProvider } from "./theme-context";
+import { FeatureFlagContextProvider } from "./contexts/FeatureFlagContext";
 import { StartWorkspaceModalContextProvider } from "./workspaces/start-workspace-modal-context";
 import { BrowserRouter } from "react-router-dom";
 
@@ -23,21 +24,23 @@ ReactDOM.render(
     <React.StrictMode>
         <UserContextProvider>
             <AdminContextProvider>
-                <PaymentContextProvider>
-                    <LicenseContextProvider>
-                        <TeamsContextProvider>
-                            <ProjectContextProvider>
-                                <ThemeContextProvider>
-                                    <StartWorkspaceModalContextProvider>
-                                        <BrowserRouter>
-                                            <App />
-                                        </BrowserRouter>
-                                    </StartWorkspaceModalContextProvider>
-                                </ThemeContextProvider>
-                            </ProjectContextProvider>
-                        </TeamsContextProvider>
-                    </LicenseContextProvider>
-                </PaymentContextProvider>
+                <FeatureFlagContextProvider>
+                    <PaymentContextProvider>
+                        <LicenseContextProvider>
+                            <TeamsContextProvider>
+                                <ProjectContextProvider>
+                                    <ThemeContextProvider>
+                                        <StartWorkspaceModalContextProvider>
+                                            <BrowserRouter>
+                                                <App />
+                                            </BrowserRouter>
+                                        </StartWorkspaceModalContextProvider>
+                                    </ThemeContextProvider>
+                                </ProjectContextProvider>
+                            </TeamsContextProvider>
+                        </LicenseContextProvider>
+                    </PaymentContextProvider>
+                </FeatureFlagContextProvider>
             </AdminContextProvider>
         </UserContextProvider>
     </React.StrictMode>,


### PR DESCRIPTION
## Description

Add a feature-flagged entry in the admin sidebar that will show a placeholder blocked repositories admin UI.

The feature flag is enabled for non-production environments (ie preview and staging).

## Related Issue(s)
Part of #11030 

## How to test

Start the preview environment and see the new `Repositories` menu item in the `Admin` menu:

<img width="1560" alt="image" src="https://user-images.githubusercontent.com/8225907/178252843-26b31b53-e838-43bf-bb0b-28f8a8ec22a5.png">

The link takes you to an empty placeholder page:

<img width="1481" alt="image" src="https://user-images.githubusercontent.com/8225907/178254579-9f22704c-e9dd-498e-aced-7ccd0199076a.png">


## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
