### PR TITLE
[alerts] change alert for adding new nodes rapidly to only count if node type is regular workspace

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/nodes/alerts.libsonnet
@@ -32,7 +32,7 @@
               summary: "Autoscaler is adding new nodes rapidly",
               description: 'Autoscaler in cluster {{ $labels.cluster }} is rapidly adding new nodes.',
             },
-            expr: '((sum(cluster_autoscaler_nodes_count) by (cluster)) - (sum(cluster_autoscaler_nodes_count offset 10m) by (cluster))) > 15',
+            expr: '((sum(kube_node_labels{nodepool=~"workspace-.*"}) by (cluster)) - (sum(kube_node_labels{nodepool=~"workspace-.*"} offset 10m) by (cluster))) > 15',
           },
           {
             alert: 'AutoscaleFailure',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[alerts] change alert for adding new nodes rapidly to only count if node type is regular workspace

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
