### PR TITLE
[local-preview] Remove `cert-manager` dependency

### DIFF
--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -54,45 +54,121 @@ cat "${HOME}"/.local/share/mkcert/rootCA.pem >> /etc/ssl/certs/ca-certificates.c
 # also send root cert into a volume
 cat "${HOME}"/.local/share/mkcert/rootCA.pem > /var/gitpod/gitpod-ca.crt
 
-cat << EOF > /var/lib/rancher/k3s/server/manifests/ca-pair.yaml
+FN_CACERT="./ca.pem"
+FN_SSLCERT="./ssl.crt"
+FN_SSLKEY="./ssl.key"
+
+cat "${HOME}"/.local/share/mkcert/rootCA.pem > "$FN_CACERT"
+mkcert -cert-file "$FN_SSLCERT" \
+  -key-file "$FN_SSLKEY" \
+  "*.ws.${DOMAIN}" "*.${DOMAIN}" "${DOMAIN}" "reg.${DOMAIN}" "registry.default.svc.cluster.local" "gitpod.default" "ws-manager.default.svc" "ws-manager" "ws-manager-dev" "registry-facade" "server" "ws-manager-bridge" "ws-proxy" "ws-manager" "ws-daemon.default.svc" "ws-daemon" "wsdaemon"
+
+CACERT=$(base64 -w0 < "$FN_CACERT")
+SSLCERT=$(base64 -w0 < "$FN_SSLCERT")
+SSLKEY=$(base64 -w0 < "$FN_SSLKEY")
+
+mkdir -p /var/lib/rancher/k3s/server/manifests/gitpod
+
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/customCA-cert.yaml
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: ca-key-pair
+  labels:
+    app: gitpod
 data:
-  ca.crt: $(base64 -w0 "${HOME}"/.local/share/mkcert/rootCA.pem)
-  tls.crt: $(base64 -w0 "${HOME}"/.local/share/mkcert/rootCA.pem)
-  tls.key: $(base64 -w0 "${HOME}"/.local/share/mkcert/rootCA-key.pem)
+  ca.crt: $CACERT
 EOF
 
-cat << EOF > /var/lib/rancher/k3s/server/manifests/issuer.yaml
-apiVersion: cert-manager.io/v1
-kind: Issuer
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/https-cert.yaml
+---
+apiVersion: v1
+kind: Secret
 metadata:
-  name: ca-issuer
-spec:
-  ca:
-    secretName: ca-key-pair
+  name: https-certificates
+  labels:
+    app: gitpod
+type: kubernetes.io/tls
+data:
+  tls.crt: $SSLCERT
+  tls.key: $SSLKEY
 EOF
 
-echo "creating Gitpod SSL secret..."
-cat << EOF > /var/lib/rancher/k3s/server/manifests/https-cert.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/builtin-registry-certs.yaml
+---
+apiVersion: v1
+kind: Secret
 metadata:
-  name: https-cert
-spec:
-  secretName: https-certificates
-  issuerRef:
-    name: ca-issuer
-    kind: Issuer
-  dnsNames:
-    - "$DOMAIN"
-    - "*.$DOMAIN"
-    - "*.ws.$DOMAIN"
+  name: builtin-registry-certs
+  labels:
+    app: gitpod
+type: kubernetes.io/tls
+data:
+  ca.crt: $CACERT
+  tls.crt: $SSLCERT
+  tls.key: $SSLKEY
 EOF
 
-mkdir -p /var/lib/rancher/k3s/server/manifests/gitpod
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/ws-manager-tls.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ws-manager-tls
+  labels:
+    app: gitpod
+type: kubernetes.io/tls
+data:
+  ca.crt: $CACERT
+  tls.crt: $SSLCERT
+  tls.key: $SSLKEY
+EOF
+
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/ws-manager-client-tls.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ws-manager-client-tls
+  labels:
+    app: gitpod
+type: kubernetes.io/tls
+data:
+  ca.crt: $CACERT
+  tls.crt: $SSLCERT
+  tls.key: $SSLKEY
+EOF
+
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/ws-daemon-tls.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ws-daemon-tls
+  labels:
+    app: gitpod
+type: kubernetes.io/tls
+data:
+  ca.crt: $CACERT
+  tls.crt: $SSLCERT
+  tls.key: $SSLKEY
+EOF
+
+cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/builtin-registry-facade-cert.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: builtin-registry-facade-cert
+  labels:
+    app: gitpod
+type: kubernetes.io/tls
+data:
+  ca.crt: $CACERT
+  tls.crt: $SSLCERT
+  tls.key: $SSLKEY
+EOF
 
 /gitpod-installer init > config.yaml
 yq e -i '.domain = "'"${DOMAIN}"'"' config.yaml
@@ -119,8 +195,10 @@ ctr images pull "docker.io/gitpod/workspace-full:latest" >/dev/null &
 
 # store files in `gitpod.debug` for debugging purposes
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/gitpod.debug; done
-# remove NetowrkPolicy resources as they are not relevant here
+# remove unused resources
 rm /var/lib/rancher/k3s/server/manifests/gitpod/*NetworkPolicy*
+rm /var/lib/rancher/k3s/server/manifests/gitpod/*Certificate*
+rm /var/lib/rancher/k3s/server/manifests/gitpod/*Issuer*
 # update PersistentVolumeClaim's to use k3s's `local-path` storage class
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*PersistentVolumeClaim*.yaml; do yq e -i '.spec.storageClassName="local-path"' "$f"; done
 # Set `volumeClassTemplate` so that each replica creates its own PVC

--- a/install/preview/leeway.Dockerfile
+++ b/install/preview/leeway.Dockerfile
@@ -15,8 +15,6 @@ RUN chmod +x /bin/mkcert
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static /tini
 RUN chmod +x /tini
 
-ADD https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml /var/lib/rancher/k3s/server/manifests/cert-manager.yaml
-
 ADD https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 /bin/yq
 RUN chmod +x /bin/yq
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR removes the dependency of `cert-manager` and thus
reducing resource usage. This is replaced by the usage of
`mkcert` instead. 

Each certificate is induvidually generated on those domains
and stored into specific files for `k3s` to apply them which
is then used by Gitpod.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11303 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[local-preview] Remove `cert-manager` dependency
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
