### PR TITLE
[content-service] Switch to http/1.1 for gitlab.com repositories

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -74,6 +74,11 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 			return err
 		}
 
+		// TODO: remove workaround once https://gitlab.com/gitlab-org/gitaly/-/issues/4248 is fixed
+		if strings.Contains(ws.RemoteURI, "gitlab.com") {
+			_ = ws.Git(ctx, "config", "http.version", "HTTP/1.1")
+		}
+
 		log.WithField("stage", "init").WithField("location", ws.Location).Debug("Running git clone on workspace")
 		return ws.Clone(ctx)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://cloudlogging.app.goo.gl/od9cfrmv7YVSiTnM9

Similar issue to #10338

## How to test
- Open https://gitlab.com/gitlab-org/gitlab in a workspace

## Release Notes
```release-note
Switch to http/1.1 for gitlab.com repositories
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
