### PR TITLE
[usage] Make endTime non-mandatory for billed session

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -47,7 +47,9 @@ function TeamUsage() {
         return "Prebuild";
     };
 
-    const getHours = (endTime: number, startTime: number) => {
+    const getHours = (endTime: number | undefined, startTime: number) => {
+        if (!endTime) return "";
+
         return (endTime - startTime) / (1000 * 60 * 60) + "hrs";
     };
 
@@ -95,7 +97,10 @@ function TeamUsage() {
                         </div>
                         <div className="my-auto">
                             <span className="text-gray-700">
-                                {getHours(new Date(usage.endTime).getTime(), new Date(usage.startTime).getTime())}
+                                {getHours(
+                                    usage.endTime ? new Date(usage.endTime).getTime() : undefined,
+                                    new Date(usage.startTime).getTime(),
+                                )}
                             </span>
                         </div>
                         <div className="my-auto">

--- a/components/gitpod-protocol/src/usage.ts
+++ b/components/gitpod-protocol/src/usage.ts
@@ -26,8 +26,8 @@ export interface BillableSession {
     // When the workspace started
     startTime: string;
 
-    // When the workspace ended
-    endTime: string;
+    // When the workspace ended. Not set when the workspace is still running.
+    endTime?: string;
 
     // The credits used for this session
     credits: number;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2132,7 +2132,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             workspaceType: mandatory(s.getWorkspaceType()) as WorkspaceType,
             workspaceClass: mandatory(s.getWorkspaceClass()),
             startTime: mandatory(s.getStartTime(), (t) => t!.toDate().toISOString()),
-            endTime: mandatory(s.getEndTime(), (t) => t!.toDate().toISOString()),
+            endTime: s.getEndTime()?.toDate().toISOString(),
             credits: s.getCredits(), // optional
         };
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Because it won't be set when the instance is still running.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
