### PR TITLE
Add missing permission to watch node object

### DIFF
--- a/install/installer/pkg/components/ws-manager/role.go
+++ b/install/installer/pkg/components/ws-manager/role.go
@@ -32,6 +32,7 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Verbs: []string{
 						"get",
 						"list",
+						"watch",
 					},
 				},
 				{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We missed the add `watch` node clusterrole permission to ws-manager.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
We missed adding the watch node permission in PR #11337.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
