### PR TITLE
[usage] Tiny fix to use variable rather than literal value in test

### DIFF
--- a/components/usage/pkg/controller/reconciler_test.go
+++ b/components/usage/pkg/controller/reconciler_test.go
@@ -206,7 +206,7 @@ func TestUsageReportConversionToDBUsageRecords(t *testing.T) {
 						Type:               db.WorkspaceType_Regular,
 						WorkspaceID:        workspaceID,
 						UsageAttributionID: teamAttributionID,
-						CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
+						CreationTime:       creationTime,
 						StoppedTime:        db.VarcharTime{},
 					},
 				},


### PR DESCRIPTION
## Description
Use variable instead of equivalent constant.


## How to test

unit tests.
## Release Notes

```release-note
NONE
```