### PR TITLE
[usage] Rename misnamed column in usage table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
@@ -11,10 +11,10 @@ import { Transformer } from "../transformer";
 @Entity()
 export class DBWorkspaceInstanceUsage {
     @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
-    workspaceId: string;
+    instanceId: string;
 
     @Column("varchar")
-    @Index()
+    @Index("ind_attributionId")
     attributionId: string;
 
     @Column({
@@ -22,7 +22,7 @@ export class DBWorkspaceInstanceUsage {
         precision: 6,
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
     })
-    @Index()
+    @Index("ind_startedAt")
     startedAt: string;
 
     @Column({
@@ -31,7 +31,7 @@ export class DBWorkspaceInstanceUsage {
         nullable: true,
         transformer: Transformer.MAP_ISO_STRING_TO_TIMESTAMP_DROP,
     })
-    @Index()
+    @Index("ind_stoppedAt")
     stoppedAt: string;
 
     @Column("double")

--- a/components/gitpod-db/src/typeorm/migration/1657722262390-RenameWorkspaceIdColumn.ts
+++ b/components/gitpod-db/src/typeorm/migration/1657722262390-RenameWorkspaceIdColumn.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RenameWorkspaceIdColumn1657722262390 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`IDX_e759ab5fcf57350da51fcf56bc\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`IDX_25d77dfa246b93672c317e26ad\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`IDX_1358af969a29fd9e0c6cabf37c\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
+
+        await queryRunner.query(
+            `CREATE TABLE \`d_b_workspace_instance_usage\` (\`instanceId\` char(36) NOT NULL, \`attributionId\` varchar(255) NOT NULL, \`startedAt\` timestamp(6) NOT NULL, \`stoppedAt\` timestamp(6) NULL, \`creditsUsed\` double NOT NULL, \`generationId\` int NOT NULL, \`deleted\` tinyint NOT NULL, INDEX \`ind_attributionId\` (\`attributionId\`), INDEX \`ind_startedAt\` (\`startedAt\`), INDEX \`ind_stoppedAt\` (\`stoppedAt\`), PRIMARY KEY (\`instanceId\`)) ENGINE=InnoDB`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`ind_stoppedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_startedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_attributionId\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
+    }
+}

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -243,7 +243,7 @@ func usageReportToUsageRecords(report UsageReport) []db.WorkspaceInstanceUsage {
 			}
 
 			usageRecords = append(usageRecords, db.WorkspaceInstanceUsage{
-				WorkspaceID:   instance.ID,
+				InstanceID:    instance.ID,
 				AttributionID: attributionId,
 				StartedAt:     instance.CreationTime.Time(),
 				StoppedAt:     stoppedAt,

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -15,7 +15,7 @@ import (
 )
 
 type WorkspaceInstanceUsage struct {
-	WorkspaceID   uuid.UUID     `gorm:"primary_key;column:workspaceId;type:char;size:36;" json:"workspaceId"`
+	InstanceID    uuid.UUID     `gorm:"primary_key;column:instanceId;type:char;size:36;" json:"instanceId"`
 	AttributionID AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
 	StartedAt     time.Time     `gorm:"column:startedAt;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"startedAt"`
 	StoppedAt     sql.NullTime  `gorm:"column:stoppedAt;type:timestamp;" json:"stoppedAt"`
@@ -31,7 +31,7 @@ func (u *WorkspaceInstanceUsage) TableName() string {
 
 func CreateUsageRecords(ctx context.Context, conn *gorm.DB, records []WorkspaceInstanceUsage) error {
 	db := conn.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "workspaceId"}},
+		Columns:   []clause.Column{{Name: "instanceId"}},
 		UpdateAll: true,
 	})
 

--- a/components/usage/pkg/db/workspace_instance_usage_test.go
+++ b/components/usage/pkg/db/workspace_instance_usage_test.go
@@ -29,7 +29,7 @@ func TestCanCreateUsageRecords(t *testing.T) {
 		{
 			Name: "One workspace instance",
 			UsageRecords: []db.WorkspaceInstanceUsage{{
-				WorkspaceID:   instanceID,
+				InstanceID:    instanceID,
 				AttributionID: teamAttributionID,
 				StartedAt:     time.Now(),
 				StoppedAt:     sql.NullTime{},
@@ -67,7 +67,7 @@ func TestCanHandleDuplicateRecords(t *testing.T) {
 			Name: "The same instance twice",
 			UsageRecords: []db.WorkspaceInstanceUsage{
 				{
-					WorkspaceID:   instanceID,
+					InstanceID:    instanceID,
 					AttributionID: teamAttributionID,
 					StartedAt:     instanceStartTime,
 					StoppedAt:     sql.NullTime{},
@@ -76,7 +76,7 @@ func TestCanHandleDuplicateRecords(t *testing.T) {
 					Deleted:       false,
 				},
 				{
-					WorkspaceID:   instanceID,
+					InstanceID:    instanceID,
 					AttributionID: teamAttributionID,
 					StartedAt:     instanceStartTime,
 					StoppedAt:     sql.NullTime{},


### PR DESCRIPTION
## Description

Change the name of the `workspaceId` column to `instanceId` in the `d_b_workspace_instance_usage` table as that's what it stores.

As there is no production data in this table the migration is simply to drop the table and recreate it.

/hold because this is based on https://github.com/gitpod-io/gitpod/pull/11343.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/10323

## How to test

Connecting to the database in the preview env for this PR shows the table with the correct column name.

## Release Notes
```release-note
NONE
```

## Documentation

## Werft options:

- [x] /werft with-preview