### PR TITLE
[ws-manager-bridge] Remove HasMoreResources admission constraint

### DIFF
--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -56,11 +56,9 @@ export type WorkspaceManagerConnectionInfo = Pick<WorkspaceCluster, "name" | "ur
 export type AdmissionConstraint =
     | AdmissionConstraintFeaturePreview
     | AdmissionConstraintHasPermission
-    | AdmissionConstraintHasMoreResources
     | AdmissionConstraintHasClass;
 export type AdmissionConstraintFeaturePreview = { type: "has-feature-preview" };
 export type AdmissionConstraintHasPermission = { type: "has-permission"; permission: PermissionName };
-export type AdmissionConstraintHasMoreResources = { type: "has-more-resources" };
 export type AdmissionConstraintHasClass = { type: "has-class"; id: string; displayName: string };
 
 export namespace AdmissionConstraint {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -464,7 +464,6 @@ export class WorkspaceStarter {
             // we add additional information to the user to help with cluster selection
             const euser: ExtendedUser = {
                 ...user,
-                getsMoreResources: await this.userService.userGetsMoreResources(user),
             };
 
             // choose a cluster and start the instance

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -6,15 +6,18 @@
 
 import "reflect-metadata";
 
-import { Container } from 'inversify';
+import { Container } from "inversify";
 import { suite, test } from "@testdeck/mocha";
-import * as chai from 'chai';
+import * as chai from "chai";
 import { IWorkspaceClusterStartSet, WorkspaceManagerClientProvider } from "./client-provider";
-import { WorkspaceManagerClientProviderCompositeSource, WorkspaceManagerClientProviderSource } from "./client-provider-source";
+import {
+    WorkspaceManagerClientProviderCompositeSource,
+    WorkspaceManagerClientProviderSource,
+} from "./client-provider-source";
 import { WorkspaceCluster, WorkspaceClusterWoTLS } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { User, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { PromisifiedWorkspaceManagerClient } from ".";
-import { Constraint, constraintHasPermissions, constraintInverseMoreResources, constraintMoreResources, ExtendedUser, intersect, invert } from "./constraints";
+import { Constraint, constraintHasPermissions, ExtendedUser, intersect, invert } from "./constraints";
 const expect = chai.expect;
 
 @suite
@@ -25,47 +28,132 @@ class TestClientProvider {
         const c = new Container();
         c.bind(WorkspaceManagerClientProvider).toSelf().inSingletonScope();
         c.bind(WorkspaceManagerClientProviderCompositeSource).toSelf().inSingletonScope();
-        c.bind(WorkspaceManagerClientProviderSource).toDynamicValue((): WorkspaceManagerClientProviderSource => {
-            const cluster: WorkspaceCluster[] = [
-                { name: "c1", govern: true, maxScore: 100, score: 0, state: "cordoned", url: "", admissionConstraints: [] },
-                { name: "c2", govern: true, maxScore: 100, score: 50, state: "cordoned", url: "", admissionConstraints: [] },
-                { name: "c3", govern: false, maxScore: 100, score: 50, state: "cordoned", url: "", admissionConstraints: [] },
-                { name: "a1", govern: true, maxScore: 100, score: 0, state: "available", url: "", admissionConstraints: [] },
-                { name: "a2", govern: true, maxScore: 100, score: 50, state: "available", url: "", admissionConstraints: [] },
-                { name: "a3", govern: false, maxScore: 100, score: 50, state: "available", url: "", admissionConstraints: [] },
-                {
-                    name: "con1", govern: true, maxScore: 100, score: 50, state: "available", url: "", admissionConstraints: [
-                        { type: "has-permission", permission: "new-workspace-cluster" },
-                    ]
-                },
-                {
-                    name: "con2", govern: true, maxScore: 100, score: 50, state: "available", url: "", admissionConstraints: [
-                        { type: "has-permission", permission: "monitor" },    // This is meant to representent a permission that does not take special predence (cmp. constraints.ts)
-                    ]
-                },
-            ];
-            return <WorkspaceManagerClientProviderSource>{
-                getAllWorkspaceClusters: async () => { return cluster as WorkspaceClusterWoTLS[] },
-                getWorkspaceCluster: async (name: string) => {
-                    return cluster.find(c => c.name === name);
-                }
-            };
-        }).inSingletonScope();
+        c.bind(WorkspaceManagerClientProviderSource)
+            .toDynamicValue((): WorkspaceManagerClientProviderSource => {
+                const cluster: WorkspaceCluster[] = [
+                    {
+                        name: "c1",
+                        govern: true,
+                        maxScore: 100,
+                        score: 0,
+                        state: "cordoned",
+                        url: "",
+                        admissionConstraints: [],
+                    },
+                    {
+                        name: "c2",
+                        govern: true,
+                        maxScore: 100,
+                        score: 50,
+                        state: "cordoned",
+                        url: "",
+                        admissionConstraints: [],
+                    },
+                    {
+                        name: "c3",
+                        govern: false,
+                        maxScore: 100,
+                        score: 50,
+                        state: "cordoned",
+                        url: "",
+                        admissionConstraints: [],
+                    },
+                    {
+                        name: "a1",
+                        govern: true,
+                        maxScore: 100,
+                        score: 0,
+                        state: "available",
+                        url: "",
+                        admissionConstraints: [],
+                    },
+                    {
+                        name: "a2",
+                        govern: true,
+                        maxScore: 100,
+                        score: 50,
+                        state: "available",
+                        url: "",
+                        admissionConstraints: [],
+                    },
+                    {
+                        name: "a3",
+                        govern: false,
+                        maxScore: 100,
+                        score: 50,
+                        state: "available",
+                        url: "",
+                        admissionConstraints: [],
+                    },
+                    {
+                        name: "con1",
+                        govern: true,
+                        maxScore: 100,
+                        score: 50,
+                        state: "available",
+                        url: "",
+                        admissionConstraints: [{ type: "has-permission", permission: "new-workspace-cluster" }],
+                    },
+                    {
+                        name: "con2",
+                        govern: true,
+                        maxScore: 100,
+                        score: 50,
+                        state: "available",
+                        url: "",
+                        admissionConstraints: [
+                            { type: "has-permission", permission: "monitor" }, // This is meant to representent a permission that does not take special predence (cmp. constraints.ts)
+                        ],
+                    },
+                ];
+                return <WorkspaceManagerClientProviderSource>{
+                    getAllWorkspaceClusters: async () => {
+                        return cluster as WorkspaceClusterWoTLS[];
+                    },
+                    getWorkspaceCluster: async (name: string) => {
+                        return cluster.find((c) => c.name === name);
+                    },
+                };
+            })
+            .inSingletonScope();
         this.provider = c.get(WorkspaceManagerClientProvider);
 
         // we don't actually want to try and connect here
-        this.provider.get = async (name: string, grpcOptions?: object): Promise<PromisifiedWorkspaceManagerClient> => { return {} as PromisifiedWorkspaceManagerClient };
+        this.provider.get = async (name: string, grpcOptions?: object): Promise<PromisifiedWorkspaceManagerClient> => {
+            return {} as PromisifiedWorkspaceManagerClient;
+        };
     }
 
     @test
     public async getStartClusterSets() {
-        await this.expectInstallations([["a2", "a3"]], await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance), "default case");
-        await this.expectInstallations([["con1"], ["a2", "a3", "con1"]], await this.provider.getStartClusterSets({ rolesOrPermissions: ["new-workspace-cluster"] } as User,
-            {} as Workspace, {} as WorkspaceInstance), "new workspace cluster");
-        await this.expectInstallations([["a2", "a3", "con2"]], await this.provider.getStartClusterSets({ rolesOrPermissions: ["monitor"] } as User,
-            {} as Workspace, {} as WorkspaceInstance), "cluster has permission w/o precedence, user too");
-        await this.expectInstallations([["a2", "a3"]], await this.provider.getStartClusterSets({} as User,
-            {} as Workspace, {} as WorkspaceInstance), "cluster has permission w/o precedence, user NOT");
+        await this.expectInstallations(
+            [["a2", "a3"]],
+            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance),
+            "default case",
+        );
+        await this.expectInstallations(
+            [["con1"], ["a2", "a3", "con1"]],
+            await this.provider.getStartClusterSets(
+                { rolesOrPermissions: ["new-workspace-cluster"] } as User,
+                {} as Workspace,
+                {} as WorkspaceInstance,
+            ),
+            "new workspace cluster",
+        );
+        await this.expectInstallations(
+            [["a2", "a3", "con2"]],
+            await this.provider.getStartClusterSets(
+                { rolesOrPermissions: ["monitor"] } as User,
+                {} as Workspace,
+                {} as WorkspaceInstance,
+            ),
+            "cluster has permission w/o precedence, user too",
+        );
+        await this.expectInstallations(
+            [["a2", "a3"]],
+            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance),
+            "cluster has permission w/o precedence, user NOT",
+        );
     }
 
     @test
@@ -77,35 +165,61 @@ class TestClientProvider {
     @test
     public testIntersect() {
         expect(materializeConstraint(intersect(everything, nothing)), "eveything U nothing == nothing").to.be.empty;
-        expect(materializeConstraint(intersect(everything, everything, nothing)), "eveything U everything U nothing == nothing").to.be.empty;
-        expect(materializeConstraint(intersect(everything, everything)), "eveything U everything == everything").to.be.eql(materializeConstraint(everything));
+        expect(
+            materializeConstraint(intersect(everything, everything, nothing)),
+            "eveything U everything U nothing == nothing",
+        ).to.be.empty;
+        expect(
+            materializeConstraint(intersect(everything, everything)),
+            "eveything U everything == everything",
+        ).to.be.eql(materializeConstraint(everything));
 
-        const something = (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => all.filter(c => c.name === "a1");
+        const something = (
+            all: WorkspaceClusterWoTLS[],
+            user: ExtendedUser,
+            workspace: Workspace,
+            instance: WorkspaceInstance,
+        ) => all.filter((c) => c.name === "a1");
         expect(materializeConstraint(intersect(something, nothing)), "something U nothing == nothing").to.be.empty;
-        expect(materializeConstraint(intersect(everything, something)), "eveything U something == something").to.be.eql(materializeConstraint(something));
-        expect(materializeConstraint(intersect(everything, something, nothing)), "everything U something U nothing == nothing").to.be.empty;
+        expect(materializeConstraint(intersect(everything, something)), "eveything U something == something").to.be.eql(
+            materializeConstraint(something),
+        );
+        expect(
+            materializeConstraint(intersect(everything, something, nothing)),
+            "everything U something U nothing == nothing",
+        ).to.be.empty;
 
-        expect(materializeConstraint(intersect(everything, invert(nothing))), "everything U invert(nothing) == everything").to.be.eql(materializeConstraint(everything));
+        expect(
+            materializeConstraint(intersect(everything, invert(nothing))),
+            "everything U invert(nothing) == everything",
+        ).to.be.eql(materializeConstraint(everything));
     }
 
     @test
     public testConstraintNewWorkspaceCluster() {
         const clusters: WorkspaceClusterWoTLS[] = [
-            {name: "a1", admissionConstraints: [{ type: "has-permission", permission: "new-workspace-cluster" }]} as WorkspaceClusterWoTLS,
-            {name: "b1" } as WorkspaceClusterWoTLS,
-        ]
-        expect(constraintHasPermissions("monitor")(clusters, {} as ExtendedUser, {} as Workspace, {} as WorkspaceInstance).map(c => c.name)).to.be.empty;
-        expect(constraintHasPermissions("new-workspace-cluster")(clusters, {rolesOrPermissions:["new-workspace-cluster"]} as ExtendedUser, {} as Workspace, {} as WorkspaceInstance).map(c => c.name)).to.be.eql(["a1"]);
-    }
-
-    @test
-    public testConstraintHasMoreResources() {
-        const clusters: WorkspaceClusterWoTLS[] = [
-            {name: "a1", admissionConstraints: [{ type: "has-more-resources" }]} as WorkspaceClusterWoTLS,
-            {name: "b1" } as WorkspaceClusterWoTLS,
-        ]
-        expect(constraintMoreResources(clusters, {} as ExtendedUser, {} as Workspace, {} as WorkspaceInstance).map(c => c.name), "more resources").to.be.eql(["a1"]);
-        expect(constraintInverseMoreResources(clusters, {} as ExtendedUser, {} as Workspace, {} as WorkspaceInstance).map(c => c.name), "inverse more resources").to.be.eql(["b1"]);
+            {
+                name: "a1",
+                admissionConstraints: [{ type: "has-permission", permission: "new-workspace-cluster" }],
+            } as WorkspaceClusterWoTLS,
+            { name: "b1" } as WorkspaceClusterWoTLS,
+        ];
+        expect(
+            constraintHasPermissions("monitor")(
+                clusters,
+                {} as ExtendedUser,
+                {} as Workspace,
+                {} as WorkspaceInstance,
+            ).map((c) => c.name),
+        ).to.be.empty;
+        expect(
+            constraintHasPermissions("new-workspace-cluster")(
+                clusters,
+                { rolesOrPermissions: ["new-workspace-cluster"] } as ExtendedUser,
+                {} as Workspace,
+                {} as WorkspaceInstance,
+            ).map((c) => c.name),
+        ).to.be.eql(["a1"]);
     }
 
     private async expectInstallations(expectedSets: string[][], actual: IWorkspaceClusterStartSet, msg: string) {
@@ -130,21 +244,30 @@ class TestClientProvider {
         expect(eOverage, `missing some cluster(s)/sets (${msg})`).to.be.empty;
         expect(aOverage, `got too many cluster(s)/sets (${msg})`).to.be.empty;
     }
-
 }
 
-const everything = (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => all;
-const nothing = (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => [];
+const everything = (
+    all: WorkspaceClusterWoTLS[],
+    user: ExtendedUser,
+    workspace: Workspace,
+    instance: WorkspaceInstance,
+) => all;
+const nothing = (
+    all: WorkspaceClusterWoTLS[],
+    user: ExtendedUser,
+    workspace: Workspace,
+    instance: WorkspaceInstance,
+) => [];
 
 function materializeConstraint(c: Constraint): string[] {
     const cluster: WorkspaceClusterWoTLS[] = [
-        {name: "a1"} as WorkspaceClusterWoTLS,
-        {name: "a2"} as WorkspaceClusterWoTLS,
-        {name: "a3"} as WorkspaceClusterWoTLS,
-        {name: "a4"} as WorkspaceClusterWoTLS,
+        { name: "a1" } as WorkspaceClusterWoTLS,
+        { name: "a2" } as WorkspaceClusterWoTLS,
+        { name: "a3" } as WorkspaceClusterWoTLS,
+        { name: "a4" } as WorkspaceClusterWoTLS,
     ];
 
-    return c(cluster, {} as ExtendedUser, {} as Workspace, {} as WorkspaceInstance).map(cluster => cluster.name);
+    return c(cluster, {} as ExtendedUser, {} as Workspace, {} as WorkspaceInstance).map((cluster) => cluster.name);
 }
 
-module.exports = new TestClientProvider()
+module.exports = new TestClientProvider();

--- a/components/ws-manager-api/typescript/src/constraints.ts
+++ b/components/ws-manager-api/typescript/src/constraints.ts
@@ -11,10 +11,7 @@ import { AdmissionConstraint, WorkspaceClusterWoTLS } from "@gitpod/gitpod-proto
  * ExtendedUser adds additional attributes to a user which are helpful
  * during cluster selection.
  */
-export interface ExtendedUser extends User {
-    level?: string;
-    getsMoreResources?: boolean;
-}
+export interface ExtendedUser extends User {}
 
 export interface WorkspaceClusterConstraintSet {
     name: string;

--- a/components/ws-manager-api/typescript/src/constraints.ts
+++ b/components/ws-manager-api/typescript/src/constraints.ts
@@ -11,7 +11,7 @@ import { AdmissionConstraint, WorkspaceClusterWoTLS } from "@gitpod/gitpod-proto
  * ExtendedUser adds additional attributes to a user which are helpful
  * during cluster selection.
  */
-export interface ExtendedUser extends User  {
+export interface ExtendedUser extends User {
     level?: string;
     getsMoreResources?: boolean;
 }
@@ -28,60 +28,38 @@ export interface WorkspaceClusterConstraintSet {
 const workspaceClusterSets: WorkspaceClusterConstraintSet[] = [
     {
         name: "new workspace cluster",
-        constraint: constraintHasPermissions("new-workspace-cluster")
+        constraint: constraintHasPermissions("new-workspace-cluster"),
     },
     {
-        name: "regional more resources",
-        constraint:
-            intersect(
-                constraintRegional,
-                constraintMoreResources
-            )
+        name: "regional",
+        constraint: intersect(constraintRegional),
     },
     {
-        name: "regional regular",
-        constraint:
-            intersect(
-                constraintRegional,
-                constraintInverseMoreResources
-            )
-    },
-    {
-        name: "non-regional more resources",
-        constraint:
-            intersect(
-                invert(constraintRegional),
-                constraintMoreResources
-            )
-    },
-    {
-        name: "non-regional non-paying",
-        constraint:
-            intersect(
-                invert(constraintRegional),
-                constraintInverseMoreResources
-            )
+        name: "non-regional",
+        constraint: intersect(invert(constraintRegional)),
     },
 ];
 
 /**
  * workspaceClusterSetsAuthorized applies the constraint "is user authorized" to all workspaceClusterSets
  */
-export const workspaceClusterSetsAuthorized = workspaceClusterSets.map(set => ({
+export const workspaceClusterSetsAuthorized = workspaceClusterSets.map((set) => ({
     ...set,
-    constraint: intersect(
-        set.constraint,
-        constraintUserIsAuthorized,
-    )
+    constraint: intersect(set.constraint, constraintUserIsAuthorized),
 }));
 
-export type Constraint = (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => WorkspaceClusterWoTLS[]
+export type Constraint = (
+    all: WorkspaceClusterWoTLS[],
+    user: ExtendedUser,
+    workspace: Workspace,
+    instance: WorkspaceInstance,
+) => WorkspaceClusterWoTLS[];
 
 export function invert(c: Constraint): Constraint {
     return (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => {
         const s = c(all, user, workspace, instance);
-        return all.filter(c => !s.find(sc => c.name === sc.name));
-    }
+        return all.filter((c) => !s.find((sc) => c.name === sc.name));
+    };
 }
 
 export function intersect(...cs: Constraint[]): Constraint {
@@ -91,14 +69,16 @@ export function intersect(...cs: Constraint[]): Constraint {
             return all;
         }
 
-        const sets = cs.map(c => c(all, user, workspace, instance));
+        const sets = cs.map((c) => c(all, user, workspace, instance));
 
-        return sets[0].filter(c => sets.slice(1).every(s => s.includes(c)));
-    }
+        return sets[0].filter((c) => sets.slice(1).every((s) => s.includes(c)));
+    };
 }
 
 function hasPermissionConstraint(cluster: WorkspaceClusterWoTLS, permission: PermissionName): boolean {
-    return !!cluster.admissionConstraints?.find(constraint => AdmissionConstraint.hasPermission(constraint, permission));
+    return !!cluster.admissionConstraints?.find((constraint) =>
+        AdmissionConstraint.hasPermission(constraint, permission),
+    );
 }
 
 /**
@@ -108,8 +88,8 @@ function hasPermissionConstraint(cluster: WorkspaceClusterWoTLS, permission: Per
  */
 export function constraintInverseHasPermissions(...permissions: PermissionName[]): Constraint {
     return (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => {
-        return all.filter(cluster => !permissions.some(p => hasPermissionConstraint(cluster, p)))
-    }
+        return all.filter((cluster) => !permissions.some((p) => hasPermissionConstraint(cluster, p)));
+    };
 }
 
 /**
@@ -119,42 +99,41 @@ export function constraintInverseHasPermissions(...permissions: PermissionName[]
  */
 export function constraintHasPermissions(...permissions: PermissionName[]): Constraint {
     return (all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance) => {
-        return all.filter(cluster => permissions.some(p => hasPermissionConstraint(cluster, p)));
-    }
+        return all.filter((cluster) => permissions.some((p) => hasPermissionConstraint(cluster, p)));
+    };
 }
 
-export function constraintRegional(all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): WorkspaceClusterWoTLS[] {
+export function constraintRegional(
+    all: WorkspaceClusterWoTLS[],
+    user: ExtendedUser,
+    workspace: Workspace,
+    instance: WorkspaceInstance,
+): WorkspaceClusterWoTLS[] {
     // TODO(cw): implement me
     return [];
 }
-
-export function constraintInverseMoreResources(all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): WorkspaceClusterWoTLS[] {
-    return all.filter(cluster => !cluster.admissionConstraints?.find(constraint => constraint.type === "has-more-resources"));
-}
-
-export function constraintMoreResources(all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): WorkspaceClusterWoTLS[] {
-    return all.filter(cluster => !!cluster.admissionConstraints?.find(constraint => constraint.type === "has-more-resources"));
-}
-
 
 /**
  * This Constraint filters out clusters that the user is not allowed to access
  * @returns
  */
-export function constraintUserIsAuthorized(all: WorkspaceClusterWoTLS[], user: ExtendedUser, workspace: Workspace, instance: WorkspaceInstance): WorkspaceClusterWoTLS[] {
-    return all.filter(cluster => userMayAccessCluster(cluster, user));
+export function constraintUserIsAuthorized(
+    all: WorkspaceClusterWoTLS[],
+    user: ExtendedUser,
+    workspace: Workspace,
+    instance: WorkspaceInstance,
+): WorkspaceClusterWoTLS[] {
+    return all.filter((cluster) => userMayAccessCluster(cluster, user));
 }
 
 function userMayAccessCluster(cluster: WorkspaceClusterWoTLS, user: ExtendedUser): boolean {
     const userPermissions = RolesOrPermissions.toPermissionSet(user.rolesOrPermissions);
-    return (cluster.admissionConstraints || []).every(c => {
+    return (cluster.admissionConstraints || []).every((c) => {
         switch (c.type) {
-            case "has-more-resources":
-                return !!user.getsMoreResources;
             case "has-permission":
                 return userPermissions.has(c.permission);
             default:
-                return true;    // no reason to exclude user
+                return true; // no reason to exclude user
         }
-    })
+    });
 }

--- a/components/ws-manager-bridge-api/cluster-service.proto
+++ b/components/ws-manager-bridge-api/cluster-service.proto
@@ -58,8 +58,8 @@ message AdmissionConstraint {
   oneof constraint {
     FeaturePreview has_feature_preview = 1;
     HasPermission has_permission = 2;
-    // deprecated anr removed: has_user_level = 3;
-    bool has_more_resources = 4;
+    // deprecated and removed: has_user_level = 3;
+    // deprecated and removed: bool has_more_resources = 4;
   }
 }
 

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -15,7 +15,6 @@ import {
     AdmissionConstraint,
     AdmissionConstraintHasPermission,
     WorkspaceClusterWoTLS,
-    AdmissionConstraintHasMoreResources,
 } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import {
     ClusterServiceService,
@@ -232,8 +231,6 @@ export class ClusterService implements IClusterServiceServer {
                                             return false;
                                         }
                                         break;
-                                    case "has-more-resources":
-                                        return false;
                                 }
                                 return true;
                             });
@@ -343,9 +340,6 @@ function convertToGRPC(ws: WorkspaceClusterWoTLS): ClusterStatus {
                 perm.setPermission(c.permission);
                 constraint.setHasPermission(perm);
                 break;
-            case "has-more-resources":
-                constraint.setHasMoreResources(true);
-                break;
             default:
                 return;
         }
@@ -369,9 +363,6 @@ function mapAdmissionConstraint(c: GRPCAdmissionConstraint | undefined): Admissi
         }
 
         return <AdmissionConstraintHasPermission>{ type: "has-permission", permission };
-    }
-    if (c.hasHasMoreResources()) {
-        return <AdmissionConstraintHasMoreResources>{ type: "has-more-resources" };
     }
     return;
 }

--- a/dev/gpctl/cmd/clusters-update.go
+++ b/dev/gpctl/cmd/clusters-update.go
@@ -87,7 +87,7 @@ var clustersUpdateMaxScoreCmd = &cobra.Command{
 }
 
 var clustersUpdateAdmissionConstraintCmd = &cobra.Command{
-	Use:   "admission-constraint add|remove has-feature-preview|has-permission=<permission>|has-more-resources",
+	Use:   "admission-constraint add|remove has-feature-preview|has-permission=<permission>",
 	Short: "Updates a cluster's admission constraints",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -122,17 +122,6 @@ var clustersUpdateAdmissionConstraintCmd = &cobra.Command{
 							HasPermission: &api.AdmissionConstraint_HasPermission{
 								Permission: strings.TrimPrefix(args[1], "has-permission="),
 							},
-						},
-					},
-				},
-			}
-		} else if strings.HasPrefix(args[1], "has-more-resources") {
-			request.Property = &api.UpdateRequest_AdmissionConstraint{
-				AdmissionConstraint: &api.ModifyAdmissionConstraint{
-					Add: add,
-					Constraint: &api.AdmissionConstraint{
-						Constraint: &api.AdmissionConstraint_HasMoreResources{
-							HasMoreResources: true,
 						},
 					},
 				},


### PR DESCRIPTION
## Description
This PR removes the `has-more-resources` admission constraint. We have since started using workspace classes for this functionality, hence clean up this bit of code.


This PR is part of a stack of changes:
- https://github.com/gitpod-io/gitpod/pull/11383
- ➡️ https://github.com/gitpod-io/gitpod/pull/11384
- https://github.com/gitpod-io/gitpod/pull/11385

## How to test
There should be no functional changes due to this removal.

## Release Notes
```release-notes
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
