### PR TITLE
Simple UI for Prebuild Events (sneak preview)

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -74,6 +74,7 @@ const NewProject = React.lazy(() => import(/* webpackPrefetch: true */ "./projec
 const ConfigureProject = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ConfigureProject"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Project"));
+const Events = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Events"));
 const ProjectSettings = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ProjectSettings"));
 const ProjectVariables = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/ProjectVariables"));
 const Prebuilds = React.lazy(() => import(/* webpackPrefetch: true */ "./projects/Prebuilds"));
@@ -397,6 +398,9 @@ function App() {
                             path={projectsPathMainWithParams}
                             render={(props) => {
                                 const { resourceOrPrebuild } = props.match.params;
+                                if (resourceOrPrebuild === "events") {
+                                    return <Events />;
+                                }
                                 if (resourceOrPrebuild === "prebuilds") {
                                     return <Prebuilds />;
                                 }
@@ -445,6 +449,9 @@ function App() {
                                     }
                                     if (maybeProject === "usage") {
                                         return <TeamUsage />;
+                                    }
+                                    if (resourceOrPrebuild === "events") {
+                                        return <Events />;
                                     }
                                     if (resourceOrPrebuild === "prebuilds") {
                                         return <Prebuilds />;

--- a/components/dashboard/src/projects/Events.tsx
+++ b/components/dashboard/src/projects/Events.tsx
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import moment from "moment";
+import { PrebuildEvent, Project } from "@gitpod/gitpod-protocol";
+import { useContext, useEffect, useState } from "react";
+import { useLocation, useRouteMatch } from "react-router";
+import Header from "../components/Header";
+import { ItemsList, Item, ItemField } from "../components/ItemsList";
+import { getGitpodService } from "../service/service";
+import { TeamsContext, getCurrentTeam } from "../teams/teams-context";
+import { toRemoteURL } from "./render-utils";
+import Spinner from "../icons/Spinner.svg";
+import NoAccess from "../icons/NoAccess.svg";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { openAuthorizeWindow } from "../provider-utils";
+
+export default function () {
+    const location = useLocation();
+
+    const { teams } = useContext(TeamsContext);
+    const team = getCurrentTeam(location, teams);
+
+    const match = useRouteMatch<{ team: string; resource: string }>("/(t/)?:team/:resource");
+    const projectSlug = match?.params?.resource;
+
+    const [project, setProject] = useState<Project | undefined>();
+
+    const [isLoadingEvents, setIsLoadingEvents] = useState<boolean>(false);
+    const [events, setEvents] = useState<PrebuildEvent[]>([]);
+
+    const [searchFilter, setSearchFilter] = useState<string | undefined>();
+
+    const [showAuthBanner, setShowAuthBanner] = useState<{ host: string } | undefined>(undefined);
+
+    useEffect(() => {
+        updateProject();
+    }, [teams]);
+
+    useEffect(() => {
+        if (!project) {
+            return;
+        }
+        (async () => {
+            try {
+                await updatePrebuildEvents();
+            } catch (error) {
+                if (error && error.code === ErrorCodes.NOT_AUTHENTICATED) {
+                    setShowAuthBanner({ host: new URL(project.cloneUrl).hostname });
+                } else {
+                    console.error("Getting events failed", error);
+                }
+            }
+        })();
+    }, [project]);
+
+    const updateProject = async () => {
+        if (!teams || !projectSlug) {
+            return;
+        }
+        const projects = !!team
+            ? await getGitpodService().server.getTeamProjects(team.id)
+            : await getGitpodService().server.getUserProjects();
+
+        // Find project matching with slug, otherwise with name
+        const project = projectSlug && projects.find((p) => (p.slug ? p.slug === projectSlug : p.name === projectSlug));
+
+        if (!project) {
+            return;
+        }
+
+        setProject(project);
+    };
+
+    const updatePrebuildEvents = async () => {
+        if (!project) {
+            return;
+        }
+        setIsLoadingEvents(true);
+        try {
+            const events = await getGitpodService().server.getPrebuildEvents(project.id);
+            setEvents(events);
+        } finally {
+            setIsLoadingEvents(false);
+        }
+    };
+
+    const tryAuthorize = async (host: string, onSuccess: () => void) => {
+        try {
+            await openAuthorizeWindow({
+                host,
+                onSuccess,
+                onError: (error) => {
+                    console.log(error);
+                },
+            });
+        } catch (error) {
+            console.log(error);
+        }
+    };
+
+    const onConfirmShowAuthModal = async (host: string) => {
+        setShowAuthBanner(undefined);
+        await tryAuthorize(host, async () => {
+            // update remote session
+            await getGitpodService().reconnect();
+
+            // retry fetching events
+            updatePrebuildEvents().catch((e) => console.log(e));
+        });
+    };
+
+    const filter = (event: PrebuildEvent) => {
+        if (
+            searchFilter &&
+            `${formatDate(event.creationTime)} ${event.commit} ${event.branch}`
+                .toLowerCase()
+                .includes(searchFilter.toLowerCase()) === false
+        ) {
+            return false;
+        }
+        return true;
+    };
+
+    const formatDate = (date: string | undefined) => {
+        return date ? moment(date).fromNow() : "";
+    };
+
+    const renderStatus = (event: PrebuildEvent) => {
+        return event.status;
+    };
+
+    return (
+        <>
+            <Header
+                title="Prebuild Events"
+                subtitle={
+                    <h2 className="tracking-wide">
+                        View recent prebuild events for{" "}
+                        <a className="gp-link" href={project?.cloneUrl!}>
+                            {toRemoteURL(project?.cloneUrl || "")}
+                        </a>
+                        .
+                    </h2>
+                }
+            />
+            <div className="app-container">
+                {showAuthBanner ? (
+                    <div className="mt-8 rounded-xl text-gray-500 bg-gray-50 dark:bg-gray-800 flex-col">
+                        <div className="p-8 text-center">
+                            <img src={NoAccess} alt="" title="No Access" className="m-auto mb-4" />
+                            <div className="text-center text-gray-600 dark:text-gray-50 pb-3 font-bold">No Access</div>
+                            <div className="text-center dark:text-gray-400 pb-3">
+                                Authorize {showAuthBanner.host} <br />
+                                to access project information.
+                            </div>
+                            <button
+                                className={`primary mr-2 py-2`}
+                                onClick={() => onConfirmShowAuthModal(showAuthBanner.host)}
+                            >
+                                Authorize Provider
+                            </button>
+                        </div>
+                    </div>
+                ) : (
+                    <>
+                        <div className="flex mt-8">
+                            <div className="flex">
+                                <div className="py-4">
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        height="16"
+                                    >
+                                        <path
+                                            fill="#A8A29E"
+                                            d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
+                                        />
+                                    </svg>
+                                </div>
+                                <input
+                                    type="search"
+                                    placeholder="Search Recent Events"
+                                    onChange={(e) => setSearchFilter(e.target.value)}
+                                />
+                            </div>
+                            <div className="flex-1" />
+                        </div>
+                        <ItemsList className="mt-2">
+                            <Item header={true} className="grid grid-cols-3">
+                                <ItemField className="my-auto">
+                                    <span>Time</span>
+                                </ItemField>
+                                <ItemField className="my-auto">
+                                    <span>Commit</span>
+                                </ItemField>
+                                <ItemField className="my-auto">
+                                    <span>Prebuild Status</span>
+                                </ItemField>
+                            </Item>
+                            {isLoadingEvents && (
+                                <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm pt-16 pb-40">
+                                    <img className="h-4 w-4 animate-spin" src={Spinner} />
+                                    <span>Fetching Prebuild Events...</span>
+                                </div>
+                            )}
+                            {events
+                                .filter(filter)
+                                .slice(0, 10)
+                                .map((event, index) => {
+                                    const status = renderStatus(event);
+
+                                    return (
+                                        <Item key={`event-${index}-${event.id}`} className="grid grid-cols-3 group">
+                                            <ItemField className="flex items-center my-auto">
+                                                <div className="truncate">
+                                                    <p>{formatDate(event.creationTime)}</p>
+                                                </div>
+                                            </ItemField>
+                                            <ItemField className="flex items-center my-auto">
+                                                <div className="truncate">
+                                                    <div className="text-base text-gray-500 dark:text-gray-50 font-medium mb-1 truncate">
+                                                        {event?.branch}
+                                                    </div>
+                                                    <p>{event?.commit?.substring(0, 8)}</p>
+                                                </div>
+                                            </ItemField>
+                                            <ItemField className="flex items-center my-auto">
+                                                {event.prebuildId && (
+                                                    <a
+                                                        className="text-base text-gray-900 dark:text-gray-50 font-medium uppercase mb-1 cursor-pointer"
+                                                        href={`/${
+                                                            !!team ? "t/" + team.slug : "projects"
+                                                        }/${projectSlug}/${event.prebuildId}`}
+                                                    >
+                                                        {<>{status}</>}
+                                                    </a>
+                                                )}
+                                                {!event.prebuildId && (
+                                                    <div className="truncate">
+                                                        <div className="text-base text-gray-500 dark:text-gray-50 font-medium uppercase mb-1 truncate">
+                                                            {status}
+                                                        </div>
+                                                        <p>{event?.message}</p>
+                                                    </div>
+                                                )}
+                                            </ItemField>
+                                        </Item>
+                                    );
+                                })}
+                        </ItemsList>
+                    </>
+                )}
+            </div>
+            <div></div>
+        </>
+    );
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -37,6 +37,7 @@ import {
     PrebuildWithStatus,
     StartPrebuildResult,
     PartialProject,
+    PrebuildEvent,
 } from "./teams-projects-protocol";
 import { JsonRpcProxy, JsonRpcServer } from "./messaging/proxy-factory";
 import { Disposable, CancellationTokenSource } from "vscode-jsonrpc";
@@ -181,6 +182,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getTeamProjects(teamId: string): Promise<Project[]>;
     getUserProjects(): Promise<Project[]>;
     getProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
+    getPrebuildEvents(projectId: string): Promise<PrebuildEvent[]>;
     findPrebuilds(params: FindPrebuildsParams): Promise<PrebuildWithStatus[]>;
     findPrebuildByWorkspaceID(workspaceId: string): Promise<PrebuiltWorkspace | undefined>;
     getPrebuild(prebuildId: string): Promise<PrebuildWithStatus | undefined>;
@@ -378,7 +380,7 @@ export const createServerMock = function <C extends GitpodClient, S extends Gitp
         get: (target: S, property: keyof S) => {
             const result = target[property];
             if (!result) {
-                throw new Error(`Method ${property} not implemented`);
+                throw new Error(`Method ${String(property)} not implemented`);
             }
             return result;
         },

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -7,6 +7,7 @@
 import { PrebuiltWorkspaceState } from "./protocol";
 import { v4 as uuidv4 } from "uuid";
 import { DeepPartial } from "./util/deep-partial";
+import { WebhookEvent } from "./webhook-event";
 
 export interface ProjectConfig {
     ".gitpod.yml": string;
@@ -151,4 +152,16 @@ export interface TeamMembershipInvite {
 
     /** This is a flag that triggers the HARD DELETION of this entity */
     deleted?: boolean;
+}
+
+export interface PrebuildEvent {
+    id: string;
+    creationTime: string;
+    status: WebhookEvent.Status | WebhookEvent.PrebuildStatus;
+    message?: string;
+    prebuildId?: string;
+    projectId?: string;
+    cloneUrl?: string;
+    branch?: string;
+    commit?: string;
 }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -47,6 +47,7 @@ import {
     TeamMemberRole,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
     WorkspaceType,
+    PrebuildEvent,
 } from "@gitpod/gitpod-protocol";
 import { ResponseError } from "vscode-jsonrpc";
 import {
@@ -2290,6 +2291,20 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
 
         return repositories;
+    }
+
+    public async getPrebuildEvents(ctx: TraceContext, projectId: string): Promise<PrebuildEvent[]> {
+        traceAPIParams(ctx, { projectId });
+        const user = this.checkAndBlockUser("getPrebuildEvents");
+
+        const project = await this.projectsService.getProject(projectId);
+        if (!project) {
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "Project not found");
+        }
+        await this.guardProjectOperation(user, projectId, "get");
+
+        const events = await this.projectsService.getPrebuildEvents(project.cloneUrl);
+        return events;
     }
 
     async triggerPrebuild(

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -215,6 +215,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         trackLocation: { group: "default", points: 1 },
         identifyUser: { group: "default", points: 1 },
         getIDEOptions: { group: "default", points: 1 },
+        getPrebuildEvents: { group: "default", points: 1 },
     };
 
     return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -78,6 +78,7 @@ import {
     SnapshotContext,
     SSHPublicKeyValue,
     UserSSHPublicKeyValue,
+    PrebuildEvent,
 } from "@gitpod/gitpod-protocol";
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
@@ -2372,6 +2373,14 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             }
             throw error;
         }
+    }
+
+    public async getPrebuildEvents(ctx: TraceContext, projectId: string): Promise<PrebuildEvent[]> {
+        this.checkAndBlockUser("getPrebuildEvents");
+        throw new ResponseError(
+            ErrorCodes.EE_FEATURE,
+            `Prebuild Events are implemented in Gitpod's Enterprise Edition`,
+        );
     }
 
     public async triggerPrebuild(


### PR DESCRIPTION
## Description
<img width="1385" alt="Screen Shot 2022-07-15 at 11 21 42" src="https://user-images.githubusercontent.com/914497/179199195-18fee89e-3086-40d2-825d-b0b750f80eae.png">



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/10764

## How to test
<!-- Provide steps to test this PR -->
1. Verify you do not see "Prebuild Events" in the menu, as this is a 🛹  PR without any discussions about proper UI design.
2. Push a commit to a repository configured as a project with this preview environment and verify you see webhook events rendered on: https://at-prebuild-events.preview.gitpod-dev.com/projects/YOUR-PROJECT/events

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
