### PR TITLE
Refactor cert to create and wait in the background

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -521,7 +521,7 @@ export async function issueMetaCerts(
     metaClusterCertParams.ip = getCoreDevIngressIP();
     metaClusterCertParams.bucketPrefixTail = "";
     metaClusterCertParams.additionalSubdomains = additionalSubdomains;
-    return await issueCertificate(werft, metaClusterCertParams, { ...metaEnv(), slice });
+    return issueCertificate(werft, metaClusterCertParams, { ...metaEnv(), slice });
 }
 
 async function installMetaCertificates(

--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -509,7 +509,7 @@ export async function issueMetaCerts(
     certsNamespace: string,
     domain: string,
     slice: string,
-) {
+): Promise<boolean> {
     const additionalSubdomains: string[] = ["", "*.", `*.ws.`];
     var metaClusterCertParams = new IssueCertificateParams();
     metaClusterCertParams.pathToTemplate = "/workspace/.werft/util/templates";
@@ -521,7 +521,7 @@ export async function issueMetaCerts(
     metaClusterCertParams.ip = getCoreDevIngressIP();
     metaClusterCertParams.bucketPrefixTail = "";
     metaClusterCertParams.additionalSubdomains = additionalSubdomains;
-    await issueCertificate(werft, metaClusterCertParams, { ...metaEnv(), slice });
+    return await issueCertificate(werft, metaClusterCertParams, { ...metaEnv(), slice });
 }
 
 async function installMetaCertificates(


### PR DESCRIPTION
## Description
Refactor the way we create and wait for certs.

These changes should lead to:
- Less failures, as we retry and wait 5 times
- Earlier failures, as we fail out before we start deploying things

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
