### PR TITLE
[ws-daemon] do not fail workspace if git status failed during dispose 

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -422,9 +422,12 @@ func (s *WorkspaceService) DisposeWorkspace(ctx context.Context, req *api.Dispos
 	// Update the git status prior to deleting the workspace
 	repo, err = sess.UpdateGitStatus(ctx, sess.PersistentVolumeClaim)
 	if err != nil {
+		// do not fail workspace because we were unable to get git status
+		// which can happen for various reasons, including user corrupting his .git folder somehow
+		// instead we log the error and continue cleaning up workspace
+		// todo(pavel): it would be great if we can somehow bubble this up to user without failing workspace
 		log.WithError(err).Error("cannot get git status")
 		span.LogKV("error", err.Error())
-		return nil, status.Error(codes.Internal, "cannot get git status")
 	}
 	if repo != nil {
 		resp.GitStatus = repo

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -426,7 +426,7 @@ func (s *WorkspaceService) DisposeWorkspace(ctx context.Context, req *api.Dispos
 		// which can happen for various reasons, including user corrupting his .git folder somehow
 		// instead we log the error and continue cleaning up workspace
 		// todo(pavel): it would be great if we can somehow bubble this up to user without failing workspace
-		log.WithError(err).Error("cannot get git status")
+		log.WithError(err).Warn("cannot get git status")
 		span.LogKV("error", err.Error())
 	}
 	if repo != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
(This PR is stacked on top of https://github.com/gitpod-io/gitpod/pull/11330, please review commit: https://github.com/gitpod-io/gitpod/commit/8d2d1c6d686a03efb2be274fb3831f534fbf8ded)

Some workspaces fail with `cannot get git status`, which is not a critical error.
Observed in some cases it failed due to potentially corrupt\misconfigured .git folder (potentially due to user's actions).

This PR would make it so that we don't fail workspace when this happens and instead continue disposing it.
For example, we already do that if workspace folder does not contain .git folder in it:
https://github.com/gitpod-io/gitpod/blob/905be0afd12bc43d348591225727ae5c3181982a/components/ws-daemon/pkg/internal/session/workspace.go#L309-L312

Main reasoning is that even if we cannot get git status, all that means is that we not going to show the user in dashboard uncommitted changes, which should not be a reason for failing whole workspace.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Open workspace and corrupt your .git folder
Observe that workspace still finishes correctly, albeit without showing any uncommitted changes in dashboard.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
