### PR TITLE
[usage] Use floating point values to hold instance credit usage

### DIFF
--- a/components/usage/pkg/controller/billing.go
+++ b/components/usage/pkg/controller/billing.go
@@ -7,7 +7,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -69,7 +68,7 @@ type WorkspacePricer struct {
 	creditMinutesByWorkspaceClass map[string]float64
 }
 
-func (p *WorkspacePricer) CreditsUsedByInstance(instance *db.WorkspaceInstanceForUsage, maxStopTime time.Time) int64 {
+func (p *WorkspacePricer) CreditsUsedByInstance(instance *db.WorkspaceInstanceForUsage, maxStopTime time.Time) float64 {
 	runtime := instance.WorkspaceRuntimeSeconds(maxStopTime)
 	class := defaultWorkspaceClass
 	if instance.WorkspaceClass != "" {
@@ -78,9 +77,9 @@ func (p *WorkspacePricer) CreditsUsedByInstance(instance *db.WorkspaceInstanceFo
 	return p.Credits(class, runtime)
 }
 
-func (p *WorkspacePricer) Credits(workspaceClass string, runtimeInSeconds int64) int64 {
+func (p *WorkspacePricer) Credits(workspaceClass string, runtimeInSeconds int64) float64 {
 	inMinutes := float64(runtimeInSeconds) / 60
-	return int64(math.Ceil(p.CreditsPerMinuteForClass(workspaceClass) * inMinutes))
+	return p.CreditsPerMinuteForClass(workspaceClass) * inMinutes
 }
 
 func (p *WorkspacePricer) CreditsPerMinuteForClass(workspaceClass string) float64 {

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -140,12 +141,12 @@ func (u UsageReport) CreditSummaryForTeams(pricer *WorkspacePricer, maxStopTime 
 			continue
 		}
 
-		var credits int64
+		var credits float64
 		for _, instance := range instances {
 			credits += pricer.CreditsUsedByInstance(&instance, maxStopTime)
 		}
 
-		creditsPerTeamID[id] = credits
+		creditsPerTeamID[id] = int64(math.Ceil(credits))
 	}
 
 	return creditsPerTeamID
@@ -248,7 +249,7 @@ func usageReportToUsageRecords(report UsageReport, pricer *WorkspacePricer, now 
 				AttributionID: attributionId,
 				StartedAt:     instance.CreationTime.Time(),
 				StoppedAt:     stoppedAt,
-				CreditsUsed:   float64(pricer.CreditsUsedByInstance(&instance, now)),
+				CreditsUsed:   pricer.CreditsUsedByInstance(&instance, now),
 				GenerationId:  0,
 				Deleted:       false,
 			})


### PR DESCRIPTION
## Description

Per instance, we want to work with fractional credits and only round the total for a team when we submit usage reports to stripe.

## Related Issue(s)
Part of #9036 

## How to test
Unit tests

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-preview
