### PR TITLE
[usage] Request signed upload URL from `content-service`

### DIFF
--- a/components/usage/BUILD.yaml
+++ b/components/usage/BUILD.yaml
@@ -8,6 +8,7 @@ packages:
     deps:
       - components/common-go:lib
       - components/usage-api/go:lib
+      - components/content-service-api/go:lib
       - :init-testdb
     env:
       - CGO_ENABLED=0
@@ -21,6 +22,7 @@ packages:
     deps:
       - components/common-go:lib
       - components/usage-api/go:lib
+      - components/content-service-api/go:lib
     srcs:
       - "**/*.go"
       - "go.mod"

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/content-service/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/usage-api v0.0.0-00010101000000-000000000000
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.7
@@ -35,6 +36,8 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.4 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -45,13 +48,15 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/usage-api => ../usage-api/go // leeway
 

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -269,6 +269,10 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
@@ -515,6 +519,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/components/usage/pkg/contentservice/client.go
+++ b/components/usage/pkg/contentservice/client.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package contentservice
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/content-service/api"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type Interface interface {
+	GetSignedUploadUrl(ctx context.Context) (string, error)
+}
+
+type Client struct {
+	url string
+}
+
+func New(url string) *Client {
+	return &Client{url: url}
+}
+
+func (c *Client) GetSignedUploadUrl(ctx context.Context) (string, error) {
+	conn, err := grpc.Dial(c.url, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return "", fmt.Errorf("failed to dial content-service gRPC server: %w", err)
+	}
+	defer conn.Close()
+
+	uc := api.NewUsageReportServiceClient(conn)
+
+	resp, err := uc.UploadURL(ctx, &api.UsageReportUploadURLRequest{Name: "some-name"})
+	if err != nil {
+		return "", fmt.Errorf("failed to obtain signed upload URL: %w", err)
+	}
+
+	return resp.Url, nil
+}

--- a/components/usage/pkg/contentservice/noop.go
+++ b/components/usage/pkg/contentservice/noop.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package contentservice
+
+import "context"
+
+type NoOpClient struct{}
+
+func (c *NoOpClient) GetSignedUploadUrl(ctx context.Context) (string, error) { return "", nil }

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -36,13 +37,15 @@ type UsageReconciler struct {
 	conn              *gorm.DB
 	pricer            *WorkspacePricer
 	billingController BillingController
+	contentService    contentservice.Interface
 }
 
-func NewUsageReconciler(conn *gorm.DB, pricer *WorkspacePricer, billingController BillingController) *UsageReconciler {
+func NewUsageReconciler(conn *gorm.DB, pricer *WorkspacePricer, billingController BillingController, contentService contentservice.Interface) *UsageReconciler {
 	return &UsageReconciler{
 		conn:              conn,
 		pricer:            pricer,
 		billingController: billingController,
+		contentService:    contentService,
 		nowFunc:           time.Now,
 	}
 }

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -91,10 +91,17 @@ func (u *UsageReconciler) Reconcile() (err error) {
 	}
 
 	stat, err := f.Stat()
+	filePath := filepath.Join(dir, stat.Name())
 	if err != nil {
 		return fmt.Errorf("failed to get file stats: %w", err)
 	}
-	log.Infof("Wrote usage report into %s", filepath.Join(dir, stat.Name()))
+	log.Infof("Wrote usage report into %s", filePath)
+
+	uploadURL, err := u.contentService.GetSignedUploadUrl(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to obtain signed upload URL: %w", err)
+	}
+	log.Infof("signed upload url: %s", uploadURL)
 
 	err = db.CreateUsageRecords(ctx, u.conn, usageReportToUsageRecords(report, u.pricer, u.nowFunc().UTC()))
 	if err != nil {

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -29,7 +29,7 @@ type Config struct {
 
 	StripeCredentialsFile string `json:"stripeCredentialsFile,omitempty"`
 
-	ContentServiceUrl string `json:"contentServiceUrl,omitempty"`
+	ContentServiceAddress string `json:"contentServiceAddress,omitempty"`
 
 	Server *baseserver.Configuration `json:"server,omitempty"`
 }
@@ -74,8 +74,8 @@ func Start(cfg Config) error {
 	}
 
 	var contentService contentservice.Interface = &contentservice.NoOpClient{}
-	if cfg.ContentServiceUrl != "" {
-		contentService = contentservice.New(cfg.ContentServiceUrl)
+	if cfg.ContentServiceAddress != "" {
+		contentService = contentservice.New(cfg.ContentServiceAddress)
 	}
 
 	ctrl, err := controller.New(schedule, controller.NewUsageReconciler(conn, pricer, billingController, contentService))

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -20,8 +20,8 @@ import (
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
-		ControllerSchedule: time.Hour.String(),
-		ContentServiceUrl:  fmt.Sprintf("%s:%d", content_service.Component, content_service.RPCPort),
+		ControllerSchedule:    time.Hour.String(),
+		ContentServiceAddress: fmt.Sprintf("%s:%d", content_service.Component, content_service.RPCPort),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -5,6 +5,8 @@ package usage
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
@@ -21,7 +23,7 @@ import (
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
 		ControllerSchedule:    time.Hour.String(),
-		ContentServiceAddress: fmt.Sprintf("%s:%d", content_service.Component, content_service.RPCPort),
+		ContentServiceAddress: net.JoinHostPort(content_service.Component, strconv.Itoa(content_service.RPCPort)),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gitpod-io/gitpod/usage/pkg/server"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,7 @@ import (
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
 		ControllerSchedule: time.Hour.String(),
+		ContentServiceUrl:  fmt.Sprintf("%s:%d", content_service.Component, content_service.RPCPort),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -23,7 +23,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 	require.JSONEq(t,
 		`{
        "controllerSchedule": "2m",
-       "contentServiceUrl": "content-service:8080",
+       "contentServiceAddress": "content-service:8080",
        "stripeCredentialsFile": "stripe-secret/apikeys",
        "server": {
          "services": {

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -23,6 +23,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 	require.JSONEq(t,
 		`{
        "controllerSchedule": "2m",
+       "contentServiceUrl": "content-service:8080",
        "stripeCredentialsFile": "stripe-secret/apikeys",
        "server": {
          "services": {


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/11474 added a new `UsageReportService` to `content-service` that allowed S3 signed upload URLs to be retrieved for the purpose of uploading usage reports to cloud storage.

This PR hooks up the `usage` component  with the `content-service` so that it requests a signed upload URL from `content-service` each time it runs.

 Subsequent PRs will use this signed URL to actually upload usage reports to cloud storage.

## Related Issue(s)
Part of #9036 
Builds on https://github.com/gitpod-io/gitpod/pull/11474

## How to test

Look at the logs for the `usage` component in the preview environment for this PR. When usage reconciliation runs it successfully requests a signed upload URL from the `content-service`:

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/8225907/180182227-c5a2bde7-52c8-4389-ab25-883ed8ef91c8.png">

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:
- [x] /werft with-preview
