### PR TITLE
[alerts] change load avg alert to critical

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -13,14 +13,15 @@
             alert: 'GitpodWorkspaceNodeHighNormalizedLoadAverage',
             labels: {
               severity: 'warning',
+              team: 'workspace'
             },
-            'for': '2m',
+            'for': '10m',
             annotations: {
-              runbook_url: 'https://github.com/gitpod-io/observability/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md',
-              summary: "Workspace node's normalized load average is higher than 3 for more than 2 minutes. Check for abuse.",
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md',
+              summary: "Workspace node's normalized load average is higher than 10 for more than 10 minutes. Check for abuse.",
               description: 'Node {{ $labels.node }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.',
             },
-            expr: 'nodepool:node_load1:normalized{nodepool=~".*workspace.*"} > 3',
+            expr: 'nodepool:node_load1:normalized{nodepool=~".*workspace.*"} > 10',
           },
           {
             alert: 'AutoscalerAddsNodesTooFast',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add critical alert for when load avg is high for too long.

First, why change to critical alert:
if load average is high for too long, it will affect all workspaces on that node, so we want to react to that fast, hence critical alert (otherwise on call person can potentially be working on something else and might miss this for some time).

Why change duration to 10 min:
We want to minimize amount of false positives as much as possible. We should alert\wake up someone only on sustained high load average. 

Why change load avg check to above 10:
Again, we want to be alerted only on legit signal. Load avg above 10 for more then 10 min should signal in almost all cases that something really bad is going on on that node. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
