### PR TITLE
[usage] Store workspace, project, type & class

### DIFF
--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -36,7 +36,7 @@ func (us *UsageService) ListBilledUsage(ctx context.Context, in *v1.ListBilledUs
 		}
 		billedSession := &v1.BilledSession{
 			AttributionId:  string(usageRecord.AttributionID),
-			UserId:         usageRecord.UserID,
+			UserId:         usageRecord.UserID.String(),
 			WorkspaceId:    usageRecord.WorkspaceID,
 			WorkspaceType:  string(usageRecord.WorkspaceType),
 			ProjectId:      usageRecord.ProjectID,

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -244,13 +244,23 @@ func usageReportToUsageRecords(report UsageReport, pricer *WorkspacePricer, now 
 				stoppedAt = sql.NullTime{Time: instance.StoppedTime.Time(), Valid: true}
 			}
 
+			projectID := ""
+			if instance.ProjectID.Valid {
+				projectID = instance.ProjectID.String
+			}
+
 			usageRecords = append(usageRecords, db.WorkspaceInstanceUsage{
-				InstanceID:    instance.ID,
-				AttributionID: attributionId,
-				StartedAt:     instance.CreationTime.Time(),
-				StoppedAt:     stoppedAt,
-				CreditsUsed:   pricer.CreditsUsedByInstance(&instance, now),
-				GenerationID:  0,
+				InstanceID:     instance.ID,
+				AttributionID:  attributionId,
+				WorkspaceID:    instance.WorkspaceID,
+				ProjectID:      projectID,
+				UserID:         instance.OwnerID,
+				WorkspaceType:  instance.Type,
+				WorkspaceClass: instance.WorkspaceClass,
+				StartedAt:      instance.CreationTime.Time(),
+				StoppedAt:      stoppedAt,
+				CreditsUsed:    pricer.CreditsUsedByInstance(&instance, now),
+				GenerationID:   0,
 			})
 		}
 	}

--- a/components/usage/pkg/db/dbtest/workspace.go
+++ b/components/usage/pkg/db/dbtest/workspace.go
@@ -5,6 +5,7 @@
 package dbtest
 
 import (
+	"database/sql"
 	"github.com/gitpod-io/gitpod/common-go/namegen"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/google/uuid"
@@ -34,6 +35,14 @@ func NewWorkspace(t *testing.T, workspace db.Workspace) db.Workspace {
 		ownerID = workspace.OwnerID
 	}
 
+	projectID := sql.NullString{
+		String: "",
+		Valid:  false,
+	}
+	if workspace.ProjectID.Valid {
+		projectID = workspace.ProjectID
+	}
+
 	workspaceType := db.WorkspaceType_Regular
 	if workspace.Type != "" {
 		workspaceType = workspace.Type
@@ -58,6 +67,7 @@ func NewWorkspace(t *testing.T, workspace db.Workspace) db.Workspace {
 		ID:         id,
 		OwnerID:    ownerID,
 		Type:       workspaceType,
+		ProjectID:  projectID,
 		ContextURL: contextURL,
 		Context:    context,
 		Config:     config,

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -62,7 +62,16 @@ func ListWorkspaceInstancesInRange(ctx context.Context, conn *gorm.DB, from, to 
 
 	tx := conn.WithContext(ctx).
 		Table(fmt.Sprintf("%s as wsi", (&WorkspaceInstance{}).TableName())).
-		Select("wsi.id as id, ws.projectId as projectId, ws.type as workspaceType, wsi.workspaceClass as workspaceClass, wsi.usageAttributionId as usageAttributionId, wsi.stoppedTime as stoppedTime, wsi.creationTime as creationTime").
+		Select("wsi.id as id, "+
+			"ws.projectId as projectId, "+
+			"ws.type as workspaceType, "+
+			"wsi.workspaceClass as workspaceClass, "+
+			"wsi.usageAttributionId as usageAttributionId, "+
+			"wsi.stoppedTime as stoppedTime, "+
+			"wsi.creationTime as creationTime, "+
+			"ws.ownerId as ownerId, "+
+			"ws.id as workspaceId",
+		).
 		Joins(fmt.Sprintf("LEFT JOIN %s AS ws ON wsi.workspaceId = ws.id", (&Workspace{}).TableName())).
 		Where(
 			conn.Where("wsi.stoppedTime >= ?", TimeToISO8601(from)).Or("wsi.stoppedTime = ?", ""),
@@ -117,6 +126,8 @@ const (
 
 type WorkspaceInstanceForUsage struct {
 	ID                 uuid.UUID      `gorm:"column:id;type:char;size:36;" json:"id"`
+	WorkspaceID        string         `gorm:"column:workspaceId;type:char;size:36;" json:"workspaceId"`
+	OwnerID            uuid.UUID      `gorm:"column:ownerId;type:char;size:36;" json:"ownerId"`
 	ProjectID          sql.NullString `gorm:"column:projectId;type:char;size:36;" json:"projectId"`
 	WorkspaceClass     string         `gorm:"column:workspaceClass;type:varchar;size:255;" json:"workspaceClass"`
 	Type               WorkspaceType  `gorm:"column:workspaceType;type:char;size:16;default:regular;" json:"workspaceType"`

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -19,7 +19,7 @@ type WorkspaceInstanceUsage struct {
 	InstanceID    uuid.UUID     `gorm:"primary_key;column:instanceId;type:char;size:36;" json:"instanceId"`
 	AttributionID AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
 
-	UserID         string        `gorm:"column:userId;type:varchar;size:255;" json:"userId"`
+	UserID         uuid.UUID     `gorm:"column:userId;type:varchar;size:255;" json:"userId"`
 	WorkspaceID    string        `gorm:"column:workspaceId;type:varchar;size:255;" json:"workspaceId"`
 	ProjectID      string        `gorm:"column:projectId;type:varchar;size:255;" json:"projectId"`
 	WorkspaceType  WorkspaceType `gorm:"column:workspaceType;type:varchar;size:255;" json:"workspaceType"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. Retrieve OwnerID and ProjectID when querying workspace instances (joined with Workspaces)
2. Populate fields from the retrieved WorksapceInstancesForUsage into the report
3. Store these in the DB

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
