### PR TITLE
[local-preview] show `DOMAIN` in the output

### DIFF
--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -4,6 +4,11 @@
 
 set -e
 
+# Set Domain to `127-0-0-1.nip.io` if not set
+if [ -z "${DOMAIN}" ]; then
+  export DOMAIN="127-0-0-1.nip.io"
+fi
+
 if [ "$1" != "logging" ]; then
   $0 logging 2>&1 | /prettylog
   exit
@@ -24,11 +29,6 @@ total_cores=$(nproc)
 if [ "${total_cores}" -lt "${REQUIRED_CORES}" ]; then
     echo "Preview installation of Gitpod requires a system with at least 4 CPU Cores"
     exit 1
-fi
-
-# Set Domain to `127-0-0-1.nip.io` if not set
-if [ -z "${DOMAIN}" ]; then
-  DOMAIN="127-0-0-1.nip.io"
 fi
 
 echo "Gitpod Domain: $DOMAIN"

--- a/install/preview/prettylog/main.go
+++ b/install/preview/prettylog/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -24,7 +25,7 @@ var msgs = []struct {
 	{Msg: "downloading images", Success: "--output-split-files"},
 	{Msg: "preparing Gitpod preview installation", Success: "rm -rf /var/lib/rancher/k3s/server/manifests/gitpod"},
 	{Msg: "starting Gitpod", Success: "gitpod-telemetry-init"},
-	{Msg: "Gitpod is running"},
+	{Msg: fmt.Sprintf("Gitpod is running. Visit https://%s to access the dashboard", os.Getenv("DOMAIN"))},
 }
 
 func main() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the `local-preview` to printout
the Domain of the Gitpod Instance for users to
access.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11316 

## How to test
<!-- Provide steps to test this PR -->
```bash
docker run -p 443:443 --privileged --name gitpod --rm -it -v gitpod:/var/gitpod eu.gcr.io/gitpod-core-dev/build/local-preview:tar-local-preview-domain.0
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[local-preview] show `DOMAIN` in the output
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
