### PR TITLE
[usage] Persist credits used for each instance in the usage store

### DIFF
--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -33,11 +33,17 @@ func (f ReconcilerFunc) Reconcile() error {
 type UsageReconciler struct {
 	nowFunc           func() time.Time
 	conn              *gorm.DB
+	pricer            *WorkspacePricer
 	billingController BillingController
 }
 
-func NewUsageReconciler(conn *gorm.DB, billingController BillingController) *UsageReconciler {
-	return &UsageReconciler{conn: conn, billingController: billingController, nowFunc: time.Now}
+func NewUsageReconciler(conn *gorm.DB, pricer *WorkspacePricer, billingController BillingController) *UsageReconciler {
+	return &UsageReconciler{
+		conn:              conn,
+		pricer:            pricer,
+		billingController: billingController,
+		nowFunc:           time.Now,
+	}
 }
 
 type UsageReconcileStatus struct {

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -142,12 +142,7 @@ func (u UsageReport) CreditSummaryForTeams(pricer *WorkspacePricer, maxStopTime 
 
 		var credits int64
 		for _, instance := range instances {
-			runtime := instance.WorkspaceRuntimeSeconds(maxStopTime)
-			class := defaultWorkspaceClass
-			if instance.WorkspaceClass != "" {
-				class = instance.WorkspaceClass
-			}
-			credits += pricer.Credits(class, runtime)
+			credits += pricer.CreditsUsedByInstance(&instance, maxStopTime)
 		}
 
 		creditsPerTeamID[id] = credits

--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -149,6 +149,7 @@ func TestUsageReport_CreditSummaryForTeams(t *testing.T) {
 }
 
 func TestUsageReportConversionToDBUsageRecords(t *testing.T) {
+	maxStopTime := time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)
 	teamID := uuid.New().String()
 	teamAttributionID := db.NewTeamAttributionID(teamID)
 	instanceId := uuid.New()
@@ -178,7 +179,7 @@ func TestUsageReportConversionToDBUsageRecords(t *testing.T) {
 				AttributionID: teamAttributionID,
 				StartedAt:     creationTime.Time(),
 				StoppedAt:     sql.NullTime{Time: stoppedTime.Time(), Valid: true},
-				CreditsUsed:   0,
+				CreditsUsed:   470,
 				GenerationId:  0,
 			}},
 		},
@@ -200,7 +201,7 @@ func TestUsageReportConversionToDBUsageRecords(t *testing.T) {
 				AttributionID: teamAttributionID,
 				StartedAt:     creationTime.Time(),
 				StoppedAt:     sql.NullTime{},
-				CreditsUsed:   0,
+				CreditsUsed:   470,
 				GenerationId:  0,
 			}},
 		},
@@ -208,7 +209,7 @@ func TestUsageReportConversionToDBUsageRecords(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			actual := usageReportToUsageRecords(s.Report)
+			actual := usageReportToUsageRecords(s.Report, DefaultWorkspacePricer, maxStopTime)
 			require.Equal(t, s.Expected, actual)
 		})
 	}


### PR DESCRIPTION
## Description

Calculate and persist credits used for each instance in the usage store. 

On each usage reconciliation run, we store the reconciled usage in the database. This information should include the number of credits consumed by each instance.

Previously, this value was set to 0 for all instances.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/10323

## How to test

Unit tests.

To test manually, run the usage component locally against the database from a preview environment that has had at least one workspace started in it. When the reconciler runs, see that the value for `creditsUsed` is populated in the `d_b_workspace_instance_usage` table:

<img width="1576" alt="image" src="https://user-images.githubusercontent.com/8225907/179184876-5227c599-66f3-46b2-b1a7-0b31c9029cdb.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:

- [x] /werft with-preview
