### PR TITLE
[server, protocol] GuardedCostCenter and AttributionId.parse/render (3/5)

### DIFF
--- a/components/gitpod-protocol/src/attribution.ts
+++ b/components/gitpod-protocol/src/attribution.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export type AttributionId = UserAttributionId | TeamAttributionId;
+export type AttributionTarget = "user" | "team";
+
+export interface UserAttributionId {
+    kind: "user";
+    userId: string;
+}
+export interface TeamAttributionId {
+    kind: "team";
+    teamId: string;
+}
+
+export namespace AttributionId {
+    const SEPARATOR = ":";
+
+    export function parse(s: string): UserAttributionId | TeamAttributionId | undefined {
+        if (!s) {
+            return undefined;
+        }
+        const parts = s.split(":");
+        if (parts.length !== 2) {
+            return undefined;
+        }
+        switch (parts[0]) {
+            case "user":
+                return { kind: "user", userId: parts[1] };
+            case "team":
+                return { kind: "team", teamId: parts[1] };
+            default:
+                return undefined;
+        }
+    }
+
+    export function render(id: AttributionId): string {
+        switch (id.kind) {
+            case "user":
+                return `user${SEPARATOR}${id.userId}`;
+            case "team":
+                return `team${SEPARATOR}${id.teamId}`;
+        }
+    }
+}

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -694,7 +694,7 @@ export interface Workspace {
 
 export type WorkspaceSoftDeletion = "user" | "gc";
 
-export type WorkspaceType = "regular" | "prebuild" | "probe";
+export type WorkspaceType = "regular" | "prebuild" | "probe"; // TODO(gpl) Removed prove here
 
 export namespace Workspace {
     export function getFullRepositoryName(ws: Workspace): string | undefined {

--- a/components/server/src/auth/resource-access.spec.ts
+++ b/components/server/src/auth/resource-access.spec.ts
@@ -21,9 +21,10 @@ import {
     GuardedResourceKind,
     RepositoryResourceGuard,
     SharedWorkspaceAccessGuard,
+    GuardedCostCenter,
 } from "./resource-access";
 import { PrebuiltWorkspace, User, UserEnvVar, Workspace, WorkspaceType } from "@gitpod/gitpod-protocol/lib/protocol";
-import { TeamMemberInfo, TeamMemberRole, WorkspaceInstance } from "@gitpod/gitpod-protocol";
+import { Team, TeamMemberInfo, TeamMemberRole, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { HostContextProvider } from "./host-context-provider";
 
 class MockedRepositoryResourceGuard extends RepositoryResourceGuard {
@@ -229,6 +230,145 @@ class TestResourceAccess {
             expect(await res.canAccess(t.resource, "get")).to.be.eq(
                 t.isAllowed,
                 `"${t.name}" expected canAccess(resource, "get") === ${t.isAllowed}, but was ${res}`,
+            );
+        }
+    }
+
+    @test public async costCenterResourceGuard() {
+        const createUser = (): User => {
+            return {
+                id: "123",
+                name: "testuser",
+                creationDate: new Date(2000, 1, 1).toISOString(),
+                identities: [
+                    {
+                        authId: "123",
+                        authName: "testuser",
+                        authProviderId: "github.com",
+                    },
+                ],
+            };
+        };
+
+        const tests: {
+            name: string;
+            isOwner?: boolean;
+            teamRole?: TeamMemberRole;
+            operation: ResourceAccessOp;
+            expectation: boolean;
+        }[] = [
+            // member
+            {
+                name: "member - get",
+                teamRole: "member",
+                operation: "get",
+                expectation: false,
+            },
+            {
+                name: "member - update",
+                teamRole: "member",
+                operation: "update",
+                expectation: false,
+            },
+            {
+                name: "member - update",
+                teamRole: "member",
+                operation: "create",
+                expectation: false,
+            },
+            {
+                name: "member - delete",
+                teamRole: "member",
+                operation: "delete",
+                expectation: false,
+            },
+            // team owner
+            {
+                name: "team owner - get",
+                teamRole: "owner",
+                operation: "get",
+                expectation: true,
+            },
+            {
+                name: "team owner - update",
+                teamRole: "owner",
+                operation: "update",
+                expectation: true,
+            },
+            {
+                name: "team owner - update",
+                teamRole: "owner",
+                operation: "create",
+                expectation: true,
+            },
+            {
+                name: "team owner - delete",
+                teamRole: "owner",
+                operation: "delete",
+                expectation: true,
+            },
+            // owner
+            {
+                name: "owner - get",
+                isOwner: true,
+                operation: "get",
+                expectation: true,
+            },
+            {
+                name: "owner - update",
+                isOwner: true,
+                operation: "update",
+                expectation: true,
+            },
+            {
+                name: "owner - update",
+                isOwner: true,
+                operation: "create",
+                expectation: true,
+            },
+            {
+                name: "owner - delete",
+                isOwner: true,
+                operation: "delete",
+                expectation: true,
+            },
+        ];
+
+        for (const t of tests) {
+            const user = createUser();
+            const team: Team = {
+                id: "team-123",
+                name: "test-team",
+                creationTime: user.creationDate,
+                slug: "test-team",
+            };
+            const resourceGuard = new CompositeResourceAccessGuard([
+                new OwnerResourceGuard(user.id),
+                new TeamMemberResourceGuard(user.id),
+                new SharedWorkspaceAccessGuard(),
+                new MockedRepositoryResourceGuard(true),
+            ]);
+
+            let owner: GuardedCostCenter["owner"] | undefined = undefined;
+            if (t.isOwner) {
+                owner = { kind: "user", userId: user.id };
+            } else if (!!t.teamRole) {
+                const teamMembers: TeamMemberInfo[] = [
+                    {
+                        userId: user.id,
+                        role: t.teamRole,
+                        memberSince: user.creationDate,
+                    },
+                ];
+                owner = { kind: "team", team, members: teamMembers };
+            }
+            if (!owner) {
+                throw new Error("Bad test data: expected isOwner OR teamRole to be configured!");
+            }
+            const actual = await resourceGuard.canAccess({ kind: "costCenter", owner }, "get");
+            expect(actual).to.be.eq(
+                t.expectation,
+                `"${t.name}" expected canAccess(resource, "${t.operation}") === ${t.expectation}, but was ${actual}`,
             );
         }
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #10325 

## How to test
 - `(cd components/server && yarn test)`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
