### PR TITLE
[usage] Store credits as integer values in the usage table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
@@ -34,7 +34,7 @@ export class DBWorkspaceInstanceUsage {
     @Index("ind_stoppedAt")
     stoppedAt: string;
 
-    @Column("int")
+    @Column("bigint")
     creditsUsed: number;
 
     @Column()

--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance-usage.ts
@@ -34,7 +34,7 @@ export class DBWorkspaceInstanceUsage {
     @Index("ind_stoppedAt")
     stoppedAt: string;
 
-    @Column("double")
+    @Column("int")
     creditsUsed: number;
 
     @Column()

--- a/components/gitpod-db/src/typeorm/migration/1658123555591-ChangeUsageCreditsColumnType.ts
+++ b/components/gitpod-db/src/typeorm/migration/1658123555591-ChangeUsageCreditsColumnType.ts
@@ -14,7 +14,7 @@ export class New1658123371893 implements MigrationInterface {
         await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
 
         await queryRunner.query(
-            `CREATE TABLE \`d_b_workspace_instance_usage\` (\`instanceId\` char(36) NOT NULL, \`attributionId\` varchar(255) NOT NULL, \`startedAt\` timestamp(6) NOT NULL, \`stoppedAt\` timestamp(6) NULL, \`creditsUsed\` int NOT NULL, \`generationId\` int NOT NULL, \`deleted\` tinyint NOT NULL, INDEX \`ind_attributionId\` (\`attributionId\`), INDEX \`ind_startedAt\` (\`startedAt\`), INDEX \`ind_stoppedAt\` (\`stoppedAt\`), PRIMARY KEY (\`instanceId\`)) ENGINE=InnoDB`,
+            `CREATE TABLE \`d_b_workspace_instance_usage\` (\`instanceId\` char(36) NOT NULL, \`attributionId\` varchar(255) NOT NULL, \`startedAt\` timestamp(6) NOT NULL, \`stoppedAt\` timestamp(6) NULL, \`creditsUsed\` bigint NOT NULL, \`generationId\` int NOT NULL, \`deleted\` tinyint NOT NULL, INDEX \`ind_attributionId\` (\`attributionId\`), INDEX \`ind_startedAt\` (\`startedAt\`), INDEX \`ind_stoppedAt\` (\`stoppedAt\`), PRIMARY KEY (\`instanceId\`)) ENGINE=InnoDB`,
         );
     }
 

--- a/components/gitpod-db/src/typeorm/migration/1658123555591-ChangeUsageCreditsColumnType.ts
+++ b/components/gitpod-db/src/typeorm/migration/1658123555591-ChangeUsageCreditsColumnType.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class New1658123371893 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`ind_stoppedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_startedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_attributionId\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
+
+        await queryRunner.query(
+            `CREATE TABLE \`d_b_workspace_instance_usage\` (\`instanceId\` char(36) NOT NULL, \`attributionId\` varchar(255) NOT NULL, \`startedAt\` timestamp(6) NOT NULL, \`stoppedAt\` timestamp(6) NULL, \`creditsUsed\` int NOT NULL, \`generationId\` int NOT NULL, \`deleted\` tinyint NOT NULL, INDEX \`ind_attributionId\` (\`attributionId\`), INDEX \`ind_startedAt\` (\`startedAt\`), INDEX \`ind_stoppedAt\` (\`stoppedAt\`), PRIMARY KEY (\`instanceId\`)) ENGINE=InnoDB`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`ind_stoppedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_startedAt\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP INDEX \`ind_attributionId\` ON \`d_b_workspace_instance_usage\``);
+        await queryRunner.query(`DROP TABLE \`d_b_workspace_instance_usage\``);
+    }
+}

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -248,7 +248,7 @@ func usageReportToUsageRecords(report UsageReport, pricer *WorkspacePricer, now 
 				AttributionID: attributionId,
 				StartedAt:     instance.CreationTime.Time(),
 				StoppedAt:     stoppedAt,
-				CreditsUsed:   float64(pricer.CreditsUsedByInstance(&instance, now)),
+				CreditsUsed:   pricer.CreditsUsedByInstance(&instance, now),
 				GenerationId:  0,
 				Deleted:       false,
 			})

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -19,7 +19,7 @@ type WorkspaceInstanceUsage struct {
 	AttributionID AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
 	StartedAt     time.Time     `gorm:"column:startedAt;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"startedAt"`
 	StoppedAt     sql.NullTime  `gorm:"column:stoppedAt;type:timestamp;" json:"stoppedAt"`
-	CreditsUsed   int64         `gorm:"column:creditsUsed;type:int;" json:"creditsUsed"`
+	CreditsUsed   int64         `gorm:"column:creditsUsed;type:bigint;" json:"creditsUsed"`
 	GenerationId  int           `gorm:"column:generationId;type:int;" json:"generationId"`
 	Deleted       bool          `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -19,7 +19,7 @@ type WorkspaceInstanceUsage struct {
 	AttributionID AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
 	StartedAt     time.Time     `gorm:"column:startedAt;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"startedAt"`
 	StoppedAt     sql.NullTime  `gorm:"column:stoppedAt;type:timestamp;" json:"stoppedAt"`
-	CreditsUsed   float64       `gorm:"column:creditsUsed;type:double;" json:"creditsUsed"`
+	CreditsUsed   int64         `gorm:"column:creditsUsed;type:int;" json:"creditsUsed"`
 	GenerationId  int           `gorm:"column:generationId;type:int;" json:"generationId"`
 	Deleted       bool          `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }


### PR DESCRIPTION
## Description

Workspace credits per minute can be configured as fractional values, but we always want to bill and display usage in whole numbers of credits. This PR changes the type of the field that stores credits consumed per workspace instance to be an integer.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9036 and [this comment](https://github.com/gitpod-io/gitpod/pull/11406#discussion_r922071042) on #11406.

## How to test

Connect to the database for the preview and describe the `d_b_workspace_instance_usage` table:

![image](https://user-images.githubusercontent.com/8225907/179454185-b52c8179-99fe-491a-9ba1-417b6cb13d3c.png)

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:
- [x] /werft with-preview
