### PR TITLE
Support VSCodium for Settings Sync

### DIFF
--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -57,10 +57,12 @@ const jetBrainsGateway: OAuthClient = {
     ],
 };
 
-function createVSCodeClient(protocol: "vscode" | "vscode-insiders"): OAuthClient {
+function createVSCodeClient(protocol: "vscode" | "vscode-insiders" | "vscodium"): OAuthClient {
     return {
         id: protocol + "-" + "gitpod",
-        name: `VS Code${protocol === "vscode-insiders" ? " Insiders" : ""}: Gitpod extension`,
+        name: `VS${protocol === "vscodium" ? "Codium" : " Code"}${
+            protocol === "vscode-insiders" ? " Insiders" : ""
+        }: Gitpod extension`,
         redirectUris: [protocol + "://gitpod.gitpod-desktop/complete-gitpod-auth"],
         allowedGrants: ["authorization_code"],
         scopes: [
@@ -79,6 +81,7 @@ function createVSCodeClient(protocol: "vscode" | "vscode-insiders"): OAuthClient
 
 const vscode = createVSCodeClient("vscode");
 const vscodeInsiders = createVSCodeClient("vscode-insiders");
+const vscodium = createVSCodeClient("vscodium");
 
 export const inMemoryDatabase: InMemory = {
     clients: {
@@ -86,6 +89,7 @@ export const inMemoryDatabase: InMemory = {
         [jetBrainsGateway.id]: jetBrainsGateway,
         [vscode.id]: vscode,
         [vscodeInsiders.id]: vscodeInsiders,
+        [vscodium.id]: vscodium,
     },
     tokens: {},
     scopes: {},


### PR DESCRIPTION
## Description
Support VSCodium for Settings Sync by adding it as an OAuth client, just like regular VS Code and its Insiders counterpart.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. Install [VSCodium](https://github.com/VSCodium/vscodium)
2. Open it and install Gitpod for VS Code (not on Open VSX, so use https://github.com/gitpod-io/gitpod-vscode-desktop/releases/download/v0.0.41/gitpod-desktop-0.0.41.vsix)
3. Go to user settings (<kbd>F1</kbd> -> "Preferences: Open Settings (JSON))
4. Add a new field, `gitpod.host` with the value of `https://ft-add-vsc6ddae4c45e.preview.gitpod-dev.com/`
5. Go through the process of setting up settings sync - [docs](https://www.gitpod.io/docs/ides-and-editors/settings-sync#enabling-settings-sync-in-vs-code-desktop=)
6. Make sure it works by installing an extension and checking whether it is installed in workspaces created in this PR's preview environment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
