### PR TITLE
[code] Generate stable image for 1.69.1

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: cbc5eccb5c4dae7d145ad4c1fd825cf9aec4bb6b
+  codeCommit: 971d2f15e8df4000a19e45387f48100add465ce7
   codeQuality: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.3.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.1.3.tar.gz"


### PR DESCRIPTION
## Description
Update code to `1.69.1`

<img width="560" alt="Screenshot 2022-07-12 at 15 41 33" src="https://user-images.githubusercontent.com/2318450/178591370-f8c31763-2eb7-4ef5-9b14-0dc8ce3f5a6c.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

/werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe

- [x] /werft with-preview
