### PR TITLE
Revert "[ws-manager] do not overwrite failed state"

### DIFF
--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -350,7 +350,11 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 		result.Phase = api.WorkspacePhase_STOPPING
 
 		_, podFailedBeforeBeingStopped := pod.Annotations[workspaceFailedBeforeStoppingAnnotation]
-		if podFailedBeforeBeingStopped {
+		if !podFailedBeforeBeingStopped {
+			// While the pod is being deleted we do not care or want to know about any failure state.
+			// If the pod got stopped because it failed we will have sent out a Stopping status with a "failure"
+			result.Conditions.Failed = ""
+		} else {
 			if _, ok := pod.Annotations[workspaceNeverReadyAnnotation]; ok {
 				// The workspace is never ready, so there is no need for a stopping phase.
 				result.Phase = api.WorkspacePhase_STOPPED

--- a/components/ws-manager/pkg/manager/testdata/status_containerd4214_STOPPING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_containerd4214_STOPPING00.golden
@@ -20,7 +20,6 @@
         },
         "phase": 6,
         "conditions": {
-            "failed": "container workspace completed; containers of a workspace pod are not supposed to do that. Reason: ",
             "final_backup_complete": 1,
             "volume_snapshot": {}
         },

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED01.golden
@@ -20,7 +20,7 @@
         },
         "phase": 6,
         "conditions": {
-            "failed": "ungraceful shutdown - teardown was unsuccessful: socket did not appear before context was canceled; last backup failed: testing the backup failure mode.",
+            "failed": "last backup failed: testing the backup failure mode.",
             "final_backup_complete": 1,
             "volume_snapshot": {}
         },

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING02.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING02.golden
@@ -20,7 +20,6 @@
         },
         "phase": 6,
         "conditions": {
-            "failed": "ungraceful shutdown - teardown was unsuccessful: socket did not appear before context was canceled",
             "final_backup_complete": 1,
             "volume_snapshot": {}
         },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This reverts #11419 because it causes all normally closed workspaces to report error `container workspace completed; containers of a workspace pod are not supposed to do that. Reason:`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in preview environment
2. stop it
3. should not show an error

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
