### PR TITLE
  [ws-manager] fix incorrect handling of failure state for workspaces 

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -45,12 +45,13 @@ type metrics struct {
 	volumeRestoreTimeHistVec  *prometheus.HistogramVec
 
 	// Counter
-	totalStartsCounterVec         *prometheus.CounterVec
-	totalStopsCounterVec          *prometheus.CounterVec
-	totalBackupCounterVec         *prometheus.CounterVec
-	totalBackupFailureCounterVec  *prometheus.CounterVec
-	totalRestoreCounterVec        *prometheus.CounterVec
-	totalRestoreFailureCounterVec *prometheus.CounterVec
+	totalStartsCounterVec                     *prometheus.CounterVec
+	totalStopsCounterVec                      *prometheus.CounterVec
+	totalBackupCounterVec                     *prometheus.CounterVec
+	totalBackupFailureCounterVec              *prometheus.CounterVec
+	totalRestoreCounterVec                    *prometheus.CounterVec
+	totalRestoreFailureCounterVec             *prometheus.CounterVec
+	totalUnintentionalWorkspaceStopCounterVec *prometheus.CounterVec
 
 	// Gauge
 	totalOpenPortGauge prometheus.GaugeFunc
@@ -135,6 +136,12 @@ func newMetrics(m *Manager) *metrics {
 			Name:      "workspace_restores_failure_total",
 			Help:      "total number of workspace restore failures",
 		}, []string{"type", "class"}),
+		totalUnintentionalWorkspaceStopCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkspaceSubsystem,
+			Name:      "workspace_unintentional_stop_total",
+			Help:      "total number of workspaces when container stopped without being deleted prior",
+		}, []string{"type", "class"}),
 		totalOpenPortGauge: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
@@ -197,6 +204,7 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 		m.totalBackupFailureCounterVec,
 		m.totalRestoreCounterVec,
 		m.totalRestoreFailureCounterVec,
+		m.totalUnintentionalWorkspaceStopCounterVec,
 		m.totalOpenPortGauge,
 	}
 	for _, c := range collectors {

--- a/components/ws-manager/pkg/manager/testdata/actOnPodEvent_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/actOnPodEvent_wsstartup_Creating00.golden
@@ -1,24 +1,3 @@
 {
-    "actions": [
-        {
-            "Func": "markWorkspace",
-            "Params": {
-                "annotations": [
-                    {
-                        "Name": "gitpod/failedBeforeStopping",
-                        "Value": "true",
-                        "Delete": false
-                    }
-                ],
-                "workspaceID": "foobar"
-            }
-        },
-        {
-            "Func": "stopWorkspace",
-            "Params": {
-                "gracePeriod": 30000000000,
-                "workspaceID": "foobar"
-            }
-        }
-    ]
+    "actions": null
 }

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED01.golden
@@ -20,7 +20,7 @@
         },
         "phase": 6,
         "conditions": {
-            "failed": "last backup failed: testing the backup failure mode.",
+            "failed": "ungraceful shutdown - teardown was unsuccessful: socket did not appear before context was canceled; last backup failed: testing the backup failure mode.",
             "final_backup_complete": 1,
             "volume_snapshot": {}
         },

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING02.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING02.golden
@@ -20,6 +20,7 @@
         },
         "phase": 6,
         "conditions": {
+            "failed": "ungraceful shutdown - teardown was unsuccessful: socket did not appear before context was canceled",
             "final_backup_complete": 1,
             "volume_snapshot": {}
         },

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
@@ -16,7 +16,6 @@
         },
         "phase": 3,
         "conditions": {
-            "failed": "container sync completed; containers of a workspace pod are not supposed to do that. Reason: ",
             "volume_snapshot": {}
         },
         "message": "workspace initializer is running",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes two issues:
1. As described in https://github.com/gitpod-io/gitpod/issues/10315#issuecomment-1185810931 it resolves an issue of sending sometimes incorrectly to server empty failed state, even though prior to that we might have sent failure error message. This breaks opening that workspace again, as server will incorrectly assume that there was a backup created (no failure error) and will attempt to restore second workspace from backup, which will fail, thus completely breaking opening that workspace for the customer.
2. We incorrectly mark completed container as an error.  When container is stopped, it is will be in a completed state. That is not an error. 
This two fixes need to go hand in hand.
For more info, see the link above for the comment describing the issue in greater detail.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10315

## How to test
<!-- Provide steps to test this PR -->
Open workspace in preview env
Close it
It should close normally.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
