### PR TITLE
Call finalizeWorkspaceContent if the workspace Pod in Terminating

### DIFF
--- a/components/ws-manager/pkg/manager/monitor_test.go
+++ b/components/ws-manager/pkg/manager/monitor_test.go
@@ -15,6 +15,7 @@ import (
 	ctesting "github.com/gitpod-io/gitpod/common-go/testing"
 	"github.com/gitpod-io/gitpod/ws-manager/pkg/clock"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestActOnPodEvent(t *testing.T) {
@@ -34,7 +35,8 @@ func TestActOnPodEvent(t *testing.T) {
 		Test: func(t *testing.T, input interface{}) interface{} {
 			fixture := input.(*workspaceObjects)
 			manager := Manager{
-				clock: clock.LogicalOnly(),
+				Clientset: fake.NewClientBuilder().Build(),
+				clock:     clock.LogicalOnly(),
 			}
 			status, serr := manager.getWorkspaceStatus(*fixture)
 			if serr != nil {
@@ -42,7 +44,7 @@ func TestActOnPodEvent(t *testing.T) {
 			}
 
 			var rec actRecorder
-			err := actOnPodEvent(context.Background(), &rec, status, fixture)
+			err := actOnPodEvent(context.Background(), &rec, &manager, status, fixture)
 
 			result := actOnPodEventResult{Actions: rec.Records}
 			if err != nil {

--- a/install/installer/pkg/components/ws-manager/role.go
+++ b/install/installer/pkg/components/ws-manager/role.go
@@ -25,6 +25,16 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
+					APIGroups: []string{""},
+					Resources: []string{
+						"nodes",
+					},
+					Verbs: []string{
+						"get",
+						"list",
+					},
+				},
+				{
 					APIGroups: []string{"snapshot.storage.k8s.io"},
 					Resources: []string{
 						"volumesnapshotcontents",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When the node goes NotReady, the workspace Pod goes into a Terminating state.
In this case, the workspace Pod `status.containerStatuses.state` is still `Running`.

We should try to backup the workspace content if the Pod is Terminating and the underlying node is not ready or even gone.

This is the node taint if the node turns into a NotReady state.
![image](https://user-images.githubusercontent.com/49380831/179006988-9100f5df-1988-4199-b295-357029a171b7.png)

This is the current workspace Pod spec.toleration
![image](https://user-images.githubusercontent.com/49380831/179007038-4fb4657b-bbc7-4211-9f6c-c8e01b1a4f71.png)

Therefore, for the cases
- `node.kubernetes.io/disk-pressure` and `node.kubernetes.io/memory-pressure`: the workspace Pod keeps in tolerance indefinitely. -> We would not handle this case because the tolerance second is not configured.
- `node.kubernetes.io/network-unavailable`: the workspace Pod tolerance duration is 30 seconds. -> We handle this case
- `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable`: the workspace Pod tolerance duration is 300 seconds. -> We handle this case

After the current time - the node's taint.timeAdded > the workspace pod tolerance time, the ws-manager starts back up the content.

https://www.loom.com/share/8e0e870e6bed40809d4ac8ac1159b1e2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11336

## How to test
<!-- Provide steps to test this PR -->
1. Create 2 nodes, 1 control plane node, 1 worker node (using the workspace-preview).
2. Launch a workspace, and the workspace Pod should be located on the worker node 🙏 .
3. SSH into the worker node, disabling the k3s-agent `systemctl disable k3s-agent`.
4. Waits for the node in NotReady state `kubectl get node -w`.
5. Waits for the workspace pod in Terminating state `kubectl get pod -l component=workspace -w`.
6. Check the workspace pod content is back up successfully.

Note: after the node removal, the terminating pod will be removed by Kubernetes after a while. (About 1 minutes)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Try to backup content when the node goes into the NotReady state
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
