### PR TITLE
Implement hasReadAccess for Bitbucket

### DIFF
--- a/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
@@ -12,13 +12,13 @@ import { AuthProviderParams } from "../auth/auth-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { DevData } from "../dev/dev-data";
 import { TokenProvider } from "../user/token-provider";
-import { BitbucketApiFactory, BasicAuthBitbucketApiFactory } from "./bitbucket-api-factory";
+import { BitbucketApiFactory } from "./bitbucket-api-factory";
 import { BitbucketRepositoryProvider } from "./bitbucket-repository-provider";
 import { BitbucketTokenHelper } from "./bitbucket-token-handler";
 const expect = chai.expect;
 import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
 
-@suite(timeout(10000), retries(2), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET"))
+@suite(timeout(10000), retries(0), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET"))
 class TestBitbucketRepositoryProvider {
     protected repoProvider: BitbucketRepositoryProvider;
     protected user: User;
@@ -52,7 +52,7 @@ class TestBitbucketRepositoryProvider {
                     getFreshPortAuthenticationToken: async (user: User, workspaceId: string) =>
                         DevData.createPortAuthTestToken(workspaceId),
                 });
-                bind(BitbucketApiFactory).to(BasicAuthBitbucketApiFactory).inSingletonScope();
+                bind(BitbucketApiFactory).toSelf().inSingletonScope();
                 bind(HostContextProvider).toConstantValue({
                     get: (hostname: string) => {
                         authProvider: {
@@ -72,7 +72,7 @@ class TestBitbucketRepositoryProvider {
             host: "bitbucket.org",
             owner: "gitpod",
             name: "integration-tests",
-            cloneUrl: "https://gitpod-test@bitbucket.org/gitpod/integration-tests.git",
+            cloneUrl: "https://bitbucket.org/gitpod/integration-tests.git",
             description: "This is the repository used for integration tests.",
             webUrl: "https://bitbucket.org/gitpod/integration-tests",
         });
@@ -87,6 +87,16 @@ class TestBitbucketRepositoryProvider {
             100,
         );
         expect(result).to.deep.equal(["da2119f51b0e744cb6b36399f8433b477a4174ef"]);
+    }
+
+    @test public async testHasReadAccess_positive() {
+        const result = await this.repoProvider.hasReadAccess(this.user, "gitpod", "integration-tests");
+        expect(result).to.be.true;
+    }
+
+    @test public async testHasReadAccess_negative() {
+        const result = await this.repoProvider.hasReadAccess(this.user, "foobar", "private-repo");
+        expect(result).to.be.false;
     }
 }
 

--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -105,8 +105,16 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     }
 
     async hasReadAccess(user: User, owner: string, repo: string): Promise<boolean> {
-        // FIXME(janx): Not implemented yet
-        return false;
+        const api = await this.apiFactory.create(user);
+        try {
+            await api.repositories.get({ workspace: owner, repo_slug: repo });
+            // we assume that if the current token is good to read the repository details,
+            // then the repository is accessible
+            return true;
+        } catch (err) {
+            console.warn({ userId: user.id }, "hasReadAccess error", err, { owner, repo });
+            return false;
+        }
     }
 
     public async getCommitHistory(


### PR DESCRIPTION
## Description
As described in #11190 this PR implements the missing BitbucketRepositoryProvider.hasReadAccess

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11190

## How to test
Note, those tests are not executed in werft. One need to drive them manually.
* grab an OAuth2 token for bitbucket.org and set it in you env using this command:
  ```
  export GITPOD_TEST_TOKEN_BITBUCKET='{ "value": "FOOBAR=", "username": "x-token-auth", "scopes": []  }'
  ```
* run test 
  ```
   yarn mocha --opts mocha.opts /workspace/gitpod/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
   ```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
