### PR TITLE
[ws-manager-bridge] Remove HasUserLevel admission constraint

### DIFF
--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -56,12 +56,10 @@ export type WorkspaceManagerConnectionInfo = Pick<WorkspaceCluster, "name" | "ur
 export type AdmissionConstraint =
     | AdmissionConstraintFeaturePreview
     | AdmissionConstraintHasPermission
-    | AdmissionConstraintHasUserLevel
     | AdmissionConstraintHasMoreResources
     | AdmissionConstraintHasClass;
 export type AdmissionConstraintFeaturePreview = { type: "has-feature-preview" };
 export type AdmissionConstraintHasPermission = { type: "has-permission"; permission: PermissionName };
-export type AdmissionConstraintHasUserLevel = { type: "has-user-level"; level: string };
 export type AdmissionConstraintHasMoreResources = { type: "has-more-resources" };
 export type AdmissionConstraintHasClass = { type: "has-class"; id: string; displayName: string };
 

--- a/components/ws-manager-bridge-api/cluster-service.proto
+++ b/components/ws-manager-bridge-api/cluster-service.proto
@@ -58,7 +58,7 @@ message AdmissionConstraint {
   oneof constraint {
     FeaturePreview has_feature_preview = 1;
     HasPermission has_permission = 2;
-    string has_user_level = 3;
+    // deprecated anr removed: has_user_level = 3;
     bool has_more_resources = 4;
   }
 }

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -15,7 +15,6 @@ import {
     AdmissionConstraint,
     AdmissionConstraintHasPermission,
     WorkspaceClusterWoTLS,
-    AdmissionConstraintHasUserLevel,
     AdmissionConstraintHasMoreResources,
 } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import {
@@ -233,10 +232,6 @@ export class ClusterService implements IClusterServiceServer {
                                             return false;
                                         }
                                         break;
-                                    case "has-user-level":
-                                        if (v.level === (c as AdmissionConstraintHasUserLevel).level) {
-                                            return false;
-                                        }
                                     case "has-more-resources":
                                         return false;
                                 }
@@ -348,9 +343,6 @@ function convertToGRPC(ws: WorkspaceClusterWoTLS): ClusterStatus {
                 perm.setPermission(c.permission);
                 constraint.setHasPermission(perm);
                 break;
-            case "has-user-level":
-                constraint.setHasUserLevel(c.level);
-                break;
             case "has-more-resources":
                 constraint.setHasMoreResources(true);
                 break;
@@ -377,13 +369,6 @@ function mapAdmissionConstraint(c: GRPCAdmissionConstraint | undefined): Admissi
         }
 
         return <AdmissionConstraintHasPermission>{ type: "has-permission", permission };
-    }
-    if (c.hasHasUserLevel()) {
-        const level = c.getHasUserLevel();
-        if (!level) {
-            return;
-        }
-        return <AdmissionConstraintHasUserLevel>{ type: "has-user-level", level };
     }
     if (c.hasHasMoreResources()) {
         return <AdmissionConstraintHasMoreResources>{ type: "has-more-resources" };

--- a/dev/gpctl/cmd/clusters-update.go
+++ b/dev/gpctl/cmd/clusters-update.go
@@ -87,7 +87,7 @@ var clustersUpdateMaxScoreCmd = &cobra.Command{
 }
 
 var clustersUpdateAdmissionConstraintCmd = &cobra.Command{
-	Use:   "admission-constraint add|remove has-feature-preview|has-permission=<permission>|has-user-level=<level>|has-more-resources",
+	Use:   "admission-constraint add|remove has-feature-preview|has-permission=<permission>|has-more-resources",
 	Short: "Updates a cluster's admission constraints",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -122,17 +122,6 @@ var clustersUpdateAdmissionConstraintCmd = &cobra.Command{
 							HasPermission: &api.AdmissionConstraint_HasPermission{
 								Permission: strings.TrimPrefix(args[1], "has-permission="),
 							},
-						},
-					},
-				},
-			}
-		} else if strings.HasPrefix(args[1], "has-user-level=") {
-			request.Property = &api.UpdateRequest_AdmissionConstraint{
-				AdmissionConstraint: &api.ModifyAdmissionConstraint{
-					Add: add,
-					Constraint: &api.AdmissionConstraint{
-						Constraint: &api.AdmissionConstraint_HasUserLevel{
-							HasUserLevel: strings.TrimPrefix(args[1], "has-user-level="),
 						},
 					},
 				},


### PR DESCRIPTION
## Description
This PR removes the `has-user-level` admission constraint. We never actually used this constrained, so it was just deadweight.

This PR is part of a stack of changes:
- ➡️ 
-
- 

## How to test
This PR should not actually incur functional changes of any sort.


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
