### PR TITLE
Record webhook events

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -65,6 +65,8 @@ import { TeamSubscription2DB } from "./team-subscription-2-db";
 import { TeamSubscription2DBImpl } from "./typeorm/team-subscription-2-db-impl";
 import { TypeORMBlockedRepositoryDBImpl } from "./typeorm/blocked-repository-db-impl";
 import { BlockedRepositoryDB } from "./blocked-repository-db";
+import { WebhookEventDB } from "./webhook-event-db";
+import { WebhookEventDBImpl } from "./typeorm/webhook-event-db-impl";
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -139,6 +141,8 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
     bind(TeamDB).toService(TeamDBImpl);
     bind(ProjectDBImpl).toSelf().inSingletonScope();
     bind(ProjectDB).toService(ProjectDBImpl);
+    bind(WebhookEventDBImpl).toSelf().inSingletonScope();
+    bind(WebhookEventDB).toService(WebhookEventDBImpl);
 
     // com concerns
     bind(AccountingDB).to(TypeORMAccountingDBImpl).inSingletonScope();

--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -38,3 +38,4 @@ export * from "./typeorm/entity/db-account-entry";
 export * from "./project-db";
 export * from "./team-db";
 export * from "./installation-admin-db";
+export * from "./webhook-event-db";

--- a/components/gitpod-db/src/typeorm/entity/db-webhook-event.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-webhook-event.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { Entity, Column, PrimaryColumn, Index } from "typeorm";
+
+import { Transformer } from "../../typeorm/transformer";
+import { WebhookEvent } from "@gitpod/gitpod-protocol";
+
+@Entity()
+// on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
+export class DBWebhookEvent implements WebhookEvent {
+    @PrimaryColumn("uuid")
+    id: string;
+
+    @Column()
+    @Index("ind_creationTime")
+    creationTime: string;
+
+    @Column()
+    type: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    authorizedUserId?: string;
+
+    @Column()
+    rawEvent: string;
+
+    @Column()
+    @Index("ind_status")
+    status: WebhookEvent.Status;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    message?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    @Index("ind_prebuildStatus")
+    prebuildStatus?: WebhookEvent.PrebuildStatus;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    @Index("ind_prebuildId")
+    prebuildId?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    projectId?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    @Index("ind_cloneUrl")
+    cloneUrl?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    branch?: string;
+
+    @Column({
+        default: "",
+        transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
+    })
+    commit?: string;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
+}

--- a/components/gitpod-db/src/typeorm/migration/1657702361007-AddWebhookEvent.ts
+++ b/components/gitpod-db/src/typeorm/migration/1657702361007-AddWebhookEvent.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddWebhookEvent1657702361007 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TABLE IF NOT EXISTS `d_b_webhook_event` ( `id` char(36) NOT NULL, `creationTime` varchar(255) NOT NULL, `type` char(60) NOT NULL, `authorizedUserId` char(36) NULL, `status` char(60) NOT NULL, `message` text NULL, `rawEvent` text NOT NULL, `cloneUrl` char(255) NULL, `branch` char(255) NULL, `commit` varchar(255) NULL, `projectId` char(36) NULL, `prebuildStatus` char(60) NULL, `prebuildId` char(36) NULL, `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY(`id`), KEY `ind_dbsync` (`_lastModified`), KEY `ind_cloneUrl` (`cloneUrl`), KEY `ind_status` (`status`), KEY `ind_prebuildStatus` (`prebuildStatus`), KEY `ind_prebuildId` (`prebuildId`), KEY `ind_creationTime` (`creationTime`) ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP TABLE `d_b_webhook_event`;");
+    }
+}

--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { injectable, inject } from "inversify";
+import { Repository } from "typeorm";
+import { v4 as uuidv4 } from "uuid";
+
+import { TypeORM } from "./typeorm";
+import { WebhookEventDB } from "../webhook-event-db";
+import { DBWebhookEvent } from "./entity/db-webhook-event";
+import { WebhookEvent } from "@gitpod/gitpod-protocol";
+
+@injectable()
+export class WebhookEventDBImpl implements WebhookEventDB {
+    @inject(TypeORM) protected readonly typeORM: TypeORM;
+
+    protected async getEntityManager() {
+        return (await this.typeORM.getConnection()).manager;
+    }
+
+    protected async getRepo(): Promise<Repository<DBWebhookEvent>> {
+        return (await this.getEntityManager()).getRepository(DBWebhookEvent);
+    }
+
+    async createEvent(parts: Omit<WebhookEvent, "id">): Promise<WebhookEvent> {
+        const repo = await this.getRepo();
+        const newEvent: WebhookEvent = {
+            ...parts,
+            id: uuidv4(),
+            creationTime: new Date().toISOString(),
+        };
+        return await repo.save(newEvent);
+    }
+
+    async updateEvent(id: string, update: Partial<WebhookEvent>): Promise<void> {
+        const repo = await this.getRepo();
+        const safeUpdate: Partial<WebhookEvent> = { ...update, id };
+        delete safeUpdate.type;
+        delete safeUpdate.rawEvent;
+        await repo.save(safeUpdate);
+    }
+
+    async findByCloneUrl(cloneUrl: string, limit?: number): Promise<WebhookEvent[]> {
+        const repo = await this.getRepo();
+        const query = repo.createQueryBuilder("event");
+        query.where("event.cloneUrl = :cloneUrl", { cloneUrl });
+        query.orderBy("creationTime", "DESC");
+        query.limit(limit);
+        return query.getMany();
+    }
+}

--- a/components/gitpod-db/src/webhook-event-db.spec.db.ts
+++ b/components/gitpod-db/src/webhook-event-db.spec.db.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import * as chai from "chai";
+import { suite, test, timeout } from "mocha-typescript";
+import { testContainer } from "./test-container";
+import { TypeORM } from "./typeorm/typeorm";
+import { WebhookEventDB } from "./webhook-event-db";
+import { DBWebhookEvent } from "./typeorm/entity/db-webhook-event";
+const expect = chai.expect;
+
+@suite
+@timeout(5000)
+export class WebhookEventDBSpec {
+    typeORM = testContainer.get<TypeORM>(TypeORM);
+    db = testContainer.get<WebhookEventDB>(WebhookEventDB);
+
+    async before() {
+        await this.clear();
+    }
+
+    async after() {
+        await this.clear();
+    }
+
+    protected async clear() {
+        const connection = await this.typeORM.getConnection();
+        const manager = connection.manager;
+        await manager.clear(DBWebhookEvent);
+    }
+
+    @test public async testSafeUpdate() {
+        const event = await this.db.createEvent({
+            rawEvent: "payload as string",
+            status: "received",
+            type: "push",
+        });
+        const cloneUrl = "http://gitlab.local/project/repo";
+        await this.db.updateEvent(event.id, {
+            status: "ignored",
+            rawEvent: "should not be overriden",
+            type: "should not be overriden",
+            cloneUrl,
+        });
+
+        const updated = (await this.db.findByCloneUrl(cloneUrl))[0];
+        expect(updated, "should be found").to.be.not.undefined;
+        expect(updated.status, "status should be updated").to.equal("ignored");
+        expect(updated.type, "type should not be updated").to.equal("push");
+        expect(updated.rawEvent, "rawEvent should not be updated").to.equal("payload as string");
+    }
+}
+
+module.exports = WebhookEventDBSpec;

--- a/components/gitpod-db/src/webhook-event-db.ts
+++ b/components/gitpod-db/src/webhook-event-db.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { WebhookEvent } from "@gitpod/gitpod-protocol";
+
+export const WebhookEventDB = Symbol("WebhookEventDB");
+export interface WebhookEventDB {
+    createEvent(parts: Omit<WebhookEvent, "id" | "creationTime">): Promise<WebhookEvent>;
+    updateEvent(id: string, update: Partial<WebhookEvent>): Promise<void>;
+    findByCloneUrl(cloneUrl: string, limit?: number): Promise<WebhookEvent[]>;
+}

--- a/components/gitpod-protocol/src/index.ts
+++ b/components/gitpod-protocol/src/index.ts
@@ -20,3 +20,4 @@ export * from "./teams-projects-protocol";
 export * from "./snapshot-url";
 export * from "./oss-allowlist";
 export * from "./installation-admin-protocol";
+export * from "./webhook-event";

--- a/components/gitpod-protocol/src/webhook-event.ts
+++ b/components/gitpod-protocol/src/webhook-event.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export interface WebhookEvent {
+    id: string;
+    creationTime: string;
+    type: "push" | string;
+
+    /**
+     * Typically the webhook installer is referenced here.
+     */
+    authorizedUserId?: string;
+
+    /**
+     * webhook event's payload
+     */
+    rawEvent: string;
+
+    /**
+     * The general status of the received webhook event.
+     */
+    status: WebhookEvent.Status;
+
+    /**
+     * Optional message to help understand errors with handling events.
+     */
+    message?: string;
+
+    /**
+     * If the webhook event is considered to trigger a prebuild, the `prebuildStatus`
+     * contains a more specific status.
+     */
+    prebuildStatus?: WebhookEvent.PrebuildStatus;
+
+    /**
+     * If `prebuildStatus` is `prebuild_triggered` this points to a prebuild.
+     */
+    prebuildId?: string;
+
+    projectId?: string;
+
+    cloneUrl?: string;
+
+    branch?: string;
+
+    commit?: string;
+}
+
+export namespace WebhookEvent {
+    export type Status = "received" | "dismissed_unauthorized" | "ignored" | "processed";
+    export type PrebuildStatus = "ignored_unconfigured" | "prebuild_trigger_failed" | "prebuild_triggered";
+}


### PR DESCRIPTION
## Description
This PR adds recording of webhook events received for GH/GHE/GL/BB/BBS.

For each `push` event received for any configured repositories, a record will be stored in the DB containing the raw payload necessary to trigger a prebuild at any time. To start with a 🛹, the actual trigger remains untouched here, only the status is updated up the the point of a successful prebuild trigger (or any error case.) The status updates will be already beneficial in the follow up PR to render updates on the dashboard.

The proposed DB table is quite simple. 

```
mysql> describe d_b_webhook_event;
+------------------+--------------+------+-----+----------------------+--------------------------------+
| Field            | Type         | Null | Key | Default              | Extra                          |
+------------------+--------------+------+-----+----------------------+--------------------------------+
| id               | char(36)     | NO   | PRI | NULL                 |                                |
| creationTime     | varchar(255) | NO   | MUL | NULL                 |                                |
| type             | char(60)     | NO   |     | NULL                 |                                |
| authorizedUserId | char(36)     | YES  |     | NULL                 |                                |
| status           | char(60)     | NO   |     | NULL                 |                                |
| message          | text         | YES  |     | NULL                 |                                |
| rawEvent         | text         | NO   |     | NULL                 |                                |
| cloneUrl         | char(255)    | YES  | MUL | NULL                 |                                |
| branch           | char(255)    | YES  |     | NULL                 |                                |
| commit           | varchar(255) | YES  |     | NULL                 |                                |
| projectId        | char(36)     | YES  |     | NULL                 |                                |
| prebuildStatus   | char(60)     | YES  |     | NULL                 |                                |
| prebuildId       | char(36)     | YES  |     | NULL                 |                                |
| deleted          | tinyint(4)   | NO   |     | 0                    |                                |
| _lastModified    | timestamp(6) | NO   | MUL | CURRENT_TIMESTAMP(6) | on update CURRENT_TIMESTAMP(6) |
+------------------+--------------+------+-----+----------------------+--------------------------------+
15 rows in set (0.02 sec)
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related #10764

## How to test
Push a commit to a repository configured as a project with this preview environment and verify you see webhook events stored in the DB. 

```
mysql> select type, status, prebuildStatus from d_b_webhook_event;
+------+-----------+--------------------+
| type | status    | prebuildStatus     |
+------+-----------+--------------------+
| push | processed | prebuild_triggered |
+------+-----------+--------------------+
1 row in set (0.00 sec)
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-clean-slate-deployment
