### PR TITLE
[ws-daemon] Add support for limiting number of processes in workspaces

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_proc_limit_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_proc_limit_v2.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cgroup
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+
+	v2 "github.com/containerd/cgroups/v2"
+	"github.com/gitpod-io/gitpod/common-go/log"
+)
+
+type ProcLimiterV2 struct {
+	limits *v2.Resources
+
+	cond *sync.Cond
+}
+
+func NewProcLimiterV2(processes int64) (*ProcLimiterV2, error) {
+	return &ProcLimiterV2{
+		limits: &v2.Resources{
+			Pids: &v2.Pids{
+				Max: processes,
+			},
+		},
+
+		cond: sync.NewCond(&sync.Mutex{}),
+	}, nil
+}
+
+func (c *ProcLimiterV2) Name() string  { return "proc-limiter-v2" }
+func (c *ProcLimiterV2) Type() Version { return Version2 }
+
+func (c *ProcLimiterV2) Apply(ctx context.Context, basePath, cgroupPath string) error {
+	update := make(chan struct{}, 1)
+	go func() {
+		defer close(update)
+
+		for {
+			c.cond.L.Lock()
+			c.cond.Wait()
+			c.cond.L.Unlock()
+
+			if ctx.Err() != nil {
+				return
+			}
+
+			update <- struct{}{}
+		}
+	}()
+
+	go func() {
+		log.WithField("cgroupPath", cgroupPath).Debug("starting proc limiting")
+
+		_, err := v2.NewManager(basePath, filepath.Join("/", cgroupPath), c.limits)
+		if err != nil {
+			log.WithError(err).WithField("basePath", basePath).WithField("cgroupPath", cgroupPath).WithField("limits", c.limits).Error("cannot write proc limits")
+		}
+
+		for {
+			select {
+			case <-update:
+				_, err := v2.NewManager(basePath, filepath.Join("/", cgroupPath), c.limits)
+				if err != nil {
+					log.WithError(err).WithField("basePath", basePath).WithField("cgroupPath", cgroupPath).WithField("limits", c.limits).Error("cannot write proc limits")
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *ProcLimiterV2) Update(processes int64) {
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+
+	c.limits = &v2.Resources{
+		Pids: &v2.Pids{
+			Max: processes,
+		},
+	}
+
+	c.cond.Broadcast()
+}

--- a/components/ws-daemon/pkg/daemon/config.go
+++ b/components/ws-daemon/pkg/daemon/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Uidmapper      iws.UidmapperConfig `json:"uidmapper"`
 	CPULimit       cpulimit.Config     `json:"cpulimit"`
 	IOLimit        IOLimitConfig       `json:"ioLimit"`
+	ProcLimit      int64               `json:"procLimit"`
 	Hosts          hosts.Config        `json:"hosts"`
 	DiskSpaceGuard diskguard.Config    `json:"disk"`
 }

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -45,9 +45,13 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ControlPeriod:  util.Duration(15 * time.Second),
 	}
 	var ioLimitConfig daemon.IOLimitConfig
+
+	var procLimit int64
+
 	runtimeMapping := make(map[string]string)
 	// default runtime mapping
 	runtimeMapping[ctx.Config.Workspace.Runtime.ContainerDRuntimeDir] = "/mnt/node0"
+
 	ctx.WithExperimental(func(ucfg *experimental.Config) error {
 		if ucfg.Workspace == nil {
 			return nil
@@ -70,6 +74,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				runtimeMapping[value.Path] = value.Value
 			}
 		}
+
+		procLimit = ucfg.Workspace.ProcLimit
 
 		return nil
 	})
@@ -116,8 +122,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Size:  70000,
 				}},
 			},
-			CPULimit: cpuLimitConfig,
-			IOLimit:  ioLimitConfig,
+			CPULimit:  cpuLimitConfig,
+			IOLimit:   ioLimitConfig,
+			ProcLimit: procLimit,
 			Hosts: hosts.Config{
 				Enabled:       true,
 				NodeHostsFile: "/mnt/hosts",

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -70,6 +70,8 @@ type WorkspaceConfig struct {
 		ReadIOPS         int64             `json:"readIOPS"`
 	} `json:"ioLimits"`
 
+	ProcLimit int64 `json:"procLimit"`
+
 	WSManagerRateLimits map[string]grpc.RateLimit `json:"wsManagerRateLimits,omitempty"`
 
 	RegistryFacade struct {


### PR DESCRIPTION
## Description

Allow setting a limit to the number of processes inside a workspace. By default, we have none.

## How to test
- Edit ws-daemon configmap and set `"procLimit": 512`
- Start a workspace
- Open a terminal and run `while true; do sleep 1 && date & done`
- Check you sporadically see `bash: fork: retry: Resource temporarily unavailable`

**

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add support for limiting number of processes in workspaces
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview

Note: testing this requires cgroups v2