### PR TITLE
[usage] ListUsage filters by time range

### DIFF
--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -7,8 +7,6 @@ package apiv1
 import (
 	"context"
 	"database/sql"
-	"testing"
-
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -20,68 +18,118 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
 )
 
 func TestUsageService_ListBilledUsage(t *testing.T) {
-	srv := baseserver.NewForTests(t,
-		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
-	)
-
-	dbconn := dbtest.ConnectForTests(t)
-	v1.RegisterUsageServiceServer(srv.GRPC(), NewUsageService(dbconn))
-	baseserver.StartServerForTests(t, srv)
-
-	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoError(t, err)
-
-	client := v1.NewUsageServiceClient(conn)
 	ctx := context.Background()
 
-	const attributionID = "team:123-456-789"
-	instanceId := uuid.New()
-	startedAt := timestamppb.Now()
-	instanceUsages := []db.WorkspaceInstanceUsage{
-		{
-			InstanceID:    instanceId,
-			AttributionID: attributionID,
-			StartedAt:     startedAt.AsTime(),
-			StoppedAt:     sql.NullTime{},
-			CreditsUsed:   0,
-			GenerationID:  0,
-		},
-	}
-	dbtest.CreateWorkspaceInstanceUsageRecords(t, dbconn, instanceUsages...)
+	attributionID := db.NewTeamAttributionID(uuid.New().String())
 
 	type Expectation struct {
 		Code        codes.Code
 		InstanceIds []string
 	}
 
-	scenarios := []struct {
-		name          string
-		AttributionID string
-		Expect        Expectation
-	}{
+	type Scenario struct {
+		name      string
+		Instances []db.WorkspaceInstanceUsage
+		Request   *v1.ListBilledUsageRequest
+		Expect    Expectation
+	}
+
+	scenarios := []Scenario{
 		{
-			name:          "returns one usage record",
-			AttributionID: attributionID,
+			name:      "fails when From is after To",
+			Instances: nil,
+			Request: &v1.ListBilledUsageRequest{
+				AttributionId: string(attributionID),
+				From:          timestamppb.New(time.Date(2022, 07, 1, 13, 0, 0, 0, time.UTC)),
+				To:            timestamppb.New(time.Date(2022, 07, 1, 12, 0, 0, 0, time.UTC)),
+			},
 			Expect: Expectation{
-				Code:        codes.OK,
-				InstanceIds: []string{instanceId.String()},
+				Code:        codes.InvalidArgument,
+				InstanceIds: nil,
 			},
 		},
+		{
+			name:      "fails when time range is greater than 31 days",
+			Instances: nil,
+			Request: &v1.ListBilledUsageRequest{
+				AttributionId: string(attributionID),
+				From:          timestamppb.New(time.Date(2022, 7, 1, 13, 0, 0, 0, time.UTC)),
+				To:            timestamppb.New(time.Date(2022, 8, 1, 13, 0, 1, 0, time.UTC)),
+			},
+			Expect: Expectation{
+				Code:        codes.InvalidArgument,
+				InstanceIds: nil,
+			},
+		},
+		(func() Scenario {
+			start := time.Date(2022, 07, 1, 13, 0, 0, 0, time.UTC)
+			attrID := db.NewTeamAttributionID(uuid.New().String())
+			var instances []db.WorkspaceInstanceUsage
+			var instanceIDs []string
+			for i := 0; i < 10; i++ {
+				instance := dbtest.NewWorkspaceInstanceUsage(t, db.WorkspaceInstanceUsage{
+					AttributionID: attrID,
+					StartedAt:     start.Add(time.Duration(i) * 24 * time.Hour),
+					StoppedAt: sql.NullTime{
+						Time:  start.Add(time.Duration(i)*24*time.Hour + time.Hour),
+						Valid: true,
+					},
+				})
+				instances = append(instances, instance)
+
+				instanceIDs = append(instanceIDs, instance.InstanceID.String())
+			}
+
+			return Scenario{
+				name:      "filters results to specified time range",
+				Instances: instances,
+				Request: &v1.ListBilledUsageRequest{
+					AttributionId: string(attrID),
+					From:          timestamppb.New(start),
+					To:            timestamppb.New(start.Add(5 * 24 * time.Hour)),
+				},
+				Expect: Expectation{
+					Code:        codes.OK,
+					InstanceIds: instanceIDs[0:5],
+				},
+			}
+		})(),
 	}
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			resp, err := client.ListBilledUsage(ctx, &v1.ListBilledUsageRequest{
-				AttributionId: scenario.AttributionID,
-			})
+			dbconn := dbtest.ConnectForTests(t)
+			dbtest.CreateWorkspaceInstanceUsageRecords(t, dbconn, scenario.Instances...)
+
+			srv := baseserver.NewForTests(t,
+				baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+			)
+
+			v1.RegisterUsageServiceServer(srv.GRPC(), NewUsageService(dbconn))
+			baseserver.StartServerForTests(t, srv)
+
+			conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+
+			client := v1.NewUsageServiceClient(conn)
+
+			resp, err := client.ListBilledUsage(ctx, scenario.Request)
+			require.Equal(t, scenario.Expect.Code, status.Code(err))
+
+			if err != nil {
+				return
+			}
+
 			var instanceIds []string
 			for _, billedSession := range resp.Sessions {
 				instanceIds = append(instanceIds, billedSession.InstanceId)
 			}
-			require.Equal(t, scenario.Expect.Code, status.Code(err))
+
 			require.Equal(t, scenario.Expect.InstanceIds, instanceIds)
 		})
 	}

--- a/components/usage/pkg/db/dbtest/workspace_instance_usage.go
+++ b/components/usage/pkg/db/dbtest/workspace_instance_usage.go
@@ -5,14 +5,90 @@
 package dbtest
 
 import (
+	"database/sql"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+	"math/rand"
 	"testing"
+	"time"
 )
+
+func NewWorkspaceInstanceUsage(t *testing.T, record db.WorkspaceInstanceUsage) db.WorkspaceInstanceUsage {
+	t.Helper()
+
+	userID := uuid.New()
+	if record.UserID.ID() != 0 {
+		userID = record.UserID
+	}
+
+	instanceID := uuid.New()
+	if record.InstanceID.ID() != 0 {
+		instanceID = record.InstanceID
+	}
+
+	attributionID := db.NewUserAttributionID(userID.String())
+	if record.AttributionID != "" {
+		attributionID = record.AttributionID
+	}
+
+	workspaceID := GenerateWorkspaceID()
+	if record.WorkspaceID != "" {
+		workspaceID = record.WorkspaceID
+	}
+
+	projectID := uuid.New().String()
+	if record.ProjectID != "" {
+		projectID = record.ProjectID
+	}
+
+	workspaceType := db.WorkspaceType_Regular
+	if record.WorkspaceType != "" {
+		workspaceType = record.WorkspaceType
+	}
+
+	workspaceClass := db.WorkspaceClass_Default
+	if record.WorkspaceClass != "" {
+		workspaceClass = record.WorkspaceClass
+	}
+
+	credits := rand.Float64()
+	if record.CreditsUsed != 0 {
+		credits = record.CreditsUsed
+	}
+
+	started := time.Date(2022, 7, 14, 10, 30, 30, 5000, time.UTC)
+	if !record.StartedAt.IsZero() {
+		started = record.StartedAt
+	}
+
+	stopped := sql.NullTime{}
+	if record.StoppedAt.Valid {
+		stopped = record.StoppedAt
+	}
+
+	return db.WorkspaceInstanceUsage{
+		InstanceID:     instanceID,
+		AttributionID:  attributionID,
+		UserID:         userID,
+		WorkspaceID:    workspaceID,
+		ProjectID:      projectID,
+		WorkspaceType:  workspaceType,
+		WorkspaceClass: workspaceClass,
+		CreditsUsed:    credits,
+		StartedAt:      started,
+		StoppedAt:      stopped,
+		GenerationID:   0,
+	}
+}
 
 func CreateWorkspaceInstanceUsageRecords(t *testing.T, conn *gorm.DB, instancesUsages ...db.WorkspaceInstanceUsage) []db.WorkspaceInstanceUsage {
 	t.Helper()
+
+	if len(instancesUsages) == 0 {
+		return nil
+	}
 
 	var ids []string
 	for _, instanceUsage := range instancesUsages {

--- a/components/usage/pkg/db/workspace_instance_usage.go
+++ b/components/usage/pkg/db/workspace_instance_usage.go
@@ -49,11 +49,22 @@ func CreateUsageRecords(ctx context.Context, conn *gorm.DB, records []WorkspaceI
 	return db.CreateInBatches(records, 1000).Error
 }
 
-func ListUsage(ctx context.Context, conn *gorm.DB, attributionId AttributionID) ([]WorkspaceInstanceUsage, error) {
+func ListUsage(ctx context.Context, conn *gorm.DB, attributionId AttributionID, from, to time.Time) ([]WorkspaceInstanceUsage, error) {
 	db := conn.WithContext(ctx)
 
 	var usageRecords []WorkspaceInstanceUsage
-	result := db.Order("startedAt").Find(&usageRecords, "attributionId = ?", attributionId)
+	result := db.
+		Order("startedAt").
+		Where("attributionId = ?", attributionId).
+		// started before, finished inside query range
+		Where("? <= stoppedAt AND stoppedAt < ?", from, to).
+		// started inside query range, finished inside
+		Or("startedAt >= ? AND stoppedAt < ?", from, to).
+		// started inside query range, finished outside
+		Or("? <= startedAt AND startedAt < ?", from, to).
+		// started before query range, still running
+		Or("startedAt <= ? AND (stoppedAt > ? OR stoppedAt IS NULL)", from, to).
+		Find(&usageRecords)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get usage records: %s", result.Error)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements filtering of Usage records by time

* When range is not supplied, it takes now as the end, and fetches last 31 days

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
