### PR TITLE
[usage] Persist usage reports in database

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
@@ -11,10 +11,10 @@ import { Transformer } from "../transformer";
 @Entity()
 export class DBWorkspaceInstanceUsage {
     @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
-    workspaceId: string;
+    instanceId: string;
 
     @Column("varchar")
-    @Index()
+    @Index("ind_attributionId")
     attributionId: string;
 
     @Column({
@@ -22,7 +22,7 @@ export class DBWorkspaceInstanceUsage {
         precision: 6,
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
     })
-    @Index()
+    @Index("ind_startedAt")
     startedAt: string;
 
     @Column({
@@ -31,7 +31,7 @@ export class DBWorkspaceInstanceUsage {
         nullable: true,
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
     })
-    @Index()
+    @Index("ind_stoppedAt")
     stoppedAt: string;
 
     @Column("double")

--- a/components/gitpod-db/src/typeorm/migration/1657722262390-RenameWorkspaceIdColumn.ts
+++ b/components/gitpod-db/src/typeorm/migration/1657722262390-RenameWorkspaceIdColumn.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RenameWorkspaceIdColumn1657722262390 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`IDX_e759ab5fcf57350da51fcf56bc\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`IDX_25d77dfa246b93672c317e26ad\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`IDX_1358af969a29fd9e0c6cabf37c\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
+
+        await queryRunner.query(
+            `CREATE TABLE \`d_b_workspace_instance_usage\` (\`instanceId\` char(36) NOT NULL, \`attributionId\` varchar(255) NOT NULL, \`startedAt\` timestamp(6) NOT NULL, \`stoppedAt\` timestamp(6) NULL, \`creditsUsed\` double NOT NULL, \`generationId\` int NOT NULL, \`deleted\` tinyint NOT NULL, INDEX \`ind_attributionId\` (\`attributionId\`), INDEX \`ind_startedAt\` (\`startedAt\`), INDEX \`ind_stoppedAt\` (\`stoppedAt\`), PRIMARY KEY (\`instanceId\`)) ENGINE=InnoDB`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`ind_stoppedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_startedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_attributionId\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
+    }
+}

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -213,7 +213,7 @@ func trimStartStopTime(instances []db.WorkspaceInstanceForUsage, maximumStart, m
 	return updated
 }
 
-func groupInstancesByAttributionID(instances []db.WorkspaceInstanceForUsage) map[db.AttributionID][]db.WorkspaceInstanceForUsage {
+func groupInstancesByAttributionID(instances []db.WorkspaceInstanceForUsage) UsageReport {
 	result := map[db.AttributionID][]db.WorkspaceInstanceForUsage{}
 	for _, instance := range instances {
 		if _, ok := result[instance.UsageAttributionID]; !ok {

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -243,7 +243,7 @@ func usageReportToUsageRecords(report UsageReport) []db.WorkspaceInstanceUsage {
 			}
 
 			usageRecords = append(usageRecords, db.WorkspaceInstanceUsage{
-				WorkspaceID:   instance.ID,
+				InstanceID:    instance.ID,
 				AttributionID: attributionId,
 				StartedAt:     instance.CreationTime.Time(),
 				StoppedAt:     stoppedAt,

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -239,7 +239,7 @@ func usageReportToUsageRecords(report UsageReport) []db.WorkspaceInstanceUsage {
 		for _, instance := range instances {
 			var stoppedAt sql.NullTime
 			if instance.StoppedTime.IsSet() {
-				stoppedAt.Time = instance.StoppedTime.Time()
+				stoppedAt = sql.NullTime{Time: instance.StoppedTime.Time(), Valid: true}
 			}
 
 			usageRecords = append(usageRecords, db.WorkspaceInstanceUsage{

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type WorkspaceInstanceUsage struct {
+	WorkspaceID   uuid.UUID     `gorm:"primary_key;column:workspaceId;type:char;size:36;" json:"workspaceId"`
+	AttributionID AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
+	StartedAt     time.Time     `gorm:"column:startedAt;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"startedAt"`
+	StoppedAt     sql.NullTime  `gorm:"column:stoppedAt;type:timestamp;" json:"stoppedAt"`
+	CreditsUsed   float64       `gorm:"column:creditsUsed;type:double;" json:"creditsUsed"`
+	GenerationId  int           `gorm:"column:generationId;type:int;" json:"generationId"`
+	Deleted       bool          `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
+}
+
+// TableName sets the insert table name for this struct type
+func (u *WorkspaceInstanceUsage) TableName() string {
+	return "d_b_workspace_instance_usage"
+}
+
+func CreateUsageRecords(ctx context.Context, conn *gorm.DB, records []WorkspaceInstanceUsage) error {
+	db := conn.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "workspaceId"}},
+		UpdateAll: true,
+	})
+
+	return db.CreateInBatches(records, 1000).Error
+}

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -15,7 +15,7 @@ import (
 )
 
 type WorkspaceInstanceUsage struct {
-	WorkspaceID   uuid.UUID     `gorm:"primary_key;column:workspaceId;type:char;size:36;" json:"workspaceId"`
+	InstanceID    uuid.UUID     `gorm:"primary_key;column:instanceId;type:char;size:36;" json:"instanceId"`
 	AttributionID AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
 	StartedAt     time.Time     `gorm:"column:startedAt;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"startedAt"`
 	StoppedAt     sql.NullTime  `gorm:"column:stoppedAt;type:timestamp;" json:"stoppedAt"`
@@ -31,7 +31,7 @@ func (u *WorkspaceInstanceUsage) TableName() string {
 
 func CreateUsageRecords(ctx context.Context, conn *gorm.DB, records []WorkspaceInstanceUsage) error {
 	db := conn.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "workspaceId"}},
+		Columns:   []clause.Column{{Name: "instanceId"}},
 		UpdateAll: true,
 	})
 

--- a/components/usage/pkg/db/workspace_instance_usage_test.go
+++ b/components/usage/pkg/db/workspace_instance_usage_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanCreateUsageRecords(t *testing.T) {
+	teamID := uuid.New().String()
+	teamAttributionID := db.NewTeamAttributionID(teamID)
+	instanceID := uuid.New()
+	ctx := context.Background()
+
+	scenarios := []struct {
+		Name         string
+		UsageRecords []db.WorkspaceInstanceUsage
+	}{
+		{
+			Name: "One workspace instance",
+			UsageRecords: []db.WorkspaceInstanceUsage{{
+				WorkspaceID:   instanceID,
+				AttributionID: teamAttributionID,
+				StartedAt:     time.Now(),
+				StoppedAt:     sql.NullTime{},
+				CreditsUsed:   0,
+				GenerationId:  0,
+				Deleted:       false,
+			}},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		conn := dbtest.ConnectForTests(t)
+		t.Run(scenario.Name, func(t *testing.T) {
+			t.Cleanup(func() {
+				require.NoError(t, conn.Where(instanceID).Delete(&db.WorkspaceInstanceUsage{}).Error)
+			})
+
+			require.NoError(t, db.CreateUsageRecords(ctx, conn, scenario.UsageRecords))
+		})
+	}
+}
+
+func TestCanHandleDuplicateRecords(t *testing.T) {
+	teamID := uuid.New().String()
+	teamAttributionID := db.NewTeamAttributionID(teamID)
+	instanceID := uuid.New()
+	instanceStartTime := time.Now()
+	ctx := context.Background()
+
+	scenarios := []struct {
+		Name         string
+		UsageRecords []db.WorkspaceInstanceUsage
+	}{
+		{
+			Name: "The same instance twice",
+			UsageRecords: []db.WorkspaceInstanceUsage{
+				{
+					WorkspaceID:   instanceID,
+					AttributionID: teamAttributionID,
+					StartedAt:     instanceStartTime,
+					StoppedAt:     sql.NullTime{},
+					CreditsUsed:   0,
+					GenerationId:  0,
+					Deleted:       false,
+				},
+				{
+					WorkspaceID:   instanceID,
+					AttributionID: teamAttributionID,
+					StartedAt:     instanceStartTime,
+					StoppedAt:     sql.NullTime{},
+					CreditsUsed:   0,
+					GenerationId:  0,
+					Deleted:       false,
+				},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		conn := dbtest.ConnectForTests(t)
+		t.Run(scenario.Name, func(t *testing.T) {
+			t.Cleanup(func() {
+				require.NoError(t, conn.Where(instanceID).Delete(&db.WorkspaceInstanceUsage{}).Error)
+			})
+
+			require.NoError(t, db.CreateUsageRecords(ctx, conn, scenario.UsageRecords))
+		})
+	}
+}

--- a/components/usage/pkg/db/workspace_instance_usage_test.go
+++ b/components/usage/pkg/db/workspace_instance_usage_test.go
@@ -29,7 +29,7 @@ func TestCanCreateUsageRecords(t *testing.T) {
 		{
 			Name: "One workspace instance",
 			UsageRecords: []db.WorkspaceInstanceUsage{{
-				WorkspaceID:   instanceID,
+				InstanceID:    instanceID,
 				AttributionID: teamAttributionID,
 				StartedAt:     time.Now(),
 				StoppedAt:     sql.NullTime{},
@@ -67,7 +67,7 @@ func TestCanHandleDuplicateRecords(t *testing.T) {
 			Name: "The same instance twice",
 			UsageRecords: []db.WorkspaceInstanceUsage{
 				{
-					WorkspaceID:   instanceID,
+					InstanceID:    instanceID,
 					AttributionID: teamAttributionID,
 					StartedAt:     instanceStartTime,
 					StoppedAt:     sql.NullTime{},
@@ -76,7 +76,7 @@ func TestCanHandleDuplicateRecords(t *testing.T) {
 					Deleted:       false,
 				},
 				{
-					WorkspaceID:   instanceID,
+					InstanceID:    instanceID,
 					AttributionID: teamAttributionID,
 					StartedAt:     instanceStartTime,
 					StoppedAt:     sql.NullTime{},


### PR DESCRIPTION
## Description

Store the usage report in the database table created in #11311 whenever usage reconciliation runs.

⚠️ This PR does not yet populate the `creditsUsed` or `generationId` fields ⚠️ 

## Related Issue(s)

Part of #10323 

## How to test

Run the usage component against the database in this PR's preview environment:

* Port forward to the database in the preview env
* Edit the local config `components/usage/config.json` for the usage controller to run every 10s.
* Run the usage component:
```bash
DB_USERNAME=gitpod DB_PASSWORD=<> DB_HOST=localhost DB_PORT=3306 go run . run
```
(get the password from `server` environment)
* Wait a while for reconciliation to run a couple of times.
* Connect to the port-forwarded database with eg `mycli` and observe the data in `d_b_workspace_instance_usage`.

Unit tests.

## Release Notes

```release-note
NONE
```

## Werft options:

- [ ] /werft with-preview
