### PR TITLE
[ws-manager] Add event to workspace Pod when the PVC restored from the VolumeSnapshot

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -329,7 +329,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 		err = wait.PollWithContext(ctx, 100*time.Millisecond, 5*time.Minute, pvcRunning(m.Clientset, pvc.Name, pvc.Namespace))
 		if err != nil {
 			if startContext.VolumeSnapshot != nil && startContext.VolumeSnapshot.VolumeSnapshotName != "" {
-				m.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "PersistentVolumeClaim", "PVC %q restored from volume snapshot %q failed %v", pvc.Name, startContext.VolumeSnapshot.VolumeSnapshotName, err)
+				m.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "PersistentVolumeClaim", "PVC %q restore from volume snapshot %q failed %v", pvc.Name, startContext.VolumeSnapshot.VolumeSnapshotName, err)
 				clog.WithError(err).Warnf("unexpected error waiting for PVC %s volume snapshot %s", pvc.Name, startContext.VolumeSnapshot.VolumeSnapshotName)
 			} else {
 				m.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "PersistentVolumeClaim", "PVC %q created failed %v", pvc.Name, err)

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -332,7 +332,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 				m.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "PersistentVolumeClaim", "PVC %q restore from volume snapshot %q failed %v", pvc.Name, startContext.VolumeSnapshot.VolumeSnapshotName, err)
 				clog.WithError(err).Warnf("unexpected error waiting for PVC %s volume snapshot %s", pvc.Name, startContext.VolumeSnapshot.VolumeSnapshotName)
 			} else {
-				m.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "PersistentVolumeClaim", "PVC %q created failed %v", pvc.Name, err)
+				m.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "PersistentVolumeClaim", "PVC %q create failed %v", pvc.Name, err)
 				clog.WithError(err).Warnf("unexpected error waiting for PVC %s", pvc.Name)
 			}
 		} else {

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -175,7 +175,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	clog.Info("StartWorkspace")
 	reqs, _ := protojson.Marshal(req)
 	safeReqs, _ := log.RedactJSON(reqs)
-	log.WithField("req", string(safeReqs)).Debug("StartWorkspace request received")
+	clog.WithField("req", string(safeReqs)).Debug("StartWorkspace request received")
 
 	// Make sure the objects we're about to create do not exist already
 	switch req.Type {
@@ -248,11 +248,11 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 				// restore volume snapshot from handle
 				err = m.restoreVolumeSnapshotFromHandle(ctx, startContext.VolumeSnapshot.VolumeSnapshotName, startContext.VolumeSnapshot.VolumeSnapshotHandle)
 				if err != nil {
-					log.WithError(err).Error("was unable to restore volume snapshot")
+					clog.WithError(err).Error("was unable to restore volume snapshot")
 					return nil, err
 				}
 			} else if err != nil {
-				log.WithError(err).Error("was unable to get volume snapshot")
+				clog.WithError(err).Error("was unable to get volume snapshot")
 				return nil, err
 			}
 		}
@@ -342,7 +342,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 				wsType := api.WorkspaceType_name[int32(req.Type)]
 				hist, err := m.metrics.volumeRestoreTimeHistVec.GetMetricWithLabelValues(wsType, req.Spec.Class)
 				if err != nil {
-					log.WithError(err).WithField("type", wsType).Warn("cannot get volume restore time histogram metric")
+					clog.WithError(err).WithField("type", wsType).Warn("cannot get volume restore time histogram metric")
 				} else if endTime.IsZero() {
 					endTime = time.Now()
 					hist.Observe(endTime.Sub(startTime).Seconds())


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We add an event to the workspace Pod in #10889 for the take volume snapshot operation (InProgress, ReadyToUse).
In this PR, we add an event to the workspace Pod when the PVC is restored from the VolumeSnapshot.
Hence, we would know the workspace Pod PVC is restored from the VolumeSnapshot or not.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10887

## How to test
<!-- Provide steps to test this PR -->
1. Create a preview environment and enable the feature flag `persistent_volume_claim`.
2. Launch a workspace
3. Describe the workspace pod, and the event message should matches
    ```console
    Events:
      Type    Reason                  Age   From                     Message
      ----    ------                  ----  ----                     -------
      Normal  PersistentVolumeClaim   19s   ws-manager               PVC "<pvd-name>" created successfully
    ```
4.  and write a large data into it.
    ```console
    dd if=/dev/urandom of=data bs=16M count=1
    ```
5. Stop the workspace.
6. Relaunch the workspace, and describe the workspace pod, the event message should matches
    ```console
    Events:
      Type    Reason                  Age   From                     Message
      ----    ------                  ----  ----                     -------
      Normal  PersistentVolumeClaim   3s    ws-manager               PVC "<pvc-name>" restored from volume snapshot "<volume-snapshot-name>" successfully
    ```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[experimental] Add PVC created message to the workspace pod event
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
