### PR TITLE
[ws-daemon] Increase number of concurrent backup uploads

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -118,8 +118,8 @@ func NewWorkspaceService(ctx context.Context, cfg Config, kubernetesNamespace st
 			BackupWaitingTimeHist:       waitingTimeHist,
 			BackupWaitingTimeoutCounter: waitingTimeoutCounter,
 		},
-		// we permit three concurrent backups at any given time, hence the three in the channel
-		backupWorkspaceLimiter: make(chan struct{}, 3),
+		// we permit five concurrent backups at any given time, hence the five in the channel
+		backupWorkspaceLimiter: make(chan struct{}, 5),
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Now that we have better performance, we can increase the concurrency.

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
