### PR TITLE
Add our Extension control manifest to the IDE proxy

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 412debcdce97027594b55f85871951f0aa87c2fc
+  codeCommit: 3fef802aa6bfd601cf182315ba949931401772f8
   codeQuality: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.1.4.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.1.3.tar.gz"

--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -18,7 +18,6 @@ RUN for FILE in `ls /bin/gitpod-local-companion*`;do \
   gzip -v -f -9 -k "$FILE"; \
 done
 
-
 FROM caddy/caddy:2.4.6-alpine
 
 COPY conf/Caddyfile /etc/caddy/Caddyfile

--- a/components/ide-proxy/conf/Caddyfile
+++ b/components/ide-proxy/conf/Caddyfile
@@ -71,6 +71,7 @@
 		# static assets configure cache headers and do not check for changes
 		header {
 			Cache-Control "public, max-age=31536000"
+			Access-Control-Allow-Origin *
 			# remove Last-Modified header
 			-Last-Modified
 		}

--- a/components/ide-proxy/static/code/marketplace.json
+++ b/components/ide-proxy/static/code/marketplace.json
@@ -1,0 +1,78 @@
+{
+  "malicious": [],
+  "deprecated": {
+      "msjsdiag.debugger-for-chrome": {
+          "disallowInstall": true,
+          "extension": {
+              "id": "ms-vscode.js-debug",
+              "displayName": "JavaScript Debugger"
+          }
+      },
+      "abusaidm.html-snippets": true,
+      "ms-vscode.vscode-typescript-tslint-plugin": true,
+      "auchenberg.vscode-browser-preview": {
+          "disallowInstall": false,
+          "extension": {
+              "id": "ms-vscode.live-server",
+              "displayName": "Live Preview"
+          }
+      },
+      "rust-lang.rust": {
+          "disallowInstall": true,
+          "extension": {
+              "id": "rust-lang.rust-analyzer",
+              "displayName": "rust-analyzer"
+          }
+      },
+      "KnisterPeter.vscode-github": {
+          "disallowInstall": true,
+          "extension": {
+              "id": "GitHub.vscode-pull-request-github",
+              "displayName": "GitHub Pull Requests and Issues"
+          }
+      },
+      "antfu.vue-i18n-ally": {
+          "disallowInstall": true,
+          "extension": {
+              "id": "lokalise.i18n-ally",
+              "displayName": "i18n Ally"
+          }
+      },
+      "antfu.i18n-ally": {
+          "disallowInstall": true,
+          "extension": {
+              "id": "lokalise.i18n-ally",
+              "displayName": "i18n Ally"
+          }
+      },
+      "redhat.vscode-didact": {
+          "disallowInstall": false,
+          "extension": {
+              "id": "vsls-contrib.codetour",
+              "displayName": "CodeTour"
+          }
+      },
+      "CoenraadS.bracket-pair-colorizer-2": {
+          "settings": [
+              "editor.bracketPairColorization.enabled",
+              "editor.guides.bracketPairs"
+          ]
+      },
+      "CoenraadS.bracket-pair-colorizer": {
+          "settings": [
+              "editor.bracketPairColorization.enabled",
+              "editor.guides.bracketPairs"
+          ]
+      },
+      "redhat.vscode-wsdl2rest": true,
+      "ms-vscode.node-debug2": true,
+      "ms-vscode.node-debug": true,
+      "HookyQR.beautify": true,
+      "tht13.python": true,
+      "lonefy.vscode-JS-CSS-HTML-formatter": true,
+      "ikappas.phpcs": true,
+      "heptio.jsonnet": true,
+      "eg2.vscode-npm-script": true
+  },
+  "migrateToPreRelease": {}
+}

--- a/install/installer/pkg/components/blobserve/configmap.go
+++ b/install/installer/pkg/components/blobserve/configmap.go
@@ -39,18 +39,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PrePull: []string{},
 					Workdir: "/ide",
 					Replacements: []blobserve.StringReplacement{{
-						Search:      "vscode-webview.net",
-						Replacement: ctx.Config.Domain,
-						Path:        "/ide/out/vs/workbench/workbench.web.api.js",
-					}, {
-						Search:      "vscode-webview.net",
-						Replacement: ctx.Config.Domain,
-						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
-					}, {
-						Search:      "vscode-webview.net",
-						Replacement: ctx.Config.Domain,
-						Path:        "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
-					}, {
 						Search:      "vscode-cdn.net",
 						Replacement: ctx.Config.Domain,
 						Path:        "/ide/out/vs/workbench/workbench.web.api.js",
@@ -69,6 +57,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					}, {
 						Search:      "open-vsx.org",
 						Replacement: openVSXProxyUrl,
+						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
+					}, {
+						Search:      "ide.gitpod.io/code/markeplace.json",
+						Replacement: fmt.Sprintf("ide.%s/code/marketplace.json", ctx.Config.Domain),
 						Path:        "/ide/out/vs/workbench/workbench.web.main.js",
 					}},
 					InlineStatic: []blobserve.InlineReplacement{{


### PR DESCRIPTION
## Description
Adds https://github.com/gitpod-io/openvsx.org.json/blob/main/marketplace.json as a static asset to our IDE proxy.

## Related Issue(s)

Part of https://github.com/gitpod-io/openvscode-server/pull/380.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
