### PR TITLE
Clean code from GitpodServerLauncher and update JetBrains backend-plugin to work when user has proxies

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/testclient/TestClient.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/testclient/TestClient.java
@@ -10,6 +10,8 @@ import io.gitpod.gitpodprotocol.api.GitpodServerLauncher;
 import io.gitpod.gitpodprotocol.api.entities.SendHeartBeatOptions;
 import io.gitpod.gitpodprotocol.api.entities.User;
 
+import java.util.Collections;
+
 public class TestClient {
     public static void main(String[] args) throws Exception {
         String uri = "wss://gitpod.io/api/v1";
@@ -17,7 +19,7 @@ public class TestClient {
         String origin = "https://CHANGE-ME.gitpod.io/";
 
         GitpodClient client = new GitpodClient();
-        GitpodServerLauncher.create(client).listen(uri, origin, token, "Test", "Test");
+        GitpodServerLauncher.create(client).listen(uri, origin, token, "Test", "Test", Collections.emptyList(), null);
         GitpodServer gitpodServer = client.getServer();
         User user = gitpodServer.getLoggedInUser().join();
         System.out.println("logged in user:" + user);

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
@@ -16,6 +16,8 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.util.LowMemoryWatcher
 import com.intellij.remoteDev.util.onTerminationOrNow
 import com.intellij.util.application
+import com.intellij.util.net.ssl.CertificateManager
+import com.intellij.util.proxy.CommonProxy
 import com.jetbrains.rd.util.lifetime.Lifetime
 import git4idea.config.GitVcsApplicationSettings
 import io.gitpod.gitpodprotocol.api.GitpodClient
@@ -42,6 +44,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.jetbrains.ide.BuiltInServerManager
 import java.net.URI
+import java.net.URL
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
@@ -271,14 +274,20 @@ class GitpodManager : Disposable {
         val connect = {
             val originalClassLoader = Thread.currentThread().contextClassLoader
             try {
+                val proxies = CommonProxy.getInstance().select(URL(info.gitpodHost))
+                val sslContext = CertificateManager.getInstance().sslContext
+
                 // see https://intellij-support.jetbrains.com/hc/en-us/community/posts/360003146180/comments/360000376240
                 Thread.currentThread().contextClassLoader = HeartbeatService::class.java.classLoader
+
                 launcher.listen(
                         info.gitpodApi.endpoint,
                         info.gitpodHost,
                         plugin.pluginId.idString,
                         plugin.version,
-                        tokenResponse.token
+                        tokenResponse.token,
+                        proxies,
+                        sslContext
                 )
             } finally {
                 Thread.currentThread().contextClassLoader = originalClassLoader


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Clean code from GitpodServerLauncher and update JetBrains backend-plugin to work when the user has proxies.

This reverts the hotfix from https://github.com/gitpod-io/gitpod/pull/11232 and passes a default `SslContextFactory` to `HttpClient`, which the root cause of the issue https://github.com/gitpod-io/gitpod/issues/11228. For reference, this is the error message the server was triggering:
```
java.lang.IllegalStateException: HttpClient has no SslContextFactory, wss:// URI's are not supported in this configuration
at io.gitpod.gitpodprotocol.api.GitpodServerLauncher.listen
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #11291

## How to test
<!-- Provide steps to test this PR -->
- Open https://felladrin-11291.preview.gitpod-dev.com/#referrer:jetbrains-gateway:intellij/https://github.com/gitpod-io/empty
- Get the instance of the workspace by running `env | grep GITPOD_INSTANCE_ID`
- Check if [heartbeats are sent to set to the server](https://github.com/gitpod-io/gitpod/pull/11230).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Gitpod Plugin for JetBrains IDEs was updated to properly handle network proxies.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
