### PR TITLE
[common-go] Add experiments client & ConfigCat implementation

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package experiments
+
+import (
+	"context"
+	configcat "github.com/configcat/go-sdk/v7"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+const (
+	projectIDAttribute = "project_id"
+	teamIDAttribute    = "team_id"
+	teamNameAttribute  = "team_name"
+)
+
+func newConfigCatClient(sdkKey string) *configCatClient {
+	return &configCatClient{
+		client: configcat.NewCustomClient(configcat.Config{
+			SDKKey:       sdkKey,
+			PollInterval: 3 * time.Minute,
+			HTTPTimeout:  3 * time.Second,
+			Logger:       &configCatLogger{log.Log},
+		}),
+	}
+}
+
+var _ Client = (*configCatClient)(nil)
+
+type configCatClient struct {
+	client *configcat.Client
+}
+
+func (c *configCatClient) GetBoolValue(_ context.Context, experimentName string, defaultValue bool, attributes Attributes) bool {
+	return c.client.GetBoolValue(experimentName, defaultValue, attributesToUser(attributes))
+}
+
+func (c *configCatClient) GetIntValue(_ context.Context, experimentName string, defaultValue int, attributes Attributes) int {
+	return c.client.GetIntValue(experimentName, defaultValue, attributesToUser(attributes))
+}
+
+func (c *configCatClient) GetFloatValue(_ context.Context, experimentName string, defaultValue float64, attributes Attributes) float64 {
+	return c.client.GetFloatValue(experimentName, defaultValue, attributesToUser(attributes))
+}
+
+func (c *configCatClient) GetStringValue(_ context.Context, experimentName string, defaultValue string, attributes Attributes) string {
+	return c.client.GetStringValue(experimentName, defaultValue, attributesToUser(attributes))
+}
+
+func attributesToUser(attributes Attributes) configcat.UserData {
+	custom := make(map[string]string)
+
+	if attributes.TeamID != "" {
+		custom[teamIDAttribute] = attributes.TeamID
+	}
+
+	if attributes.TeamName != "" {
+		custom[teamNameAttribute] = attributes.TeamName
+	}
+
+	if attributes.ProjectID != "" {
+		custom[projectIDAttribute] = attributes.ProjectID
+	}
+
+	return configcat.UserData{
+		Identifier: attributes.UserID,
+		Email:      attributes.UserEmail,
+		Country:    "",
+		Custom:     custom,
+	}
+}
+
+type configCatLogger struct {
+	*logrus.Entry
+}
+
+func (l *configCatLogger) GetLevel() configcat.LogLevel {
+	return l.Level
+}

--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package experiments
+
+import "context"
+
+// IsMyFirstFeatureFlagEnabled example usage of a flag
+func IsMyFirstFeatureFlagEnabled(ctx context.Context, client Client, attributes Attributes) bool {
+	return client.GetBoolValue(ctx, "isMyFirstFeatureEnabled", false, attributes)
+}

--- a/components/common-go/experiments/noop.go
+++ b/components/common-go/experiments/noop.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package experiments
+
+import "context"
+
+var _ Client = (*alwaysReturningDefaultValueClient)(nil)
+
+type alwaysReturningDefaultValueClient struct{}
+
+func NewAlwaysReturningDefaultValueClient() Client {
+	return &alwaysReturningDefaultValueClient{}
+}
+
+func (c *alwaysReturningDefaultValueClient) GetBoolValue(_ context.Context, _ string, defaultValue bool, _ Attributes) bool {
+	return defaultValue
+}
+
+func (c *alwaysReturningDefaultValueClient) GetIntValue(_ context.Context, _ string, defaultValue int, _ Attributes) int {
+	return defaultValue
+}
+
+func (c *alwaysReturningDefaultValueClient) GetFloatValue(_ context.Context, _ string, defaultValue float64, _ Attributes) float64 {
+	return defaultValue
+}
+
+func (c *alwaysReturningDefaultValueClient) GetStringValue(_ context.Context, _ string, defaultValue string, _ Attributes) string {
+	return defaultValue
+}

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package experiments
+
+import (
+	"context"
+	"os"
+)
+
+type Client interface {
+	GetBoolValue(ctx context.Context, experimentName string, defaultValue bool, attributes Attributes) bool
+	GetIntValue(ctx context.Context, experimentName string, defaultValue int, attributes Attributes) int
+	GetFloatValue(ctx context.Context, experimentName string, defaultValue float64, attributes Attributes) float64
+	GetStringValue(ctx context.Context, experimentName string, defaultValue string, attributes Attributes) string
+}
+
+type Attributes struct {
+	UserID    string
+	UserEmail string
+	ProjectID string
+	TeamID    string
+	TeamName  string
+}
+
+// NewClient constructs a new experiments.Client. This is NOT A SINGLETON.
+// You should normally only call this once in the lifecycle of an application, clients are independent of each other will refresh flags on their own.
+// If the environment contains CONFIGCAT_SDK_KEY value, it vill be used to construct a ConfigCat client.
+// Otherwise, it returns a client which always returns the default value. This client is used for Self-Hosted installations.
+func NewClient() Client {
+	sdkKey := os.Getenv("CONFIGCAT_SDK_KEY")
+	if sdkKey == "" {
+		return NewAlwaysReturningDefaultValueClient()
+	}
+
+	return newConfigCatClient(sdkKey)
+}

--- a/components/common-go/experiments/types_test.go
+++ b/components/common-go/experiments/types_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package experiments
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewClient_WithoutEnvSet(t *testing.T) {
+	client := NewClient()
+	require.IsType(t, &alwaysReturningDefaultValueClient{}, client)
+}
+
+func TestNewClient_WithConfigcatEnvSet(t *testing.T) {
+	t.Setenv("CONFIGCAT_SDK_KEY", "foo-bar")
+	client := NewClient()
+	require.IsType(t, &configCatClient{}, client)
+}

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	github.com/configcat/go-sdk/v7 v7.6.0
 	github.com/containerd/cgroups v1.0.4
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/hashicorp/golang-lru v0.5.1
@@ -37,6 +38,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cilium/ebpf v0.4.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect

--- a/components/common-go/go.sum
+++ b/components/common-go/go.sum
@@ -50,6 +50,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -68,6 +70,8 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/configcat/go-sdk/v7 v7.6.0 h1:CthQJ7DMz4bvUrpc8aek6VouJjisCvZCfuTG2gyNzL4=
+github.com/configcat/go-sdk/v7 v7.6.0/go.mod h1:2245V6Igy1Xz6GXvcYuK5z996Ct0VyzyuI470XS6aTw=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/cgroups v1.0.4/go.mod h1:nLNQtsF7Sl2HxNebu77i1R0oDlhiTG+kO4JTrUzo6IA=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
@@ -89,6 +93,7 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -159,6 +164,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Implement experiments Client abstraction in golang. This largely follows the same format as the server/dashboard version.

To use the client, the environment must have the SDK key set, otherwise returns a client which always returns a default value.

Thanks to @Furisto who started the implementation!

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
