### PR TITLE
Add namespace flag to cert debug command

### DIFF
--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -15,10 +15,7 @@ const prepareSlices = {
 };
 
 export async function prepare(werft: Werft, config: JobConfig) {
-    if (!config.withPreview)
-    {
-        return
-    }
+
     werft.phase(phaseName);
     try {
         werft.log(prepareSlices.CONFIGURE_CORE_DEV, prepareSlices.CONFIGURE_CORE_DEV);

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -23,6 +23,10 @@ export async function prepare(werft: Werft, config: JobConfig) {
         configureDocker();
         configureStaticClustersAccess();
         werft.done(prepareSlices.CONFIGURE_CORE_DEV);
+        if (!config.withPreview)
+        {
+            return
+        }
         var certReady = issueCertificate(werft, config);
         decideHarvesterVMCreation(werft, config);
         await certReady

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -66,7 +66,7 @@ function retrieveFailedCertDebug(certName: string, slice: string) {
         `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs get certificate ${certName} -o yaml`,
         { silent: true },
     ).stdout.trim();
-    const certificateDebug = exec(`KUBECONFIG=${CORE_DEV_KUBECONFIG_PATH} cmctl status certificate ${certName}`);
+    const certificateDebug = exec(`KUBECONFIG=${CORE_DEV_KUBECONFIG_PATH} cmctl status certificate ${certName} -n certs`);
     exec(`kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs delete certificate ${certName}`, {
         slice: slice,
     });


### PR DESCRIPTION
## Description
Adds a namespace flag to the `cmctl` debug command on cert failure

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
