### PR TITLE
[code] Update stable to 1.69.2

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-cc059a57be4856e56a5e83de87e6c9b81263e3fe" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-050c611f28564c6c7b1e58db470f07997dfb4730" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates stable VS Code version to 1.69.2.

Using stable VS Code in [prev env](https://afalz-upda5069630ad0.preview.gitpod-dev.com), version is correct:

<img width="558" alt="Screenshot 2022-07-19 at 13 18 56" src="https://user-images.githubusercontent.com/2318450/179738062-134a9025-3683-48ef-94b9-c93739dcc5f8.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/10990

## How to test
Switch to stable in the preview environment and in the about dialog confirm you are running 1.69.2

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

- [x] /werft with-preview