### PR TITLE
Remove no more used annotation "gitpod.io/containerIsGone"

### DIFF
--- a/components/common-go/kubernetes/kubernetes.go
+++ b/components/common-go/kubernetes/kubernetes.go
@@ -46,10 +46,6 @@ const (
 	// CPULimitAnnotation enforces a strict CPU limit on a workspace by virtue of ws-daemon
 	CPULimitAnnotation = "gitpod.io/cpuLimit"
 
-	// ContainerIsGoneAnnotation is used as workaround for containerd https://github.com/containerd/containerd/pull/4214
-	// which might cause workspace container status propagation to fail, which in turn would keep a workspace running indefinitely.
-	ContainerIsGoneAnnotation = "gitpod.io/containerIsGone"
-
 	// WorkspaceURLAnnotation is the annotation on the WS pod which contains the public workspace URL.
 	WorkspaceURLAnnotation = "gitpod/url"
 

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -376,7 +376,8 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 		}
 	}
 
-	if status.Phase == api.WorkspacePhase_CREATING {
+	switch status.Phase {
+	case api.WorkspacePhase_CREATING:
 		// The workspace has been scheduled on the cluster which means that we can start initializing it
 		go func() {
 			err := m.initializeWorkspaceContent(ctx, pod)
@@ -389,9 +390,8 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 				}
 			}
 		}()
-	}
 
-	if status.Phase == api.WorkspacePhase_INITIALIZING {
+	case api.WorkspacePhase_INITIALIZING:
 		// workspace is initializing (i.e. running but without the ready annotation yet). Start probing and depending on
 		// the result add the appropriate annotation or stop the workspace. waitForWorkspaceReady takes care that it does not
 		// run for the same workspace multiple times.
@@ -406,9 +406,8 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 				}
 			}
 		}()
-	}
 
-	if status.Phase == api.WorkspacePhase_RUNNING {
+	case api.WorkspacePhase_RUNNING:
 		// We need to register the finalizer before the pod is deleted (see https://book.kubebuilder.io/reference/using-finalizers.html).
 		// TODO (cw): Figure out if we can replace the "neverReady" flag.
 		err = m.modifyFinalizer(ctx, workspaceID, gitpodFinalizerName, true)
@@ -428,9 +427,8 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 		if err != nil {
 			log.WithError(err).Warn("was unable to remove workspace secret")
 		}
-	}
 
-	if status.Phase == api.WorkspacePhase_STOPPING {
+	case api.WorkspacePhase_STOPPING:
 		if !isPodBeingDeleted(pod) {
 			// this might be the case if a headless workspace has just completed but has not been deleted by anyone, yet
 			err := m.stopWorkspace(ctx, workspaceID, stopWorkspaceNormallyGracePeriod)
@@ -508,9 +506,8 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 				go m.finalizeWorkspaceContent(ctx, wso)
 			}
 		}
-	}
 
-	if status.Phase == api.WorkspacePhase_STOPPED {
+	case api.WorkspacePhase_STOPPED:
 		// we've disposed already - try to remove the finalizer and call it a day
 		return m.modifyFinalizer(ctx, workspaceID, gitpodFinalizerName, false)
 	}

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -486,10 +486,8 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 			}
 		}
 
-		_, gone := wso.Pod.Annotations[wsk8s.ContainerIsGoneAnnotation]
 		_, alreadyFinalized := wso.Pod.Annotations[startedDisposalAnnotation]
-
-		if (terminated || gone) && !alreadyFinalized {
+		if terminated && !alreadyFinalized {
 			if wso.Pod.Annotations[workspaceFailedBeforeStoppingAnnotation] == util.BooleanTrueString && wso.Pod.Annotations[workspaceNeverReadyAnnotation] == util.BooleanTrueString {
 				// The workspace is never ready, so there is no need for a finalizer.
 				if _, ok := pod.Annotations[workspaceExplicitFailAnnotation]; !ok {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The annotation "gitpod.io/containerIsGone" is no more used. Removing it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None 

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
