### PR TITLE
[content-service] Do not stash untracked files

### DIFF
--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -114,7 +114,7 @@ func runGitInit(ctx context.Context, gInit *GitInitializer) (err error) {
 	)
 	defer tracing.FinishSpan(span, &err)
 	if git.IsWorkingCopy(gInit.Location) {
-		out, err := gInit.GitWithOutput(ctx, "stash", "push", "-u")
+		out, err := gInit.GitWithOutput(ctx, "stash", "push", "--no-include-untracked")
 		if err != nil {
 			var giterr git.OpFailedError
 			if errors.As(err, &giterr) && strings.Contains(giterr.Output, "You do not have the initial commit yet") {
@@ -122,6 +122,7 @@ func runGitInit(ctx context.Context, gInit *GitInitializer) (err error) {
 				// In this case that's not an error though, hence we don't want to fail here.
 			} else {
 				// git returned a non-zero exit code because of some reason we did not anticipate or an actual failure.
+				log.WithError(err).WithField("output", string(out)).Error("unexpected git stash error")
 				return xerrors.Errorf("prebuild initializer: %w", err)
 			}
 		}


### PR DESCRIPTION
## Description

Avoiding issues with files included in the prebuild that could be owned by a different issue (permission issues).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10953

## How to test
- Open a workspace using https://github.com/aledbf/supervisor-bug
- Check the directory letsencrypt exists and the file acme.json is owned by root

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
