### PR TITLE
[supervisor] Refactor content-init error handling

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1326,7 +1326,10 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 		fnReady = "/.workspace/.gitpod/ready"
 		log.Info("Detected content.json in /.workspace folder, assuming PVC feature enabled")
 	}
-	f, err := os.Open(fn)
+
+	var contentFile *os.File
+
+	contentFile, err = os.Open(fn)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.WithError(err).Error("cannot open init descriptor")
@@ -1363,7 +1366,10 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 		return
 	}
 
-	src, err := executor.Execute(ctx, "/workspace", f, true)
+	defer contentFile.Close()
+
+	var src csapi.WorkspaceInitSource
+	src, err = executor.Execute(ctx, "/workspace", contentFile, true)
 	if err != nil {
 		return
 	}
@@ -1373,6 +1379,7 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 		// file is gone - we're good
 		err = nil
 	}
+
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description

Ensure we close the content file and avoid [redeclaring `err` variable](https://go.dev/ref/spec#Short_variable_declarations) (used in [defer](https://github.com/gitpod-io/gitpod/blob/1882d6692663fa82775de1761f261c546bd2aed9/components/supervisor/pkg/supervisor/supervisor.go#L1310))

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
