### PR TITLE
Fix cert exec commands to correctly return debug

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -109,7 +109,7 @@ function createCertificateResource(
     && kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} apply -f cert.yaml`;
 
     werft.log(shellOpts.slice, "Creating certificate Custom Resource");
-    const rc = exec(cmd, { slice: shellOpts.slice }).code;
+    const rc = exec(cmd, { slice: shellOpts.slice, dontCheckRc: true }).code;
 
     if (rc != 0) {
         werft.fail(shellOpts.slice, "Failed to create the certificate Custom Resource");
@@ -134,7 +134,7 @@ function copyCachedSecret(werft: Werft, params: InstallCertificateParams, slice:
     | sed 's/${params.certName}/${params.certSecretName}/g' \
     | kubectl --kubeconfig ${params.destinationKubeconfig} apply --namespace=${params.destinationNamespace} -f -`;
 
-    const rc = exec(cmd, { slice: slice }).code;
+    const rc = exec(cmd, { slice: slice, dontCheckRc: true }).code;
 
     if (rc != 0) {
         werft.fail(


### PR DESCRIPTION
## Description
Fixes cert logic to correctly return the debug from the commands

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
