### PR TITLE
[dashboard] Next steps nudge for local-preview 

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -47,7 +47,8 @@ import { StartWorkspaceModal } from "./workspaces/StartWorkspaceModal";
 import { parseProps } from "./start/StartWorkspace";
 import SelectIDEModal from "./settings/SelectIDEModal";
 import { StartPage, StartPhase } from "./start/StartPage";
-import { isGitpodIo } from "./utils";
+import { isGitpodIo, isLocalPreview } from "./utils";
+import Alert from "./components/Alert";
 import { BlockedRepositories } from "./admin/BlockedRepositories";
 import { AppNotifications } from "./AppNotifications";
 
@@ -347,6 +348,28 @@ function App() {
         <Route>
             <div className="container">
                 <Menu />
+                {isLocalPreview() && (
+                    <div className="app-container mt-2">
+                        <Alert type="warning" className="app-container rounded-md">
+                            You are using a <b>local preview</b> installation, intended for exploring the product on a
+                            single machine without requiring a Kubernetes cluster.{" "}
+                            <a
+                                className="gp-link hover:text-gray-600"
+                                href="https://www.gitpod.io/community-license?utm_source=local-preview"
+                            >
+                                Request a community license
+                            </a>{" "}
+                            or{" "}
+                            <a
+                                className="gp-link hover:text-gray-600"
+                                href="https://www.gitpod.io/contact/sales?utm_source=local-preview"
+                            >
+                                contact sales
+                            </a>{" "}
+                            to get a professional license for running Gitpod in production.
+                        </Alert>
+                    </div>
+                )}
                 <AppNotifications />
                 <Switch>
                     <Route path={projectsPathNew} exact component={NewProject} />

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -58,8 +58,12 @@ export function isGitpodIo() {
     );
 }
 
+export function isLocalPreview() {
+    return window.location.hostname === "preview.gitpod-self-hosted.com";
+}
+
 function trimResource(resource: string): string {
-    return resource.split('/').filter(Boolean).join('/');
+    return resource.split("/").filter(Boolean).join("/");
 }
 
 // Returns 'true' if a 'pathname' is a part of 'resources' provided.
@@ -69,9 +73,9 @@ function trimResource(resource: string): string {
 // 'pathname' arg can be provided via `location.pathname`.
 export function inResource(pathname: string, resources: string[]): boolean {
     // Removes leading and trailing '/'
-    const trimmedResource = trimResource(pathname)
+    const trimmedResource = trimResource(pathname);
 
     // Checks if a path is part of a resource.
     // E.g. "api/userspace/resource" path is a part of resource "api/userspace"
-    return resources.map(res => trimmedResource.startsWith(trimResource(res))).some(Boolean)
+    return resources.map((res) => trimmedResource.startsWith(trimResource(res))).some(Boolean);
 }

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-# Set Domain to `127-0-0-1.nip.io` if not set
+# Set Domain to `preview.gitpod-self-hosted.com` if not set
 if [ -z "${DOMAIN}" ]; then
-  export DOMAIN="127-0-0-1.nip.io"
+  export DOMAIN="preview.gitpod-self-hosted.com"
 fi
 
 # Create a USER_ID to be used everywhere

--- a/install/preview/manifests/coredns.yaml
+++ b/install/preview/manifests/coredns.yaml
@@ -56,18 +56,18 @@ metadata:
   namespace: kube-system
 data:
   gitpod.db: |
-    ; 127-0-0-1.nip.io test file
-    127-0-0-1.nip.io.       IN      SOA    sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
-    127-0-0-1.nip.io.       IN      CNAME  proxy.default.svc.cluster.local.
-    *.127-0-0-1.nip.io.     IN      CNAME  proxy.default.svc.cluster.local.
-    *.ws.127-0-0-1.nip.io.  IN      CNAME  proxy.default.svc.cluster.local.
+    ; preview.gitpod-self-hosted.com test file
+    preview.gitpod-self-hosted.com.       IN      SOA    sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+    preview.gitpod-self-hosted.com.       IN      CNAME  proxy.default.svc.cluster.local.
+    *.preview.gitpod-self-hosted.com.     IN      CNAME  proxy.default.svc.cluster.local.
+    *.ws.preview.gitpod-self-hosted.com.  IN      CNAME  proxy.default.svc.cluster.local.
   Corefile: |
     .:53 {
         errors
         health
         ready
-        # extra configuration for `127-0-0-1.nip.io`
-        file /etc/coredns/gitpod.db 127-0-0-1.nip.io
+        # extra configuration for `preview.gitpod-self-hosted.com`
+        file /etc/coredns/gitpod.db preview.gitpod-self-hosted.com
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, After `local-preview` is exited There are no
direct concrete steps for users to take.

This PR fixes this by adding a new `Alert` box to the
global dashboard if we notice that they are on a Gitpod
`local-preview` DOMAIN, which is `preview.gitpod-self-hosted.com`
(our own DOMAIN) from now.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/11381

## How to test
<!-- Provide steps to test this PR -->

Run
```
docker run -p 443:443 --privileged --name gitpod --rm -it -v gitpod:/var/gitpod eu.gcr.io/gitpod-core-dev/build/local-preview:tar-lp-out-nudge.19
````
and see the nudge being present.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] Next steps nudge for local-preview
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->



## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
