### PR TITLE
Specify the KUBECONFIG var in the cmctl command

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -100,7 +100,7 @@ function waitForCertificateReadiness(werft: Werft, certName: string, slice: stri
             `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs get certificate ${certName} -o yaml`,
             { silent: true },
         ).stdout.trim();
-        const certificateDebug = exec(`cmctl status certificate ${certName}`);
+        const certificateDebug = exec(`KUBECONFIG=${CORE_DEV_KUBECONFIG_PATH} cmctl status certificate ${certName}`);
         exec(`kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs delete certificate ${certName}`, {
             slice: slice,
         });


### PR DESCRIPTION
## Description
Specify the KUBECONFIG in the cmctl command

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
