### PR TITLE
Extend werft-credential-helper to work outside of workspaces and update jobs

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -51,6 +51,10 @@ pod:
   - name: fluent-bit-external
     secret:
       secretName: fluent-bit-external
+  - name: github-token-gitpod-bot
+    secret:
+      defaultMode: 420
+      secretName: github-token-gitpod-bot
   # - name: deploy-key
   #   secret:
   #     secretName: deploy-key
@@ -112,6 +116,8 @@ pod:
       mountPath: /mnt/secrets/harvester-k3s-dockerhub-pull-account
     - name: fluent-bit-external
       mountPath: /mnt/fluent-bit-external
+    - mountPath: /mnt/secrets/github-token-gitpod-bot
+      name: github-token-gitpod-bot
     # - name: deploy-key
     #   mountPath: /mnt/secrets/deploy-key
     #   readOnly: true
@@ -131,8 +137,6 @@ pod:
       value: http://athens-athens-proxy.athens.svc.cluster.local:9999
     - name: GOCACHE
       value: /go-build-cache
-    - name: WERFT_HOST
-      value: "werft.werft.svc.cluster.local:7777"
     - name: NODENAME
       valueFrom:
         fieldRef:
@@ -212,6 +216,11 @@ pod:
         secretKeyRef:
           name: replicated
           key: token
+    # Used by the Werft CLI through werft-credential-helper.sh
+    - name: WERFT_GITHUB_TOKEN_PATH
+      value: "/mnt/secrets/github-token-gitpod-bot/token"
+    - name: WERFT_CREDENTIAL_HELPER
+      value: "/workspace/dev/preview/werft-credential-helper.sh"
     command:
       - bash
       - -c

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -96,8 +96,6 @@ pod:
       value: http://athens-athens-proxy.athens.svc.cluster.local:9999
     - name: GOCACHE
       value: /go-build-cache
-    - name: WERFT_HOST
-      value: "werft.werft.svc.cluster.local:7777"
     - name: NODENAME
       valueFrom:
         fieldRef:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -30,18 +30,12 @@ pod:
         - name: sh-playground-dns-perm # this sa is used for the DNS management
           mountPath: /mnt/secrets/sh-playground-dns-perm
       env:
-        - name: WERFT_HOST
-          value: "werft.werft.svc.cluster.local:7777"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
         - name: TF_VAR_sa_creds
           value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
         - name: TF_VAR_dns_sa_creds
           value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
-        - name: WERFT_K8S_NAMESPACE
-          value: "werft"
-        - name: WERFT_K8S_LABEL
-          value: "component=werft"
         - name: NODENAME
           valueFrom:
             fieldRef:

--- a/.werft/ide-integration-tests-startup-jetbrains.yaml
+++ b/.werft/ide-integration-tests-startup-jetbrains.yaml
@@ -10,6 +10,10 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
     - name: config
       emptyDir: {}
+    - name: github-token-gitpod-bot
+      secret:
+        defaultMode: 420
+        secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-werft-cli-grpc-changes.2
@@ -25,6 +29,11 @@ pod:
             secretKeyRef:
               name: github-roboquat-automatic-changelog
               key: token
+        # Used by the Werft CLI through werft-credential-helper.sh
+        - name: WERFT_GITHUB_TOKEN_PATH
+          value: "/mnt/secrets/github-token-gitpod-bot/token"
+        - name: WERFT_CREDENTIAL_HELPER
+          value: "/workspace/dev/preview/werft-credential-helper.sh"
       volumeMounts:
         - name: gcp-sa
           mountPath: /mnt/secrets/gcp-sa
@@ -32,6 +41,8 @@ pod:
         - name: config
           mountPath: /config
           readOnly: false
+        - mountPath: /mnt/secrets/github-token-gitpod-bot
+          name: github-token-gitpod-bot
       command:
         - bash
         - -c

--- a/.werft/ide-integration-tests-startup-vscode.yaml
+++ b/.werft/ide-integration-tests-startup-vscode.yaml
@@ -10,6 +10,10 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
     - name: config
       emptyDir: {}
+    - name: github-token-gitpod-bot
+      secret:
+        defaultMode: 420
+        secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-werft-cli-grpc-changes.2
@@ -40,6 +44,11 @@ pod:
             secretKeyRef:
               name: slack-webhook-urls
               key: ide_jobs
+        # Used by the Werft CLI through werft-credential-helper.sh
+        - name: WERFT_GITHUB_TOKEN_PATH
+          value: "/mnt/secrets/github-token-gitpod-bot/token"
+        - name: WERFT_CREDENTIAL_HELPER
+          value: "/workspace/dev/preview/werft-credential-helper.sh"
       volumeMounts:
         - name: gcp-sa
           mountPath: /mnt/secrets/gcp-sa
@@ -47,6 +56,8 @@ pod:
         - name: config
           mountPath: /config
           readOnly: false
+        - mountPath: /mnt/secrets/github-token-gitpod-bot
+          name: github-token-gitpod-bot
       command:
         - bash
         - -c
@@ -60,8 +71,6 @@ pod:
           if [[ $LAST_COMMIT_MSG =~ "integration test" ]]; then exit 0; fi
 
           BRANCH="inte-test/"$(date +%Y%m%d%H%M%S)
-
-          export WERFT_CREDENTIAL_HELPER=/workspace/dev/preview/werft-credential-helper.sh
 
           FAILURE_COUNT=0
           RUN_COUNT=0

--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -52,7 +52,7 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
 
         try {
             exec(
-                `WERFT_HOST="werft-grpc.gitpod-dev.com:443" WERFT_TLS_MODE="system" GITHUB_TOKEN_PATH="/mnt/secrets/gitpod-bot-github-token/token" WERFT_CREDENTIAL_HELPER="./dev/preview/werft-credential-helper.sh" KUBECONFIG=/workspace/gitpod/kubeconfigs/core-dev werft run --remote-job-path ${testFile} ${annotation} github`,
+                `werft run --remote-job-path ${testFile} ${annotation} github`,
                 {
                     slice: upgradeConfig.phase,
                 },

--- a/.werft/jobs/build/trigger-integration-tests.ts
+++ b/.werft/jobs/build/trigger-integration-tests.ts
@@ -29,10 +29,10 @@ export async function triggerIntegrationTests(werft: Werft, config: JobConfig, u
 
         exec(`git config --global user.name "${username}"`);
         const annotations = [
-            `version=${imageVersion}`,
-            `namespace=${config.previewEnvironment.namespace}`,
-            `username=${username}`,
-            `updateGitHubStatus=gitpod-io/gitpod`,
+            `version="${imageVersion}"`,
+            `namespace="${config.previewEnvironment.namespace}"`,
+            `username="${username}"`,
+            `updateGitHubStatus="gitpod-io/gitpod"`,
         ]
             .map((annotation) => `-a ${annotation}`)
             .join(" ");

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -30,18 +30,12 @@ pod:
     - name: sh-playground-dns-perm # this sa is used for the DNS management
       mountPath: /mnt/secrets/sh-playground-dns-perm
     env:
-      - name: WERFT_HOST
-        value: "werft.werft.svc.cluster.local:7777"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
       - name: TF_VAR_sa_creds
         value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
       - name: TF_VAR_dns_sa_creds
         value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
-      - name: WERFT_K8S_NAMESPACE
-        value: "werft"
-      - name: WERFT_K8S_LABEL
-        value: "component=werft"
       - name: NODENAME
         valueFrom:
           fieldRef:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -38,8 +38,6 @@ pod:
         - name: harvester-k3s-dockerhub-pull-account
           mountPath: /mnt/secrets/harvester-k3s-dockerhub-pull-account
       env:
-        - name: WERFT_HOST
-          value: "werft.werft.svc.cluster.local:7777"
         - name: HONEYCOMB_DATASET
           value: "werft"
         - name: HONEYCOMB_API_KEY

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -10,6 +10,10 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
     - name: config
       emptyDir: {}
+    - name: github-token-gitpod-bot
+      secret:
+        defaultMode: 420
+        secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:ljb-werft-cli-grpc-changes.2
@@ -40,6 +44,11 @@ pod:
             secretKeyRef:
               name: integration-test-user
               key: token
+        # Used by the Werft CLI through werft-credential-helper.sh
+        - name: WERFT_GITHUB_TOKEN_PATH
+          value: "/mnt/secrets/github-token-gitpod-bot/token"
+        - name: WERFT_CREDENTIAL_HELPER
+          value: "/workspace/dev/preview/werft-credential-helper.sh"
       volumeMounts:
         - name: gcp-sa
           mountPath: /mnt/secrets/gcp-sa
@@ -47,6 +56,8 @@ pod:
         - name: config
           mountPath: /config
           readOnly: false
+        - mountPath: /mnt/secrets/github-token-gitpod-bot
+          name: github-token-gitpod-bot
       command:
         - bash
         - -c
@@ -57,7 +68,6 @@ pod:
           FAILURE_COUNT=0
           RUN_COUNT=0
           declare -A FAILURE_TESTS
-          export WERFT_CREDENTIAL_HELPER=/workspace/dev/preview/werft-credential-helper.sh
 
           function cleanup ()
           {

--- a/dev/preview/werft-credential-helper.sh
+++ b/dev/preview/werft-credential-helper.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-curl --silent localhost:22999/_supervisor/v1/token/git/github.com/ | jq -r '.token'
+if [[ -f $WERFT_GITHUB_TOKEN_PATH ]]; then
+    cat "$WERFT_GITHUB_TOKEN_PATH"
+else
+    curl --silent localhost:22999/_supervisor/v1/token/git/github.com/ | jq -r '.token'
+fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This updates the `werft-credential-helper.sh` script so that it works outside of workspaces and updates all the Werft jobs that use the Werft CLI to set the required environment variable `WERFT_GITHUB_TOKEN_PATH`. It also sets `WERFT_CREDENTIAL_HELPER` as the value that is set in the Dockerfile uses `/workspace/gitpod` as that is where the repository is cloned in workspaces, but in Werft it's in `/workspace`.

This is prerequisite to requiring authentication when using the Werft CLI.

Places where we use the CLI to trigger other jobs:

- [x] `build.yaml`
  - https://github.com/gitpod-io/gitpod/blob/ac58e182c2e7a985e1dee78deba03e07c405ecaa/.werft/jobs/build/trigger-integration-tests.ts#L39
  - https://github.com/gitpod-io/gitpod/blob/b05b848db227f07e1dc2b5180a627dcc0c9edf38/.werft/jobs/build/self-hosted-upgrade-tests.ts#L55
- [x] `workspace-run-integration-tests.yaml`
  - https://github.com/gitpod-io/gitpod/blob/4cb262710665803774dcb8e6f88af7f9e76e3c80/.werft/workspace-run-integration-tests.yaml#L123
- [x] `ide-integration-tests-startup-vscode.yaml`
  - https://github.com/gitpod-io/gitpod/blob/4cb262710665803774dcb8e6f88af7f9e76e3c80/.werft/ide-integration-tests-startup-vscode.yaml#L129
-  [x] `ide-integration-tests-startup-jetbrains.yaml`
    - https://github.com/gitpod-io/gitpod/blob/4cb262710665803774dcb8e6f88af7f9e76e3c80/.werft/ide-integration-tests-startup-jetbrains.yaml#L102

From what I could tell, the following jobs doesn't use the Werft CLI so I removed the WERFT_ environment variables 

- .werft/gke-installer-tests.yaml
- .werft/k3s-installer-tests.yaml

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/3027

## How to test
<!-- Provide steps to test this PR -->

The only job I can easily test which triggers another job using the Werft CLI is the build job. Below I used it to tigger the integration test job. It was able to do so successfully ([see job](https://werft.gitpod-dev.com/job/gitpod-build-mads-werft-credential-helper.11))

```
werft job run github -a with-integration-tests=true -a with-preview=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

N/A

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
